### PR TITLE
ICU-13685  c: add @preview (retry)

### DIFF
--- a/icu4c/source/Doxyfile.in
+++ b/icu4c/source/Doxyfile.in
@@ -242,7 +242,8 @@ ALIASES                = "memo=\par Note:\n" \
                          "deprecated=\xrefitem deprecated \"Deprecated\" \"Deprecated List\"" \
                          "obsolete=\xrefitem obsolete \"Obsolete\" \"Obsolete List\"" \
                          "system=\xrefitem system \"System\" \"System List\" \n Do not use unless you know what you are doing." \
-                         "internal=\xrefitem internal \"Internal\"  \"Internal List\"  Do not use. This API is for internal use only."
+                         "internal=\xrefitem internal \"Internal\"  \"Internal List\"  Do not use. This API is for internal use only." \
+                         "preview=\xrefitem preview \"Preview\"  \"Preview List\"  This API is a technical preview. It may change in an upcoming release.
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"

--- a/icu4c/source/common/unicode/icuplug.h
+++ b/icu4c/source/common/unicode/icuplug.h
@@ -100,7 +100,7 @@
  * SHOULD call uplug_setPlugName to indicate a human readable plugin name.</li></ol>
  * 
  *
- * \internal ICU 4.4 Technology Preview
+ * \preview ICU 4.4
  */
 
 
@@ -121,7 +121,7 @@
  * @{
  * Opaque structure passed to/from a plugin. 
  * use the APIs to access it.
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 
 struct UPlugData;
@@ -132,13 +132,13 @@ typedef struct UPlugData UPlugData;
 /**
  * Random Token to identify a valid ICU plugin. Plugins must return this 
  * from the entrypoint.
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 #define UPLUG_TOKEN 0x54762486
 
 /**
  * Max width of names, symbols, and configuration strings
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 #define UPLUG_NAME_MAX              100
 
@@ -147,13 +147,13 @@ typedef struct UPlugData UPlugData;
  * Return value from a plugin entrypoint. 
  * Must always be set to UPLUG_TOKEN
  * @see UPLUG_TOKEN
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 typedef uint32_t UPlugTokenReturn;
 
 /**
  * Reason code for the entrypoint's call
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 typedef enum {
     UPLUG_REASON_QUERY = 0,     /**< The plugin is being queried for info. **/
@@ -172,7 +172,7 @@ typedef enum {
  *     INITIAL:  UNKNOWN
  *       QUERY:   INVALID ->  { LOW | HIGH }
  *     ERR -> INVALID
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 typedef enum {
     UPLUG_LEVEL_INVALID = 0,     /**< The plugin is invalid, hasn't called uplug_setLevel, or can't load. **/
@@ -191,7 +191,7 @@ typedef enum {
  * @param plug the UPlugData handle. 
  * @param status the plugin's extended status code.
  * @return A valid plugin must return UPLUG_TOKEN
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 typedef UPlugTokenReturn (U_EXPORT2 UPlugEntrypoint) (
                   UPlugData *plug,
@@ -206,7 +206,7 @@ typedef UPlugTokenReturn (U_EXPORT2 UPlugEntrypoint) (
  * @see u_cleanup()
  * @param plug plugin
  * @param dontUnload  set true if this plugin can't be unloaded
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 U_INTERNAL void U_EXPORT2 
 uplug_setPlugNoUnload(UPlugData *plug, UBool dontUnload);
@@ -215,7 +215,7 @@ uplug_setPlugNoUnload(UPlugData *plug, UBool dontUnload);
  * Set the level of this plugin.
  * @param plug plugin data handle
  * @param level the level of this plugin
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 U_INTERNAL void U_EXPORT2
 uplug_setPlugLevel(UPlugData *plug, UPlugLevel level);
@@ -224,7 +224,7 @@ uplug_setPlugLevel(UPlugData *plug, UPlugLevel level);
  * Get the level of this plugin.
  * @param plug plugin data handle
  * @return the level of this plugin
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 U_INTERNAL UPlugLevel U_EXPORT2
 uplug_getPlugLevel(UPlugData *plug);
@@ -234,7 +234,7 @@ uplug_getPlugLevel(UPlugData *plug);
  * For example, if UPLUG_LEVEL_LOW is returned, then low level plugins may load
  * if UPLUG_LEVEL_HIGH is returned, then only high level plugins may load.
  * @return the lowest level of plug which can currently load
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 U_INTERNAL UPlugLevel U_EXPORT2
 uplug_getCurrentLevel(void);
@@ -243,7 +243,7 @@ uplug_getCurrentLevel(void);
 /**
  * Get plug load status
  * @return The error code of this plugin's load attempt.
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 U_INTERNAL UErrorCode U_EXPORT2
 uplug_getPlugLoadStatus(UPlugData *plug); 
@@ -252,7 +252,7 @@ uplug_getPlugLoadStatus(UPlugData *plug);
  * Set the human-readable name of this plugin.
  * @param plug plugin data handle
  * @param name the name of this plugin. The first UPLUG_NAME_MAX characters willi be copied into a new buffer.
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 U_INTERNAL void U_EXPORT2
 uplug_setPlugName(UPlugData *plug, const char *name);
@@ -261,7 +261,7 @@ uplug_setPlugName(UPlugData *plug, const char *name);
  * Get the human-readable name of this plugin.
  * @param plug plugin data handle
  * @return the name of this plugin
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 U_INTERNAL const char * U_EXPORT2
 uplug_getPlugName(UPlugData *plug);
@@ -270,7 +270,7 @@ uplug_getPlugName(UPlugData *plug);
  * Return the symbol name for this plugin, if known.
  * @param plug plugin data handle
  * @return the symbol name, or NULL
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 U_INTERNAL const char * U_EXPORT2
 uplug_getSymbolName(UPlugData *plug);
@@ -280,7 +280,7 @@ uplug_getSymbolName(UPlugData *plug);
  * @param plug plugin data handle
  * @param status error code
  * @return the library name, or NULL
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 U_INTERNAL const char * U_EXPORT2
 uplug_getLibraryName(UPlugData *plug, UErrorCode *status);
@@ -290,7 +290,7 @@ uplug_getLibraryName(UPlugData *plug, UErrorCode *status);
  * Plugins could use this to load data out of their 
  * @param plug plugin data handle
  * @return the library, or NULL
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 U_INTERNAL void * U_EXPORT2
 uplug_getLibrary(UPlugData *plug);
@@ -299,7 +299,7 @@ uplug_getLibrary(UPlugData *plug);
  * Return the plugin-specific context data.
  * @param plug plugin data handle
  * @return the context, or NULL if not set
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 U_INTERNAL void * U_EXPORT2
 uplug_getContext(UPlugData *plug);
@@ -308,7 +308,7 @@ uplug_getContext(UPlugData *plug);
  * Set the plugin-specific context data.
  * @param plug plugin data handle
  * @param context new context to set
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 U_INTERNAL void U_EXPORT2
 uplug_setContext(UPlugData *plug, void *context);
@@ -319,7 +319,7 @@ uplug_setContext(UPlugData *plug, void *context);
  * The string is in the platform default codepage.
  * @param plug plugin data handle
  * @return configuration string, or else null.
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 U_INTERNAL const char * U_EXPORT2
 uplug_getConfiguration(UPlugData *plug);
@@ -337,7 +337,7 @@ uplug_getConfiguration(UPlugData *plug);
  * @param prior pass in 'NULL' to get the first (most recent) plug, 
  *  otherwise pass the value returned on a prior call to uplug_nextPlug
  * @return the next oldest plugin, or NULL if no more.
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 U_INTERNAL UPlugData* U_EXPORT2
 uplug_nextPlug(UPlugData *prior);
@@ -352,7 +352,7 @@ uplug_nextPlug(UPlugData *prior);
  * @param config user specified configuration string, if available, or NULL.
  * @param status error result
  * @return the new UPlugData associated with this plugin, or NULL if error.
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 U_INTERNAL UPlugData* U_EXPORT2
 uplug_loadPlugFromEntrypoint(UPlugEntrypoint *entrypoint, const char *config, UErrorCode *status);
@@ -366,7 +366,7 @@ uplug_loadPlugFromEntrypoint(UPlugEntrypoint *entrypoint, const char *config, UE
  * @param config configuration string, or NULL
  * @param status error result
  * @return the new UPlugData associated with this plugin, or NULL if error.
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 U_INTERNAL UPlugData* U_EXPORT2
 uplug_loadPlugFromLibrary(const char *libName, const char *sym, const char *config, UErrorCode *status);
@@ -376,7 +376,7 @@ uplug_loadPlugFromLibrary(const char *libName, const char *sym, const char *conf
  * Will request the plugin to be unloaded, and close the library if needed
  * @param plug plugin handle to close
  * @param status error result
- * @internal ICU 4.4 Technology Preview
+ * @preview ICU 4.4
  */
 U_INTERNAL void U_EXPORT2
 uplug_removePlug(UPlugData *plug, UErrorCode *status);

--- a/icu4c/source/common/unicode/utext.h
+++ b/icu4c/source/common/unicode/utext.h
@@ -701,7 +701,7 @@ utext_extract(UText *ut,
  * Returns U_SENTINEL (-1) if the position is at the end of the
  * text.
  *
- * @internal ICU 4.4 technology preview
+ * @preview ICU 4.4
  */
 #define UTEXT_CURRENT32(ut)  \
     ((ut)->chunkOffset < (ut)->chunkLength && ((ut)->chunkContents)[(ut)->chunkOffset]<0xd800 ? \

--- a/icu4c/source/i18n/reldtfmt.h
+++ b/icu4c/source/i18n/reldtfmt.h
@@ -194,7 +194,7 @@ public:
      * date and time formatters associated with this object.
      * @param result Output param to receive the pattern.
      * @return       A reference to 'result'.
-     * @internal ICU 4.2 technology preview
+     * @preview ICU 4.2
      */
     virtual UnicodeString& toPattern(UnicodeString& result, UErrorCode& status) const;
 
@@ -202,7 +202,7 @@ public:
      * Get the date pattern for the the date formatter associated with this object.
      * @param result Output param to receive the date pattern.
      * @return       A reference to 'result'.
-     * @internal ICU 4.2 technology preview
+     * @preview ICU 4.2
      */
     virtual UnicodeString& toPatternDate(UnicodeString& result, UErrorCode& status) const;
 
@@ -210,7 +210,7 @@ public:
      * Get the time pattern for the the time formatter associated with this object.
      * @param result Output param to receive the time pattern.
      * @return       A reference to 'result'.
-     * @internal ICU 4.2 technology preview
+     * @preview ICU 4.2
      */
     virtual UnicodeString& toPatternTime(UnicodeString& result, UErrorCode& status) const;
 
@@ -221,7 +221,7 @@ public:
      *
      * @param datePattern   The date pattern to be applied.
      * @param timePattern   The time pattern to be applied.
-     * @internal ICU 4.2 technology preview
+     * @preview ICU 4.2
      */
     virtual void applyPatterns(const UnicodeString& datePattern, const UnicodeString& timePattern, UErrorCode &status);
 

--- a/icu4c/source/i18n/unicode/decimfmt.h
+++ b/icu4c/source/i18n/unicode/decimfmt.h
@@ -1295,7 +1295,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
 #ifndef U_HIDE_INTERNAL_API
     /**
      * Whether to show the plus sign on positive (non-negative) numbers; for example, "+12"
-     * @internal Technical Preview
+     * @preview
      */
     UBool isSignAlwaysShown() const;
 #endif  /* U_HIDE_INTERNAL_API */
@@ -1303,7 +1303,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
     /**
      * Set whether to show the plus sign on positive (non-negative) numbers; for example, "+12"
      * @param value The new setting for whether to show plus sign on positive numbers
-     * @internal Technical Preview
+     * @preview
      */
     virtual void setSignAlwaysShown(UBool value);
 
@@ -1675,7 +1675,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      *
      * @see setMinimumGroupingDigits
      * @see getGroupingSize
-     * @internal technology preview
+     * @preview
      */
     int32_t getMinimumGroupingDigits() const;
 
@@ -1688,7 +1688,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      *
      * @param newValue the new value of minimum grouping digits.
      * @see getMinimumGroupingDigits
-     * @internal technology preview
+     * @preview
      */
     virtual void setMinimumGroupingDigits(int32_t newValue);
 
@@ -1736,7 +1736,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * Returns whether to ignore exponents when parsing.
      *
      * @see #setParseNoExponent
-     * @internal This API is a technical preview. It may change in an upcoming release.
+     * @preview
      */
     virtual UBool isParseNoExponent() const;
 
@@ -1746,7 +1746,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * 5).
      *
      * @param value true to prevent exponents from being parsed; false to allow them to be parsed.
-     * @internal This API is a technical preview. It may change in an upcoming release.
+     * @preview
      */
     virtual void setParseNoExponent(UBool value);
 
@@ -1754,7 +1754,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * Returns whether parsing is sensitive to case (lowercase/uppercase).
      *
      * @see #setParseCaseSensitive
-     * @internal This API is a technical preview. It may change in an upcoming release.
+     * @preview
      */
     virtual UBool isParseCaseSensitive() const;
 
@@ -1765,7 +1765,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * Currency symbols are never case-folded. For example, "us$1.00" will not parse in case-insensitive
      * mode, even though "US$1.00" parses.
      *
-     * @internal This API is a technical preview. It may change in an upcoming release.
+     * @preview
      */
     virtual void setParseCaseSensitive(UBool value);
 
@@ -1774,7 +1774,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * By default, setMaximumIntegerDigits truncates high-order digits silently.
      *
      * @see setFormatFailIfMoreThanMaxDigits
-     * @internal This API is a technical preview. It may change in an upcoming release.
+     * @preview
      */
     virtual UBool isFormatFailIfMoreThanMaxDigits() const;
 
@@ -1782,7 +1782,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * Sets whether truncation of high-order integer digits should result in an error.
      * By default, setMaximumIntegerDigits truncates high-order digits silently.
      *
-     * @internal This API is a technical preview. It may change in an upcoming release.
+     * @preview
      */
     virtual void setFormatFailIfMoreThanMaxDigits(UBool value);
 

--- a/icu4c/source/i18n/unicode/smpdtfmt.h
+++ b/icu4c/source/i18n/unicode/smpdtfmt.h
@@ -1113,21 +1113,21 @@ public:
      * The caller should not delete the TimeZoneFormat object after
      * it is adopted by this call.
      * @param timeZoneFormatToAdopt The TimeZoneFormat object to be adopted.
-     * @internal ICU 49 technology preview
+     * @preview ICU 49
      */
     virtual void adoptTimeZoneFormat(TimeZoneFormat* timeZoneFormatToAdopt);
 
     /**
      * Sets the TimeZoneFormat to be used by this date/time formatter.
      * @param newTimeZoneFormat The TimeZoneFormat object to copy.
-     * @internal ICU 49 technology preview
+     * @preview ICU 49
      */
     virtual void setTimeZoneFormat(const TimeZoneFormat& newTimeZoneFormat);
 
     /**
      * Gets the time zone format object associated with this date/time formatter.
      * @return the time zone format associated with this date/time formatter.
-     * @internal ICU 49 technology preview
+     * @preview ICU 49
      */
     virtual const TimeZoneFormat* getTimeZoneFormat(void) const;
 

--- a/icu4c/source/i18n/unicode/udat.h
+++ b/icu4c/source/i18n/unicode/udat.h
@@ -1581,7 +1581,7 @@ udat_getContext(const UDateFormat* fmt, UDisplayContextType type, UErrorCode* st
 * @param status A pointer to a UErrorCode to receive any errors
 * @return The total buffer size needed; if greater than resultLength, the output was truncated.
 * @see udat_applyPatternRelative
-* @internal ICU 4.2 technology preview
+* @preview ICU 4.2
 */
 U_INTERNAL int32_t U_EXPORT2
 udat_toPatternRelativeDate(const UDateFormat *fmt,
@@ -1598,7 +1598,7 @@ udat_toPatternRelativeDate(const UDateFormat *fmt,
 * @param status A pointer to a UErrorCode to receive any errors
 * @return The total buffer size needed; if greater than resultLength, the output was truncated.
 * @see udat_applyPatternRelative
-* @internal ICU 4.2 technology preview
+* @preview ICU 4.2
 */
 U_INTERNAL int32_t U_EXPORT2
 udat_toPatternRelativeTime(const UDateFormat *fmt,
@@ -1616,7 +1616,7 @@ udat_toPatternRelativeTime(const UDateFormat *fmt,
 * @param timePatternLength The length of timePattern, or -1 if null-terminated.
 * @param status A pointer to a UErrorCode to receive any errors
 * @see udat_toPatternRelativeDate, udat_toPatternRelativeTime
-* @internal ICU 4.2 technology preview
+* @preview ICU 4.2
 */
 U_INTERNAL void U_EXPORT2
 udat_applyPatternRelative(UDateFormat *format,

--- a/icu4c/source/i18n/unicode/unum.h
+++ b/icu4c/source/i18n/unicode/unum.h
@@ -1027,7 +1027,7 @@ typedef enum UNumberFormatAttribute {
    * Minimum grouping digits, technology preview.
    * See DecimalFormat::getMinimumGroupingDigits().
    *
-   * @internal technology preview
+   * @preview
    */
   UNUM_MINIMUM_GROUPING_DIGITS = 22,
   /* TODO: test C API when it becomes @draft */
@@ -1079,14 +1079,14 @@ typedef enum UNumberFormatAttribute {
   /**
    * Whether parsing is sensitive to case (lowercase/uppercase).
    * TODO: Add to the test suite.
-   * @internal This API is a technical preview. It may change in an upcoming release.
+   * @preview
    */
   UNUM_PARSE_CASE_SENSITIVE = 0x1004,
 
   /**
    * Formatting: whether to show the plus sign on non-negative numbers.
    * TODO: Add to the test suite.
-   * @internal This API is a technical preview. It may change in an upcoming release.
+   * @preview
    */
   UNUM_SIGN_ALWAYS_SHOWN = 0x1005,
 } UNumberFormatAttribute;

--- a/icu4c/source/i18n/unicode/upluralrules.h
+++ b/icu4c/source/i18n/unicode/upluralrules.h
@@ -164,7 +164,7 @@ uplrules_select(const UPluralRules *uplrules,
  * @param capacity The capacity of the keyword buffer.
  * @param status A pointer to a UErrorCode to receive any errors.
  * @return The length of keyword.
- * @internal ICU 59 technology preview, may be removed in the future
+ * @preview ICU 59
  */
 U_INTERNAL int32_t U_EXPORT2
 uplrules_selectWithFormat(const UPluralRules *uplrules,

--- a/icu4c/source/layoutex/layout/playout.h
+++ b/icu4c/source/layoutex/layout/playout.h
@@ -32,21 +32,21 @@
 /**
  * The opaque type for a paragraph layout.
  *
- * @internal
+ * @preview
  */
 typedef void pl_paragraph;
 
 /**
  * The opaque type for a line in a paragraph layout.
  *
- * @internal
+ * @preview
  */
 typedef void pl_line;
 
 /**
  * The opaque type for a visual run in a line.
  *
- * @internal
+ * @preview
  */
 typedef void pl_visualRun;
 
@@ -93,7 +93,7 @@ typedef void pl_visualRun;
  * @see longine.h
  * @see plruns.h
  *
- * @internal
+ * @preview
  */
 U_INTERNAL pl_paragraph * U_EXPORT2
 pl_create(const LEUnicode chars[],
@@ -113,7 +113,7 @@ pl_create(const LEUnicode chars[],
  *                  closed. Once this routine returns the object
  *                  can no longer be referenced
  *
- * @internal
+ * @preview
  */
 U_INTERNAL void U_EXPORT2
 pl_close(pl_paragraph *paragraph);
@@ -128,7 +128,7 @@ pl_close(pl_paragraph *paragraph);
  *
  * @return <code>TRUE</code> if any of the text requires complex processing.
  *
- * @internal
+ * @preview
  */
 
 U_INTERNAL le_bool U_EXPORT2
@@ -144,7 +144,7 @@ pl_isComplex(const LEUnicode chars[],
  *
  * @return the resolved paragraph level.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL UBiDiLevel U_EXPORT2
 pl_getParagraphLevel(pl_paragraph *paragraph);
@@ -158,7 +158,7 @@ pl_getParagraphLevel(pl_paragraph *paragraph);
  *         <code>UBIDI_RTL</code> if the text is all right to left,
  *         or <code>UBIDI_MIXED</code> if the text has mixed direction.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL UBiDiDirection U_EXPORT2
 pl_getTextDirection(pl_paragraph *paragraph);
@@ -176,7 +176,7 @@ pl_getTextDirection(pl_paragraph *paragraph);
  *
  * @return the ascent value.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_getAscent(const pl_paragraph *paragraph);
@@ -189,7 +189,7 @@ pl_getAscent(const pl_paragraph *paragraph);
  *
  * @return the decent value.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_getDescent(const pl_paragraph *paragraph);
@@ -202,7 +202,7 @@ pl_getDescent(const pl_paragraph *paragraph);
  *
  * @return the leading value.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_getLeading(const pl_paragraph *paragraph);
@@ -212,7 +212,7 @@ pl_getLeading(const pl_paragraph *paragraph);
  *
  * @param paragraph the <code>pl_paragraph</code>
  *
- * @internal
+ * @preview
  */
 U_INTERNAL void U_EXPORT2
 pl_reflow(pl_paragraph *paragraph);
@@ -233,7 +233,7 @@ pl_reflow(pl_paragraph *paragraph);
  *
  * @see pl_line
  *
- * @internal
+ * @preview
  */
 U_INTERNAL pl_line * U_EXPORT2
 pl_nextLine(pl_paragraph *paragraph, float width);
@@ -245,7 +245,7 @@ pl_nextLine(pl_paragraph *paragraph, float width);
  *
  * @param line the <code>pl_line</code> object to close.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL void U_EXPORT2
 pl_closeLine(pl_line *line);
@@ -257,7 +257,7 @@ pl_closeLine(pl_line *line);
  *
  * @return the number of visual runs.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_countLineRuns(const pl_line *line);
@@ -270,7 +270,7 @@ pl_countLineRuns(const pl_line *line);
  *
  * @return the ascent of the line.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_getLineAscent(const pl_line *line);
@@ -283,7 +283,7 @@ pl_getLineAscent(const pl_line *line);
  *
  * @return the descent of the line.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_getLineDescent(const pl_line *line);
@@ -296,7 +296,7 @@ pl_getLineDescent(const pl_line *line);
  *
  * @return the leading of the line.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_getLineLeading(const pl_line *line);
@@ -310,7 +310,7 @@ pl_getLineLeading(const pl_line *line);
  *
  * @return the width of the line.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_getLineWidth(const pl_line *line);
@@ -329,7 +329,7 @@ pl_getLineWidth(const pl_line *line);
  *
  * @see pl_visualRun
  *
- * @internal
+ * @preview
  */
 U_INTERNAL const pl_visualRun * U_EXPORT2
 pl_getLineVisualRun(const pl_line *line, le_int32 runIndex);
@@ -346,7 +346,7 @@ pl_getLineVisualRun(const pl_line *line, le_int32 runIndex);
  *
  * @see le_font
  *
- * @internal
+ * @preview
  */
 U_INTERNAL const le_font * U_EXPORT2
 pl_getVisualRunFont(const pl_visualRun *run);
@@ -359,7 +359,7 @@ pl_getVisualRunFont(const pl_visualRun *run);
  * @return the direction of the run. This will be <code>UBIDI_LTR</code> if the
  *         run is left-to-right and <code>UBIDI_RTL</code> if the line is right-to-left.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL UBiDiDirection U_EXPORT2
 pl_getVisualRunDirection(const pl_visualRun *run);
@@ -371,7 +371,7 @@ pl_getVisualRunDirection(const pl_visualRun *run);
  *
  * @return the number of glyphs.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_getVisualRunGlyphCount(const pl_visualRun *run);
@@ -386,7 +386,7 @@ pl_getVisualRunGlyphCount(const pl_visualRun *run);
  *         is owned by the <code>pl_visualRun</code> object and must not be deleted.
  *         It will remain valid as long as the <code>pl_visualRun</code> object is valid.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL const LEGlyphID * U_EXPORT2
 pl_getVisualRunGlyphs(const pl_visualRun *run);
@@ -404,7 +404,7 @@ pl_getVisualRunGlyphs(const pl_visualRun *run);
  *         is owned by the <code>pl_visualRun</code> object and must not be deleted.
  *         It will remain valid as long as the <code>pl_visualRun</code> object is valid.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL const float * U_EXPORT2
 pl_getVisualRunPositions(const pl_visualRun *run);
@@ -419,7 +419,7 @@ pl_getVisualRunPositions(const pl_visualRun *run);
  *         is owned by the <code>pl_visualRun</code> object and must not be deleted.
  *         It will remain valid as long as the <code>pl_visualRun</code> object is valid.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL const le_int32 * U_EXPORT2
 pl_getVisualRunGlyphToCharMap(const pl_visualRun *run);
@@ -432,7 +432,7 @@ pl_getVisualRunGlyphToCharMap(const pl_visualRun *run);
  *
  * @return the ascent value of this run's font.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_getVisualRunAscent(const pl_visualRun *run);
@@ -445,7 +445,7 @@ pl_getVisualRunAscent(const pl_visualRun *run);
  *
  * @return the descent value of this run's font.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_getVisualRunDescent(const pl_visualRun *run);
@@ -458,7 +458,7 @@ pl_getVisualRunDescent(const pl_visualRun *run);
  *
  * @return the leading value of this run's font.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_getVisualRunLeading(const pl_visualRun *run);

--- a/icu4c/source/layoutex/layout/plruns.h
+++ b/icu4c/source/layoutex/layout/plruns.h
@@ -20,17 +20,17 @@
 
 /**
  * Opaque datatype representing an array of font runs
- * @internal
+ * @preview
  */
 typedef void pl_fontRuns;
 /**
  * Opaque datatype representing an array of value runs
- * @internal
+ * @preview
  */
 typedef void pl_valueRuns;
 /**
  * Opaque datatype representing an array of locale runs
- * @internal
+ * @preview
  */
 typedef void pl_localeRuns;
 
@@ -56,7 +56,7 @@ typedef void pl_localeRuns;
  *
  * @param count is the number of entries in the two arrays.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL pl_fontRuns * U_EXPORT2
 pl_openFontRuns(const le_font **fonts,
@@ -72,7 +72,7 @@ pl_openFontRuns(const le_font **fonts,
  *
  * @see pl_addFontRun
  *
- * @internal
+ * @preview
  */
 U_INTERNAL pl_fontRuns * U_EXPORT2
 pl_openEmptyFontRuns(le_int32 initialCapacity);
@@ -83,7 +83,7 @@ pl_openEmptyFontRuns(le_int32 initialCapacity);
  *
  * @param fontRuns is the <code>pl_fontRuns</code> object.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL void U_EXPORT2
 pl_closeFontRuns(pl_fontRuns *fontRuns);
@@ -95,7 +95,7 @@ pl_closeFontRuns(pl_fontRuns *fontRuns);
  *
  * @return the number of entries in the limit indices array.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_getFontRunCount(const pl_fontRuns *fontRuns);
@@ -105,7 +105,7 @@ pl_getFontRunCount(const pl_fontRuns *fontRuns);
  *
  * @param fontRuns is the <code>pl_fontRuns</code> object.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL void U_EXPORT2
 pl_resetFontRuns(pl_fontRuns *fontRuns);
@@ -118,7 +118,7 @@ pl_resetFontRuns(pl_fontRuns *fontRuns);
  *
  * @return the last limit index.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_getFontRunLastLimit(const pl_fontRuns *fontRuns);
@@ -131,7 +131,7 @@ pl_getFontRunLastLimit(const pl_fontRuns *fontRuns);
  *
  * @return the limit index for the run, or -1 if <code>run</code> is out of bounds.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_getFontRunLimit(const pl_fontRuns *fontRuns,
@@ -147,7 +147,7 @@ pl_getFontRunLimit(const pl_fontRuns *fontRuns,
  *
  * @return the <code>le_font</code> associated with the given text run.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL const le_font * U_EXPORT2
 pl_getFontRunFont(const pl_fontRuns *fontRuns,
@@ -170,7 +170,7 @@ pl_getFontRunFont(const pl_fontRuns *fontRuns,
  * @return the run index where the font and limit index were stored, or -1 if 
  *         the run cannot be added.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_addFontRun(pl_fontRuns *fontRuns,
@@ -189,7 +189,7 @@ pl_addFontRun(pl_fontRuns *fontRuns,
  *
  * @param count is the number of entries in the two arrays.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL pl_valueRuns * U_EXPORT2
 pl_openValueRuns(const le_int32 *values,
@@ -205,7 +205,7 @@ pl_openValueRuns(const le_int32 *values,
  *
  * @see pl_addValueRun
  *
- * @internal
+ * @preview
  */
 U_INTERNAL pl_valueRuns * U_EXPORT2
 pl_openEmptyValueRuns(le_int32 initialCapacity);
@@ -216,7 +216,7 @@ pl_openEmptyValueRuns(le_int32 initialCapacity);
  *
  * @param valueRuns is the <code>pl_valueRuns</code> object.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL void U_EXPORT2
 pl_closeValueRuns(pl_valueRuns *valueRuns);
@@ -228,7 +228,7 @@ pl_closeValueRuns(pl_valueRuns *valueRuns);
  *
  * @return the number of value runs.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_getValueRunCount(const pl_valueRuns *valueRuns);
@@ -238,7 +238,7 @@ pl_getValueRunCount(const pl_valueRuns *valueRuns);
  *
  * @param valueRuns is the <code>pl_valueRuns</code> object.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL void U_EXPORT2
 pl_resetValueRuns(pl_valueRuns *valueRuns);
@@ -251,7 +251,7 @@ pl_resetValueRuns(pl_valueRuns *valueRuns);
  *
  * @return the last limit index.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_getValueRunLastLimit(const pl_valueRuns *valueRuns);
@@ -264,7 +264,7 @@ pl_getValueRunLastLimit(const pl_valueRuns *valueRuns);
  *
  * @return the limit index for the run, or -1 if <code>run</code> is out of bounds.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_getValueRunLimit(const pl_valueRuns *valueRuns,
@@ -280,7 +280,7 @@ pl_getValueRunLimit(const pl_valueRuns *valueRuns,
  *
  * @return the value associated with the given text run.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_getValueRunValue(const pl_valueRuns *valueRuns,
@@ -302,7 +302,7 @@ pl_getValueRunValue(const pl_valueRuns *valueRuns,
  * @return the run index where the font and limit index were stored, or -1 if 
  *         the run cannot be added.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_addValueRun(pl_valueRuns *valueRuns,
@@ -321,7 +321,7 @@ pl_addValueRun(pl_valueRuns *valueRuns,
  *
  * @param count is the number of entries in the two arrays.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL pl_localeRuns * U_EXPORT2
 pl_openLocaleRuns(const char **locales,
@@ -337,7 +337,7 @@ pl_openLocaleRuns(const char **locales,
  *
  * @see pl_addLocaleRun
  *
- * @internal
+ * @preview
  */
 U_INTERNAL pl_localeRuns * U_EXPORT2
 pl_openEmptyLocaleRuns(le_int32 initialCapacity);
@@ -348,7 +348,7 @@ pl_openEmptyLocaleRuns(le_int32 initialCapacity);
  *
  * @param localeRuns is the <code>pl_localeRuns</code> object.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL void U_EXPORT2
 pl_closeLocaleRuns(pl_localeRuns *localeRuns);
@@ -360,7 +360,7 @@ pl_closeLocaleRuns(pl_localeRuns *localeRuns);
  *
  * @return the number of entries in the limit indices array.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_getLocaleRunCount(const pl_localeRuns *localeRuns);
@@ -370,7 +370,7 @@ pl_getLocaleRunCount(const pl_localeRuns *localeRuns);
  *
  * @param localeRuns is the <code>pl_localeRuns</code> object.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL void U_EXPORT2
 pl_resetLocaleRuns(pl_localeRuns *localeRuns);
@@ -383,7 +383,7 @@ pl_resetLocaleRuns(pl_localeRuns *localeRuns);
  *
  * @return the last limit index.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_getLocaleRunLastLimit(const pl_localeRuns *localeRuns);
@@ -396,7 +396,7 @@ pl_getLocaleRunLastLimit(const pl_localeRuns *localeRuns);
  *
  * @return the limit index for the run, or -1 if <code>run</code> is out of bounds.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_getLocaleRunLimit(const pl_localeRuns *localeRuns,
@@ -412,7 +412,7 @@ pl_getLocaleRunLimit(const pl_localeRuns *localeRuns,
  *
  * @return the <code>le_font</code> associated with the given text run.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL const char * U_EXPORT2
 pl_getLocaleRunLocale(const pl_localeRuns *localeRuns,
@@ -435,7 +435,7 @@ pl_getLocaleRunLocale(const pl_localeRuns *localeRuns,
  * @return the run index where the font and limit index were stored, or -1 if 
  *         the run cannot be added.
  *
- * @internal
+ * @preview
  */
 U_INTERNAL le_int32 U_EXPORT2
 pl_addLocaleRun(pl_localeRuns *localeRuns,

--- a/icu4c/source/test/intltest/colldata.h
+++ b/icu4c/source/test/intltest/colldata.h
@@ -14,8 +14,8 @@
  */
 
 /*
- * Note: This module was incldued in ICU 4.0.1 as @internal technology preview for supporting
- * Boyer-Moore string search API. For now, only SSearchTest depends on this module. I temporaly
+ * Note: This module was incldued in ICU 4.0.1 as technology @preview for supporting
+ * Boyer-Moore string search API. For now, only SSearchTest depends on this module. I temporarily
  * moved the module from i18n directory to intltest, because we have no plan to publish this
  * as public API. (2012-12-18 yoshito)
  */


### PR DESCRIPTION
ICU-13685

re-open from #7 

Tech Preview should not be 'do not use', but `@internal` in Doxygen comes with an ominous warning.

Add `@preview` as a doxygen command such that:

> `@preview ICU 4.4` 

gives:

<img width="637" alt="atpreview" src="https://user-images.githubusercontent.com/855219/42478525-de54568e-8389-11e8-98c0-467df9b74ac4.png">
