### PR TITLE
ICU-10464 Make installation of icu-config optional

### DIFF
--- a/icu4c/source/Makefile.in
+++ b/icu4c/source/Makefile.in
@@ -48,6 +48,8 @@ ALL_PKGCONFIG_SUFFIX=uc i18n
 DOXYGEN = @DOXYGEN@
 DOCZIP = icu-docs.zip
 
+INSTALL_ICU_CONFIG = @INSTALL_ICU_CONFIG@
+
 ## Files to remove for 'make clean'
 CLEANFILES = *~
 
@@ -64,7 +66,9 @@ SUBDIRS =  stubdata common i18n $(LAYOUTEX) $(ICUIO) $(TOOLS) $(DATASUBDIR) $(EX
 
 SECTION = 1
 
+ifeq ($(INSTALL_ICU_CONFIG),true)
 MANX_FILES = config/icu-config.$(SECTION)
+endif
 
 ALL_MAN_FILES = $(MANX_FILES)
 
@@ -187,7 +191,9 @@ install-icu: $(INSTALLED_BUILT_FILES)
 	@$(MKINSTALLDIRS) $(DESTDIR)$(libdir)/pkgconfig
 	$(INSTALL_DATA) $(ALL_PKGCONFIG_FILES) $(DESTDIR)$(libdir)/pkgconfig/
 	$(INSTALL_DATA) $(top_srcdir)/../LICENSE $(DESTDIR)$(pkgdatadir)/LICENSE
+ifeq ($(INSTALL_ICU_CONFIG),true)
 	$(INSTALL_SCRIPT) $(top_builddir)/config/icu-config $(DESTDIR)$(bindir)/icu-config
+endif
 	$(INSTALL_DATA) $(top_builddir)/config/Makefile.inc $(DESTDIR)$(pkglibdir)/Makefile.inc
 	$(INSTALL_DATA) $(top_builddir)/config/pkgdata.inc $(DESTDIR)$(pkglibdir)/pkgdata.inc
 #	@echo icuinfo.xml is built after make check.
@@ -350,7 +356,9 @@ config.status: $(srcdir)/configure $(srcdir)/common/unicode/uvernum.h
 
 install-manx: $(MANX_FILES)
 	$(MKINSTALLDIRS) $(DESTDIR)$(mandir)/man$(SECTION)
+ifneq ($(MANX_FILES),)
 	$(INSTALL_DATA) $? $(DESTDIR)$(mandir)/man$(SECTION)
+endif
 
 config/%.$(SECTION): $(srcdir)/config/%.$(SECTION).in
 	cd $(top_builddir) \

--- a/icu4c/source/configure
+++ b/icu4c/source/configure
@@ -716,6 +716,7 @@ CFLAGS
 CC
 ENABLE_RELEASE
 ENABLE_DEBUG
+INSTALL_ICU_CONFIG
 CPPFLAGS
 host_os
 host_vendor
@@ -775,6 +776,7 @@ SHELL'
 ac_subst_files=''
 ac_user_opts='
 enable_option_checking
+enable_icu_config
 enable_debug
 enable_release
 with_cross_build
@@ -1443,6 +1445,7 @@ Optional Features:
   --disable-option-checking  ignore unrecognized --enable/--with options
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
+  --enable-icu-config     install icu-config
   --enable-debug          build debug libraries and enable the U_DEBUG define default=no
   --enable-release        build release libraries default=yes
   --enable-strict         compile with strict compiler options default=yes
@@ -2796,6 +2799,21 @@ UCONFIG_CPPFLAGS=""
 # UCONFIG_CFLAGS: contains a copy of anything that needs to be set by end users
 # such as -std
 UCONFIG_CFLAGS=""
+
+# Check whether to install icu-config
+# Check whether --enable-icu-config was given.
+if test "${enable_icu_config+set}" = set; then :
+  enableval=$enable_icu_config; case "${enableval}" in
+            yes) enable_icu_config=true ;;
+            no) enable_icu_config=false ;;
+            *) as_fn_error $? "bad value '${enableval}' for --enable-icu-config" "$LINENO" 5 ;;
+        esac
+else
+  enable_icu_config=true
+fi
+
+INSTALL_ICU_CONFIG=$enable_icu_config
+
 
 # Check whether to build debug libraries
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to build debug libraries" >&5

--- a/icu4c/source/configure.ac
+++ b/icu4c/source/configure.ac
@@ -100,6 +100,16 @@ UCONFIG_CPPFLAGS=""
 # such as -std
 UCONFIG_CFLAGS=""
 
+# Check whether to install icu-config
+AC_ARG_ENABLE([icu-config],
+    AS_HELP_STRING([--enable-icu-config], [install icu-config]),
+        [case "${enableval}" in
+            yes) enable_icu_config=true ;;
+            no) enable_icu_config=false ;;
+            *) AC_MSG_ERROR([bad value '${enableval}' for --enable-icu-config]) ;;
+        esac], [enable_icu_config=true])
+AC_SUBST(INSTALL_ICU_CONFIG, [$enable_icu_config])
+
 # Check whether to build debug libraries
 AC_MSG_CHECKING([whether to build debug libraries])
 enabled=no


### PR DESCRIPTION
Make installation of `icu-config` optional.

Users who do not want to install `icu-config` must pass either `--disable-icu-config` or `--enable-icu-config=no` to `configure`.

From version 64.1, `icu-config` will not be installed by default.

Signed-off-by: Hugh McMaster <hugh.mcmaster@outlook.com>