### PR TITLE
ICU-20034 Locale assignment operator should set the locale to bogus if OOM occurs.

### DIFF
--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -458,6 +458,11 @@ Locale &Locale::operator=(const Locale &other)
     } else {
         if (other.baseName) {
             baseName = uprv_strdup(other.baseName);
+            if (baseName == nullptr) {
+                // if memory allocation fails, set this object to bogus.
+                fIsBogus = TRUE;
+                return *this;
+            }
         }
     }
 

--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -444,6 +444,8 @@ Locale &Locale::operator=(const Locale &other)
     if(other.fullName != other.fullNameBuffer) {
         fullName = (char *)uprv_malloc(sizeof(char)*(uprv_strlen(other.fullName)+1));
         if (fullName == NULL) {
+            // if memory allocation fails, set this object to bogus.
+            fIsBogus = TRUE;
             return *this;
         }
     }


### PR DESCRIPTION
The Locale class assignment operator should set the locale to "bogus" if an out-of-memory (OOM) error occurs when attempting to copy data over from the other locale.