### PR TITLE
ICU-20042 Improve OOM handling in PluralRules class.

### DIFF
--- a/icu4c/source/i18n/plurrule.cpp
+++ b/icu4c/source/i18n/plurrule.cpp
@@ -102,15 +102,13 @@ PluralRules&
 PluralRules::operator=(const PluralRules& other) {
     if (this != &other) {
         delete mRules;
+        mRules = nullptr;
         mInternalStatus = other.mInternalStatus;
         if (U_FAILURE(mInternalStatus)) {
             // bail out early if the object we were copying from was already 'invalid'.
             return *this;
         }
-        if (other.mRules == nullptr) {
-            mRules = nullptr;
-        }
-        else {
+        if (other.mRules != nullptr) {
             mRules = new RuleChain(*other.mRules);
             if (mRules == nullptr) {
                 mInternalStatus = U_MEMORY_ALLOCATION_ERROR;

--- a/icu4c/source/i18n/plurrule.cpp
+++ b/icu4c/source/i18n/plurrule.cpp
@@ -65,14 +65,14 @@ UOBJECT_DEFINE_RTTI_IMPLEMENTATION(PluralKeywordEnumeration)
 
 PluralRules::PluralRules(UErrorCode& /*status*/)
 :   UObject(),
-    mRules(NULL),
+    mRules(nullptr),
     mInternalStatus(U_ZERO_ERROR)
 {
 }
 
 PluralRules::PluralRules(const PluralRules& other)
 : UObject(other),
-    mRules(NULL),
+    mRules(nullptr),
     mInternalStatus(U_ZERO_ERROR)
 {
     *this=other;
@@ -126,15 +126,15 @@ PluralRules::operator=(const PluralRules& other) {
 
 StringEnumeration* PluralRules::getAvailableLocales(UErrorCode &status) {
     if (U_FAILURE(status)) {
-        return NULL;
+        return nullptr;
     }
     StringEnumeration *result = new PluralAvailableLocalesEnumeration(status);
-    if (result == NULL && U_SUCCESS(status)) {
+    if (result == nullptr && U_SUCCESS(status)) {
         status = U_MEMORY_ALLOCATION_ERROR;
     }
     if (U_FAILURE(status)) {
         delete result;
-        result = NULL;
+        result = nullptr;
     }
     return result;
 }
@@ -143,17 +143,17 @@ StringEnumeration* PluralRules::getAvailableLocales(UErrorCode &status) {
 PluralRules* U_EXPORT2
 PluralRules::createRules(const UnicodeString& description, UErrorCode& status) {
     if (U_FAILURE(status)) {
-        return NULL;
+        return nullptr;
     }
 
     PluralRuleParser parser;
     LocalPointer<PluralRules> newRules(new PluralRules(status), status);
     if (U_FAILURE(status)) {
-        return NULL;
+        return nullptr;
     }
     parser.parse(description, newRules.getAlias(), status);
     if (U_FAILURE(status)) {
-        newRules.adoptInstead(NULL);
+        newRules.adoptInstead(nullptr);
     }
     return newRules.orphan();
 }
@@ -174,13 +174,13 @@ const SharedPluralRules *LocaleCacheKey<SharedPluralRules>::createObject(
     PluralRules *pr = PluralRules::internalForLocale(
             localeId, UPLURAL_TYPE_CARDINAL, status);
     if (U_FAILURE(status)) {
-        return NULL;
+        return nullptr;
     }
     SharedPluralRules *result = new SharedPluralRules(pr);
-    if (result == NULL) {
+    if (result == nullptr) {
         status = U_MEMORY_ALLOCATION_ERROR;
         delete pr;
-        return NULL;
+        return nullptr;
     }
     result->addRef();
     return result;
@@ -193,13 +193,13 @@ const SharedPluralRules* U_EXPORT2
 PluralRules::createSharedInstance(
         const Locale& locale, UPluralType type, UErrorCode& status) {
     if (U_FAILURE(status)) {
-        return NULL;
+        return nullptr;
     }
     if (type != UPLURAL_TYPE_CARDINAL) {
         status = U_UNSUPPORTED_ERROR;
-        return NULL;
+        return nullptr;
     }
-    const SharedPluralRules *result = NULL;
+    const SharedPluralRules *result = nullptr;
     UnifiedCache::getByLocale(locale, result, status);
     return result;
 }
@@ -217,11 +217,11 @@ PluralRules::forLocale(const Locale& locale, UPluralType type, UErrorCode& statu
     const SharedPluralRules *shared = createSharedInstance(
             locale, type, status);
     if (U_FAILURE(status)) {
-        return NULL;
+        return nullptr;
     }
     PluralRules *result = (*shared)->clone();
     shared->removeRef();
-    if (result == NULL) {
+    if (result == nullptr) {
         status = U_MEMORY_ALLOCATION_ERROR;
     }
     return result;
@@ -230,11 +230,11 @@ PluralRules::forLocale(const Locale& locale, UPluralType type, UErrorCode& statu
 PluralRules* U_EXPORT2
 PluralRules::internalForLocale(const Locale& locale, UPluralType type, UErrorCode& status) {
     if (U_FAILURE(status)) {
-        return NULL;
+        return nullptr;
     }
     if (type >= UPLURAL_TYPE_COUNT) {
         status = U_ILLEGAL_ARGUMENT_ERROR;
-        return NULL;
+        return nullptr;
     }
     LocalPointer<PluralRules> newObj(new PluralRules(status), status);
     if (U_FAILURE(status)) {
@@ -271,7 +271,7 @@ PluralRules::select(double number) const {
 
 UnicodeString
 PluralRules::select(const IFixedDecimal &number) const {
-    if (mRules == NULL) {
+    if (mRules == nullptr) {
         return UnicodeString(TRUE, PLURAL_DEFAULT_RULE, -1);
     }
     else {
@@ -284,7 +284,7 @@ PluralRules::select(const IFixedDecimal &number) const {
 StringEnumeration*
 PluralRules::getKeywords(UErrorCode& status) const {
     if (U_FAILURE(status)) {
-        return NULL;
+        return nullptr;
     }
     if (U_FAILURE(mInternalStatus)) {
         status = mInternalStatus;
@@ -292,7 +292,7 @@ PluralRules::getKeywords(UErrorCode& status) const {
     }
     LocalPointer<StringEnumeration> nameEnumerator(new PluralKeywordEnumeration(mRules, status), status);
     if (U_FAILURE(status)) {
-        return NULL;
+        return nullptr;
     }
     return nameEnumerator.orphan();
 }
@@ -400,7 +400,7 @@ PluralRules::getSamples(const UnicodeString &keyword, double *dest,
         return 0;
     }
     RuleChain *rc = rulesForKeyword(keyword);
-    if (rc == NULL) {
+    if (rc == nullptr) {
         return 0;
     }
     int32_t numSamples = getSamplesFromString(rc->fIntegerSamples, dest, destCapacity, status);
@@ -413,7 +413,7 @@ PluralRules::getSamples(const UnicodeString &keyword, double *dest,
 
 RuleChain *PluralRules::rulesForKeyword(const UnicodeString &keyword) const {
     RuleChain *rc;
-    for (rc = mRules; rc != NULL; rc = rc->fNext) {
+    for (rc = mRules; rc != nullptr; rc = rc->fNext) {
         if (rc->fKeyword == keyword) {
             break;
         }
@@ -427,7 +427,7 @@ PluralRules::isKeyword(const UnicodeString& keyword) const {
     if (0 == keyword.compare(PLURAL_KEYWORD_OTHER, 5)) {
         return true;
     }
-    return rulesForKeyword(keyword) != NULL;
+    return rulesForKeyword(keyword) != nullptr;
 }
 
 UnicodeString
@@ -453,13 +453,13 @@ PluralRules::operator==(const PluralRules& other) const  {
         return FALSE;
     }
     myKeywordList->reset(status);
-    while ((ptrKeyword=myKeywordList->snext(status))!=NULL) {
+    while ((ptrKeyword=myKeywordList->snext(status))!=nullptr) {
         if (!other.isKeyword(*ptrKeyword)) {
             return FALSE;
         }
     }
     otherKeywordList->reset(status);
-    while ((ptrKeyword=otherKeywordList->snext(status))!=NULL) {
+    while ((ptrKeyword=otherKeywordList->snext(status))!=nullptr) {
         if (!this->isKeyword(*ptrKeyword)) {
             return FALSE;
         }
@@ -492,14 +492,14 @@ PluralRuleParser::parse(const UnicodeString& ruleData, PluralRules *prules, UErr
         }
         switch (type) {
         case tAnd:
-            U_ASSERT(curAndConstraint != NULL);
+            U_ASSERT(curAndConstraint != nullptr);
             curAndConstraint = curAndConstraint->add(status);
             break;
         case tOr:
             {
-                U_ASSERT(currentChain != NULL);
+                U_ASSERT(currentChain != nullptr);
                 OrConstraint *orNode=currentChain->ruleHeader;
-                while (orNode->next != NULL) {
+                while (orNode->next != nullptr) {
                     orNode = orNode->next;
                 }
                 orNode->next= new OrConstraint();
@@ -508,17 +508,17 @@ PluralRuleParser::parse(const UnicodeString& ruleData, PluralRules *prules, UErr
                     break;
                 }
                 orNode=orNode->next;
-                orNode->next=NULL;
+                orNode->next=nullptr;
                 curAndConstraint = orNode->add(status);
             }
             break;
         case tIs:
-            U_ASSERT(curAndConstraint != NULL);
+            U_ASSERT(curAndConstraint != nullptr);
             U_ASSERT(curAndConstraint->value == -1);
-            U_ASSERT(curAndConstraint->rangeList == NULL);
+            U_ASSERT(curAndConstraint->rangeList == nullptr);
             break;
         case tNot:
-            U_ASSERT(curAndConstraint != NULL);
+            U_ASSERT(curAndConstraint != nullptr);
             curAndConstraint->negated=TRUE;
             break;
 
@@ -529,7 +529,7 @@ PluralRuleParser::parse(const UnicodeString& ruleData, PluralRules *prules, UErr
         case tWithin:
         case tEqual:
             {
-                U_ASSERT(curAndConstraint != NULL);
+                U_ASSERT(curAndConstraint != nullptr);
                 LocalPointer<UVector32> newRangeList(new UVector32(status), status);
                 if (U_FAILURE(status)) {
                     break;
@@ -544,13 +544,13 @@ PluralRuleParser::parse(const UnicodeString& ruleData, PluralRules *prules, UErr
             }
             break;
         case tNumber:
-            U_ASSERT(curAndConstraint != NULL);
+            U_ASSERT(curAndConstraint != nullptr);
             if ( (curAndConstraint->op==AndConstraint::MOD)&&
                  (curAndConstraint->opNum == -1 ) ) {
                 curAndConstraint->opNum=getNumberValue(token);
             }
             else {
-                if (curAndConstraint->rangeList == NULL) {
+                if (curAndConstraint->rangeList == nullptr) {
                     // this is for an 'is' rule
                     curAndConstraint->value = getNumberValue(token);
                 } else {
@@ -576,7 +576,7 @@ PluralRuleParser::parse(const UnicodeString& ruleData, PluralRules *prules, UErr
         case tComma:
             // TODO: rule syntax checking is inadequate, can happen with badly formed rules.
             //       Catch cases like "n mod 10, is 1" here instead.
-            if (curAndConstraint == NULL || curAndConstraint->rangeList == NULL) {
+            if (curAndConstraint == nullptr || curAndConstraint->rangeList == nullptr) {
                 status = U_UNEXPECTED_TOKEN;
                 break;
             }
@@ -587,7 +587,7 @@ PluralRuleParser::parse(const UnicodeString& ruleData, PluralRules *prules, UErr
             curAndConstraint->rangeList->addElement(-1, status);  // range Hi
             break;
         case tMod:
-            U_ASSERT(curAndConstraint != NULL);
+            U_ASSERT(curAndConstraint != nullptr);
             curAndConstraint->op=AndConstraint::MOD;
             break;
         case tVariableN:
@@ -595,24 +595,24 @@ PluralRuleParser::parse(const UnicodeString& ruleData, PluralRules *prules, UErr
         case tVariableF:
         case tVariableT:
         case tVariableV:
-            U_ASSERT(curAndConstraint != NULL);
+            U_ASSERT(curAndConstraint != nullptr);
             curAndConstraint->digitsType = type;
             break;
         case tKeyword:
             {
             RuleChain *newChain = new RuleChain;
-            if (newChain == NULL) {
+            if (newChain == nullptr) {
                 status = U_MEMORY_ALLOCATION_ERROR;
                 break;
             }
             newChain->fKeyword = token;
-            if (prules->mRules == NULL) {
+            if (prules->mRules == nullptr) {
                 prules->mRules = newChain;
             } else {
                 // The new rule chain goes at the end of the linked list of rule chains,
                 //   unless there is an "other" keyword & chain. "other" must remain last.
                 RuleChain *insertAfter = prules->mRules;
-                while (insertAfter->fNext!=NULL &&
+                while (insertAfter->fNext!=nullptr &&
                        insertAfter->fNext->fKeyword.compare(PLURAL_KEYWORD_OTHER, 5) != 0 ){
                     insertAfter=insertAfter->fNext;
                 }
@@ -675,7 +675,7 @@ PluralRules::getRuleFromResource(const Locale& locale, UPluralType type, UErrorC
     if (U_FAILURE(errCode)) {
         return emptyStr;
     }
-    LocalUResourceBundlePointer rb(ures_openDirect(NULL, "plurals", &errCode));
+    LocalUResourceBundlePointer rb(ures_openDirect(nullptr, "plurals", &errCode));
     if(U_FAILURE(errCode)) {
         return emptyStr;
     }
@@ -692,7 +692,7 @@ PluralRules::getRuleFromResource(const Locale& locale, UPluralType type, UErrorC
         errCode = U_ILLEGAL_ARGUMENT_ERROR;
         return emptyStr;
     }
-    LocalUResourceBundlePointer locRes(ures_getByKey(rb.getAlias(), typeKey, NULL, &errCode));
+    LocalUResourceBundlePointer locRes(ures_getByKey(rb.getAlias(), typeKey, nullptr, &errCode));
     if(U_FAILURE(errCode)) {
         return emptyStr;
     }
@@ -700,7 +700,7 @@ PluralRules::getRuleFromResource(const Locale& locale, UPluralType type, UErrorC
     const char *curLocaleName=locale.getName();
     const UChar* s = ures_getStringByKey(locRes.getAlias(), curLocaleName, &resLen, &errCode);
 
-    if (s == NULL) {
+    if (s == nullptr) {
         // Check parent locales.
         UErrorCode status = U_ZERO_ERROR;
         char parentLocaleName[ULOC_FULLNAME_CAPACITY];
@@ -711,14 +711,14 @@ PluralRules::getRuleFromResource(const Locale& locale, UPluralType type, UErrorC
                                        ULOC_FULLNAME_CAPACITY, &status) > 0) {
             resLen=0;
             s = ures_getStringByKey(locRes.getAlias(), parentLocaleName, &resLen, &status);
-            if (s != NULL) {
+            if (s != nullptr) {
                 errCode = U_ZERO_ERROR;
                 break;
             }
             status = U_ZERO_ERROR;
         }
     }
-    if (s==NULL) {
+    if (s==nullptr) {
         return emptyStr;
     }
 
@@ -726,18 +726,18 @@ PluralRules::getRuleFromResource(const Locale& locale, UPluralType type, UErrorC
     u_UCharsToChars(s, setKey, resLen + 1);
     // printf("\n PluralRule: %s\n", setKey);
 
-    LocalUResourceBundlePointer ruleRes(ures_getByKey(rb.getAlias(), "rules", NULL, &errCode));
+    LocalUResourceBundlePointer ruleRes(ures_getByKey(rb.getAlias(), "rules", nullptr, &errCode));
     if(U_FAILURE(errCode)) {
         return emptyStr;
     }
-    LocalUResourceBundlePointer setRes(ures_getByKey(ruleRes.getAlias(), setKey, NULL, &errCode));
+    LocalUResourceBundlePointer setRes(ures_getByKey(ruleRes.getAlias(), setKey, nullptr, &errCode));
     if (U_FAILURE(errCode)) {
         return emptyStr;
     }
 
     int32_t numberKeys = ures_getSize(setRes.getAlias());
     UnicodeString result;
-    const char *key=NULL;
+    const char *key=nullptr;
     for(int32_t i=0; i<numberKeys; ++i) {   // Keys are zero, one, few, ...
         UnicodeString rules = ures_getNextUnicodeString(setRes.getAlias(), &key, &errCode);
         UnicodeString uKey(key, -1, US_INV);
@@ -753,7 +753,7 @@ PluralRules::getRuleFromResource(const Locale& locale, UPluralType type, UErrorC
 UnicodeString
 PluralRules::getRules() const {
     UnicodeString rules;
-    if (mRules != NULL) {
+    if (mRules != nullptr) {
         mRules->dumpRules(rules);
     }
     return rules;
@@ -763,11 +763,11 @@ AndConstraint::AndConstraint() {
     op = AndConstraint::NONE;
     opNum=-1;
     value = -1;
-    rangeList = NULL;
+    rangeList = nullptr;
     negated = FALSE;
     integerOnly = FALSE;
     digitsType = none;
-    next = NULL;
+    next = nullptr;
     fInternalStatus = U_ZERO_ERROR;
 }
 
@@ -779,8 +779,8 @@ AndConstraint::AndConstraint(const AndConstraint& other) {
     this->op = other.op;
     this->opNum=other.opNum;
     this->value=other.value;
-    this->rangeList=NULL;
-    if (other.rangeList != NULL) {
+    this->rangeList=nullptr;
+    if (other.rangeList != nullptr) {
         LocalPointer<UVector32> newRangeList(new UVector32(fInternalStatus), fInternalStatus);
         if (U_FAILURE(fInternalStatus)) {
             return;
@@ -791,8 +791,8 @@ AndConstraint::AndConstraint(const AndConstraint& other) {
     this->integerOnly=other.integerOnly;
     this->negated=other.negated;
     this->digitsType = other.digitsType;
-    if (other.next==NULL) {
-        this->next=NULL;
+    if (other.next==nullptr) {
+        this->next=nullptr;
     }
     else {
         this->next = new AndConstraint(*other.next);
@@ -830,7 +830,7 @@ AndConstraint::isFulfilled(const IFixedDecimal &number) {
         if (op == MOD) {
             n = fmod(n, opNum);
         }
-        if (rangeList == NULL) {
+        if (rangeList == nullptr) {
             result = value == -1 ||    // empty rule
                      n == value;       //  'is' rule
             break;
@@ -865,8 +865,8 @@ AndConstraint::add(UErrorCode& status) {
 
 
 OrConstraint::OrConstraint() {
-    childNode = NULL;
-    next = NULL;
+    childNode = nullptr;
+    next = nullptr;
     fInternalStatus = U_ZERO_ERROR;
 }
 
@@ -875,8 +875,8 @@ OrConstraint::OrConstraint(const OrConstraint& other) {
     if (U_FAILURE(fInternalStatus)) {
         return; // stop early if the object we are copying from is invalid.
     }
-    if ( other.childNode == NULL ) {
-        this->childNode = NULL;
+    if ( other.childNode == nullptr ) {
+        this->childNode = nullptr;
     }
     else {
         this->childNode = new AndConstraint(*(other.childNode));
@@ -885,8 +885,8 @@ OrConstraint::OrConstraint(const OrConstraint& other) {
             return;
         }
     }
-    if (other.next == NULL ) {
-        this->next = NULL;
+    if (other.next == nullptr ) {
+        this->next = nullptr;
     }
     else {
         this->next = new OrConstraint(*(other.next));
@@ -915,10 +915,10 @@ OrConstraint::add(UErrorCode& status) {
     }
     OrConstraint *curOrConstraint=this;
     {
-        while (curOrConstraint->next!=NULL) {
+        while (curOrConstraint->next!=nullptr) {
             curOrConstraint = curOrConstraint->next;
         }
-        U_ASSERT(curOrConstraint->childNode == NULL);
+        U_ASSERT(curOrConstraint->childNode == nullptr);
         curOrConstraint->childNode = new AndConstraint();
         if (curOrConstraint->childNode == nullptr) {
             status = U_MEMORY_ALLOCATION_ERROR;
@@ -932,10 +932,10 @@ OrConstraint::isFulfilled(const IFixedDecimal &number) {
     OrConstraint* orRule=this;
     UBool result=FALSE;
 
-    while (orRule!=NULL && !result) {
+    while (orRule!=nullptr && !result) {
         result=TRUE;
         AndConstraint* andRule = orRule->childNode;
-        while (andRule!=NULL && result) {
+        while (andRule!=nullptr && result) {
             result = andRule->isFulfilled(number);
             andRule=andRule->next;
         }
@@ -946,18 +946,18 @@ OrConstraint::isFulfilled(const IFixedDecimal &number) {
 }
 
 
-RuleChain::RuleChain(): fKeyword(), fNext(NULL), ruleHeader(NULL), fDecimalSamples(), fIntegerSamples(),
+RuleChain::RuleChain(): fKeyword(), fNext(nullptr), ruleHeader(nullptr), fDecimalSamples(), fIntegerSamples(),
                         fDecimalSamplesUnbounded(FALSE), fIntegerSamplesUnbounded(FALSE), fInternalStatus(U_ZERO_ERROR) {
 }
 
 RuleChain::RuleChain(const RuleChain& other) :
-        fKeyword(other.fKeyword), fNext(NULL), ruleHeader(NULL), fDecimalSamples(other.fDecimalSamples),
+        fKeyword(other.fKeyword), fNext(nullptr), ruleHeader(nullptr), fDecimalSamples(other.fDecimalSamples),
         fIntegerSamples(other.fIntegerSamples), fDecimalSamplesUnbounded(other.fDecimalSamplesUnbounded),
         fIntegerSamplesUnbounded(other.fIntegerSamplesUnbounded), fInternalStatus(other.fInternalStatus) {
     if (U_FAILURE(this->fInternalStatus)) {
         return; // stop early if the object we are copying from is invalid. 
     }
-    if (other.ruleHeader != NULL) {
+    if (other.ruleHeader != nullptr) {
         this->ruleHeader = new OrConstraint(*(other.ruleHeader));
         if (this->ruleHeader == nullptr) {
             this->fInternalStatus = U_MEMORY_ALLOCATION_ERROR;
@@ -968,7 +968,7 @@ RuleChain::RuleChain(const RuleChain& other) :
             return; // exit early.
         }
     }
-    if (other.fNext != NULL ) {
+    if (other.fNext != nullptr ) {
         this->fNext = new RuleChain(*other.fNext);
         if (this->fNext == nullptr) {
             this->fInternalStatus = U_MEMORY_ALLOCATION_ERROR;
@@ -988,7 +988,7 @@ RuleChain::~RuleChain() {
 UnicodeString
 RuleChain::select(const IFixedDecimal &number) const {
     if (!number.isNaN() && !number.isInfinite()) {
-        for (const RuleChain *rules = this; rules != NULL; rules = rules->fNext) {
+        for (const RuleChain *rules = this; rules != nullptr; rules = rules->fNext) {
              if (rules->ruleHeader->isFulfilled(number)) {
                  return rules->fKeyword;
              }
@@ -1020,17 +1020,17 @@ void
 RuleChain::dumpRules(UnicodeString& result) {
     UChar digitString[16];
 
-    if ( ruleHeader != NULL ) {
+    if ( ruleHeader != nullptr ) {
         result +=  fKeyword;
         result += COLON;
         result += SPACE;
         OrConstraint* orRule=ruleHeader;
-        while ( orRule != NULL ) {
+        while ( orRule != nullptr ) {
             AndConstraint* andRule=orRule->childNode;
-            while ( andRule != NULL ) {
-                if ((andRule->op==AndConstraint::NONE) &&  (andRule->rangeList==NULL) && (andRule->value == -1)) {
+            while ( andRule != nullptr ) {
+                if ((andRule->op==AndConstraint::NONE) &&  (andRule->rangeList==nullptr) && (andRule->value == -1)) {
                     // Empty Rules.
-                } else if ( (andRule->op==AndConstraint::NONE) && (andRule->rangeList==NULL) ) {
+                } else if ( (andRule->op==AndConstraint::NONE) && (andRule->rangeList==nullptr) ) {
                     result += tokenString(andRule->digitsType);
                     result += UNICODE_STRING_SIMPLE(" is ");
                     if (andRule->negated) {
@@ -1047,7 +1047,7 @@ RuleChain::dumpRules(UnicodeString& result) {
                         uprv_itou(digitString,16, andRule->opNum,10,0);
                         result += UnicodeString(digitString);
                     }
-                    if (andRule->rangeList==NULL) {
+                    if (andRule->rangeList==nullptr) {
                         if (andRule->negated) {
                             result += UNICODE_STRING_SIMPLE(" is not ");
                             uprv_itou(digitString,16, andRule->value,10,0);
@@ -1090,16 +1090,16 @@ RuleChain::dumpRules(UnicodeString& result) {
                         }
                     }
                 }
-                if ( (andRule=andRule->next) != NULL) {
+                if ( (andRule=andRule->next) != nullptr) {
                     result += UNICODE_STRING_SIMPLE(" and ");
                 }
             }
-            if ( (orRule = orRule->next) != NULL ) {
+            if ( (orRule = orRule->next) != nullptr ) {
                 result += UNICODE_STRING_SIMPLE(" or ");
             }
         }
     }
-    if ( fNext != NULL ) {
+    if ( fNext != nullptr ) {
         result += UNICODE_STRING_SIMPLE("; ");
         fNext->dumpRules(result);
     }
@@ -1118,7 +1118,7 @@ RuleChain::getKeywords(int32_t capacityOfKeywords, UnicodeString* keywords, int3
         return U_BUFFER_OVERFLOW_ERROR;
     }
 
-    if ( fNext != NULL ) {
+    if ( fNext != nullptr ) {
         return fNext->getKeywords(capacityOfKeywords, keywords, arraySize);
     }
     else {
@@ -1132,7 +1132,7 @@ RuleChain::isKeyword(const UnicodeString& keywordParam) const {
         return TRUE;
     }
 
-    if ( fNext != NULL ) {
+    if ( fNext != nullptr ) {
         return fNext->isKeyword(keywordParam);
     }
     else {
@@ -1143,7 +1143,7 @@ RuleChain::isKeyword(const UnicodeString& keywordParam) const {
 
 PluralRuleParser::PluralRuleParser() :
         ruleIndex(0), token(), type(none), prevType(none),
-        curAndConstraint(NULL), currentChain(NULL), rangeLowIdx(-1), rangeHiIdx(-1)
+        curAndConstraint(nullptr), currentChain(nullptr), rangeLowIdx(-1), rangeHiIdx(-1)
 {
 }
 
@@ -1443,7 +1443,7 @@ PluralKeywordEnumeration::PluralKeywordEnumeration(RuleChain *header, UErrorCode
     fKeywordNames.setDeleter(uprv_deleteUObject);
     UBool  addKeywordOther = TRUE;
     RuleChain *node = header;
-    while (node != NULL) {
+    while (node != nullptr) {
         auto newElem = new UnicodeString(node->fKeyword);
         if (newElem == nullptr) {
             status = U_MEMORY_ALLOCATION_ERROR;
@@ -1479,7 +1479,7 @@ PluralKeywordEnumeration::snext(UErrorCode& status) {
     if (U_SUCCESS(status) && pos < fKeywordNames.size()) {
         return (const UnicodeString*)fKeywordNames.elementAt(pos++);
     }
-    return NULL;
+    return nullptr;
 }
 
 void
@@ -1749,41 +1749,41 @@ int32_t FixedDecimal::getVisibleFractionDigitCount() const {
 
 
 PluralAvailableLocalesEnumeration::PluralAvailableLocalesEnumeration(UErrorCode &status) {
-    fLocales = NULL;
-    fRes = NULL;
+    fLocales = nullptr;
+    fRes = nullptr;
     fOpenStatus = status;
     if (U_FAILURE(status)) {
         return;
     }
     fOpenStatus = U_ZERO_ERROR;
-    LocalUResourceBundlePointer rb(ures_openDirect(NULL, "plurals", &fOpenStatus));
-    fLocales = ures_getByKey(rb.getAlias(), "locales", NULL, &fOpenStatus);
+    LocalUResourceBundlePointer rb(ures_openDirect(nullptr, "plurals", &fOpenStatus));
+    fLocales = ures_getByKey(rb.getAlias(), "locales", nullptr, &fOpenStatus);
 }
 
 PluralAvailableLocalesEnumeration::~PluralAvailableLocalesEnumeration() {
     ures_close(fLocales);
     ures_close(fRes);
-    fLocales = NULL;
-    fRes = NULL;
+    fLocales = nullptr;
+    fRes = nullptr;
 }
 
 const char *PluralAvailableLocalesEnumeration::next(int32_t *resultLength, UErrorCode &status) {
     if (U_FAILURE(status)) {
-        return NULL;
+        return nullptr;
     }
     if (U_FAILURE(fOpenStatus)) {
         status = fOpenStatus;
-        return NULL;
+        return nullptr;
     }
     fRes = ures_getNextResource(fLocales, fRes, &status);
-    if (fRes == NULL || U_FAILURE(status)) {
+    if (fRes == nullptr || U_FAILURE(status)) {
         if (status == U_INDEX_OUTOFBOUNDS_ERROR) {
             status = U_ZERO_ERROR;
         }
-        return NULL;
+        return nullptr;
     }
     const char *result = ures_getKey(fRes);
-    if (resultLength != NULL) {
+    if (resultLength != nullptr) {
         *resultLength = static_cast<int32_t>(uprv_strlen(result));
     }
     return result;

--- a/icu4c/source/i18n/plurrule_impl.h
+++ b/icu4c/source/i18n/plurrule_impl.h
@@ -310,17 +310,18 @@ public:
         NONE,
         MOD
     } RuleOp;
-    RuleOp  op;
-    int32_t opNum;           // for mod expressions, the right operand of the mod.
-    int32_t     value;       // valid for 'is' rules only.
-    UVector32   *rangeList;  // for 'in', 'within' rules. Null otherwise.
-    UBool   negated;           // TRUE for negated rules.
-    UBool   integerOnly;     // TRUE for 'within' rules.
-    tokenType digitsType;    // n | i | v | f constraint.
-    AndConstraint *next;
-    UErrorCode fInternalStatus;
+    RuleOp op = AndConstraint::NONE;
+    int32_t opNum = -1;             // for mod expressions, the right operand of the mod.
+    int32_t value = -1;             // valid for 'is' rules only.
+    UVector32 *rangeList = nullptr; // for 'in', 'within' rules. Null otherwise.
+    UBool negated = FALSE;          // TRUE for negated rules.
+    UBool integerOnly = FALSE;      // TRUE for 'within' rules.
+    tokenType digitsType = none;    // n | i | v | f constraint.
+    AndConstraint *next = nullptr;
+    // Internal error status, used for errors that occur during the copy constructor.
+    UErrorCode fInternalStatus = U_ZERO_ERROR;    
 
-    AndConstraint();
+    AndConstraint() = default;
     AndConstraint(const AndConstraint& other);
     virtual ~AndConstraint();
     AndConstraint* add(UErrorCode& status);
@@ -330,11 +331,12 @@ public:
 
 class OrConstraint : public UMemory  {
 public:
-    AndConstraint *childNode;
-    OrConstraint *next;
-    UErrorCode fInternalStatus;
-    OrConstraint();
+    AndConstraint *childNode = nullptr;
+    OrConstraint *next = nullptr;
+    // Internal error status, used for errors that occur during the copy constructor.
+    UErrorCode fInternalStatus = U_ZERO_ERROR;
 
+    OrConstraint() = default;
     OrConstraint(const OrConstraint& other);
     virtual ~OrConstraint();
     AndConstraint* add(UErrorCode& status);
@@ -345,15 +347,16 @@ public:
 class RuleChain : public UMemory  {
 public:
     UnicodeString   fKeyword;
-    RuleChain      *fNext;
-    OrConstraint   *ruleHeader;
+    RuleChain      *fNext = nullptr;
+    OrConstraint   *ruleHeader = nullptr;
     UnicodeString   fDecimalSamples;  // Samples strings from rule source
     UnicodeString   fIntegerSamples;  //   without @decimal or @integer, otherwise unprocessed.
-    UBool           fDecimalSamplesUnbounded;
-    UBool           fIntegerSamplesUnbounded;
-    UErrorCode      fInternalStatus;
+    UBool           fDecimalSamplesUnbounded = FALSE;
+    UBool           fIntegerSamplesUnbounded = FALSE;
+    // Internal error status, used for errors that occur during the copy constructor.
+    UErrorCode      fInternalStatus = U_ZERO_ERROR;
 
-    RuleChain();
+    RuleChain() = default;
     RuleChain(const RuleChain& other);
     virtual ~RuleChain();
 
@@ -387,8 +390,8 @@ class U_I18N_API PluralAvailableLocalesEnumeration: public StringEnumeration {
     virtual int32_t count(UErrorCode& status) const;
   private:
     UErrorCode      fOpenStatus;
-    UResourceBundle *fLocales;
-    UResourceBundle *fRes;
+    UResourceBundle *fLocales = nullptr;
+    UResourceBundle *fRes = nullptr;
 };
 
 U_NAMESPACE_END

--- a/icu4c/source/i18n/plurrule_impl.h
+++ b/icu4c/source/i18n/plurrule_impl.h
@@ -181,7 +181,6 @@ private:
        kRangeList,
        kSamples
     };
-
 };
 
 enum PluralOperand {
@@ -319,11 +318,12 @@ public:
     UBool   integerOnly;     // TRUE for 'within' rules.
     tokenType digitsType;    // n | i | v | f constraint.
     AndConstraint *next;
+    UErrorCode fInternalStatus;
 
     AndConstraint();
     AndConstraint(const AndConstraint& other);
     virtual ~AndConstraint();
-    AndConstraint* add();
+    AndConstraint* add(UErrorCode& status);
     // UBool isFulfilled(double number);
     UBool isFulfilled(const IFixedDecimal &number);
 };
@@ -332,11 +332,12 @@ class OrConstraint : public UMemory  {
 public:
     AndConstraint *childNode;
     OrConstraint *next;
+    UErrorCode fInternalStatus;
     OrConstraint();
 
     OrConstraint(const OrConstraint& other);
     virtual ~OrConstraint();
-    AndConstraint* add();
+    AndConstraint* add(UErrorCode& status);
     // UBool isFulfilled(double number);
     UBool isFulfilled(const IFixedDecimal &number);
 };
@@ -350,7 +351,7 @@ public:
     UnicodeString   fIntegerSamples;  //   without @decimal or @integer, otherwise unprocessed.
     UBool           fDecimalSamplesUnbounded;
     UBool           fIntegerSamplesUnbounded;
-
+    UErrorCode      fInternalStatus;
 
     RuleChain();
     RuleChain(const RuleChain& other);

--- a/icu4c/source/i18n/unicode/plurrule.h
+++ b/icu4c/source/i18n/unicode/plurrule.h
@@ -499,6 +499,12 @@ private:
     UnicodeString   getRuleFromResource(const Locale& locale, UPluralType type, UErrorCode& status);
     RuleChain      *rulesForKeyword(const UnicodeString &keyword) const;
 
+    /**
+    * An internal status variable used to indicate that the object is in an 'invalid' state.
+    * Used by copy constructor, the assignment operator and the clone method.
+    */
+    UErrorCode mInternalStatus;
+
     friend class PluralRuleParser;
 };
 


### PR DESCRIPTION
Improve the handling of out-of-memory (OOM) errors in the PluralRules class. Use an internal error code to better report errors during clone and copy construction, use LocalPointer in some places to prevent memory leaks when OOM occurs, and also use nullptr instead of NULL.