### PR TITLE
ICU-13814 Fix define for excluding renaming from VS IntelliSense

### DIFF
--- a/icu4c/source/common/unicode/urename.h
+++ b/icu4c/source/common/unicode/urename.h
@@ -34,7 +34,7 @@
 #if !U_DISABLE_RENAMING
 
 // Disable Renaming for Visual Studio's IntelliSense feature, so that 'Go-to-Definition' (F12) will work.
-#if defined(_MSC_VER) && defined(__INTELLISENSE__)
+#if defined(_MSC_VER) && !defined(__INTELLISENSE__)
 
 /* We need the U_ICU_ENTRY_POINT_RENAME definition. There's a default one in unicode/uvernum.h we can use, but we will give
    the platform a chance to define it first.
@@ -1830,7 +1830,7 @@
 #define ztrans_setTime U_ICU_ENTRY_POINT_RENAME(ztrans_setTime)
 #define ztrans_setTo U_ICU_ENTRY_POINT_RENAME(ztrans_setTo)
 
-#endif /* defined(_MSC_VER) && defined(__INTELLISENSE__) */
+#endif /* defined(_MSC_VER) && !defined(__INTELLISENSE__) */
 
 #endif /* U_DISABLE_RENAMING */
 

--- a/icu4c/source/tools/genren/genren.pl
+++ b/icu4c/source/tools/genren/genren.pl
@@ -107,7 +107,7 @@ print HEADER <<"EndOfHeaderComment";
 #if !U_DISABLE_RENAMING
 
 // Disable Renaming for Visual Studio's IntelliSense feature, so that 'Go-to-Definition' (F12) will work.
-#if defined(_MSC_VER) && defined(__INTELLISENSE__)
+#if defined(_MSC_VER) && !defined(__INTELLISENSE__)
 
 /* We need the U_ICU_ENTRY_POINT_RENAME definition. There's a default one in unicode/uvernum.h we can use, but we will give
    the platform a chance to define it first.
@@ -242,7 +242,7 @@ foreach(sort keys(%CFuncs)) {
 
 print HEADER <<"EndOfHeaderFooter";
 
-#endif /* defined(_MSC_VER) && defined(__INTELLISENSE__) */
+#endif /* defined(_MSC_VER) && !defined(__INTELLISENSE__) */
 #endif /* U_DISABLE_RENAMING */
 #endif /* URENAME_H */
 


### PR DESCRIPTION
This is a follow-up to ICU-13814.
In the SVN commit the logic was mixed up for the IntelliSense define. We actually want to turn *off* the renaming defines inside IntelliSense so that  VS doesn't get confused when you press F12.
