### PR TITLE
ICU-13829 Languagematcher: Fixes straightforward code issues.

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/locale/XLikelySubtags.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/locale/XLikelySubtags.java
@@ -3,14 +3,6 @@
 package com.ibm.icu.impl.locale;
 
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TreeMap;
-
 import com.ibm.icu.impl.ICUData;
 import com.ibm.icu.impl.ICUResourceBundle;
 import com.ibm.icu.impl.Utility;
@@ -21,6 +13,13 @@ import com.ibm.icu.util.ICUException;
 import com.ibm.icu.util.ULocale;
 import com.ibm.icu.util.ULocale.Minimize;
 import com.ibm.icu.util.UResourceBundle;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeMap;
 
 public class XLikelySubtags {
 
@@ -143,8 +142,8 @@ public class XLikelySubtags {
                 throw new ICUException("too many subtags");
             }
             String lang = parts[0].toLowerCase();
-            String p2 = parts.length < 2 ? "": parts[1];
-            String p3 = parts.length < 3 ? "": parts[2];
+            String p2 = parts.length < 2 ? "" : parts[1];
+            String p3 = parts.length < 3 ? "" : parts[2];
             return p2.length() < 4 ? new LSR(lang, "", p2) : new LSR(lang, p2, p3);
 
             //            Matcher matcher = LANGUAGE_PATTERN.matcher(languageIdentifier);
@@ -166,7 +165,7 @@ public class XLikelySubtags {
         public static LSR fromMaximalized(String language, String script, String region) {
             String canonicalLanguage = LANGUAGE_ALIASES.getCanonical(language);
             // script is ok
-            String canonicalRegion = REGION_ALIASES.getCanonical(region); // getCanonical(REGION_ALIASES.get(region));
+            String canonicalRegion = REGION_ALIASES.getCanonical(region);
 
             return DEFAULT.maximize(canonicalLanguage, script, canonicalRegion);
         }

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/locale/XLikelySubtags.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/locale/XLikelySubtags.java
@@ -3,6 +3,15 @@
 package com.ibm.icu.impl.locale;
 
 import java.util.Collection;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeMap;
+
 import com.ibm.icu.impl.ICUData;
 import com.ibm.icu.impl.ICUResourceBundle;
 import com.ibm.icu.impl.Utility;
@@ -13,13 +22,6 @@ import com.ibm.icu.util.ICUException;
 import com.ibm.icu.util.ULocale;
 import com.ibm.icu.util.ULocale.Minimize;
 import com.ibm.icu.util.UResourceBundle;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TreeMap;
 
 public class XLikelySubtags {
 

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/locale/XLikelySubtags.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/locale/XLikelySubtags.java
@@ -3,7 +3,6 @@
 package com.ibm.icu.impl.locale;
 
 import java.util.Collection;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/locale/XLocaleDistance.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/locale/XLocaleDistance.java
@@ -739,7 +739,7 @@ public class XLocaleDistance {
      * ULocales must be in canonical, addLikelySubtags format. Returns distance
      */
     public int distanceRaw(
-            String desiredLang, String supportedlang,
+            String desiredLang, String supportedLang,
             String desiredScript, String supportedScript,
             String desiredRegion, String supportedRegion,
             int threshold,
@@ -747,7 +747,7 @@ public class XLocaleDistance {
 
         Output<DistanceTable> subtable = new Output<DistanceTable>();
 
-        int distance = languageDesired2Supported.getDistance(desiredLang, supportedlang, subtable, true);
+        int distance = languageDesired2Supported.getDistance(desiredLang, supportedLang, subtable, true);
         boolean scriptFirst = distanceOption == DistanceOption.SCRIPT_FIRST;
         if (scriptFirst) {
             distance >>= 2;

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/locale/XLocaleMatcher.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/locale/XLocaleMatcher.java
@@ -2,6 +2,13 @@
 // License & terms of use: http://www.unicode.org/copyright.html#License
 package com.ibm.icu.impl.locale;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
 import com.ibm.icu.impl.locale.XCldrStub.ImmutableMultimap;
 import com.ibm.icu.impl.locale.XCldrStub.ImmutableSet;
 import com.ibm.icu.impl.locale.XCldrStub.LinkedHashMultimap;
@@ -11,12 +18,6 @@ import com.ibm.icu.impl.locale.XLocaleDistance.DistanceOption;
 import com.ibm.icu.util.LocalePriorityList;
 import com.ibm.icu.util.Output;
 import com.ibm.icu.util.ULocale;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 
 /**
  * Immutable class that picks best match between user's desired locales and application's supported locales.

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/locale/XLocaleMatcher.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/locale/XLocaleMatcher.java
@@ -2,13 +2,6 @@
 // License & terms of use: http://www.unicode.org/copyright.html#License
 package com.ibm.icu.impl.locale;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-
 import com.ibm.icu.impl.locale.XCldrStub.ImmutableMultimap;
 import com.ibm.icu.impl.locale.XCldrStub.ImmutableSet;
 import com.ibm.icu.impl.locale.XCldrStub.LinkedHashMultimap;
@@ -18,6 +11,12 @@ import com.ibm.icu.impl.locale.XLocaleDistance.DistanceOption;
 import com.ibm.icu.util.LocalePriorityList;
 import com.ibm.icu.util.Output;
 import com.ibm.icu.util.ULocale;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 
 /**
  * Immutable class that picks best match between user's desired locales and application's supported locales.
@@ -39,7 +38,6 @@ public class XLocaleMatcher {
     private final Map<LSR, Set<ULocale>> supportedLanguages; // the locales in the collection are ordered!
     private final Set<ULocale> exactSupportedLocales; // the locales in the collection are ordered!
     private final ULocale defaultLanguage;
-
 
     public static class Builder {
         private Set<ULocale> supportedLanguagesList;


### PR DESCRIPTION
Incorporates the easiest elements from the new language matcher code that is held locally in Google.

ICU4J builds and all unit tests pass.
