### PR TITLE
ICU-13138 mingw: add 'd' suffix to the names of binary files with Debug configuration

### DIFF
--- a/icu4c/source/config/mh-mingw
+++ b/icu4c/source/config/mh-mingw
@@ -42,6 +42,11 @@ THREADSCFLAGS = -mthreads
 THREADSCXXFLAGS = -mthreads
 LIBCPPFLAGS =
 
+## Add 'd' suffix to the names of binary files with Debug configuration
+ifeq ($(ENABLE_DEBUG),1)
+ICULIBSUFFIX:=$(ICULIBSUFFIX)d#M#
+endif
+
 # Commands to link. Link with C++ in case static libraries are used.
 LINK.c=       $(CXX) $(CXXFLAGS) $(LDFLAGS)
 #LINK.cc=      $(CXX) $(CXXFLAGS) $(LDFLAGS)

--- a/icu4c/source/config/mh-mingw64
+++ b/icu4c/source/config/mh-mingw64
@@ -42,6 +42,11 @@ THREADSCFLAGS = -mthreads
 THREADSCXXFLAGS = -mthreads
 LIBCPPFLAGS =
 
+## Add 'd' suffix to the names of binary files with Debug configuration
+ifeq ($(ENABLE_DEBUG),1)
+ICULIBSUFFIX:=$(ICULIBSUFFIX)d#M#
+endif
+
 # Commands to link. Link with C++ in case static libraries are used.
 LINK.c=       $(CXX) $(CXXFLAGS) $(LDFLAGS)
 #LINK.cc=      $(CXX) $(CXXFLAGS) $(LDFLAGS)


### PR DESCRIPTION
For builds using Cygwin and MSVC with Debug configuration,
'.dll' and '.lib' binaries has 'd' suffix.

Doing the same for builds using mingw and mingw64,
based on the code from MSVC toolchain.

This is a repeat of PR https://github.com/unicode-org/icu/pull/9.