### PR TITLE
ICU-13712 ICU4C does not report OOM if it fails to memory map the data file(s)

### DIFF
--- a/icu4c/source/common/umapfile.cpp
+++ b/icu4c/source/common/umapfile.cpp
@@ -232,6 +232,7 @@
 #endif
         close(fd); /* no longer needed */
         if(data==MAP_FAILED) {
+            // Possibly check for errno for ENOMEM, and report U_MEMORY_ALLOCATION_ERROR?
             return FALSE;
         }
 
@@ -297,6 +298,7 @@
         p=uprv_malloc(fileLength);
         if(p==NULL) {
             fclose(file);
+            // Possibly return U_MEMORY_ALLOCATION_ERROR?
             return FALSE;
         }
 
@@ -441,6 +443,7 @@
             data=mmap(0, length, PROT_READ, MAP_PRIVATE, fd, 0);
             close(fd); /* no longer needed */
             if(data==MAP_FAILED) {
+                // Possibly check errorno for ENOMEM, and report U_MEMORY_ALLOCATION_ERROR?
                 return FALSE;
             }
             pData->map = (char *)data + length;

--- a/icu4c/source/common/umapfile.cpp
+++ b/icu4c/source/common/umapfile.cpp
@@ -64,7 +64,7 @@
 #       include "unicode/udata.h"
 #       define LIB_PREFIX "lib"
 #       define LIB_SUFFIX ".dll"
-        /* This is inconvienient until we figure out what to do with U_ICUDATA_NAME in utypes.h */
+        /* This is inconvenient until we figure out what to do with U_ICUDATA_NAME in utypes.h */
 #       define U_ICUDATA_ENTRY_NAME "icudt" U_ICU_VERSION_SHORT U_LIB_SUFFIX_C_NAME_STRING "_dat"
 #   endif
 #elif MAP_IMPLEMENTATION==MAP_STDIO
@@ -84,7 +84,10 @@
  *----------------------------------------------------------------------------*/
 #if MAP_IMPLEMENTATION==MAP_NONE
     U_CFUNC UBool
-    uprv_mapFile(UDataMemory *pData, const char *path, UErrorCode *ec) {
+    uprv_mapFile(UDataMemory *pData, const char *path, UErrorCode *status) {
+        if (U_FAILURE(*status)) {
+            return FALSE;
+        }
         UDataMemory_init(pData); /* Clear the output struct. */
         return FALSE;            /* no file access */
     }
@@ -98,12 +101,16 @@
          UDataMemory *pData,    /* Fill in with info on the result doing the mapping. */
                                 /*   Output only; any original contents are cleared.  */
          const char *path,      /* File path to be opened/mapped.                     */
-         UErrorCode *ec         /* Error status, used to report out-of-memory errors. */
+         UErrorCode *status     /* Error status, used to report out-of-memory errors. */
          )
     {
         HANDLE map;
         HANDLE file;
-        
+
+        if (U_FAILURE(*status)) {
+            return FALSE;
+        }
+
         UDataMemory_init(pData); /* Clear the output struct.        */
 
         /* open the input file */
@@ -137,7 +144,7 @@
             // If we failed to open the file due to an out-of-memory error, then we want
             // to report that error back to the caller.
             if (HRESULT_FROM_WIN32(GetLastError()) == E_OUTOFMEMORY) {
-                *ec = U_MEMORY_ALLOCATION_ERROR;
+                *status = U_MEMORY_ALLOCATION_ERROR;
             }
             return FALSE;
         }
@@ -175,7 +182,7 @@
             // If we failed to create the mapping due to an out-of-memory error, then 
             // we want to report that error back to the caller.
             if (HRESULT_FROM_WIN32(GetLastError()) == E_OUTOFMEMORY) {
-                *ec = U_MEMORY_ALLOCATION_ERROR;
+                *status = U_MEMORY_ALLOCATION_ERROR;
             }
             return FALSE;
         }
@@ -204,11 +211,15 @@
 
 #elif MAP_IMPLEMENTATION==MAP_POSIX
     U_CFUNC UBool
-    uprv_mapFile(UDataMemory *pData, const char *path, UErrorCode *ec) {
+    uprv_mapFile(UDataMemory *pData, const char *path, UErrorCode *status) {
         int fd;
         int length;
         struct stat mystat;
         void *data;
+
+        if (U_FAILURE(*status)) {
+            return FALSE;
+        }
 
         UDataMemory_init(pData); /* Clear the output struct.        */
 
@@ -232,7 +243,7 @@
 #endif
         close(fd); /* no longer needed */
         if(data==MAP_FAILED) {
-            // Possibly check for errno for ENOMEM, and report U_MEMORY_ALLOCATION_ERROR?
+            // Possibly check the errno value for ENOMEM, and report U_MEMORY_ALLOCATION_ERROR?
             return FALSE;
         }
 
@@ -275,10 +286,14 @@
     }
 
     U_CFUNC UBool
-    uprv_mapFile(UDataMemory *pData, const char *path, UErrorCode *ec) {
+    uprv_mapFile(UDataMemory *pData, const char *path, UErrorCode *status) {
         FILE *file;
         int32_t fileLength;
         void *p;
+
+        if (U_FAILURE(*status)) {
+            return FALSE;
+        }
 
         UDataMemory_init(pData); /* Clear the output struct.        */
         /* open the input file */
@@ -298,7 +313,7 @@
         p=uprv_malloc(fileLength);
         if(p==NULL) {
             fclose(file);
-            // Possibly return U_MEMORY_ALLOCATION_ERROR?
+            *status = U_MEMORY_ALLOCATION_ERROR;
             return FALSE;
         }
 
@@ -364,7 +379,7 @@
      *
      *                    TODO:  This works the way ICU historically has, but the
      *                           whole data fallback search path is so complicated that
-     *                           proabably almost no one will ever really understand it,
+     *                           probably almost no one will ever really understand it,
      *                           the potential for confusion is large.  (It's not just 
      *                           this one function, but the whole scheme.)
      *                            
@@ -404,13 +419,17 @@
 
 #   define DATA_TYPE "dat"
 
-    U_CFUNC UBool uprv_mapFile(UDataMemory *pData, const char *path, UErrorCode *ec) {
+    U_CFUNC UBool uprv_mapFile(UDataMemory *pData, const char *path, UErrorCode *status) {
         const char *inBasename;
         char *basename;
         char pathBuffer[1024];
         const DataHeader *pHeader;
         dllhandle *handle;
         void *val=0;
+
+        if (U_FAILURE(*status)) {
+            return FALSE;
+        }
 
         inBasename=uprv_strrchr(path, U_FILE_SEP_CHAR);
         if(inBasename==NULL) {
@@ -443,7 +462,7 @@
             data=mmap(0, length, PROT_READ, MAP_PRIVATE, fd, 0);
             close(fd); /* no longer needed */
             if(data==MAP_FAILED) {
-                // Possibly check errorno for ENOMEM, and report U_MEMORY_ALLOCATION_ERROR?
+                // Possibly check the errorno value for ENOMEM, and report U_MEMORY_ALLOCATION_ERROR?
                 return FALSE;
             }
             pData->map = (char *)data + length;

--- a/icu4c/source/common/umapfile.h
+++ b/icu4c/source/common/umapfile.h
@@ -29,7 +29,7 @@
 #include "unicode/udata.h"
 #include "putilimp.h"
 
-U_CFUNC UBool uprv_mapFile(UDataMemory *pdm, const char *path);
+U_CFUNC UBool uprv_mapFile(UDataMemory *pdm, const char *path, UErrorCode *status);
 U_CFUNC void  uprv_unmapFile(UDataMemory *pData);
 
 /* MAP_NONE: no memory mapping, no file access at all */

--- a/icu4c/source/common/uresbund.cpp
+++ b/icu4c/source/common/uresbund.cpp
@@ -367,7 +367,12 @@ static UResourceDataEntry *init_entry(const char *localeID, const char *path, UE
         /* this is the actual loading */
         res_load(&(r->fData), r->fPath, r->fName, status);
 
-        if (U_FAILURE(*status)) { 
+        if (U_FAILURE(*status)) {
+            /* if we failed to load due to an out-of-memory error, exit early. */
+            if (*status == U_MEMORY_ALLOCATION_ERROR) {
+                uprv_free(r);
+                return NULL;
+            }
             /* we have no such entry in dll, so it will always use fallback */
             *status = U_USING_FALLBACK_WARNING;
             r->fBogus = U_USING_FALLBACK_WARNING;
@@ -537,6 +542,11 @@ loadParentsExceptRoot(UResourceDataEntry *&t1,
         UErrorCode usrStatus = U_ZERO_ERROR;
         if (usingUSRData) {  // This code inserts user override data into the inheritance chain.
             u2 = init_entry(name, usrDataPath, &usrStatus);
+            // If we failed due to out-of-memory, report that to the caller and exit early.
+            if (usrStatus == U_MEMORY_ALLOCATION_ERROR) {
+                *status = usrStatus;
+                return FALSE;
+            }
         }
 
         if (usingUSRData && U_SUCCESS(usrStatus) && u2->fBogus == U_ZERO_ERROR) {
@@ -642,21 +652,32 @@ static UResourceDataEntry *entryOpen(const char* path, const char* localeID,
         /* We're going to skip all the locales that do not have any data */
         r = findFirstExisting(path, name, &isRoot, &hasChopped, &isDefault, &intStatus);
 
+        // If we failed due to out-of-memory, report the failure and exit early.
+        if (intStatus == U_MEMORY_ALLOCATION_ERROR) {
+            *status = intStatus;
+            goto finishUnlock;
+        }
+
         if(r != NULL) { /* if there is one real locale, we can look for parents. */
             t1 = r;
             hasRealData = TRUE;
             if ( usingUSRData ) {  /* This code inserts user override data into the inheritance chain */
                 UErrorCode usrStatus = U_ZERO_ERROR;
                 UResourceDataEntry *u1 = init_entry(t1->fName, usrDataPath, &usrStatus);
-               if ( u1 != NULL ) {
-                 if(u1->fBogus == U_ZERO_ERROR) {
-                   u1->fParent = t1;
-                   r = u1;
-                 } else {
-                   /* the USR override data wasn't found, set it to be deleted */
-                   u1->fCountExisting = 0;
-                 }
-               }
+                // If we failed due to out-of-memory, report the failure and exit early.
+                if (intStatus == U_MEMORY_ALLOCATION_ERROR) {
+                    *status = intStatus;
+                    goto finishUnlock;
+                }
+                if ( u1 != NULL ) {
+                    if(u1->fBogus == U_ZERO_ERROR) {
+                        u1->fParent = t1;
+                        r = u1;
+                    } else {
+                        /* the USR override data wasn't found, set it to be deleted */
+                        u1->fCountExisting = 0;
+                    }
+                }
             }
             if (hasChopped && !isRoot) {
                 if (!loadParentsExceptRoot(t1, name, UPRV_LENGTHOF(name), usingUSRData, usrDataPath, status)) {
@@ -671,6 +692,11 @@ static UResourceDataEntry *entryOpen(const char* path, const char* localeID,
             /* insert default locale */
             uprv_strcpy(name, uloc_getDefault());
             r = findFirstExisting(path, name, &isRoot, &hasChopped, &isDefault, &intStatus);
+            // If we failed due to out-of-memory, report the failure and exit early.
+            if (intStatus == U_MEMORY_ALLOCATION_ERROR) {
+                *status = intStatus;
+                goto finishUnlock;
+            }
             intStatus = U_USING_DEFAULT_WARNING;
             if(r != NULL) { /* the default locale exists */
                 t1 = r;
@@ -690,6 +716,11 @@ static UResourceDataEntry *entryOpen(const char* path, const char* localeID,
         if(r == NULL) {
             uprv_strcpy(name, kRootLocaleName);
             r = findFirstExisting(path, name, &isRoot, &hasChopped, &isDefault, &intStatus);
+            // If we failed due to out-of-memory, report the failure and exit early.
+            if (intStatus == U_MEMORY_ALLOCATION_ERROR) {
+                *status = intStatus;
+                goto finishUnlock;
+            }
             if(r != NULL) {
                 t1 = r;
                 intStatus = U_USING_DEFAULT_WARNING;


### PR DESCRIPTION
ICU does not report Out-Of-Memory (OOM) if it fails to memory map the data file(s) when calling the platform API(s) to do so.

When you are using ICU with memory-mapped data file(s), and ICU fails to map the data file due to being out-of-memory, it does not bubble this failure up to the API that was called.

For example:
```c++
 char localeID[] = u8"en_US";
 ucol_getKeywordValuesForLocale("collation", localeID, false, &status);
```

If the memory-mapped data file can't be loaded at all due to being Out-of-memory in the above code snippet, then you will get back the error `U_MISSING_RESOURCE_ERROR`, rather than `U_MEMORY_ALLOCATION_ERROR`, which might be a bit surprising to the caller of the API.

This can lead to the application thinking that there are no resources for "en_US" or "en" (or even "root").
If ICU can't load the data file due to being out-of-memory, then it would likely be better to report as such.

**Note:** This change currently only checks the platform APIs on Windows, as I don't have access to other systems to test on at the moment.