### PR TITLE
ICU-13810 Fix typo in datefmt.h

### DIFF
--- a/icu4c/source/i18n/unicode/datefmt.h
+++ b/icu4c/source/i18n/unicode/datefmt.h
@@ -48,7 +48,7 @@ class DateTimePatternGenerator;
  * explicit template instantiation. see digitlst.h
  * (When building DLLs for Windows this is required.)
  */
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN && not defined(U_IN_DOXYGEN)
+#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN && !defined(U_IN_DOXYGEN)
 template class U_I18N_API EnumSet<UDateFormatBooleanAttribute,
             0, 
             UDAT_BOOLEAN_ATTRIBUTE_COUNT>;


### PR DESCRIPTION
I missed this when reviewing the changes in PR #29.
