### PR TITLE
ICU-13483 Use a real time zone to make tests work in Android.

### DIFF
--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/DateFormatRegressionTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/DateFormatRegressionTest.java
@@ -437,7 +437,9 @@ public class DateFormatRegressionTest extends TestFmwk {
     public void Test4089106() {
         TimeZone def = TimeZone.getDefault();
         try {
-            TimeZone z = new SimpleTimeZone((int) (1.25 * 3600000), "FAKEZONE");
+            // It's necessary to use a real existing time zone here, some systems (Android) will not
+            // accept any arbitrary TimeZone object to be used as the default.
+            TimeZone z = new SimpleTimeZone(-12 * 60 * 60 * 1000, "GMT-12:00");
             TimeZone.setDefault(z);
             SimpleDateFormat f = new SimpleDateFormat();
             if (!f.getTimeZone().equals(z))

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/timezone/TimeZoneTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/timezone/TimeZoneTest.java
@@ -495,8 +495,10 @@ public class TimeZoneTest extends TestFmwk
 
     @Test
     public void TestGenericAPI() {
-        String id = "NewGMT";
-        int offset = 12345;
+        // It's necessary to use a real existing time zone here, some systems (Android) will not
+        // accept any arbitrary TimeZone object to be used as the default.
+        String id = "GMT-12:00";
+        int offset = -12 * 60 * 60 * 1000;
 
         SimpleTimeZone zone = new SimpleTimeZone(offset, id);
         if (zone.useDaylightTime()) errln("FAIL: useDaylightTime should return false");


### PR DESCRIPTION
When running in Android, java.util.TimeZone.getDefault() will only
return a TimeZone object for a time zone that actually exists, so when
passing a bogus test TimeZone object to setDefault() and afterwards
calling getDefault() it won't return that same time zone.

Changing our tests to instead use a real existing (but otherwise unused)
time zone instead makes the tests work in Android as well.

Neither of these tests was testing the ability to set an arbitrarily
made up time zone as the default, so no test coverage is lost.