### PR TITLE
ICU-13686 ICU4C: Prevent double file separators on data file paths.

### DIFF
--- a/icu4c/source/common/udata.cpp
+++ b/icu4c/source/common/udata.cpp
@@ -1252,7 +1252,8 @@ doOpenChoice(const char *path, const char *type, const char *name,
         tocEntryName.append(".", *pErrorCode).append(type, *pErrorCode);
         tocEntryPath.append(".", *pErrorCode).append(type, *pErrorCode);
     }
-    tocEntryPathSuffix = tocEntryPath.data()+tocEntrySuffixIndex; /* suffix starts here */
+    // The +1 is for the U_FILE_SEP_CHAR that is always appended above.
+    tocEntryPathSuffix = tocEntryPath.data() + tocEntrySuffixIndex + 1; /* suffix starts here */
 
 #ifdef UDATA_DEBUG
     fprintf(stderr, " tocEntryName = %s\n", tocEntryName.data());

--- a/icu4c/source/common/udata.cpp
+++ b/icu4c/source/common/udata.cpp
@@ -604,6 +604,7 @@ const char *UDataPathIterator::next(UErrorCode *pErrorCode)
 
             if(*suffix)  /* tack on suffix */
             {
+                pathBuffer.ensureEndsWithFileSeparator(*pErrorCode);
                 pathBuffer.append(suffix, *pErrorCode);
             }
         }


### PR DESCRIPTION
When looking at the file paths that are used to open data files in the debugger, it was noticed that ICU very often ends up with double separators in the file paths.

For example, some of the paths end up looking similar to the following:
- "`globalization\icu\\zoneinfo64.res`"
- "`globalization\icu\\metaZones.res`"
- "`.\\timezoneTypes.res`"

Initially, the thinking was that this was because the `UDataPathIterator` class doesn't check if both the current path and the suffix have separators when appending the suffix.
( https://github.com/unicode-org/icu/blob/master/icu4c/source/common/udata.cpp#L605 ).
The initially proposed change (see the attachment on the Issue [ICU-13636](https://unicode-org.atlassian.net/browse/ICU-13686)) added a method to the `CharString` class to check if the string ends with a separator or not, and then used that in the `UDataPathIterator` next function.

However, the feedback from Markus was that the suffix shouldn't really start with a separator.

From examining the code some more, the suffix is always being prepended with a file separator in the `doOpenChoice` function. If we simply increment the suffix index by one, then the suffix string no longer starts with the file separator character, and we no longer have the issue of double separators in the file paths.