### PR TITLE
ICU-20062 Set the Python -B flag to inhibit the writing of .pyc files.

### DIFF
--- a/icu4c/as_is/bomlist.py
+++ b/icu4c/as_is/bomlist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python -B
 
 # Copyright (C) 2016 and later: Unicode, Inc. and others.
 # License & terms of use: http://www.unicode.org/copyright.html

--- a/icu4c/source/test/depstest/dependencies.py
+++ b/icu4c/source/test/depstest/dependencies.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/python -B
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2016 and later: Unicode, Inc. and others.

--- a/icu4c/source/test/depstest/depstest.py
+++ b/icu4c/source/test/depstest/depstest.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/python -B
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2016 and later: Unicode, Inc. and others.

--- a/icu4c/source/tools/icu-svnprops-check.py
+++ b/icu4c/source/tools/icu-svnprops-check.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/python -B
 
 # Copyright (C) 2016 and later: Unicode, Inc. and others.
 # License & terms of use: http://www.unicode.org/copyright.html

--- a/tools/release/c/bomfix.py
+++ b/tools/release/c/bomfix.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python -B
 # -*- coding: utf-8 -*-
 
 #

--- a/tools/scripts/bldicures.py
+++ b/tools/scripts/bldicures.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python -B
 #
 # Copyright (C) 2017 and later: Unicode, Inc. and others.
 # License & terms of use: http://www.unicode.org/copyright.html

--- a/tools/unicode/c/genprops/misc/ucdcopy.py
+++ b/tools/unicode/c/genprops/misc/ucdcopy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.4
+#!/usr/bin/python2.4 -B
 #
 # Copyright (C) 2017 and later: Unicode, Inc. and others.
 # License & terms of use: http://www.unicode.org/copyright.html

--- a/tools/unicode/c/genuca/genteststub.py
+++ b/tools/unicode/c/genuca/genteststub.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python -B
 #
 # Copyright (C) 2017 and later: Unicode, Inc. and others.
 # License & terms of use: http://www.unicode.org/copyright.html

--- a/tools/unicode/py/parsescriptmetadata.py
+++ b/tools/unicode/py/parsescriptmetadata.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python -B
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2017 and later: Unicode, Inc. and others.

--- a/tools/unicode/py/preparseucd.py
+++ b/tools/unicode/py/preparseucd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python -B
 # -*- coding: utf-8 -*-
 # © 2016 and later: Unicode, Inc. and others.
 # License & terms of use: http://www.unicode.org/copyright.html


### PR DESCRIPTION
This will prevent littering the source tree with spurious .pyc files.
The potential faster execution when re-running a script that has an
up-to-date .pyc file is negligible.