### PR TITLE
Fix return type of StringTrieBuilder::hashNode

### DIFF
--- a/icu4c/source/common/stringtriebuilder.cpp
+++ b/icu4c/source/common/stringtriebuilder.cpp
@@ -373,7 +373,7 @@ StringTrieBuilder::registerFinalValue(int32_t value, UErrorCode &errorCode) {
     return newNode;
 }
 
-UBool
+int32_t
 StringTrieBuilder::hashNode(const void *node) {
     return ((const Node *)node)->hashCode();
 }

--- a/icu4c/source/common/unicode/stringtriebuilder.h
+++ b/icu4c/source/common/unicode/stringtriebuilder.h
@@ -66,7 +66,7 @@ class U_COMMON_API StringTrieBuilder : public UObject {
 public:
 #ifndef U_HIDE_INTERNAL_API
     /** @internal */
-    static UBool hashNode(const void *node);
+    static int32_t hashNode(const void *node);
     /** @internal */
     static UBool equalNodes(const void *left, const void *right);
 #endif  /* U_HIDE_INTERNAL_API */


### PR DESCRIPTION
...where UBool was supposedly a typo.  (Found with Clang's new
-fsanitize=implicit-conversion while building LibreOffice.)