### PR TITLE
ICU-20065 Prevent crash on Collator::makeInstance fail when optimized…

### DIFF
--- a/icu4c/source/i18n/coll.cpp
+++ b/icu4c/source/i18n/coll.cpp
@@ -448,6 +448,13 @@ Collator* U_EXPORT2 Collator::createInstance(const Locale& desiredLocale,
 #endif
     {
         coll = makeInstance(desiredLocale, status);
+        // Either returns NULL with U_FAILURE(status), or non-NULL with U_SUCCESS(status)
+    }
+    // The use of *coll in setAttributesFromKeywords can cause causes the NULL check
+    // to be optimized out of the delete even though setAttributesFromKeywords returns
+    // immediately if U_FAILURE(status), so we add a check here.
+    if (U_FAILURE(status)) {
+        return NULL;
     }
     setAttributesFromKeywords(desiredLocale, *coll, status);
     if (U_FAILURE(status)) {

--- a/icu4c/source/i18n/coll.cpp
+++ b/icu4c/source/i18n/coll.cpp
@@ -450,8 +450,8 @@ Collator* U_EXPORT2 Collator::createInstance(const Locale& desiredLocale,
         coll = makeInstance(desiredLocale, status);
         // Either returns NULL with U_FAILURE(status), or non-NULL with U_SUCCESS(status)
     }
-    // The use of *coll in setAttributesFromKeywords can cause causes the NULL check
-    // to be optimized out of the delete even though setAttributesFromKeywords returns
+    // The use of *coll in setAttributesFromKeywords can cause the NULL check to be
+    // optimized out of the delete even though setAttributesFromKeywords returns
     // immediately if U_FAILURE(status), so we add a check here.
     if (U_FAILURE(status)) {
         return NULL;


### PR DESCRIPTION
In Collator::createInstance, before the call to setAttributesFromKeywords, Collator* Coll will be NULL if U_FAILURE(status). In that case (FAILURE status), setAttributesFromKeywords returns immediately and does not use the dereferenced value *coll. However, the fact that Coll is dereferenced allows C++ compilers to optimize out the NULL check in the subsequent delete. In that case a failure in makeInstance due to a bad key-value such as "collation=private-kana" will cause the "delete Coll" to crash. So we add a seemingly-redundant check for U_FAILURE(status), and return NULL if TRUE, before the call to setAttributesFromKeywords.

##### Checklist

- [x] Issue filed at https://unicode-org.atlassian.net :  ICU-20065
- [x] Update PR title to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added - no doc updates needed, but comments in code explain what is going on.
