### PR TITLE
ICU-20000 Workaround for BigDecimal.stripTrailingZeros() differences.

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/number/Scale.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/number/Scale.java
@@ -42,7 +42,7 @@ public class Scale {
             // Attempt to convert the BigDecimal to a magnitude multiplier.
             // ICU-20000: JDKs have inconsistent behavior on stripTrailingZeros() for Zero.
             arbitrary =
-                arbitrary.compareTo(BigInteger.ZERO) == 0
+                arbitrary.compareTo(BigDecimal.ZERO) == 0
                     ? BigDecimal.ZERO
                     : arbitrary.stripTrailingZeros();
             if (arbitrary.precision() == 1 && arbitrary.unscaledValue().equals(BigInteger.ONE)) {

--- a/icu4j/main/classes/core/src/com/ibm/icu/number/Scale.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/number/Scale.java
@@ -40,7 +40,10 @@ public class Scale {
     private Scale(int magnitude, BigDecimal arbitrary, MathContext mc) {
         if (arbitrary != null) {
             // Attempt to convert the BigDecimal to a magnitude multiplier.
-            arbitrary = arbitrary.stripTrailingZeros();
+            arbitrary =
+                arbitrary.unscaledValue().equals(BigInteger.ZERO)
+                    ? BigDecimal.ZERO
+                    : arbitrary.stripTrailingZeros();
             if (arbitrary.precision() == 1 && arbitrary.unscaledValue().equals(BigInteger.ONE)) {
                 // Success!
                 magnitude -= arbitrary.scale();

--- a/icu4j/main/classes/core/src/com/ibm/icu/number/Scale.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/number/Scale.java
@@ -40,8 +40,9 @@ public class Scale {
     private Scale(int magnitude, BigDecimal arbitrary, MathContext mc) {
         if (arbitrary != null) {
             // Attempt to convert the BigDecimal to a magnitude multiplier.
+            // ICU-20000: JDKs have inconsistent behavior on stripTrailingZeros() for Zero.
             arbitrary =
-                arbitrary.unscaledValue().equals(BigInteger.ZERO)
+                arbitrary.compareTo(BigInteger.ZERO) == 0
                     ? BigDecimal.ZERO
                     : arbitrary.stripTrailingZeros();
             if (arbitrary.precision() == 1 && arbitrary.unscaledValue().equals(BigInteger.ONE)) {


### PR DESCRIPTION
Different implementations of BigDecimal.stripTrailingZeros(), in
different versions of the JDK (and different versions of Android), have
differences in their handling of zero. To avoid this, ICU4J can return
BigDecimal.ZERO for any value that is equal to zero, instead of calling
BigDecimal.stripTrailingZeros() in this problematic case.