### PR TITLE
ICU-20054 Revert "ICU-20054 Adding depstest *.pyc to gitignore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -422,7 +422,6 @@ icu4c/source/test/cintltst/release
 icu4c/source/test/cintltst/x64
 icu4c/source/test/cintltst/x86
 icu4c/source/test/compat/Makefile
-icu4c/source/test/depstest/*.pyc
 icu4c/source/test/hdrtst/*.[co]
 icu4c/source/test/hdrtst/Makefile
 icu4c/source/test/hdrtst/cfiles.txt


### PR DESCRIPTION
This reverts commit b3629170a80489a94a8f93d0008beb72584c6540.

Made obsolete by commit bfc0093b7f776f0137ddd7bc9ef98f118842dd6e.