### PR TITLE
ICU-13530 Use LocalPointer instead of raw new in umutablecptrie.cpp

### DIFF
--- a/icu4c/source/common/umutablecptrie.cpp
+++ b/icu4c/source/common/umutablecptrie.cpp
@@ -1505,12 +1505,12 @@ umutablecptrie_open(uint32_t initialValue, uint32_t errorValue, UErrorCode *pErr
     if (U_FAILURE(*pErrorCode)) {
         return nullptr;
     }
-    MutableCodePointTrie *trie = new MutableCodePointTrie(initialValue, errorValue, *pErrorCode);
+    LocalPointer<MutableCodePointTrie> trie(
+        new MutableCodePointTrie(initialValue, errorValue, *pErrorCode), *pErrorCode);
     if (U_FAILURE(*pErrorCode)) {
-        delete trie;
         return nullptr;
     }
-    return reinterpret_cast<UMutableCPTrie *>(trie);
+    return reinterpret_cast<UMutableCPTrie *>(trie.orphan());
 }
 
 U_CAPI UMutableCPTrie * U_EXPORT2
@@ -1521,13 +1521,12 @@ umutablecptrie_clone(const UMutableCPTrie *other, UErrorCode *pErrorCode) {
     if (other == nullptr) {
         return nullptr;
     }
-    MutableCodePointTrie *clone = new MutableCodePointTrie(
-        *reinterpret_cast<const MutableCodePointTrie *>(other), *pErrorCode);
+    LocalPointer<MutableCodePointTrie> clone(
+        new MutableCodePointTrie(*reinterpret_cast<const MutableCodePointTrie *>(other), *pErrorCode), *pErrorCode);
     if (U_FAILURE(*pErrorCode)) {
-        delete clone;
         return nullptr;
     }
-    return reinterpret_cast<UMutableCPTrie *>(clone);
+    return reinterpret_cast<UMutableCPTrie *>(clone.orphan());
 }
 
 U_CAPI void U_EXPORT2


### PR DESCRIPTION
Use LocalPointer instead of raw new in umutablecptrie.cpp so that an ErrorCode will be set in the case of out-of-memory (OOM) failure.

##### Checklist

- [x] Issue filed at https://unicode-org.atlassian.net :  ICU-13530
- [x] Update PR title to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added
