### PR TITLE
ICU-13696 Parse local currency ISO codes as case-insensitive.

### DIFF
--- a/icu4c/source/i18n/numparse_currency.cpp
+++ b/icu4c/source/i18n/numparse_currency.cpp
@@ -111,7 +111,9 @@ bool CombinedCurrencyMatcher::matchCurrency(StringSegment& segment, ParsedNumber
 
     int32_t overlap2;
     if (!fCurrency2.isEmpty()) {
-        overlap2 = segment.getCaseSensitivePrefixLength(fCurrency2);
+        // ISO codes should be accepted case-insensitive.
+        // https://unicode-org.atlassian.net/browse/ICU-13696
+        overlap2 = segment.getCommonPrefixLength(fCurrency2);
     } else {
         overlap2 = -1;
     }

--- a/icu4c/source/test/intltest/numfmtst.cpp
+++ b/icu4c/source/test/intltest/numfmtst.cpp
@@ -3861,6 +3861,7 @@ NumberFormatTest::TestParseCurrencyInUCurr() {
         "1.00 US DOLLAR",  // case in-sensitive
         "$1.00",
         "USD1.00",
+        "usd1.00", // case in-sensitive: #13696
         "US dollar1.00",
         "US dollars1.00",
         "$1.00",
@@ -5876,7 +5877,6 @@ NumberFormatTest::TestParseCurrencyInUCurr() {
 
     const char* WRONG_DATA[] = {
         // Following are missing one last char in the currency name
-        "usd1.00", // case sensitive
         "1.00 Nicaraguan Cordob",
         "1.00 Namibian Dolla",
         "1.00 Namibian dolla",

--- a/icu4c/source/test/testdata/numberformattestspecification.txt
+++ b/icu4c/source/test/testdata/numberformattestspecification.txt
@@ -1668,7 +1668,32 @@ pattern	lenient	parse	output	breaks
 0E0'.'x	1	5E3.x	5000
 0E0'.'x	0	5E3.x	5000
 
-test parse lowercase currency
+test parse() lowercase currency
+set locale en
+set pattern ¤¤0
+set currency USD
+begin
+parse	output	breaks
+USD123	123
+USD 123	123	HK
+usd123	123	K
+usd 123	123	HK
+Usd123	123	K
+Usd 123	123	HK
+// US$ is not used for US dollars in en-US
+US$123	fail	H
+us$123	fail
+Us$123	fail
+123 US dollars	123	K
+123 US DOLLARS	123	K
+123 us dollars	123	K
+// Foreign currencies are not accepted in .parse()
+GBP123	fail
+gbp123	fail
+British pounds 123	fail
+british POUNDS 123	fail
+
+test parseCurrency() lowercase currency
 set locale en
 set pattern ¤¤0
 set currency USD
@@ -1676,17 +1701,20 @@ begin
 parse	output	outputCurrency	breaks
 USD123	123	USD
 USD 123	123	USD	H
-// C does not currently accept case-insensitive ISO codes
-usd123	123	USD	C
-usd 123	123	USD	CH
-Usd123	123	USD	C
-Usd 123	123	USD	CH
+usd123	123	USD
+usd 123	123	USD	H
+Usd123	123	USD
+Usd 123	123	USD	H
 US$123	123	USD	C
 us$123	fail	fail
 Us$123	fail	fail
 123 US dollars	123	USD
 123 US DOLLARS	123	USD
 123 us dollars	123	USD
+GBP123	123	GBP
+gbp123	123	GBP	C
+British pounds 123	123	GBP	H
+british POUNDS 123	123	GBP	H
 
 
 

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/parse/CombinedCurrencyMatcher.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/parse/CombinedCurrencyMatcher.java
@@ -146,7 +146,9 @@ public class CombinedCurrencyMatcher implements NumberParseMatcher {
 
         int overlap2;
         if (!currency2.isEmpty()) {
-            overlap2 = segment.getCaseSensitivePrefixLength(currency2);
+            // ISO codes should be accepted case-insensitive.
+            // https://unicode-org.atlassian.net/browse/ICU-13696
+            overlap2 = segment.getCommonPrefixLength(currency2);
         } else {
             overlap2 = -1;
         }

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/data/numberformattestspecification.txt
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/data/numberformattestspecification.txt
@@ -1676,10 +1676,10 @@ begin
 parse	output	breaks
 USD123	123
 USD 123	123	HK
-usd123	123	CK
-usd 123	123	CHK
-Usd123	123	CK
-Usd 123	123	CHK
+usd123	123	K
+usd 123	123	HK
+Usd123	123	K
+Usd 123	123	HK
 // US$ is not used for US dollars in en-US
 US$123	fail	H
 us$123	fail
@@ -1689,7 +1689,7 @@ Us$123	fail
 123 us dollars	123	K
 // Foreign currencies are not accepted in .parse()
 GBP123	fail
-gbp123	fail	C
+gbp123	fail
 British pounds 123	fail
 british POUNDS 123	fail
 
@@ -1701,10 +1701,10 @@ begin
 parse	output	outputCurrency	breaks
 USD123	123	USD
 USD 123	123	USD	H
-usd123	123	USD	C
-usd 123	123	USD	CH
-Usd123	123	USD	C
-Usd 123	123	USD	CH
+usd123	123	USD
+usd 123	123	USD	H
+Usd123	123	USD
+Usd 123	123	USD	H
 US$123	123	USD	C
 us$123	fail	fail
 Us$123	fail	fail

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/data/numberformattestspecification.txt
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/data/numberformattestspecification.txt
@@ -1668,7 +1668,32 @@ pattern	lenient	parse	output	breaks
 0E0'.'x	1	5E3.x	5000
 0E0'.'x	0	5E3.x	5000
 
-test parse lowercase currency
+test parse() lowercase currency
+set locale en
+set pattern ¤¤0
+set currency USD
+begin
+parse	output	breaks
+USD123	123
+USD 123	123	HK
+usd123	123	CK
+usd 123	123	CHK
+Usd123	123	CK
+Usd 123	123	CHK
+// US$ is not used for US dollars in en-US
+US$123	fail	H
+us$123	fail
+Us$123	fail
+123 US dollars	123	K
+123 US DOLLARS	123	K
+123 us dollars	123	K
+// Foreign currencies are not accepted in .parse()
+GBP123	fail
+gbp123	fail	C
+British pounds 123	fail
+british POUNDS 123	fail
+
+test parseCurrency() lowercase currency
 set locale en
 set pattern ¤¤0
 set currency USD
@@ -1676,7 +1701,6 @@ begin
 parse	output	outputCurrency	breaks
 USD123	123	USD
 USD 123	123	USD	H
-// C does not currently accept case-insensitive ISO codes
 usd123	123	USD	C
 usd 123	123	USD	CH
 Usd123	123	USD	C
@@ -1687,6 +1711,10 @@ Us$123	fail	fail
 123 US dollars	123	USD
 123 US DOLLARS	123	USD
 123 us dollars	123	USD
+GBP123	123	GBP
+gbp123	123	GBP	C
+British pounds 123	123	GBP	H
+british POUNDS 123	123	GBP	H
 
 
 

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/NumberFormatTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/NumberFormatTest.java
@@ -817,7 +817,7 @@ public class NumberFormatTest extends TestFmwk {
                 {"1.00 UAE dirha", "4", "-1", "0", "4"},
                 {"1.00 us dollar", "14", "-1", "14", "-1"},
                 {"1.00 US DOLLAR", "14", "-1", "14", "-1"},
-                {"1.00 usd", "4", "-1", "8", "-1"},
+                {"1.00 usd", "8", "-1", "8", "-1"},
                 {"1.00 USD", "8", "-1", "8", "-1"},
         };
         ULocale locale = new ULocale("en_US");
@@ -6092,8 +6092,8 @@ public class NumberFormatTest extends TestFmwk {
         df.setCurrency(Currency.getInstance("ICU"));
         ParsePosition ppos = new ParsePosition(0);
         df.parseCurrency("icu123", ppos);
-        assertEquals("Should fail to parse", 0, ppos.getIndex());
-        assertEquals("Should fail to parse", 0, ppos.getErrorIndex());
+        assertEquals("Should succeed", 6, ppos.getIndex());
+        assertEquals("Should succeed", -1, ppos.getErrorIndex());
     }
 
     @Test


### PR DESCRIPTION
ICU4J 60 and 61 parsed ISO codes as case-insensitive in .parse().  This was changed to case-sensitive as a side-effect of ICU-13736.  However, ICU-13696 says that it is desirable for the codes to be parsed case-insensitive.  This change will make ICU 63, both C and J, have the ICU4J 60 and 61 behavior.

The current ticket, ICU-13696, says that this should be able to be toggled by an `@internal` flag.  I have not included such a flag in this PR, because it is very easy for users to change the behavior back via a patch, and a flag would add complexity, particularly because this feature would want to bubble all the way up to the DecimalFormat API.

Also see http://b/112469513

##### Checklist

- [x] Issue filed at https://unicode-org.atlassian.net :  ICU-13696
- [x] Update PR title to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added
