### PR TITLE
ICU-20051 fix '@goods=: command not found' warning during build

### DIFF
--- a/icu4c/source/test/Makefile.in
+++ b/icu4c/source/test/Makefile.in
@@ -88,7 +88,7 @@ xcheck-recursive check-recursive check-exhaustive-recursive:
 	@$(MKINSTALLDIRS) $(STATUS_TMP)
 	@mystatus=$(STATUS_FULL)/status.$$$$.deleteme ; \
 	$(RMV) "$$mystatus".* ; \
-	@goods=; \
+	goods=; \
 	bads=; \
 	target=`echo $@ | sed s/-recursive//`; \
 	list='$(SUBDIRS)'; for subdir in $$list; do \
@@ -137,8 +137,8 @@ $(STATUS_FULL)/status.$(STATUS_NUM).deleteme.%: pcheck_setup
 
 # print out status
 pcheck: $(STATUS_FILES)
-	@goods= ; \
-	bads= ; \
+	@goods=; \
+	bads=; \
 	echo "----------------------------------------"; \
 	for subdir in $(SUBDIRS); do \
 	  if [ -s "$(MYSTATUS_R).$$subdir" ]; then \


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed at https://unicode-org.atlassian.net :  ICU-______
- [x] Update PR title to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

