### PR TITLE
ICU-20083 Enable Address sanitizer in ICU4C builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,19 +12,19 @@ matrix:
       script:   cd icu4c/source && ./runConfigureICU Linux && make -j2 check
 
     - language: cpp
-      env:      BUILD=ICU4C_CLANG
-      compiler: clang
-      script:   cd icu4c/source && ./runConfigureICU Linux && make -j2 check
-
-    - language: cpp
       env:      BUILD=MACINTOSH
       os:       osx
       compiler: clang
       script:   cd icu4c/source && ./runConfigureICU MacOSX && make -j2 check
 
+    # Clang Linux with address sanitizer.
+    # Note - the 'sudo: true' option forces Travis to use a Virtual machine on GCE instead of
+    #        a Container on EC2 or Packet. Asan builds of ICU fail otherwise.
     - language: cpp
+      env:      BUILD=ICU4C_CLANG_ASAN
       os:       linux
       dist:     trusty
+      sudo:     true
       compiler: clang
       addons:
           apt:
@@ -33,8 +33,5 @@ matrix:
                   - llvm-toolchain-trusty-5.0
               packages:
                   - clang-5.0
-      env:
-          - BUILD=ASAN
       script:
-          - echo not yet
-          # - cd icu4c/source && CPPFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address" ./runConfigureICU --enable-debug --disable-release Linux --disable-renaming && make -j2 check
+          - cd icu4c/source && CPPFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address" ./runConfigureICU --enable-debug --disable-release Linux --disable-renaming && make -j2 check


### PR DESCRIPTION
Enable address sanitizer in Travis build. Make it the default for Clang on Linux builds.
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed at https://unicode-org.atlassian.net :  ICU-______
- [ ] Update PR title to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

