### PR TITLE
ICU-13530 fix doxygen warnings: hide internals, hide struct/enum typedefs, avoid fwd+real struct decl

### DIFF
--- a/icu4c/source/common/unicode/ucptrie.h
+++ b/icu4c/source/common/unicode/ucptrie.h
@@ -41,7 +41,6 @@ U_CDECL_BEGIN
  * @see UMutableCPTrie
  * @draft ICU 63
  */
-struct UCPTrie;
 typedef struct UCPTrie UCPTrie;
 
 /**
@@ -53,7 +52,7 @@ typedef struct UCPTrie UCPTrie;
  * @see ucptrie_getType
  * @draft ICU 63
  */
-enum UCPTrieType {
+typedef enum UCPTrieType {
     /**
      * For ucptrie_openFromBinary() to accept any type.
      * ucptrie_getType() will return the actual type.
@@ -70,8 +69,7 @@ enum UCPTrieType {
      * @draft ICU 63
      */
     UCPTRIE_TYPE_SMALL
-};
-typedef enum UCPTrieType UCPTrieType;
+} UCPTrieType;
 
 /**
  * Selectors for the number of bits in a UCPTrie data value.
@@ -81,7 +79,7 @@ typedef enum UCPTrieType UCPTrieType;
  * @see ucptrie_getValueWidth
  * @draft ICU 63
  */
-enum UCPTrieValueWidth {
+typedef enum UCPTrieValueWidth {
     /**
      * For ucptrie_openFromBinary() to accept any data value width.
      * ucptrie_getValueWidth() will return the actual data value width.
@@ -105,8 +103,7 @@ enum UCPTrieValueWidth {
      * @draft ICU 63
      */
     UCPTRIE_VALUE_BITS_8
-};
-typedef enum UCPTrieValueWidth UCPTrieValueWidth;
+} UCPTrieValueWidth;
 
 /**
  * Selectors for how ucptrie_getRange() should report value ranges overlapping with surrogates.
@@ -115,7 +112,7 @@ typedef enum UCPTrieValueWidth UCPTrieValueWidth;
  * @see ucptrie_getRange
  * @draft ICU 63
  */
-enum UCPTrieRangeOption {
+typedef enum UCPTrieRangeOption {
     /**
      * ucptrie_getRange() enumerates all same-value ranges as stored in the trie.
      * Most users should use this option.
@@ -151,8 +148,7 @@ enum UCPTrieRangeOption {
      * but those values are not to be associated with the lead surrogate code *points*.
      */
     UCPTRIE_RANGE_FIXED_ALL_SURROGATES
-};
-typedef enum UCPTrieRangeOption UCPTrieRangeOption;
+} UCPTrieRangeOption;
 
 /**
  * Opens a trie from its binary form, stored in 32-bit-aligned memory.

--- a/icu4c/source/common/unicode/ucptrie.h
+++ b/icu4c/source/common/unicode/ucptrie.h
@@ -24,6 +24,20 @@ U_CDECL_BEGIN
  * @see UMutableCPTrie
  */
 
+#ifndef U_IN_DOXYGEN
+/** @internal */
+typedef union UCPTrieData {
+    /** @internal */
+    const void *ptr0;
+    /** @internal */
+    const uint16_t *ptr16;
+    /** @internal */
+    const uint32_t *ptr32;
+    /** @internal */
+    const uint8_t *ptr8;
+} UCPTrieData;
+#endif
+
 /**
  * Immutable Unicode code point trie structure.
  * Fast, reasonably compact, map from Unicode code points (U+0000..U+10FFFF) to integer values.
@@ -41,7 +55,56 @@ U_CDECL_BEGIN
  * @see UMutableCPTrie
  * @draft ICU 63
  */
+struct UCPTrie {
+#ifndef U_IN_DOXYGEN
+    /** @internal */
+    const uint16_t *index;
+    /** @internal */
+    UCPTrieData data;
+
+    /** @internal */
+    int32_t indexLength;
+    /** @internal */
+    int32_t dataLength;
+    /** Start of the last range which ends at U+10FFFF. @internal */
+    UChar32 highStart;
+    /** highStart>>12 @internal */
+    uint16_t shifted12HighStart;
+
+    /** @internal */
+    int8_t type;  // UCPTrieType
+    /** @internal */
+    int8_t valueWidth;  // UCPTrieValueWidth
+
+    /** padding/reserved @internal */
+    uint32_t reserved32;
+    /** padding/reserved @internal */
+    uint16_t reserved16;
+
+    /**
+     * Internal index-3 null block offset.
+     * Set to an impossibly high value (e.g., 0xffff) if there is no dedicated index-3 null block.
+     * @internal
+     */
+    uint16_t index3NullOffset;
+    /**
+     * Internal data null block offset, not shifted.
+     * Set to an impossibly high value (e.g., 0xfffff) if there is no dedicated data null block.
+     * @internal
+     */
+    int32_t dataNullOffset;
+    /** @internal */
+    uint32_t nullValue;
+
+#ifdef UCPTRIE_DEBUG
+    /** @internal */
+    const char *name;
+#endif
+#endif
+};
+#ifndef U_IN_DOXYGEN
 typedef struct UCPTrie UCPTrie;
+#endif
 
 /**
  * Selectors for the type of a UCPTrie.
@@ -52,7 +115,7 @@ typedef struct UCPTrie UCPTrie;
  * @see ucptrie_getType
  * @draft ICU 63
  */
-typedef enum UCPTrieType {
+enum UCPTrieType {
     /**
      * For ucptrie_openFromBinary() to accept any type.
      * ucptrie_getType() will return the actual type.
@@ -69,7 +132,10 @@ typedef enum UCPTrieType {
      * @draft ICU 63
      */
     UCPTRIE_TYPE_SMALL
-} UCPTrieType;
+};
+#ifndef U_IN_DOXYGEN
+typedef enum UCPTrieType UCPTrieType;
+#endif
 
 /**
  * Selectors for the number of bits in a UCPTrie data value.
@@ -79,7 +145,7 @@ typedef enum UCPTrieType {
  * @see ucptrie_getValueWidth
  * @draft ICU 63
  */
-typedef enum UCPTrieValueWidth {
+enum UCPTrieValueWidth {
     /**
      * For ucptrie_openFromBinary() to accept any data value width.
      * ucptrie_getValueWidth() will return the actual data value width.
@@ -103,7 +169,10 @@ typedef enum UCPTrieValueWidth {
      * @draft ICU 63
      */
     UCPTRIE_VALUE_BITS_8
-} UCPTrieValueWidth;
+};
+#ifndef U_IN_DOXYGEN
+typedef enum UCPTrieValueWidth UCPTrieValueWidth;
+#endif
 
 /**
  * Selectors for how ucptrie_getRange() should report value ranges overlapping with surrogates.
@@ -112,7 +181,7 @@ typedef enum UCPTrieValueWidth {
  * @see ucptrie_getRange
  * @draft ICU 63
  */
-typedef enum UCPTrieRangeOption {
+enum UCPTrieRangeOption {
     /**
      * ucptrie_getRange() enumerates all same-value ranges as stored in the trie.
      * Most users should use this option.
@@ -148,7 +217,10 @@ typedef enum UCPTrieRangeOption {
      * but those values are not to be associated with the lead surrogate code *points*.
      */
     UCPTRIE_RANGE_FIXED_ALL_SURROGATES
-} UCPTrieRangeOption;
+};
+#ifndef U_IN_DOXYGEN
+typedef enum UCPTrieRangeOption UCPTrieRangeOption;
+#endif
 
 /**
  * Opens a trie from its binary form, stored in 32-bit-aligned memory.
@@ -554,68 +626,7 @@ ucptrie_toBinary(const UCPTrie *trie, void *data, int32_t capacity, UErrorCode *
 
 /* Internal definitions ----------------------------------------------------- */
 
-/** @internal */
-typedef union UCPTrieData {
-    /** @internal */
-    const void *ptr0;
-    /** @internal */
-    const uint16_t *ptr16;
-    /** @internal */
-    const uint32_t *ptr32;
-    /** @internal */
-    const uint8_t *ptr8;
-} UCPTrieData;
-
-/**
- * Internal trie structure definition.
- * Visible only for use by API macros.
- * @internal
- */
-struct UCPTrie {
-    /** @internal */
-    const uint16_t *index;
-    /** @internal */
-    UCPTrieData data;
-
-    /** @internal */
-    int32_t indexLength;
-    /** @internal */
-    int32_t dataLength;
-    /** Start of the last range which ends at U+10FFFF. @internal */
-    UChar32 highStart;
-    /** highStart>>12 @internal */
-    uint16_t shifted12HighStart;
-
-    /** @internal */
-    int8_t type;  // UCPTrieType
-    /** @internal */
-    int8_t valueWidth;  // UCPTrieValueWidth
-
-    /** padding/reserved @internal */
-    uint32_t reserved32;
-    /** padding/reserved @internal */
-    uint16_t reserved16;
-
-    /**
-     * Internal index-3 null block offset.
-     * Set to an impossibly high value (e.g., 0xffff) if there is no dedicated index-3 null block.
-     * @internal
-     */
-    uint16_t index3NullOffset;
-    /**
-     * Internal data null block offset, not shifted.
-     * Set to an impossibly high value (e.g., 0xfffff) if there is no dedicated data null block.
-     * @internal
-     */
-    int32_t dataNullOffset;
-    /** @internal */
-    uint32_t nullValue;
-
-#ifdef UCPTRIE_DEBUG
-    /** @internal */
-    const char *name;
-#endif
-};
+#ifndef U_IN_DOXYGEN
 
 /**
  * Internal implementation constants.
@@ -692,4 +703,5 @@ ucptrie_internalU8PrevIndex(const UCPTrie *trie, UChar32 c,
 
 U_CDECL_END
 
+#endif  // U_IN_DOXYGEN
 #endif

--- a/icu4c/source/common/unicode/umutablecptrie.h
+++ b/icu4c/source/common/unicode/umutablecptrie.h
@@ -44,7 +44,6 @@ U_CDECL_BEGIN
  * @see umutablecptrie_buildImmutable
  * @draft ICU 63
  */
-struct UMutableCPTrie;
 typedef struct UMutableCPTrie UMutableCPTrie;
 
 /**


### PR DESCRIPTION
- [ ] Issue filed at https://unicode-org.atlassian.net :  ICU-13530
- [ ] Update PR title to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

