### PR TITLE
ICU-13645 Clean up implementation of Locale::operator=(const Locale&).

### DIFF
--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -434,19 +434,19 @@ Locale& Locale::operator=(const Locale& other) {
     setToBogus();
 
     if (other.fullName == other.fullNameBuffer) {
-      uprv_strcpy(fullNameBuffer, other.fullNameBuffer);
+        uprv_strcpy(fullNameBuffer, other.fullNameBuffer);
     } else if (other.fullName == nullptr) {
-      fullName = nullptr;
+        fullName = nullptr;
     } else {
-      fullName = uprv_strdup(other.fullName);
-      if (fullName == nullptr) return *this;
+        fullName = uprv_strdup(other.fullName);
+        if (fullName == nullptr) return *this;
     }
 
     if (other.baseName == other.fullName) {
-      baseName = fullName;
+        baseName = fullName;
     } else if (other.baseName != nullptr) {
-      baseName = uprv_strdup(other.baseName);
-      if (baseName == nullptr) return *this;
+        baseName = uprv_strdup(other.baseName);
+        if (baseName == nullptr) return *this;
     }
 
     uprv_strcpy(language, other.language);

--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -431,29 +431,18 @@ Locale& Locale::operator=(const Locale& other) {
         return *this;
     }
 
-    if (fullName != fullNameBuffer) {
-        uprv_free(fullName);
-    }
+    setToBogus();
 
-    if (baseName != fullName) {
-        uprv_free(baseName);
-    }
-
-    baseName = fullName = fullNameBuffer;
-    fIsBogus = TRUE;
-
-    if (other.fullName == nullptr) {
-      fullName = nullptr;
-    } else if (other.fullName == other.fullNameBuffer) {
+    if (other.fullName == other.fullNameBuffer) {
       uprv_strcpy(fullNameBuffer, other.fullNameBuffer);
+    } else if (other.fullName == nullptr) {
+      fullName = nullptr;
     } else {
       fullName = uprv_strdup(other.fullName);
       if (fullName == nullptr) return *this;
     }
 
-    if (other.baseName == nullptr) {
-      baseName = nullptr;
-    } else if (other.baseName == other.fullName) {
+    if (other.baseName == other.fullName) {
       baseName = fullName;
     } else {
       baseName = uprv_strdup(other.baseName);

--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -444,7 +444,7 @@ Locale& Locale::operator=(const Locale& other) {
 
     if (other.baseName == other.fullName) {
       baseName = fullName;
-    } else {
+    } else if (other.baseName != nullptr) {
       baseName = uprv_strdup(other.baseName);
       if (baseName == nullptr) return *this;
     }

--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -426,56 +426,47 @@ Locale::Locale(const Locale &other)
     *this = other;
 }
 
-Locale &Locale::operator=(const Locale &other)
-{
+Locale& Locale::operator=(const Locale& other) {
     if (this == &other) {
         return *this;
     }
 
-    /* Free our current storage */
+    if (fullName != fullNameBuffer) {
+        uprv_free(fullName);
+    }
+
     if (baseName != fullName) {
         uprv_free(baseName);
     }
-    baseName = NULL;
-    if(fullName != fullNameBuffer) {
-        uprv_free(fullName);
-        fullName = fullNameBuffer;
-    }
 
-    /* Allocate the full name if necessary */
-    if(other.fullName != other.fullNameBuffer) {
-        fullName = (char *)uprv_malloc(sizeof(char)*(uprv_strlen(other.fullName)+1));
-        if (fullName == NULL) {
-            // if memory allocation fails, set this object to bogus.
-            fIsBogus = TRUE;
-            return *this;
-        }
-    }
-    /* Copy the full name */
-    uprv_strcpy(fullName, other.fullName);
+    baseName = fullName = fullNameBuffer;
+    fIsBogus = TRUE;
 
-    /* Copy the baseName if it differs from fullName. */
-    if (other.baseName == other.fullName) {
-        baseName = fullName;
+    if (other.fullName == nullptr) {
+      fullName = nullptr;
+    } else if (other.fullName == other.fullNameBuffer) {
+      uprv_strcpy(fullNameBuffer, other.fullNameBuffer);
     } else {
-        if (other.baseName) {
-            baseName = uprv_strdup(other.baseName);
-            if (baseName == nullptr) {
-                // if memory allocation fails, set this object to bogus.
-                fIsBogus = TRUE;
-                return *this;
-            }
-        }
+      fullName = uprv_strdup(other.fullName);
+      if (fullName == nullptr) return *this;
     }
 
-    /* Copy the language and country fields */
+    if (other.baseName == nullptr) {
+      baseName = nullptr;
+    } else if (other.baseName == other.fullName) {
+      baseName = fullName;
+    } else {
+      baseName = uprv_strdup(other.baseName);
+      if (baseName == nullptr) return *this;
+    }
+
     uprv_strcpy(language, other.language);
     uprv_strcpy(script, other.script);
     uprv_strcpy(country, other.country);
 
-    /* The variantBegin is an offset, just copy it */
     variantBegin = other.variantBegin;
     fIsBogus = other.fIsBogus;
+
     return *this;
 }
 


### PR DESCRIPTION
Organizing the implementation like this instead will (hopefully) make it
more clear what's being done and make it possible to use analogous
control flow in the copy and move implementations of operator=().