### PR TITLE
ICU-13812 Define U_FALLTHROUGH for GCC 7+ for ICU4C.

### DIFF
--- a/icu4c/source/common/unicode/platform.h
+++ b/icu4c/source/common/unicode/platform.h
@@ -517,6 +517,8 @@ namespace std {
             (__has_feature(cxx_attributes) && __has_warning("-Wimplicit-fallthrough"))
 #       define U_FALLTHROUGH [[clang::fallthrough]]
 #   endif
+#elif defined(__GNUC__) && (__GNUC__ >= 7)
+#   define U_FALLTHROUGH __attribute__((fallthrough))
 #endif
 
 #ifndef U_FALLTHROUGH


### PR DESCRIPTION
Currently `U_FALLTHROUGH` is not defined for GCC, meaning that any `switch case` statements with fall-throughs will generate warnings when building ICU4C.

In GCC 7, they added support for: "`_attribute_((fallthrough))`" which we can now use for `U_FALLTHROUGH`, which eliminates many warnings.

##### Checklist

- [x] Issue filed at https://unicode-org.atlassian.net :  ICU-13812
- [x] Update PR title to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

