### PR TITLE
ICU-20098 check extlang with length of leading language subtag in ICU4J

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/locale/LanguageTag.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/locale/LanguageTag.java
@@ -41,7 +41,7 @@ public class LanguageTag {
     // Map contains grandfathered tags and its preferred mappings from
     // http://www.ietf.org/rfc/rfc5646.txt
     private static final Map<AsciiUtil.CaseInsensitiveKey, String[]> GRANDFATHERED =
-        new HashMap<AsciiUtil.CaseInsensitiveKey, String[]>();
+        new HashMap<>();
 
     static {
         // grandfathered = irregular           ; non-redundant tags registered
@@ -234,6 +234,10 @@ public class LanguageTag {
         if (itr.isDone() || sts.isError()) {
             return false;
         }
+        if (_language.length() > 3) {
+            // extlang might be used with 2*3ALPHA language subtag only.
+            return false;
+        }
 
         boolean found = false;
 
@@ -244,7 +248,7 @@ public class LanguageTag {
             }
             found = true;
             if (_extlangs.isEmpty()) {
-                _extlangs = new ArrayList<String>(3);
+                _extlangs = new ArrayList<>(3);
             }
             _extlangs.add(s);
             sts._parseLength = itr.currentEnd();
@@ -309,7 +313,7 @@ public class LanguageTag {
             }
             found = true;
             if (_variants.isEmpty()) {
-                _variants = new ArrayList<String>(3);
+                _variants = new ArrayList<>(3);
             }
             _variants.add(s);
             sts._parseLength = itr.currentEnd();
@@ -352,7 +356,7 @@ public class LanguageTag {
                 }
 
                 if (_extensions.size() == 0) {
-                    _extensions = new ArrayList<String>(4);
+                    _extensions = new ArrayList<>(4);
                 }
                 _extensions.add(sb.toString());
                 found = true;
@@ -452,7 +456,7 @@ public class LanguageTag {
                     break;
                 }
                 if (variants == null) {
-                    variants = new ArrayList<String>();
+                    variants = new ArrayList<>();
                 }
                 if (JDKIMPL) {
                     variants.add(var);  // Do not canonicalize!
@@ -499,7 +503,7 @@ public class LanguageTag {
                 privateuse = ext.getValue();
             } else {
                 if (extensions == null) {
-                    extensions = new ArrayList<String>();
+                    extensions = new ArrayList<>();
                 }
                 extensions.add(locextKey.toString() + SEP + ext.getValue());
             }

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/ULocaleTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/ULocaleTest.java
@@ -4151,7 +4151,9 @@ public class ULocaleTest extends TestFmwk {
                 {"en-u-baz-ca-islamic-civil",   "en@attribute=baz;calendar=islamic-civil",  NOERROR},
                 {"en-a-bar-u-ca-islamic-civil-x-u-foo", "en@a=bar;calendar=islamic-civil;x=u-foo",  NOERROR},
                 {"en-a-bar-u-baz-ca-islamic-civil-x-u-foo", "en@a=bar;attribute=baz;calendar=islamic-civil;x=u-foo",    NOERROR},
-
+                /* #20098 */
+                {"hant-cmn-TW",         "hant",                 Integer.valueOf(5)},
+                {"zh-cmn-TW",           "cmn_TW",               NOERROR},
         };
 
         for (int i = 0; i < langtag_to_locale.length; i++) {
@@ -4306,7 +4308,7 @@ public class ULocaleTest extends TestFmwk {
         for (String[] testcase : TESTCASES) {
             ULocale loc = ULocale.forLanguageTag(testcase[0]);
 
-            Set<String> expectedAttributes = new HashSet<String>();
+            Set<String> expectedAttributes = new HashSet<>();
             if (testcase[1] != null) {
                 String[] attrs = testcase[1].split(",");
                 for (String s : attrs) {
@@ -4314,7 +4316,7 @@ public class ULocaleTest extends TestFmwk {
                 }
             }
 
-            Map<String, String> expectedKeywords = new HashMap<String, String>();
+            Map<String, String> expectedKeywords = new HashMap<>();
             if (testcase[2] != null) {
                 String[] ukeys = testcase[2].split(",");
                 for (int i = 0; i < ukeys.length; i++) {
@@ -4646,7 +4648,7 @@ public class ULocaleTest extends TestFmwk {
                 "zh_Hant_TW",
         };
 
-        TreeSet<ULocale> sortedLocales = new TreeSet<ULocale>();
+        TreeSet<ULocale> sortedLocales = new TreeSet<>();
         for (ULocale locale : locales) {
             sortedLocales.add(locale);
         }


### PR DESCRIPTION
This is a fix for ICU-20098 in ICU4J.  PR #102 was already created for ICU4C.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed at https://unicode-org.atlassian.net :  ICU-______
- [x] Update PR title to include Issue number
- [ ] Issue accepted
- [x ] Tests included
- [N/A] Documentation is changed or added

