### PR TITLE
ICU-20075 Prevent buffer overflow in uprv_getDefaultLocaleID if POSIX locale includes '@'

### DIFF
--- a/icu4c/source/common/putil.cpp
+++ b/icu4c/source/common/putil.cpp
@@ -1668,7 +1668,8 @@ The leftmost codepage (.xxx) wins.
     /* Note that we scan the *uncorrected* ID. */
     if ((p = uprv_strrchr(posixID, '@')) != NULL) {
         if (correctedPOSIXLocale == NULL) {
-            correctedPOSIXLocale = static_cast<char *>(uprv_malloc(uprv_strlen(posixID)+1));
+            /* new locale can be 1 char longer than old one if @ -> __ */
+            correctedPOSIXLocale = static_cast<char *>(uprv_malloc(uprv_strlen(posixID)+2));
             /* Exit on memory allocation error. */
             if (correctedPOSIXLocale == NULL) {
                 return NULL;
@@ -1685,7 +1686,7 @@ The leftmost codepage (.xxx) wins.
         }
 
         if (uprv_strchr(correctedPOSIXLocale,'_') == NULL) {
-            uprv_strcat(correctedPOSIXLocale, "__"); /* aa@b -> aa__b */
+            uprv_strcat(correctedPOSIXLocale, "__"); /* aa@b -> aa__b (note this can make the new locale 1 char longer) */
         }
         else {
             uprv_strcat(correctedPOSIXLocale, "_"); /* aa_CC@b -> aa_CC_b */


### PR DESCRIPTION
In the portion of uprv_getDefaultLocaleID conditionalized with #if U_POSIX_LOCALE, a buffer "correctedPOSIXLocale" for editing the POSIX locale is malloc'ed with a size equal to the input locale, plus 1 for zero terminator. This assumes that the editing will never increase the length of the locale ID beyond the length of the current locale. However, any '@' in the POSIX locale is replaced with two underscores "__" which does increase the length by 1. The buffer needs to be malloc'ed with one additional byte.

This depends on both being able to sent the environment variable LANG (or LC_TYPE) before the test starts, and also depends on being able to detect a write 1 beyond the end of a malloc'ed buffer. Both of these are hard to accomplish in a programmatic self-test; they need to be tested separately, probably using a standalone test built with a compile option or malloc library that can detect buffer overwrites, coupled with setting the environment variable before running the test.

##### Checklist

- [x] Issue filed at https://unicode-org.atlassian.net :  ICU-20075
- [x] Update PR title to include Issue number
- [x] Issue accepted
- [ ] Tests included => no reasonable way to have a self-test for this
- [x] Documentation is changed or added => just inline comments
