### PR TITLE
ICU-20136 Check U_HAVE_TZ* values

### DIFF
--- a/icu4c/source/common/putilimp.h
+++ b/icu4c/source/common/putilimp.h
@@ -132,7 +132,7 @@ typedef size_t uintptr_t;
 #   define U_TIMEZONE timezone
 #endif
 
-#ifdef U_TZNAME
+#if defined(U_TZNAME) || defined(U_HAVE_TZNAME)
     /* Use the predefined value. */
 #elif U_PLATFORM_USES_ONLY_WIN32_API
     /* not usable on all windows platforms */

--- a/icu4c/source/common/putilimp.h
+++ b/icu4c/source/common/putilimp.h
@@ -94,7 +94,7 @@ typedef size_t uintptr_t;
 #   define U_NL_LANGINFO_CODESET CODESET
 #endif
 
-#ifdef U_TZSET
+#if defined(U_TZSET) || defined(U_HAVE_TZSET)
     /* Use the predefined value. */
 #elif U_PLATFORM_USES_ONLY_WIN32_API
     // UWP doesn't support tzset or environment variables for tz


### PR DESCRIPTION
Currently if no value is found on a platform for either `U_TZSET` or `U_TZNAME` the build will fail. This because the value will fall through to the default else.

The configure currently exposes both `U_HAVE_TZSET` and `U_HAVE_TZSET` so this should be checked to provide a predefined value. This adds the same behavior that is present in the `U_TIMEZONE` block.

##### Checklist

- [X] Issue filed at https://unicode-org.atlassian.net :  ICU-20136
- [X] Update PR title to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

