### PR TITLE
ICU-20133 Undeprecate Transliterator.Position#hashCode

### DIFF
--- a/icu4j/main/classes/translit/src/com/ibm/icu/text/Transliterator.java
+++ b/icu4j/main/classes/translit/src/com/ibm/icu/text/Transliterator.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
+import java.util.Objects;
 
 import com.ibm.icu.impl.ICUData;
 import com.ibm.icu.impl.ICUResourceBundle;
@@ -372,16 +373,11 @@ public abstract class Transliterator implements StringTransform  {
         }
 
         /**
-         * Mock implementation of hashCode(). This implementation always returns a constant
-         * value. When Java assertion is enabled, this method triggers an assertion failure.
-         * @internal
-         * @deprecated This API is ICU internal only.
+         * @draft ICU 63
          */
         @Override
-        @Deprecated
         public int hashCode() {
-            assert false : "hashCode not designed";
-            return 42;
+            return Objects.hash(contextStart, contextLimit, start, limit);
         }
 
         /**

--- a/icu4j/main/tests/translit/src/com/ibm/icu/dev/test/translit/TransliteratorTest.java
+++ b/icu4j/main/tests/translit/src/com/ibm/icu/dev/test/translit/TransliteratorTest.java
@@ -3949,4 +3949,18 @@ the ::BEGIN/::END stuff)
             "exception for a rule of '\\'");
         }
     }
+
+    /**
+     * Tests equals and hashCode implementation of Transliterator.Position
+     */
+    @Test
+    public void TestPositionEquals() {
+        Transliterator.Position position1 = new Transliterator.Position(1, 0, 0, 0);
+        Transliterator.Position position2 = new Transliterator.Position(0, 0, 0, 0);
+        assertNotEquals("2 different positions are not equal", position1, position2);
+        assertNotEquals("2 different positions have different hash codes", position1.hashCode(), position2.hashCode());
+        Transliterator.Position position3 = new Transliterator.Position(1, 0, 0, 0);
+        assertEquals("2 positions are equal", position1, position3);
+        assertEquals("2 positions have the same hash codes", position1.hashCode(), position3.hashCode());
+    }
 }


### PR DESCRIPTION
Create a proper hash code with Objects.hash instead of returning 42

##### Checklist

- [x] Issue filed at https://unicode-org.atlassian.net :  ICU-20133
- [x] Update PR title to include Issue number
- [ ] Issue accepted
- [x] Tests included
- [x] Documentation is changed or added

