### PR TITLE
ICU-13417 Pass length from Locale::forLanguageTag() to ultag_parse().

### DIFF
--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -858,12 +858,6 @@ Locale::forLanguageTag(StringPiece tag, UErrorCode& status)
         return result;
     }
 
-    // TODO: Remove the need for a const char* to a NUL terminated buffer.
-    const CharString tag_nul(tag, status);
-    if (U_FAILURE(status)) {
-        return result;
-    }
-
     // If a BCP-47 language tag is passed as the language parameter to the
     // normal Locale constructor, it will actually fall back to invoking
     // uloc_forLanguageTag() to parse it if it somehow is able to detect that
@@ -893,8 +887,9 @@ Locale::forLanguageTag(StringPiece tag, UErrorCode& status)
             return result;
         }
 
-        reslen = uloc_forLanguageTag(
-                tag_nul.data(),
+        reslen = uloc_forLanguageTagImpl(
+                tag.data(),
+                tag.length(),
                 buffer,
                 resultCapacity,
                 &parsedLength,

--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -46,6 +46,7 @@
 #include "cstring.h"
 #include "uassert.h"
 #include "uhash.h"
+#include "ulocimp.h"
 #include "ucln_cmn.h"
 #include "ustr_imp.h"
 #include "charstr.h"
@@ -887,7 +888,7 @@ Locale::forLanguageTag(StringPiece tag, UErrorCode& status)
             return result;
         }
 
-        reslen = uloc_forLanguageTagImpl(
+        reslen = ulocimp_forLanguageTag(
                 tag.data(),
                 tag.length(),
                 buffer,

--- a/icu4c/source/common/uloc_tag.cpp
+++ b/icu4c/source/common/uloc_tag.cpp
@@ -2416,6 +2416,23 @@ uloc_forLanguageTag(const char* langtag,
                     int32_t localeIDCapacity,
                     int32_t* parsedLength,
                     UErrorCode* status) {
+    return uloc_forLanguageTagImpl(
+            langtag,
+            -1,
+            localeID,
+            localeIDCapacity,
+            parsedLength,
+            status);
+}
+
+
+U_CAPI int32_t U_EXPORT2
+uloc_forLanguageTagImpl(const char* langtag,
+                        int32_t tagLen,
+                        char* localeID,
+                        int32_t localeIDCapacity,
+                        int32_t* parsedLength,
+                        UErrorCode* status) {
     ULanguageTag *lt;
     int32_t reslen = 0;
     const char *subtag, *p;
@@ -2423,7 +2440,7 @@ uloc_forLanguageTag(const char* langtag,
     int32_t i, n;
     UBool noRegion = TRUE;
 
-    lt = ultag_parse(langtag, -1, parsedLength, status);
+    lt = ultag_parse(langtag, tagLen, parsedLength, status);
     if (U_FAILURE(*status)) {
         return 0;
     }

--- a/icu4c/source/common/uloc_tag.cpp
+++ b/icu4c/source/common/uloc_tag.cpp
@@ -2416,7 +2416,7 @@ uloc_forLanguageTag(const char* langtag,
                     int32_t localeIDCapacity,
                     int32_t* parsedLength,
                     UErrorCode* status) {
-    return uloc_forLanguageTagImpl(
+    return ulocimp_forLanguageTag(
             langtag,
             -1,
             localeID,
@@ -2427,12 +2427,12 @@ uloc_forLanguageTag(const char* langtag,
 
 
 U_CAPI int32_t U_EXPORT2
-uloc_forLanguageTagImpl(const char* langtag,
-                        int32_t tagLen,
-                        char* localeID,
-                        int32_t localeIDCapacity,
-                        int32_t* parsedLength,
-                        UErrorCode* status) {
+ulocimp_forLanguageTag(const char* langtag,
+                       int32_t tagLen,
+                       char* localeID,
+                       int32_t localeIDCapacity,
+                       int32_t* parsedLength,
+                       UErrorCode* status) {
     ULanguageTag *lt;
     int32_t reslen = 0;
     const char *subtag, *p;

--- a/icu4c/source/common/ulocimp.h
+++ b/icu4c/source/common/ulocimp.h
@@ -62,6 +62,38 @@ ulocimp_getCountry(const char *localeID,
                    const char **pEnd);
 
 /**
+ * Returns a locale ID for the specified BCP47 language tag string.
+ * If the specified language tag contains any ill-formed subtags,
+ * the first such subtag and all following subtags are ignored.
+ * <p>
+ * This implements the 'Language-Tag' production of BCP47, and so
+ * supports grandfathered (regular and irregular) as well as private
+ * use language tags.  Private use tags are represented as 'x-whatever',
+ * and grandfathered tags are converted to their canonical replacements
+ * where they exist.  Note that a few grandfathered tags have no modern
+ * replacement, these will be converted using the fallback described in
+ * the first paragraph, so some information might be lost.
+ * @param langtag   the input BCP47 language tag.
+ * @param tagLen    the length of langtag, or -1 to call uprv_strlen().
+ * @param localeID  the output buffer receiving a locale ID for the
+ *                  specified BCP47 language tag.
+ * @param localeIDCapacity  the size of the locale ID output buffer.
+ * @param parsedLength  if not NULL, successfully parsed length
+ *                      for the input language tag is set.
+ * @param err       error information if receiving the locald ID
+ *                  failed.
+ * @return          the length of the locale ID.
+ * @internal ICU 63
+ */
+U_STABLE int32_t U_EXPORT2
+ulocimp_forLanguageTag(const char* langtag,
+                       int32_t tagLen,
+                       char* localeID,
+                       int32_t localeIDCapacity,
+                       int32_t* parsedLength,
+                       UErrorCode* err);
+
+/**
  * Get the region to use for supplemental data lookup. Uses
  * (1) any region specified by locale tag "rg"; if none then
  * (2) any unicode_region_tag in the locale ID; if none then

--- a/icu4c/source/common/unicode/uloc.h
+++ b/icu4c/source/common/unicode/uloc.h
@@ -1142,6 +1142,16 @@ uloc_forLanguageTag(const char* langtag,
                     int32_t* parsedLength,
                     UErrorCode* err);
 
+#ifndef U_HIDE_SYSTEM_API
+U_STABLE int32_t U_EXPORT2
+uloc_forLanguageTagImpl(const char* langtag,
+                        int32_t tagLen,
+                        char* localeID,
+                        int32_t localeIDCapacity,
+                        int32_t* parsedLength,
+                        UErrorCode* err);
+#endif  /* U_HIDE_SYSTEM_API */
+
 /**
  * Returns a well-formed language tag for this locale ID. 
  * <p> 

--- a/icu4c/source/common/unicode/uloc.h
+++ b/icu4c/source/common/unicode/uloc.h
@@ -1142,16 +1142,6 @@ uloc_forLanguageTag(const char* langtag,
                     int32_t* parsedLength,
                     UErrorCode* err);
 
-#ifndef U_HIDE_SYSTEM_API
-U_STABLE int32_t U_EXPORT2
-uloc_forLanguageTagImpl(const char* langtag,
-                        int32_t tagLen,
-                        char* localeID,
-                        int32_t localeIDCapacity,
-                        int32_t* parsedLength,
-                        UErrorCode* err);
-#endif  /* U_HIDE_SYSTEM_API */
-
 /**
  * Returns a well-formed language tag for this locale ID. 
  * <p> 


### PR DESCRIPTION
If not passed a length, ultag_parse() will call uprv_strlen(), requiring
the input buffer to be NUL terminated. This is unnecessary.