### PR TITLE
ICU-20147 Fix MSVC warning C4251 for SimpleModifier::fParameters, and other warnings too

### DIFF
--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -738,7 +738,7 @@ Locale::addLikelySubtags(UErrorCode& status) {
     // The maximized locale ID string is often longer, but there is no good
     // heuristic to estimate just how much longer. Leave that to CharString.
     CharString maximizedLocaleID;
-    int32_t maximizedLocaleIDCapacity = uprv_strlen(fullName);
+    int32_t maximizedLocaleIDCapacity = static_cast<int32_t>(uprv_strlen(fullName));
 
     char* buffer;
     int32_t reslen;
@@ -797,7 +797,7 @@ Locale::minimizeSubtags(UErrorCode& status) {
     // "en__POSIX"), minimized locale ID strings will be either the same length
     // or shorter than their input.
     CharString minimizedLocaleID;
-    int32_t minimizedLocaleIDCapacity = uprv_strlen(fullName);
+    int32_t minimizedLocaleIDCapacity = static_cast<int32_t>(uprv_strlen(fullName));
 
     char* buffer;
     int32_t reslen;
@@ -952,7 +952,7 @@ Locale::toLanguageTag(ByteSink& sink, UErrorCode& status) const
     // All simple language tags will have the exact same length as BCP-47
     // strings as they have as ICU locale IDs (like "en-US" for "en_US").
     LocalMemory<char> scratch;
-    int32_t scratch_capacity = uprv_strlen(fullName);
+    int32_t scratch_capacity = static_cast<int32_t>(uprv_strlen(fullName));
 
     if (scratch_capacity == 0) {
         scratch_capacity = 3;  // "und"
@@ -1324,7 +1324,9 @@ public:
             if (key == nullptr) {
                 status = U_ILLEGAL_ARGUMENT_ERROR;
             } else {
-                if (resultLength != nullptr) *resultLength = uprv_strlen(key);
+                if (resultLength != nullptr) {
+                    *resultLength = static_cast<int32_t>(uprv_strlen(key));
+                }
                 return key;
             }
         }
@@ -1493,7 +1495,7 @@ Locale::getUnicodeKeywordValue(StringPiece keywordName,
         return;
     }
 
-    sink.Append(unicode_value, uprv_strlen(unicode_value));
+    sink.Append(unicode_value, static_cast<int32_t>(uprv_strlen(unicode_value)));
 }
 
 void

--- a/icu4c/source/i18n/gregocal.cpp
+++ b/icu4c/source/i18n/gregocal.cpp
@@ -572,7 +572,7 @@ int32_t GregorianCalendar::handleComputeMonthStart(int32_t eyear, int32_t month,
         julianDay += isLeap?kLeapNumDays[month]:kNumDays[month];
     }
 
-    return julianDay;
+    return static_cast<int32_t>(julianDay);
 }
 
 int32_t GregorianCalendar::handleGetMonthLength(int32_t extendedYear, int32_t month)  const

--- a/icu4c/source/i18n/gregoimp.h
+++ b/icu4c/source/i18n/gregoimp.h
@@ -300,7 +300,7 @@ inline int32_t Grego::millisToJulianDay(double millis) {
 
 inline int32_t Grego::gregorianShift(int32_t eyear) {
   int64_t y = (int64_t)eyear-1;
-  int32_t gregShift = ClockMath::floorDivide(y, (int64_t)400) - ClockMath::floorDivide(y, (int64_t)100) + 2;
+  int32_t gregShift = static_cast<int32_t>(ClockMath::floorDivide(y, (int64_t)400) - ClockMath::floorDivide(y, (int64_t)100) + 2);
   return gregShift;
 }
 

--- a/icu4c/source/i18n/number_types.h
+++ b/icu4c/source/i18n/number_types.h
@@ -190,7 +190,7 @@ class U_I18N_API Modifier {
      * A fill-in for getParameters(). obj will always be set; if non-null, the other
      * two fields are also safe to read.
      */
-    struct Parameters {
+    struct U_I18N_API Parameters {
         const ModifierStore* obj = nullptr;
         int8_t signum;
         StandardPlural::Form plural;

--- a/icu4c/source/io/ufmt_cmn.cpp
+++ b/icu4c/source/io/ufmt_cmn.cpp
@@ -235,7 +235,7 @@ ufmt_defaultCPToUnicode(const char *s, int32_t sSize,
         return 0;
 
     if(sSize <= 0) {
-        sSize = uprv_strlen(s) + 1;
+        sSize = static_cast<int32_t>(uprv_strlen(s)) + 1;
     }
     
     /* perform the conversion in one swoop */

--- a/icu4c/source/io/uprintf.cpp
+++ b/icu4c/source/io/uprintf.cpp
@@ -183,7 +183,7 @@ u_vfprintf(    UFILE        *f,
     else {
         pattern = buffer;
     }
-    u_charsToUChars(patternSpecification, pattern, size);
+    u_charsToUChars(patternSpecification, pattern, static_cast<int32_t>(size));
 
     /* do the work */
     count = u_vfprintf_u(f, pattern, ap);

--- a/icu4c/source/io/ustream.cpp
+++ b/icu4c/source/io/ustream.cpp
@@ -123,7 +123,7 @@ operator>>(STD_ISTREAM& stream, UnicodeString& str)
             /* Was the character consumed? */
             if (us != uBuffer) {
                 /* Reminder: ibm-1390 & JISX0213 can output 2 Unicode code points */
-                int32_t uBuffSize = us-uBuffer;
+                int32_t uBuffSize = static_cast<int32_t>(us-uBuffer);
                 int32_t uBuffIdx = 0;
                 while (uBuffIdx < uBuffSize) {
                     U16_NEXT(uBuffer, uBuffIdx, uBuffSize, ch32);

--- a/icu4c/source/tools/gencfu/gencfu.cpp
+++ b/icu4c/source/tools/gencfu/gencfu.cpp
@@ -319,7 +319,7 @@ int  main(int argc, char **argv) {
         return NULL;
     }
 
-    long t = fread(result, 1, fileSize, file);
+    long t = static_cast<long>(fread(result, 1, fileSize, file));
     if (t != fileSize)  {
         delete [] result;
         fclose(file);

--- a/icu4c/source/tools/gencnval/gencnval.c
+++ b/icu4c/source/tools/gencnval/gencnval.c
@@ -965,7 +965,7 @@ createNormalizedAliasStrings(char *normalizedStrings, const char *origStringBloc
         if (currStrLen > 0) {
             int32_t normStrLen;
             ucnv_io_stripForCompare(normalizedStrings, origStringBlock);
-            normStrLen = uprv_strlen(normalizedStrings);
+            normStrLen = (int32_t)uprv_strlen(normalizedStrings);
             if (normStrLen > 0) {
                 uprv_memset(normalizedStrings + normStrLen, 0, currStrSize - normStrLen);
             }

--- a/icu4c/source/tools/gensprep/gensprep.c
+++ b/icu4c/source/tools/gensprep/gensprep.c
@@ -355,7 +355,7 @@ strprepProfileLineFn(void *context,
     if (*s == '@') {
         /* special directive */
         s++;
-        length = fields[0][1] - s;
+        length = (int32_t)(fields[0][1] - s);
         if (length >= NORMALIZE_DIRECTIVE_LEN
             && uprv_strncmp(s, NORMALIZE_DIRECTIVE, NORMALIZE_DIRECTIVE_LEN) == 0) {
             options[NORMALIZE].doesOccur = TRUE;

--- a/icu4c/source/tools/pkgdata/pkgdata.cpp
+++ b/icu4c/source/tools/pkgdata/pkgdata.cpp
@@ -511,7 +511,7 @@ main(int argc, char* argv[]) {
 static int runCommand(const char* command, UBool specialHandling) {
     char *cmd = NULL;
     char cmdBuffer[SMALL_BUFFER_MAX_SIZE];
-    int32_t len = strlen(command);
+    int32_t len = static_cast<int32_t>(strlen(command));
 
     if (len == 0) {
         return 0;
@@ -1226,7 +1226,7 @@ static int32_t pkg_installFileMode(const char *installDir, const char *srcDir, c
     if (f != NULL) {
         for(;;) {
             if (T_FileStream_readLine(f, buffer, SMALL_BUFFER_MAX_SIZE) != NULL) {
-                bufferLength = uprv_strlen(buffer);
+                bufferLength = static_cast<int32_t>(uprv_strlen(buffer));
                 /* Remove new line character. */
                 if (bufferLength > 0) {
                     buffer[bufferLength-1] = 0;

--- a/icu4c/source/tools/toolutil/filestrm.cpp
+++ b/icu4c/source/tools/toolutil/filestrm.cpp
@@ -104,14 +104,14 @@ T_FileStream_tmpfile()
 U_CAPI int32_t U_EXPORT2
 T_FileStream_read(FileStream* fileStream, void* addr, int32_t len)
 {
-    return fread(addr, 1, len, (FILE*)fileStream);
+    return static_cast<int32_t>(fread(addr, 1, len, (FILE*)fileStream));
 }
 
 U_CAPI int32_t U_EXPORT2
 T_FileStream_write(FileStream* fileStream, const void* addr, int32_t len)
 {
 
-    return fwrite(addr, 1, len, (FILE*)fileStream);
+    return static_cast<int32_t>(fwrite(addr, 1, len, (FILE*)fileStream));
 }
 
 U_CAPI void U_EXPORT2

--- a/icu4c/source/tools/toolutil/filetools.cpp
+++ b/icu4c/source/tools/toolutil/filetools.cpp
@@ -134,7 +134,7 @@ static int32_t whichFileModTimeIsLater(const char *file1, const char *file2) {
 /* Swap the file separater character given with the new one in the file path. */
 U_CAPI void U_EXPORT2
 swapFileSepChar(char *filePath, const char oldFileSepChar, const char newFileSepChar) {
-    for (int32_t i = 0, length = uprv_strlen(filePath); i < length; i++) {
+    for (int32_t i = 0, length = static_cast<int32_t>(uprv_strlen(filePath)); i < length; i++) {
         filePath[i] = (filePath[i] == oldFileSepChar ) ? newFileSepChar : filePath[i];
     }
 }

--- a/icu4c/source/tools/toolutil/package.cpp
+++ b/icu4c/source/tools/toolutil/package.cpp
@@ -610,7 +610,7 @@ Package::readPackage(const char *filename) {
             memcpy(prefix, s, ++prefixLength);  // include the /
         } else {
             // Use the package basename as prefix.
-            int32_t inPkgNameLength=strlen(inPkgName);
+            int32_t inPkgNameLength= static_cast<int32_t>(strlen(inPkgName));
             memcpy(prefix, inPkgName, inPkgNameLength);
             prefixLength=inPkgNameLength;
 
@@ -1043,7 +1043,7 @@ Package::addItem(const char *name, uint8_t *data, int32_t length, UBool isDataOw
         memset(items+idx, 0, sizeof(Item));
 
         // copy the item's name
-        items[idx].name=allocString(TRUE, strlen(name));
+        items[idx].name=allocString(TRUE, static_cast<int32_t>(strlen(name)));
         strcpy(items[idx].name, name);
         pathToTree(items[idx].name);
     } else {

--- a/icu4c/source/tools/toolutil/udbgutil.cpp
+++ b/icu4c/source/tools/toolutil/udbgutil.cpp
@@ -400,7 +400,7 @@ U_CAPI  int32_t
 paramStatic(const USystemParams *param, char *target, int32_t targetCapacity, UErrorCode *status) {
   if(param->paramStr==NULL) return paramEmpty(param,target,targetCapacity,status);
   if(U_FAILURE(*status))return 0;
-  int32_t len = uprv_strlen(param->paramStr);
+  int32_t len = static_cast<int32_t>(uprv_strlen(param->paramStr));
   if(target!=NULL) {
     uprv_strncpy(target,param->paramStr,uprv_min(len,targetCapacity));
   }
@@ -412,14 +412,14 @@ static const char *nullString = "(null)";
 static int32_t stringToStringBuffer(char *target, int32_t targetCapacity, const char *str, UErrorCode *status) {
   if(str==NULL) str=nullString;
 
-  int32_t len = uprv_strlen(str);
+  int32_t len = static_cast<int32_t>(uprv_strlen(str));
   if (U_SUCCESS(*status)) {
     if(target!=NULL) {
       uprv_strncpy(target,str,uprv_min(len,targetCapacity));
     }
   } else {
     const char *s = u_errorName(*status);
-    len = uprv_strlen(s);
+    len = static_cast<int32_t>(uprv_strlen(s));
     if(target!=NULL) {
       uprv_strncpy(target,s,uprv_min(len,targetCapacity));
     }


### PR DESCRIPTION
##### Checklist

- [x] Issue filed at https://unicode-org.atlassian.net :  ICU-20147
- [x] Update PR title to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

