### PR TITLE
ICU-20050 Fixing memory leaks in move and copy assignment in Number*Formatter

### DIFF
--- a/icu4c/source/i18n/numrange_fluent.cpp
+++ b/icu4c/source/i18n/numrange_fluent.cpp
@@ -227,18 +227,26 @@ LocalizedNumberRangeFormatter::LocalizedNumberRangeFormatter(LocalizedNumberRang
 
 LocalizedNumberRangeFormatter::LocalizedNumberRangeFormatter(NFS<LNF>&& src) U_NOEXCEPT
         : NFS<LNF>(std::move(src)) {
-    // No additional fields to assign
+    // Steal the compiled formatter
+    LNF&& _src = static_cast<LNF&&>(src);
+    fImpl = _src.fImpl;
+    _src.fImpl = nullptr;
 }
 
 LocalizedNumberRangeFormatter& LocalizedNumberRangeFormatter::operator=(const LNF& other) {
     NFS<LNF>::operator=(static_cast<const NFS<LNF>&>(other));
-    // No additional fields to assign
+    // Do not steal; just clear
+    delete fImpl;
+    fImpl = nullptr;
     return *this;
 }
 
 LocalizedNumberRangeFormatter& LocalizedNumberRangeFormatter::operator=(LNF&& src) U_NOEXCEPT {
     NFS<LNF>::operator=(static_cast<NFS<LNF>&&>(src));
-    // No additional fields to assign
+    // Steal the compiled formatter
+    delete fImpl;
+    fImpl = src.fImpl;
+    src.fImpl = nullptr;
     return *this;
 }
 

--- a/icu4c/source/i18n/unicode/numberformatter.h
+++ b/icu4c/source/i18n/unicode/numberformatter.h
@@ -2358,6 +2358,8 @@ class U_I18N_API LocalizedNumberFormatter
 
     LocalizedNumberFormatter(impl::MacroProps &&macros, const Locale &locale);
 
+    void clear();
+
     void lnfMoveHelper(LocalizedNumberFormatter&& src);
 
     /**

--- a/icu4c/source/i18n/unicode/numberrangeformatter.h
+++ b/icu4c/source/i18n/unicode/numberrangeformatter.h
@@ -625,6 +625,8 @@ class U_I18N_API LocalizedNumberRangeFormatter
 
     LocalizedNumberRangeFormatter(impl::RangeMacroProps &&macros, const Locale &locale);
 
+    void clear();
+
     // To give the fluent setters access to this class's constructor:
     friend class NumberRangeFormatterSettings<UnlocalizedNumberRangeFormatter>;
     friend class NumberRangeFormatterSettings<LocalizedNumberRangeFormatter>;

--- a/icu4c/source/test/intltest/numbertest.h
+++ b/icu4c/source/test/intltest/numbertest.h
@@ -257,6 +257,7 @@ class NumberRangeFormatterTest : public IntlTest {
     void testIdentity();
     void testDifferentFormatters();
     void testPlurals();
+    void testCopyMove();
 
     void runIndexedTest(int32_t index, UBool exec, const char *&name, char *par = 0);
 

--- a/icu4c/source/test/intltest/numbertest_api.cpp
+++ b/icu4c/source/test/intltest/numbertest_api.cpp
@@ -2372,8 +2372,15 @@ void NumberFormatterApiTest::copyMove() {
     assertTrue("[constructor] Source should be reset after move", l1.getCompiled() == nullptr);
 
     // Reset l1 and l2 to check for macro-props copying for behavior testing
+    // Make the test more interesting: also warm them up with a compiled formatter.
     l1 = NumberFormatter::withLocale("en");
+    l1.formatInt(1, status);
+    l1.formatInt(1, status);
+    l1.formatInt(1, status);
     l2 = NumberFormatter::withLocale("en");
+    l2.formatInt(1, status);
+    l2.formatInt(1, status);
+    l2.formatInt(1, status);
 
     // Copy assignment
     l1 = l3;


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed at https://unicode-org.atlassian.net :  ICU-20050
- [x] Update PR title to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

