### PR TITLE
ICU-13830 Fixing CurrencyDisplayNames.getInstance(Locale) boolean attribute behavior.

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/text/CurrencyDisplayNames.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/CurrencyDisplayNames.java
@@ -51,7 +51,7 @@ public abstract class CurrencyDisplayNames {
      * @stable ICU 54
      */
     public static CurrencyDisplayNames getInstance(Locale locale) {
-        return getInstance(locale, true);
+        return getInstance(locale, false);
     }
 
     /**

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/CurrencyTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/CurrencyTest.java
@@ -320,6 +320,18 @@ public class CurrencyTest extends TestFmwk {
         assertNotNull("have currency data for Germany (Java Locale)", cdn);
         assertEquals("de_USD_name (Locale)", "US-Dollar", cdn.getName("USD"));
         assertNull("de_FOO_name (Locale)", cdn.getName("FOO"));
+
+        // Locale version with noSubstitute=false
+        cdn = CurrencyDisplayNames.getInstance(Locale.GERMANY, false);
+        assertNotNull("have currency data for Germany (Java Locale, false)", cdn);
+        assertEquals("de_USD_name (Locale, false)", "US-Dollar", cdn.getName("USD"));
+        assertEquals("de_USD_plural_foo (Locale, false)", "US-Dollar", cdn.getPluralName("USD", "foo"));
+
+        // Locale version with no boolean attribute; should behave the same as noSubstitute=false
+        cdn = CurrencyDisplayNames.getInstance(Locale.GERMANY);
+        assertNotNull("have currency data for Germany (Java Locale, default)", cdn);
+        assertEquals("de_USD_name (Locale, default)", "US-Dollar", cdn.getName("USD"));
+        assertEquals("de_USD_plural_foo (Locale, default)", "US-Dollar", cdn.getPluralName("USD", "foo"));
     }
 
     // Coverage-only test of CurrencyData


### PR DESCRIPTION
##### Checklist

- [x] Issue filed at https://unicode-org.atlassian.net :  ICU-13830
- [x] Update PR title to include Issue number
- [x] Issue accepted
- [x] Tests included
- [x] Documentation is changed or added

