### PR TITLE
ICU-20157 Fix MSVC C4251: Need to export explicit template instantiation, plus some more warning fixes.

### DIFF
--- a/icu4c/source/common/sharedobject.h
+++ b/icu4c/source/common/sharedobject.h
@@ -104,7 +104,7 @@ public:
     /**
      * Deletes this object if it has no references.
      * Available for non-cached SharedObjects only. Ownership of cached objects
-     * is with the UnifiedCache, which is soley responsible for eviction and deletion.
+     * is with the UnifiedCache, which is solely responsible for eviction and deletion.
      */
     void deleteIfZeroRefCount() const;
 

--- a/icu4c/source/common/umutex.h
+++ b/icu4c/source/common/umutex.h
@@ -212,7 +212,7 @@ umtx_atomic_dec(u_atomic_int32_t *p);
 
 U_NAMESPACE_END
 
-#endif  /* Low Level Atomic Ops Platfrom Chain */
+#endif  /* Low Level Atomic Ops Platform Chain */
 
 
 
@@ -326,7 +326,7 @@ U_NAMESPACE_END
  *************************************************************************************************/
 
 #if defined(U_USER_MUTEX_H)
-// #inlcude "U_USER_MUTEX_H"
+// #include "U_USER_MUTEX_H"
 #include U_MUTEX_XSTR(U_USER_MUTEX_H)
 
 #elif U_PLATFORM_USES_ONLY_WIN32_API
@@ -396,7 +396,7 @@ struct UConditionVar {
 #else
 
 /*
- *  Unknow platform type.
+ *  Unknown platform type.
  *      This is an error condition. ICU requires mutexes.
  */
 
@@ -408,7 +408,7 @@ struct UConditionVar {
 
 /**************************************************************************************
  *
- *  Mutex Implementation function declaratations.
+ *  Mutex Implementation function declarations.
  *     Declarations are platform neutral.
  *     Implementations, in umutex.cpp, are platform specific.
  *

--- a/icu4c/source/common/umutex.h
+++ b/icu4c/source/common/umutex.h
@@ -56,6 +56,13 @@ U_NAMESPACE_END
 
 U_NAMESPACE_BEGIN
 
+// Export an explicit template instantiation of std::atomic<int32_t>. 
+// When building DLLs for Windows this is required as it is used as a data member of the exported SharedObject class.
+// See digitlst.h, pluralaffix.h, datefmt.h, and others for similar examples.
+#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
+template struct U_COMMON_API std::atomic<int32_t>;
+#endif
+
 typedef std::atomic<int32_t> u_atomic_int32_t;
 #define ATOMIC_INT32_T_INITIALIZER(val) ATOMIC_VAR_INIT(val)
 

--- a/icu4c/source/test/cintltst/callcoll.c
+++ b/icu4c/source/test/cintltst/callcoll.c
@@ -416,7 +416,7 @@ static void doTestVariant(UCollator* myCollation, const UChar source[], const UC
     ucol_getSortKey(myCollation, target, -1,   sortKey2a, sortklen2+1);
 
     /* Check that sort key generated with null terminated string is identical  */
-    /*  to that generted with a length specified.                              */
+    /*  to that generated with a length specified.                              */
     if (uprv_strcmp((const char *)sortKey1, (const char *)sortKey1a) != 0 ||
         uprv_strcmp((const char *)sortKey2, (const char *)sortKey2a) != 0 ) {
         log_err("Sort Keys from null terminated and explicit length strings differ.\n");
@@ -424,8 +424,8 @@ static void doTestVariant(UCollator* myCollation, const UChar source[], const UC
 
     /*memcmp(sortKey1, sortKey2,sortklenmax);*/
     temp= uprv_strcmp((const char *)sortKey1, (const char *)sortKey2);
-    gSortklen1 = uprv_strlen((const char *)sortKey1)+1;
-    gSortklen2 = uprv_strlen((const char *)sortKey2)+1;
+    gSortklen1 = (int)uprv_strlen((const char *)sortKey1)+1;
+    gSortklen2 = (int)uprv_strlen((const char *)sortKey2)+1;
     if(sortklen1 != gSortklen1){
         log_err("SortKey length does not match Expected: %i Got: %i\n",sortklen1, gSortklen1);
         log_verbose("Generated sortkey: %s\n", sortKeyToString(myCollation, sortKey1, buffer, &len));
@@ -745,7 +745,7 @@ static void TestTertiary()
     UErrorCode status=U_ZERO_ERROR;
     static const char str[]="& C < ch, cH, Ch, CH & Five, 5 & Four, 4 & one, 1 & Ampersand; '&' & Two, 2 ";
     UChar rules[sizeof(str)];
-    len = strlen(str);
+    len = (int32_t)strlen(str);
     u_uastrcpy(rules, str);
 
     myCollation=ucol_openRules(rules, len, UCOL_OFF, UCOL_DEFAULT_STRENGTH, NULL, &status);
@@ -770,7 +770,7 @@ static void TestPrimary( )
     UErrorCode status=U_ZERO_ERROR;
     static const char str[]="& C < ch, cH, Ch, CH & Five, 5 & Four, 4 & one, 1 & Ampersand; '&' & Two, 2 ";   
     UChar rules[sizeof(str)];
-    len = strlen(str);
+    len = (int32_t)strlen(str);
     u_uastrcpy(rules, str);
 
     myCollation=ucol_openRules(rules, len, UCOL_OFF, UCOL_DEFAULT_STRENGTH,NULL, &status);
@@ -797,7 +797,7 @@ static void TestSecondary()
     UErrorCode status=U_ZERO_ERROR;
     static const char str[]="& C < ch, cH, Ch, CH & Five, 5 & Four, 4 & one, 1 & Ampersand; '&' & Two, 2 ";
     UChar rules[sizeof(str)];
-    len = strlen(str);
+    len = (int32_t)strlen(str);
     u_uastrcpy(rules, str);
 
     myCollation=ucol_openRules(rules, len, UCOL_OFF, UCOL_DEFAULT_STRENGTH,NULL, &status);
@@ -822,7 +822,7 @@ static void TestIdentical()
     UErrorCode status=U_ZERO_ERROR;
     static const char str[]="& C < ch, cH, Ch, CH & Five, 5 & Four, 4 & one, 1 & Ampersand; '&' & Two, 2 ";
     UChar rules[sizeof(str)];
-    len = strlen(str);
+    len = (int32_t)strlen(str);
     u_uastrcpy(rules, str);
 
     myCollation=ucol_openRules(rules, len, UCOL_OFF, UCOL_IDENTICAL, NULL,&status);
@@ -846,7 +846,7 @@ static void TestExtra()
     UErrorCode status = U_ZERO_ERROR;
     static const char str[]="& C < ch, cH, Ch, CH & Five, 5 & Four, 4 & one, 1 & Ampersand; '&' & Two, 2 ";
     UChar rules[sizeof(str)];
-    len = strlen(str);
+    len = (int32_t)strlen(str);
     u_uastrcpy(rules, str);
 
     myCollation=ucol_openRules(rules, len, UCOL_OFF, UCOL_DEFAULT_STRENGTH,NULL, &status);
@@ -1102,7 +1102,7 @@ static void TestSurrogates(void)
 {
     static const char       str[]          = 
                               "&z<'\\uD800\\uDC00'<'\\uD800\\uDC0A\\u0308'<A";
-          int         len          = strlen(str);
+          int         len          = (int)strlen(str);
           int         rlen         = 0;
           UChar      rules[sizeof(str)];
           UCollator  *myCollation;

--- a/icu4c/source/test/iotest/filetst.c
+++ b/icu4c/source/test/iotest/filetst.c
@@ -731,7 +731,7 @@ static void TestfgetsNewLineHandling(void) {
 static void TestLineCount(const char *prefixLine, const char *line, int32_t numRepititions) {
     UChar buffer[64];
     UChar expectedBuffer[64];
-    int32_t lineLen = static_cast<int32_t>(strlen(line));
+    int32_t lineLen = (int32_t)strlen(line);
     UChar *returnedUCharBuffer;
     int32_t repetitions;
     UFILE *myFile = NULL;

--- a/icu4c/source/test/iotest/filetst.c
+++ b/icu4c/source/test/iotest/filetst.c
@@ -731,7 +731,7 @@ static void TestfgetsNewLineHandling(void) {
 static void TestLineCount(const char *prefixLine, const char *line, int32_t numRepititions) {
     UChar buffer[64];
     UChar expectedBuffer[64];
-    int32_t lineLen = strlen(line);
+    int32_t lineLen = static_cast<int32_t>(strlen(line));
     UChar *returnedUCharBuffer;
     int32_t repetitions;
     UFILE *myFile = NULL;

--- a/icu4c/source/test/iotest/trnstst.c
+++ b/icu4c/source/test/iotest/trnstst.c
@@ -193,7 +193,7 @@ static void TestTranslitFileOut(void)
         return;
     }
 
-    len=fread(ubuf, sizeof(UChar), u_strlen(compare), infile);
+    len= (int)fread(ubuf, sizeof(UChar), u_strlen(compare), infile);
     log_verbose("Read %d UChars\n", len);
     if(len != u_strlen(compare))
     {

--- a/icu4c/source/tools/genrb/reslist.cpp
+++ b/icu4c/source/tools/genrb/reslist.cpp
@@ -1395,7 +1395,7 @@ SRBRoot::compactKeys(UErrorCode &errorCode) {
                 int32_t offset;
                 suffix = keys + map[j].oldpos;
                 for (suffixLimit = suffix; *suffixLimit != 0; ++suffixLimit) {}
-                offset = (int32_t)(keyLimit - key) - (suffixLimit - suffix);
+                offset = static_cast<int32_t>((keyLimit - key) - (suffixLimit - suffix));
                 if (offset < 0) {
                     break;  /* suffix cannot be longer than the original */
                 }

--- a/icu4c/source/tools/toolutil/unewdata.cpp
+++ b/icu4c/source/tools/toolutil/unewdata.cpp
@@ -61,17 +61,17 @@ udata_create(const char *dir, const char *type, const char *name,
     length = 0;					/* Start with nothing */
     if(dir != NULL  && *dir !=0)	/* Add directory length if one was given */
     {
-    	length += strlen(dir);
+    	length += static_cast<int32_t>(strlen(dir));
 	
     	/* Add 1 if dir doesn't end with path sep */
         if (dir[strlen(dir) - 1]!= U_FILE_SEP_CHAR) {
             length++;
         }
 	}
-    length += strlen(name);		/* Add the filename length */
+    length += static_cast<int32_t>(strlen(name));		/* Add the filename length */
 
     if(type != NULL  && *type !=0) { /* Add directory length if  given */
-        length += strlen(type);
+        length += static_cast<int32_t>(strlen(type));
     }
 
         


### PR DESCRIPTION
The change in ICU-12505 caused `#define U_HAVE_STD_ATOMICS 1`  to be set all the time, for all platforms.

Previously, it was only set if `U_HAVE_ATOMIC` was set either by a autoconf test or manually, meaning that Windows-based platforms used the Interlocked* APIs instead.

While looking through the errors on MSVC and trying to clean them up I noticed the following new error in ICU 63.1

```
> icu4c\source\common\sharedobject.h(176): warning C4251: 'icu_62::SharedObject::hardRefCount': struct 'std::atomic<int>' needs to have dll-interface to be used by clients of class 'icu_62::SharedObject' (compiling source file unifiedcache.cpp)
```

We need to export an explicit template instantiation for `std::atomic<int32_t>` since it is used as a data member of the exported class SharedObject.

Note: Also fixing some more MSVC warnings and typos along with this change.

##### Checklist

- [x] Issue filed at https://unicode-org.atlassian.net :  ICU-20157
- [x] Update PR title to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added
