### PR TITLE
ICU-20153 Make ICU4J JapaneseCalendar constants non-inlineable.

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/util/JapaneseCalendar.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/util/JapaneseCalendar.java
@@ -351,31 +351,43 @@ public class JapaneseCalendar extends GregorianCalendar {
     /**
      * @stable ICU 2.8
      */
-    static public final int CURRENT_ERA = ERA_RULES.getCurrentEraIndex();
+    static public final int CURRENT_ERA;
 
     /**
      * Constant for the era starting on Sept. 8, 1868 AD.
      * @stable  ICU 2.8
      */
-    static public final int MEIJI = 232;
+    static public final int MEIJI;
 
     /**
      * Constant for the era starting on July 30, 1912 AD.
      * @stable ICU 2.8
      */
-    static public final int TAISHO = 233;
+    static public final int TAISHO;
 
     /**
      * Constant for the era starting on Dec. 25, 1926 AD.
      * @stable ICU 2.8
      */
-    static public final int SHOWA = 234;
+    static public final int SHOWA;
 
     /**
      * Constant for the era starting on Jan. 7, 1989 AD.
      * @stable ICU 2.8
      */
-    static public final int HEISEI = 235;
+    static public final int HEISEI;
+
+    // We want to make these era constants initialized in a static initializer
+    // block to prevent javac to inline these values in a consumer code.
+    // By doing so, we can keep better binary compatibility across versions even
+    // these values are changed.
+    static {
+        MEIJI = 232;
+        TAISHO = 233;
+        SHOWA = 234;
+        HEISEI = 235;
+        CURRENT_ERA = ERA_RULES.getCurrentEraIndex();
+    }
 
     /**
      * Override GregorianCalendar.  We should really handle YEAR_WOY and


### PR DESCRIPTION
Updated era constants (HEISEI/SHOWA...) initialization to static initializer block. By doing so, we would make java compiler not to inline these values in consumer codes. This should allow us to support better binary compatibility across versions. There are no API changes.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed at https://unicode-org.atlassian.net :  ICU-20153
- [x] Update PR title to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

