### PR TITLE
ICU-20066 fixup .travis.yml

### DIFF
--- a/.cpyskip.txt
+++ b/.cpyskip.txt
@@ -10,6 +10,7 @@
 # git stuff
 # .git is ignored by code.
 #.git/*
+.github/*
 .gitignore
 .gitattributes
 .travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,6 @@ matrix:
           - cd icu4c/source && CPPFLAGS="-fsanitize=thread" LDFLAGS="-fsanitize=thread" ./runConfigureICU --enable-debug --disable-release Linux --disable-renaming && make -j2 check
 
     # copyright scan / future linter
-    - name "lint"
+    - name: "lint"
       script:
           - perl tools/scripts/cpysearch/cpyscan.pl


### PR DESCRIPTION
- correct typo from 518f10b7a90a7bca1dd554601a681ba9f341f583

- [x] Issue filed at https://unicode-org.atlassian.net :  ICU-20066
- [x] Update PR title to include Issue number
- [x] Issue accepted

