### PR TITLE
ICU-11319 Add tests for compact decimal in zh-Hant and zh-Hant-HK.

### DIFF
--- a/icu4c/source/test/intltest/numbertest_api.cpp
+++ b/icu4c/source/test/intltest/numbertest_api.cpp
@@ -403,6 +403,22 @@ void NumberFormatterApiTest::notationCompact() {
             9990000,
             u"10M");
 
+    assertFormatSingle(
+            u"Compact in zh-Hant-HK",
+            u"compact-short",
+            NumberFormatter::with().notation(Notation::compactShort()),
+            Locale("zh-Hant-HK"),
+            1e7,
+            u"10M");
+
+    assertFormatSingle(
+            u"Compact in zh-Hant",
+            u"compact-short",
+            NumberFormatter::with().notation(Notation::compactShort()),
+            Locale("zh-Hant"),
+            1e7,
+            u"1000\u842C");
+
     // NOTE: There is no API for compact custom data in C++
     // and thus no "Compact Somali No Figure" test
 }

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
@@ -369,6 +369,22 @@ public class NumberFormatterApiTest {
                 9990000,
                 "10M");
 
+        assertFormatSingle(
+                "Compact in zh-Hant-HK",
+                "compact-short",
+                NumberFormatter.with().notation(Notation.compactShort()),
+                new ULocale("zh-Hant-HK"),
+                1e7,
+                "10M");
+
+        assertFormatSingle(
+                "Compact in zh-Hant",
+                "compact-short",
+                NumberFormatter.with().notation(Notation.compactShort()),
+                new ULocale("zh-Hant"),
+                1e7,
+                "1000\u842C");
+
         Map<String, Map<String, String>> compactCustomData = new HashMap<String, Map<String, String>>();
         Map<String, String> entry = new HashMap<String, String>();
         entry.put("one", "Kun");


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed at https://unicode-org.atlassian.net :  ICU-11319
- [x] Update PR title to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

