### PR TITLE
ICU-20085 Revert workaround for pseudolocale region codes for display names.

### DIFF
--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/ICUResourceBundleTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/ICUResourceBundleTest.java
@@ -718,13 +718,7 @@ public final class ICUResourceBundleTest extends TestFmwk {
         }
 
         for (int i = 0; i < locales.length; ++i) {
-            // The region codes used for pseudolocales don't have display names.
-            // That might however change in the future, in which case skipping
-            // testing of these names here would become irrelevant:
-            // https://unicode.org/cldr/trac/ticket/10880
-            String country = locales[i].getCountry();
-            if (!"XA".equals(country) && !"XB".equals(country)
-                    && !hasLocalizedCountryFor(ULocale.ENGLISH, locales[i])){
+            if (!hasLocalizedCountryFor(ULocale.ENGLISH, locales[i])){
                  errln("Could not get English localized country for " + locales[i]);
             }
             if(!hasLocalizedLanguageFor(ULocale.ENGLISH, locales[i])){


### PR DESCRIPTION
This reverts commit 1dccd7472e9f2db4830293b9d33500ea4b4ce082.