### PR TITLE
ICU-20119 update C++ dependencies, fix bugs

### DIFF
--- a/icu4c/source/common/cmemory.h
+++ b/icu4c/source/common/cmemory.h
@@ -172,7 +172,7 @@ public:
      * @return *this
      */
     LocalMemory<T> &moveFrom(LocalMemory<T> &src) U_NOEXCEPT {
-        delete[] LocalPointerBase<T>::ptr;
+        uprv_free(LocalPointerBase<T>::ptr);
         LocalPointerBase<T>::ptr=src.ptr;
         src.ptr=NULL;
         return *this;

--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -1332,7 +1332,7 @@ public:
 };
 
 // Out-of-line virtual destructor to serve as the "key function".
-UnicodeKeywordEnumeration::~UnicodeKeywordEnumeration() {}
+UnicodeKeywordEnumeration::~UnicodeKeywordEnumeration() = default;
 
 StringEnumeration *
 Locale::createKeywords(UErrorCode &status) const

--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -1311,7 +1311,7 @@ KeywordEnumeration::~KeywordEnumeration() {
 class UnicodeKeywordEnumeration : public KeywordEnumeration {
 public:
     using KeywordEnumeration::KeywordEnumeration;
-    virtual ~UnicodeKeywordEnumeration() = default;
+    virtual ~UnicodeKeywordEnumeration();
 
     virtual const char* next(int32_t* resultLength, UErrorCode& status) {
         const char* legacy_key = KeywordEnumeration::next(nullptr, status);
@@ -1330,6 +1330,9 @@ public:
         return nullptr;
     }
 };
+
+// Out-of-line virtual destructor to serve as the "key function".
+UnicodeKeywordEnumeration::~UnicodeKeywordEnumeration() {}
 
 StringEnumeration *
 Locale::createKeywords(UErrorCode &status) const

--- a/icu4c/source/i18n/erarules.cpp
+++ b/icu4c/source/i18n/erarules.cpp
@@ -99,7 +99,7 @@ static int32_t compareEncodedDateWithYMD(int encoded, int year, int month, int d
     }
 }
 
-EraRules::EraRules(LocalArray<int32_t>& eraStartDates, int32_t numEras)
+EraRules::EraRules(LocalMemory<int32_t>& eraStartDates, int32_t numEras)
     : numEras(numEras) {
     startDates.moveFrom(eraStartDates);
     initCurrentEra();
@@ -116,7 +116,7 @@ EraRules* EraRules::createInstance(const char *calType, UBool includeTentativeEr
     ures_getByKey(rb.getAlias(), "calendarData", rb.getAlias(), &status);
     ures_getByKey(rb.getAlias(), calType, rb.getAlias(), &status);
     ures_getByKey(rb.getAlias(), "eras", rb.getAlias(), &status);
-        
+
     if (U_FAILURE(status)) {
         return nullptr;
     }
@@ -124,8 +124,9 @@ EraRules* EraRules::createInstance(const char *calType, UBool includeTentativeEr
     int32_t numEras = ures_getSize(rb.getAlias());
     int32_t firstTentativeIdx = MAX_INT32;
 
-    LocalArray<int32_t> startDates(new int32_t[numEras], status);
-    if (U_FAILURE(status)) {
+    LocalMemory<int32_t> startDates(reinterpret_cast<int32_t *>(uprv_malloc(numEras * 4)));
+    if (startDates.isNull()) {
+        status = U_MEMORY_ALLOCATION_ERROR;
         return nullptr;
     }
     uprv_memset(startDates.getAlias(), 0 , numEras * sizeof(int32_t));

--- a/icu4c/source/i18n/erarules.cpp
+++ b/icu4c/source/i18n/erarules.cpp
@@ -124,7 +124,7 @@ EraRules* EraRules::createInstance(const char *calType, UBool includeTentativeEr
     int32_t numEras = ures_getSize(rb.getAlias());
     int32_t firstTentativeIdx = MAX_INT32;
 
-    LocalMemory<int32_t> startDates(reinterpret_cast<int32_t *>(uprv_malloc(numEras * 4)));
+    LocalMemory<int32_t> startDates(static_cast<int32_t *>(uprv_malloc(numEras * sizeof(int32_t))));
     if (startDates.isNull()) {
         status = U_MEMORY_ALLOCATION_ERROR;
         return nullptr;

--- a/icu4c/source/i18n/erarules.h
+++ b/icu4c/source/i18n/erarules.h
@@ -4,23 +4,24 @@
 #ifndef ERARULES_H_
 #define ERARULES_H_
 
-#include "unicode/localpointer.h"
 #include "unicode/utypes.h"
 
 #if !UCONFIG_NO_FORMATTING
 
+#include "unicode/localpointer.h"
 #include "unicode/uobject.h"
+#include "cmemory.h"
 
 U_NAMESPACE_BEGIN
 
-// Export an explicit template instantiation of LocalArray used as a data member of EraRules.
+// Export an explicit template instantiation of LocalMemory used as a data member of EraRules.
 // When building DLLs for Windows this is required even though no direct access leaks out of the i18n library.
 // See digitlst.h, pluralaffix.h, datefmt.h, and others for similar examples.
 #if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
 // Ignore warning 4661 as LocalPointerBase does not use operator== or operator!=
 #pragma warning(suppress: 4661)
 template class U_I18N_API LocalPointerBase<int32_t>;
-template class U_I18N_API LocalArray<int32_t>;
+template class U_I18N_API LocalMemory<int32_t>;
 #endif
 
 class U_I18N_API EraRules : public UMemory {
@@ -77,11 +78,11 @@ public:
     }
 
 private:
-    EraRules(LocalArray<int32_t>& eraStartDates, int32_t numEra);
+    EraRules(LocalMemory<int32_t>& eraStartDates, int32_t numEra);
 
     void initCurrentEra();
 
-    LocalArray<int32_t> startDates;
+    LocalMemory<int32_t> startDates;
     int32_t numEras;
     int32_t currentEra;
 };

--- a/icu4c/source/test/depstest/dependencies.txt
+++ b/icu4c/source/test/depstest/dependencies.txt
@@ -160,9 +160,8 @@ library: common
     static_unicode_sets
     uiter edits
     ucasemap ucasemap_titlecase_brkiter script_runs
-    uprops ubidi_props ucase uscript uscript_props
+    uprops ubidi_props ucase uscript uscript_props characterproperties
     ubidi ushape ubiditransform
-    listformatter
     resourcebundle service_registration resbund_cnv ures_cnv icudataver ucat
     currency
     locale_display_names2
@@ -174,7 +173,7 @@ library: common
     ucharstriebuilder ucharstrieiterator
     bytestriebuilder bytestrieiterator
     hashtable uhash uvector uvector32 uvector64 ulist
-    propsvec utrie2 utrie2_builder
+    propsvec utrie2 utrie2_builder ucptrie umutablecptrie utrie_swap
     sort
     uinit utypes errorcode
     icuplug
@@ -206,7 +205,7 @@ group: breakiterator
   deps
     resourcebundle service_registration
     schriter utext uniset_core uniset_props
-    uhash ustack utrie
+    uhash ustack utrie2_builder
     ucharstrie bytestrie
     ucharstriebuilder  # for filteredbrk.o
     normlzr  # for dictbe.o, should switch to Normalizer2
@@ -256,7 +255,7 @@ group: stringprep
   deps
     unorm  # could change to use filterednormalizer2 directly for Unicode 3.2 normalization
     normalizer2
-    ubidi_props
+    ubidi_props utrie
 
 group: canonical_iterator
     caniter.o
@@ -274,7 +273,8 @@ group: normalizer2
   deps
     uniset_core
     bytestream bytesinkutil  # for UTF-8 output
-    utrie2_builder  # for building CanonIterData & FCD
+    umutablecptrie  # for building CanonIterData & FCD
+    utrie_swap  # TODO(ICU-20170): move unorm2_swap() to a separate file
     uvector  # for building CanonIterData
     uhash  # for the instance cache
     udata
@@ -307,7 +307,7 @@ group: uniset_closure
 group: uniset_props
     uniset_props.o ruleiter.o
   deps
-    uniset_core uprops unistr_case
+    uniset_core uprops unistr_case characterproperties
     parsepos
     resourcebundle
     propname unames
@@ -397,6 +397,12 @@ group: uprops
     ubidi_props
     unistr_case ustring_case  # only for case folding
     ucase
+
+group: characterproperties
+    characterproperties.o
+  deps
+    uprops
+    uniset_core
 
 group: propname
     propname.o
@@ -524,7 +530,7 @@ group: uinit
 group: converter_selector
     ucnvsel.o
   deps
-    conversion propsvec utrie2_builder uset ucnv_set
+    conversion propsvec utrie2_builder utrie_swap uset ucnv_set
 
 group: ucnvdisp  # ucnv_getDisplayName()
     ucnvdisp.o
@@ -558,11 +564,6 @@ group: service_registration
   deps
     locale_display_names resourcebundle
     hashtable uvector
-
-group: listformatter
-    listformatter.o ulistformatter.o
-  deps
-    resourcebundle simpleformatter
 
 group: ucat  # message-catalog-like API
     ucat.o
@@ -685,20 +686,34 @@ group: propsvec
   deps
     sort utrie2_builder
 
+group: utrie_swap
+    utrie_swap.o
+  deps
+    udata
+
+group: umutablecptrie
+    umutablecptrie.o
+  deps
+    ucptrie
+
+group: ucptrie
+    ucptrie.o
+  deps
+    platform
+
 group: utrie2_builder
     utrie2_builder.o
   deps
     platform
     utrie2
     utrie  # for utrie2_fromUTrie()
-    ucol_swp  # for utrie_swap()
 
-group: utrie2
+group: utrie2  # Try to switch users to ucptrie.
     utrie2.o
   deps
     platform
 
-group: utrie  # Callers should use utrie2 instead.
+group: utrie  # Callers should use ucptrie instead.
     utrie.o
   deps
     platform
@@ -767,7 +782,7 @@ group: icuplug
 group: ucol_swp
     ucol_swp.o
   deps
-    utrie2  # Format version 4 uses UTrie2.
+    utrie_swap
 
 group: errorcode  # ErrorCode base class
     errorcode.o
@@ -812,6 +827,7 @@ library: i18n
     region localedata genderinfo charset_detector spoof_detection
     alphabetic_index collation collation_builder string_search
     dayperiodrules
+    listformatter
     formatting formattable_cnv regex regex_cnv translit
     double_conversion number_representation numberformatter numberparser
     universal_time_scale
@@ -867,7 +883,7 @@ group: collation
     ucol_res.o ucol_sit.o ucoleitr.o
   deps
     bytestream normalizer2 resourcebundle service_registration unifiedcache
-    ucharstrieiterator uiter ulist uset usetiter uvector32 uvector64
+    ucharstrieiterator uiter ulist uset usetiter uvector32 uvector64 utrie2
     uclean_i18n propname
 
 group: collation_builder
@@ -885,6 +901,11 @@ group: dayperiodrules
     dayperiodrules.o
   deps
     resourcebundle uclean_i18n
+
+group: listformatter
+    listformatter.o ulistformatter.o
+  deps
+    resourcebundle simpleformatter format uclean_i18n
 
 group: double_conversion
     double-conversion.o double-conversion-bignum.o double-conversion-bignum-dtoa.o
@@ -914,6 +935,7 @@ group: numberformatter
     number_patternmodifier.o number_patternstring.o number_rounding.o
     number_scientific.o number_skeletons.o
     currpinf.o dcfmtsym.o numsys.o
+    numrange_fluent.o numrange_impl.o
     # pluralrules
     standardplural.o plurrule.o
   deps
@@ -949,6 +971,7 @@ group: formatting
     # dateformat
     astro.o buddhcal.o calendar.o cecal.o chnsecal.o coptccal.o dangical.o ethpccal.o
     gregocal.o gregoimp.o hebrwcal.o indiancal.o islamcal.o japancal.o persncal.o taiwncal.o
+    erarules.o  # mostly for Japanese eras
     ucal.o
     basictz.o olsontz.o rbtz.o simpletz.o timezone.o tzrule.o tztrans.o
     vtzone.o vzone.o wintzimpl.o zonemeta.o zrule.o ztrans.o
@@ -961,6 +984,7 @@ group: formatting
     choicfmt.o msgfmt.o plurfmt.o selfmt.o umsg.o
   deps
     decnumber formattable format units numberformatter numberparser
+    listformatter
     dayperiodrules
     collation collation_builder  # for rbnf
     common


### PR DESCRIPTION
Updated intra-library dependencies, adjusted for new and moved files.
http://site.icu-project.org/processes/release/tasks/healthy-code#TOC-Check-library-dependencies

EraRules was using global new & delete via LocalArray<primitive type> which is a no-no. Changed to use LocalMemory, and fixed a bug in LocalMemory::moveFrom().

locid.cpp: The dependencies checker looks for virtual destructors that are missing (implicit) or defined inside the class declaration, because if that is done in a header file the destructor cannot serve as the "key function". Inside a .cpp file this would not be a problem, but the tool cannot distinguish. So moved the destructor definition outside the class declaration.