### PR TITLE
ICU-20119 Fixes for run-without-data BRS test. In all cases an error

### DIFF
--- a/icu4c/source/test/intltest/calregts.cpp
+++ b/icu4c/source/test/intltest/calregts.cpp
@@ -1411,6 +1411,11 @@ void CalendarRegressionTest::test4118384()
 
     delete cal;
     cal = Calendar::createInstance(Locale("th_TH@calendar=buddhist"),status);
+    if(U_FAILURE(status)) {
+      dataerrln("Error creating calendar %s", u_errorName(status));
+      delete cal;
+      return;
+    }    
     // test deprecated functions
     if (cal->getLeastMaximum(Calendar::HOUR) != 11 ||
         cal->getMaximum(Calendar::HOUR) != 11) {
@@ -1425,6 +1430,11 @@ void CalendarRegressionTest::test4118384()
     delete cal;
     // test deprecated functions
     cal = Calendar::createInstance(Locale("ja_JP@calendar=japanese"),status);
+    if(U_FAILURE(status)) {
+      dataerrln("Error creating calendar %s", u_errorName(status));
+      delete cal;
+      return;
+    }    
     if (cal->getLeastMaximum(Calendar::HOUR) != 11 ||
         cal->getMaximum(Calendar::HOUR) != 11) {
         errln("Fail: Japanese:[deprecated functions] maximum of HOUR field should be 11\n");

--- a/icu4c/source/test/intltest/loctest.cpp
+++ b/icu4c/source/test/intltest/loctest.cpp
@@ -1770,13 +1770,17 @@ LocaleTest::TestCreateUnicodeKeywords(void) {
     status.errIfFailureAndReset("key #1");
     assertEquals("resultLength", 2, resultLength);
     assertTrue("key != nullptr", key != nullptr);
-    assertEquals("calendar", "ca", key);
+    if (key != nullptr) {
+        assertEquals("calendar", "ca", key);
+    }
 
     key = keys->next(&resultLength, status);
     status.errIfFailureAndReset("key #2");
     assertEquals("resultLength", 2, resultLength);
     assertTrue("key != nullptr", key != nullptr);
-    assertEquals("collation", "co", key);
+    if (key != nullptr) {
+        assertEquals("collation", "co", key);
+    }
 
     key = keys->next(&resultLength, status);
     status.errIfFailureAndReset("end of keys");
@@ -1789,12 +1793,16 @@ LocaleTest::TestCreateUnicodeKeywords(void) {
     skey = keys->snext(status);
     status.errIfFailureAndReset("skey #1");
     assertTrue("skey != nullptr", skey != nullptr);
-    assertEquals("calendar", "ca", *skey);
+    if (skey != nullptr) {
+        assertEquals("calendar", "ca", *skey);
+    }
 
     skey = keys->snext(status);
     status.errIfFailureAndReset("skey #2");
     assertTrue("skey != nullptr", skey != nullptr);
-    assertEquals("collation", "co", *skey);
+    if (skey != nullptr) {
+        assertEquals("collation", "co", *skey);
+    }
 
     skey = keys->snext(status);
     status.errIfFailureAndReset("end of keys");

--- a/icu4c/source/test/intltest/numfmtst.cpp
+++ b/icu4c/source/test/intltest/numfmtst.cpp
@@ -8947,6 +8947,10 @@ void NumberFormatTest::Test20073_StrictPercentParseErrorIndex() {
     IcuTestErrorCode status(*this, "Test20073_StrictPercentParseErrorIndex");
     ParsePosition parsePosition(0);
     DecimalFormat df(u"0%", {"en-us", status}, status);
+    if (U_FAILURE(status)) {
+        dataerrln("Unable to create DecimalFormat instance.");
+        return;
+    }
     df.setLenient(FALSE);
     Formattable result;
     df.parse(u"%2%", result, parsePosition);
@@ -9202,22 +9206,26 @@ void NumberFormatTest::Test20037_ScientificIntegerOverflow() {
     IcuTestErrorCode status(*this, "Test20037_ScientificIntegerOverflow");
 
     LocalPointer<NumberFormat> nf(NumberFormat::createInstance(status));
+    if (U_FAILURE(status)) {
+        dataerrln("Unable to create NumberFormat instance.");
+        return;
+    }
     Formattable result;
 
     // Test overflow of exponent
     nf->parse(u"1E-2147483648", result, status);
     StringPiece sp = result.getDecimalNumber(status);
     assertEquals(u"Should snap to zero",
-        u"0",
-        {sp.data(), sp.length(), US_INV});
+                 u"0",
+                 {sp.data(), sp.length(), US_INV});
 
     // Test edge case overflow of exponent
     result = Formattable();
     nf->parse(u"1E-2147483647E-1", result, status);
     sp = result.getDecimalNumber(status);
     assertEquals(u"Should not overflow and should parse only the first exponent",
-        u"1E-2147483647",
-        {sp.data(), sp.length(), US_INV});
+                 u"1E-2147483647",
+                 {sp.data(), sp.length(), US_INV});
 }
 
 void NumberFormatTest::Test13840_ParseLongStringCrash() {


### PR DESCRIPTION
check was needed in the test cases to prevent a segmentation fault.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed at https://unicode-org.atlassian.net :  ICU-______
- [ ] Update PR title to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

