### PR TITLE
ICU-20119 BRS63RC Fixed ICU4J plugin build issue

### DIFF
--- a/icu4j/eclipse-build/pdebuild/build.properties
+++ b/icu4j/eclipse-build/pdebuild/build.properties
@@ -216,7 +216,7 @@ javacVerbose=true
 compilerArg=-inlineJSR -enableJavadoc -encoding UTF-8
 
 # Default value for the version of the source code. This value is used when compiling plug-ins that do not set the Bundle-RequiredExecutionEnvironment or set javacSource in build.properties
-javacSource=1.6
+javacSource=1.7
 
 # Default value for the version of the byte code targeted. This value is used when compiling plug-ins that do not set the Bundle-RequiredExecutionEnvironment or set javacTarget in build.properties.
 javacTarget=1.7


### PR DESCRIPTION
ICU4J plugin build configuration still used 1.6 as java source version. It must be changed to 1.7.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed at https://unicode-org.atlassian.net :  ICU-20119
- [x] Update PR title to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

