### PR TITLE
ICU-20191 Don't use Win32 APIs on Cygwin (#185)

### DIFF
--- a/icu4c/source/common/putil.cpp
+++ b/icu4c/source/common/putil.cpp
@@ -1737,7 +1737,7 @@ The leftmost codepage (.xxx) wins.
 
     return posixID;
 
-#elif U_PLATFORM_HAS_WIN32_API
+#elif U_PLATFORM_USES_ONLY_WIN32_API
 #define POSIX_LOCALE_CAPACITY 64
     UErrorCode status = U_ZERO_ERROR;
     char *correctedPOSIXLocale = nullptr;

--- a/icu4c/source/common/wintz.cpp
+++ b/icu4c/source/common/wintz.cpp
@@ -13,7 +13,7 @@
 
 #include "unicode/utypes.h"
 
-#if U_PLATFORM_HAS_WIN32_API
+#if U_PLATFORM_USES_ONLY_WIN32_API
 
 #include "wintz.h"
 #include "cmemory.h"
@@ -123,4 +123,4 @@ uprv_detectWindowsTimeZone()
 }
 
 U_NAMESPACE_END
-#endif /* U_PLATFORM_HAS_WIN32_API  */
+#endif /* U_PLATFORM_USES_ONLY_WIN32_API  */

--- a/icu4c/source/common/wintz.h
+++ b/icu4c/source/common/wintz.h
@@ -16,7 +16,7 @@
 
 #include "unicode/utypes.h"
 
-#if U_PLATFORM_HAS_WIN32_API
+#if U_PLATFORM_USES_ONLY_WIN32_API
 
 /**
  * \file 
@@ -31,6 +31,6 @@ U_CDECL_END
 U_CFUNC const char* U_EXPORT2
 uprv_detectWindowsTimeZone();
 
-#endif /* U_PLATFORM_HAS_WIN32_API  */
+#endif /* U_PLATFORM_USES_ONLY_WIN32_API  */
 
 #endif /* __WINTZ */


### PR DESCRIPTION
This was fixed in earlier commits (see, for example, ICU-12786), but
the problem was reintroduced in commits f8ba68e and fcb82cb.

(cherry picked from commit 7d99ba4e578f3f10f6319b26873edb41ce557046)

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed at https://unicode-org.atlassian.net :  ICU-20191
- [x] Update PR title to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

