### PR TITLE
ICU-20193 urename.h shouldn't be ignored by other compilers except VS IntelliSense (#189)

### DIFF
--- a/icu4c/source/common/unicode/urename.h
+++ b/icu4c/source/common/unicode/urename.h
@@ -34,7 +34,7 @@
 #if !U_DISABLE_RENAMING
 
 // Disable Renaming for Visual Studio's IntelliSense feature, so that 'Go-to-Definition' (F12) will work.
-#if defined(_MSC_VER) && !defined(__INTELLISENSE__)
+#if !(defined(_MSC_VER) && defined(__INTELLISENSE__))
 
 /* We need the U_ICU_ENTRY_POINT_RENAME definition. There's a default one in unicode/uvernum.h we can use, but we will give
    the platform a chance to define it first.
@@ -1858,7 +1858,7 @@
 #define ztrans_setTime U_ICU_ENTRY_POINT_RENAME(ztrans_setTime)
 #define ztrans_setTo U_ICU_ENTRY_POINT_RENAME(ztrans_setTo)
 
-#endif /* defined(_MSC_VER) && !defined(__INTELLISENSE__) */
+#endif /* !(defined(_MSC_VER) && defined(__INTELLISENSE__)) */
 #endif /* U_DISABLE_RENAMING */
 #endif /* URENAME_H */
 

--- a/icu4c/source/tools/genren/genren.pl
+++ b/icu4c/source/tools/genren/genren.pl
@@ -107,7 +107,7 @@ print HEADER <<"EndOfHeaderComment";
 #if !U_DISABLE_RENAMING
 
 // Disable Renaming for Visual Studio's IntelliSense feature, so that 'Go-to-Definition' (F12) will work.
-#if defined(_MSC_VER) && !defined(__INTELLISENSE__)
+#if !(defined(_MSC_VER) && defined(__INTELLISENSE__))
 
 /* We need the U_ICU_ENTRY_POINT_RENAME definition. There's a default one in unicode/uvernum.h we can use, but we will give
    the platform a chance to define it first.
@@ -242,7 +242,7 @@ foreach(sort keys(%CFuncs)) {
 
 print HEADER <<"EndOfHeaderFooter";
 
-#endif /* defined(_MSC_VER) && !defined(__INTELLISENSE__) */
+#endif /* !(defined(_MSC_VER) && defined(__INTELLISENSE__)) */
 #endif /* U_DISABLE_RENAMING */
 #endif /* URENAME_H */
 


### PR DESCRIPTION
The macro _MSC_VER is not defined in other compilers.
Change the logic and so urename.h is ignored on VS IntelliSense

(cherry picked from commit ff72d74d1eeedb6f4ae9326a87f90eaad7b8595d)

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed at https://unicode-org.atlassian.net :  ICU-20193
- [x] Update PR title to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

