### PR TITLE
ICU-20192 Add Automatic-Module-Name to META-INF/MANIFEST.MF

### DIFF
--- a/icu4j/main/classes/charset/manifest.stub
+++ b/icu4j/main/classes/charset/manifest.stub
@@ -14,3 +14,4 @@ Bundle-Version: @IMPLVERSION@
 Bundle-Vendor: Unicode, Inc.
 Bundle-Copyright: @COPYRIGHT@
 Bundle-RequiredExecutionEnvironment: @EXECENV@
+Automatic-Module-Name: com.ibm.icu.charset

--- a/icu4j/main/classes/localespi/manifest.stub
+++ b/icu4j/main/classes/localespi/manifest.stub
@@ -14,3 +14,4 @@ Bundle-Version: @IMPLVERSION@
 Bundle-Vendor: Unicode, Inc.
 Bundle-Copyright: @COPYRIGHT@
 Bundle-RequiredExecutionEnvironment: @EXECENV@
+Automatic-Module-Name: com.ibm.icu.localespi

--- a/icu4j/manifest.stub
+++ b/icu4j/manifest.stub
@@ -15,5 +15,5 @@ Bundle-Vendor: Unicode, Inc.
 Bundle-Copyright: @COPYRIGHT@
 Bundle-RequiredExecutionEnvironment: @EXECENV@
 Main-Class: com.ibm.icu.util.VersionInfo
-Export-Package: com.ibm.icu.lang,com.ibm.icu.math,com.ibm.icu.text,com.ibm.icu.util
+Export-Package: com.ibm.icu.lang,com.ibm.icu.math,com.ibm.icu.number,com.ibm.icu.text,com.ibm.icu.util
 Automatic-Module-Name: com.ibm.icu

--- a/icu4j/manifest.stub
+++ b/icu4j/manifest.stub
@@ -16,3 +16,4 @@ Bundle-Copyright: @COPYRIGHT@
 Bundle-RequiredExecutionEnvironment: @EXECENV@
 Main-Class: com.ibm.icu.util.VersionInfo
 Export-Package: com.ibm.icu.lang,com.ibm.icu.math,com.ibm.icu.text,com.ibm.icu.util
+Automatic-Module-Name: com.ibm.icu


### PR DESCRIPTION
Added Automatic-Module-Name field to META-INF/MANIFEST.MF.
The line makes this library available for all modular jars 
containing module-info having been compiled with Java 9 or higher.

Please change the module name "com.ibm.icu" if it is not appropriate.
This is a very important decision, because the libraries using this library
will declare the name in their module-info.java as below:
```
requires  com.ibm.icu;
```

Checklist 
- [x] Issue filed at https://unicode-org.atlassian.net : ICU-20192 
- [x] Update PR title to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added