### PR TITLE
ICU-20196 Fix MSVC/clang compiler warning C4251, and other warnings.

### DIFF
--- a/icu4c/source/common/uloc_tag.cpp
+++ b/icu4c/source/common/uloc_tag.cpp
@@ -2132,7 +2132,7 @@ ultag_parse(const char* tag, int32_t tagLen, int32_t* parsedLen, UErrorCode* sta
             // The preferred tag for a redundant tag is always shorter than redundant
             // tag. A redundant tag may or may not be followed by other subtags.
             // (i.e. "zh-yue" or "zh-yue-u-co-pinyin").
-            if (uprv_strnicmp(redundantTag, tagBuf, redundantTagLen) == 0) {
+            if (uprv_strnicmp(redundantTag, tagBuf, static_cast<uint32_t>(redundantTagLen)) == 0) {
                 const char* redundantTagEnd = tagBuf + redundantTagLen;
                 if (*redundantTagEnd  == '\0' || *redundantTagEnd == SEP) {
                     const char* preferredTag = REDUNDANT[i + 1];
@@ -2644,7 +2644,7 @@ uloc_toLanguageTag(const char* localeID,
     const char* pKeywordStart;
 
     /* Note: uloc_canonicalize returns "en_US_POSIX" for input locale ID "".  See #6835 */
-    int32_t resultCapacity = uprv_strlen(localeID);
+    int32_t resultCapacity = static_cast<int32_t>(uprv_strlen(localeID));
     if (resultCapacity > 0) {
         char* buffer;
 

--- a/icu4c/source/i18n/unicode/datefmt.h
+++ b/icu4c/source/i18n/unicode/datefmt.h
@@ -45,7 +45,7 @@ class DateTimePatternGenerator;
 
 /**
  * \cond
- * explicit template instantiation. see digitlst.h
+ * Export an explicit template instantiation. (See digitlst.h, datefmt.h, and others.)
  * (When building DLLs for Windows this is required.)
  */
 #if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN && !defined(U_IN_DOXYGEN)

--- a/icu4c/source/i18n/unicode/decimfmt.h
+++ b/icu4c/source/i18n/unicode/decimfmt.h
@@ -68,7 +68,7 @@ class NumberParserImpl;
  * explicit template instantiation. see digitlst.h
  * (When building DLLs for Windows this is required.)
  */
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
+#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN && !defined(U_IN_DOXYGEN)
 template class U_I18N_API    EnumSet<UNumberFormatAttribute,
             UNUM_MAX_NONBOOLEAN_ATTRIBUTE+1,
             UNUM_LIMIT_BOOLEAN_ATTRIBUTE>;

--- a/icu4c/source/i18n/unicode/numberrangeformatter.h
+++ b/icu4c/source/i18n/unicode/numberrangeformatter.h
@@ -180,6 +180,16 @@ class NumberRangeFormatterImpl;
 
 } // namespace impl
 
+/**
+ * \cond
+ * Export an explicit template instantiation. See datefmt.h
+ * (When building DLLs for Windows this is required.)
+ */
+#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN && !defined(U_IN_DOXYGEN)
+template struct U_I18N_API std::atomic<impl::NumberRangeFormatterImpl*>;
+#endif
+/** \endcond */
+
 // Other helper classes would go here, but there are none.
 
 namespace impl {  // icu::number::impl


### PR DESCRIPTION
This fixes MSVC/clang compiler warning C4251 by exporting an explicit template instantiation, which is required when building DLLs on Windows. This PR also fixes a few other warnings as well.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed at https://unicode-org.atlassian.net :  ICU-20196
- [x] Update PR title to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

