### PR TITLE
ICU-20198 Add issue browse link to PR template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,8 +10,8 @@ You will be automatically asked to sign the contributors license before the PR i
 
 ##### Checklist
 
-- [ ] Issue filed at https://unicode-org.atlassian.net :  ICU-______
-- [ ] Update PR title to include Issue number
+- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
+- [ ] Updated PR title and link in previous line to include Issue number
 - [ ] Issue accepted
 - [ ] Tests included
 - [ ] Documentation is changed or added


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

This change will create a link from GitHub to Jira on every PR.  Right now a browser extension is required for this functionality.

The issue is closed.  I can open a new issue or re-open the old one to accept a new commit.

##### Checklist

- [x] Issue filed at https://unicode-org.atlassian.net :  ICU-20003
- [x] Update PR title to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

