### PR TITLE
ICU-20192 Add Automatic-Module-Name to META-INF/MANIFEST.MF (#193)

### DIFF
--- a/icu4j/main/classes/charset/manifest.stub
+++ b/icu4j/main/classes/charset/manifest.stub
@@ -14,3 +14,4 @@ Bundle-Version: @IMPLVERSION@
 Bundle-Vendor: Unicode, Inc.
 Bundle-Copyright: @COPYRIGHT@
 Bundle-RequiredExecutionEnvironment: @EXECENV@
+Automatic-Module-Name: com.ibm.icu.charset

--- a/icu4j/main/classes/localespi/manifest.stub
+++ b/icu4j/main/classes/localespi/manifest.stub
@@ -14,3 +14,4 @@ Bundle-Version: @IMPLVERSION@
 Bundle-Vendor: Unicode, Inc.
 Bundle-Copyright: @COPYRIGHT@
 Bundle-RequiredExecutionEnvironment: @EXECENV@
+Automatic-Module-Name: com.ibm.icu.localespi

--- a/icu4j/manifest.stub
+++ b/icu4j/manifest.stub
@@ -15,4 +15,5 @@ Bundle-Vendor: Unicode, Inc.
 Bundle-Copyright: @COPYRIGHT@
 Bundle-RequiredExecutionEnvironment: @EXECENV@
 Main-Class: com.ibm.icu.util.VersionInfo
-Export-Package: com.ibm.icu.lang,com.ibm.icu.math,com.ibm.icu.text,com.ibm.icu.util
+Export-Package: com.ibm.icu.lang,com.ibm.icu.math,com.ibm.icu.number,com.ibm.icu.text,com.ibm.icu.util
+Automatic-Module-Name: com.ibm.icu


### PR DESCRIPTION
* Add Automatic-Module-Name to META-INF/MANIFEST.MF

* Added com.ibm.icu.number in Export-Package list

* Add Automatic-Module-Name to charset and localespi

(cherry picked from commit 2e580c050409ad61c08d6d83f433110e48a67680)

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20192
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

