### PR TITLE
ICU-20214 Fix namespace error on Cygwin (maint-63)

### DIFF
--- a/icu4c/source/i18n/unicode/numberrangeformatter.h
+++ b/icu4c/source/i18n/unicode/numberrangeformatter.h
@@ -185,7 +185,7 @@ class NumberRangeFormatterImpl;
  * Export an explicit template instantiation. See datefmt.h
  * (When building DLLs for Windows this is required.)
  */
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN && !defined(U_IN_DOXYGEN)
+#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM < U_PF_CYGWIN && !defined(U_IN_DOXYGEN)
 template struct U_I18N_API std::atomic<impl::NumberRangeFormatterImpl*>;
 #endif
 /** \endcond */


### PR DESCRIPTION
(cherry picked from commit 31b89b54840361fdfc367ef02019b10424cdb75c)

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20214
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

