### PR TITLE
ICU-20132 Pass ByteSink from Locale::toLanguageTag() to uloc_toLanguageTag()

### DIFF
--- a/icu4c/source/common/ulocimp.h
+++ b/icu4c/source/common/ulocimp.h
@@ -10,6 +10,7 @@
 #ifndef ULOCIMP_H
 #define ULOCIMP_H
 
+#include "unicode/bytestream.h"
 #include "unicode/uloc.h"
 
 /**
@@ -60,6 +61,31 @@ U_CFUNC int32_t
 ulocimp_getCountry(const char *localeID,
                    char *country, int32_t countryCapacity,
                    const char **pEnd);
+
+/**
+ * Writes a well-formed language tag for this locale ID.
+ *
+ * **Note**: When `strict` is FALSE, any locale fields which do not satisfy the
+ * BCP47 syntax requirement will be omitted from the result.  When `strict` is
+ * TRUE, this function sets U_ILLEGAL_ARGUMENT_ERROR to the `err` if any locale
+ * fields do not satisfy the BCP47 syntax requirement.
+ *
+ * @param localeID  the input locale ID
+ * @param sink      the output sink receiving the BCP47 language
+ *                  tag for this Locale.
+ * @param strict    boolean value indicating if the function returns
+ *                  an error for an ill-formed input locale ID.
+ * @param err       error information if receiving the language
+ *                  tag failed.
+ * @return          The length of the BCP47 language tag.
+ *
+ * @internal ICU 64
+ */
+U_STABLE void U_EXPORT2
+ulocimp_toLanguageTag(const char* localeID,
+                      icu::ByteSink& sink,
+                      UBool strict,
+                      UErrorCode* err);
 
 /**
  * Returns a locale ID for the specified BCP47 language tag string.

--- a/icu4c/source/test/cintltst/cloctst.h
+++ b/icu4c/source/test/cintltst/cloctst.h
@@ -126,6 +126,7 @@ static void TestLikelySubtags(void);
 static void TestForLanguageTag(void);
 static void TestInvalidLanguageTag(void);
 static void TestToLanguageTag(void);
+static void TestBug20132(void);
 static void TestLangAndRegionCanonicalize(void);
 
 static void TestToUnicodeLocaleKey(void);


### PR DESCRIPTION
This eliminates the need for a scratch buffer in Locale::toLanguageTag()
and also the need for counting bytes required in uloc_toLanguageTag(),
something that ByteSink will now handle correctly and thereby
eliminating the bug where too few bytes required was returned.