### PR TITLE
ICU-20231 Adding tests for accounting with variable currency widths.

### DIFF
--- a/icu4c/source/test/intltest/numbertest_api.cpp
+++ b/icu4c/source/test/intltest/numbertest_api.cpp
@@ -1893,12 +1893,59 @@ void NumberFormatterApiTest::sign() {
     assertFormatSingle(
             u"Sign Accounting Negative Hidden",
             u"currency/USD unit-width-hidden sign-accounting",
-            NumberFormatter::with().sign(UNumberSignDisplay::UNUM_SIGN_ACCOUNTING)
+            NumberFormatter::with()
+                    .sign(UNumberSignDisplay::UNUM_SIGN_ACCOUNTING)
                     .unit(USD)
                     .unitWidth(UNUM_UNIT_WIDTH_HIDDEN),
             Locale::getEnglish(),
             -444444,
             u"(444,444.00)");
+
+    assertFormatSingle(
+            u"Sign Accounting Negative Narrow",
+            u"currency/USD unit-width-narrow sign-accounting",
+            NumberFormatter::with()
+                .sign(UNumberSignDisplay::UNUM_SIGN_ACCOUNTING)
+                .unit(USD)
+                .unitWidth(UNUM_UNIT_WIDTH_NARROW),
+            Locale::getCanada(),
+            -444444,
+            u"($444,444.00)");
+
+    assertFormatSingle(
+            u"Sign Accounting Negative Short",
+            u"currency/USD sign-accounting",
+            NumberFormatter::with()
+                .sign(UNumberSignDisplay::UNUM_SIGN_ACCOUNTING)
+                .unit(USD)
+                .unitWidth(UNUM_UNIT_WIDTH_SHORT),
+            Locale::getCanada(),
+            -444444,
+            u"(US$444,444.00)");
+
+    assertFormatSingle(
+            u"Sign Accounting Negative Iso Code",
+            u"currency/USD unit-width-iso-code sign-accounting",
+            NumberFormatter::with()
+                .sign(UNumberSignDisplay::UNUM_SIGN_ACCOUNTING)
+                .unit(USD)
+                .unitWidth(UNUM_UNIT_WIDTH_ISO_CODE),
+            Locale::getCanada(),
+            -444444,
+            u"(USD 444,444.00)");
+
+    // Note: CLDR does not provide an accounting pattern for long name currency.
+    // We fall back to normal currency format. This may change in the future.
+    assertFormatSingle(
+            u"Sign Accounting Negative Full Name",
+            u"currency/USD unit-width-full-name sign-accounting",
+            NumberFormatter::with()
+                .sign(UNumberSignDisplay::UNUM_SIGN_ACCOUNTING)
+                .unit(USD)
+                .unitWidth(UNUM_UNIT_WIDTH_FULL_NAME),
+            Locale::getCanada(),
+            -444444,
+            u"-444,444.00 US dollars");
 }
 
 void NumberFormatterApiTest::decimal() {

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
@@ -385,8 +385,8 @@ public class NumberFormatterApiTest {
                 1e7,
                 "1000\u842C");
 
-        Map<String, Map<String, String>> compactCustomData = new HashMap<String, Map<String, String>>();
-        Map<String, String> entry = new HashMap<String, String>();
+        Map<String, Map<String, String>> compactCustomData = new HashMap<>();
+        Map<String, String> entry = new HashMap<>();
         entry.put("one", "Kun");
         entry.put("other", "0KK");
         compactCustomData.put("1000", entry);
@@ -1887,6 +1887,40 @@ public class NumberFormatterApiTest {
                 ULocale.ENGLISH,
                 -444444,
                 "(444,444.00)");
+
+        assertFormatSingle(
+                "Sign Accounting Negative Narrow",
+                "currency/USD unit-width-narrow sign-accounting",
+                NumberFormatter.with().sign(SignDisplay.ACCOUNTING).unit(USD).unitWidth(UnitWidth.NARROW),
+                ULocale.CANADA,
+                -444444,
+                "($444,444.00)");
+
+        assertFormatSingle(
+                "Sign Accounting Negative Short",
+                "currency/USD sign-accounting",
+                NumberFormatter.with().sign(SignDisplay.ACCOUNTING).unit(USD).unitWidth(UnitWidth.SHORT),
+                ULocale.CANADA,
+                -444444,
+                "(US$444,444.00)");
+
+        assertFormatSingle(
+                "Sign Accounting Negative Iso Code",
+                "currency/USD unit-width-iso-code sign-accounting",
+                NumberFormatter.with().sign(SignDisplay.ACCOUNTING).unit(USD).unitWidth(UnitWidth.ISO_CODE),
+                ULocale.CANADA,
+                -444444,
+                "(USD 444,444.00)");
+
+        // Note: CLDR does not provide an accounting pattern for long name currency.
+        // We fall back to normal currency format. This may change in the future.
+        assertFormatSingle(
+                "Sign Accounting Negative Full Name",
+                "currency/USD unit-width-full-name sign-accounting",
+                NumberFormatter.with().sign(SignDisplay.ACCOUNTING).unit(USD).unitWidth(UnitWidth.FULL_NAME),
+                ULocale.CANADA,
+                -444444,
+                "-444,444.00 US dollars");
     }
 
     @Test
@@ -2256,7 +2290,7 @@ public class NumberFormatterApiTest {
         methodsWithLowerBoundN1.add("truncateAt");
 
         // Some of the methods require an object to be called upon.
-        Map<String, Object> targets = new HashMap<String, Object>();
+        Map<String, Object> targets = new HashMap<>();
         targets.put("withMinDigits", Precision.integer());
         targets.put("withMaxDigits", Precision.integer());
         targets.put("withMinExponentDigits", Notation.scientific());


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20231
- [x] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

