### PR TITLE
ICU-20214 Fix cross build for Mingw-w64

### DIFF
--- a/icu4c/source/i18n/unicode/numberrangeformatter.h
+++ b/icu4c/source/i18n/unicode/numberrangeformatter.h
@@ -185,7 +185,7 @@ class NumberRangeFormatterImpl;
  * Export an explicit template instantiation. See datefmt.h
  * (When building DLLs for Windows this is required.)
  */
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM < U_PF_CYGWIN && !defined(U_IN_DOXYGEN)
+#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM < U_PF_MINGW && !defined(U_IN_DOXYGEN)
 template struct U_I18N_API std::atomic<impl::NumberRangeFormatterImpl*>;
 #endif
 /** \endcond */


### PR DESCRIPTION
Building on Debian GNU Linux with `configure --host=x86_64-w64-mingw32 && make` failed with a compiler error:

    i18n/unicode/numberrangeformatter.h:189:33: error:
      explicit instantiation of
      ‘struct std::atomic<icu_63::number::impl::NumberRangeFormatterImpl*>’
      in namespace ‘icu_63::number’
      (which does not enclose namespace ‘std’) [-fpermissive]

Signed-off-by: Stefan Weil <sw@weilnetz.de>

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

