### PR TITLE
ICU-13701 Adding custom logic for nickel rounding, C and J.

### DIFF
--- a/icu4c/source/i18n/number_decimalquantity.h
+++ b/icu4c/source/i18n/number_decimalquantity.h
@@ -76,7 +76,7 @@ class U_I18N_API DecimalQuantity : public IFixedDecimal, public UMemory {
      * <p>If rounding to a power of ten, use the more efficient {@link #roundToMagnitude} instead.
      *
      * @param roundingIncrement The increment to which to round.
-     * @param mathContext The {@link RoundingMode} to use if rounding is necessary.
+     * @param roundingMode The {@link RoundingMode} to use if rounding is necessary.
      */
     void roundToIncrement(double roundingIncrement, RoundingMode roundingMode,
                           int32_t maxFrac, UErrorCode& status);
@@ -85,11 +85,20 @@ class U_I18N_API DecimalQuantity : public IFixedDecimal, public UMemory {
     void truncate();
 
     /**
+     * Rounds the number to the nearest multiple of 5 at the specified magnitude.
+     * For example, when magnitude == -2, this performs rounding to the nearest 0.05.
+     *
+     * @param magnitude The magnitude at which the digit should become either 0 or 5.
+     * @param roundingMode Rounding strategy.
+     */
+    void roundToNickel(int32_t magnitude, RoundingMode roundingMode, UErrorCode& status);
+
+    /**
      * Rounds the number to a specified magnitude (power of ten).
      *
      * @param roundingMagnitude The power of ten to which to round. For example, a value of -2 will
      *     round to 2 decimal places.
-     * @param mathContext The {@link RoundingMode} to use if rounding is necessary.
+     * @param roundingMode The {@link RoundingMode} to use if rounding is necessary.
      */
     void roundToMagnitude(int32_t magnitude, RoundingMode roundingMode, UErrorCode& status);
 
@@ -381,6 +390,8 @@ class U_I18N_API DecimalQuantity : public IFixedDecimal, public UMemory {
      * Used for testing.
      */
     bool explicitExactDouble = false;
+
+    void roundToMagnitude(int32_t magnitude, RoundingMode roundingMode, bool nickel, UErrorCode& status);
 
     /**
      * Returns a single digit from the BCD list. No internal state is changed by calling this method.

--- a/icu4c/source/test/intltest/numbertest.h
+++ b/icu4c/source/test/intltest/numbertest.h
@@ -128,6 +128,7 @@ class DecimalQuantityTest : public IntlTest {
     void testHardDoubleConversion();
     void testToDouble();
     void testMaxDigits();
+    void testNickelRounding();
 
     void runIndexedTest(int32_t index, UBool exec, const char *&name, char *par = 0);
 

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/DecimalQuantity.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/DecimalQuantity.java
@@ -62,6 +62,17 @@ public interface DecimalQuantity extends PluralRules.IFixedDecimal {
     public void roundToIncrement(BigDecimal roundingInterval, MathContext mathContext);
 
     /**
+     * Rounds the number to the nearest multiple of 5 at the specified magnitude.
+     * For example, when magnitude == -2, this performs rounding to the nearest 0.05.
+     *
+     * @param magnitude
+     *            The magnitude at which the digit should become either 0 or 5.
+     * @param mathContext
+     *            Rounding strategy.
+     */
+    public void roundToNickel(int magnitude, MathContext mathContext);
+
+    /**
      * Rounds the number to a specified magnitude (power of ten).
      *
      * @param roundingMagnitude

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/impl/number/DecimalQuantity_SimpleStorage.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/impl/number/DecimalQuantity_SimpleStorage.java
@@ -364,6 +364,12 @@ public class DecimalQuantity_SimpleStorage implements DecimalQuantity {
   }
 
   @Override
+  public void roundToNickel(int roundingMagnitude, MathContext mathContext) {
+    BigDecimal nickel = BigDecimal.valueOf(5).scaleByPowerOfTen(roundingMagnitude);
+    roundToIncrement(nickel, mathContext);
+  }
+
+  @Override
   public void roundToMagnitude(int roundingMagnitude, MathContext mathContext) {
     if (roundingMagnitude < -1000) {
       roundToInfinity();


### PR DESCRIPTION
Avoids expensive arithmetic when performing nickel rounding for currencies such as CAD, CHF, and DKK.

Note: This is not the only PR for ICU-13701.  I am sending this PR separately because the change is more complex than I expect the other changes to be.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-13701
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

