### PR TITLE
ICU-20244 Fix gcc stringop-overflow warning/error in uloc.cpp.

### DIFF
--- a/icu4c/source/common/uloc.cpp
+++ b/icu4c/source/common/uloc.cpp
@@ -1738,7 +1738,7 @@ _canonicalize(const char* localeID,
         len = (int32_t)uprv_strlen(d);
 
         if (name != NULL) {
-            uprv_strncpy(name, d, len);
+            uprv_memcpy(name, d, len);
         }
     } else if(_isIDSeparator(*tmpLocaleID)) {
         const char *scriptID;


### PR DESCRIPTION
Hi,

When building with LTO support and -Wall -Wextra -Werror, you might end up in your final program having build errors in ICO code:

```
uloc.cpp: In function ‘_ZL13_canonicalizePKcPcijP10UErrorCode.part.9’:
uloc.cpp:1741: error: ‘strncpy’ specified bound depends on the length of the source argument [-Werror=stringop-overflow=]
uloc.cpp:1738: note: length computed here
lto1: all warnings being treated as errors
```

gcc simply complains that it is not so efficient to use strncpy using the exact lenght of the string computed by memcpy, since it will check for end of string uselessly. Instead using memcpy has the same behavior and is more efficient since it doesn't check the end of string.

I have not signed the CLA. Is this necessary for such a trivial pull request ?

Cheers,
Romain