### PR TITLE
ICU-20202 Replace UVector with MemoryPool in CalendarDataSink.

### DIFF
--- a/icu4c/source/i18n/dtfmtsym.cpp
+++ b/icu4c/source/i18n/dtfmtsym.cpp
@@ -1500,7 +1500,7 @@ struct CalendarDataSink : public ResourceSink {
      * To avoid double deletion, 'maps' won't take ownership of the objects. Instead,
      * 'mapRefs' will own them and will delete them when CalendarDataSink is deleted.
      */
-    UVector mapRefs;
+    MemoryPool<Hashtable> mapRefs;
 
     // Paths and the aliases they point to
     UVector aliasPathPairs;
@@ -1518,7 +1518,7 @@ struct CalendarDataSink : public ResourceSink {
     // Initializes CalendarDataSink with default values
     CalendarDataSink(UErrorCode& status)
     :   arrays(FALSE, status), arraySizes(FALSE, status), maps(FALSE, status),
-        mapRefs(deleteHashtable, NULL, 10, status),
+        mapRefs(),
         aliasPathPairs(uprv_deleteUObject, uhash_compareUnicodeString, status),
         currentCalendarType(), nextCalendarType(),
         resourcesToVisit(NULL), aliasRelativePath() {
@@ -1688,14 +1688,14 @@ struct CalendarDataSink : public ResourceSink {
             if (value.getType() == URES_STRING) {
                 // We are on a leaf, store the map elements into the stringMap
                 if (i == 0) {
-                    LocalPointer<Hashtable> stringMapPtr(new Hashtable(FALSE, errorCode), errorCode);
-                    stringMap = stringMapPtr.getAlias();
+                    // mapRefs will keep ownership of 'stringMap':
+                    stringMap = mapRefs.create(FALSE, errorCode);
+                    if (stringMap == NULL) {
+                        errorCode = U_MEMORY_ALLOCATION_ERROR;
+                        return;
+                    }
                     maps.put(path, stringMap, errorCode);
-                    // mapRefs will take ownership of 'stringMap':
-                    mapRefs.addElement(stringMap, errorCode);
                     if (U_FAILURE(errorCode)) { return; }
-                    // Only release ownership after mapRefs takes it (no error happened):
-                    stringMapPtr.orphan();
                     stringMap->setValueDeleter(uprv_deleteUObject);
                 }
                 U_ASSERT(stringMap != NULL);
@@ -1838,11 +1838,6 @@ struct CalendarDataSink : public ResourceSink {
     // Deleter function to be used by 'arrays'
     static void U_CALLCONV deleteUnicodeStringArray(void *uArray) {
         delete[] static_cast<UnicodeString *>(uArray);
-    }
-
-    // Deleter function to be used by 'maps'
-    static void U_CALLCONV deleteHashtable(void *table) {
-        delete static_cast<Hashtable *>(table);
     }
 };
 // Virtual destructors have to be defined out of line


### PR DESCRIPTION
CalendarDataSink doesn't use any of the additional functionality
provided by UVector, it just needs a simple way to keep track of
allocated objects to delete them after it's done using them.