### PR TITLE
ICU-20202 MemoryPool and uloc_key_type structs inherit from UMemory. …

### DIFF
--- a/icu4c/source/common/cmemory.h
+++ b/icu4c/source/common/cmemory.h
@@ -32,6 +32,10 @@
 #include <string.h>
 #include "unicode/localpointer.h"
 
+#ifdef __cplusplus
+#include "unicode/uobject.h"
+#endif
+
 #if U_DEBUG && defined(UPRV_MALLOC_COUNT)
 #include <stdio.h>
 #endif
@@ -701,7 +705,7 @@ inline H *MaybeStackHeaderAndArray<H, T, stackCapacity>::orphanOrClone(int32_t l
  * It doesn't do anything more than that, and is intentionally kept minimalist.
  */
 template<typename T>
-class MemoryPool {
+class MemoryPool : public UMemory {
     enum { STACK_CAPACITY = 8 };
 public:
     MemoryPool() : count(0), pool() {}

--- a/icu4c/source/common/uloc_keytype.cpp
+++ b/icu4c/source/common/uloc_keytype.cpp
@@ -10,6 +10,7 @@
 
 #include "unicode/utypes.h"
 #include "unicode/unistr.h"
+#include "unicode/uobject.h"
 
 #include "charstr.h"
 #include "cmemory.h"
@@ -33,17 +34,17 @@ typedef enum {
     SPECIALTYPE_RG_KEY_VALUE = 4
 } SpecialType;
 
-typedef struct LocExtKeyData {
+struct LocExtKeyData : public icu::UMemory {
     const char*     legacyId;
     const char*     bcpId;
     icu::LocalUHashtablePointer typeMap;
     uint32_t        specialTypes;
-} LocExtKeyData;
+};
 
-typedef struct LocExtType {
+struct LocExtType : public icu::UMemory {
     const char*     legacyId;
     const char*     bcpId;
-} LocExtType;
+};
 
 static icu::MemoryPool<icu::CharString>* gKeyTypeStringPool = NULL;
 static icu::MemoryPool<LocExtKeyData>* gLocExtKeyDataEntries = NULL;


### PR DESCRIPTION
…Fixes dependencies on global operator new().

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

