### PR TITLE
ICU-20202 Merge #ifdef __cplusplus blocks.

### DIFF
--- a/icu4c/source/common/cmemory.h
+++ b/icu4c/source/common/cmemory.h
@@ -32,10 +32,6 @@
 #include <string.h>
 #include "unicode/localpointer.h"
 
-#ifdef __cplusplus
-#include "unicode/uobject.h"
-#endif
-
 #if U_DEBUG && defined(UPRV_MALLOC_COUNT)
 #include <stdio.h>
 #endif
@@ -127,6 +123,7 @@ uprv_deleteUObject(void *obj);
 #ifdef __cplusplus
 
 #include <utility>
+#include "unicode/uobject.h"
 
 U_NAMESPACE_BEGIN
 


### PR DESCRIPTION
For historical reasons (commit 3b12074b4092241a7e73ec8c7ea6be75548b1b82),
all C++ code (even #include statements) in cmemory.h is contained in an
#ifdef block at the end of the file. A recent bugfix inadvertently added
an additional #ifdef __cplusplus block at the beginning of the file to
add a new #include statement so that C++ #include statements now are
found in two places (commit 1bad36b91afa1fb33a0d45902a163a923d6e860a).