### PR TITLE
ICU-20084 IntlTest, add WHERE macro; remove redundant TEST macros.

### DIFF
--- a/icu4c/source/test/intltest/dcfmapts.cpp
+++ b/icu4c/source/test/intltest/dcfmapts.cpp
@@ -649,27 +649,27 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
     UErrorCode status = U_ZERO_ERROR;
 
     LocalPointer<DecimalFormat> df(new DecimalFormat("###", status), status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     if (status == U_MISSING_RESOURCE_ERROR) {
         return;
     }
     number::impl::DecimalQuantity fd;
     df->formatToDecimalQuantity(44, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(44, fd.getPluralOperand(PLURAL_OPERAND_N));
     ASSERT_EQUAL(0, fd.getPluralOperand(PLURAL_OPERAND_V));
     ASSERT_EQUAL(FALSE, fd.isNegative());
 
     df->formatToDecimalQuantity(-44, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(44, fd.getPluralOperand(PLURAL_OPERAND_N));
     ASSERT_EQUAL(0, fd.getPluralOperand(PLURAL_OPERAND_V));
     ASSERT_EQUAL(TRUE, fd.isNegative());
 
     df.adoptInsteadAndCheckErrorCode(new DecimalFormat("###.00##", status), status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     df->formatToDecimalQuantity(123.456, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(3, fd.getPluralOperand(PLURAL_OPERAND_V)); // v
     ASSERT_EQUAL(456, fd.getPluralOperand(PLURAL_OPERAND_F)); // f
     ASSERT_EQUAL(456, fd.getPluralOperand(PLURAL_OPERAND_T)); // t
@@ -679,7 +679,7 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
     ASSERT_EQUAL(FALSE, fd.isNegative());
 
     df->formatToDecimalQuantity(-123.456, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(3, fd.getPluralOperand(PLURAL_OPERAND_V)); // v
     ASSERT_EQUAL(456, fd.getPluralOperand(PLURAL_OPERAND_F)); // f
     ASSERT_EQUAL(456, fd.getPluralOperand(PLURAL_OPERAND_T)); // t
@@ -691,7 +691,7 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
     // test max int digits
     df->setMaximumIntegerDigits(2);
     df->formatToDecimalQuantity(123.456, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(3, fd.getPluralOperand(PLURAL_OPERAND_V)); // v
     ASSERT_EQUAL(456, fd.getPluralOperand(PLURAL_OPERAND_F)); // f
     ASSERT_EQUAL(456, fd.getPluralOperand(PLURAL_OPERAND_T)); // t
@@ -701,7 +701,7 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
     ASSERT_EQUAL(FALSE, fd.isNegative());
 
     df->formatToDecimalQuantity(-123.456, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(3, fd.getPluralOperand(PLURAL_OPERAND_V)); // v
     ASSERT_EQUAL(456, fd.getPluralOperand(PLURAL_OPERAND_F)); // f
     ASSERT_EQUAL(456, fd.getPluralOperand(PLURAL_OPERAND_T)); // t
@@ -714,7 +714,7 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
     df->setMaximumIntegerDigits(2000000000);
     df->setMaximumFractionDigits(2);
     df->formatToDecimalQuantity(123.456, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(2, fd.getPluralOperand(PLURAL_OPERAND_V)); // v
     ASSERT_EQUAL(46, fd.getPluralOperand(PLURAL_OPERAND_F)); // f
     ASSERT_EQUAL(46, fd.getPluralOperand(PLURAL_OPERAND_T)); // t
@@ -724,7 +724,7 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
     ASSERT_EQUAL(FALSE, fd.isNegative());
 
     df->formatToDecimalQuantity(-123.456, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(2, fd.getPluralOperand(PLURAL_OPERAND_V)); // v
     ASSERT_EQUAL(46, fd.getPluralOperand(PLURAL_OPERAND_F)); // f
     ASSERT_EQUAL(46, fd.getPluralOperand(PLURAL_OPERAND_T)); // t
@@ -738,7 +738,7 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
     df->setRoundingIncrement(7.3);
 
     df->formatToDecimalQuantity(30.0, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(2, fd.getPluralOperand(PLURAL_OPERAND_V)); // v
     ASSERT_EQUAL(20, fd.getPluralOperand(PLURAL_OPERAND_F)); // f
     ASSERT_EQUAL(2, fd.getPluralOperand(PLURAL_OPERAND_T)); // t
@@ -748,7 +748,7 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
     ASSERT_EQUAL(FALSE, fd.isNegative());
 
     df->formatToDecimalQuantity(-30.0, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(2, fd.getPluralOperand(PLURAL_OPERAND_V)); // v
     ASSERT_EQUAL(20, fd.getPluralOperand(PLURAL_OPERAND_F)); // f
     ASSERT_EQUAL(2, fd.getPluralOperand(PLURAL_OPERAND_T)); // t
@@ -758,9 +758,9 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
     ASSERT_EQUAL(TRUE, fd.isNegative());
 
     df.adoptInsteadAndCheckErrorCode(new DecimalFormat("###", status), status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     df->formatToDecimalQuantity(123.456, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(0, fd.getPluralOperand(PLURAL_OPERAND_V));
     ASSERT_EQUAL(0, fd.getPluralOperand(PLURAL_OPERAND_F));
     ASSERT_EQUAL(0, fd.getPluralOperand(PLURAL_OPERAND_T));
@@ -769,9 +769,9 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
     ASSERT_EQUAL(FALSE, fd.isNegative());
 
     df.adoptInsteadAndCheckErrorCode(new DecimalFormat("###.0", status), status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     df->formatToDecimalQuantity(123.01, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(1, fd.getPluralOperand(PLURAL_OPERAND_V));
     ASSERT_EQUAL(0, fd.getPluralOperand(PLURAL_OPERAND_F));
     ASSERT_EQUAL(0, fd.getPluralOperand(PLURAL_OPERAND_T));
@@ -780,9 +780,9 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
     ASSERT_EQUAL(FALSE, fd.isNegative());
 
     df.adoptInsteadAndCheckErrorCode(new DecimalFormat("###.0", status), status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     df->formatToDecimalQuantity(123.06, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(1, fd.getPluralOperand(PLURAL_OPERAND_V));
     ASSERT_EQUAL(1, fd.getPluralOperand(PLURAL_OPERAND_F));
     ASSERT_EQUAL(1, fd.getPluralOperand(PLURAL_OPERAND_T));
@@ -791,9 +791,9 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
     ASSERT_EQUAL(FALSE, fd.isNegative());
 
     df.adoptInsteadAndCheckErrorCode(new DecimalFormat("@@@@@", status), status);  // Significant Digits
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     df->formatToDecimalQuantity(123, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(2, fd.getPluralOperand(PLURAL_OPERAND_V));
     ASSERT_EQUAL(0, fd.getPluralOperand(PLURAL_OPERAND_F));
     ASSERT_EQUAL(0, fd.getPluralOperand(PLURAL_OPERAND_T));
@@ -802,9 +802,9 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
     ASSERT_EQUAL(FALSE, fd.isNegative());
 
     df.adoptInsteadAndCheckErrorCode(new DecimalFormat("@@@@@", status), status);  // Significant Digits
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     df->formatToDecimalQuantity(1.23, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(4, fd.getPluralOperand(PLURAL_OPERAND_V));
     ASSERT_EQUAL(2300, fd.getPluralOperand(PLURAL_OPERAND_F));
     ASSERT_EQUAL(23, fd.getPluralOperand(PLURAL_OPERAND_T));
@@ -813,24 +813,24 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
     ASSERT_EQUAL(FALSE, fd.isNegative());
 
     df->formatToDecimalQuantity(uprv_getInfinity(), fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(TRUE, fd.isNaN() || fd.isInfinite());
     df->formatToDecimalQuantity(0.0, fd, status);
     ASSERT_EQUAL(FALSE, fd.isNaN() || fd.isInfinite());
     df->formatToDecimalQuantity(uprv_getNaN(), fd, status);
     ASSERT_EQUAL(TRUE, fd.isNaN() || fd.isInfinite());
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
 
     // Test Big Decimal input.
     // 22 digits before and after decimal, will exceed the precision of a double
     //    and force DecimalFormat::getFixedDecimal() to work with a digit list.
     df.adoptInsteadAndCheckErrorCode(
         new DecimalFormat("#####################0.00####################", status), status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     Formattable fable("12.34", status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     df->formatToDecimalQuantity(fable, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(2, fd.getPluralOperand(PLURAL_OPERAND_V));
     ASSERT_EQUAL(34, fd.getPluralOperand(PLURAL_OPERAND_F));
     ASSERT_EQUAL(34, fd.getPluralOperand(PLURAL_OPERAND_T));
@@ -839,9 +839,9 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
     ASSERT_EQUAL(FALSE, fd.isNegative());
 
     fable.setDecimalNumber("12.3456789012345678900123456789", status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     df->formatToDecimalQuantity(fable, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(22, fd.getPluralOperand(PLURAL_OPERAND_V));
     ASSERT_EQUAL(3456789012345678900LL, fd.getPluralOperand(PLURAL_OPERAND_F));
     ASSERT_EQUAL(34567890123456789LL, fd.getPluralOperand(PLURAL_OPERAND_T));
@@ -851,9 +851,9 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
 
     // On field overflow, Integer part is truncated on the left, fraction part on the right.
     fable.setDecimalNumber("123456789012345678901234567890.123456789012345678901234567890", status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     df->formatToDecimalQuantity(fable, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(22, fd.getPluralOperand(PLURAL_OPERAND_V));
     ASSERT_EQUAL(1234567890123456789LL, fd.getPluralOperand(PLURAL_OPERAND_F));
     ASSERT_EQUAL(1234567890123456789LL, fd.getPluralOperand(PLURAL_OPERAND_T));
@@ -863,9 +863,9 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
 
     // Digits way to the right of the decimal but within the format's precision aren't truncated
     fable.setDecimalNumber("1.0000000000000000000012", status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     df->formatToDecimalQuantity(fable, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(22, fd.getPluralOperand(PLURAL_OPERAND_V));
     ASSERT_EQUAL(12, fd.getPluralOperand(PLURAL_OPERAND_F));
     ASSERT_EQUAL(12, fd.getPluralOperand(PLURAL_OPERAND_T));
@@ -875,9 +875,9 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
 
     // Digits beyond the precision of the format are rounded away
     fable.setDecimalNumber("1.000000000000000000000012", status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     df->formatToDecimalQuantity(fable, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(2, fd.getPluralOperand(PLURAL_OPERAND_V));
     ASSERT_EQUAL(0, fd.getPluralOperand(PLURAL_OPERAND_F));
     ASSERT_EQUAL(0, fd.getPluralOperand(PLURAL_OPERAND_T));
@@ -887,9 +887,9 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
 
     // Negative numbers come through
     fable.setDecimalNumber("-1.0000000000000000000012", status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     df->formatToDecimalQuantity(fable, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(22, fd.getPluralOperand(PLURAL_OPERAND_V));
     ASSERT_EQUAL(12, fd.getPluralOperand(PLURAL_OPERAND_F));
     ASSERT_EQUAL(12, fd.getPluralOperand(PLURAL_OPERAND_T));
@@ -899,9 +899,9 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
 
     // MinFractionDigits from format larger than from number.
     fable.setDecimalNumber("1000000000000000000000.3", status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     df->formatToDecimalQuantity(fable, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(2, fd.getPluralOperand(PLURAL_OPERAND_V));
     ASSERT_EQUAL(30, fd.getPluralOperand(PLURAL_OPERAND_F));
     ASSERT_EQUAL(3, fd.getPluralOperand(PLURAL_OPERAND_T));
@@ -910,9 +910,9 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
     ASSERT_EQUAL(FALSE, fd.isNegative());
 
     fable.setDecimalNumber("1000000000000000050000.3", status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     df->formatToDecimalQuantity(fable, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(2, fd.getPluralOperand(PLURAL_OPERAND_V));
     ASSERT_EQUAL(30, fd.getPluralOperand(PLURAL_OPERAND_F));
     ASSERT_EQUAL(3, fd.getPluralOperand(PLURAL_OPERAND_T));
@@ -922,9 +922,9 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
 
     // Test some int64_t values that are out of the range of a double
     fable.setInt64(4503599627370496LL);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     df->formatToDecimalQuantity(fable, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(2, fd.getPluralOperand(PLURAL_OPERAND_V));
     ASSERT_EQUAL(0, fd.getPluralOperand(PLURAL_OPERAND_F));
     ASSERT_EQUAL(0, fd.getPluralOperand(PLURAL_OPERAND_T));
@@ -933,9 +933,9 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
     ASSERT_EQUAL(FALSE, fd.isNegative());
 
     fable.setInt64(4503599627370497LL);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     df->formatToDecimalQuantity(fable, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(2, fd.getPluralOperand(PLURAL_OPERAND_V));
     ASSERT_EQUAL(0, fd.getPluralOperand(PLURAL_OPERAND_F));
     ASSERT_EQUAL(0, fd.getPluralOperand(PLURAL_OPERAND_T));
@@ -944,9 +944,9 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
     ASSERT_EQUAL(FALSE, fd.isNegative());
 
     fable.setInt64(9223372036854775807LL);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     df->formatToDecimalQuantity(fable, fd, status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
     ASSERT_EQUAL(2, fd.getPluralOperand(PLURAL_OPERAND_V));
     ASSERT_EQUAL(0, fd.getPluralOperand(PLURAL_OPERAND_F));
     ASSERT_EQUAL(0, fd.getPluralOperand(PLURAL_OPERAND_T));
@@ -1024,11 +1024,6 @@ void IntlTestDecimalFormatAPI::TestRequiredDecimalPoint() {
         errln((UnicodeString)"ERROR: unexpected parse(2)");
     }
 }
-
-// WHERE Macro yields a literal string of the form "source_file_name:line number "
-#define WHERE __FILE__ ":" XLINE(__LINE__) " "
-#define XLINE(s) LINE(s)
-#define LINE(s) #s
 
 void IntlTestDecimalFormatAPI::testErrorCode() {
     // Try each DecimalFormat constructor with an errorCode set on input,

--- a/icu4c/source/test/intltest/intltest.h
+++ b/icu4c/source/test/intltest/intltest.h
@@ -127,11 +127,11 @@ UnicodeString toString(UBool b);
         break; \
     }
 
-#define TEST_ASSERT_TRUE(x) \
-  assertTrue(#x, (x), FALSE, FALSE, __FILE__, __LINE__)
 
-#define TEST_ASSERT_STATUS(x) \
-  assertSuccess(#x, (x), FALSE, __FILE__, __LINE__)
+// WHERE Macro yields a literal string of the form "source_file_name:line number "
+#define WHERE __FILE__ ":" XLINE(__LINE__) " "
+#define XLINE(s) LINE(s)
+#define LINE(s) #s
 
 class IntlTest : public TestLog {
 public:

--- a/icu4c/source/test/intltest/itutil.cpp
+++ b/icu4c/source/test/intltest/itutil.cpp
@@ -874,47 +874,47 @@ void EnumSetTest::TestEnumSet() {
     logln("Enum is from [%d..%d]\n", MAX_NONBOOLEAN+1,
           LIMIT_BOOLEAN);
 
-    TEST_ASSERT_TRUE(flags.get(THING1) == FALSE);
-    TEST_ASSERT_TRUE(flags.get(THING2) == FALSE);
-    TEST_ASSERT_TRUE(flags.get(THING3) == FALSE);
+    assertFalse(WHERE, flags.get(THING1));
+    assertFalse(WHERE, flags.get(THING2));
+    assertFalse(WHERE, flags.get(THING3));
 
     logln("get(thing1)=%d, get(thing2)=%d, get(thing3)=%d\n",          flags.get(THING1),          flags.get(THING2),          flags.get(THING3));
     logln("Value now: %d\n", flags.getAll());
     flags.clear();
     logln("clear -Value now: %d\n", flags.getAll());
     logln("get(thing1)=%d, get(thing2)=%d, get(thing3)=%d\n",          flags.get(THING1),          flags.get(THING2),          flags.get(THING3));
-    TEST_ASSERT_TRUE(flags.get(THING1) == FALSE);
-    TEST_ASSERT_TRUE(flags.get(THING2) == FALSE);
-    TEST_ASSERT_TRUE(flags.get(THING3) == FALSE);
+    assertFalse(WHERE, flags.get(THING1));
+    assertFalse(WHERE, flags.get(THING2));
+    assertFalse(WHERE, flags.get(THING3));
     flags.add(THING1);
     logln("set THING1 -Value now: %d\n", flags.getAll());
-    TEST_ASSERT_TRUE(flags.get(THING1) == TRUE);
-    TEST_ASSERT_TRUE(flags.get(THING2) == FALSE);
-    TEST_ASSERT_TRUE(flags.get(THING3) == FALSE);
+    assertTrue(WHERE, flags.get(THING1));
+    assertFalse(WHERE, flags.get(THING2));
+    assertFalse(WHERE, flags.get(THING3));
     logln("get(thing1)=%d, get(thing2)=%d, get(thing3)=%d\n",          flags.get(THING1),          flags.get(THING2),          flags.get(THING3));
     flags.add(THING3);
     logln("set THING3 -Value now: %d\n", flags.getAll());
-    TEST_ASSERT_TRUE(flags.get(THING1) == TRUE);
-    TEST_ASSERT_TRUE(flags.get(THING2) == FALSE);
-    TEST_ASSERT_TRUE(flags.get(THING3) == TRUE);
+    assertTrue(WHERE, flags.get(THING1));
+    assertFalse(WHERE, flags.get(THING2));
+    assertTrue(WHERE, flags.get(THING3));
     logln("get(thing1)=%d, get(thing2)=%d, get(thing3)=%d\n",          flags.get(THING1),          flags.get(THING2),          flags.get(THING3));
     flags.remove(THING2);
-    TEST_ASSERT_TRUE(flags.get(THING1) == TRUE);
-    TEST_ASSERT_TRUE(flags.get(THING2) == FALSE);
-    TEST_ASSERT_TRUE(flags.get(THING3) == TRUE);
+    assertTrue(WHERE, flags.get(THING1));
+    assertFalse(WHERE, flags.get(THING2));
+    assertTrue(WHERE, flags.get(THING3));
     logln("remove THING2 -Value now: %d\n", flags.getAll());
     logln("get(thing1)=%d, get(thing2)=%d, get(thing3)=%d\n",          flags.get(THING1),          flags.get(THING2),          flags.get(THING3));
     flags.remove(THING1);
-    TEST_ASSERT_TRUE(flags.get(THING1) == FALSE);
-    TEST_ASSERT_TRUE(flags.get(THING2) == FALSE);
-    TEST_ASSERT_TRUE(flags.get(THING3) == TRUE);
+    assertFalse(WHERE, flags.get(THING1));
+    assertFalse(WHERE, flags.get(THING2));
+    assertTrue(WHERE, flags.get(THING3));
     logln("remove THING1 -Value now: %d\n", flags.getAll());
     logln("get(thing1)=%d, get(thing2)=%d, get(thing3)=%d\n",          flags.get(THING1),          flags.get(THING2),          flags.get(THING3));
 
     flags.clear();
     logln("clear -Value now: %d\n", flags.getAll());
     logln("get(thing1)=%d, get(thing2)=%d, get(thing3)=%d\n",          flags.get(THING1),          flags.get(THING2),          flags.get(THING3));
-    TEST_ASSERT_TRUE(flags.get(THING1) == FALSE);
-    TEST_ASSERT_TRUE(flags.get(THING2) == FALSE);
-    TEST_ASSERT_TRUE(flags.get(THING3) == FALSE);
+    assertFalse(WHERE, flags.get(THING1));
+    assertFalse(WHERE, flags.get(THING2));
+    assertFalse(WHERE, flags.get(THING3));
 }

--- a/icu4c/source/test/intltest/loctest.cpp
+++ b/icu4c/source/test/intltest/loctest.cpp
@@ -2327,7 +2327,7 @@ void LocaleTest::checkRegisteredCollators(const char *expectExtra) {
     int32_t count1=0,count2=0;
     Hashtable oldHash(status);
     Hashtable newHash(status);
-    TEST_ASSERT_STATUS(status);
+    assertSuccess(WHERE, status);
 
     UnicodeString expectStr(expectExtra?expectExtra:"n/a", "");
 

--- a/icu4c/source/test/intltest/numfmtst.cpp
+++ b/icu4c/source/test/intltest/numfmtst.cpp
@@ -2195,7 +2195,7 @@ void NumberFormatTest::TestSymbolsWithBadLocale(void) {
     for (i = 0; i < UPRV_LENGTHOF(badLocales); i++) {
         const char *localeName = badLocales[i];
         Locale locBad(localeName);
-        TEST_ASSERT_TRUE(!locBad.isBogus());
+        assertTrue(WHERE, !locBad.isBogus());
         UErrorCode status = U_ZERO_ERROR;
         UnicodeString intlCurrencySymbol((UChar)0xa4);
 

--- a/icu4c/source/test/intltest/rbbiapts.cpp
+++ b/icu4c/source/test/intltest/rbbiapts.cpp
@@ -1389,9 +1389,9 @@ void RBBIAPITest::TestFilteredBreakIteratorBuilder() {
       prtbrks(filteredBI.getAlias(), frText, *this);
 
       // Verify ==
-      TEST_ASSERT_TRUE(*frenchBI   == *frenchBI);
-      TEST_ASSERT_TRUE(*filteredBI != *frenchBI);
-      TEST_ASSERT_TRUE(*frenchBI   != *filteredBI);
+      assertTrue(WHERE, *frenchBI   == *frenchBI);
+      assertTrue(WHERE, *filteredBI != *frenchBI);
+      assertTrue(WHERE, *frenchBI   != *filteredBI);
     } else {
       dataerrln("French BI: not valid.");
 	}

--- a/icu4c/source/test/intltest/rbbitst.cpp
+++ b/icu4c/source/test/intltest/rbbitst.cpp
@@ -4356,13 +4356,6 @@ void RBBITest::TestEmoji() {
 
 // TestBug12519  -  Correct handling of Locales by assignment / copy / clone
 
-// WHERE Macro yields a literal string of the form "source_file_name:line number "
-// TODO: propose something equivalent as a test framework addition.
-
-#define WHERE __FILE__ ":" XLINE(__LINE__) " "
-#define XLINE(s) LINE(s)
-#define LINE(s) #s
-
 void RBBITest::TestBug12519() {
     UErrorCode status = U_ZERO_ERROR;
     LocalPointer<RuleBasedBreakIterator> biEn((RuleBasedBreakIterator *)BreakIterator::createWordInstance(Locale::getEnglish(), status));

--- a/icu4c/source/test/intltest/ustrtest.cpp
+++ b/icu4c/source/test/intltest/ustrtest.cpp
@@ -2204,7 +2204,7 @@ UnicodeStringTest::TestUInt16Pointers() {
 
     UErrorCode errorCode = U_ZERO_ERROR;
     int32_t length = UnicodeString(u"def").extract(arr, 4, errorCode);
-    TEST_ASSERT_STATUS(errorCode);
+    assertSuccess(WHERE, errorCode);
     assertEquals("def from extract()", UnicodeString(u"def"), UnicodeString(arr, length));
 }
 
@@ -2226,7 +2226,7 @@ UnicodeStringTest::TestWCharPointers() {
 
     UErrorCode errorCode = U_ZERO_ERROR;
     int32_t length = UnicodeString(u"def").extract(arr, 4, errorCode);
-    TEST_ASSERT_STATUS(errorCode);
+    assertSuccess(WHERE, errorCode);
     assertEquals("def from extract()", UnicodeString(u"def"), UnicodeString(arr, length));
 #endif
 }


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

