### PR TITLE
ICU-20265 Use noexcept instead of throw() in C++ >= 11.

### DIFF
--- a/icu4c/source/common/cmemory.h
+++ b/icu4c/source/common/cmemory.h
@@ -281,10 +281,10 @@ template<typename T, int32_t stackCapacity>
 class MaybeStackArray {
 public:
     // No heap allocation. Use only on the stack.
-    static void* U_EXPORT2 operator new(size_t) U_NO_THROW = delete;
-    static void* U_EXPORT2 operator new[](size_t) U_NO_THROW = delete;
+    static void* U_EXPORT2 operator new(size_t) U_NOEXCEPT = delete;
+    static void* U_EXPORT2 operator new[](size_t) U_NOEXCEPT = delete;
 #if U_HAVE_PLACEMENT_NEW
-    static void* U_EXPORT2 operator new(size_t, void*) U_NO_THROW = delete;
+    static void* U_EXPORT2 operator new(size_t, void*) U_NOEXCEPT = delete;
 #endif
 
     /**
@@ -496,10 +496,10 @@ template<typename H, typename T, int32_t stackCapacity>
 class MaybeStackHeaderAndArray {
 public:
     // No heap allocation. Use only on the stack.
-    static void* U_EXPORT2 operator new(size_t) U_NO_THROW = delete;
-    static void* U_EXPORT2 operator new[](size_t) U_NO_THROW = delete;
+    static void* U_EXPORT2 operator new(size_t) U_NOEXCEPT = delete;
+    static void* U_EXPORT2 operator new[](size_t) U_NOEXCEPT = delete;
 #if U_HAVE_PLACEMENT_NEW
-    static void* U_EXPORT2 operator new(size_t, void*) U_NO_THROW = delete;
+    static void* U_EXPORT2 operator new(size_t, void*) U_NOEXCEPT = delete;
 #endif
 
     /**

--- a/icu4c/source/common/unicode/uobject.h
+++ b/icu4c/source/common/unicode/uobject.h
@@ -20,6 +20,7 @@
 #define __UOBJECT_H__
 
 #include "unicode/utypes.h"
+#include "unicode/platform.h"
 
 /**
  * \file
@@ -28,7 +29,9 @@
 
 /**
  * \def U_NO_THROW
- *         Define this to define the throw() specification so
+ *         Since ICU 64, use U_NOEXCEPT instead.
+ *
+ *         Previously, define this to define the throw() specification so
  *                 certain functions do not throw any exceptions
  *
  *         UMemory operator new methods should have the throw() specification 
@@ -37,7 +40,7 @@
  *         constructor is still called, and if the constructor references member 
  *         data, (which it typically does), the result is a segmentation violation.
  *
- * @stable ICU 4.2
+ * @stable ICU 4.2. Since ICU 64, Use U_NOEXCEPT instead. See ICU-20422.
  */
 #ifndef U_NO_THROW
 #define U_NO_THROW throw()
@@ -125,14 +128,14 @@ public:
      * for ICU4C C++ classes
      * @stable ICU 2.4
      */
-    static void * U_EXPORT2 operator new(size_t size) U_NO_THROW;
+    static void * U_EXPORT2 operator new(size_t size) U_NOEXCEPT;
 
     /**
      * Override for ICU4C C++ memory management.
      * See new().
      * @stable ICU 2.4
      */
-    static void * U_EXPORT2 operator new[](size_t size) U_NO_THROW;
+    static void * U_EXPORT2 operator new[](size_t size) U_NOEXCEPT;
 
     /**
      * Override for ICU4C C++ memory management.
@@ -142,14 +145,14 @@ public:
      * for ICU4C C++ classes
      * @stable ICU 2.4
      */
-    static void U_EXPORT2 operator delete(void *p) U_NO_THROW;
+    static void U_EXPORT2 operator delete(void *p) U_NOEXCEPT;
 
     /**
      * Override for ICU4C C++ memory management.
      * See delete().
      * @stable ICU 2.4
      */
-    static void U_EXPORT2 operator delete[](void *p) U_NO_THROW;
+    static void U_EXPORT2 operator delete[](void *p) U_NOEXCEPT;
 
 #if U_HAVE_PLACEMENT_NEW
     /**
@@ -157,14 +160,14 @@ public:
      * See new().
      * @stable ICU 2.6
      */
-    static inline void * U_EXPORT2 operator new(size_t, void *ptr) U_NO_THROW { return ptr; }
+    static inline void * U_EXPORT2 operator new(size_t, void *ptr) U_NOEXCEPT { return ptr; }
 
     /**
      * Override for ICU4C C++ memory management for STL.
      * See delete().
      * @stable ICU 2.6
      */
-    static inline void U_EXPORT2 operator delete(void *, void *) U_NO_THROW {}
+    static inline void U_EXPORT2 operator delete(void *, void *) U_NOEXCEPT {}
 #endif /* U_HAVE_PLACEMENT_NEW */
 #if U_HAVE_DEBUG_LOCATION_NEW
     /**
@@ -174,7 +177,7 @@ public:
       * @param file   The file where the allocation was requested
       * @param line   The line where the allocation was requested 
       */ 
-    static void * U_EXPORT2 operator new(size_t size, const char* file, int line) U_NO_THROW;
+    static void * U_EXPORT2 operator new(size_t size, const char* file, int line) U_NOEXCEPT;
     /**
       * This method provides a matching delete for the MFC debug new
       * 
@@ -182,7 +185,7 @@ public:
       * @param file   The file where the allocation was requested
       * @param line   The line where the allocation was requested 
       */ 
-    static void U_EXPORT2 operator delete(void* p, const char* file, int line) U_NO_THROW;
+    static void U_EXPORT2 operator delete(void* p, const char* file, int line) U_NOEXCEPT;
 #endif /* U_HAVE_DEBUG_LOCATION_NEW */
 #endif /* U_OVERRIDE_CXX_ALLOCATION */
 

--- a/icu4c/source/common/uobject.cpp
+++ b/icu4c/source/common/uobject.cpp
@@ -58,32 +58,32 @@ U_NAMESPACE_BEGIN
  * and replace with uprv_malloc/uprv_free.
  */
 
-void * U_EXPORT2 UMemory::operator new(size_t size) U_NO_THROW {
+void * U_EXPORT2 UMemory::operator new(size_t size) U_NOEXCEPT {
     return uprv_malloc(size);
 }
 
-void U_EXPORT2 UMemory::operator delete(void *p) U_NO_THROW {
+void U_EXPORT2 UMemory::operator delete(void *p) U_NOEXCEPT {
     if(p!=NULL) {
         uprv_free(p);
     }
 }
 
-void * U_EXPORT2 UMemory::operator new[](size_t size) U_NO_THROW {
+void * U_EXPORT2 UMemory::operator new[](size_t size) U_NOEXCEPT {
     return uprv_malloc(size);
 }
 
-void U_EXPORT2 UMemory::operator delete[](void *p) U_NO_THROW {
+void U_EXPORT2 UMemory::operator delete[](void *p) U_NOEXCEPT {
     if(p!=NULL) {
         uprv_free(p);
     }
 }
 
 #if U_HAVE_DEBUG_LOCATION_NEW
-void * U_EXPORT2 UMemory::operator new(size_t size, const char* /*file*/, int /*line*/) U_NO_THROW {
+void * U_EXPORT2 UMemory::operator new(size_t size, const char* /*file*/, int /*line*/) U_NOEXCEPT {
     return UMemory::operator new(size);
 }
 
-void U_EXPORT2 UMemory::operator delete(void* p, const char* /*file*/, int /*line*/) U_NO_THROW {
+void U_EXPORT2 UMemory::operator delete(void* p, const char* /*file*/, int /*line*/) U_NOEXCEPT {
     UMemory::operator delete(p);
 }
 #endif /* U_HAVE_DEBUG_LOCATION_NEW */

--- a/icu4c/source/common/uresimp.h
+++ b/icu4c/source/common/uresimp.h
@@ -109,10 +109,10 @@ U_NAMESPACE_BEGIN
 class U_COMMON_API StackUResourceBundle {
 public:
     // No heap allocation. Use only on the stack.
-    static void* U_EXPORT2 operator new(size_t) U_NO_THROW = delete;
-    static void* U_EXPORT2 operator new[](size_t) U_NO_THROW = delete;
+    static void* U_EXPORT2 operator new(size_t) U_NOEXCEPT = delete;
+    static void* U_EXPORT2 operator new[](size_t) U_NOEXCEPT = delete;
 #if U_HAVE_PLACEMENT_NEW
-    static void* U_EXPORT2 operator new(size_t, void*) U_NO_THROW = delete;
+    static void* U_EXPORT2 operator new(size_t, void*) U_NOEXCEPT = delete;
 #endif
 
     StackUResourceBundle();

--- a/icu4c/source/i18n/fphdlimp.h
+++ b/icu4c/source/i18n/fphdlimp.h
@@ -73,10 +73,10 @@ class FieldPositionIteratorHandler : public FieldPositionHandler {
   // to be destroyed before status goes out of scope.  Easiest thing is to
   // allocate us on the stack in the same (or narrower) scope as status has.
   // This attempts to encourage that by blocking heap allocation.
-  static void* U_EXPORT2 operator new(size_t) U_NO_THROW = delete;
-  static void* U_EXPORT2 operator new[](size_t) U_NO_THROW = delete;
+  static void* U_EXPORT2 operator new(size_t) U_NOEXCEPT = delete;
+  static void* U_EXPORT2 operator new[](size_t) U_NOEXCEPT = delete;
 #if U_HAVE_PLACEMENT_NEW
-  static void* U_EXPORT2 operator new(size_t, void*) U_NO_THROW = delete;
+  static void* U_EXPORT2 operator new(size_t, void*) U_NOEXCEPT = delete;
 #endif
 
  public:


### PR DESCRIPTION
Hi,

When building in C++ >= 11 with clang and the -Wdeprecated flag, ICU headers emit a warning for U_NO_THROW usage. It is today defined as "throw()" which is deprecated in C++11, and shall be replaced by "noexecpt" instead.

Note: my company is currently figuring out the paperwork for the CLA.

Cheers,
Romain