### PR TITLE
ICU-20276 Accept nullptr|"" as the 2nd parameter in Locale::setUnicodeKeywordValue

### DIFF
--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -1451,11 +1451,6 @@ Locale::setUnicodeKeywordValue(StringPiece keywordName,
     const char* legacy_value =
         uloc_toLegacyType(keywordName_nul.data(), keywordValue_nul.data());
 
-    if (legacy_value == nullptr) {
-        status = U_ILLEGAL_ARGUMENT_ERROR;
-        return;
-    }
-
     setKeywordValue(legacy_key, legacy_value, status);
 }
 

--- a/icu4c/source/test/intltest/loctest.cpp
+++ b/icu4c/source/test/intltest/loctest.cpp
@@ -1969,6 +1969,19 @@ LocaleTest::TestSetUnicodeKeywordValueStringPiece(void) {
 
     static const char expected[] = "de@calendar=buddhist;collation=phonebook";
     assertEquals("", expected, l.getName());
+
+    l.setUnicodeKeywordValue("co", nullptr, status);
+    status.errIfFailureAndReset();
+
+    assertEquals("setUnicodeKeywordValue('co', nullptr') should remove collation value",
+                 "de@calendar=buddhist", l.getName());
+
+    l.setUnicodeKeywordValue("ca", "", status);
+    status.errIfFailureAndReset();
+
+    assertEquals("setUnicodeKeywordValue('ca', nullptr') should remove calendar value",
+                 "de", l.getName());
+
 }
 
 void


### PR DESCRIPTION
Accept nullptr or "" as the 2nd parameter in Locale::setUnicodeKeywordValue

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20276
- [X] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [X] Tests included
- [ ] Documentation is changed or added

