### PR TITLE
ICU-20276 Accept empty strings in Locale::setUnicodeKeywordValue().

### DIFF
--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -1448,12 +1448,16 @@ Locale::setUnicodeKeywordValue(StringPiece keywordName,
         return;
     }
 
-    const char* legacy_value =
-        uloc_toLegacyType(keywordName_nul.data(), keywordValue_nul.data());
+    const char* legacy_value = nullptr;
 
-    if (legacy_value == nullptr) {
-        status = U_ILLEGAL_ARGUMENT_ERROR;
-        return;
+    if (!keywordValue_nul.isEmpty()) {
+        legacy_value =
+            uloc_toLegacyType(keywordName_nul.data(), keywordValue_nul.data());
+
+        if (legacy_value == nullptr) {
+            status = U_ILLEGAL_ARGUMENT_ERROR;
+            return;
+        }
     }
 
     setKeywordValue(legacy_key, legacy_value, status);

--- a/icu4c/source/test/intltest/loctest.cpp
+++ b/icu4c/source/test/intltest/loctest.cpp
@@ -1969,6 +1969,26 @@ LocaleTest::TestSetUnicodeKeywordValueStringPiece(void) {
 
     static const char expected[] = "de@calendar=buddhist;collation=phonebook";
     assertEquals("", expected, l.getName());
+
+    l.setUnicodeKeywordValue("cu", nullptr, status);
+    status.errIfFailureAndReset();
+    assertEquals("", expected, l.getName());
+
+    l.setUnicodeKeywordValue("!!", nullptr, status);
+    assertEquals("status", U_ILLEGAL_ARGUMENT_ERROR, status.reset());
+    assertEquals("", expected, l.getName());
+
+    l.setUnicodeKeywordValue("co", "!!", status);
+    assertEquals("status", U_ILLEGAL_ARGUMENT_ERROR, status.reset());
+    assertEquals("", expected, l.getName());
+
+    l.setUnicodeKeywordValue("co", nullptr, status);
+    status.errIfFailureAndReset();
+
+    l.setUnicodeKeywordValue("ca", "", status);
+    status.errIfFailureAndReset();
+
+    assertEquals("", Locale::getGerman().getName(), l.getName());
 }
 
 void


### PR DESCRIPTION
The API documentation is perfectly clear about this, an empty string for
the value means that the keyword should be removed:

  @param keywordValue value of the keyword to be set. If 0-length or
   NULL, will result in the keyword being removed. No error is given if
   that keyword does not exist.
