### PR TITLE
ICU-10923 warn if Python≯3, but fix 1 err message

### DIFF
--- a/icu4c/source/data/BUILDRULES.py
+++ b/icu4c/source/data/BUILDRULES.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2018 and later: Unicode, Inc. and others.
 # License & terms of use: http://www.unicode.org/copyright.html
 
+from __future__ import print_function
 from distutils.sysconfig import parse_makefile
 
 from buildtool import *

--- a/icu4c/source/data/buildtool/__main__.py
+++ b/icu4c/source/data/buildtool/__main__.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2018 and later: Unicode, Inc. and others.
 # License & terms of use: http://www.unicode.org/copyright.html
 
+from __future__ import print_function
 import argparse
 import glob as pyglob
 import sys
@@ -170,6 +171,8 @@ def main():
     else:
         print("Format not supported: %s" % args.format)
         return 1
+    if sys.version_info.major < 3:
+        print("Warning: Please upgrade to Python 3+, you have %s" % sys.version, file=sys.stderr)
     return 0
 
 if __name__ == "__main__":


### PR DESCRIPTION
`configure PYTHON3=python2.7` is enough to test this.
