### PR TITLE
ICU-20281 Reenable the VS2015 build bot. Use manual install of Py3.

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -81,27 +81,34 @@ jobs:
         filename: icu4c/source/allinone/icucheck.bat
         arguments: 'x86 Release'
 #-------------------------------------------------------------------------
-# Disabled until the VS2015 image has Python 3 working.
+# Using a manual install of Python 3, until the vs2015 image has it 
+# by default.
 #
-#- job: ICU4C_MSVC_x64_Release_VS2015
-#  displayName: 'C: MSVC 64-bit Release (VS 2015)'
-#  timeoutInMinutes: 30
-#  pool:
-#    vmImage: 'vs2015-win2012r2'
-#    demands: 
-#      - msbuild
-#      - visualstudio
-#      - Cmd
-#  steps:
-#    - task: VSBuild@1
-#      displayName: 'Build Solution'
-#      inputs:
-#        solution: icu4c/source/allinone/allinone.sln
-#        platform: x64
-#        configuration: Release
-#        msbuildArgs: '/p:SkipUWP=true'
-#    - task: BatchScript@1
-#      displayName: 'Run Tests (icucheck.bat)'
-#      inputs:
-#        filename: icu4c/source/allinone/icucheck.bat
-#        arguments: 'x64 Release'
+- job: ICU4C_MSVC_x64_Release_VS2015
+  displayName: 'C: MSVC 64-bit Release (VS 2015)'
+  timeoutInMinutes: 30
+  pool:
+    vmImage: 'vs2015-win2012r2'
+    demands: 
+      - msbuild
+      - visualstudio
+      - Cmd
+  steps:
+    - powershell: 'Invoke-WebRequest https://www.python.org/ftp/python/3.7.1/python-3.7.1-amd64-webinstall.exe -OutFile c:\py3-setup.exe'
+    - script: |
+        c:\py3-setup.exe /quiet PrependPath=1 InstallAllUsers=1 Include_launcher=1 InstallLauncherAllUsers=1 Include_test=0 Include_doc=0 Include_dev=0 Include_debug=0 Include_tcltk=0 TargetDir=c:\py3
+    - script: |
+        python --version
+        py -3 --version
+    - task: VSBuild@1
+      displayName: 'Build Solution'
+      inputs:
+        solution: icu4c/source/allinone/allinone.sln
+        platform: x64
+        configuration: Release
+        msbuildArgs: '/p:SkipUWP=true'
+    - task: BatchScript@1
+      displayName: 'Run Tests (icucheck.bat)'
+      inputs:
+        filename: icu4c/source/allinone/icucheck.bat
+        arguments: 'x64 Release'


### PR DESCRIPTION
This is a somewhat hacky workaround until the VS2015 images are updated to include Python 3 by default.
(Using the webinstaller with various options to try and limit the amount downloaded on each build.)

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20281
- [x] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

