### PR TITLE
ICU-20186 Adding test for leading and trailing spaces in DecimalFormat.

### DIFF
--- a/icu4c/source/test/intltest/numfmtst.cpp
+++ b/icu4c/source/test/intltest/numfmtst.cpp
@@ -411,6 +411,10 @@ void NumberFormatTest::Test20186_SpacesAroundSemicolon() {
     df = DecimalFormat(u"0.00;0.00", {"en-us", status}, status);
     expect2(df, 1, u"1.00");
     expect(df, -1, u"1.00");  // parses as 1, not -1
+
+    df = DecimalFormat(u" 0.00 ; -0.00 ", {"en-us", status}, status);
+    expect2(df, 1, u" 1.00 ");
+    expect2(df, -1, u" -1.00 ");
 }
 
 /*

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/NumberFormatTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/NumberFormatTest.java
@@ -270,6 +270,10 @@ public class NumberFormatTest extends TestFmwk {
         df = new DecimalFormat("0.00;0.00");
         expect2(df, 1, "1.00");
         expect(df, -1, "1.00");  // parses as 1, not -1
+
+        df = new DecimalFormat(" 0.00 ; -0.00 ");
+        expect2(df, 1, " 1.00 ");
+        expect2(df, -1, " -1.00 ");
     }
 
     // Test exponential pattern


### PR DESCRIPTION
Follow-up to #184

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20186
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

