### PR TITLE
ICU-20287 ICU4J source tarball does not contain maven pom templates

### DIFF
--- a/icu4j/build.xml
+++ b/icu4j/build.xml
@@ -1094,6 +1094,7 @@
                 eol="lf">
             <include name="demos/**/*"/>
             <include name="main/**/*"/>
+            <include name="maven/**/*"/>
             <include name="perf-tests/**/*"/>
             <include name="samples/**/*"/>
             <include name="tools/**/*"/>


### PR DESCRIPTION
Simple change to include the missing pom templates.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20287
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

