### PR TITLE
ICU-20295 Fix wrong java doc of "{#link" in TimeZoneFormat

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/text/TimeZoneFormat.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/TimeZoneFormat.java
@@ -723,7 +723,7 @@ public class TimeZoneFormat extends UFormat implements Freezable<TimeZoneFormat>
      * Sets the default parse options.
      * <p>
      * <b>Note:</b> By default, an instance of <code>TimeZoneFormat</code>
-     * created by {#link {@link #getInstance(ULocale)} has no parse options set.
+     * created by {@link #getInstance(ULocale)} has no parse options set.
      *
      * @param options the default parse options.
      * @return this object.


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20295
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [x] Documentation is changed or added

