### PR TITLE
ICU-10923 Fixing broken dependency names in BUILDRULES.py.

### DIFF
--- a/icu4c/source/data/BUILDRULES.py
+++ b/icu4c/source/data/BUILDRULES.py
@@ -120,7 +120,7 @@ def generate(config, glob, common_vars):
         # Depends on timezoneTypes.res and keyTypeData.res.
         # TODO: We should not need this dependency to build collation.
         # TODO: Bake keyTypeData.res into the common library?
-        [DepTarget("coll_ucadata"), DepTarget("misc")])
+        [DepTarget("coll_ucadata"), DepTarget("misc_res")])
 
     requests += generate_tree(config, glob, common_vars,
         "brkitr",
@@ -129,7 +129,7 @@ def generate(config, glob, common_vars):
         "BRK_RES_CLDR_VERSION",
         "BRK_RES_SOURCE",
         False,
-        [DepTarget("brkitr_brk"), DepTarget("brkitr_dictionaries")])
+        [DepTarget("brkitr_brk"), DepTarget("dictionaries")])
 
     requests += generate_tree(config, glob, common_vars,
         "rbnf",


### PR DESCRIPTION
Fixes warnings and a flaky test.

This is likely the cause of the test failure on #305.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-10923
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

