### PR TITLE
ICU-20307 Add reldatefmt.h and compactdecimalformat.h into cxxfiles.txt

### DIFF
--- a/icu4c/source/test/hdrtst/cxxfiles.txt
+++ b/icu4c/source/test/hdrtst/cxxfiles.txt
@@ -30,6 +30,7 @@ choicfmt.h
 coleitr.h
 coll.h
 colldata.h
+compactdecimalformat.h
 convert.h
 cpdtrans.h
 curramt.h
@@ -79,6 +80,7 @@ rbnf.h
 rbtz.h
 regex.h
 region.h
+reldatefmt.h
 rep.h
 resbund.h
 schriter.h


### PR DESCRIPTION
…t/cxxfiles.txt

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20307
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

