### PR TITLE
ICU-10923 Adding --filterDir option to genrb.

### DIFF
--- a/icu4c/source/test/intltest/restsnew.h
+++ b/icu4c/source/test/intltest/restsnew.h
@@ -38,6 +38,8 @@ public:
 
     void TestGetByFallback(void);
 
+    void TestFilter(void);
+
 private:
     /**
      * The assignment operator has no real implementation.

--- a/icu4c/source/test/testdata/BUILDRULES.py
+++ b/icu4c/source/test/testdata/BUILDRULES.py
@@ -97,6 +97,17 @@ def generate_rb(config, glob, common_vars):
             tool = IcuTool("genrb"),
             args = "-s {IN_DIR} -d {TMP_DIR} {INPUT_FILES[0]}",
             format_with = {}
+        ),
+        SingleExecutionRequest(
+            name = "filtertest",
+            category = "tests",
+            dep_files = [],
+            input_files = [InFile("filtertest.txt")],
+            output_files = [OutFile("filtertest.res")],
+            tool = IcuTool("genrb"),
+            args = "-s {IN_DIR} -d {OUT_DIR} -i {OUT_DIR} "
+                "--filterDir {IN_DIR}/filters filtertest.txt",
+            format_with = {}
         )
     ]
 

--- a/icu4c/source/test/testdata/filters/filtertest.txt
+++ b/icu4c/source/test/testdata/filters/filtertest.txt
@@ -1,0 +1,6 @@
+# Copyright (C) 2018 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
+
+-/alabama
++/alabama/alaska/arizona
+-/fornia/illinois

--- a/icu4c/source/test/testdata/filtertest.txt
+++ b/icu4c/source/test/testdata/filtertest.txt
@@ -1,0 +1,20 @@
+// Copyright (C) 2018 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+
+filtertest {
+    alabama {
+        alaska {
+            arizona {"arkansas"}
+            california {"colorado"}
+        }
+        connecticut {
+            arizona {"delaware"}
+            california {"florida"}
+        }
+    }
+    // test suffixes
+    fornia {
+        hawaii {"idaho"}
+        illinois {"indiana"}
+    }
+}

--- a/icu4c/source/tools/genrb/Makefile.in
+++ b/icu4c/source/tools/genrb/Makefile.in
@@ -38,7 +38,7 @@ CPPFLAGS += -DUNISTR_FROM_CHAR_EXPLICIT=explicit -DUNISTR_FROM_STRING_EXPLICIT=e
 LIBS = $(LIBICUTOOLUTIL) $(LIBICUI18N) $(LIBICUUC) $(DEFAULT_LIBS) $(LIB_M)
 
 OBJECTS = errmsg.o genrb.o parse.o read.o reslist.o ustr.o rbutil.o \
-wrtjava.o rle.o wrtxml.o prscmnts.o
+wrtjava.o rle.o wrtxml.o prscmnts.o filterrb.o
 DERB_OBJ = derb.o
 
 DEPS = $(OBJECTS:.o=.d)

--- a/icu4c/source/tools/genrb/filterrb.cpp
+++ b/icu4c/source/tools/genrb/filterrb.cpp
@@ -1,0 +1,167 @@
+// © 2018 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+
+#include <iostream>
+#include <stack>
+
+#include "filterrb.h"
+#include "errmsg.h"
+
+
+const char* PathFilter::kEInclusionNames[] = {
+    "INCLUDE",
+    "PARTIAL",
+    "EXCLUDE"
+};
+
+
+ResKeyPath::ResKeyPath() {}
+
+ResKeyPath::ResKeyPath(const std::string& path, UErrorCode& status) {
+    if (path.empty() || path[0] != '/') {
+        std::cerr << "genrb error: path must start with /: " << path << std::endl;
+        status = U_PARSE_ERROR;
+        return;
+    }
+    size_t i;
+    size_t j = 0;
+    while (true) {
+        i = j + 1;
+        j = path.find('/', i);
+        std::string key = path.substr(i, j - i);
+        if (key.empty()) {
+            std::cerr << "genrb error: empty subpaths and trailing slashes are not allowed: " << path << std::endl;
+            status = U_PARSE_ERROR;
+            return;
+        }
+        push(key);
+        if (j == std::string::npos) {
+            break;
+        }
+    }
+}
+
+void ResKeyPath::push(const std::string& key) {
+    fPath.push_back(key);
+}
+
+void ResKeyPath::pop() {
+    fPath.pop_back();
+}
+
+const std::list<std::string>& ResKeyPath::pieces() const {
+    return fPath;
+}
+
+std::ostream& operator<<(std::ostream& out, const ResKeyPath& value) {
+    if (value.pieces().empty()) {
+        out << "/";
+    } else for (auto& key : value.pieces()) {
+        out << "/" << key;
+    }
+    return out;
+}
+
+
+void SimpleRuleBasedPathFilter::addRule(const std::string& ruleLine, UErrorCode& status) {
+    if (ruleLine.empty()) {
+        std::cerr << "genrb error: empty filter rules are not allowed" << std::endl;
+        status = U_PARSE_ERROR;
+        return;
+    }
+    bool inclusionRule = false;
+    if (ruleLine[0] == '+') {
+        inclusionRule = true;
+    } else if (ruleLine[0] != '-') {
+        std::cerr << "genrb error: rules must start with + or -: " << ruleLine << std::endl;
+        status = U_PARSE_ERROR;
+        return;
+    }
+    ResKeyPath path(ruleLine.substr(1), status);
+    addRule(path, inclusionRule, status);
+}
+
+void SimpleRuleBasedPathFilter::addRule(const ResKeyPath& path, bool inclusionRule, UErrorCode& status) {
+    if (U_FAILURE(status)) {
+        return;
+    }
+    Tree* node = &fRoot;
+    for (auto& key : path.pieces()) {
+        // note: operator[] auto-constructs default values
+        node = &node->fChildren[key];
+    }
+    if (isVerbose() && (node->fIncluded != PARTIAL || !node->fChildren.empty())) {
+        std::cout << "genrb info: rule on path " << path
+            << " overrides previous rules" << std::endl;
+    }
+    node->fIncluded = inclusionRule ? INCLUDE : EXCLUDE;
+    node->fChildren.clear();
+}
+
+PathFilter::EInclusion SimpleRuleBasedPathFilter::match(const ResKeyPath& path) const {
+    const Tree* node = &fRoot;
+
+    // defaultResult "bubbles up" the nearest "definite" inclusion/exclusion rule
+    EInclusion defaultResult = INCLUDE;
+    if (node->fIncluded != PARTIAL) {
+        // rules handled here: "+/" and "-/"
+        defaultResult = node->fIncluded;
+    }
+
+    // isLeaf is whether the filter tree can provide no additional information
+    // even if additional subpaths are added to the given key
+    bool isLeaf = false;
+
+    for (auto& key : path.pieces()) {
+        auto child = node->fChildren.find(key);
+        // Leaf case 1: input path descends outside the filter tree
+        if (child == node->fChildren.end()) {
+            isLeaf = true;
+            break;
+        }
+        node = &child->second;
+        if (node->fIncluded != PARTIAL) {
+            defaultResult = node->fIncluded;
+        }
+    }
+
+    // Leaf case 2: input path exactly matches a filter leaf
+    if (node->fChildren.empty()) {
+        isLeaf = true;
+    }
+
+    // Always return PARTIAL if we are not at a leaf
+    if (!isLeaf) {
+        return PARTIAL;
+    }
+
+    // If leaf node is PARTIAL, return the default
+    if (node->fIncluded == PARTIAL) {
+        return defaultResult;
+    }
+
+    return node->fIncluded;
+}
+
+void SimpleRuleBasedPathFilter::Tree::print(std::ostream& out, int32_t indent) const {
+    for (int32_t i=0; i<indent; i++) out << "\t";
+    out << "included: " << kEInclusionNames[fIncluded] << std::endl;
+    for (auto& child : fChildren) {
+        for (int32_t i=0; i<indent; i++) out << "\t";
+        out << child.first << ": {" << std::endl;
+        child.second.print(out, indent + 1);
+        for (int32_t i=0; i<indent; i++) out << "\t";
+        out << "}" << std::endl;
+    }
+}
+
+void SimpleRuleBasedPathFilter::print(std::ostream& out) const {
+    out << "SimpleRuleBasedPathFilter {" << std::endl;
+    fRoot.print(out, 1);
+    out << "}";
+}
+
+std::ostream& operator<<(std::ostream& out, const SimpleRuleBasedPathFilter& value) {
+    value.print(out);
+    return out;
+}

--- a/icu4c/source/tools/genrb/filterrb.h
+++ b/icu4c/source/tools/genrb/filterrb.h
@@ -1,0 +1,124 @@
+// © 2018 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+
+#ifndef __FILTERRB_H__
+#define __FILTERRB_H__
+
+#include <list>
+#include <string>
+#include <map>
+#include <ostream>
+
+#include "unicode/utypes.h"
+
+
+/**
+ * Represents an absolute path into a resource bundle.
+ * For example: "/units/length/meter"
+ */
+class ResKeyPath {
+public:
+    /** Constructs an empty path (top of tree) */
+    ResKeyPath();
+
+    /** Constructs from a string path */
+    ResKeyPath(const std::string& path, UErrorCode& status);
+
+    void push(const std::string& key);
+    void pop();
+
+    const std::list<std::string>& pieces() const;
+
+  private:
+    std::list<std::string> fPath;
+};
+
+std::ostream& operator<<(std::ostream& out, const ResKeyPath& value);
+
+
+/**
+ * Interface used to determine whether to include or reject pieces of a
+ * resource bundle based on their absolute path.
+ */
+class PathFilter {
+public:
+    enum EInclusion {
+        INCLUDE,
+        PARTIAL,
+        EXCLUDE
+    };
+
+    static const char* kEInclusionNames[];
+
+    /**
+     * Returns an EInclusion on whether or not the given path should be included.
+     *
+     * INCLUDE = include the whole subtree
+     * PARTIAL = recurse into the subtree
+     * EXCLUDE = reject the whole subtree
+     */
+    virtual EInclusion match(const ResKeyPath& path) const = 0;
+};
+
+
+/**
+ * Implementation of PathFilter for a list of inclusion/exclusion rules.
+ *
+ * For example, given this list of filter rules:
+ *
+ *     -/alabama
+ *     +/alabama/alaska/arizona
+ *     -/fornia/hawaii
+ *
+ * You get the following structure:
+ *
+ *     SimpleRuleBasedPathFilter {
+ *       included: PARTIAL
+ *       alabama: {
+ *         included: EXCLUDE
+ *         alaska: {
+ *           included: PARTIAL
+ *           arizona: {
+ *             included: INCLUDE
+ *           }
+ *         }
+ *       }
+ *       fornia: {
+ *         included: PARTIAL
+ *         hawaii: {
+ *           included: EXCLUDE
+ *         }
+ *       }
+ *     }
+ */
+class SimpleRuleBasedPathFilter : public PathFilter {
+public:
+    void addRule(const std::string& ruleLine, UErrorCode& status);
+    void addRule(const ResKeyPath& path, bool inclusionRule, UErrorCode& status);
+
+    EInclusion match(const ResKeyPath& path) const override;
+
+    void print(std::ostream& out) const;
+
+private:
+    struct Tree {
+        /**
+         * Information on the USER-SPECIFIED inclusion/exclusion.
+         *
+         * INCLUDE = this path exactly matches a "+" rule
+         * PARTIAL = this path does not match any rule, but subpaths exist
+         * EXCLUDE = this path exactly matches a "-" rule
+         */
+        EInclusion fIncluded = PARTIAL;
+        std::map<std::string, Tree> fChildren;
+
+        void print(std::ostream& out, int32_t indent) const;
+    };
+
+    Tree fRoot;
+};
+
+std::ostream& operator<<(std::ostream& out, const SimpleRuleBasedPathFilter& value);
+
+
+#endif //__FILTERRB_H__

--- a/icu4c/source/tools/genrb/genrb.vcxproj
+++ b/icu4c/source/tools/genrb/genrb.vcxproj
@@ -226,6 +226,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="errmsg.c" />
+    <ClCompile Include="filterrb.cpp" />
     <ClCompile Include="genrb.cpp" />
     <ClCompile Include="parse.cpp">
       <DisableLanguageExtensions>false</DisableLanguageExtensions>
@@ -250,6 +251,7 @@
   <ItemGroup>
     <ClInclude Include="errmsg.h" />
     <ClInclude Include="genrb.h" />
+    <ClInclude Include="filterrb.h" />
     <ClInclude Include="parse.h" />
     <ClInclude Include="prscmnts.h" />
     <ClInclude Include="rbutil.h" />

--- a/icu4c/source/tools/genrb/genrb.vcxproj.filters
+++ b/icu4c/source/tools/genrb/genrb.vcxproj.filters
@@ -18,6 +18,9 @@
     <ClCompile Include="errmsg.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="filterrb.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="genrb.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -51,6 +54,9 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="errmsg.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="filterrb.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="genrb.h">

--- a/icu4c/source/tools/genrb/reslist.h
+++ b/icu4c/source/tools/genrb/reslist.h
@@ -23,6 +23,8 @@
 #define KEY_SPACE_SIZE 65536
 #define RESLIST_MAX_INT_VECTOR 2048
 
+#include <functional>
+
 #include "unicode/utypes.h"
 #include "unicode/unistr.h"
 #include "unicode/ures.h"
@@ -36,7 +38,9 @@
 
 U_CDECL_BEGIN
 
+class PathFilter;
 class PseudoListResource;
+class ResKeyPath;
 
 struct ResFile {
     ResFile()
@@ -212,6 +216,19 @@ struct SResource {
     void write(UNewDataMemory *mem, uint32_t *byteOffset);
     virtual void handleWrite(UNewDataMemory *mem, uint32_t *byteOffset);
 
+    /**
+     * Applies the given filter with the given base path to this resource.
+     * Removes child resources rejected by the filter recursively.
+     * 
+     * @param bundle Needed in order to access the key for this and child resources.
+     */
+    virtual void applyFilter(const PathFilter& filter, ResKeyPath& path, const SRBRoot* bundle);
+
+    /**
+     * Calls the given function for every key ID present in this tree.
+     */
+    virtual void collectKeys(std::function<void(int32_t)> collector) const;
+
     int8_t   fType;     /* nominal type: fRes (when != 0xffffffff) may use subtype */
     UBool    fWritten;  /* res_write() can exit early */
     uint32_t fRes;      /* resource item word; RES_BOGUS=0xffffffff if not known yet */
@@ -231,7 +248,10 @@ public:
               fCount(0), fFirst(NULL) {}
     virtual ~ContainerResource();
 
-    virtual void handlePreflightStrings(SRBRoot *bundle, UHashtable *stringSet, UErrorCode &errorCode);
+    void handlePreflightStrings(SRBRoot *bundle, UHashtable *stringSet, UErrorCode &errorCode) override;
+
+    void collectKeys(std::function<void(int32_t)> collector) const override;
+
 protected:
     void writeAllRes16(SRBRoot *bundle);
     void preWriteAllRes(uint32_t *byteOffset);
@@ -254,9 +274,11 @@ public:
 
     void add(SResource *res, int linenumber, UErrorCode &errorCode);
 
-    virtual void handleWrite16(SRBRoot *bundle);
-    virtual void handlePreWrite(uint32_t *byteOffset);
-    virtual void handleWrite(UNewDataMemory *mem, uint32_t *byteOffset);
+    void handleWrite16(SRBRoot *bundle) override;
+    void handlePreWrite(uint32_t *byteOffset) override;
+    void handleWrite(UNewDataMemory *mem, uint32_t *byteOffset) override;
+
+    void applyFilter(const PathFilter& filter, ResKeyPath& path, const SRBRoot* bundle) override;
 
     int8_t fTableType;  // determined by table_write16() for table_preWrite() & table_write()
     SRBRoot *fRoot;


### PR DESCRIPTION
This PR contains initial changes to add `--filterDir` to genrb.

Unused values are scrubbed, but based on inspection of the .res files, unused keys are not yet being scrubbed.  I want to sync with you briefly on the right way to scrub the keys.  I currently plan to do it all in the `compactKeys()` function, which takes the initial list of keys (hard to change) and converts it to an optimized list (easier to change).

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-10923
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

