### PR TITLE
ICU-20302 Timezone detection fails on Windows 7.

### DIFF
--- a/icu4c/source/common/wintz.cpp
+++ b/icu4c/source/common/wintz.cpp
@@ -35,7 +35,7 @@
 
 U_NAMESPACE_BEGIN
 
-// The value of MAX_TIMEZONE_ID_LENGTH is 128, which is defined in DYNAMIC_TIME_ZONE_INFORMATION
+// The max size of TimeZoneKeyName is 128, defined in DYNAMIC_TIME_ZONE_INFORMATION
 #define MAX_TIMEZONE_ID_LENGTH 128
 
 /**
@@ -44,7 +44,7 @@ U_NAMESPACE_BEGIN
 * Note: We use the Win32 API GetDynamicTimeZoneInformation to get the current time zone info.
 * This API returns a non-localized time zone name, which we can then map to an ICU time zone name.
 */
-U_CFUNC const char* U_EXPORT2
+U_INTERNAL const char* U_EXPORT2
 uprv_detectWindowsTimeZone()
 {
     UErrorCode status = U_ZERO_ERROR;
@@ -79,7 +79,7 @@ uprv_detectWindowsTimeZone()
 
     // convert from wchar_t* (UTF-16 on Windows) to char* (UTF-8).
     u_strToUTF8(dynamicTZKeyName, UPRV_LENGTHOF(dynamicTZKeyName), nullptr,
-        reinterpret_cast<const UChar*>(dynamicTZI.TimeZoneKeyName), UPRV_LENGTHOF(dynamicTZI.TimeZoneKeyName), &status);
+        reinterpret_cast<const UChar*>(dynamicTZI.TimeZoneKeyName), -1, &status);
 
     if (U_FAILURE(status)) {
         return nullptr;

--- a/icu4c/source/test/cintltst/putiltst.c
+++ b/icu4c/source/test/cintltst/putiltst.c
@@ -214,8 +214,19 @@ static void TestPUtilAPI(void){
             log_info("Note: t_timezone offset of %ld (for %s : %s) is not a multiple of 30min.", tzoffset, uprv_tzname(0), uprv_tzname(1));
         }
         /*tzoffset=uprv_getUTCtime();*/
-
     }
+
+#if U_PLATFORM_USES_ONLY_WIN32_API 
+    log_verbose("Testing uprv_detectWindowsTimeZone() ....\n");
+    {
+        char* timezone = uprv_detectWindowsTimeZone();
+        if (timezone == NULL) {
+            log_err("ERROR: uprv_detectWindowsTimeZone failed (returned NULL).\n");
+        } else {
+            log_verbose("Detected TimeZone = %s\n", timezone);
+        }   
+    }
+#endif
 }
 
 static void TestVersion(void)


### PR DESCRIPTION
From debugging the issue on Windows 7:
It seems that the `DYNAMIC_TIME_ZONE_INFORMATION` struct returned by the Windows API `GetDynamicTimeZoneInformation` may have garbage data after the null terminator.

For example, when the Time Zone is set to "Pacific Standard Time" this is contents of the 256 byte (128 wchar_t) `TimeZoneKeyName` buffer after calling the API:
```
0x000000000015EB2C  50 00 61 00 63 00 69 00 66 00 69 00 63 00 20 00 53 00 74  P.a.c.i.f.i.c. .S.t
0x000000000015EB3F  00 61 00 6e 00 64 00 61 00 72 00 64 00 20 00 54 00 69 00  .a.n.d.a.r.d. .T.i.
0x000000000015EB52  6d 00 65 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  m.e................
0x000000000015EB65  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ...................
0x000000000015EB78  c0 7e 0f 00 00 00 00 00 0d 00 00 00 00 00 00 00 d8 69 9a  ﾀ~..............ﾘi・
0x000000000015EB8B  77 00 00 00 00 4c 02 07 00 00 00 00 00 eb 74 48 03 b7 92  w....L.......・tH.ｷ・
0x000000000015EB9E  00 00 40 a4 13 00 00 00 00 00 4c 02 07 00 00 00 00 00 58  ..@､......L.......X
0x000000000015EBB1  a1 12 00 00 00 00 00 0d 00 00 00 00 00 00 00 00 00 00 00  ｡..................
0x000000000015EBC4  00 00 00 00 d0 7c 0f 00 00 00 00 00 00 00 00 00 00 00 00  ....ﾐ|.............
0x000000000015EBD7  00 d8 7e 0f 00 00 00 00 00 70 85 0f 00 00 00 00 00 08 00  .ﾘ~......p・........
```

The string is always null-terminated. However the buffer isn't always zeroed first on Windows 7.
This looks to have been fixed on later versions of Windows, but looks like the fix wasn't back-ported to Windows 7.

This causes `u_strToUTF8` to return back the error `U_BUFFER_OVERFLOW_ERROR` since we pass in the full length (128) of the buffer, rather than telling it to stop at the null terminator.

The fix is to tell the ICU API `u_strToUTF8` to treat the input buffer as null-terminated and stop at the Null, rather than using the full length of the buffer.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20302
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

