### PR TITLE
ICU-20315 Fix MSYS2 build break: Don't prepend the source dir if it is just a current directory (.) path.

### DIFF
--- a/icu4c/source/tools/makeconv/makeconv.cpp
+++ b/icu4c/source/tools/makeconv/makeconv.cpp
@@ -292,7 +292,7 @@ int main(int argc, char* argv[])
         const char *arg = getLongPathname(*argv);
 
         const char* sourcedir = options[OPT_SOURCEDIR].value;
-        if (sourcedir != NULL && *sourcedir != 0) {
+        if (sourcedir != NULL && *sourcedir != 0 && *sourcedir != '.') {
             pathBuf.clear();
             pathBuf.appendPathPart(sourcedir, localError);
             pathBuf.appendPathPart(arg, localError);


### PR DESCRIPTION
The MSYS2 builds were accidentally broken with ICU-10923. 

The call to `makeconv` is slightly different now, and the program will internally combine the input source path argument with the converter path/name.

Before:
```
PATH=../lib:../stubdata:../tools/ctestfw:$PATH  ../bin/makeconv -c -d ./out/build/icudt62l ./mappings/cns-11643-1992.ucm
```
After:
```
PATH=../lib:../stubdata:../tools/ctestfw:$PATH  ../bin/makeconv -s . -d ./out/build/icudt63l -c mappings/cns-11643-1992.ucm
```

The problem is that the leading "." on the path (`./mappings/`) ends up confusing the MSYS heuristics that are used for translating Unix/POSIX paths to Windows style paths.

This change restores the MSYS2 builds, so that they actually work now.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20315
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

