### PR TITLE
ICU-20348 Fixing DecimalFormat set affix currency behavior.

### DIFF
--- a/icu4c/source/data/locales/fr_CH.txt
+++ b/icu4c/source/data/locales/fr_CH.txt
@@ -4,7 +4,7 @@ fr_CH{
     NumberElements{
         latn{
             patterns{
-                currencyFormat{"#,##0.00 ¤;-#,##0.00 ¤"}
+                currencyFormat{"#,##0.00 ¤"}
                 percentFormat{"#,##0%"}
             }
             symbols{

--- a/icu4c/source/i18n/decimfmt.cpp
+++ b/icu4c/source/i18n/decimfmt.cpp
@@ -74,7 +74,8 @@ DecimalFormat::DecimalFormat(const UnicodeString& pattern, DecimalFormatSymbols*
                              UNumberFormatStyle style, UErrorCode& status)
         : DecimalFormat(symbolsToAdopt, status) {
     // If choice is a currency type, ignore the rounding information.
-    if (style == UNumberFormatStyle::UNUM_CURRENCY || style == UNumberFormatStyle::UNUM_CURRENCY_ISO ||
+    if (style == UNumberFormatStyle::UNUM_CURRENCY ||
+        style == UNumberFormatStyle::UNUM_CURRENCY_ISO ||
         style == UNumberFormatStyle::UNUM_CURRENCY_ACCOUNTING ||
         style == UNumberFormatStyle::UNUM_CASH_CURRENCY ||
         style == UNumberFormatStyle::UNUM_CURRENCY_STANDARD ||
@@ -933,12 +934,14 @@ UnicodeString& DecimalFormat::toPattern(UnicodeString& result) const {
     // TODO: Consider putting this logic in number_patternstring.cpp instead.
     ErrorCode localStatus;
     DecimalFormatProperties tprops(*fields->properties);
-    bool useCurrency = ((!tprops.currency.isNull()) || !tprops.currencyPluralInfo.fPtr.isNull() ||
-                        !tprops.currencyUsage.isNull() || AffixUtils::hasCurrencySymbols(
-            tprops.positivePrefixPattern, localStatus) || AffixUtils::hasCurrencySymbols(
-            tprops.positiveSuffixPattern, localStatus) || AffixUtils::hasCurrencySymbols(
-            tprops.negativePrefixPattern, localStatus) || AffixUtils::hasCurrencySymbols(
-            tprops.negativeSuffixPattern, localStatus));
+    bool useCurrency = (
+        !tprops.currency.isNull() ||
+        !tprops.currencyPluralInfo.fPtr.isNull() ||
+        !tprops.currencyUsage.isNull() ||
+        AffixUtils::hasCurrencySymbols(tprops.positivePrefixPattern, localStatus) ||
+        AffixUtils::hasCurrencySymbols(tprops.positiveSuffixPattern, localStatus) ||
+        AffixUtils::hasCurrencySymbols(tprops.negativePrefixPattern, localStatus) ||
+        AffixUtils::hasCurrencySymbols(tprops.negativeSuffixPattern, localStatus));
     if (useCurrency) {
         tprops.minimumFractionDigits = fields->exportedProperties->minimumFractionDigits;
         tprops.maximumFractionDigits = fields->exportedProperties->maximumFractionDigits;

--- a/icu4c/source/i18n/number_mapper.h
+++ b/icu4c/source/i18n/number_mapper.h
@@ -63,6 +63,7 @@ class PropertiesAffixPatternProvider : public AffixPatternProvider, public UMemo
     UnicodeString posSuffix;
     UnicodeString negPrefix;
     UnicodeString negSuffix;
+    bool isCurrencyPattern;
 
     const UnicodeString& getStringInternal(int32_t flags) const;
 

--- a/icu4c/source/test/intltest/numfmtst.h
+++ b/icu4c/source/test/intltest/numfmtst.h
@@ -285,6 +285,7 @@ class NumberFormatTest: public CalendarTimeZoneTest {
     void Test20037_ScientificIntegerOverflow();
     void Test13840_ParseLongStringCrash();
     void Test13850_EmptyStringCurrency();
+    void Test20348_CurrencyPrefixOverride();
 
  private:
     UBool testFormattableAsUFormattable(const char *file, int line, Formattable &f);

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/PatternStringUtils.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/PatternStringUtils.java
@@ -46,20 +46,10 @@ public class PatternStringUtils {
         boolean alwaysShowDecimal = properties.getDecimalSeparatorAlwaysShown();
         int exponentDigits = Math.min(properties.getMinimumExponentDigits(), dosMax);
         boolean exponentShowPlusSign = properties.getExponentSignAlwaysShown();
-        String pp = properties.getPositivePrefix();
-        String ppp = properties.getPositivePrefixPattern();
-        String ps = properties.getPositiveSuffix();
-        String psp = properties.getPositiveSuffixPattern();
-        String np = properties.getNegativePrefix();
-        String npp = properties.getNegativePrefixPattern();
-        String ns = properties.getNegativeSuffix();
-        String nsp = properties.getNegativeSuffixPattern();
+        PropertiesAffixPatternProvider affixes = new PropertiesAffixPatternProvider(properties);
 
         // Prefixes
-        if (ppp != null) {
-            sb.append(ppp);
-        }
-        AffixUtils.escape(pp, sb);
+        sb.append(affixes.getString(AffixPatternProvider.FLAG_POS_PREFIX));
         int afterPrefixPos = sb.length();
 
         // Figure out the grouping sizes.
@@ -150,10 +140,7 @@ public class PatternStringUtils {
 
         // Suffixes
         int beforeSuffixPos = sb.length();
-        if (psp != null) {
-            sb.append(psp);
-        }
-        AffixUtils.escape(ps, sb);
+        sb.append(affixes.getString(AffixPatternProvider.FLAG_POS_SUFFIX));
 
         // Resolve Padding
         if (paddingWidth != -1) {
@@ -188,20 +175,13 @@ public class PatternStringUtils {
 
         // Negative affixes
         // Ignore if the negative prefix pattern is "-" and the negative suffix is empty
-        if (np != null
-                || ns != null
-                || (npp == null && nsp != null)
-                || (npp != null && (npp.length() != 1 || npp.charAt(0) != '-' || nsp.length() != 0))) {
+        if (affixes.hasNegativeSubpattern()) {
             sb.append(';');
-            if (npp != null)
-                sb.append(npp);
-            AffixUtils.escape(np, sb);
+            sb.append(affixes.getString(AffixPatternProvider.FLAG_NEG_PREFIX));
             // Copy the positive digit format into the negative.
             // This is optional; the pattern is the same as if '#' were appended here instead.
             sb.append(sb, afterPrefixPos, beforeSuffixPos);
-            if (nsp != null)
-                sb.append(nsp);
-            AffixUtils.escape(ns, sb);
+            sb.append(affixes.getString(AffixPatternProvider.FLAG_NEG_SUFFIX));
         }
 
         return sb.toString();

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/NumberFormatTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/NumberFormatTest.java
@@ -6373,4 +6373,37 @@ public class NumberFormatTest extends TestFmwk {
 
         assertEquals("Should round-trip without crashing", expectedUString, actualUString);
     }
+
+    @Test
+    public void test20348_CurrencyPrefixOverride() {
+        DecimalFormat fmt = (DecimalFormat) NumberFormat.getCurrencyInstance(ULocale.ENGLISH);
+        assertEquals("Initial pattern",
+            "¤#,##0.00", fmt.toPattern());
+        assertEquals("Initial prefix",
+            "¤", fmt.getPositivePrefix());
+        assertEquals("Initial suffix",
+            "-¤", fmt.getNegativePrefix());
+        assertEquals("Initial format",
+            "\u00A4100.00", fmt.format(100));
+
+        fmt.setPositivePrefix("$");
+        assertEquals("Set positive prefix pattern",
+            "$#,##0.00;-\u00A4#,##0.00", fmt.toPattern());
+        assertEquals("Set positive prefix prefix",
+            "$", fmt.getPositivePrefix());
+        assertEquals("Set positive prefix suffix",
+            "-¤", fmt.getNegativePrefix());
+        assertEquals("Set positive prefix format",
+            "$100.00", fmt.format(100));
+
+        fmt.setNegativePrefix("-$");
+        assertEquals("Set negative prefix pattern",
+            "$#,##0.00;'-'$#,##0.00", fmt.toPattern());
+        assertEquals("Set negative prefix prefix",
+            "$", fmt.getPositivePrefix());
+        assertEquals("Set negative prefix suffix",
+            "-$", fmt.getNegativePrefix());
+        assertEquals("Set negative prefix format",
+            "$100.00", fmt.format(100));
+    }
 }

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/PatternStringTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/PatternStringTest.java
@@ -72,19 +72,19 @@ public class PatternStringTest {
     @Test
     public void testToPatternWithProperties() {
         Object[][] cases = {
-                { new DecimalFormatProperties().setPositivePrefix("abc"), "abc#" },
-                { new DecimalFormatProperties().setPositiveSuffix("abc"), "#abc" },
+                { new DecimalFormatProperties().setPositivePrefix("abc"), "abc#;-#" },
+                { new DecimalFormatProperties().setPositiveSuffix("abc"), "#abc;-#" },
                 { new DecimalFormatProperties().setPositivePrefixPattern("abc"), "abc#" },
                 { new DecimalFormatProperties().setPositiveSuffixPattern("abc"), "#abc" },
                 { new DecimalFormatProperties().setNegativePrefix("abc"), "#;abc#" },
-                { new DecimalFormatProperties().setNegativeSuffix("abc"), "#;#abc" },
+                { new DecimalFormatProperties().setNegativeSuffix("abc"), "#;-#abc" },
                 { new DecimalFormatProperties().setNegativePrefixPattern("abc"), "#;abc#" },
-                { new DecimalFormatProperties().setNegativeSuffixPattern("abc"), "#;#abc" },
-                { new DecimalFormatProperties().setPositivePrefix("+"), "'+'#" },
+                { new DecimalFormatProperties().setNegativeSuffixPattern("abc"), "#;-#abc" },
+                { new DecimalFormatProperties().setPositivePrefix("+"), "'+'#;-#" },
                 { new DecimalFormatProperties().setPositivePrefixPattern("+"), "+#" },
-                { new DecimalFormatProperties().setPositivePrefix("+'"), "'+'''#" },
-                { new DecimalFormatProperties().setPositivePrefix("'+"), "'''+'#" },
-                { new DecimalFormatProperties().setPositivePrefix("'"), "''#" },
+                { new DecimalFormatProperties().setPositivePrefix("+'"), "'+'''#;-#" },
+                { new DecimalFormatProperties().setPositivePrefix("'+"), "'''+'#;-#" },
+                { new DecimalFormatProperties().setPositivePrefix("'"), "''#;-#" },
                 { new DecimalFormatProperties().setPositivePrefixPattern("+''"), "+''#" }, };
 
         for (Object[] cas : cases) {


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

If this looks good, I will make the same change in ICU4J.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20348
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

