### PR TITLE
ICU-20353 Fix MSVC Warning/Error C4251 with CodePointMatcherWarehouse and MemoryPool

### DIFF
--- a/icu4c/source/common/cmemory.h
+++ b/icu4c/source/common/cmemory.h
@@ -285,7 +285,7 @@ inline T *LocalMemory<T>::allocateInsteadAndCopy(int32_t newCapacity, int32_t le
  *
  * WARNING: MaybeStackArray only works with primitive (plain-old data) types.
  * It does NOT know how to call a destructor! If you work with classes with
- * destructors, consider LocalArray in localpointer.h.
+ * destructors, consider LocalArray in localpointer.h or MemoryPool.
  */
 template<typename T, int32_t stackCapacity>
 class MaybeStackArray {
@@ -692,9 +692,8 @@ inline H *MaybeStackHeaderAndArray<H, T, stackCapacity>::orphanOrClone(int32_t l
  *
  * It doesn't do anything more than that, and is intentionally kept minimalist.
  */
-template<typename T>
+template<typename T, int32_t stackCapacity = 8>
 class MemoryPool : public UMemory {
-    enum { STACK_CAPACITY = 8 };
 public:
     MemoryPool() : count(0), pool() {}
 
@@ -730,7 +729,7 @@ public:
     T* create(Args&&... args) {
         int32_t capacity = pool.getCapacity();
         if (count == capacity &&
-            pool.resize(capacity == STACK_CAPACITY ? 32 : 2 * capacity,
+            pool.resize(capacity == stackCapacity ? 4 * capacity : 2 * capacity,
                         capacity) == nullptr) {
             return nullptr;
         }
@@ -739,7 +738,7 @@ public:
 
 private:
     int32_t count;
-    MaybeStackArray<T*, STACK_CAPACITY> pool;
+    MaybeStackArray<T*, stackCapacity> pool;
 };
 
 U_NAMESPACE_END

--- a/icu4c/source/i18n/numparse_affixes.h
+++ b/icu4c/source/i18n/numparse_affixes.h
@@ -47,13 +47,14 @@ class CodePointMatcher : public NumberParseMatcher, public UMemory {
 } // namespace impl
 } // namespace numparse
 
-// Export a explicit template instantiations of MaybeStackArray and CompactUnicodeString.
+// Export a explicit template instantiations of MaybeStackArray, MemoryPool and CompactUnicodeString.
 // When building DLLs for Windows this is required even though no direct access leaks out of the i18n library.
 // (See digitlst.h, pluralaffix.h, datefmt.h, and others for similar examples.)
-// Note: These need to be outside of the impl::numparse namespace, or Clang will generate a compile error.
+// Note: These need to be outside of the numparse::impl namespace, or Clang will generate a compile error.
 #if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
+template class U_I18N_API MaybeStackArray<numparse::impl::CodePointMatcher*, 8>; 
 template class U_I18N_API MaybeStackArray<UChar, 4>;
-template class U_I18N_API MaybeStackArray<numparse::impl::CodePointMatcher*, 3>;
+template class U_I18N_API MemoryPool<numparse::impl::CodePointMatcher, 8>;
 template class U_I18N_API numparse::impl::CompactUnicodeString<4>;
 #endif
 


### PR DESCRIPTION
This was accidentally regressed in [ICU-20202](https://unicode-org.atlassian.net/browse/ICU-20202), but since we don't have any build bots (CI builds) that treat this warning as an error, we didn't notice it at the time. (Aside: I have a separate issue/ticket to treat this warning as an error in the CI builds, so that we can catch this in the future...)

Note: I had to move the `STACK_CAPACITY ` value out of the anonymous enum, so that it could be used in the header `numparse_affixes.h`. However, there might be another/better way to do this. Please feel free to suggest other ideas.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20353
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

