### PR TITLE
ICU-20351 Warning cleanup changes for ICU4C under MSVC.

### DIFF
--- a/icu4c/source/common/uloc_tag.cpp
+++ b/icu4c/source/common/uloc_tag.cpp
@@ -1324,13 +1324,13 @@ _appendKeywordsToLanguageTag(const char* localeID, icu::ByteSink& sink, UBool st
                     for (attr = firstAttr; attr; attr = attr->next) {
                         sink.Append("-", 1);
                         sink.Append(
-                                attr->attribute, uprv_strlen(attr->attribute));
+                                attr->attribute, static_cast<int32_t>(uprv_strlen(attr->attribute)));
                     }
                 } else {
                     sink.Append("-", 1);
-                    sink.Append(ext->key, uprv_strlen(ext->key));
+                    sink.Append(ext->key, static_cast<int32_t>(uprv_strlen(ext->key)));
                     sink.Append("-", 1);
-                    sink.Append(ext->value, uprv_strlen(ext->value));
+                    sink.Append(ext->value, static_cast<int32_t>(uprv_strlen(ext->value)));
                 }
             }
         }

--- a/icu4c/source/extra/uconv/uconv.cpp
+++ b/icu4c/source/extra/uconv/uconv.cpp
@@ -736,7 +736,7 @@ ConvertFile::convertFile(const char *pname,
         willexit = FALSE;
 
         // input file offset at the beginning of the next buffer
-        infoffset += rd;
+        infoffset += static_cast<uint32_t>(rd);
 
         rd = fread(buf, 1, bufsz, infile);
         if (ferror(infile) != 0) {
@@ -974,7 +974,7 @@ ConvertFile::convertFile(const char *pname,
                         // input file offset of the current byte buffer +
                         // byte buffer offset of where the current Unicode buffer is converted from +
                         // fromoffsets[Unicode offset]
-                        ferroffset = infoffset + (prevbufp - buf) + fromoffset;
+                        ferroffset = static_cast<int32_t>(infoffset + (prevbufp - buf) + fromoffset);
                         errtag = "problemCvtFromU";
                     } else {
                         // Do not use fromoffsets if (t != NULL) because the Unicode text may

--- a/icu4c/source/i18n/erarules.h
+++ b/icu4c/source/i18n/erarules.h
@@ -20,10 +20,14 @@ U_NAMESPACE_BEGIN
 #if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
 #if defined(_MSC_VER)
 // Ignore warning 4661 as LocalPointerBase does not use operator== or operator!=
-#pragma warning(suppress: 4661)
+#pragma warning(push)
+#pragma warning(disable: 4661)
 #endif
 template class U_I18N_API LocalPointerBase<int32_t>;
 template class U_I18N_API LocalMemory<int32_t>;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 #endif
 
 class U_I18N_API EraRules : public UMemory {

--- a/icu4c/source/i18n/number_decimfmtprops.h
+++ b/icu4c/source/i18n/number_decimfmtprops.h
@@ -23,10 +23,14 @@ U_NAMESPACE_BEGIN
 #if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
 #if defined(_MSC_VER)
 // Ignore warning 4661 as LocalPointerBase does not use operator== or operator!=
-#pragma warning(suppress: 4661)
+#pragma warning(push)
+#pragma warning(disable: 4661)
 #endif
 template class U_I18N_API LocalPointerBase<CurrencyPluralInfo>;
 template class U_I18N_API LocalPointer<CurrencyPluralInfo>;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 #endif
 
 namespace number {

--- a/icu4c/source/i18n/number_patternmodifier.h
+++ b/icu4c/source/i18n/number_patternmodifier.h
@@ -23,10 +23,14 @@ U_NAMESPACE_BEGIN
 #if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
 #if defined(_MSC_VER)
 // Ignore warning 4661 as LocalPointerBase does not use operator== or operator!=
-#pragma warning(suppress: 4661)
+#pragma warning(push)
+#pragma warning(disable : 4661)
 #endif
 template class U_I18N_API LocalPointerBase<number::impl::AdoptingModifierStore>;
 template class U_I18N_API LocalPointer<number::impl::AdoptingModifierStore>;
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 #endif
 
 namespace number {

--- a/icu4c/source/i18n/numparse_types.h
+++ b/icu4c/source/i18n/numparse_types.h
@@ -63,7 +63,7 @@ class CompactUnicodeString {
 
     CompactUnicodeString(const UnicodeString& text)
             : fBuffer(text.length() + 1) {
-        memcpy(fBuffer.getAlias(), text.getBuffer(), sizeof(UChar) * text.length());
+        uprv_memcpy(fBuffer.getAlias(), text.getBuffer(), sizeof(UChar) * text.length());
         fBuffer[text.length()] = 0;
     }
 

--- a/icu4c/source/io/uscanf_p.cpp
+++ b/icu4c/source/io/uscanf_p.cpp
@@ -323,7 +323,7 @@ u_scanf_skip_leading_ws(UFILE   *input,
     UBool isNotEOF;
 
     /* skip all leading ws in the input */
-    while( (isNotEOF = ufile_getch(input, &c)) && (c == pad || u_isWhitespace(c)) )
+    while( ((isNotEOF = ufile_getch(input, &c)) == TRUE) && (c == pad || u_isWhitespace(c)) )
     {
         count++;
     }
@@ -357,7 +357,7 @@ u_scanf_skip_leading_positive_sign(UFILE   *input,
 
         if (U_SUCCESS(localStatus)) {
             /* skip all leading ws in the input */
-            while( (isNotEOF = ufile_getch(input, &c)) && (count < symbolLen && c == plusSymbol[count]) )
+            while( ((isNotEOF = ufile_getch(input, &c)) == TRUE) && (count < symbolLen && c == plusSymbol[count]) )
             {
                 count++;
             }
@@ -855,7 +855,7 @@ u_scanf_string_handler(UFILE        *input,
         return -1;
 
     while( (info->fWidth == -1 || count < info->fWidth) 
-        && (isNotEOF = ufile_getch(input, &c))
+        && ((isNotEOF = ufile_getch(input, &c)) == TRUE)
         && (!info->fIsString || (c != info->fPadChar && !u_isWhitespace(c))))
     {
 
@@ -946,7 +946,7 @@ u_scanf_ustring_handler(UFILE       *input,
     count = 0;
 
     while( (info->fWidth == -1 || count < info->fWidth)
-        && (isNotEOF = ufile_getch(input, &c))
+        && ((isNotEOF = ufile_getch(input, &c)) == TRUE)
         && (!info->fIsString || (c != info->fPadChar && !u_isWhitespace(c))))
     {
 
@@ -1249,7 +1249,7 @@ u_scanf_scanset_handler(UFILE       *input,
 
         /* grab characters one at a time and make sure they are in the scanset */
         while(chLeft > 0) {
-            if ((isNotEOF = ufile_getch32(input, &c)) && uset_contains(scanset, c)) {
+            if ( ((isNotEOF = ufile_getch32(input, &c)) == TRUE) && uset_contains(scanset, c) ) {
                 readCharacter = TRUE;
                 if (!info->fSkipArg) {
                     int32_t idx = 0;

--- a/icu4c/source/test/cintltst/callcoll.c
+++ b/icu4c/source/test/cintltst/callcoll.c
@@ -1197,14 +1197,14 @@ TestInvalidRules(){
         UParseError parseError;
         UErrorCode status = U_ZERO_ERROR;
         UCollator* coll=0;
-        u_charsToUChars(rulesArr[i],rules,uprv_strlen(rulesArr[i])+1);
-        u_charsToUChars(preContextArr[i],preContextExp,uprv_strlen(preContextArr[i])+1);
-        u_charsToUChars(postContextArr[i],postContextExp,uprv_strlen(postContextArr[i])+1);
+        u_charsToUChars(rulesArr[i], rules, (int32_t)uprv_strlen(rulesArr[i]) + 1);
+        u_charsToUChars(preContextArr[i], preContextExp, (int32_t)uprv_strlen(preContextArr[i]) + 1);
+        u_charsToUChars(postContextArr[i], postContextExp, (int32_t)uprv_strlen(postContextArr[i]) + 1);
         /* clean up stuff in parseError */
-        u_memset(parseError.preContext,0x0000,U_PARSE_CONTEXT_LEN);      
-        u_memset(parseError.postContext,0x0000,U_PARSE_CONTEXT_LEN);
+        u_memset(parseError.preContext, 0x0000, U_PARSE_CONTEXT_LEN);
+        u_memset(parseError.postContext, 0x0000, U_PARSE_CONTEXT_LEN);
         /* open the rules and test */
-        coll = ucol_openRules(rules,u_strlen(rules),UCOL_OFF,UCOL_DEFAULT_STRENGTH,&parseError,&status);
+        coll = ucol_openRules(rules, u_strlen(rules), UCOL_OFF, UCOL_DEFAULT_STRENGTH, &parseError, &status);
         (void)coll;   /* Suppress set but not used warning. */
         if(u_strcmp(parseError.preContext,preContextExp)!=0){
             log_err_status(status, "preContext in UParseError for ucol_openRules does not match: \"%s\"\n",

--- a/icu4c/source/test/cintltst/cbiditst.c
+++ b/icu4c/source/test/cintltst/cbiditst.c
@@ -514,7 +514,7 @@ static UBool matchingPair(UBiDi *bidi, int32_t i, char c1, char c2)
     if ((level & 1) == 0) {
         return FALSE;
     }
-    len = strlen(mates1Chars);
+    len = (int)strlen(mates1Chars);
     for (k = 0; k < len; k++) {
         if ((c1 == mates1Chars[k]) && (c2 == mates2Chars[k])) {
             return TRUE;
@@ -4126,7 +4126,7 @@ checkResultLength(UBiDi *pBiDi, const char *srcChars, const char *destChars,
                   const char* option, UBiDiLevel level) {
     int32_t actualLen;
     if (strcmp(mode, "UBIDI_REORDER_INVERSE_NUMBERS_AS_L") == 0)
-        actualLen = strlen(destChars);
+        actualLen = (int32_t)strlen(destChars);
     else
         actualLen = ubidi_getResultLength(pBiDi);
     if (actualLen != destLen) {
@@ -4206,7 +4206,7 @@ testReorderRunsOnly(void) {
         ubidi_setReorderingOptions(pBiDi, option==0 ? UBIDI_OPTION_REMOVE_CONTROLS
                                                     : UBIDI_OPTION_INSERT_MARKS);
         for (i = 0, nCases = UPRV_LENGTHOF(testCases); i < nCases; i++) {
-            srcLen = strlen(testCases[i].textIn);
+            srcLen = (int32_t)strlen(testCases[i].textIn);
             pseudoToU16(srcLen, testCases[i].textIn, src);
             for(j = 0; j < 2; j++) {
                 log_verbose("Now doing test for option %d, case %d, level %d\n",
@@ -4292,7 +4292,7 @@ testReorderingMode(void) {
 
     for (tc = 0; tc < TC_COUNT; tc++) {
         const char *srcChars = textIn[tc];
-        srcLen = strlen(srcChars);
+        srcLen = (int32_t)strlen(srcChars);
         pseudoToU16(srcLen, srcChars, src);
 
         for (mode = 0; mode < MODES_COUNT; mode++) {
@@ -4864,9 +4864,9 @@ testContext(void) {
 
     for (tc = 0; tc < CONTEXT_COUNT; tc++) {
         cc = contextData[tc];
-        proLength = strlen(cc.prologue);
+        proLength = (int32_t)strlen(cc.prologue);
         pseudoToU16(proLength, cc.prologue, prologue);
-        epiLength = strlen(cc.epilogue);
+        epiLength = (int32_t)strlen(cc.epilogue);
         pseudoToU16(epiLength, cc.epilogue, epilogue);
         /* in the call below, prologue and epilogue are swapped to show
            that the next call will override this call */
@@ -4875,7 +4875,7 @@ testContext(void) {
         testOK &= assertSuccessful("swapped ubidi_setContext", &rc);
         ubidi_setContext(pBiDi, prologue, -1, epilogue, -1, &rc);
         testOK &= assertSuccessful("regular ubidi_setContext", &rc);
-        srcLen = strlen(cc.source);
+        srcLen = (int32_t)strlen(cc.source);
         pseudoToU16(srcLen, cc.source, src);
         ubidi_setPara(pBiDi, src, srcLen, cc.paraLevel, NULL, &rc);
         testOK &= assertSuccessful("ubidi_setPara", &rc);
@@ -4917,7 +4917,7 @@ testBracketOverflow(void) {
     int32_t len;
 
     bidi = ubidi_open();
-    len = uprv_strlen(TEXT);
+    len = (int32_t)uprv_strlen(TEXT);
     pseudoToU16(len, TEXT, src);
     ubidi_setPara(bidi, src, len, UBIDI_DEFAULT_LTR , NULL, &status);
     if (U_FAILURE(status)) {

--- a/icu4c/source/test/cintltst/ccaltst.c
+++ b/icu4c/source/test/cintltst/ccaltst.c
@@ -1629,7 +1629,7 @@ static void TestGetKeywordValuesForLocale() {
                 ALLList = ulist_getListFromEnum(ALL);
                 for (j = 0; j < size; j++) {
                     if ((value = uenum_next(all, &valueLength, &status)) != NULL && U_SUCCESS(status)) {
-                        if (!ulist_containsString(ALLList, value, uprv_strlen(value))) {
+                        if (!ulist_containsString(ALLList, value, (int32_t)uprv_strlen(value))) {
                             log_err("Locale %s have %s not in ALL\n", loc, value);
                             matchAll = FALSE;
                             break;

--- a/icu4c/source/test/cintltst/ccapitst.c
+++ b/icu4c/source/test/cintltst/ccapitst.c
@@ -852,7 +852,7 @@ static void TestConvert()
 
 
         /*Reads in the file*/
-        while(!feof(ucs_file_in)&&(i+=fread(ucs_file_buffer+i, sizeof(UChar), 1, ucs_file_in)))
+        while(!feof(ucs_file_in)&&(i+=(int32_t)fread(ucs_file_buffer+i, sizeof(UChar), 1, ucs_file_in)))
         {
             myUChar = ucs_file_buffer[i-1];
             
@@ -895,7 +895,7 @@ static void TestConvert()
                      NULL,
                      targetcapacity2,
                      output_cp_buffer,
-                     strlen(output_cp_buffer),
+                     (int32_t)strlen(output_cp_buffer),
                      &err);
         /*if there is an buffer overflow then trap the values and pass them and make the actual call*/
 
@@ -907,7 +907,7 @@ static void TestConvert()
                    uchar2,
                    targetsize+1,
                    output_cp_buffer,
-                   strlen(output_cp_buffer),
+                   (int32_t)strlen(output_cp_buffer),
                    &err);
 
             if(U_FAILURE(err))
@@ -947,12 +947,12 @@ static void TestConvert()
             log_err("\nFAILURE: ucnv_fromUChars with targetLength 0 is expected to fail and throw U_BUFFER_OVERFLOW_ERROR\n");
         }
         /*toUChars with error conditions*/
-        targetsize = ucnv_toUChars(myConverter, uchar2, targetsize, output_cp_buffer, strlen(output_cp_buffer), &err);
+        targetsize = ucnv_toUChars(myConverter, uchar2, targetsize, output_cp_buffer, (int32_t)strlen(output_cp_buffer), &err);
         if(targetsize != 0){
             log_err("\nFAILURE: ucnv_toUChars with err != U_ZERO_ERROR is expected to fail and return 0\n");
         }
         err=U_ZERO_ERROR;
-        targetsize = ucnv_toUChars(myConverter, uchar2, -1, output_cp_buffer, strlen(output_cp_buffer), &err);
+        targetsize = ucnv_toUChars(myConverter, uchar2, -1, output_cp_buffer, (int32_t)strlen(output_cp_buffer), &err);
         if(targetsize != 0 || err != U_ILLEGAL_ARGUMENT_ERROR){
             log_err("\nFAILURE: ucnv_toUChars with targetsize < 0 is expected to throw U_ILLEGAL_ARGUMENT_ERROR and return 0\n");
         }
@@ -962,7 +962,7 @@ static void TestConvert()
             log_err("\nFAILURE: ucnv_toUChars with sourceLength 0 is expected to return 0\n");
         }
         targetcapacity2=0; 
-        targetsize = ucnv_toUChars(myConverter, NULL, targetcapacity2, output_cp_buffer,  strlen(output_cp_buffer), &err);
+        targetsize = ucnv_toUChars(myConverter, NULL, targetcapacity2, output_cp_buffer, (int32_t)strlen(output_cp_buffer), &err);
         if (err != U_STRING_NOT_TERMINATED_WARNING) {
             log_err("\nFAILURE: ucnv_toUChars(targetLength)->%s instead of U_STRING_NOT_TERMINATED_WARNING\n",
                     u_errorName(err));
@@ -2545,7 +2545,7 @@ static void testFromTruncatedUTF8(UConverter *utf8Cnv, UConverter *cnv, const ch
 
     for(i=0; i<UPRV_LENGTHOF(badUTF8); ++i) {
         /* truncated sequence? */
-        int32_t length=strlen(badUTF8[i]);
+        int32_t length = (int32_t)strlen(badUTF8[i]);
         if(!isOneTruncatedUTF8(badUTF8[i], length)) {
             continue;
         }
@@ -2608,7 +2608,7 @@ static void testFromBadUTF8(UConverter *utf8Cnv, UConverter *cnv, const char *co
     expectLength=char0Length;
 
     for(i=0; i<UPRV_LENGTHOF(badUTF8); ++i) {
-        int32_t length=strlen(badUTF8[i]);
+        int32_t length = (int32_t)strlen(badUTF8[i]);
         memcpy(utf8+utf8Length, badUTF8[i], length);
         utf8Length+=length;
 

--- a/icu4c/source/test/cintltst/cdattst.c
+++ b/icu4c/source/test/cintltst/cdattst.c
@@ -551,7 +551,7 @@ static void TestRelativeDateFormat()
 
                 strPtr = u_strstr(strDateTime, minutesStr);
                 if ( strPtr != NULL ) {
-                    int32_t beginIndex = strPtr - strDateTime;
+                    int32_t beginIndex = (int32_t)(strPtr - strDateTime);
                     if ( fp.beginIndex != beginIndex ) {
                         log_err("UFieldPosition beginIndex %d, expected %d, in udat_format timeStyle SHORT dateStyle (%d | UDAT_RELATIVE)\n", fp.beginIndex, beginIndex, *stylePtr );
                     }
@@ -1058,7 +1058,7 @@ static void VerifygetSymbols(UDateFormat* datfor, UDateFormatSymbolType type, in
     UErrorCode status = U_ZERO_ERROR;
     UChar *result=NULL;
     int32_t resultlength, resultlengthout;
-    int32_t patternSize = strlen(expected) + 1;
+    int32_t patternSize = (int32_t)strlen(expected) + 1;
 
     pattern=(UChar*)malloc(sizeof(UChar) * patternSize);
     u_unescape(expected, pattern, patternSize);
@@ -1093,7 +1093,7 @@ static void VerifysetSymbols(UDateFormat* datfor, UDateFormatSymbolType type, in
     UChar *value=NULL;
     int32_t resultlength, resultlengthout;
     UErrorCode status = U_ZERO_ERROR;
-    int32_t valueLen, valueSize = strlen(expected) + 1;
+    int32_t valueLen, valueSize = (int32_t)strlen(expected) + 1;
 
     value=(UChar*)malloc(sizeof(UChar) * valueSize);
     valueLen = u_unescape(expected, value, valueSize);

--- a/icu4c/source/test/cintltst/cldrtest.c
+++ b/icu4c/source/test/cintltst/cldrtest.c
@@ -1432,22 +1432,22 @@ static void TestAvailableIsoCodes(void){
     UChar* isoCode = (UChar*)malloc(sizeof(UChar) * (uprv_strlen(usdCode) + 1));
 
     /* testing available codes with no time ranges */
-    u_charsToUChars(eurCode, isoCode, uprv_strlen(usdCode) + 1);
+    u_charsToUChars(eurCode, isoCode, (int32_t)uprv_strlen(usdCode) + 1);
     if (ucurr_isAvailable(isoCode, U_DATE_MIN, U_DATE_MAX, &errorCode) == FALSE) {
        log_data_err("FAIL: ISO code (%s) is not found.\n", eurCode);
     }
 
-    u_charsToUChars(usdCode, isoCode, uprv_strlen(zzzCode) + 1);
+    u_charsToUChars(usdCode, isoCode, (int32_t)uprv_strlen(zzzCode) + 1);
     if (ucurr_isAvailable(isoCode, U_DATE_MIN, U_DATE_MAX, &errorCode) == FALSE) {
        log_data_err("FAIL: ISO code (%s) is not found.\n", usdCode);
     }
 
-    u_charsToUChars(zzzCode, isoCode, uprv_strlen(zzzCode) + 1);
+    u_charsToUChars(zzzCode, isoCode, (int32_t)uprv_strlen(zzzCode) + 1);
     if (ucurr_isAvailable(isoCode, U_DATE_MIN, U_DATE_MAX, &errorCode) == TRUE) {
        log_err("FAIL: ISO code (%s) is reported as available, but it doesn't exist.\n", zzzCode);
     }
 
-    u_charsToUChars(lastCode, isoCode, uprv_strlen(zzzCode) + 1);
+    u_charsToUChars(lastCode, isoCode, (int32_t)uprv_strlen(zzzCode) + 1);
     if (ucurr_isAvailable(isoCode, U_DATE_MIN, U_DATE_MAX, &errorCode) == FALSE) {
        log_data_err("FAIL: ISO code (%s) is not found.\n", lastCode);
     }

--- a/icu4c/source/test/cintltst/cloctst.c
+++ b/icu4c/source/test/cintltst/cloctst.c
@@ -2271,9 +2271,9 @@ static void TestCanonicalizationBuffer(void)
         "-foo-bar-baz-foo-bar-baz-foo-bar-baz-foo-bar-baz"
         "-foo-barz"
     ;
-    static const size_t len = sizeof name - 1;  // Without NUL terminator.
+    static const size_t len = sizeof(name) - 1;  // Without NUL terminator.
 
-    int32_t reslen = uloc_canonicalize(name, buffer, len, &status);
+    int32_t reslen = uloc_canonicalize(name, buffer, (int32_t)len, &status);
 
     if (U_FAILURE(status)) {
         log_err("FAIL: uloc_canonicalize(%s) => %s, expected !U_FAILURE()\n",
@@ -5709,7 +5709,7 @@ static int32_t getExpectedReturnValue(const errorData* data)
     if (data->uerror == U_BUFFER_OVERFLOW_ERROR ||
         data->uerror == U_STRING_NOT_TERMINATED_WARNING)
     {
-        return strlen(data->expected);
+        return (int32_t)strlen(data->expected);
     }
     else
     {
@@ -5725,7 +5725,7 @@ static int32_t getBufferSize(const errorData* data, int32_t actualSize)
     }
     else if (data->bufferSize < 0)
     {
-        return strlen(data->expected) + 1;
+        return (int32_t)strlen(data->expected) + 1;
     }
     else
     {
@@ -6030,7 +6030,7 @@ static void TestBug20132(void) {
 
     static const char inloc[] = "C";
     static const char expected[] = "en-US-u-va-posix";
-    const int32_t expected_len = uprv_strlen(expected);
+    const int32_t expected_len = (int32_t)uprv_strlen(expected);
 
     /* Before ICU-20132 was fixed, calling uloc_toLanguageTag() with a too small
      * buffer would not immediately return the buffer size actually needed, but
@@ -6164,7 +6164,7 @@ static void TestForLanguageTag(void) {
         locale[0] = 0;
         expParsedLen = langtag_to_locale[i].len;
         if (expParsedLen == FULL_LENGTH) {
-            expParsedLen = uprv_strlen(langtag_to_locale[i].bcpID);
+            expParsedLen = (int32_t)uprv_strlen(langtag_to_locale[i].bcpID);
         }
         uloc_forLanguageTag(langtag_to_locale[i].bcpID, locale, sizeof(locale), &parsedLen, &status);
         if (U_FAILURE(status)) {

--- a/icu4c/source/test/cintltst/cmsccoll.c
+++ b/icu4c/source/test/cintltst/cmsccoll.c
@@ -1819,7 +1819,7 @@ static void TestVariableTopSetting(void) {
   }
 }
 
-static void TestMaxVariable() {
+static void TestMaxVariable(void) {
   UErrorCode status = U_ZERO_ERROR;
   UColReorderCode oldMax, max;
   UCollator *coll;
@@ -4102,11 +4102,11 @@ static void TestCroatianSortKey(void) {
         return;
     }
 
-    uiter_setString(&iter, text, length);
+    uiter_setString(&iter, text, (int32_t)length);
 
     actualSortKeyLen = ucol_nextSortKeyPart(
         ucol, &iter, (uint32_t*)uStateInfo,
-        textSortKey, lenSortKey, &status
+        textSortKey, (int32_t)lenSortKey, &status
         );
 
     if (actualSortKeyLen == lenSortKey) {

--- a/icu4c/source/test/cintltst/cmsgtst.c
+++ b/icu4c/source/test/cintltst/cmsgtst.c
@@ -1123,7 +1123,7 @@ static void MessageLength(void)
     }
 }
 
-static void TestMessageWithUnusedArgNumber() {
+static void TestMessageWithUnusedArgNumber(void) {
     UErrorCode errorCode = U_ZERO_ERROR;
     U_STRING_DECL(pattern, "abc {1} def", 11);
     UChar x[2] = { 0x78, 0 };  // "x"

--- a/icu4c/source/test/cintltst/cnmdptst.c
+++ b/icu4c/source/test/cintltst/cnmdptst.c
@@ -966,7 +966,7 @@ static void TestGetKeywordValuesForLocale(void) {
             ALLList = ulist_getListFromEnum(ALL);
             for (j = 0; j < size; j++) {
                 if ((value = uenum_next(all, &valueLength, &status)) != NULL && U_SUCCESS(status)) {
-                    if (!ulist_containsString(ALLList, value, uprv_strlen(value))) {
+                    if (!ulist_containsString(ALLList, value, (int32_t)uprv_strlen(value))) {
                         log_err("Locale %s have %s not in ALL\n", loc, value);
                         matchAll = FALSE;
                         break;

--- a/icu4c/source/test/cintltst/creststn.c
+++ b/icu4c/source/test/cintltst/creststn.c
@@ -2794,7 +2794,7 @@ static void TestCLDRStyleAliases(void) {
       /* instead of sprintf(resource, "a%i", i); */
       a = ures_getByKeyWithFallback(alias, resource, a, &status);
       result = tres_getString(a, -1, NULL, &len, &status);
-      u_charsToUChars(expects[i], expected, strlen(expects[i])+1);
+      u_charsToUChars(expects[i], expected, (int32_t)strlen(expects[i])+1);
       if(U_FAILURE(status) || !result || u_strcmp(result, expected)) {
         log_err("CLDR style aliases failed resource with name \"%s\" resource, exp %s, got %S (%s)\n", resource, expects[i], result, myErrorName(status)); 
         status = U_ZERO_ERROR;

--- a/icu4c/source/test/cintltst/currtest.c
+++ b/icu4c/source/test/cintltst/currtest.c
@@ -171,21 +171,21 @@ static void TestFractionDigitOverride(void) {
     }
     /* Make sure that you can format normal fraction digits. */
     unum_formatDouble(fmt, 123.456, buffer, UPRV_LENGTHOF(buffer), NULL, &status);
-    u_unescape(expectedFirst, expectedBuf, strlen(expectedFirst)+1);
+    u_unescape(expectedFirst, expectedBuf, (int32_t)strlen(expectedFirst)+1);
     if (u_strcmp(buffer, expectedBuf) != 0) {
        log_err("Error: unum_formatDouble didn't return %s\n", expectedFirst);
     }
     /* Make sure that you can format 2 fraction digits. */
     unum_setAttribute(fmt, UNUM_FRACTION_DIGITS, 2);
     unum_formatDouble(fmt, 123.456, buffer, UPRV_LENGTHOF(buffer), NULL, &status);
-    u_unescape(expectedSecond, expectedBuf, strlen(expectedSecond)+1);
+    u_unescape(expectedSecond, expectedBuf, (int32_t)strlen(expectedSecond)+1);
     if (u_strcmp(buffer, expectedBuf) != 0) {
        log_err("Error: unum_formatDouble didn't return %s\n", expectedSecond);
     }
     /* Make sure that you can format more fraction digits. */
     unum_setAttribute(fmt, UNUM_FRACTION_DIGITS, 3);
     unum_formatDouble(fmt, 123.456, buffer, UPRV_LENGTHOF(buffer), NULL, &status);
-    u_unescape(expectedThird, expectedBuf, strlen(expectedThird)+1);
+    u_unescape(expectedThird, expectedBuf, (int32_t)strlen(expectedThird)+1);
     if (u_strcmp(buffer, expectedBuf) != 0) {
        log_err("Error: unum_formatDouble didn't return %s\n", expectedThird);
     }
@@ -252,7 +252,7 @@ static void TestNumericCode(void) {
     int32_t numCode;
 
     for (i = 0; NUMCODE_TESTDATA[i].alphaCode; i++) {
-        int32_t length = uprv_strlen(NUMCODE_TESTDATA[i].alphaCode);
+        int32_t length = (int32_t)uprv_strlen(NUMCODE_TESTDATA[i].alphaCode);
         u_charsToUChars(NUMCODE_TESTDATA[i].alphaCode, code, length + 1);  // +1 includes the NUL
         numCode = ucurr_getNumericCode(code);
         if (numCode != NUMCODE_TESTDATA[i].numericCode) {

--- a/icu4c/source/test/cintltst/custrtrn.c
+++ b/icu4c/source/test/cintltst/custrtrn.c
@@ -702,7 +702,7 @@ static void Test_UChar_UTF8_API(void){
         out16[0]=0x55aa;
         uDestLen=0;
         u_strFromUTF8WithSub(out16, UPRV_LENGTHOF(out16), &uDestLen,
-                             (const char *)withTrail8, uprv_strlen((const char *)withTrail8),
+                             (const char *)withTrail8, (int32_t)uprv_strlen((const char *)withTrail8),
                              0x50005, &numSubstitutions,
                              &err);
         if(U_FAILURE(err) || uDestLen!=u_strlen(withTrail16Sub50005) ||
@@ -1023,7 +1023,7 @@ Test_FromUTF8Lenient(void) {
         *pb!=(char)0xff;
         pb+=srcLength+1, pu+=destLength0+1, ++number
     ) {
-        srcLength=uprv_strlen(pb);
+        srcLength=(int32_t)uprv_strlen(pb);
         destLength0=u_strlen(pu);
 
         /* preflighting with NUL-termination */

--- a/icu4c/source/test/cintltst/idnatest.c
+++ b/icu4c/source/test/cintltst/idnatest.c
@@ -825,7 +825,7 @@ static void TestLength(){
 static void TestJB5273(){
     static const char INVALID_DOMAIN_NAME[] = "xn--m\\u00FCller.de";
     UChar invalid_idn[25] = {'\0'};
-    int32_t len = u_unescape(INVALID_DOMAIN_NAME, invalid_idn, strlen(INVALID_DOMAIN_NAME));
+    int32_t len = u_unescape(INVALID_DOMAIN_NAME, invalid_idn, (int32_t)strlen(INVALID_DOMAIN_NAME));
     UChar output[50] = {'\0'};
     UErrorCode status = U_ZERO_ERROR;
     UParseError prsError;
@@ -923,7 +923,7 @@ static void TestUTS46() {
         log_err("uidna_labelToASCII_UTF8() failed: %s\n", u_errorName(errorCode));
     }
     errorCode = U_ZERO_ERROR;
-    length = uidna_labelToUnicodeUTF8(uts46, fA_sharps8, strlen(fA_sharps8),
+    length = uidna_labelToUnicodeUTF8(uts46, fA_sharps8, (int32_t)strlen(fA_sharps8),
                                       dest8, UPRV_LENGTHOF(dest8), &info, &errorCode);
     if( U_FAILURE(errorCode) || length != 4 || 0 != memcmp(dest8, fa_sharps8, 5) ||
         !info.isTransitionalDifferent || info.errors != 0
@@ -931,7 +931,7 @@ static void TestUTS46() {
         log_err("uidna_labelToUnicodeUTF8() failed: %s\n", u_errorName(errorCode));
     }
     errorCode = U_ZERO_ERROR;
-    length = uidna_nameToASCII_UTF8(uts46, fA_sharps8, strlen(fA_sharps8),
+    length = uidna_nameToASCII_UTF8(uts46, fA_sharps8, (int32_t)strlen(fA_sharps8),
                                     dest8, 4, &info, &errorCode);
     if( errorCode != U_STRING_NOT_TERMINATED_WARNING ||
         length != 4 || 0 != memcmp(dest8, fass8, 4) ||
@@ -1001,13 +1001,13 @@ static void TestUTS46() {
         log_err("uidna_labelToASCII_UTF8(dest=NULL) failed: %s\n", u_errorName(errorCode));
     }
     errorCode = U_ZERO_ERROR;
-    length = uidna_labelToUnicodeUTF8(uts46, fA_sharps8, strlen(fA_sharps8),
+    length = uidna_labelToUnicodeUTF8(uts46, fA_sharps8, (int32_t)strlen(fA_sharps8),
                                       dest8, -1, &info, &errorCode);
     if(errorCode != U_ILLEGAL_ARGUMENT_ERROR) {
         log_err("uidna_labelToUnicodeUTF8(capacity<0) failed: %s\n", u_errorName(errorCode));
     }
     errorCode = U_ZERO_ERROR;
-    length = uidna_nameToASCII_UTF8(uts46, dest8, strlen(fA_sharps8),
+    length = uidna_nameToASCII_UTF8(uts46, dest8, (int32_t)strlen(fA_sharps8),
                                     dest8, 4, &info, &errorCode);
     if(errorCode != U_ILLEGAL_ARGUMENT_ERROR) {
         log_err("uidna_nameToASCII_UTF8(src==dest!=NULL) failed: %s\n", u_errorName(errorCode));

--- a/icu4c/source/test/cintltst/nucnvtst.c
+++ b/icu4c/source/test/cintltst/nucnvtst.c
@@ -5507,7 +5507,7 @@ static void TestJB5275_1(){
     }
     targetLimit = target;
     target = dest;
-    printUSeq(target, targetLimit-target);
+    printUSeq(target, (int)(targetLimit-target));
     while(target<targetLimit){
         if(*exp!=*target){
             log_err("did not get the expected output. \\u%04X != \\u%04X (got)\n", *exp, *target);
@@ -5554,7 +5554,7 @@ static void TestJB5275(){
     targetLimit = target;
     target = dest;
 
-    printUSeq(target, targetLimit-target);
+    printUSeq(target, (int)(targetLimit-target));
     
     while(target<targetLimit){
         if(*exp!=*target){

--- a/icu4c/source/test/cintltst/putiltst.c
+++ b/icu4c/source/test/cintltst/putiltst.c
@@ -26,6 +26,9 @@
 #include "toolutil.h"
 #include "uinvchar.h"
 #include <stdio.h>
+#if U_PLATFORM_USES_ONLY_WIN32_API 
+#include "wintz.h"
+#endif
 
 /* See the comments on U_SIGNED_RIGHT_SHIFT_IS_ARITHMETIC. */
 static void TestSignedRightShiftIsArithmetic(void) {
@@ -219,7 +222,7 @@ static void TestPUtilAPI(void){
 #if U_PLATFORM_USES_ONLY_WIN32_API 
     log_verbose("Testing uprv_detectWindowsTimeZone() ....\n");
     {
-        char* timezone = uprv_detectWindowsTimeZone();
+        const char* timezone = uprv_detectWindowsTimeZone();
         if (timezone == NULL) {
             log_err("ERROR: uprv_detectWindowsTimeZone failed (returned NULL).\n");
         } else {

--- a/icu4c/source/test/cintltst/reapits.c
+++ b/icu4c/source/test/cintltst/reapits.c
@@ -55,8 +55,9 @@ log_err("Test Failure at file %s:%d - ASSERT(%s) failed.\n", __FILE__, __LINE__,
     status = U_ZERO_ERROR; \
     re = uregex_openC(pattern, flags, NULL, &status);  \
     TEST_ASSERT_SUCCESS(status);   \
-    srcString = (UChar *)malloc((strlen(testString)+2)*sizeof(UChar)); \
-    u_uastrncpy(srcString, testString,  strlen(testString)+1); \
+    int32_t testStringLen = (int32_t)strlen(testString); \
+    srcString = (UChar *)malloc( (testStringLen + 2) * sizeof(UChar) ); \
+    u_uastrncpy(srcString, testString, testStringLen + 1); \
     uregex_setText(re, srcString, -1, &status); \
     TEST_ASSERT_SUCCESS(status);  \
     if (U_SUCCESS(status)) {
@@ -849,7 +850,7 @@ static void TestRegexCAPI(void) {
         status = U_ZERO_ERROR;
         uregex_setText(re, text1, -1, &status);
         memset(buf, -1, sizeof(buf));
-        resultSz = uregex_replaceFirst(re, replText, -1, buf, strlen("Replace <aa> x1x x...x."), &status);
+        resultSz = uregex_replaceFirst(re, replText, -1, buf, (int32_t)strlen("Replace <aa> x1x x...x."), &status);
         TEST_ASSERT(status == U_STRING_NOT_TERMINATED_WARNING);
         TEST_ASSERT_STRING("Replace <aa> x1x x...x.", buf, FALSE);
         TEST_ASSERT(resultSz == (int32_t)strlen("Replace xaax x1x x...x."));
@@ -860,7 +861,7 @@ static void TestRegexCAPI(void) {
          */
         status = U_ZERO_ERROR;
         memset(buf, -1, sizeof(buf));
-        resultSz = uregex_replaceFirst(re, replText, -1, buf, strlen("Replace <aa> x1x x...x."), &status);
+        resultSz = uregex_replaceFirst(re, replText, -1, buf, (int32_t)strlen("Replace <aa> x1x x...x."), &status);
         TEST_ASSERT(status == U_STRING_NOT_TERMINATED_WARNING);
         TEST_ASSERT_STRING("Replace <aa> x1x x...x.", buf, FALSE);
         TEST_ASSERT(resultSz == (int32_t)strlen("Replace xaax x1x x...x."));
@@ -875,7 +876,7 @@ static void TestRegexCAPI(void) {
         /* Buffer too small by one */
         status = U_ZERO_ERROR;
         memset(buf, -1, sizeof(buf));
-        resultSz = uregex_replaceFirst(re, replText, -1, buf, strlen("Replace <aa> x1x x...x.")-1, &status);
+        resultSz = uregex_replaceFirst(re, replText, -1, buf, (int32_t)strlen("Replace <aa> x1x x...x.")-1, &status);
         TEST_ASSERT(status == U_BUFFER_OVERFLOW_ERROR);
         TEST_ASSERT_STRING("Replace <aa> x1x x...x", buf, FALSE);
         TEST_ASSERT(resultSz == (int32_t)strlen("Replace xaax x1x x...x."));
@@ -906,8 +907,8 @@ static void TestRegexCAPI(void) {
         u_uastrncpy(text2, "No match here.",  UPRV_LENGTHOF(text2));
         u_uastrncpy(replText, "<$1>", UPRV_LENGTHOF(replText));
         u_uastrncpy(replText2, "<<$1>>", UPRV_LENGTHOF(replText2));
-        expectedResultSize = strlen(expectedResult);
-        expectedResultSize2 = strlen(expectedResult2);
+        expectedResultSize = (int32_t)strlen(expectedResult);
+        expectedResultSize2 = (int32_t)strlen(expectedResult2);
 
         status = U_ZERO_ERROR;
         re = uregex_openC(pattern, 0, NULL, &status);
@@ -943,7 +944,7 @@ static void TestRegexCAPI(void) {
          */
         status = U_ZERO_ERROR;
         memset(buf, -1, sizeof(buf));
-        resultSize = uregex_replaceAll(re, replText, -1, buf, strlen("Replace xaax x1x x...x."), &status);
+        resultSize = uregex_replaceAll(re, replText, -1, buf, (int32_t)strlen("Replace xaax x1x x...x."), &status);
         TEST_ASSERT(status == U_STRING_NOT_TERMINATED_WARNING);
         TEST_ASSERT_STRING("Replace <aa> <1> <...>.", buf, FALSE);
         TEST_ASSERT(resultSize == (int32_t)strlen("Replace <aa> <1> <...>."));
@@ -1190,7 +1191,7 @@ static void TestRegexCAPI(void) {
                 TEST_ASSERT_STRING("tag-b",   fields[3], TRUE);
                 TEST_ASSERT_STRING("  third", fields[4], TRUE);
                 TEST_ASSERT(fields[5] == NULL);
-                spaceNeeded = strlen("first .tag-a. second.tag-b.  third.");  /* "." at NUL positions */
+                spaceNeeded = (int32_t)strlen("first .tag-a. second.tag-b.  third.");  /* "." at NUL positions */
                 TEST_ASSERT(spaceNeeded == requiredCapacity);
             }
         }
@@ -1209,7 +1210,7 @@ static void TestRegexCAPI(void) {
             TEST_ASSERT_STRING(" second<tag-b>  third", fields[1], TRUE);
             TEST_ASSERT(!memcmp(&fields[2],&minus1,sizeof(UChar*)));
 
-            spaceNeeded = strlen("first . second<tag-b>  third.");  /* "." at NUL positions */
+            spaceNeeded = (int32_t)strlen("first . second<tag-b>  third.");  /* "." at NUL positions */
             TEST_ASSERT(spaceNeeded == requiredCapacity);
         }
 
@@ -1228,7 +1229,7 @@ static void TestRegexCAPI(void) {
             TEST_ASSERT_STRING(" second<tag-b>  third", fields[2], TRUE);
             TEST_ASSERT(!memcmp(&fields[3],&minus1,sizeof(UChar*)));
 
-            spaceNeeded = strlen("first .tag-a. second<tag-b>  third.");  /* "." at NUL positions */
+            spaceNeeded = (int32_t)strlen("first .tag-a. second<tag-b>  third.");  /* "." at NUL positions */
             TEST_ASSERT(spaceNeeded == requiredCapacity);
         }
 
@@ -1249,13 +1250,13 @@ static void TestRegexCAPI(void) {
             TEST_ASSERT_STRING("  third", fields[4], TRUE);
             TEST_ASSERT(!memcmp(&fields[5],&minus1,sizeof(UChar*)));
 
-            spaceNeeded = strlen("first .tag-a. second.tag-b.  third.");  /* "." at NUL positions */
+            spaceNeeded = (int32_t)strlen("first .tag-a. second.tag-b.  third.");  /* "." at NUL positions */
             TEST_ASSERT(spaceNeeded == requiredCapacity);
         }
 
         /* Split, end of text is a field delimiter.   */
         status = U_ZERO_ERROR;
-        sz = strlen("first <tag-a> second<tag-b>");
+        sz = (int32_t)strlen("first <tag-a> second<tag-b>");
         uregex_setText(re, textToSplit, sz, &status);
         TEST_ASSERT_SUCCESS(status);
 
@@ -1277,7 +1278,7 @@ static void TestRegexCAPI(void) {
                 TEST_ASSERT(fields[5] == NULL);
                 TEST_ASSERT(fields[8] == NULL);
                 TEST_ASSERT(!memcmp(&fields[9],&minus1,sizeof(UChar*)));
-                spaceNeeded = strlen("first .tag-a. second.tag-b..");  /* "." at NUL positions */
+                spaceNeeded = (int32_t)strlen("first .tag-a. second.tag-b..");  /* "." at NUL positions */
                 TEST_ASSERT(spaceNeeded == requiredCapacity);
             }
         }
@@ -2142,7 +2143,7 @@ static void TestUTextAPI(void) {
 
         /* Split, end of text is a field delimiter.   */
         status = U_ZERO_ERROR;
-        uregex_setText(re, textToSplit, strlen("first <tag-a> second<tag-b>"), &status);
+        uregex_setText(re, textToSplit, (int32_t)strlen("first <tag-a> second<tag-b>"), &status);
         TEST_ASSERT_SUCCESS(status);
 
         /* The TEST_ASSERT_SUCCESS call above should change too... */

--- a/icu4c/source/test/cintltst/sorttest.c
+++ b/icu4c/source/test/cintltst/sorttest.c
@@ -28,7 +28,7 @@
 #include "uarrsort.h"
 
 static void
-SortTest() {
+SortTest(void) {
     uint16_t small[]={ 8, 1, 2, 5, 4, 3, 7, 6 };
     int32_t medium[]={ 10, 8, 1, 2, 5, 5, -1, 6, 4, 3, 9, 7, 5 };
     uint32_t large[]={ 21, 10, 20, 19, 11, 12, 13, 10, 10, 10, 10,
@@ -131,7 +131,7 @@ linesComparator(const void *context, const void *left, const void *right) {
     return ucol_strcoll(coll, leftLine->s, STR_LEN, rightLine->s, STR_LEN);
 }
 
-static void StableSortTest() {
+static void StableSortTest(void) {
     UErrorCode errorCode=U_ZERO_ERROR;
     UCollator *coll;
     Line *lines, *p;

--- a/icu4c/source/test/cintltst/spooftest.c
+++ b/icu4c/source/test/cintltst/spooftest.c
@@ -132,7 +132,7 @@ static void TestOpenFromSource() {
     TEST_ASSERT_NE(f, NULL);
     confusables = malloc(3000000);
     if (f != NULL) {
-        confusablesLength = fread(confusables, 1, 3000000, f);
+        confusablesLength = (int)fread(confusables, 1, 3000000, f);
         fclose(f);
     }
 
@@ -142,7 +142,7 @@ static void TestOpenFromSource() {
     TEST_ASSERT_NE(f, NULL);
     confusablesWholeScript = malloc(1000000);
     if (f != NULL) {
-        confusablesWholeScriptLength = fread(confusablesWholeScript, 1, 1000000, f);
+        confusablesWholeScriptLength = (int)fread(confusablesWholeScript, 1, 1000000, f);
         fclose(f);
     }
 

--- a/icu4c/source/test/cintltst/ucnvseltst.c
+++ b/icu4c/source/test/cintltst/ucnvseltst.c
@@ -165,8 +165,8 @@ static FILE *fopenOrError(const char *filename) {
     int32_t needLen;
     FILE *f;
     char fnbuf[FILENAME_BUFFER];
-    const char* directory= ctest_dataSrcDir();
-    needLen = uprv_strlen(directory)+uprv_strlen(TDSRCPATH)+uprv_strlen(filename)+1;
+    const char* directory = ctest_dataSrcDir();
+    needLen = (int32_t)(uprv_strlen(directory) + uprv_strlen(TDSRCPATH) + uprv_strlen(filename) + 1);
     if(needLen > FILENAME_BUFFER) {
         log_err("FAIL: Could not load %s. Filename buffer overflow, needed %d but buffer is %d\n",
                 filename, needLen, FILENAME_BUFFER);

--- a/icu4c/source/test/cintltst/uenumtst.c
+++ b/icu4c/source/test/cintltst/uenumtst.c
@@ -369,7 +369,7 @@ static void verifyEnumeration(int line, UEnumeration *u, const char * const * co
       return;
     }
     if(compareToChar!=NULL) {
-      u_charsToUChars(compareToChar[i], buf, strlen(compareToChar[i])+1);
+      u_charsToUChars(compareToChar[i], buf, (int32_t)strlen(compareToChar[i])+1);
       if(u_strncmp(ustr,buf,len)) {
         int j;
         log_err("%s:%d: FAIL: ustring #%d expected '%s' got '%s'\n", __FILE__, line, i, compareToChar[i], austrdup(ustr));

--- a/icu4c/source/test/cintltst/uformattedvaluetst.c
+++ b/icu4c/source/test/cintltst/uformattedvaluetst.c
@@ -139,7 +139,7 @@ static void AssertAllPartsEqual(
 
     char message[256];
     uprv_strncpy(message, messagePrefix, 256);
-    int32_t prefixEnd = uprv_strlen(messagePrefix);
+    int32_t prefixEnd = (int32_t)uprv_strlen(messagePrefix);
     message[prefixEnd++] = ':';
     message[prefixEnd++] = ' ';
     U_ASSERT(prefixEnd < 256);

--- a/icu4c/source/test/intltest/bytestrietest.cpp
+++ b/icu4c/source/test/intltest/bytestrietest.cpp
@@ -691,7 +691,7 @@ void BytesTrieTest::checkNext(BytesTrie &trie,
                               const StringAndValue data[], int32_t dataLength) {
     BytesTrie::State state;
     for(int32_t i=0; i<dataLength; ++i) {
-        int32_t stringLength= (i&1) ? -1 : strlen(data[i].s);
+        int32_t stringLength= (i&1) ? -1 : static_cast<int32_t>(strlen(data[i].s));
         UStringTrieResult result;
         if( !USTRINGTRIE_HAS_VALUE(result=trie.next(data[i].s, stringLength)) ||
             result!=trie.current()
@@ -706,7 +706,7 @@ void BytesTrieTest::checkNext(BytesTrie &trie,
             errln("trie value for %s changes when repeating current()/getValue()", data[i].s);
         }
         trie.reset();
-        stringLength=strlen(data[i].s);
+        stringLength = static_cast<int32_t>(strlen(data[i].s));
         result=trie.current();
         for(int32_t j=0; j<stringLength; ++j) {
             if(!USTRINGTRIE_HAS_NEXT(result)) {
@@ -776,8 +776,8 @@ void BytesTrieTest::checkNextWithState(BytesTrie &trie,
             trie.resetToState(noState);
         }
         const char *expectedString=data[i].s;
-        int32_t stringLength=strlen(expectedString);
-        int32_t partialLength=stringLength/3;
+        int32_t stringLength= static_cast<int32_t>(strlen(expectedString));
+        int32_t partialLength = stringLength / 3;
         for(int32_t j=0; j<partialLength; ++j) {
             if(!USTRINGTRIE_MATCHES(trie.next(expectedString[j]))) {
                 errln("trie.next()=USTRINGTRIE_NO_MATCH for a prefix of %s", data[i].s);
@@ -831,7 +831,7 @@ void BytesTrieTest::checkNextString(BytesTrie &trie,
                                     const StringAndValue data[], int32_t dataLength) {
     for(int32_t i=0; i<dataLength; ++i) {
         const char *expectedString=data[i].s;
-        int32_t stringLength=strlen(expectedString);
+        int32_t stringLength = static_cast<int32_t>(strlen(expectedString));
         if(!trie.next(expectedString, stringLength/2)) {
             errln("trie.next(up to middle of string)=USTRINGTRIE_NO_MATCH for %s", data[i].s);
             continue;

--- a/icu4c/source/test/intltest/dcfmapts.cpp
+++ b/icu4c/source/test/intltest/dcfmapts.cpp
@@ -645,6 +645,12 @@ void IntlTestDecimalFormatAPI::TestScale()
     sprintf(tmp, "(%g==%g)", (double)lhs, (double)rhs); \
     assertTrue(tmp, (lhs==rhs), FALSE, TRUE, __FILE__, __LINE__); }
 
+#if defined(_MSC_VER)
+// Ignore the noisy warning 4805 (comparisons between int and bool) in the function below as we use the ICU TRUE/FALSE macros
+// which are int values, whereas some of the DecimalQuantity methods return C++ bools.
+#pragma warning(push)
+#pragma warning(disable: 4805)
+#endif
 void IntlTestDecimalFormatAPI::TestFixedDecimal() {
     UErrorCode status = U_ZERO_ERROR;
 
@@ -957,6 +963,10 @@ void IntlTestDecimalFormatAPI::TestFixedDecimal() {
     ASSERT_EQUAL(FALSE, fd.isNegative());
 
 }
+#if defined(_MSC_VER)
+// Re-enable 4805 warnings (comparisons between int and bool).
+#pragma warning(pop)
+#endif
 
 void IntlTestDecimalFormatAPI::TestBadFastpath() {
     UErrorCode status = U_ZERO_ERROR;

--- a/icu4c/source/test/intltest/dcfmtest.cpp
+++ b/icu4c/source/test/intltest/dcfmtest.cpp
@@ -501,7 +501,7 @@ UChar *DecimalFormatTest::ReadAndConvertFile(const char *fileName, int32_t &ulen
     fileSize = ftell(f);
     fileBuf = new char[fileSize];
     fseek(f, 0, SEEK_SET);
-    amtRead = fread(fileBuf, 1, fileSize, f);
+    amtRead = static_cast<int32_t>(fread(fileBuf, 1, fileSize, f));
     if (amtRead != fileSize || fileSize <= 0) {
         errln("Error reading test data file.");
         goto cleanUpAndReturn;

--- a/icu4c/source/test/intltest/idnaconf.cpp
+++ b/icu4c/source/test/intltest/idnaconf.cpp
@@ -73,7 +73,7 @@ UBool IdnaConfTest::ReadAndConvertFile(){
     }
 
     const char* name = "idna_conf.txt";     // test data file
-    int t = strlen(path) + strlen(name) + 1;
+    int t = static_cast<int>(strlen(path) + strlen(name) + 1);
     char* absolute_name = new char[t];
     strcpy(absolute_name, path);
     strcat(absolute_name, name);
@@ -108,14 +108,14 @@ UBool IdnaConfTest::ReadAndConvertFile(){
                                 NULL,           //  dest,
                                 0,              //  destCapacity,
                                 source,
-                                source_len,
+                                static_cast<int32_t>(source_len),
                                 &status);
     if (status == U_BUFFER_OVERFLOW_ERROR) {
         // Buffer Overflow is expected from the preflight operation.
         status = U_ZERO_ERROR;
         UChar * dest = NULL;
         dest = new UChar[ dest_len + 1];
-        ucnv_toUChars(conv, dest, dest_len + 1, source, source_len, &status);
+        ucnv_toUChars(conv, dest, dest_len + 1, source, static_cast<int32_t>(source_len), &status);
         // Do not know the "if possible" behavior of ucnv_toUChars()
         // Do it by ourself.
         dest[dest_len] = 0; 

--- a/icu4c/source/test/intltest/idnaref.cpp
+++ b/icu4c/source/test/intltest/idnaref.cpp
@@ -815,7 +815,7 @@ idnaref_IDNToASCII(  const UChar* src, int32_t srcLength,
             }
 
             labelStart = delimiter;
-            remainingLen = srcLength - (delimiter - src);
+            remainingLen = static_cast<int32_t>(srcLength - (delimiter - src));
         }
     }
 
@@ -972,7 +972,7 @@ idnaref_IDNToUnicode(  const UChar* src, int32_t srcLength,
             }
 
             labelStart = delimiter;
-            remainingLen = srcLength - (delimiter - src);
+            remainingLen = static_cast<int32_t>(srcLength - (delimiter - src));
         }
     }
 

--- a/icu4c/source/test/intltest/intltest.cpp
+++ b/icu4c/source/test/intltest/intltest.cpp
@@ -2188,7 +2188,7 @@ void IntlTest::setProperty(const char* propline) {
 const char* IntlTest::getProperty(const char* prop) {
     const char* val = NULL;
     for (int32_t i = 0; i < numProps; i++) {
-        int32_t plen = uprv_strlen(prop);
+        int32_t plen = static_cast<int32_t>(uprv_strlen(prop));
         if ((int32_t)uprv_strlen(proplines[i]) > plen + 1
                 && proplines[i][plen] == '='
                 && uprv_strncmp(proplines[i], prop, plen) == 0) {

--- a/icu4c/source/test/intltest/itspoof.cpp
+++ b/icu4c/source/test/intltest/itspoof.cpp
@@ -341,7 +341,7 @@ void IntlTestSpoof::testConfData() {
     int32_t  fileSize = ftell(f.getAlias());
     LocalArray<char> fileBuf(new char[fileSize]);
     fseek(f.getAlias(), 0, SEEK_SET);
-    int32_t amt_read = fread(fileBuf.getAlias(), 1, fileSize, f.getAlias());
+    int32_t amt_read = static_cast<int32_t>(fread(fileBuf.getAlias(), 1, fileSize, f.getAlias()));
     TEST_ASSERT_EQ(amt_read, fileSize);
     TEST_ASSERT(fileSize>0);
     if (amt_read != fileSize || fileSize <=0) {

--- a/icu4c/source/test/intltest/loctest.cpp
+++ b/icu4c/source/test/intltest/loctest.cpp
@@ -1854,7 +1854,7 @@ LocaleTest::TestCreateKeywordSet(void) {
             status);
     status.errIfFailureAndReset("\"%s\"", l.getName());
 
-    assertEquals("set::size()", 2, result.size());
+    assertEquals("set::size()", 2, static_cast<int32_t>(result.size()));
     assertTrue("set::find(\"calendar\")",
                result.find("calendar") != result.end());
     assertTrue("set::find(\"collation\")",
@@ -1873,7 +1873,7 @@ LocaleTest::TestCreateUnicodeKeywordSet(void) {
             status);
     status.errIfFailureAndReset("\"%s\"", l.getName());
 
-    assertEquals("set::size()", 2, result.size());
+    assertEquals("set::size()", 2, static_cast<int32_t>(result.size()));
     assertTrue("set::find(\"ca\")",
                result.find("ca") != result.end());
     assertTrue("set::find(\"co\")",

--- a/icu4c/source/test/intltest/normconf.cpp
+++ b/icu4c/source/test/intltest/normconf.cpp
@@ -482,7 +482,7 @@ UBool NormalizerConformanceTest::checkNorm(UNormalizationMode mode, int32_t opti
     std::string out8;
     Edits edits;
     Edits *editsPtr = (mode == UNORM_NFC || mode == UNORM_NFKC) ? &edits : nullptr;
-    StringByteSink<std::string> sink(&out8, exp8.length());
+    StringByteSink<std::string> sink(&out8, static_cast<int32_t>(exp8.length()));
     norm2->normalizeUTF8(0, s8, sink, editsPtr, errorCode);
     if (U_FAILURE(errorCode)) {
         errln("Normalizer2.%s.normalizeUTF8(%s) failed: %s",
@@ -505,8 +505,8 @@ UBool NormalizerConformanceTest::checkNorm(UNormalizationMode mode, int32_t opti
                          (int32_t)(out8.length() - s8.length()), edits.lengthDelta());
     Edits::Iterator iter = edits.getCoarseIterator();
     while (iter.next(errorCode)) {}
-    pass &= assertEquals("edits source length", s8.length(), iter.sourceIndex());
-    pass &= assertEquals("edits destination length", out8.length(), iter.destinationIndex());
+    pass &= assertEquals("edits source length", static_cast<int32_t>(s8.length()), iter.sourceIndex());
+    pass &= assertEquals("edits destination length", static_cast<int32_t>(out8.length()), iter.destinationIndex());
     return pass;
 }
 

--- a/icu4c/source/test/intltest/numbertest_range.cpp
+++ b/icu4c/source/test/intltest/numbertest_range.cpp
@@ -714,9 +714,9 @@ void NumberRangeFormatterTest::testPlurals() {
         {5, 5, u"5–5 britanskih funtov"}, // other + other -> other
     };
     for (auto& cas : cases) {
-        UnicodeString message = Int64ToUnicodeString(cas.first);
+        UnicodeString message = Int64ToUnicodeString(static_cast<int64_t>(cas.first));
         message += u" ";
-        message += Int64ToUnicodeString(cas.second);
+        message += Int64ToUnicodeString(static_cast<int64_t>(cas.second));
         status.setScope(message);
         UnicodeString actual = lnrf.formatFormattableRange(cas.first, cas.second, status).toString(status);
         assertEquals(message, cas.expected, actual);

--- a/icu4c/source/test/intltest/plurults.cpp
+++ b/icu4c/source/test/intltest/plurults.cpp
@@ -644,7 +644,7 @@ void PluralRulesTest::checkSelect(const LocalPointer<PluralRules> &rules, UError
         }
         double numDbl = dl.toDouble();
         const char *decimalPoint = strchr(num, '.');
-        int fractionDigitCount = decimalPoint == NULL ? 0 : (num + strlen(num) - 1) - decimalPoint;
+        int fractionDigitCount = decimalPoint == NULL ? 0 : static_cast<int>((num + strlen(num) - 1) - decimalPoint);
         int fractionDigits = fractionDigitCount == 0 ? 0 : atoi(decimalPoint + 1);
         FixedDecimal ni(numDbl, fractionDigitCount, fractionDigits);
         

--- a/icu4c/source/test/intltest/rbbimonkeytest.cpp
+++ b/icu4c/source/test/intltest/rbbimonkeytest.cpp
@@ -954,8 +954,8 @@ void RBBIMonkeyTest::testMonkey() {
         }
         test->fDumpExpansions = dumpExpansions;
         test->fVerbose = verbose;
-        test->fRandomGenerator.seed((uint32_t)seed);
-        test->fLoopCount = loopCount;
+        test->fRandomGenerator.seed(static_cast<uint32_t>(seed));
+        test->fLoopCount = static_cast<int32_t>(loopCount);
         test->setup(tests[i], status);
         if (U_FAILURE(status)) {
             dataerrln("%s:%d: error %s while starting test %s.", __FILE__, __LINE__, u_errorName(status), tests[i]);

--- a/icu4c/source/test/intltest/rbbitst.cpp
+++ b/icu4c/source/test/intltest/rbbitst.cpp
@@ -139,7 +139,7 @@ static void printStringBreaks(UText *tstr, int expected[], int expectedCount) {
     printf("code    alpha extend alphanum type word sent line name\n");
     int nextExpectedIndex = 0;
     utext_setNativeIndex(tstr, 0);
-    for (int j = 0; j < utext_nativeLength(tstr); j=utext_getNativeIndex(tstr)) {
+    for (int j = 0; j < static_cast<int>(utext_nativeLength(tstr)); j=static_cast<int>(utext_getNativeIndex(tstr))) {
         if (nextExpectedIndex < expectedCount && j >= expected[nextExpectedIndex] ) {
             printf("------------------------------------------------ %d\n", j);
             ++nextExpectedIndex;
@@ -575,7 +575,7 @@ void RBBITest::executeTest(TestParams *t, UErrorCode &status) {
     //
     //  Run the iterator backwards, verify that the same breaks are found.
     //
-    prevBP = utext_nativeLength(t->textToBreak)+2;  // start with a phony value for the last break pos seen.
+    prevBP = static_cast<int32_t>(utext_nativeLength(t->textToBreak) + 2); // start with a phony value for the last break pos seen.
     bp = t->bi->last();
     while (bp != BreakIterator::DONE) {
         if (prevBP ==  bp) {
@@ -639,10 +639,10 @@ void RBBITest::executeTest(TestParams *t, UErrorCode &status) {
     }
 
     // Check following()
-    for (i=0; i < utext_nativeLength(t->textToBreak); i++) {
+    for (i=0; i < static_cast<int32_t>(utext_nativeLength(t->textToBreak)); i++) {
         int32_t actualBreak = t->bi->following(i);
         int32_t expectedBreak = BreakIterator::DONE;
-        for (int32_t j=i+1; j <= utext_nativeLength(t->textToBreak); j++) {
+        for (int32_t j=i+1; j <= static_cast<int32_t>(utext_nativeLength(t->textToBreak)); j++) {
             if (t->getExpectedBreak(j) != 0) {
                 expectedBreak = j;
                 break;
@@ -656,7 +656,7 @@ void RBBITest::executeTest(TestParams *t, UErrorCode &status) {
     }
 
     // Check preceding()
-    for (i=utext_nativeLength(t->textToBreak); i>=0; i--) {
+    for (i=static_cast<int32_t>(utext_nativeLength(t->textToBreak)); i>=0; i--) {
         int32_t actualBreak = t->bi->preceding(i);
         int32_t expectedBreak = BreakIterator::DONE;
 
@@ -666,7 +666,7 @@ void RBBITest::executeTest(TestParams *t, UErrorCode &status) {
         // Therefore, start looking at the expected break data not at i-1, but at
         // the start of code point index - 1.
         utext_setNativeIndex(t->textToBreak, i);
-        int32_t j = utext_getNativeIndex(t->textToBreak) - 1;
+        int32_t j = static_cast<int32_t>(utext_getNativeIndex(t->textToBreak) - 1);
         for (; j >= 0; j--) {
             if (t->getExpectedBreak(j) != 0) {
                 expectedBreak = j;
@@ -1175,7 +1175,7 @@ UChar *RBBITest::ReadAndConvertFile(const char *fileName, int &ulen, const char 
     fileSize = ftell(f);
     fileBuf = new char[fileSize];
     fseek(f, 0, SEEK_SET);
-    amt_read = fread(fileBuf, 1, fileSize, f);
+    amt_read = static_cast<int>(fread(fileBuf, 1, fileSize, f));
     if (amt_read != fileSize || fileSize <= 0) {
         errln("Error reading test data file.");
         goto cleanUpAndReturn;

--- a/icu4c/source/test/intltest/regextst.cpp
+++ b/icu4c/source/test/intltest/regextst.cpp
@@ -1821,8 +1821,8 @@ void RegexTest::API_Match_UTF8() {
         REGEX_VERBOSE_TEXT(&input2);
         utext_openUChars(&empty, NULL, 0, &status);
 
-        int32_t input1Len = strlen("abcdef this is a test"); /* TODO: why not nativelen (input1) ? */
-        int32_t input2Len = strlen("not abc");
+        int32_t input1Len = static_cast<int32_t>(strlen("abcdef this is a test")); /* TODO: why not nativelen (input1) ? */
+        int32_t input2Len = static_cast<int32_t>(strlen("not abc"));
 
 
         //
@@ -3861,7 +3861,7 @@ UChar *RegexTest::ReadAndConvertFile(const char *fileName, int32_t &ulen,
     fileSize = ftell(f);
     fileBuf = new char[fileSize];
     fseek(f, 0, SEEK_SET);
-    amt_read = fread(fileBuf, 1, fileSize, f);
+    amt_read = static_cast<int32_t>(fread(fileBuf, 1, fileSize, f));
     if (amt_read != fileSize || fileSize <= 0) {
         errln("Error reading test data file.");
         goto cleanUpAndReturn;
@@ -5667,7 +5667,7 @@ void RegexTest::TestCase11049(const char *pattern, const char *data, UBool expec
     //   Size of the original char * data (invariant charset) will be <= than the equivalent UTF-8
     //   because string.unescape() will only shrink it.
     char * utf8Buffer = new char[uprv_strlen(data)+1];
-    u_strToUTF8(utf8Buffer, uprv_strlen(data)+1, NULL, dataString.getBuffer(), dataString.length(), &status);
+    u_strToUTF8(utf8Buffer, static_cast<int32_t>(uprv_strlen(data)+1), NULL, dataString.getBuffer(), dataString.length(), &status);
     REGEX_CHECK_STATUS;
     ut = utext_openUTF8(ut, utf8Buffer, -1, &status);
     REGEX_CHECK_STATUS;

--- a/icu4c/source/test/intltest/strcase.cpp
+++ b/icu4c/source/test/intltest/strcase.cpp
@@ -747,7 +747,7 @@ StringCaseTest::assertGreekUpper(const char16_t *s, const char16_t *expected) {
     msg = UnicodeString("ucasemap_utf8ToUpper/Greek(\"") + s16 + "\")";
     char dest8[1000];
     length = ucasemap_utf8ToUpper(csm.getAlias(), dest8, UPRV_LENGTHOF(dest8),
-                                  s8.data(), s8.length(), &errorCode);
+                                  s8.data(), static_cast<int32_t>(s8.length()), &errorCode);
     assertSuccess("ucasemap_utf8ToUpper", errorCode);
     StringPiece result8(dest8, length);
     UnicodeString result16From8 = UnicodeString::fromUTF8(result8);
@@ -765,7 +765,7 @@ StringCaseTest::assertGreekUpper(const char16_t *s, const char16_t *expected) {
         memset(dest8b, 0x5A, UPRV_LENGTHOF(dest8b));
         UErrorCode errorCode = U_ZERO_ERROR;
         length = ucasemap_utf8ToUpper(csm.getAlias(), dest8b, cap,
-                                      s8.data(), s8.length(), &errorCode);
+                                      s8.data(), static_cast<int32_t>(s8.length()), &errorCode);
         assertEquals(msg + cap, expected8Length, length);
         UErrorCode expectedErrorCode;
         if (cap < expected8Length) {
@@ -910,7 +910,7 @@ void StringCaseTest::TestBufferOverflow() {
     std::string data_utf8;
     data.toUTF8String(data_utf8);
 #if !UCONFIG_NO_BREAK_ITERATION
-    result = ucasemap_utf8ToTitle(csm.getAlias(), NULL, 0, data_utf8.c_str(), data_utf8.length(), errorCode);
+    result = ucasemap_utf8ToTitle(csm.getAlias(), NULL, 0, data_utf8.c_str(), static_cast<int32_t>(data_utf8.length()), errorCode);
     if (errorCode.get() != U_BUFFER_OVERFLOW_ERROR || result != (int32_t)data_utf8.length()) {
         errln("%s:%d ucasemap_toTitle(\"hello world\") failed: "
               "expected (U_BUFFER_OVERFLOW_ERROR, %d), got (%s, %d)",

--- a/icu4c/source/test/intltest/tstnorm.cpp
+++ b/icu4c/source/test/intltest/tstnorm.cpp
@@ -1577,7 +1577,7 @@ BasicNormalizerTest::TestNormalizeUTF8WithEdits() {
         u8"  AÄA\u0308A\u0308\u00ad\u0323Ä\u0323,\u00ad\u1100\u1161가\u11A8가\u3133  ";
     std::string expected = u8"  aääạ\u0308ạ\u0308,가각갃  ";
     std::string result;
-    StringByteSink<std::string> sink(&result, expected.length());
+    StringByteSink<std::string> sink(&result, static_cast<int32_t>(expected.length()));
     Edits edits;
     nfkc_cf->normalizeUTF8(0, src, sink, &edits, errorCode);
     assertSuccess("normalizeUTF8 with Edits", errorCode.get());
@@ -1780,7 +1780,7 @@ BasicNormalizerTest::TestComposeJamoTBase() {
     std::string s8(u8"\u1100\u1161\u11A7\u1100\u314F\u11A7가\u11A7");
     std::string expected8(u8"가\u11A7가\u11A7가\u11A7");
     std::string result8;
-    StringByteSink<std::string> sink(&result8, expected8.length());
+    StringByteSink<std::string> sink(&result8, static_cast<int32_t>(expected8.length()));
     nfkc->normalizeUTF8(0, s8, sink, nullptr, errorCode);
     assertSuccess("normalizeUTF8(LV+11A7)", errorCode.get());
     assertEquals("normalizeUTF8(LV+11A7)", expected8.c_str(), result8.c_str());

--- a/icu4c/source/test/intltest/usettest.cpp
+++ b/icu4c/source/test/intltest/usettest.cpp
@@ -2892,7 +2892,7 @@ static inline USetSpanCondition invertSpanCondition(USetSpanCondition spanCondit
 }
 
 static inline int32_t slen(const void *s, UBool isUTF16) {
-    return isUTF16 ? u_strlen((const UChar *)s) : strlen((const char *)s);
+    return isUTF16 ? u_strlen((const UChar *)s) : static_cast<int32_t>(strlen((const char *)s));
 }
 
 /*

--- a/icu4c/source/test/intltest/windttst.cpp
+++ b/icu4c/source/test/intltest/windttst.cpp
@@ -116,6 +116,7 @@ void Win32DateTimeTest::testLocales(DateFormatTest *log)
     for(int i = 0; i < lcidCount; i += 1) {
         UErrorCode status = U_ZERO_ERROR;
         WCHAR longDateFormat[81], longTimeFormat[81], wdBuffer[256], wtBuffer[256];
+        DWORD value = 0;
         int32_t calType = 0;
 
         // NULL localeID means ICU didn't recognize this locale
@@ -140,8 +141,9 @@ void Win32DateTimeTest::testLocales(DateFormatTest *log)
 
         GetLocaleInfoW(lcidRecords[i].lcid, LOCALE_SLONGDATE,   longDateFormat, 81);
         GetLocaleInfoW(lcidRecords[i].lcid, LOCALE_STIMEFORMAT, longTimeFormat, 81);
-        GetLocaleInfoW(lcidRecords[i].lcid, LOCALE_RETURN_NUMBER|LOCALE_ICALENDARTYPE, (LPWSTR) calType, sizeof(int32_t));
+        GetLocaleInfoW(lcidRecords[i].lcid, LOCALE_RETURN_NUMBER|LOCALE_ICALENDARTYPE, (LPWSTR)&value, sizeof(value)/sizeof(WCHAR));
 
+        calType = value;
         char localeID[64];
 
         uprv_strcpy(localeID, lcidRecords[i].localeID);

--- a/icu4c/source/tools/ctestfw/ctest.c
+++ b/icu4c/source/tools/ctestfw/ctest.c
@@ -420,7 +420,7 @@ static void iterateTestsWithLevel ( const TestNode* root,
             }
           } else {
             /* put -- out at 30 sp. */
-            int spaces = FLAG_INDENT-(strlen(root->name)+depth);
+            int spaces = FLAG_INDENT - ((int)strlen(root->name) + depth);
             if(spaces<0) spaces=0;
             log_testinfo(" %*s[OK] ", spaces,"---");
           }

--- a/icu4c/source/tools/genrb/reslist.cpp
+++ b/icu4c/source/tools/genrb/reslist.cpp
@@ -1367,7 +1367,7 @@ SRBRoot::compactKeys(UErrorCode &errorCode) {
                 keysInUse.insert(key);
             }
         });
-        fKeysCount = keysInUse.size();
+        fKeysCount = static_cast<int32_t>(keysInUse.size());
     }
 
     int32_t keysCount = fUsePoolBundle->fKeysCount + fKeysCount;

--- a/icu4c/source/tools/icuinfo/icuinfo.cpp
+++ b/icu4c/source/tools/icuinfo/icuinfo.cpp
@@ -84,6 +84,12 @@ void cmd_version(UBool /* noLoad */, UErrorCode &errorCode)
         errorCode=U_INTERNAL_PROGRAM_ERROR;
     }
 
+#if defined(_MSC_VER)
+// Ignore warning 4127, conditional expression is constant. This is intentional below.
+#pragma warning(push)
+#pragma warning(disable: 4127)
+#endif
+
     if(U_SIZEOF_WCHAR_T==sizeof(wchar_t)) {
       //printf("U_SIZEOF_WCHAR_T: %d\n", U_SIZEOF_WCHAR_T);
     } else {
@@ -107,6 +113,10 @@ void cmd_version(UBool /* noLoad */, UErrorCode &errorCode)
                 U_CHARSET_FAMILY, charsetFamily);
         errorCode=U_INTERNAL_PROGRAM_ERROR;
     }
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
     printf("\n\nICU Initialization returned: %s\n", u_errorName(initStatus));
     

--- a/icu4c/source/tools/pkgdata/pkgdata.cpp
+++ b/icu4c/source/tools/pkgdata/pkgdata.cpp
@@ -1350,8 +1350,8 @@ static int32_t pkg_generateLibraryFile(const char *targetDir, const char mode, c
 
     if (IN_STATIC_MODE(mode)) {
         if (cmd == NULL) {
-            length = uprv_strlen(pkgDataFlags[AR]) + uprv_strlen(pkgDataFlags[ARFLAGS]) + uprv_strlen(targetDir) +
-                     uprv_strlen(libFileNames[LIB_FILE_VERSION]) + uprv_strlen(objectFile) + uprv_strlen(pkgDataFlags[RANLIB]) + BUFFER_PADDING_SIZE;
+            length = static_cast<int32_t>(uprv_strlen(pkgDataFlags[AR]) + uprv_strlen(pkgDataFlags[ARFLAGS]) + uprv_strlen(targetDir) +
+                     uprv_strlen(libFileNames[LIB_FILE_VERSION]) + uprv_strlen(objectFile) + uprv_strlen(pkgDataFlags[RANLIB]) + BUFFER_PADDING_SIZE);
             if ((cmd = (char *)uprv_malloc(sizeof(char) * length)) == NULL) {
                 fprintf(stderr, "Unable to allocate memory for command.\n");
                 return -1;
@@ -1376,15 +1376,15 @@ static int32_t pkg_generateLibraryFile(const char *targetDir, const char mode, c
         }
     } else /* if (IN_DLL_MODE(mode)) */ {
         if (cmd == NULL) {
-            length = uprv_strlen(pkgDataFlags[GENLIB]) + uprv_strlen(pkgDataFlags[LDICUDTFLAGS]) +
+            length = static_cast<int32_t>(uprv_strlen(pkgDataFlags[GENLIB]) + uprv_strlen(pkgDataFlags[LDICUDTFLAGS]) +
                      ((uprv_strlen(targetDir) + uprv_strlen(libFileNames[LIB_FILE_VERSION_TMP])) * 2) +
                      uprv_strlen(objectFile) + uprv_strlen(pkgDataFlags[LD_SONAME]) +
                      uprv_strlen(pkgDataFlags[LD_SONAME][0] == 0 ? "" : libFileNames[LIB_FILE_VERSION_MAJOR]) +
-                     uprv_strlen(pkgDataFlags[RPATH_FLAGS]) + uprv_strlen(pkgDataFlags[BIR_FLAGS]) + BUFFER_PADDING_SIZE;
+                     uprv_strlen(pkgDataFlags[RPATH_FLAGS]) + uprv_strlen(pkgDataFlags[BIR_FLAGS]) + BUFFER_PADDING_SIZE);
 #if U_PLATFORM == U_PF_CYGWIN
-            length += uprv_strlen(targetDir) + uprv_strlen(libFileNames[LIB_FILE_CYGWIN_VERSION]);
+            length += static_cast<int32_t>(uprv_strlen(targetDir) + uprv_strlen(libFileNames[LIB_FILE_CYGWIN_VERSION]));
 #elif U_PLATFORM == U_PF_MINGW
-            length += uprv_strlen(targetDir) + uprv_strlen(libFileNames[LIB_FILE_MINGW]);
+            length += static_cast<int32_t>(uprv_strlen(targetDir) + uprv_strlen(libFileNames[LIB_FILE_MINGW]));
 #endif
             if ((cmd = (char *)uprv_malloc(sizeof(char) * length)) == NULL) {
                 fprintf(stderr, "Unable to allocate memory for command.\n");
@@ -1516,8 +1516,8 @@ static int32_t pkg_createWithAssemblyCode(const char *targetDir, const char mode
     uprv_strcpy(tempObjectFile, gencFilePath);
     tempObjectFile[uprv_strlen(tempObjectFile)-1] = 'o';
 
-    length = uprv_strlen(pkgDataFlags[COMPILER]) + uprv_strlen(pkgDataFlags[LIBFLAGS])
-                    + uprv_strlen(tempObjectFile) + uprv_strlen(gencFilePath) + BUFFER_PADDING_SIZE;
+    length = static_cast<int32_t>(uprv_strlen(pkgDataFlags[COMPILER]) + uprv_strlen(pkgDataFlags[LIBFLAGS])
+             + uprv_strlen(tempObjectFile) + uprv_strlen(gencFilePath) + BUFFER_PADDING_SIZE);
 
     cmd = (char *)uprv_malloc(sizeof(char) * length);
     if (cmd == NULL) {
@@ -1905,7 +1905,7 @@ static UPKGOptions *pkg_checkFlag(UPKGOptions *o) {
         char *tmpGenlibFlagBuffer = NULL;
         int32_t i, offset;
 
-        length = uprv_strlen(flag) + 1;
+        length = static_cast<int32_t>(uprv_strlen(flag) + 1);
         tmpGenlibFlagBuffer = (char *)uprv_malloc(length);
         if (tmpGenlibFlagBuffer == NULL) {
             /* Memory allocation error */
@@ -1915,7 +1915,7 @@ static UPKGOptions *pkg_checkFlag(UPKGOptions *o) {
 
         uprv_strcpy(tmpGenlibFlagBuffer, flag);
 
-        offset = uprv_strlen(rm_cmd);
+        offset = static_cast<int32_t>(uprv_strlen(rm_cmd));
 
         for (i = 0; i < (length - offset); i++) {
             flag[i] = tmpGenlibFlagBuffer[offset + i];
@@ -1928,7 +1928,7 @@ static UPKGOptions *pkg_checkFlag(UPKGOptions *o) {
     }
 
     flag = pkgDataFlags[BIR_FLAGS];
-    length = uprv_strlen(pkgDataFlags[BIR_FLAGS]);
+    length = static_cast<int32_t>(uprv_strlen(pkgDataFlags[BIR_FLAGS]));
 
     for (int32_t i = 0; i < length; i++) {
         if (flag[i] == MAP_FILE_EXT[count]) {
@@ -1988,7 +1988,7 @@ static UPKGOptions *pkg_checkFlag(UPKGOptions *o) {
     int32_t length = 0;
 
     flag = pkgDataFlags[GENLIB];
-    length = uprv_strlen(pkgDataFlags[GENLIB]);
+    length = static_cast<int32_t>(uprv_strlen(pkgDataFlags[GENLIB]));
 
     int32_t position = length - 1;
 
@@ -2006,7 +2006,7 @@ static UPKGOptions *pkg_checkFlag(UPKGOptions *o) {
     int32_t length = 0;
 
     flag = pkgDataFlags[GENLIB];
-    length = uprv_strlen(pkgDataFlags[GENLIB]);
+    length = static_cast<int32_t>(uprv_strlen(pkgDataFlags[GENLIB]));
 
     int32_t position = length - 1;
 
@@ -2117,8 +2117,8 @@ static void loadLists(UPKGOptions *o, UErrorCode *status)
                     fprintf(stderr, "pkgdata: Error: absolute path encountered. Old style paths are not supported. Use relative paths such as 'fur.res' or 'translit%cfur.res'.\n\tBad path: '%s'\n", U_FILE_SEP_CHAR, s);
                     exit(U_ILLEGAL_ARGUMENT_ERROR);
                 }
-                tmpLength = uprv_strlen(o->srcDir) + 
-                            uprv_strlen(s) + 5; /* 5 is to add a little extra space for, among other things, PKGDATA_FILE_SEP_STRING */
+                /* The +5 is to add a little extra space for, among other things, PKGDATA_FILE_SEP_STRING */
+                tmpLength = static_cast<int32_t>(uprv_strlen(o->srcDir) + uprv_strlen(s) + 5);
                 if((tmp = (char *)uprv_malloc(tmpLength)) == NULL) {
                     fprintf(stderr, "pkgdata: Error: Unable to allocate tmp buffer size: %d\n", tmpLength);
                     exit(U_MEMORY_ALLOCATION_ERROR);

--- a/icu4c/source/tools/toolutil/pkg_gencmn.cpp
+++ b/icu4c/source/tools/toolutil/pkg_gencmn.cpp
@@ -379,14 +379,14 @@ createCommonDataFile(const char *destDir, const char *name, const char *entrypoi
             "        {0, 0, 0, 0}\n"
             "    },\n"
             "    \"\", %lu, 0, {\n",
-            (unsigned long)32-4-sizeof(UDataInfo),
-            (unsigned long)fileCount,
+            static_cast<unsigned long>(32-4-sizeof(UDataInfo)),
+            static_cast<unsigned long>(fileCount),
             entrypointName,
-            (unsigned long)sizeof(UDataInfo),
+            static_cast<unsigned long>(sizeof(UDataInfo)),
             U_IS_BIG_ENDIAN,
             U_CHARSET_FAMILY,
             U_SIZEOF_UCHAR,
-            (unsigned long)fileCount
+            static_cast<unsigned long>(fileCount)
         );
         T_FileStream_writeLine(out, buffer);
 

--- a/icu4c/source/tools/toolutil/toolutil.cpp
+++ b/icu4c/source/tools/toolutil/toolutil.cpp
@@ -143,7 +143,7 @@ findDirname(const char *path, char *buffer, int32_t bufLen, UErrorCode* status) 
     resultLen = 0;
   } else {
     resultPtr = path;
-    resultLen = basename - path;
+    resultLen = static_cast<int32_t>(basename - path);
     if(resultLen<1) {
       resultLen = 1; /* '/' or '/a' -> '/' */
     }


### PR DESCRIPTION
This reduces the number of warnings when building ICU4C with MSVC from ~364 to ~25.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20351
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

