### PR TITLE
ICU-20074 Revise UPRV_UNREACHABLE macro to always call abort().

### DIFF
--- a/icu4c/source/common/normalizer2impl.cpp
+++ b/icu4c/source/common/normalizer2impl.cpp
@@ -87,7 +87,6 @@ UChar32 codePointFromValidUTF8(const uint8_t *cpStart, const uint8_t *cpLimit) {
         return ((c&7)<<18) | ((cpStart[1]&0x3f)<<12) | ((cpStart[2]&0x3f)<<6) | (cpStart[3]&0x3f);
     default:
         UPRV_UNREACHABLE;  // Should not occur.
-        return U_SENTINEL;
     }
 }
 

--- a/icu4c/source/common/rbbi.cpp
+++ b/icu4c/source/common/rbbi.cpp
@@ -729,7 +729,6 @@ struct LookAheadResults {
             }
         }
         UPRV_UNREACHABLE;
-        return -1;
     }
 
     void setPosition(int16_t key, int32_t position) {
@@ -742,7 +741,6 @@ struct LookAheadResults {
         }
         if (i >= kMaxLookaheads) {
             UPRV_UNREACHABLE;
-            i = kMaxLookaheads - 1;
         }
         fKeys[i] = key;
         fPositions[i] = position;

--- a/icu4c/source/common/rbbi_cache.cpp
+++ b/icu4c/source/common/rbbi_cache.cpp
@@ -75,8 +75,6 @@ UBool RuleBasedBreakIterator::DictionaryCache::following(int32_t fromPos, int32_
         }
     }
     UPRV_UNREACHABLE;
-    fPositionInCache = -1;
-    return FALSE;
 }
 
 
@@ -117,8 +115,6 @@ UBool RuleBasedBreakIterator::DictionaryCache::preceding(int32_t fromPos, int32_
         }
     }
     UPRV_UNREACHABLE;
-    fPositionInCache = -1;
-    return FALSE;
 }
 
 void RuleBasedBreakIterator::DictionaryCache::populateDictionary(int32_t startPos, int32_t endPos,
@@ -389,7 +385,6 @@ UBool RuleBasedBreakIterator::BreakCache::populateNear(int32_t position, UErrorC
         while (fBoundaries[fEndBufIdx] < position) {
             if (!populateFollowing()) {
                 UPRV_UNREACHABLE;
-                return false;
             }
         }
         fBufIdx = fEndBufIdx;                      // Set iterator position to the end of the buffer.

--- a/icu4c/source/common/uassert.h
+++ b/icu4c/source/common/uassert.h
@@ -10,25 +10,40 @@
 *
 * File uassert.h
 *
-*  Contains U_ASSERT macro
-*
-*    By default, U_ASSERT just wraps the C library assert macro.
-*    By changing the definition here, the assert behavior for ICU can be changed
-*    without affecting other non-ICU uses of the C library assert().
+*  Contains the U_ASSERT and UPRV_UNREACHABLE macros
 *
 ******************************************************************************
 */
-
 #ifndef U_ASSERT_H
 #define U_ASSERT_H
+
 /* utypes.h is included to get the proper define for uint8_t */
 #include "unicode/utypes.h"
+/* for abort */
+#include <stdlib.h>
+
+/**
+ * \def U_ASSERT
+ * By default, U_ASSERT just wraps the C library assert macro.
+ * By changing the definition here, the assert behavior for ICU can be changed
+ * without affecting other non - ICU uses of the C library assert().
+*/
 #if U_DEBUG
 #   include <assert.h>
 #   define U_ASSERT(exp) assert(exp)
 #else
 #   define U_ASSERT(exp)
 #endif
+
+/**
+ * \def UPRV_UNREACHABLE
+ * This macro is used to unconditionally abort if unreachable code is ever executed.
+ * @internal
+*/
+#if defined(UPRV_UNREACHABLE)
+    // Use the predefined value.
+#else
+#   define UPRV_UNREACHABLE abort()
 #endif
 
-
+#endif

--- a/icu4c/source/common/ubidi.cpp
+++ b/icu4c/source/common/ubidi.cpp
@@ -2048,7 +2048,6 @@ processPropertySeq(UBiDi *pBiDi, LevState *pLevState, uint8_t _prop,
 
         default:                        /* we should never get here */
             UPRV_UNREACHABLE;
-            break;
         }
     }
     if((addLevel) || (start < start0)) {
@@ -2252,7 +2251,6 @@ resolveImplicitLevels(UBiDi *pBiDi,
                 break;
             default:            /* we should never get here */
                 UPRV_UNREACHABLE;
-                break;
             }
         }
     }
@@ -2727,7 +2725,6 @@ ubidi_setPara(UBiDi *pBiDi, const UChar *text, int32_t length,
         default:
             /* we should never get here */
             UPRV_UNREACHABLE;
-            break;
         }
         /*
          * If there are no external levels specified and there

--- a/icu4c/source/common/ubidiln.cpp
+++ b/icu4c/source/common/ubidiln.cpp
@@ -517,7 +517,7 @@ reorderLine(UBiDi *pBiDi, UBiDiLevel minLevel, UBiDiLevel maxLevel) {
 
 /* compute the runs array --------------------------------------------------- */
 
-static int32_t getRunFromLogicalIndex(UBiDi *pBiDi, int32_t logicalIndex, UErrorCode *pErrorCode) {
+static int32_t getRunFromLogicalIndex(UBiDi *pBiDi, int32_t logicalIndex) {
     Run *runs=pBiDi->runs;
     int32_t runCount=pBiDi->runCount, visualStart=0, i, length, logicalStart;
 
@@ -531,8 +531,6 @@ static int32_t getRunFromLogicalIndex(UBiDi *pBiDi, int32_t logicalIndex, UError
     }
     /* we should never get here */
     UPRV_UNREACHABLE;
-    *pErrorCode = U_INVALID_STATE_ERROR;
-    return 0;
 }
 
 /*
@@ -688,7 +686,7 @@ ubidi_getRuns(UBiDi *pBiDi, UErrorCode *pErrorCode) {
                       *limit=start+pBiDi->insertPoints.size;
         int32_t runIndex;
         for(point=start; point<limit; point++) {
-            runIndex=getRunFromLogicalIndex(pBiDi, point->pos, pErrorCode);
+            runIndex=getRunFromLogicalIndex(pBiDi, point->pos);
             pBiDi->runs[runIndex].insertRemove|=point->flag;
         }
     }
@@ -699,7 +697,7 @@ ubidi_getRuns(UBiDi *pBiDi, UErrorCode *pErrorCode) {
         const UChar *start=pBiDi->text, *limit=start+pBiDi->length, *pu;
         for(pu=start; pu<limit; pu++) {
             if(IS_BIDI_CONTROL_CHAR(*pu)) {
-                runIndex=getRunFromLogicalIndex(pBiDi, (int32_t)(pu-start), pErrorCode);
+                runIndex=getRunFromLogicalIndex(pBiDi, (int32_t)(pu-start));
                 pBiDi->runs[runIndex].insertRemove--;
             }
         }

--- a/icu4c/source/common/uhash.cpp
+++ b/icu4c/source/common/uhash.cpp
@@ -377,7 +377,6 @@ _uhash_find(const UHashtable *hash, UHashTok key,
          * count is always < length.
          */
         UPRV_UNREACHABLE;
-        return NULL; /* Never happens if uhash_put() behaves */
     }
     return &(elements[theIndex]);
 }

--- a/icu4c/source/common/uinvchar.cpp
+++ b/icu4c/source/common/uinvchar.cpp
@@ -208,7 +208,6 @@ u_UCharsToChars(const UChar *us, char *cs, int32_t length) {
         u=*us++;
         if(!UCHAR_IS_INVARIANT(u)) {
             UPRV_UNREACHABLE; /* Variant characters were used. These are not portable in ICU. */
-            u=0;
         }
         *cs++=(char)UCHAR_TO_CHAR(u);
         --length;

--- a/icu4c/source/common/unicode/platform.h
+++ b/icu4c/source/common/unicode/platform.h
@@ -528,25 +528,6 @@ namespace std {
 #   define U_FALLTHROUGH
 #endif
 
-/**
- * \def UPRV_UNREACHABLE
- * Annotate unreachable code.
- * https://clang.llvm.org/docs/LanguageExtensions.html#builtin-unreachable
- * @internal
-*/
-#if defined(UPRV_UNREACHABLE)
-    // Use the predefined value.
-#elif U_DEBUG
-    // Assert on Debug builds to catch if "unreachable" code is reached.
-#   define UPRV_UNREACHABLE U_ASSERT(FALSE)
-#elif (defined(__GNUC__) && (U_GCC_MAJOR_MINOR >= 405)) || ( defined(__clang__))
-#   define UPRV_UNREACHABLE __builtin_unreachable()
-#elif defined(_MSC_VER)
-#   define UPRV_UNREACHABLE __assume(0)
-#else
-#   define UPRV_UNREACHABLE U_ASSERT(FALSE)
-#endif
-
 /** @} */
 
 /*===========================================================================*/

--- a/icu4c/source/common/ustr_titlecase_brkiter.cpp
+++ b/icu4c/source/common/ustr_titlecase_brkiter.cpp
@@ -78,12 +78,6 @@ BreakIterator *WholeStringBreakIterator::clone() const { return nullptr; }
 
 CharacterIterator &WholeStringBreakIterator::getText() const {
     UPRV_UNREACHABLE;  // really should not be called
-    // Returns a null reference.
-    // Otherwise we would have to define a dummy CharacterIterator,
-    // and either have it as a field and const_cast it to a non-const reference,
-    // or have it via a pointer and return a reference to that.
-    CharacterIterator *none = nullptr;
-    return *none;
 }
 UText *WholeStringBreakIterator::getUText(UText * /*fillIn*/, UErrorCode &errorCode) const {
     if (U_SUCCESS(errorCode)) {
@@ -107,8 +101,6 @@ void  WholeStringBreakIterator::setText(UText *text, UErrorCode &errorCode) {
 }
 void  WholeStringBreakIterator::adoptText(CharacterIterator* it) {
     UPRV_UNREACHABLE;  // should not be called
-    length = it->getLength();
-    delete it;
 }
 
 int32_t WholeStringBreakIterator::first() { return 0; }

--- a/icu4c/source/common/utrace.cpp
+++ b/icu4c/source/common/utrace.cpp
@@ -68,7 +68,6 @@ utrace_exit(int32_t fnNumber, int32_t returnType, ...) {
             break;
         default:
             UPRV_UNREACHABLE;
-            fmt = gExitFmt;
         }
 
         va_start(args, returnType);

--- a/icu4c/source/i18n/collationbuilder.cpp
+++ b/icu4c/source/i18n/collationbuilder.cpp
@@ -578,7 +578,6 @@ CollationBuilder::getSpecialResetPosition(const UnicodeString &str,
         return 0;
     default:
         UPRV_UNREACHABLE;
-        return 0;
     }
 
     int32_t index = findOrInsertNodeForRootCE(ce, strength, errorCode);

--- a/icu4c/source/i18n/collationdatabuilder.cpp
+++ b/icu4c/source/i18n/collationdatabuilder.cpp
@@ -853,7 +853,6 @@ CollationDataBuilder::copyFromBaseCE32(UChar32 c, uint32_t ce32, UBool withConte
         break;
     default:
         UPRV_UNREACHABLE;  // require ce32 == base->getFinalCE32(ce32)
-        break;
     }
     return ce32;
 }

--- a/icu4c/source/i18n/islamcal.cpp
+++ b/icu4c/source/i18n/islamcal.cpp
@@ -224,8 +224,6 @@ const char *IslamicCalendar::getType() const {
         break;
     default:
         UPRV_UNREACHABLE; // out of range
-        sType = "islamic";  // "islamic" is used as the generic type
-        break;
     }
     return sType;
 }
@@ -676,7 +674,6 @@ void IslamicCalendar::handleComputeFields(int32_t julianDay, UErrorCode &status)
             }
     } else { // invalid 'civil'
       UPRV_UNREACHABLE; // should not get here, out of range
-      year=month=0;
     }
 
     dayOfMonth = (days - monthStart(year, month)) + 1;

--- a/icu4c/source/i18n/number_affixutils.cpp
+++ b/icu4c/source/i18n/number_affixutils.cpp
@@ -152,7 +152,6 @@ Field AffixUtils::getFieldForType(AffixPatternType type) {
             return Field::UNUM_CURRENCY_FIELD;
         default:
             UPRV_UNREACHABLE;
-            return Field::UNUM_FIELD_COUNT; // suppress "control reaches end of non-void function"
     }
 }
 
@@ -412,7 +411,6 @@ AffixTag AffixUtils::nextToken(AffixTag tag, const UnicodeString &patternString,
             return makeTag(offset, TYPE_CURRENCY_OVERFLOW, STATE_BASE, 0);
         default:
             UPRV_UNREACHABLE;
-            return {-1}; // suppress "control reaches end of non-void function"
     }
 }
 

--- a/icu4c/source/i18n/number_grouping.cpp
+++ b/icu4c/source/i18n/number_grouping.cpp
@@ -48,7 +48,6 @@ Grouper Grouper::forStrategy(UGroupingStrategy grouping) {
         return {3, 3, 1, grouping};
     default:
         UPRV_UNREACHABLE;
-        return {}; // return a value: silence compiler warning
     }
 }
 

--- a/icu4c/source/i18n/number_modifiers.cpp
+++ b/icu4c/source/i18n/number_modifiers.cpp
@@ -93,7 +93,6 @@ bool ConstantAffixModifier::containsField(UNumberFormatFields field) const {
     (void)field;
     // This method is not currently used.
     UPRV_UNREACHABLE;
-    return false;
 }
 
 void ConstantAffixModifier::getParameters(Parameters& output) const {
@@ -183,7 +182,6 @@ bool SimpleModifier::containsField(UNumberFormatFields field) const {
     (void)field;
     // This method is not currently used.
     UPRV_UNREACHABLE;
-    return false;
 }
 
 void SimpleModifier::getParameters(Parameters& output) const {

--- a/icu4c/source/i18n/number_patternmodifier.cpp
+++ b/icu4c/source/i18n/number_patternmodifier.cpp
@@ -238,7 +238,6 @@ bool MutablePatternModifier::containsField(UNumberFormatFields field) const {
     (void)field;
     // This method is not currently used.
     UPRV_UNREACHABLE;
-    return false;
 }
 
 void MutablePatternModifier::getParameters(Parameters& output) const {
@@ -251,7 +250,6 @@ bool MutablePatternModifier::semanticallyEquivalent(const Modifier& other) const
     (void)other;
     // This method is not currently used.
     UPRV_UNREACHABLE;
-    return false;
 }
 
 int32_t MutablePatternModifier::insertPrefix(NumberStringBuilder& sb, int position, UErrorCode& status) {
@@ -309,14 +307,12 @@ UnicodeString MutablePatternModifier::getSymbol(AffixPatternType type) const {
             return UnicodeString(u"\uFFFD");
         default:
             UPRV_UNREACHABLE;
-            return UnicodeString();
     }
 }
 
 UnicodeString MutablePatternModifier::toUnicodeString() const {
     // Never called by AffixUtils
     UPRV_UNREACHABLE;
-    return UnicodeString();
 }
 
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/i18n/number_rounding.cpp
+++ b/icu4c/source/i18n/number_rounding.cpp
@@ -434,11 +434,9 @@ void RoundingImpl::apply(impl::DecimalQuantity &value, UErrorCode& status) const
         case Precision::RND_CURRENCY:
             // Call .withCurrency() before .apply()!
             UPRV_UNREACHABLE;
-            break;
 
         default:
             UPRV_UNREACHABLE;
-            break;
     }
 }
 

--- a/icu4c/source/i18n/number_scientific.cpp
+++ b/icu4c/source/i18n/number_scientific.cpp
@@ -97,7 +97,6 @@ bool ScientificModifier::containsField(UNumberFormatFields field) const {
     (void)field;
     // This method is not used for inner modifiers.
     UPRV_UNREACHABLE;
-    return false;
 }
 
 void ScientificModifier::getParameters(Parameters& output) const {

--- a/icu4c/source/i18n/number_skeletons.cpp
+++ b/icu4c/source/i18n/number_skeletons.cpp
@@ -160,7 +160,6 @@ Notation stem_to_object::notation(skeleton::StemEnum stem) {
             return Notation::simple();
         default:
             UPRV_UNREACHABLE;
-            return Notation::simple(); // return a value: silence compiler warning
     }
 }
 
@@ -177,7 +176,6 @@ MeasureUnit stem_to_object::unit(skeleton::StemEnum stem) {
             return NoUnit::permille(); // NOLINT
         default:
             UPRV_UNREACHABLE;
-            return {}; // return a value: silence compiler warning
     }
 }
 
@@ -193,7 +191,6 @@ Precision stem_to_object::precision(skeleton::StemEnum stem) {
             return Precision::currency(UCURR_USAGE_CASH);
         default:
             UPRV_UNREACHABLE;
-            return Precision::integer(); // return a value: silence compiler warning
     }
 }
 
@@ -217,7 +214,6 @@ UNumberFormatRoundingMode stem_to_object::roundingMode(skeleton::StemEnum stem) 
             return UNUM_ROUND_UNNECESSARY;
         default:
             UPRV_UNREACHABLE;
-            return UNUM_ROUND_UNNECESSARY;
     }
 }
 
@@ -666,7 +662,6 @@ skeleton::parseStem(const StringSegment& segment, const UCharsTrie& stemTrie, Se
 
         default:
             UPRV_UNREACHABLE;
-            return STATE_NULL; // return a value: silence compiler warning
     }
 }
 

--- a/icu4c/source/i18n/numrange_impl.cpp
+++ b/icu4c/source/i18n/numrange_impl.cpp
@@ -270,7 +270,6 @@ void NumberRangeFormatterImpl::format(UFormattedNumberRangeData& data, bool equa
 
         default:
             UPRV_UNREACHABLE;
-            break;
     }
 }
 

--- a/icu4c/source/i18n/plurrule.cpp
+++ b/icu4c/source/i18n/plurrule.cpp
@@ -1472,7 +1472,6 @@ PluralOperand tokenTypeToPluralOperand(tokenType tt) {
         return PLURAL_OPERAND_T;
     default:
         UPRV_UNREACHABLE;  // unexpected.
-        return PLURAL_OPERAND_N;
     }
 }
 
@@ -1685,7 +1684,6 @@ double FixedDecimal::getPluralOperand(PluralOperand operand) const {
         case PLURAL_OPERAND_V: return visibleDecimalDigitCount;
         default:
              UPRV_UNREACHABLE;  // unexpected.
-             return source;
     }
 }
 

--- a/icu4c/source/i18n/regexcmp.cpp
+++ b/icu4c/source/i18n/regexcmp.cpp
@@ -1841,8 +1841,6 @@ UBool RegexCompile::doParseActions(int32_t action)
 
     default:
         UPRV_UNREACHABLE;
-        error(U_REGEX_INTERNAL_ERROR);
-        break;
     }
 
     if (U_FAILURE(*fStatus)) {
@@ -1950,24 +1948,16 @@ int32_t RegexCompile::buildOp(int32_t type, int32_t val) {
     }
     if (type < 0 || type > 255) {
         UPRV_UNREACHABLE;
-        error(U_REGEX_INTERNAL_ERROR);
-        type = URX_RESERVED_OP;
     }
     if (val > 0x00ffffff) {
         UPRV_UNREACHABLE;
-        error(U_REGEX_INTERNAL_ERROR);
-        val = 0;
     }
     if (val < 0) {
         if (!(type == URX_RESERVED_OP_N || type == URX_RESERVED_OP)) {
             UPRV_UNREACHABLE;
-            error(U_REGEX_INTERNAL_ERROR);
-            return -1;
         }
         if (URX_TYPE(val) != 0xff) {
             UPRV_UNREACHABLE;
-            error(U_REGEX_INTERNAL_ERROR);
-            return -1;
         }
         type = URX_RESERVED_OP_N;
     }
@@ -2609,7 +2599,6 @@ void  RegexCompile::findCaseInsensitiveStarters(UChar32 c, UnicodeSet *starterCh
     if (c < UCHAR_MIN_VALUE || c > UCHAR_MAX_VALUE) {
         // This function should never be called with an invalid input character.
         UPRV_UNREACHABLE;
-        starterChars->clear();
     } else if (u_hasBinaryProperty(c, UCHAR_CASE_SENSITIVE)) {
         UChar32 caseFoldedC  = u_foldCase(c, U_FOLD_CASE_DEFAULT);
         starterChars->set(caseFoldedC, caseFoldedC);
@@ -3105,9 +3094,6 @@ void   RegexCompile::matchStartType() {
         case URX_LBN_END:
             UPRV_UNREACHABLE;     // Shouldn't get here.  These ops should be
                                  //  consumed by the scan in URX_LA_START and LB_START
-
-            break;
-
         default:
             UPRV_UNREACHABLE;
             }
@@ -3674,7 +3660,6 @@ int32_t   RegexCompile::maxMatchLength(int32_t start, int32_t end) {
             // These opcodes will be skipped over by code for URX_CRT_INIT.
             // We shouldn't encounter them here.
             UPRV_UNREACHABLE;
-            break;
 
         case URX_LOOP_SR_I:
         case URX_LOOP_DOT_I:
@@ -3695,7 +3680,6 @@ int32_t   RegexCompile::maxMatchLength(int32_t start, int32_t end) {
             // End of look-ahead ops should always be consumed by the processing at
             //  the URX_LA_START op.
             // UPRV_UNREACHABLE;
-            // break;
 
         case URX_LB_START:
             {
@@ -3876,7 +3860,6 @@ void RegexCompile::stripNOPs() {
         default:
             // Some op is unaccounted for.
             UPRV_UNREACHABLE;
-            error(U_REGEX_INTERNAL_ERROR);
         }
     }
 
@@ -4623,7 +4606,6 @@ void RegexCompile::setEval(int32_t nextOp) {
                 break;
             default:
                 UPRV_UNREACHABLE;
-                break;
             }
         }
     }

--- a/icu4c/source/i18n/rematch.cpp
+++ b/icu4c/source/i18n/rematch.cpp
@@ -881,7 +881,6 @@ UBool RegexMatcher::find(UErrorCode &status) {
     }
 
     UPRV_UNREACHABLE;
-    return FALSE;
 }
 
 
@@ -1138,7 +1137,6 @@ UBool RegexMatcher::findUsingChunk(UErrorCode &status) {
     }
 
     UPRV_UNREACHABLE;
-    return FALSE;
 }
 
 

--- a/icu4c/source/i18n/tmunit.cpp
+++ b/icu4c/source/i18n/tmunit.cpp
@@ -95,7 +95,6 @@ TimeUnit::TimeUnit(TimeUnit::UTimeUnitFields timeUnitField) {
         break;
     default:
         UPRV_UNREACHABLE;
-        break;
     }
 }
 

--- a/icu4c/source/i18n/transreg.cpp
+++ b/icu4c/source/i18n/transreg.cpp
@@ -187,7 +187,6 @@ Transliterator* TransliteratorAlias::create(UParseError& pe,
         break;
     case RULES:
         UPRV_UNREACHABLE; // don't call create() if isRuleBased() returns TRUE!
-        break;
     }
     return t;
 }
@@ -1397,7 +1396,6 @@ Transliterator* TransliteratorRegistry::instantiateEntry(const UnicodeString& ID
         return 0;
     default:
         UPRV_UNREACHABLE; // can't get here
-        return 0;
     }
 }
 U_NAMESPACE_END

--- a/icu4c/source/i18n/tzfmt.cpp
+++ b/icu4c/source/i18n/tzfmt.cpp
@@ -590,7 +590,6 @@ TimeZoneFormat::setGMTOffsetPattern(UTimeZoneFormatGMTOffsetPatternType type, co
         break;
     default:
         UPRV_UNREACHABLE;
-        break;
     }
 
     UVector* patternItems = parseOffsetPattern(pattern, required, status);

--- a/icu4c/source/i18n/umsg.cpp
+++ b/icu4c/source/i18n/umsg.cpp
@@ -464,8 +464,6 @@ umsg_vformat(   const UMessageFormat *fmt,
         default:
             // Unknown/unsupported argument type.
             UPRV_UNREACHABLE;
-            *status=U_ILLEGAL_ARGUMENT_ERROR;
-            break;
         }
     }
     UnicodeString resultStr;
@@ -593,12 +591,10 @@ umsg_vparse(const UMessageFormat *fmt,
             // understand MeasureFormats, modify this code to do the
             // right thing. [alan]
             UPRV_UNREACHABLE;
-            break;
 
         // better not happen!
         case Formattable::kArray:
             UPRV_UNREACHABLE;
-            break;
         }
     }
 

--- a/icu4c/source/i18n/usearch.cpp
+++ b/icu4c/source/i18n/usearch.cpp
@@ -3545,8 +3545,6 @@ const CEI *CEIBuffer::get(int32_t index) {
     //   that is allowed.
     if (index != limitIx) {
         UPRV_UNREACHABLE;
-
-        return NULL;
     }
 
     // Manage the circular CE buffer indexing
@@ -3584,8 +3582,6 @@ const CEI *CEIBuffer::getPrevious(int32_t index) {
     //   that is allowed.
     if (index != limitIx) {
         UPRV_UNREACHABLE;
-
-        return NULL;
     }
 
     // Manage the circular CE buffer indexing

--- a/icu4c/source/i18n/uspoof_impl.cpp
+++ b/icu4c/source/i18n/uspoof_impl.cpp
@@ -730,8 +730,6 @@ void *SpoofData::reserveSpace(int32_t numBytes,  UErrorCode &status) {
     }
     if (!fDataOwned) {
         UPRV_UNREACHABLE;
-        status = U_INTERNAL_PROGRAM_ERROR;
-        return NULL;
     }
 
     numBytes = (numBytes + 15) & ~15;   // Round up to a multiple of 16

--- a/icu4c/source/test/intltest/numbertest_affixutils.cpp
+++ b/icu4c/source/test/intltest/numbertest_affixutils.cpp
@@ -43,7 +43,6 @@ class DefaultSymbolProvider : public SymbolProvider {
                 return u"\uFFFD";
             default:
                 UPRV_UNREACHABLE;
-                return {}; // silence compiler warnings
         }
     }
 };


### PR DESCRIPTION
This change revises the `UPRV_UNREACHABLE` macro to unconditionally call `abort()`, and removes the `__builtin_unreachable()` annotation, which could have allowed the compiler to make unsafe optimizations.

This change also moves the macro out of the public `unicode\platform.h` header file and into the non-public header `cassert.h`, which feels like a better fit given that the macro is private (`UPRV_*`) and is somewhat similar in nature to an assert. (Also this is needed as the macro now causes `stdlib.h` to be included, and some code relies on including `unicode\platform.h` _before_ including `stdlib.h`).

Additionally, this change also removes any (now redundant) best effort error handling code that would have previously been executed after the "unreachable" code path was taken.

(Much thanks to Andy for pointing out the potential unsafe, or undefined, optimization problems with `__builtin_unreachable`).

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20074
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [x] Documentation is changed or added

