### PR TITLE
ICU-20211 Cherry-pick NaN fixes from CLDR. (Causes parse failures wit…

### DIFF
--- a/icu4c/source/data/locales/kl.txt
+++ b/icu4c/source/data/locales/kl.txt
@@ -16,6 +16,7 @@ kl{
             symbols{
                 decimal{","}
                 group{"."}
+                nan{"NaN"}
             }
         }
         minimalPairs{

--- a/icu4c/source/data/locales/ksh.txt
+++ b/icu4c/source/data/locales/ksh.txt
@@ -153,7 +153,7 @@ ksh{
                 infinity{"∞"}
                 list{";"}
                 minusSign{"−"}
-                nan{"¤¤¤"}
+                nan{"NaN"}
                 perMille{"‰"}
                 percentSign{"%"}
                 plusSign{"+"}

--- a/icu4c/source/data/locales/se.txt
+++ b/icu4c/source/data/locales/se.txt
@@ -156,7 +156,7 @@ se{
                 infinity{"∞"}
                 list{";"}
                 minusSign{"−"}
-                nan{"¤¤¤"}
+                nan{"NaN"}
                 perMille{"‰"}
                 percentSign{"%"}
                 plusSign{"+"}

--- a/icu4c/source/data/locales/sv.txt
+++ b/icu4c/source/data/locales/sv.txt
@@ -27,7 +27,7 @@ sv{
                 infinity{"∞"}
                 list{"؛"}
                 minusSign{"؜−"}
-                nan{"¤¤¤"}
+                nan{"NaN"}
                 perMille{"؉‏"}
                 percentSign{"٪؜"}
                 plusSign{"؜+"}
@@ -43,7 +43,7 @@ sv{
                 infinity{"∞"}
                 list{"؛"}
                 minusSign{"‎−‎"}
-                nan{"¤¤¤"}
+                nan{"NaN"}
                 perMille{"؉"}
                 percentSign{"٪"}
                 plusSign{"‎+‎"}
@@ -232,7 +232,7 @@ sv{
                 infinity{"∞"}
                 list{";"}
                 minusSign{"−"}
-                nan{"¤¤¤"}
+                nan{"NaN"}
                 perMille{"‰"}
                 percentSign{"%"}
                 plusSign{"+"}


### PR DESCRIPTION
…h currency formatter in exhaustive tests).

This is needed first in order to get the Exhaustive Tests working in the CI builds.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20211
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

