### PR TITLE
ICU-20100 Change TimeZone::getDisplayName daylight parameter to avoid macro collision.

### DIFF
--- a/icu4c/source/i18n/timezone.cpp
+++ b/icu4c/source/i18n/timezone.cpp
@@ -1182,9 +1182,9 @@ TimeZone::getDisplayName(const Locale& locale, UnicodeString& result) const
 }
 
 UnicodeString&
-TimeZone::getDisplayName(UBool daylight, EDisplayType style, UnicodeString& result)  const
+TimeZone::getDisplayName(UBool inDaylight, EDisplayType style, UnicodeString& result)  const
 {
-    return getDisplayName(daylight,style, Locale::getDefault(), result);
+    return getDisplayName(inDaylight,style, Locale::getDefault(), result);
 }
 //--------------------------------------
 int32_t
@@ -1196,7 +1196,7 @@ TimeZone::getDSTSavings()const {
 }
 //---------------------------------------
 UnicodeString&
-TimeZone::getDisplayName(UBool daylight, EDisplayType style, const Locale& locale, UnicodeString& result) const
+TimeZone::getDisplayName(UBool inDaylight, EDisplayType style, const Locale& locale, UnicodeString& result) const
 {
     UErrorCode status = U_ZERO_ERROR;
     UDate date = Calendar::getNow();
@@ -1226,8 +1226,8 @@ TimeZone::getDisplayName(UBool daylight, EDisplayType style, const Locale& local
         // Generic format many use Localized GMT as the final fallback.
         // When Localized GMT format is used, the result might not be
         // appropriate for the requested daylight value.
-        if ((daylight && timeType == UTZFMT_TIME_TYPE_STANDARD) || (!daylight && timeType == UTZFMT_TIME_TYPE_DAYLIGHT)) {
-            offset = daylight ? getRawOffset() + getDSTSavings() : getRawOffset();
+        if ((inDaylight && timeType == UTZFMT_TIME_TYPE_STANDARD) || (!inDaylight && timeType == UTZFMT_TIME_TYPE_DAYLIGHT)) {
+            offset = inDaylight ? getRawOffset() + getDSTSavings() : getRawOffset();
             if (style == SHORT_GENERIC) {
                 tzfmt->formatOffsetShortLocalizedGMT(offset, result, status);
             } else {
@@ -1240,7 +1240,7 @@ TimeZone::getDisplayName(UBool daylight, EDisplayType style, const Locale& local
             result.remove();
             return result;
         }
-        offset = daylight && useDaylightTime() ? getRawOffset() + getDSTSavings() : getRawOffset();
+        offset = inDaylight && useDaylightTime() ? getRawOffset() + getDSTSavings() : getRawOffset();
         switch (style) {
         case LONG_GMT:
             tzfmt->formatOffsetLocalizedGMT(offset, result, status);
@@ -1257,11 +1257,11 @@ TimeZone::getDisplayName(UBool daylight, EDisplayType style, const Locale& local
         UTimeZoneNameType nameType = UTZNM_UNKNOWN;
         switch (style) {
         case LONG:
-            nameType = daylight ? UTZNM_LONG_DAYLIGHT : UTZNM_LONG_STANDARD;
+            nameType = inDaylight ? UTZNM_LONG_DAYLIGHT : UTZNM_LONG_STANDARD;
             break;
         case SHORT:
         case SHORT_COMMONLY_USED:
-            nameType = daylight ? UTZNM_SHORT_DAYLIGHT : UTZNM_SHORT_STANDARD;
+            nameType = inDaylight ? UTZNM_SHORT_DAYLIGHT : UTZNM_SHORT_STANDARD;
             break;
         default:
             UPRV_UNREACHABLE;
@@ -1276,7 +1276,7 @@ TimeZone::getDisplayName(UBool daylight, EDisplayType style, const Locale& local
         if (result.isEmpty()) {
             // Fallback to localized GMT
             LocalPointer<TimeZoneFormat> tzfmt(TimeZoneFormat::createInstance(locale, status));
-            offset = daylight && useDaylightTime() ? getRawOffset() + getDSTSavings() : getRawOffset();
+            offset = inDaylight && useDaylightTime() ? getRawOffset() + getDSTSavings() : getRawOffset();
             if (style == LONG) {
                 tzfmt->formatOffsetLocalizedGMT(offset, result, status);
             } else {

--- a/icu4c/source/i18n/unicode/timezone.h
+++ b/icu4c/source/i18n/unicode/timezone.h
@@ -657,13 +657,13 @@ public:
      * If the display name is not available for the locale,
      * then this method returns a string in the localized GMT offset format
      * such as <code>GMT[+-]HH:mm</code>.
-     * @param daylight if true, return the daylight savings name.
+     * @param inDaylight if true, return the daylight savings name.
      * @param style
      * @param result the human-readable name of this time zone in the default locale.
      * @return       A reference to 'result'.
      * @stable ICU 2.0
      */
-    UnicodeString& getDisplayName(UBool daylight, EDisplayType style, UnicodeString& result) const;
+    UnicodeString& getDisplayName(UBool inDaylight, EDisplayType style, UnicodeString& result) const;
 
     /**
      * Returns a name of this time zone suitable for presentation to the user
@@ -671,7 +671,7 @@ public:
      * If the display name is not available for the locale,
      * then this method returns a string in the localized GMT offset format
      * such as <code>GMT[+-]HH:mm</code>.
-     * @param daylight if true, return the daylight savings name.
+     * @param inDaylight if true, return the daylight savings name.
      * @param style
      * @param locale the locale in which to supply the display name.
      * @param result the human-readable name of this time zone in the given locale
@@ -679,7 +679,7 @@ public:
      * @return       A refence to 'result'.
      * @stable ICU 2.0
      */
-    UnicodeString& getDisplayName(UBool daylight, EDisplayType style, const Locale& locale, UnicodeString& result) const;
+    UnicodeString& getDisplayName(UBool inDaylight, EDisplayType style, const Locale& locale, UnicodeString& result) const;
     
     /**
      * Queries if this time zone uses daylight savings time.


### PR DESCRIPTION
The `TimeZone::getDisplayName` method's "`daylight`" parameter conflicts with an existing macro in the CRT "`time.h`" header used by MinGW, causing build errors for Firefox.

The suggestion from Markus was to rename the parameter/argument to `inDaylight`.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20100
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [x] Documentation is changed or added

