### PR TITLE
ICU-20364 Cygwin builds need to set WINVER to 0x0601 for Windows 7, similar to MinGW builds.

### DIFF
--- a/icu4c/source/config/mh-cygwin
+++ b/icu4c/source/config/mh-cygwin
@@ -18,6 +18,10 @@ else
 STATICCPPFLAGS = -DU_STATIC_IMPLEMENTATION
 endif
 
+## ICU requires a minimum target of Windows 7, and WINVER is not set to this by default.
+## https://msdn.microsoft.com/en-us/library/aa383745.aspx
+CPPFLAGS += -DWINVER=0x0601 -D_WIN32_WINNT=0x0601
+
 ## Flags for position independent code
 SHAREDLIBCFLAGS = 
 SHAREDLIBCXXFLAGS = 

--- a/icu4c/source/config/mh-cygwin-msvc
+++ b/icu4c/source/config/mh-cygwin-msvc
@@ -24,6 +24,10 @@ else
 STATICCPPFLAGS = -DU_STATIC_IMPLEMENTATION
 endif
 
+## ICU requires a minimum target of Windows 7, and WINVER is not set to this by default.
+## https://msdn.microsoft.com/en-us/library/aa383745.aspx
+CPPFLAGS += -DWINVER=0x0601 -D_WIN32_WINNT=0x0601
+
 ## Flags for position independent code
 SHAREDLIBCFLAGS = 
 SHAREDLIBCXXFLAGS = 

--- a/icu4c/source/config/mh-cygwin64
+++ b/icu4c/source/config/mh-cygwin64
@@ -18,6 +18,10 @@ else
 STATICCPPFLAGS = -DU_STATIC_IMPLEMENTATION
 endif
 
+## ICU requires a minimum target of Windows 7, and WINVER is not set to this by default.
+## https://msdn.microsoft.com/en-us/library/aa383745.aspx
+CPPFLAGS += -DWINVER=0x0601 -D_WIN32_WINNT=0x0601
+
 ## Flags for position independent code
 SHAREDLIBCFLAGS = 
 SHAREDLIBCXXFLAGS = 


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20364
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

