### PR TITLE
ICU-20206 ICU4C: Make USE_WINDOWS_LCID_MAPPING_API compile-time configurable

### DIFF
--- a/icu4c/source/common/locmap.h
+++ b/icu4c/source/common/locmap.h
@@ -33,8 +33,8 @@
 U_CAPI int32_t uprv_convertToPosix(uint32_t hostid, char* posixID, int32_t posixIDCapacity, UErrorCode* status);
 
 /* Don't call these functions directly. Use uloc_getLCID instead. */
-U_CAPI uint32_t uprv_convertToLCIDPlatform(const char *localeID);   // Leverage platform conversion if possible
-U_CAPI uint32_t uprv_convertToLCID(const char *langID, const char* posixID, UErrorCode* status);
+U_CAPI uint32_t uprv_convertToLCIDPlatform(const char* localeID, UErrorCode* status); // Leverage platform conversion if possible
+U_CAPI uint32_t uprv_convertToLCID(const char* langID, const char* posixID, UErrorCode* status);
 
 #endif /* LOCMAP_H */
 

--- a/icu4c/source/common/uloc.cpp
+++ b/icu4c/source/common/uloc.cpp
@@ -2179,10 +2179,13 @@ uloc_getLCID(const char* localeID)
         return 0;
     }
 
-    // Attempt platform lookup if available
-    lcid = uprv_convertToLCIDPlatform(localeID);
-    if (lcid > 0)
-    {
+    // First, attempt Windows platform lookup if available, but fall
+    // through to catch any special cases (ICU vs Windows name differences).
+    lcid = uprv_convertToLCIDPlatform(localeID, &status);
+    if (U_FAILURE(status)) {
+        return 0;
+    }
+    if (lcid > 0) {
         // Windows found an LCID, return that
         return lcid;
     }

--- a/icu4c/source/common/unicode/uconfig.h
+++ b/icu4c/source/common/unicode/uconfig.h
@@ -369,6 +369,18 @@
 #   define UCONFIG_MSGPAT_DEFAULT_APOSTROPHE_MODE UMSGPAT_APOS_DOUBLE_OPTIONAL
 #endif
 
+/**
+ * \def UCONFIG_USE_WINDOWS_LCID_MAPPING_API
+ * On platforms where U_PLATFORM_HAS_WIN32_API is true, this switch determines
+ * if the Windows platform APIs are used for LCID<->Locale Name conversions.
+ * Otherwise, only the built-in ICU tables are used.
+ * 
+ * @internal ICU 64
+ */
+#ifndef UCONFIG_USE_WINDOWS_LCID_MAPPING_API
+#   define UCONFIG_USE_WINDOWS_LCID_MAPPING_API 1
+#endif
+
 /* i18n library switches ---------------------------------------------------- */
 
 /**


### PR DESCRIPTION
This change will enable users of ICU (like Chrome) to control the use of the LCID Platform APIs by setting `UCONFIG_USE_WINDOWS_LCID_MAPPING_API ` to 0.
(FYI for @jungshik, this would mean that the `vscomp.patch` file could be deleted in Chromium, and you could set the define instead.) 

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20206
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

