### PR TITLE
ICU-20357 Adding LocalPointer conversion methods to/from std::unique_ptr

### DIFF
--- a/icu4c/source/common/unicode/localpointer.h
+++ b/icu4c/source/common/unicode/localpointer.h
@@ -42,6 +42,8 @@
 
 #if U_SHOW_CPLUSPLUS_API
 
+#include <memory>
+
 U_NAMESPACE_BEGIN
 
 /**
@@ -223,6 +225,17 @@ public:
         src.ptr=NULL;
     }
     /**
+     * Constructs a LocalPointer from a C++11 std::unique_ptr.
+     * The LocalPointer steals the object owned by the std::unique_ptr.
+     *
+     * This constructor works via move semantics. If your std::unique_ptr is
+     * in a local variable, you must use std::move.
+     *
+     * @param p The std::unique_ptr from which the pointer will be stolen.
+     * @draft ICU 64
+     */
+    explicit LocalPointer(std::unique_ptr<T> &&p) : LocalPointerBase<T>(p.release()) {}
+    /**
      * Destructor deletes the object it owns.
      * @stable ICU 4.4
      */
@@ -238,6 +251,18 @@ public:
      */
     LocalPointer<T> &operator=(LocalPointer<T> &&src) U_NOEXCEPT {
         return moveFrom(src);
+    }
+    /**
+     * Move-assign from an std::unique_ptr to this LocalPointer.
+     * Steals the pointer from the std::unique_ptr.
+     *
+     * @param p The std::unique_ptr from which the pointer will be stolen.
+     * @return *this
+     * @draft ICU 64
+     */
+    LocalPointer<T> &operator=(std::unique_ptr<T> &&p) U_NOEXCEPT {
+        adoptInstead(p.release());
+        return *this;
     }
     // do not use #ifndef U_HIDE_DRAFT_API for moveFrom, needed by non-draft API
     /**
@@ -310,6 +335,20 @@ public:
             delete p;
         }
     }
+    /**
+     * Conversion operator to a C++11 std::unique_ptr.
+     * Disowns the object and gives it to the returned std::unique_ptr.
+     *
+     * This operator works via move semantics. If your LocalPointer is
+     * in a local variable, you must use std::move.
+     *
+     * @return An std::unique_ptr owning the pointer previously owned by this
+     *         icu::LocalPointer.
+     * @draft ICU 64
+     */
+    operator std::unique_ptr<T> () && {
+        return std::unique_ptr<T>(LocalPointerBase<T>::orphan());
+    }
 };
 
 /**
@@ -368,6 +407,17 @@ public:
         src.ptr=NULL;
     }
     /**
+     * Constructs a LocalArray from a C++11 std::unique_ptr of an array type.
+     * The LocalPointer steals the array owned by the std::unique_ptr.
+     *
+     * This constructor works via move semantics. If your std::unique_ptr is
+     * in a local variable, you must use std::move.
+     *
+     * @param p The std::unique_ptr from which the array will be stolen.
+     * @draft ICU 64
+     */
+    explicit LocalArray(std::unique_ptr<T[]> &&p) : LocalPointerBase<T>(p.release()) {}
+    /**
      * Destructor deletes the array it owns.
      * @stable ICU 4.4
      */
@@ -383,6 +433,18 @@ public:
      */
     LocalArray<T> &operator=(LocalArray<T> &&src) U_NOEXCEPT {
         return moveFrom(src);
+    }
+    /**
+     * Move-assign from an std::unique_ptr to this LocalPointer.
+     * Steals the array from the std::unique_ptr.
+     *
+     * @param p The std::unique_ptr from which the array will be stolen.
+     * @return *this
+     * @draft ICU 64
+     */
+    LocalArray<T> &operator=(std::unique_ptr<T[]> &&p) U_NOEXCEPT {
+        adoptInstead(p.release());
+        return *this;
     }
     // do not use #ifndef U_HIDE_DRAFT_API for moveFrom, needed by non-draft API
     /**
@@ -463,6 +525,20 @@ public:
      * @stable ICU 4.4
      */
     T &operator[](ptrdiff_t i) const { return LocalPointerBase<T>::ptr[i]; }
+    /**
+     * Conversion operator to a C++11 std::unique_ptr.
+     * Disowns the object and gives it to the returned std::unique_ptr.
+     *
+     * This operator works via move semantics. If your LocalPointer is
+     * in a local variable, you must use std::move.
+     *
+     * @return An std::unique_ptr owning the pointer previously owned by this
+     *         icu::LocalPointer.
+     * @draft ICU 64
+     */
+    operator std::unique_ptr<T[]> () && {
+        return std::unique_ptr<T[]>(LocalPointerBase<T>::orphan());
+    }
 };
 
 /**

--- a/icu4c/source/test/intltest/itutil.cpp
+++ b/icu4c/source/test/intltest/itutil.cpp
@@ -385,8 +385,10 @@ public:
 
     void TestLocalPointer();
     void TestLocalPointerMoveSwap();
+    void TestLocalPointerStdUniquePtr();
     void TestLocalArray();
     void TestLocalArrayMoveSwap();
+    void TestLocalArrayStdUniquePtr();
     void TestLocalXyzPointer();
     void TestLocalXyzPointerMoveSwap();
     void TestLocalXyzPointerNull();
@@ -403,8 +405,10 @@ void LocalPointerTest::runIndexedTest(int32_t index, UBool exec, const char *&na
     TESTCASE_AUTO_BEGIN;
     TESTCASE_AUTO(TestLocalPointer);
     TESTCASE_AUTO(TestLocalPointerMoveSwap);
+    TESTCASE_AUTO(TestLocalPointerStdUniquePtr);
     TESTCASE_AUTO(TestLocalArray);
     TESTCASE_AUTO(TestLocalArrayMoveSwap);
+    TESTCASE_AUTO(TestLocalArrayStdUniquePtr);
     TESTCASE_AUTO(TestLocalXyzPointer);
     TESTCASE_AUTO(TestLocalXyzPointerMoveSwap);
     TESTCASE_AUTO(TestLocalXyzPointerNull);
@@ -514,6 +518,17 @@ void LocalPointerTest::TestLocalPointerMoveSwap() {
     s3.moveFrom(s3);
 }
 
+void LocalPointerTest::TestLocalPointerStdUniquePtr() {
+    // Implicit conversion operator
+    std::unique_ptr<UnicodeString> s = LocalPointer<UnicodeString>(new UnicodeString((UChar32)0x50005));
+    // Explicit move constructor
+    LocalPointer<UnicodeString> s2(std::move(s));
+    // Conversion operator should also work with std::move
+    s = std::move(s2);
+    // Back again with move assignment
+    s2 = std::move(s);
+}
+
 // Exercise almost every LocalArray method (but not LocalPointerBase).
 void LocalPointerTest::TestLocalArray() {
     // constructor
@@ -605,6 +620,17 @@ void LocalPointerTest::TestLocalArrayMoveSwap() {
     // but do not check for any particular resulting value.
     a1.moveFrom(a1);
     a3.moveFrom(a3);
+}
+
+void LocalPointerTest::TestLocalArrayStdUniquePtr() {
+    // Implicit conversion operator
+    std::unique_ptr<UnicodeString[]> a = LocalArray<UnicodeString>(new UnicodeString[2]);
+    // Explicit move constructor
+    LocalArray<UnicodeString> a2(std::move(a));
+    // Conversion operator should also work with std::move
+    a = std::move(a2);
+    // Back again with move assignment
+    a2 = std::move(a);
 }
 
 #include "unicode/ucnvsel.h"


### PR DESCRIPTION
- Requires the right side to be an rvalue reference.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20357
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [x] Documentation is changed or added

