### PR TITLE
ICU-11725 Promoting tech-previews in DecimalFormat to @draft.

### DIFF
--- a/icu4c/source/i18n/unicode/decimfmt.h
+++ b/icu4c/source/i18n/unicode/decimfmt.h
@@ -64,18 +64,6 @@ class NumberParserImpl;
 }
 
 /**
- * \cond
- * explicit template instantiation. see digitlst.h
- * (When building DLLs for Windows this is required.)
- */
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN && !defined(U_IN_DOXYGEN)
-template class U_I18N_API    EnumSet<UNumberFormatAttribute,
-            UNUM_MAX_NONBOOLEAN_ATTRIBUTE+1,
-            UNUM_LIMIT_BOOLEAN_ATTRIBUTE>;
-#endif
-/** \endcond */
-
-/**
  * **IMPORTANT:** New users are strongly encouraged to see if
  * numberformatter.h fits their use case.  Although not deprecated, this header
  * is provided for backwards compatibility only.
@@ -1292,20 +1280,27 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      */
     virtual void setNegativeSuffix(const UnicodeString& newValue);
 
-#ifndef U_HIDE_INTERNAL_API
+#ifndef U_HIDE_DRAFT_API
     /**
      * Whether to show the plus sign on positive (non-negative) numbers; for example, "+12"
-     * @internal Technical Preview
+     *
+     * For more control over sign display, use NumberFormatter.
+     *
+     * @return Whether the sign is shown on positive numbers and zero.
+     * @draft ICU 64
      */
     UBool isSignAlwaysShown() const;
-#endif  /* U_HIDE_INTERNAL_API */
 
     /**
-     * Set whether to show the plus sign on positive (non-negative) numbers; for example, "+12"
-     * @param value The new setting for whether to show plus sign on positive numbers
-     * @internal Technical Preview
+     * Set whether to show the plus sign on positive (non-negative) numbers; for example, "+12".
+     *
+     * For more control over sign display, use NumberFormatter.
+     *
+     * @param value true to always show a sign; false to hide the sign on positive numbers and zero.
+     * @draft ICU 64
      */
-    virtual void setSignAlwaysShown(UBool value);
+    void setSignAlwaysShown(UBool value);
+#endif  /* U_HIDE_DRAFT_API */
 
     /**
      * Get the multiplier for use in percent, permill, etc.
@@ -1350,7 +1345,6 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * @draft ICU 62
      */
     int32_t getMultiplierScale(void) const;
-#endif  /* U_HIDE_DRAFT_API */
 
     /**
      * Sets a power of ten by which number should be multiplied before formatting, which
@@ -1371,7 +1365,8 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * @param newValue    the new value of the power-of-ten multiplier.
      * @draft ICU 62
      */
-    virtual void setMultiplierScale(int32_t newValue);
+    void setMultiplierScale(int32_t newValue);
+#endif  /* U_HIDE_DRAFT_API */
 
     /**
      * Get the rounding increment.
@@ -1654,8 +1649,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      */
     virtual void setSecondaryGroupingSize(int32_t newValue);
 
-#ifndef U_HIDE_INTERNAL_API
-
+#ifndef U_HIDE_DRAFT_API
     /**
      * Returns the minimum number of grouping digits.
      * Grouping separators are output if there are at least this many
@@ -1666,31 +1660,33 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * For example, if this value is 2, and the grouping size is 3, then
      * 9999 -> "9999" and 10000 -> "10,000"
      *
-     * This is a technology preview. This API may change behavior or may be removed.
-     *
      * The default value for this attribute is 0.
      * A value of 1, 0, or lower, means that the use of grouping separators
      * only depends on the grouping size (and on isGroupingUsed()).
-     * Currently, the corresponding CLDR data is not used; this is likely to change.
+     *
+     * NOTE: The CLDR data is used in NumberFormatter but not in DecimalFormat.
+     * This is for backwards compatibility reasons.
+     *
+     * For more control over grouping strategies, use NumberFormatter.
      *
      * @see setMinimumGroupingDigits
      * @see getGroupingSize
-     * @internal technology preview
+     * @draft ICU 64
      */
     int32_t getMinimumGroupingDigits() const;
 
-#endif  /* U_HIDE_INTERNAL_API */
-
-    /* Cannot use #ifndef U_HIDE_INTERNAL_API for the following draft method since it is virtual. */
     /**
      * Sets the minimum grouping digits. Setting to a value less than or
      * equal to 1 turns off minimum grouping digits.
      *
+     * For more control over grouping strategies, use NumberFormatter.
+     *
      * @param newValue the new value of minimum grouping digits.
      * @see getMinimumGroupingDigits
-     * @internal technology preview
+     * @draft ICU 64
      */
-    virtual void setMinimumGroupingDigits(int32_t newValue);
+    void setMinimumGroupingDigits(int32_t newValue);
+#endif  /* U_HIDE_DRAFT_API */
 
 
     /**
@@ -1732,13 +1728,15 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      */
     virtual void setDecimalPatternMatchRequired(UBool newValue);
 
+#ifndef U_HIDE_DRAFT_API
     /**
      * Returns whether to ignore exponents when parsing.
      *
+     * @return Whether to ignore exponents when parsing.
      * @see #setParseNoExponent
-     * @internal This API is a technical preview. It may change in an upcoming release.
+     * @draft ICU 64
      */
-    virtual UBool isParseNoExponent() const;
+    UBool isParseNoExponent() const;
 
     /**
      * Specifies whether to stop parsing when an exponent separator is encountered. For
@@ -1746,17 +1744,18 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * 5).
      *
      * @param value true to prevent exponents from being parsed; false to allow them to be parsed.
-     * @internal This API is a technical preview. It may change in an upcoming release.
+     * @draft ICU 64
      */
-    virtual void setParseNoExponent(UBool value);
+    void setParseNoExponent(UBool value);
 
     /**
      * Returns whether parsing is sensitive to case (lowercase/uppercase).
      *
+     * @return Whether parsing is case-sensitive.
      * @see #setParseCaseSensitive
-     * @internal This API is a technical preview. It may change in an upcoming release.
+     * @draft ICU 64
      */
-    virtual UBool isParseCaseSensitive() const;
+    UBool isParseCaseSensitive() const;
 
     /**
      * Whether to pay attention to case when parsing; default is to ignore case (perform
@@ -1765,26 +1764,31 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * Currency symbols are never case-folded. For example, "us$1.00" will not parse in case-insensitive
      * mode, even though "US$1.00" parses.
      *
-     * @internal This API is a technical preview. It may change in an upcoming release.
+     * @param value true to enable case-sensitive parsing (the default); false to force
+     *              case-sensitive parsing behavior.
+     * @draft ICU 64
      */
-    virtual void setParseCaseSensitive(UBool value);
+    void setParseCaseSensitive(UBool value);
 
     /**
      * Returns whether truncation of high-order integer digits should result in an error.
      * By default, setMaximumIntegerDigits truncates high-order digits silently.
      *
+     * @return Whether an error code is set if high-order digits are truncated.
      * @see setFormatFailIfMoreThanMaxDigits
-     * @internal This API is a technical preview. It may change in an upcoming release.
+     * @draft ICU 64
      */
-    virtual UBool isFormatFailIfMoreThanMaxDigits() const;
+    UBool isFormatFailIfMoreThanMaxDigits() const;
 
     /**
      * Sets whether truncation of high-order integer digits should result in an error.
      * By default, setMaximumIntegerDigits truncates high-order digits silently.
      *
-     * @internal This API is a technical preview. It may change in an upcoming release.
+     * @param value Whether to set an error code if high-order digits are truncated.
+     * @draft ICU 64
      */
-    virtual void setFormatFailIfMoreThanMaxDigits(UBool value);
+    void setFormatFailIfMoreThanMaxDigits(UBool value);
+#endif  /* U_HIDE_DRAFT_API */
 
 
     /**

--- a/icu4c/source/i18n/unicode/unum.h
+++ b/icu4c/source/i18n/unicode/unum.h
@@ -1027,16 +1027,18 @@ typedef enum UNumberFormatAttribute {
     *
    * @stable ICU 51 */
   UNUM_SCALE = 21,
-#ifndef U_HIDE_INTERNAL_API
+
+#ifndef U_HIDE_DRAFT_API
   /**
-   * Minimum grouping digits, technology preview.
+   * Minimum grouping digits; most commonly set to 2 to print "1000" instead of "1,000".
    * See DecimalFormat::getMinimumGroupingDigits().
    *
-   * @internal technology preview
+   * For better control over grouping strategies, use UNumberFormatter.
+   *
+   * @draft ICU 64
    */
   UNUM_MINIMUM_GROUPING_DIGITS = 22,
-  /* TODO: test C API when it becomes @draft */
-#endif  /* U_HIDE_INTERNAL_API */
+#endif /* U_HIDE_DRAFT_API */
 
   /** 
    * if this attribute is set to 0, it is set to UNUM_CURRENCY_STANDARD purpose,
@@ -1046,11 +1048,12 @@ typedef enum UNumberFormatAttribute {
    */
   UNUM_CURRENCY_USAGE = 23,
 
-  /* The following cannot be #ifndef U_HIDE_INTERNAL_API, needed in .h file variable declararions */
+#ifndef U_HIDE_INTERNAL_API
   /** One below the first bitfield-boolean item.
    * All items after this one are stored in boolean form.
    * @internal */
   UNUM_MAX_NONBOOLEAN_ATTRIBUTE = 0x0FFF,
+#endif /* U_HIDE_INTERNAL_API */
 
   /** If 1, specifies that if setting the "max integer digits" attribute would truncate a value, set an error status rather than silently truncating.
    * For example,  formatting the value 1234 with 4 max int digits would succeed, but formatting 12345 would fail. There is no effect on parsing.
@@ -1076,24 +1079,38 @@ typedef enum UNumberFormatAttribute {
    */
   UNUM_PARSE_DECIMAL_MARK_REQUIRED = 0x1002,
 
-  /* The following cannot be #ifndef U_HIDE_INTERNAL_API, needed in .h file variable declararions */
+#ifndef U_HIDE_DRAFT_API
+
+  /**
+   * Parsing: if set to 1, parsing is sensitive to case (lowercase/uppercase).
+   *
+   * @draft ICU 64
+   */
+  UNUM_PARSE_CASE_SENSITIVE = 0x1003,
+
+  /**
+   * Formatting: if set to 1, whether to show the plus sign on non-negative numbers.
+   *
+   * For better control over sign display, use UNumberFormatter.
+   *
+   * @draft ICU 64
+   */
+  UNUM_SIGN_ALWAYS_SHOWN = 0x1004,
+
+  /** Limit of boolean attributes.
+   * @internal */
+  UNUM_LIMIT_BOOLEAN_ATTRIBUTE = 0x1005,
+
+#else /* U_HIDE_DRAFT_API */
+#ifndef U_HIDE_INTERNAL_API
+
   /** Limit of boolean attributes.
    * @internal */
   UNUM_LIMIT_BOOLEAN_ATTRIBUTE = 0x1003,
 
-  /**
-   * Whether parsing is sensitive to case (lowercase/uppercase).
-   * TODO: Add to the test suite.
-   * @internal This API is a technical preview. It may change in an upcoming release.
-   */
-  UNUM_PARSE_CASE_SENSITIVE = 0x1004,
+#endif /* U_HIDE_INTERNAL_API */
+#endif /* U_HIDE_DRAFT_API */
 
-  /**
-   * Formatting: whether to show the plus sign on non-negative numbers.
-   * TODO: Add to the test suite.
-   * @internal This API is a technical preview. It may change in an upcoming release.
-   */
-  UNUM_SIGN_ALWAYS_SHOWN = 0x1005,
 } UNumberFormatAttribute;
 
 /**

--- a/icu4c/source/test/intltest/numfmtst.h
+++ b/icu4c/source/test/intltest/numfmtst.h
@@ -261,6 +261,11 @@ class NumberFormatTest: public CalendarTimeZoneTest {
     void TestFastFormatInt32();
     void Test11646_Equality();
     void TestParseNaN();
+    void TestFormatFailIfMoreThanMaxDigits();
+    void TestParseCaseSensitive();
+    void TestParseNoExponent();
+    void TestSignAlwaysShown();
+    void TestMinimumGroupingDigits();
     void Test11897_LocalizedPatternSeparator();
     void Test13055_PercentageRounding();
     void Test11839();

--- a/icu4j/main/classes/core/src/com/ibm/icu/text/DecimalFormat.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/DecimalFormat.java
@@ -1055,13 +1055,13 @@ public class DecimalFormat extends NumberFormat {
   /**
    * {@icu} Returns whether the sign is being shown on positive numbers.
    *
+   * @return Whether the sign is shown on positive numbers and zero.
    * @see #setSignAlwaysShown
    * @category Affixes
-   * @internal
-   * @deprecated ICU 59: This API is a technical preview. It may change in an upcoming release.
+   * @draft ICU 64
+   * @provisional This API might change or be removed in a future release.
    */
-  @Deprecated
-  public synchronized boolean getSignAlwaysShown() {
+  public synchronized boolean isSignAlwaysShown() {
     // This is not in the exported properties
     return properties.getSignAlwaysShown();
   }
@@ -1086,12 +1086,11 @@ public class DecimalFormat extends NumberFormat {
    * explicit plus sign, such as "+0;-0". The behavior when combining this method with explicit plus
    * signs in the pattern is undefined.
    *
-   * @param value true to always show a sign; false to hide the sign on positive numbers.
+   * @param value true to always show a sign; false to hide the sign on positive numbers and zero.
    * @category Affixes
-   * @internal
-   * @deprecated ICU 59: This API is technical preview. It may change in an upcoming release.
+   * @draft ICU 64
+   * @provisional This API might change or be removed in a future release.
    */
-  @Deprecated
   public synchronized void setSignAlwaysShown(boolean value) {
     properties.setSignAlwaysShown(value);
     refreshFormatter();
@@ -1959,10 +1958,9 @@ public class DecimalFormat extends NumberFormat {
    *
    * @see #setMinimumGroupingDigits
    * @category Separators
-   * @internal
-   * @deprecated ICU 59: This API is a technical preview. It may change in an upcoming release.
+   * @draft ICU 64
+   * @provisional This API might change or be removed in a future release.
    */
-  @Deprecated
   public synchronized int getMinimumGroupingDigits() {
     if (properties.getMinimumGroupingDigits() > 0) {
       return properties.getMinimumGroupingDigits();
@@ -1977,10 +1975,9 @@ public class DecimalFormat extends NumberFormat {
    *
    * @param number The minimum number of digits before grouping is triggered.
    * @category Separators
-   * @internal
-   * @deprecated ICU 59: This API is a technical preview. It may change in an upcoming release.
+   * @draft ICU 64
+   * @provisional This API might change or be removed in a future release.
    */
-  @Deprecated
   public synchronized void setMinimumGroupingDigits(int number) {
     properties.setMinimumGroupingDigits(number);
     refreshFormatter();
@@ -2282,11 +2279,10 @@ public class DecimalFormat extends NumberFormat {
    *
    * @see #setParseNoExponent
    * @category Parsing
-   * @internal
-   * @deprecated ICU 59: This API is a technical preview. It may change in an upcoming release.
+   * @draft ICU 64
+   * @provisional This API might change or be removed in a future release.
    */
-  @Deprecated
-  public synchronized boolean getParseNoExponent() {
+  public synchronized boolean isParseNoExponent() {
     return properties.getParseNoExponent();
   }
 
@@ -2297,10 +2293,9 @@ public class DecimalFormat extends NumberFormat {
    *
    * @param value true to prevent exponents from being parsed; false to allow them to be parsed.
    * @category Parsing
-   * @internal
-   * @deprecated ICU 59: This API is a technical preview. It may change in an upcoming release.
+   * @draft ICU 64
+   * @provisional This API might change or be removed in a future release.
    */
-  @Deprecated
   public synchronized void setParseNoExponent(boolean value) {
     properties.setParseNoExponent(value);
     refreshFormatter();
@@ -2311,11 +2306,10 @@ public class DecimalFormat extends NumberFormat {
    *
    * @see #setParseNoExponent
    * @category Parsing
-   * @internal
-   * @deprecated ICU 59: This API is a technical preview. It may change in an upcoming release.
+   * @draft ICU 64
+   * @provisional This API might change or be removed in a future release.
    */
-  @Deprecated
-  public synchronized boolean getParseCaseSensitive() {
+  public synchronized boolean isParseCaseSensitive() {
     return properties.getParseCaseSensitive();
   }
 
@@ -2327,10 +2321,9 @@ public class DecimalFormat extends NumberFormat {
    * @param value true to force case (uppercase/lowercase) to match when parsing; false to ignore
    *     case and perform case folding.
    * @category Parsing
-   * @internal
-   * @deprecated ICU 59: This API is a technical preview. It may change in an upcoming release.
+   * @draft ICU 64
+   * @provisional This API might change or be removed in a future release.
    */
-  @Deprecated
   public synchronized void setParseCaseSensitive(boolean value) {
     properties.setParseCaseSensitive(value);
     refreshFormatter();

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/NumberFormatTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/NumberFormatTest.java
@@ -5868,10 +5868,10 @@ public class NumberFormatTest extends TestFmwk {
     @Test
     public void testParseNoExponent() throws ParseException {
         DecimalFormat df = new DecimalFormat();
-        assertEquals("Parse no exponent has wrong default", false, df.getParseNoExponent());
+        assertEquals("Parse no exponent has wrong default", false, df.isParseNoExponent());
         Number result1 = df.parse("123E4");
         df.setParseNoExponent(true);
-        assertEquals("Parse no exponent getter is broken", true, df.getParseNoExponent());
+        assertEquals("Parse no exponent getter is broken", true, df.isParseNoExponent());
         Number result2 = df.parse("123E4");
         assertEquals("Exponent did not parse before setParseNoExponent", result1, new Long(1230000));
         assertEquals("Exponent parsed after setParseNoExponent", result2, new Long(123));
@@ -5915,17 +5915,17 @@ public class NumberFormatTest extends TestFmwk {
         for (int p = 0; p < patterns.length; p++) {
             String pat = patterns[p];
             DecimalFormat df = new DecimalFormat(pat);
-            assertEquals("parseCaseSensitive default is wrong", false, df.getParseCaseSensitive());
+            assertEquals("parseCaseSensitive default is wrong", false, df.isParseCaseSensitive());
             for (int i = 0; i < inputs.length; i++) {
                 String inp = inputs[i];
                 df.setParseCaseSensitive(false);
-                assertEquals("parseCaseSensitive getter is broken", false, df.getParseCaseSensitive());
+                assertEquals("parseCaseSensitive getter is broken", false, df.isParseCaseSensitive());
                 ParsePosition actualInsensitive = new ParsePosition(0);
                 df.parse(inp, actualInsensitive);
                 assertEquals("Insensitive, pattern "+p+", input "+i,
                         expectedParsePositions[p*2][i], actualInsensitive.getIndex());
                 df.setParseCaseSensitive(true);
-                assertEquals("parseCaseSensitive getter is broken", true, df.getParseCaseSensitive());
+                assertEquals("parseCaseSensitive getter is broken", true, df.isParseCaseSensitive());
                 ParsePosition actualSensitive = new ParsePosition(0);
                 df.parse(inp, actualSensitive);
                 assertEquals("Sensitive, pattern "+p+", input "+i,
@@ -5977,13 +5977,13 @@ public class NumberFormatTest extends TestFmwk {
         for (int i=0; i<locs.length; i++) {
             ULocale loc = locs[i];
             DecimalFormat df1 = (DecimalFormat) NumberFormat.getNumberInstance(loc);
-            assertFalse("Default should be false", df1.getSignAlwaysShown());
+            assertFalse("Default should be false", df1.isSignAlwaysShown());
             df1.setSignAlwaysShown(true);
-            assertTrue("Getter should now return true", df1.getSignAlwaysShown());
+            assertTrue("Getter should now return true", df1.isSignAlwaysShown());
             DecimalFormat df2 = (DecimalFormat) NumberFormat.getCurrencyInstance(loc);
-            assertFalse("Default should be false", df2.getSignAlwaysShown());
+            assertFalse("Default should be false", df2.isSignAlwaysShown());
             df2.setSignAlwaysShown(true);
-            assertTrue("Getter should now return true", df2.getSignAlwaysShown());
+            assertTrue("Getter should now return true", df2.isSignAlwaysShown());
             for (int j=0; j<2; j++) {
                 DecimalFormat df = (j == 0) ? df1 : df2;
                 for (int k=0; k<numbers.length; k++) {


### PR DESCRIPTION
This PR brings parity to the DecimalFormat APIs in C, C++, and Java.  Although new users are encouraged to use NumberFormatter, keeping these dozen or so APIs around as preview introduces technical debt.  The alternative to promoting them to @draft would be to remove them.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-11725
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [x] Documentation is changed or added

