### PR TITLE
ICU-20350 Fix DecimalFormatSymbols.setPatternForCurrencySpacing affecting the value across instances

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/text/DecimalFormatSymbols.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/DecimalFormatSymbols.java
@@ -1156,8 +1156,10 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
             throw new IllegalArgumentException("unknown currency spacing: " + itemType);
         }
         if (beforeCurrency) {
+            currencySpcBeforeSym = currencySpcBeforeSym.clone();
             currencySpcBeforeSym[itemType] = pattern;
         } else {
+            currencySpcAfterSym = currencySpcAfterSym.clone();
             currencySpcAfterSym[itemType] = pattern;
         }
     }

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/IntlTestDecimalFormatSymbols.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/IntlTestDecimalFormatSymbols.java
@@ -400,4 +400,25 @@ public class IntlTestDecimalFormatSymbols extends TestFmwk
             assertEquals("JDK Locale and ICU Locale should produce the same object", dfs, dfs2);
         }
     }
+
+    @Test
+    public void testSetPatternForCurrencySpacing_notSharedByInstances() {
+        for (int type = DecimalFormatSymbols.CURRENCY_SPC_CURRENCY_MATCH; type <= DecimalFormatSymbols.CURRENCY_SPC_INSERT; type++) {
+            DecimalFormatSymbols dfs1 = DecimalFormatSymbols.getInstance(Locale.US);
+            DecimalFormatSymbols dfs2 = DecimalFormatSymbols.getInstance(Locale.US);
+            final String pattern = "foobar";
+            // before
+            dfs1.setPatternForCurrencySpacing(type, false, pattern);
+            assertEquals("setPatternForCurrencySpacing() must set the pattern", pattern,
+                    dfs1.getPatternForCurrencySpacing(type, false));
+            assertNotEquals("DFS instances must not share same pattern", pattern,
+                    dfs2.getPatternForCurrencySpacing(type, false));
+            // after
+            dfs1.setPatternForCurrencySpacing(type, true, pattern);
+            assertEquals("setPatternForCurrencySpacing() must set the pattern", pattern,
+                    dfs1.getPatternForCurrencySpacing(type, true));
+            assertNotEquals("DFS instances must not share same pattern", pattern,
+                    dfs2.getPatternForCurrencySpacing(type, true));
+        }
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20350
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

