### PR TITLE
ICU-20431 Both und_XX and _XX should fall back to the default locale

### DIFF
--- a/icu4c/source/common/uresbund.cpp
+++ b/icu4c/source/common/uresbund.cpp
@@ -489,6 +489,9 @@ findFirstExisting(const char* path, char* name,
 
         /*Fallback data stuff*/
         *hasChopped = chopLocale(name);
+        if (*hasChopped && *name == '\0') {
+            uprv_strcpy(name, "und");
+        }
     }
     return r;
 }

--- a/icu4c/source/test/intltest/dtptngts.cpp
+++ b/icu4c/source/test/intltest/dtptngts.cpp
@@ -1117,7 +1117,8 @@ void IntlTestDateTimePatternGeneratorAPI::testC() {
     UErrorCode status = U_ZERO_ERROR;
     int32_t numTests = UPRV_LENGTHOF(tests);
     for (int32_t i = 0; i < numTests; ++i) {
-        DateTimePatternGenerator *gen = DateTimePatternGenerator::createInstance(Locale(tests[i][0]), status);
+        DateTimePatternGenerator *gen = DateTimePatternGenerator::createInstance(
+                Locale::forLanguageTag(tests[i][0], status), status);
         if (gen == NULL) {
             dataerrln("FAIL: DateTimePatternGenerator::createInstance failed for %s", tests[i][0]);
             return;


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-20431

When this was discussed in the 2019–01–30 ICU TC meeting, the decision was reached that the resource loading code should be updated so that any _XX locale should fall back to the default locale, just like any und_XX locale, instead of falling back directly to the root locale.