### PR TITLE
ICU-20386 Adds workaround to icu4c/source/data/Makefile.in: Help pyth…

### DIFF
--- a/icu4c/source/data/Makefile.in
+++ b/icu4c/source/data/Makefile.in
@@ -163,7 +163,7 @@ cleanpackage:
 	$(RMV) $(LIBDIR)/*$(LIB_ICUDATA_NAME)*.$(SO)* $(LIBDIR)/$(LIB_STATIC_ICUDATA_NAME).$(A)
 
 check-local:
-	@PYTHON@ -m buildtool.test
+	PYTHONPATH=$(srcdir) @PYTHON@ -m buildtool.test
 
 # Find out if we have a source archive.
 # If we have that, then use that instead of building everything from scratch.


### PR DESCRIPTION
…on to find

the buildtools directory it needs when running the ICU4C unit tests in an
out-of-source installation.
The change is a quick workaround for now for an issue that can have wide impact.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20386
- [x] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

