### PR TITLE
ICU-20385 Regex, fix pattern compile problem with look-behind pattern…

### DIFF
--- a/icu4c/source/i18n/regexcmp.cpp
+++ b/icu4c/source/i18n/regexcmp.cpp
@@ -2285,6 +2285,13 @@ void  RegexCompile::handleCloseParen() {
                 error(U_REGEX_LOOK_BEHIND_LIMIT);
                 break;
             }
+            if (minML == INT32_MAX && maxML == 0) {
+                // This condition happens when no match is possible, such as with a
+                // [set] expression containing no elements.
+                // In principle, the generated code to evaluate the expression could be deleted,
+                // but it's probably not worth the complication.
+                minML = 0;
+            }
             U_ASSERT(minML <= maxML);
 
             // Insert the min and max match len bounds into the URX_LB_CONT op that
@@ -2321,6 +2328,14 @@ void  RegexCompile::handleCloseParen() {
                 error(U_REGEX_LOOK_BEHIND_LIMIT);
                 break;
             }
+            if (minML == INT32_MAX && maxML == 0) {
+                // This condition happens when no match is possible, such as with a
+                // [set] expression containing no elements.
+                // In principle, the generated code to evaluate the expression could be deleted,
+                // but it's probably not worth the complication.
+                minML = 0;
+            }
+
             U_ASSERT(minML <= maxML);
 
             // Insert the min and max match len bounds into the URX_LB_CONT op that

--- a/icu4c/source/test/testdata/regextst.txt
+++ b/icu4c/source/test/testdata/regextst.txt
@@ -1419,10 +1419,31 @@
 "[a-z]+"                   i       "<0>Aa</0>"   # Matches JDK behavior.
 "[^a-z]+"                  i       "Aa"          # (no match) which is JDK behavior. Case fold first, then negation.
 
+# Bug 20385.  Assertion failure while compiling a negative look-behind expression consisting of a set with
+#             no contents. Meaning the [set] can never match. There is no syntax to directly express
+#             an empty set, so generate it by negating (^) a set of all code points.
+#             Also check empty sets in other contexts.
+
+"(?<![^[^a]a])"                    "<0></0>abc"
+
+"(?<![^\u0000-\U0010ffff])"        "<0></0>abc"
+"x(?<![^\u0000-\U0010ffff])"       "<0>x</0>abc"
+"x(?<![^\u0000-\U0010ffff]{1,5})"  "<0>x</0>abc"
+"x(?<![^\u0000-\U0010ffff]{0,5})"  "xabc"
+
+"(?<=[^\u0000-\U0010ffff])"        "abc"
+"(x?<=[^\u0000-\U0010ffff])"       "abc"
+"x(?<=[^\u0000-\U0010ffff]{1,5})"  "xabc"
+"x(?<=[^\u0000-\U0010ffff]{0,5})"  "<0>x</0>abc"
+
+"[^\u0000-\U0010ffff]"             "a"
+"[^[^\u0000-\U0010ffff]]"          "<0>a</0>"
+
+
 #  Random debugging, Temporary
 #
 
-"This is a string with (?:one |two |three )endings"   "<0>This is a string with two endings</0>"
+
 
 
 #


### PR DESCRIPTION
…s that cannot match.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20385
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

