### PR TITLE
ICU-20138 Implementing ufmtval_nextPosition and additional internal infrastructure.

### DIFF
--- a/icu4c/source/i18n/Makefile.in
+++ b/icu4c/source/i18n/Makefile.in
@@ -112,7 +112,7 @@ numparse_stringsegment.o numparse_parsednumber.o numparse_impl.o \
 numparse_symbols.o numparse_decimal.o numparse_scientific.o numparse_currency.o \
 numparse_affixes.o numparse_compositions.o numparse_validators.o \
 numrange_fluent.o numrange_impl.o \
-erarules.o formattedvalue.o
+erarules.o formattedvalue.o formattedval_iterimpl.o
 
 ## Header files to install
 HEADERS = $(srcdir)/unicode/*.h

--- a/icu4c/source/i18n/formattedval_impl.h
+++ b/icu4c/source/i18n/formattedval_impl.h
@@ -1,0 +1,55 @@
+// © 2018 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+
+#ifndef __FORMVAL_IMPL_H__
+#define __FORMVAL_IMPL_H__
+
+#include "unicode/utypes.h"
+#if !UCONFIG_NO_FORMATTING
+
+// This file contains compliant implementations of FormattedValue which can be
+// leveraged by ICU formatters.
+//
+// Each implementation is defined in its own cpp file in order to split
+// dependencies more modularly.
+
+#include "unicode/formattedvalue.h"
+#include "fphdlimp.h"
+#include "uvectr32.h"
+#include "util.h"
+
+U_NAMESPACE_BEGIN
+
+
+/** Implementation using FieldPositionHandler to accept fields. */
+class FormattedValueFieldPositionIteratorImpl : public UMemory, public FormattedValue {
+public:
+
+    /** @param initialFieldCapacity Initially allocate space for this many fields. */
+    FormattedValueFieldPositionIteratorImpl(int32_t initialFieldCapacity, UErrorCode& status);
+
+    virtual ~FormattedValueFieldPositionIteratorImpl();
+
+    // Implementation of FormattedValue (const):
+
+    UnicodeString toString(UErrorCode& status) const U_OVERRIDE;
+    UnicodeString toTempString(UErrorCode& status) const U_OVERRIDE;
+    Appendable& appendTo(Appendable& appendable, UErrorCode& status) const U_OVERRIDE;
+    UBool nextPosition(ConstrainedFieldPosition& cfpos, UErrorCode& status) const U_OVERRIDE;
+
+    // Additional methods used during construction phase only (non-const):
+
+    FieldPositionIteratorHandler getHandler(UErrorCode& status);
+    void appendString(UnicodeString string, UErrorCode& status);
+
+private:
+    // Final data:
+    UnicodeString fString;
+    UVector32 fFields;
+};
+
+
+U_NAMESPACE_END
+
+#endif /* #if !UCONFIG_NO_FORMATTING */
+#endif // __FORMVAL_IMPL_H__

--- a/icu4c/source/i18n/formattedval_impl.h
+++ b/icu4c/source/i18n/formattedval_impl.h
@@ -14,9 +14,10 @@
 // dependencies more modularly.
 
 #include "unicode/formattedvalue.h"
+#include "capi_helper.h"
 #include "fphdlimp.h"
-#include "uvectr32.h"
 #include "util.h"
+#include "uvectr32.h"
 
 U_NAMESPACE_BEGIN
 
@@ -47,6 +48,125 @@ private:
     UnicodeString fString;
     UVector32 fFields;
 };
+
+
+// C API Helpers for FormattedValue
+// Magic number as ASCII == "UFV"
+struct UFormattedValueImpl;
+typedef IcuCApiHelper<UFormattedValue, UFormattedValueImpl, 0x55465600> UFormattedValueApiHelper;
+struct UFormattedValueImpl : public UMemory, public UFormattedValueApiHelper {
+    // This pointer should be set by the child class.
+    FormattedValue* fFormattedValue = nullptr;
+};
+
+
+/** Implementation of the methods from U_FORMATTED_VALUE_SUBCLASS_AUTO. */
+#define UPRV_FORMATTED_VALUE_SUBCLASS_AUTO_IMPL(Name) \
+    Name::Name(Name&& src) U_NOEXCEPT { \
+        delete fData; \
+        fData = src.fData; \
+        src.fData = nullptr; \
+    } \
+    Name::~Name() { \
+        delete fData; \
+        fData = nullptr; \
+    } \
+    Name& Name::operator=(Name&& src) U_NOEXCEPT { \
+        delete fData; \
+        fData = src.fData; \
+        src.fData = nullptr; \
+        return *this; \
+    } \
+    UnicodeString Name::toString(UErrorCode& status) const { \
+        if (U_FAILURE(status)) { \
+            return ICU_Utility::makeBogusString(); \
+        } \
+        if (fData == nullptr) { \
+            status = fErrorCode; \
+            return ICU_Utility::makeBogusString(); \
+        } \
+        return fData->toString(status); \
+    } \
+    UnicodeString Name::toTempString(UErrorCode& status) const { \
+        if (U_FAILURE(status)) { \
+            return ICU_Utility::makeBogusString(); \
+        } \
+        if (fData == nullptr) { \
+            status = fErrorCode; \
+            return ICU_Utility::makeBogusString(); \
+        } \
+        return fData->toTempString(status); \
+    } \
+    Appendable& Name::appendTo(Appendable& appendable, UErrorCode& status) const { \
+        if (U_FAILURE(status)) { \
+            return appendable; \
+        } \
+        if (fData == nullptr) { \
+            status = fErrorCode; \
+            return appendable; \
+        } \
+        return fData->appendTo(appendable, status); \
+    } \
+    UBool Name::nextPosition(ConstrainedFieldPosition& cfpos, UErrorCode& status) const { \
+        if (U_FAILURE(status)) { \
+            return FALSE; \
+        } \
+        if (fData == nullptr) { \
+            status = fErrorCode; \
+            return FALSE; \
+        } \
+        return fData->nextPosition(cfpos, status); \
+    }
+
+
+/**
+ * Implementation of the standard methods for a UFormattedValue "subclass" C API.
+ * @param CPPType The public C++ type, like FormattedList
+ * @param CType The public C type, like UFormattedList
+ * @param ImplType A name to use for the implementation class
+ * @param HelperType A name to use for the "mixin" typedef for C API conversion
+ * @param Prefix The C API prefix, like ulistfmt
+ * @param MagicNumber A unique 32-bit number to use to identify this type
+ */
+#define UPRV_FORMATTED_VALUE_CAPI_AUTO_IMPL(CPPType, CType, ImplType, HelperType, Prefix, MagicNumber) \
+    U_NAMESPACE_BEGIN \
+    class ImplType; \
+    typedef IcuCApiHelper<CType, ImplType, MagicNumber> HelperType; \
+    class ImplType : public UFormattedValueImpl, public HelperType { \
+    public: \
+        ImplType(); \
+        ~ImplType(); \
+        CPPType fImpl; \
+    }; \
+    ImplType::ImplType() { \
+        fFormattedValue = &fImpl; \
+    } \
+    ImplType::~ImplType() {} \
+    U_NAMESPACE_END \
+    U_CAPI CType* U_EXPORT2 \
+    Prefix ## _openResult (UErrorCode* ec) { \
+        if (U_FAILURE(*ec)) { \
+            return nullptr; \
+        } \
+        ImplType* impl = new ImplType(); \
+        if (impl == nullptr) { \
+            *ec = U_MEMORY_ALLOCATION_ERROR; \
+            return nullptr; \
+        } \
+        return static_cast<HelperType*>(impl)->exportForC(); \
+    } \
+    U_DRAFT const UFormattedValue* U_EXPORT2 \
+    Prefix ## _resultAsValue (const CType* uresult, UErrorCode* ec) { \
+        const ImplType* result = HelperType::validate(uresult, *ec); \
+        if (U_FAILURE(*ec)) { return nullptr; } \
+        return static_cast<const UFormattedValueApiHelper*>(result)->exportConstForC(); \
+    } \
+    U_CAPI void U_EXPORT2 \
+    Prefix ## _closeResult (CType* uresult) { \
+        UErrorCode localStatus = U_ZERO_ERROR; \
+        const ImplType* impl = HelperType::validate(uresult, localStatus); \
+        delete impl; \
+    }
 
 
 U_NAMESPACE_END

--- a/icu4c/source/i18n/formattedval_iterimpl.cpp
+++ b/icu4c/source/i18n/formattedval_iterimpl.cpp
@@ -1,0 +1,87 @@
+// © 2018 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+
+#include "unicode/utypes.h"
+
+#if !UCONFIG_NO_FORMATTING
+
+// This file contains one implementation of FormattedValue.
+// Other independent implementations should go into their own cpp file for
+// better dependency modularization.
+
+#include "formattedval_impl.h"
+
+U_NAMESPACE_BEGIN
+
+
+FormattedValueFieldPositionIteratorImpl::FormattedValueFieldPositionIteratorImpl(
+        int32_t initialFieldCapacity,
+        UErrorCode& status)
+        : fFields(initialFieldCapacity * 4, status) {
+}
+
+FormattedValueFieldPositionIteratorImpl::~FormattedValueFieldPositionIteratorImpl() = default;
+
+UnicodeString FormattedValueFieldPositionIteratorImpl::toString(
+        UErrorCode&) const {
+    return fString;
+}
+
+UnicodeString FormattedValueFieldPositionIteratorImpl::toTempString(
+        UErrorCode&) const {
+    UnicodeString ret;
+    ret.fastCopyFrom(fString);
+    return ret;
+}
+
+Appendable& FormattedValueFieldPositionIteratorImpl::appendTo(
+        Appendable& appendable,
+        UErrorCode&) const {
+    appendable.appendString(fString.getBuffer(), fString.length());
+    return appendable;
+}
+
+UBool FormattedValueFieldPositionIteratorImpl::nextPosition(
+        ConstrainedFieldPosition& cfpos,
+        UErrorCode&) const {
+    U_ASSERT(fFields.size() % 4 == 0);
+    int32_t numFields = fFields.size() / 4;
+    int32_t i = cfpos.getInt64IterationContext();
+    for (; i < numFields; i++) {
+        UFieldCategory category = static_cast<UFieldCategory>(fFields.elementAti(i * 4));
+        int32_t field = fFields.elementAti(i * 4 + 1);
+        if (cfpos.matchesField(category, field)) {
+            int32_t start = fFields.elementAti(i * 4 + 2);
+            int32_t limit = fFields.elementAti(i * 4 + 3);
+            cfpos.setState(category, field, start, limit);
+            break;
+        }
+    }
+    cfpos.setInt64IterationContext(i == numFields ? i : i + 1);
+    return i < numFields;
+}
+
+
+FieldPositionIteratorHandler FormattedValueFieldPositionIteratorImpl::getHandler(
+        UErrorCode& status) {
+    return FieldPositionIteratorHandler(&fFields, status);
+}
+
+void FormattedValueFieldPositionIteratorImpl::appendString(
+        UnicodeString string,
+        UErrorCode& status) {
+    if (U_FAILURE(status)) {
+        return;
+    }
+    fString.append(string);
+    // Make the string NUL-terminated
+    if (fString.getTerminatedBuffer() == nullptr) {
+        status = U_MEMORY_ALLOCATION_ERROR;
+        return;
+    }
+}
+
+
+U_NAMESPACE_END
+
+#endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/i18n/formattedvalue.cpp
+++ b/icu4c/source/i18n/formattedvalue.cpp
@@ -6,7 +6,7 @@
 #if !UCONFIG_NO_FORMATTING
 
 #include "unicode/formattedvalue.h"
-#include "number_utypes.h"
+#include "formattedval_impl.h"
 #include "capi_helper.h"
 
 U_NAMESPACE_BEGIN
@@ -198,7 +198,7 @@ ufmtval_getString(
         const UFormattedValue* ufmtval,
         int32_t* pLength,
         UErrorCode* ec) {
-    const auto* impl = number::impl::UFormattedValueApiHelper::validate(ufmtval, *ec);
+    const auto* impl = UFormattedValueApiHelper::validate(ufmtval, *ec);
     if (U_FAILURE(*ec)) {
         return nullptr;
     }
@@ -218,7 +218,7 @@ ufmtval_nextPosition(
         const UFormattedValue* ufmtval,
         UConstrainedFieldPosition* ucfpos,
         UErrorCode* ec) {
-    const auto* fmtval = number::impl::UFormattedValueApiHelper::validate(ufmtval, *ec);
+    const auto* fmtval = UFormattedValueApiHelper::validate(ufmtval, *ec);
     auto* cfpos = UConstrainedFieldPositionImpl::validate(ucfpos, *ec);
     if (U_FAILURE(*ec)) {
         return FALSE;

--- a/icu4c/source/i18n/formattedvalue.cpp
+++ b/icu4c/source/i18n/formattedvalue.cpp
@@ -51,6 +51,19 @@ void ConstrainedFieldPosition::setState(
     fLimit = limit;
 }
 
+UBool ConstrainedFieldPosition::matchesField(UFieldCategory category, int32_t field) {
+    switch (fConstraint) {
+    case UCFPOS_CONSTRAINT_NONE:
+        return TRUE;
+    case UCFPOS_CONSTRAINT_CATEGORY:
+        return fCategory == category;
+    case UCFPOS_CONSTRAINT_FIELD:
+        return fCategory == category && fField == field;
+    default:
+        UPRV_UNREACHABLE;
+    }
+}
+
 
 FormattedValue::~FormattedValue() = default;
 
@@ -197,6 +210,20 @@ ufmtval_getString(
         *pLength = readOnlyAlias.length();
     }
     return readOnlyAlias.getBuffer();
+}
+
+
+U_DRAFT UBool U_EXPORT2
+ufmtval_nextPosition(
+        const UFormattedValue* ufmtval,
+        UConstrainedFieldPosition* ucfpos,
+        UErrorCode* ec) {
+    const auto* fmtval = number::impl::UFormattedValueApiHelper::validate(ufmtval, *ec);
+    auto* cfpos = UConstrainedFieldPositionImpl::validate(ucfpos, *ec);
+    if (U_FAILURE(*ec)) {
+        return FALSE;
+    }
+    return fmtval->fFormattedValue->nextPosition(cfpos->fImpl, *ec);
 }
 
 

--- a/icu4c/source/i18n/fphdlimp.cpp
+++ b/icu4c/source/i18n/fphdlimp.cpp
@@ -62,10 +62,16 @@ FieldPositionOnlyHandler::isRecording(void) const {
 
 FieldPositionIteratorHandler::FieldPositionIteratorHandler(FieldPositionIterator* posIter,
                                                            UErrorCode& _status)
-    : iter(posIter), vec(NULL), status(_status) {
+    : iter(posIter), vec(NULL), status(_status), fCategory(UFIELD_CATEGORY_UNDEFINED) {
   if (iter && U_SUCCESS(status)) {
     vec = new UVector32(status);
   }
+}
+
+FieldPositionIteratorHandler::FieldPositionIteratorHandler(
+    UVector32* vec,
+    UErrorCode& status)
+    : iter(nullptr), vec(vec), status(status), fCategory(UFIELD_CATEGORY_UNDEFINED) {
 }
 
 FieldPositionIteratorHandler::~FieldPositionIteratorHandler() {
@@ -79,8 +85,9 @@ FieldPositionIteratorHandler::~FieldPositionIteratorHandler() {
 
 void
 FieldPositionIteratorHandler::addAttribute(int32_t id, int32_t start, int32_t limit) {
-  if (iter && U_SUCCESS(status) && start < limit) {
+  if (vec && U_SUCCESS(status) && start < limit) {
     int32_t size = vec->size();
+    vec->addElement(fCategory, status);
     vec->addElement(id, status);
     vec->addElement(start + fShift, status);
     vec->addElement(limit + fShift, status);

--- a/icu4c/source/i18n/fphdlimp.h
+++ b/icu4c/source/i18n/fphdlimp.h
@@ -16,6 +16,7 @@
 
 #include "unicode/fieldpos.h"
 #include "unicode/fpositer.h"
+#include "unicode/formattedvalue.h"
 
 U_NAMESPACE_BEGIN
 
@@ -57,6 +58,7 @@ class FieldPositionIteratorHandler : public FieldPositionHandler {
   FieldPositionIterator* iter; // can be NULL
   UVector32* vec;
   UErrorCode status;
+  UFieldCategory fCategory;
 
   // Note, we keep a reference to status, so if status is on the stack, we have
   // to be destroyed before status goes out of scope.  Easiest thing is to
@@ -70,11 +72,24 @@ class FieldPositionIteratorHandler : public FieldPositionHandler {
 
  public:
   FieldPositionIteratorHandler(FieldPositionIterator* posIter, UErrorCode& status);
+  /** If using this constructor, you must call getError() when done formatting! */
+  FieldPositionIteratorHandler(UVector32* vec, UErrorCode& status);
   ~FieldPositionIteratorHandler();
 
   void addAttribute(int32_t id, int32_t start, int32_t limit) U_OVERRIDE;
   void shiftLast(int32_t delta) U_OVERRIDE;
   UBool isRecording(void) const U_OVERRIDE;
+
+  /** Copies a failed error code into _status. */
+  inline void getError(UErrorCode& _status) {
+    if (U_SUCCESS(_status) && U_FAILURE(status)) {
+      _status = status;
+    }
+  }
+
+  inline void setCategory(UFieldCategory category) {
+    fCategory = category;
+  }
 };
 
 U_NAMESPACE_END

--- a/icu4c/source/i18n/fpositer.cpp
+++ b/icu4c/source/i18n/fpositer.cpp
@@ -65,10 +65,10 @@ void FieldPositionIterator::setData(UVector32 *adopt, UErrorCode& status) {
       if (adopt->size() == 0) {
         delete adopt;
         adopt = NULL;
-      } else if ((adopt->size() % 3) != 0) {
+      } else if ((adopt->size() % 4) != 0) {
         status = U_ILLEGAL_ARGUMENT_ERROR;
       } else {
-        for (int i = 1; i < adopt->size(); i += 3) {
+        for (int i = 2; i < adopt->size(); i += 4) {
           if (adopt->elementAti(i) >= adopt->elementAti(i+1)) {
             status = U_ILLEGAL_ARGUMENT_ERROR;
             break;
@@ -95,6 +95,8 @@ UBool FieldPositionIterator::next(FieldPosition& fp) {
     return FALSE;
   }
 
+  // Ignore the first element of the tetrad: used for field category
+  pos++;
   fp.setField(data->elementAti(pos++));
   fp.setBeginIndex(data->elementAti(pos++));
   fp.setEndIndex(data->elementAti(pos++));

--- a/icu4c/source/i18n/i18n.vcxproj
+++ b/icu4c/source/i18n/i18n.vcxproj
@@ -238,6 +238,7 @@
     <ClCompile Include="fmtable.cpp" />
     <ClCompile Include="fmtable_cnv.cpp" />
     <ClCompile Include="format.cpp" />
+    <ClCompile Include="formattedval_iterimpl.cpp" />
     <ClCompile Include="formattedvalue.cpp" />
     <ClCompile Include="fphdlimp.cpp" />
     <ClCompile Include="fpositer.cpp" />
@@ -559,6 +560,7 @@
     <ClInclude Include="numparse_types.h" />
     <ClInclude Include="numparse_utils.h" />
     <ClInclude Include="numrange_impl.h" />
+    <ClInclude Include="formattedval_impl.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="i18n.rc" />

--- a/icu4c/source/i18n/i18n.vcxproj.filters
+++ b/icu4c/source/i18n/i18n.vcxproj.filters
@@ -156,6 +156,9 @@
     <ClCompile Include="format.cpp">
       <Filter>formatting</Filter>
     </ClCompile>
+    <ClCompile Include="formattedval_iterimpl.cpp">
+      <Filter>formatting</Filter>
+    </ClCompile>
     <ClCompile Include="formattedvalue.cpp">
       <Filter>formatting</Filter>
     </ClCompile>
@@ -792,6 +795,9 @@
       <Filter>formatting</Filter>
     </ClInclude>
     <ClInclude Include="ethpccal.h">
+      <Filter>formatting</Filter>
+    </ClInclude>
+    <ClInclude Include="formattedval_impl.h">
       <Filter>formatting</Filter>
     </ClInclude>
     <ClInclude Include="fphdlimp.h">

--- a/icu4c/source/i18n/i18n_uwp.vcxproj
+++ b/icu4c/source/i18n/i18n_uwp.vcxproj
@@ -345,6 +345,7 @@
     <ClCompile Include="fmtable.cpp" />
     <ClCompile Include="fmtable_cnv.cpp" />
     <ClCompile Include="format.cpp" />
+    <ClCompile Include="formattedval_iterimpl.cpp" />
     <ClCompile Include="formattedvalue.cpp" />
     <ClCompile Include="fphdlimp.cpp" />
     <ClCompile Include="fpositer.cpp" />
@@ -664,6 +665,7 @@
     <ClInclude Include="numparse_types.h" />
     <ClInclude Include="numparse_utils.h" />
     <ClInclude Include="numrange_impl.h" />
+    <ClInclude Include="formattedval_impl.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="i18n.rc" />

--- a/icu4c/source/i18n/number_capi.cpp
+++ b/icu4c/source/i18n/number_capi.cpp
@@ -12,6 +12,7 @@
 #include "fphdlimp.h"
 #include "number_utypes.h"
 #include "numparse_types.h"
+#include "formattedval_impl.h"
 #include "unicode/numberformatter.h"
 #include "unicode/unumberformatter.h"
 

--- a/icu4c/source/i18n/number_utypes.h
+++ b/icu4c/source/i18n/number_utypes.h
@@ -11,20 +11,9 @@
 #include "number_types.h"
 #include "number_decimalquantity.h"
 #include "number_stringbuilder.h"
-#include "capi_helper.h"
 
 U_NAMESPACE_BEGIN namespace number {
 namespace impl {
-
-
-struct UFormattedValueImpl;
-
-// Magic number as ASCII == "UFV"
-typedef IcuCApiHelper<UFormattedValue, UFormattedValueImpl, 0x55465600> UFormattedValueApiHelper;
-
-struct UFormattedValueImpl : public UMemory, public UFormattedValueApiHelper {
-    FormattedValue* fFormattedValue = nullptr;
-};
 
 
 /** Helper function used in upluralrules.cpp */

--- a/icu4c/source/i18n/unicode/formattedvalue.h
+++ b/icu4c/source/i18n/unicode/formattedvalue.h
@@ -221,6 +221,9 @@ class U_I18N_API ConstrainedFieldPosition : public UMemory {
         int32_t start,
         int32_t limit);
 
+    /** @internal */
+    UBool matchesField(UFieldCategory category, int32_t field);
+
   private:
     int64_t fContext = 0LL;
     int32_t fField = 0;

--- a/icu4c/source/i18n/unicode/uformattedvalue.h
+++ b/icu4c/source/i18n/unicode/uformattedvalue.h
@@ -54,6 +54,11 @@ typedef enum UFieldCategory {
      */
     UFIELD_CATEGORY_LIST,
 
+#ifndef U_HIDE_INTERNAL_API
+    /** @internal */
+    UFIELD_CATEGORY_COUNT
+#endif
+
 } UFieldCategory;
 
 

--- a/icu4c/source/test/cintltst/cformtst.h
+++ b/icu4c/source/test/cintltst/cformtst.h
@@ -32,8 +32,14 @@
 UChar* myDateFormat(UDateFormat *dat, UDate d); 
 
 
-// The following is implemented in uformattedvaluetest.c
-// TODO: When needed, add overload with a different category for each position
+typedef struct UFieldPositionWithCategory {
+    UFieldCategory category;
+    int32_t field;
+    int32_t beginIndex;
+    int32_t endIndex;
+} UFieldPositionWithCategory;
+
+// The following are implemented in uformattedvaluetest.c
 void checkFormattedValue(
     const char* message,
     const UFormattedValue* fv,
@@ -41,6 +47,13 @@ void checkFormattedValue(
     UFieldCategory expectedCategory,
     const UFieldPosition* expectedFieldPositions,
     int32_t expectedFieldPositionsLength);
+
+void checkMixedFormattedValue(
+    const char* message,
+    const UFormattedValue* fv,
+    const UChar* expectedString,
+    const UFieldPositionWithCategory* expectedFieldPositions,
+    int32_t length);
 
 
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/test/cintltst/unumberformattertst.c
+++ b/icu4c/source/test/cintltst/unumberformattertst.c
@@ -211,12 +211,10 @@ static void TestFormattedValue() {
         assertSuccess("Should convert without error", &ec);
         static const UFieldPosition expectedFieldPositions[] = {
             // field, begin index, end index
-            {UNUM_GROUPING_SEPARATOR_FIELD, 2, 3},
-            {UNUM_GROUPING_SEPARATOR_FIELD, 6, 7},
-            {UNUM_INTEGER_FIELD, 0, 10},
-            {UNUM_GROUPING_SEPARATOR_FIELD, 13, 14},
-            {UNUM_GROUPING_SEPARATOR_FIELD, 17, 18},
-            {UNUM_INTEGER_FIELD, 11, 21}};
+            {UNUM_INTEGER_FIELD, 0, 2},
+            {UNUM_DECIMAL_SEPARATOR_FIELD, 2, 3},
+            {UNUM_FRACTION_FIELD, 3, 5},
+            {UNUM_COMPACT_FIELD, 5, 6}};
         checkFormattedValue(
             "FormattedNumber as FormattedValue",
             fv,

--- a/icu4c/source/test/depstest/dependencies.txt
+++ b/icu4c/source/test/depstest/dependencies.txt
@@ -916,7 +916,7 @@ group: dayperiodrules
 group: listformatter
     listformatter.o ulistformatter.o
   deps
-    resourcebundle simpleformatter format uclean_i18n
+    resourcebundle simpleformatter format uclean_i18n formatted_value_iterimpl
 
 group: double_conversion
     double-conversion.o double-conversion-bignum.o double-conversion-bignum-dtoa.o
@@ -1045,6 +1045,11 @@ group: formatted_value
     formattedvalue.o
   deps
     platform
+
+group: formatted_value_iterimpl
+    formattedval_iterimpl.o
+  deps
+    formatted_value format uvector32
 
 group: format
     format.o fphdlimp.o fpositer.o ufieldpositer.o

--- a/icu4c/source/test/intltest/itformat.h
+++ b/icu4c/source/test/intltest/itformat.h
@@ -26,15 +26,28 @@ class IntlTestFormat: public IntlTest {
 };
 
 
+typedef struct UFieldPositionWithCategory {
+    UFieldCategory category;
+    int32_t field;
+    int32_t beginIndex;
+    int32_t endIndex;
+} UFieldPositionWithCategory;
+
 class IntlTestWithFieldPosition : public IntlTest {
 public:
-    // TODO: When needed, add overload with a different category for each position
     void checkFormattedValue(
         const char16_t* message,
         const FormattedValue& fv,
         UnicodeString expectedString,
         UFieldCategory expectedCategory,
         const UFieldPosition* expectedFieldPositions,
+        int32_t length);
+
+    void checkMixedFormattedValue(
+        const char16_t* message,
+        const FormattedValue& fv,
+        UnicodeString expectedString,
+        const UFieldPositionWithCategory* expectedFieldPositions,
         int32_t length);
 };
 

--- a/icu4c/source/test/intltest/numbertest_api.cpp
+++ b/icu4c/source/test/intltest/numbertest_api.cpp
@@ -2980,15 +2980,6 @@ void NumberFormatterApiTest::assertNumberFieldPositions(
         expectedFieldPositions,
         length);
 
-    // Check no field positions in an unrelated category
-    checkFormattedValue(
-        message,
-        static_cast<const FormattedValue&>(formattedNumber),
-        formattedNumber.toString(status),
-        UFIELD_CATEGORY_DATE,
-        nullptr,
-        0);
-
     // Check FormattedNumber-specific functions
     UnicodeString baseMessage = UnicodeString(message) + u": " + formattedNumber.toString(status) + u": ";
     FieldPositionIterator fpi;

--- a/icu4j/main/classes/core/src/com/ibm/icu/text/ConstrainedFieldPosition.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/ConstrainedFieldPosition.java
@@ -305,6 +305,22 @@ public class ConstrainedFieldPosition {
         fLimit = limit;
     }
 
+    /** @internal */
+    public boolean matchesField(Field field) {
+        // If this method ever becomes public, change assert to throw IllegalArgumentException
+        assert field != null;
+        switch (fConstraint) {
+        case NONE:
+            return true;
+        case CLASS:
+            return fClassConstraint.isAssignableFrom(field.getClass());
+        case FIELD:
+            return fField == field;
+        default:
+            throw new AssertionError();
+        }
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/FormattedValueTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/FormattedValueTest.java
@@ -176,7 +176,8 @@ public class FormattedValueTest {
             assertEquals(baseMessage + "limit " + i, expectedLimit, cfpos.getLimit());
             i++;
         }
-        assertFalse(baseMessage + "after loop", fv.nextPosition(cfpos));
+        boolean afterLoopResult = fv.nextPosition(cfpos);
+        assertFalse(baseMessage + "after loop: " + cfpos, afterLoopResult);
 
         // Check nextPosition constrained over each class one at a time
         for (Class<?> classConstraint : uniqueFieldClasses) {
@@ -196,7 +197,8 @@ public class FormattedValueTest {
                 assertEquals(baseMessage + "limit " + i, expectedLimit, cfpos.getLimit());
                 i++;
             }
-            assertFalse(baseMessage + "after loop", fv.nextPosition(cfpos));
+            afterLoopResult = fv.nextPosition(cfpos);
+            assertFalse(baseMessage + "after loop: " + cfpos, afterLoopResult);
         }
 
         // Check nextPosition constrained over an unrelated class
@@ -222,7 +224,8 @@ public class FormattedValueTest {
                 assertEquals(baseMessage + "limit " + i, expectedLimit, cfpos.getLimit());
                 i++;
             }
-            assertFalse(baseMessage + "after loop", fv.nextPosition(cfpos));
+            afterLoopResult = fv.nextPosition(cfpos);
+            assertFalse(baseMessage + "after loop: " + cfpos, afterLoopResult);
         }
     }
 


### PR DESCRIPTION
- Adds test infra for multi-category formatted values.
- Adds helper method ConstrainedFieldPosition#matchesField, currently internal.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20138
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

