### PR TITLE
ICU-13320 ICU4J DateFormatSymbols, add getNarrowEras/setNarrowEras

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/text/DateFormatSymbols.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/DateFormatSymbols.java
@@ -720,7 +720,7 @@ public class DateFormatSymbols implements Serializable, Cloneable {
     Map<CapitalizationContextUsage,boolean[]> capitalization = null;
 
     /**
-     * Returns era strings. For example: "AD" and "BC".
+     * Returns abbreviated era strings. For example: "AD" and "BC".
      * @return the era strings.
      * @stable ICU 2.0
      */
@@ -729,7 +729,7 @@ public class DateFormatSymbols implements Serializable, Cloneable {
     }
 
     /**
-     * Sets era strings. For example: "AD" and "BC".
+     * Sets abbreviated era strings. For example: "AD" and "BC".
      * @param newEras the new era strings.
      * @stable ICU 2.0
      */
@@ -738,7 +738,7 @@ public class DateFormatSymbols implements Serializable, Cloneable {
     }
 
     /**
-     * {@icu} Returns era name strings. For example: "Anno Domini" and "Before Christ".
+     * {@icu} Returns full era name strings. For example: "Anno Domini" and "Before Christ".
      * @return the era strings.
      * @stable ICU 3.4
      */
@@ -747,12 +747,32 @@ public class DateFormatSymbols implements Serializable, Cloneable {
     }
 
     /**
-     * {@icu} Sets era name strings. For example: "Anno Domini" and "Before Christ".
+     * {@icu} Sets full era name strings. For example: "Anno Domini" and "Before Christ".
      * @param newEraNames the new era strings.
      * @stable ICU 3.8
      */
     public void setEraNames(String[] newEraNames) {
         eraNames = duplicate(newEraNames);
+    }
+
+    /**
+     * {@icu} Returns narrow era name strings. For example: "A" and "B".
+     * @return the narrow era strings.
+     * @draft ICU 64
+     * @provisional This API might change or be removed in a future release.
+     */
+    public String[] getNarrowEras() {
+        return duplicate(narrowEras);
+    }
+
+    /**
+     * {@icu} Sets narrow era name strings. For example: "A" and "B".
+     * @param newNarrowEras the new narrow era strings.
+     * @draft ICU 64
+     * @provisional This API might change or be removed in a future release.
+     */
+    public void setNarrowEras(String[] newNarrowEras) {
+        narrowEras = duplicate(newNarrowEras);
     }
 
     /**
@@ -1458,6 +1478,7 @@ public class DateFormatSymbols implements Serializable, Cloneable {
         DateFormatSymbols that = (DateFormatSymbols) obj;
         return (Utility.arrayEquals(eras, that.eras)
                 && Utility.arrayEquals(eraNames, that.eraNames)
+                && Utility.arrayEquals(narrowEras, that.narrowEras)
                 && Utility.arrayEquals(months, that.months)
                 && Utility.arrayEquals(shortMonths, that.shortMonths)
                 && Utility.arrayEquals(narrowMonths, that.narrowMonths)

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/IntlTestDateFormatSymbols.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/IntlTestDateFormatSymbols.java
@@ -142,17 +142,32 @@ public class IntlTestDateFormatSymbols extends TestFmwk
         // just do some VERY basic tests to make sure that get/set work
 
         long count;
-        final String[] eras = en.getEras();
-        fr.setEras(eras);
-        final String[] eras1 = fr.getEras();
-        count = eras.length;
-        if( count != eras1.length) {
+        final String[] erasEn = en.getEras();
+        final String[] eraNamesEn = en.getEraNames();
+        final String[] erasNarrowEn = en.getNarrowEras();
+        fr.setEras(erasEn);
+        fr.setNarrowEras(erasNarrowEn);
+        final String[] erasFr = fr.getEras();
+        final String[] erasNarrowFr = fr.getNarrowEras();
+        count = erasEn.length;
+        if( count != erasFr.length || count != erasNarrowFr.length) {
             errln("ERROR: setEras() failed (different size array)");
         }
-        else {
+        else { // like the C++ tests
             for(int i = 0; i < count; i++) {
-                if(! eras[i].equals(eras1[i])) {
+                if(! erasEn[i].equals(erasFr[i])) {
                     errln("ERROR: setEras() failed (different string values)");
+                }
+                if(! erasNarrowEn[i].equals(erasNarrowFr[i])) {
+                    errln("ERROR: setNarrowEras() failed (different string values)");
+                }
+                if( eraNamesEn[i].length() <= erasEn[i].length() ) {
+                    // At least for English we know a wide eraName should be longer than an abbrev era
+                    errln("ERROR: english eraNames[i] not longer than eras[i]");
+                }
+                if( erasNarrowEn[i].length() >= erasEn[i].length() ) {
+                    // At least for English we know a narrowEra should be shorter than an abbrev era
+                    errln("ERROR: english erasNarrow[i] not shorter than eras[i]");
                 }
             }
         }


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-13320
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [x] Documentation is changed or added

Straightforwad addition of getNarrowEras/setNarrowEras to ICU4J DateFormatSymbols (already present in ICU4J DateFormatSymbols), parallel to the ICU4J DateFormatSymbols getters/setters for other era name widths. Note that the narrow eras were already supported in ICU4J DateFormatSymbols data loading and formatting, but I did add a test for them to the the test for object equality.