### PR TITLE
ICU-20388 ICU4C: intltest fails with a Debug Break on MSVC. (uprv_free vs free)

### DIFF
--- a/icu4c/source/test/intltest/numfmtst.cpp
+++ b/icu4c/source/test/intltest/numfmtst.cpp
@@ -2230,8 +2230,8 @@ void NumberFormatTest::TestCurrencyUnit(void){
     assertEquals("Copying from meter should fail", ec, U_ILLEGAL_ARGUMENT_ERROR);
     assertEquals("Copying should not give uninitialized ISO code", u"", failure.getISOCurrency());
 
-    uprv_free(EUR);
-    uprv_free(EUR8);
+    free(EUR);
+    free(EUR8);
 }
 
 void NumberFormatTest::TestCurrencyAmount(void){


### PR DESCRIPTION
Split off from PR #374.
We need to use `free()` with `malloc()` instead of `uprv_free()`, as the heaps can be different.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20388
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

