### PR TITLE
ICU-20393 ICU4C: Scale move assignment operator leaks fArbitrary member.

### DIFF
--- a/icu4c/source/i18n/number_multiplier.cpp
+++ b/icu4c/source/i18n/number_multiplier.cpp
@@ -65,6 +65,9 @@ Scale::Scale(Scale&& src) U_NOEXCEPT
 
 Scale& Scale::operator=(Scale&& src) U_NOEXCEPT {
     fMagnitude = src.fMagnitude;
+    if (fArbitrary != nullptr) {
+        delete fArbitrary;
+    }
     fArbitrary = src.fArbitrary;
     fError = src.fError;
     // Take ownership away from src if necessary


### PR DESCRIPTION
Split off from PR #374.

The move assignment operator leaks the `fArbitrary` member (96 bytes). We need to free the existing data before taking ownership of the moved from data.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20393
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

