### PR TITLE
ICU-20374 Formattable::internalGetCharString to create int string for types kLong, kInt64

### DIFF
--- a/icu4c/source/i18n/fmtable.cpp
+++ b/icu4c/source/i18n/fmtable.cpp
@@ -734,7 +734,8 @@ CharString *Formattable::internalGetCharString(UErrorCode &status) {
       // not print scientific notation for magnitudes greater than -5 and smaller than some amount (+5?).
       if (fDecimalQuantity->isZero()) {
         fDecimalStr->append("0", -1, status);
-      } else if (fDecimalQuantity->getMagnitude() != INT32_MIN && std::abs(fDecimalQuantity->getMagnitude()) < 5) {
+      } else if (fType==kLong || fType==kInt64 || // use toPlainString for integer types
+                  fDecimalQuantity->getMagnitude() != INT32_MIN && std::abs(fDecimalQuantity->getMagnitude()) < 5) {
         fDecimalStr->appendInvariantChars(fDecimalQuantity->toPlainString(), status);
       } else {
         fDecimalStr->appendInvariantChars(fDecimalQuantity->toScientificString(), status);

--- a/icu4c/source/test/cintltst/cnumtst.c
+++ b/icu4c/source/test/cintltst/cnumtst.c
@@ -3166,6 +3166,8 @@ static void TestParseCases(void) {
                     u_errorName(itemPtr->decStatus), itemPtr->decPos, itemPtr->decString,
                     u_errorName(status), parsePos, decstr);
         }
+
+        unum_close(unumDec);
     }
 }
 

--- a/icu4c/source/test/intltest/numfmtst.cpp
+++ b/icu4c/source/test/intltest/numfmtst.cpp
@@ -6770,7 +6770,7 @@ void NumberFormatTest::TestDecimal() {
         ASSERT_EQUALS(1234567890123LL, f.getInt64());
         ASSERT_EQUALS(1234567890123LL, f.getInt64(status));
         ASSERT_SUCCESS(status);
-        ASSERT_EQUALS("1.234567890123E+12", f.getDecimalNumber(status).data());
+        ASSERT_EQUALS("1234567890123", f.getDecimalNumber(status).data());
         ASSERT_SUCCESS(status);
     }
 


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20374
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added: N/A

In ICU 62, Formattable::internalGetCharString switched to generating a string using scientific notation for Formattables whose integer representation would require 6 digits or more. As part of this, the expected result for an existing test was changed (commit cd92fa2c88788780b2572d508f129cddb89c2e36, Wed Apr 11 05:52:58 2018) as follows:
```
-        ASSERT_EQUALS("1234567890123", f.getDecimalNumber(status));
+        ASSERT_EQUALS("1.234567890123E+12", f.getDecimalNumber(status).data());
```

Revert the internalGetCharString  behavior change for Formattables whose internal type is kLong or kInt64, and revert the test change above. Add plain C tests for this and other parse cases.

Note that ICU4J does not have parseDecimal.