### PR TITLE
ICU-20253 ICU4C RelativeDateTimeFormatter to fall back to OTHER case, as in ICU4J

### DIFF
--- a/icu4c/source/i18n/reldatefmt.cpp
+++ b/icu4c/source/i18n/reldatefmt.cpp
@@ -162,13 +162,20 @@ const UnicodeString& RelativeDateTimeCacheData::getAbsoluteUnitString(
         URelativeDateTimeUnit unit,
         int32_t pastFutureIndex,
         int32_t pluralUnit) const {
-    int32_t style = fStyle;
-    do {
-        if (relativeUnitsFormatters[style][unit][pastFutureIndex][pluralUnit] != nullptr) {
-            return relativeUnitsFormatters[style][unit][pastFutureIndex][pluralUnit];
+    while (true) {
+        int32_t style = fStyle;
+        do {
+            if (relativeUnitsFormatters[style][unit][pastFutureIndex][pluralUnit] != nullptr) {
+                return relativeUnitsFormatters[style][unit][pastFutureIndex][pluralUnit];
+            }
+            style = fallBackCache[style];
+        } while (style != -1);
+
+        if (pluralUnit == StandardPlural::OTHER) {
+            break;
         }
-        style = fallBackCache[style];
-    } while (style != -1);
+        pluralUnit = StandardPlural::OTHER;
+    }
     return nullptr;  // No formatter found.
  }
 

--- a/icu4c/source/test/cintltst/crelativedateformattest.c
+++ b/icu4c/source/test/cintltst/crelativedateformattest.c
@@ -138,6 +138,35 @@ static const char* fr_decDef_long_midSent_day[kNumOffsets*2] = {
     "dans 5 jours",         "dans 5 jours"        /*  5   */
 };
 
+static const char* ak_decDef_long_stdAlon_sec[kNumOffsets*2] = { // falls back to root
+/*  text                    numeric */
+    "-5 s",                 "-5 s",               /* -5   */
+    "-2.2 s",               "-2.2 s",             /* -2.2 */
+    "-2 s",                 "-2 s",               /* -2   */
+    "-1 s",                 "-1 s",               /* -1   */
+    "-0.7 s",               "-0.7 s",             /* -0.7 */
+    "now",                  "-0 s",               /*  -0  */
+    "now",                  "+0 s",               /*  0   */
+    "+0.7 s",               "+0.7 s",             /*  0.7 */
+    "+1 s",                 "+1 s",               /*  1   */
+    "+2 s",                 "+2 s",               /*  2   */
+    "+5 s",                 "+5 s",               /*  5   */
+};
+
+static const char* enIN_decDef_short_midSent_weds[kNumOffsets*2] = {
+/*  text                    numeric */
+    "5 Wed. ago",           "5 Wed. ago",         /* -5   */
+    "2.2 Wed. ago",         "2.2 Wed. ago",       /* -2.2 */
+    "2 Wed. ago",           "2 Wed. ago",         /* -2   */
+    "last Wed",             "1 Wed. ago",         /* -1   */
+    "0.7 Wed. ago",         "0.7 Wed. ago",       /* -0.7 */
+    "this Wed",             "0 Wed. ago",         /*  -0  */
+    "this Wed",             "in 0 Wed.",          /*  0   */
+    "in 0.7 Wed.",          "in 0.7 Wed.",        /*  0.7 */
+    "next Wed",             "in 1 Wed",           /*  1   */ // in 1 Wed. missing in logical group
+    "in 2  Wed.",           "in 2 Wed.",          /*  2   */
+    "in 5  Wed.",           "in 5 Wed."           /*  5   */
+};
 
 typedef struct {
     const char*                         locale;
@@ -156,6 +185,8 @@ static const RelDateTimeFormatTestItem fmtTestItems[] = {
     { "en", -1, UDAT_STYLE_LONG,  UDISPCTX_CAPITALIZATION_FOR_MIDDLE_OF_SENTENCE, UDAT_REL_UNIT_MINUTE,  en_decDef_long_midSent_min   },
     { "en", -1, UDAT_STYLE_LONG,  UDISPCTX_CAPITALIZATION_FOR_MIDDLE_OF_SENTENCE, UDAT_REL_UNIT_TUESDAY, en_dec0_long_midSent_tues    },
     { "fr", -1, UDAT_STYLE_LONG,  UDISPCTX_CAPITALIZATION_FOR_MIDDLE_OF_SENTENCE, UDAT_REL_UNIT_DAY,     fr_decDef_long_midSent_day   },
+    { "ak", -1, UDAT_STYLE_LONG,  UDISPCTX_CAPITALIZATION_FOR_STANDALONE,         UDAT_REL_UNIT_SECOND,  ak_decDef_long_stdAlon_sec   },
+    { "en_IN", -1, UDAT_STYLE_SHORT, UDISPCTX_CAPITALIZATION_FOR_MIDDLE_OF_SENTENCE, UDAT_REL_UNIT_WEDNESDAY, enIN_decDef_short_midSent_weds },
     { NULL,  0, (UDateRelativeDateTimeFormatterStyle)0, (UDisplayContext)0, (URelativeDateTimeUnit)0, NULL } /* terminator */
 };
 

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/RelativeDateTimeFormatterTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/RelativeDateTimeFormatterTest.java
@@ -765,6 +765,36 @@ public class RelativeDateTimeFormatterTest extends TestFmwk {
             "dans 5 jours",         "dans 5 jours"        /*  5   */
         };
 
+        String[] ak_decDef_long_stdAlon_sec = { // falls back to root
+        /*  text                    numeric */
+            "-5 s",                 "-5 s",               /* -5   */
+            "-2.2 s",               "-2.2 s",             /* -2.2 */
+            "-2 s",                 "-2 s",               /* -2   */
+            "-1 s",                 "-1 s",               /* -1   */
+            "-0.7 s",               "-0.7 s",             /* -0.7 */
+            "now",                  "-0 s",               /*  -0  */
+            "now",                  "+0 s",               /*  0   */
+            "+0.7 s",               "+0.7 s",             /*  0.7 */
+            "+1 s",                 "+1 s",               /*  1   */
+            "+2 s",                 "+2 s",               /*  2   */
+            "+5 s",                 "+5 s",               /*  5   */
+        };
+
+        String[] enIN_decDef_short_midSent_weds = {
+        /*  text                    numeric */
+            "5 Wed. ago",           "5 Wed. ago",         /* -5   */
+            "2.2 Wed. ago",         "2.2 Wed. ago",       /* -2.2 */
+            "2 Wed. ago",           "2 Wed. ago",         /* -2   */
+            "last Wed",             "1 Wed. ago",         /* -1   */
+            "0.7 Wed. ago",         "0.7 Wed. ago",       /* -0.7 */
+            "this Wed",             "0 Wed. ago",         /*  -0  */
+            "this Wed",             "in 0 Wed.",          /*  0   */
+            "in 0.7 Wed.",          "in 0.7 Wed.",        /*  0.7 */
+            "next Wed",             "in 1 Wed",           /*  1   */ // in 1 Wed. missing in logical group
+            "in 2  Wed.",           "in 2 Wed.",          /*  2   */
+            "in 5  Wed.",           "in 5 Wed."           /*  5   */
+        };
+
         class TestRelativeDateTimeUnitItem {
             public String               localeID;
             public int                  decPlaces; /* fixed decimal places; -1 to use default num formatter */
@@ -797,6 +827,11 @@ public class RelativeDateTimeFormatterTest extends TestFmwk {
                                                                     RelativeDateTimeUnit.TUESDAY, en_dec0_long_midSent_tues),
             new TestRelativeDateTimeUnitItem("fr", -1, Style.LONG,  DisplayContext.CAPITALIZATION_FOR_MIDDLE_OF_SENTENCE,
                                                                     RelativeDateTimeUnit.DAY, fr_decDef_long_midSent_day),
+            new TestRelativeDateTimeUnitItem("ak", -1, Style.LONG,  DisplayContext.CAPITALIZATION_FOR_STANDALONE,
+                                                                    RelativeDateTimeUnit.SECOND, ak_decDef_long_stdAlon_sec),
+            // ICU4J RelativeDateTimeFormatter does not currently support RelativeDateTimeUnit.WEDNESDAY
+            //new TestRelativeDateTimeUnitItem("en_IN", -1, Style.SHORT, DisplayContext.CAPITALIZATION_FOR_MIDDLE_OF_SENTENCE,
+            //                                                        RelativeDateTimeUnit.WEDNESDAY, enIN_decDef_short_midSent_weds),
         };
         for (TestRelativeDateTimeUnitItem item: items) {
             ULocale uloc = new ULocale(item.localeID);


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20253
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added: N/A

I added a test for RelativeDateTimeFormatter using locale "ak" (per the JIRA ticket), which is interesting because it falls back to root which only supports the "other" case. This test initially failed in C but passed in J. I also added a test using en_IN, which has an incomplete logical group in the data for relative Wednesdays (could not add this test in J, it does not support relative Wednesdays).

I then rolled in a slightly modified version of the patch from the ICU-20253 ticket, to make ICU4C data fallback match ICU4J, and this fixed the test failures in C.