### PR TITLE
ICU-20347 In ICU4C, parse empty string should set PARSE_ERROR as before; check ICU4J behavior

### DIFF
--- a/icu4c/source/i18n/decimfmt.cpp
+++ b/icu4c/source/i18n/decimfmt.cpp
@@ -715,6 +715,10 @@ void DecimalFormat::parse(const UnicodeString& text, Formattable& output,
         return;
     }
     if (parsePosition.getIndex() < 0 || parsePosition.getIndex() >= text.length()) {
+        if (parsePosition.getIndex() == text.length()) {
+            // If there is nothing to parse, it is an error
+            parsePosition.setErrorIndex(parsePosition.getIndex());
+        }
         return;
     }
 

--- a/icu4c/source/test/cintltst/cnumtst.c
+++ b/icu4c/source/test/cintltst/cnumtst.c
@@ -3106,6 +3106,8 @@ static const ParseCaseItem parseCaseItems[] = {
     { "en", u"0,000",            TRUE,  FALSE, U_ZERO_ERROR,            5,          0, U_ZERO_ERROR,  5,                0.0, U_ZERO_ERROR,  5, "0" },
     { "en", u"1000,000",         FALSE, FALSE, U_PARSE_ERROR,           0,          0, U_PARSE_ERROR, 0,                0.0, U_PARSE_ERROR, 0, "" },
     { "en", u"1000,000",         TRUE,  FALSE, U_ZERO_ERROR,            8,    1000000, U_ZERO_ERROR,  8,          1000000.0, U_ZERO_ERROR,  8, "1000000" },
+    { "en", u"",                 FALSE, FALSE, U_PARSE_ERROR,           0,          0, U_PARSE_ERROR, 0,                0.0, U_PARSE_ERROR, 0, "" },
+    { "en", u"",                 TRUE,  FALSE, U_PARSE_ERROR,           0,          0, U_PARSE_ERROR, 0,                0.0, U_PARSE_ERROR, 0, "" },
     { "en", u"9999990000503021", FALSE, FALSE, U_INVALID_FORMAT_ERROR, 16, 2147483647, U_ZERO_ERROR, 16, 9999990000503020.0, U_ZERO_ERROR, 16, "9999990000503021" },
     { "en", u"9999990000503021", FALSE, TRUE,  U_INVALID_FORMAT_ERROR, 16, 2147483647, U_ZERO_ERROR, 16, 9999990000503020.0, U_ZERO_ERROR, 16, "9999990000503021" },
     { "en", u"1000000.5",        FALSE, FALSE, U_ZERO_ERROR,            9,    1000000, U_ZERO_ERROR,  9,          1000000.5, U_ZERO_ERROR,  9, "1.0000005E+6"},

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/NumberFormatTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/NumberFormatTest.java
@@ -1738,10 +1738,13 @@ public class NumberFormatTest extends TestFmwk {
         Number value = null;
         try {
             value = numfmt.parse(parsetxt, ppos);
-            // Currently this succeeds (no exception) but returns null (for value).
-            logln("NumberFormat.parse empty string succeeds, ppos " + ppos.getIndex() + ", value " + value);
+            if (value==null) {
+                logln("NumberFormat.parse empty string succeeds (no exception) with null return as expected, ppos " + ppos.getIndex());
+            } else {
+                errln("NumberFormat.parse empty string succeeds (no exception) but returns non-null value " + value + ", ppos " + ppos.getIndex());
+            }
         } catch (IllegalArgumentException e){
-            logln("NumberFormat.parse empty string sets IllegalArgumentException, ppos " + ppos.getIndex() + ", value " + value);
+            errln("NumberFormat.parse empty string throws IllegalArgumentException");
         }
      }
 

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/NumberFormatTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/NumberFormatTest.java
@@ -1731,6 +1731,21 @@ public class NumberFormatTest extends TestFmwk {
     }
 
     @Test
+    public void TestParseEmpty(){
+        String parsetxt = "";
+        NumberFormat numfmt = NumberFormat.getInstance(new ULocale("en_US"), NumberFormat.NUMBERSTYLE);
+        ParsePosition ppos = new ParsePosition(0);
+        Number value = null;
+        try {
+            value = numfmt.parse(parsetxt, ppos);
+            // Currently this succeeds (no exception) but returns null (for value).
+            logln("NumberFormat.parse empty string succeeds, ppos " + ppos.getIndex() + ", value " + value);
+        } catch (IllegalArgumentException e){
+            logln("NumberFormat.parse empty string sets IllegalArgumentException, ppos " + ppos.getIndex() + ", value " + value);
+        }
+     }
+
+    @Test
     public void TestParseNull() throws ParseException {
         DecimalFormat df = new DecimalFormat();
         try {


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20347
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added: N/A

In ICU4C, parsing a 0-length string (in NumberFormat or unum_parse*) should set U_PARSE_ERROR as in ICU 61. In ICU4J, so far I just added a test to check current behavior; parsing a 0-length string (in NumberFormat) just returns null, but does not throw an IllegalArgumentException. Should it? I will adjust the test according to whatever we decide the correct behavior is.