### PR TITLE
ICU-13081 remove C++ moveFrom() functions: still draft, but obsolete …

### DIFF
--- a/icu4c/source/common/cmemory.h
+++ b/icu4c/source/common/cmemory.h
@@ -165,17 +165,6 @@ public:
      * @return *this
      */
     LocalMemory<T> &operator=(LocalMemory<T> &&src) U_NOEXCEPT {
-        return moveFrom(src);
-    }
-    /**
-     * Move assignment, leaves src with isNull().
-     * The behavior is undefined if *this and src are the same object.
-     *
-     * Can be called explicitly, does not need C++11 support.
-     * @param src source smart pointer
-     * @return *this
-     */
-    LocalMemory<T> &moveFrom(LocalMemory<T> &src) U_NOEXCEPT {
         uprv_free(LocalPointerBase<T>::ptr);
         LocalPointerBase<T>::ptr=src.ptr;
         src.ptr=NULL;

--- a/icu4c/source/common/dictbe.cpp
+++ b/icu4c/source/common/dictbe.cpp
@@ -7,6 +7,8 @@
  *******************************************************************************
  */
 
+#include <utility>
+
 #include "unicode/utypes.h"
 
 #if !UCONFIG_NO_BREAK_ITERATION
@@ -1204,8 +1206,8 @@ CjkBreakEngine::divideUpDictionaryRange( UText *inText,
                 inputMap->elementAti(inString.length()) : inString.length()+rangeStart;
         normalizedMap->addElement(nativeEnd, status);
 
-        inputMap.moveFrom(normalizedMap);
-        inString.moveFrom(normalizedInput);
+        inputMap = std::move(normalizedMap);
+        inString = std::move(normalizedInput);
     }
 
     int32_t numCodePts = inString.countChar32();

--- a/icu4c/source/common/unicode/unistr.h
+++ b/icu4c/source/common/unicode/unistr.h
@@ -1900,22 +1900,7 @@ public:
    * @return *this
    * @stable ICU 56
    */
-  UnicodeString &operator=(UnicodeString &&src) U_NOEXCEPT {
-    return moveFrom(src);
-  }
-
-  // do not use #ifndef U_HIDE_DRAFT_API for moveFrom, needed by non-draft API
-  /**
-   * Move assignment; might leave src in bogus state.
-   * This string will have the same contents and state that the source string had.
-   * The behavior is undefined if *this and src are the same object.
-   *
-   * Can be called explicitly, does not need C++11 support.
-   * @param src source string
-   * @return *this
-   * @draft ICU 56
-   */
-  UnicodeString &moveFrom(UnicodeString &src) U_NOEXCEPT;
+  UnicodeString &operator=(UnicodeString &&src) U_NOEXCEPT;
 
   /**
    * Swap strings.

--- a/icu4c/source/common/unistr.cpp
+++ b/icu4c/source/common/unistr.cpp
@@ -309,8 +309,7 @@ UnicodeString::UnicodeString(const UnicodeString& that) {
 }
 
 UnicodeString::UnicodeString(UnicodeString &&src) U_NOEXCEPT {
-  fUnion.fFields.fLengthAndFlags = kShortString;
-  moveFrom(src);
+  copyFieldsFrom(src, TRUE);
 }
 
 UnicodeString::UnicodeString(const UnicodeString& that,
@@ -572,7 +571,7 @@ UnicodeString::copyFrom(const UnicodeString &src, UBool fastCopy) {
   return *this;
 }
 
-UnicodeString &UnicodeString::moveFrom(UnicodeString &src) U_NOEXCEPT {
+UnicodeString &UnicodeString::operator=(UnicodeString &&src) U_NOEXCEPT {
   // No explicit check for self move assignment, consistent with standard library.
   // Self move assignment causes no crash nor leak but might make the object bogus.
   releaseArray();
@@ -580,7 +579,7 @@ UnicodeString &UnicodeString::moveFrom(UnicodeString &src) U_NOEXCEPT {
   return *this;
 }
 
-// Same as moveFrom() except without memory management.
+// Same as move assignment except without memory management.
 void UnicodeString::copyFieldsFrom(UnicodeString &src, UBool setSrcToBogus) U_NOEXCEPT {
   int16_t lengthAndFlags = fUnion.fFields.fLengthAndFlags = src.fUnion.fFields.fLengthAndFlags;
   if(lengthAndFlags & kUsingStackBuffer) {

--- a/icu4c/source/i18n/brktrans.cpp
+++ b/icu4c/source/i18n/brktrans.cpp
@@ -10,6 +10,8 @@
 **********************************************************************
 */
 
+#include <utility>
+
 #include "unicode/utypes.h"
 
 #if  !UCONFIG_NO_TRANSLITERATION && !UCONFIG_NO_BREAK_ITERATION
@@ -79,8 +81,8 @@ void BreakTransliterator::handleTransliterate(Replaceable& text, UTransPosition&
         {
             Mutex m;
             BreakTransliterator *nonConstThis = const_cast<BreakTransliterator *>(this);
-            boundaries.moveFrom(nonConstThis->cachedBoundaries);
-            bi.moveFrom(nonConstThis->cachedBI);
+            boundaries = std::move(nonConstThis->cachedBoundaries);
+            bi = std::move(nonConstThis->cachedBI);
         }
         if (bi.isNull()) {
             bi.adoptInstead(BreakIterator::createWordInstance(Locale::getEnglish(), status));
@@ -145,10 +147,10 @@ void BreakTransliterator::handleTransliterate(Replaceable& text, UTransPosition&
             Mutex m;
             BreakTransliterator *nonConstThis = const_cast<BreakTransliterator *>(this);
             if (nonConstThis->cachedBI.isNull()) {
-                nonConstThis->cachedBI.moveFrom(bi);
+                nonConstThis->cachedBI = std::move(bi);
             }
             if (nonConstThis->cachedBoundaries.isNull()) {
-                nonConstThis->cachedBoundaries.moveFrom(boundaries);
+                nonConstThis->cachedBoundaries = std::move(boundaries);
             }
         }
 

--- a/icu4c/source/i18n/dtfmtsym.cpp
+++ b/icu4c/source/i18n/dtfmtsym.cpp
@@ -21,6 +21,9 @@
 *   10/12/05    emmons      Added setters for eraNames, month/day by width/context
 *******************************************************************************
 */
+
+#include <utility>
+
 #include "unicode/utypes.h"
 
 #if !UCONFIG_NO_FORMATTING
@@ -1663,7 +1666,7 @@ struct CalendarDataSink : public ResourceSink {
 
         // Set the resources to visit on the next calendar
         if (!resourcesToVisitNext.isNull()) {
-            resourcesToVisit.moveFrom(resourcesToVisitNext);
+            resourcesToVisit = std::move(resourcesToVisitNext);
         }
     }
 

--- a/icu4c/source/i18n/erarules.cpp
+++ b/icu4c/source/i18n/erarules.cpp
@@ -1,6 +1,8 @@
 // © 2018 and later: Unicode, Inc. and others.
 // License & terms of use: http://www.unicode.org/copyright.html
 
+#include <utility>
+
 #include "unicode/utypes.h"
 
 #if !UCONFIG_NO_FORMATTING
@@ -101,7 +103,7 @@ static int32_t compareEncodedDateWithYMD(int encoded, int year, int month, int d
 
 EraRules::EraRules(LocalMemory<int32_t>& eraStartDates, int32_t numEras)
     : numEras(numEras) {
-    startDates.moveFrom(eraStartDates);
+    startDates = std::move(eraStartDates);
     initCurrentEra();
 }
 

--- a/icu4c/source/test/intltest/itutil.cpp
+++ b/icu4c/source/test/intltest/itutil.cpp
@@ -6,6 +6,7 @@
  * others. All Rights Reserved.
  ********************************************************************/
 
+#include <utility>
 
 /**
  * IntlTestUtilities is the medium level test class for everything in the directory "utility".
@@ -499,9 +500,9 @@ void LocalPointerTest::TestLocalPointerMoveSwap() {
         errln("swap(LocalPointer) did not swap back");
     }
     LocalPointer<UnicodeString> s3;
-    s3.moveFrom(s1);
+    s3 = std::move(s1);
     if(s3.getAlias() != p1 || s1.isValid()) {
-        errln("LocalPointer.moveFrom() did not move");
+        errln("LocalPointer = std::move() did not move");
     }
     infoln("TestLocalPointerMoveSwap() with rvalue references");
     s1 = static_cast<LocalPointer<UnicodeString> &&>(s3);
@@ -516,8 +517,8 @@ void LocalPointerTest::TestLocalPointerMoveSwap() {
     // Move self assignment leaves the object valid but in an undefined state.
     // Do it to make sure there is no crash,
     // but do not check for any particular resulting value.
-    s1.moveFrom(s1);
-    s3.moveFrom(s3);
+    s1 = std::move(s1);
+    s3 = std::move(s3);
 }
 
 void LocalPointerTest::TestLocalPointerStdUniquePtr() {
@@ -605,9 +606,9 @@ void LocalPointerTest::TestLocalArrayMoveSwap() {
         errln("swap(LocalArray) did not swap back");
     }
     LocalArray<UnicodeString> a3;
-    a3.moveFrom(a1);
+    a3 = std::move(a1);
     if(a3.getAlias() != p1 || a1.isValid()) {
-        errln("LocalArray.moveFrom() did not move");
+        errln("LocalArray = std::move() did not move");
     }
     infoln("TestLocalArrayMoveSwap() with rvalue references");
     a1 = static_cast<LocalArray<UnicodeString> &&>(a3);
@@ -622,8 +623,8 @@ void LocalPointerTest::TestLocalArrayMoveSwap() {
     // Move self assignment leaves the object valid but in an undefined state.
     // Do it to make sure there is no crash,
     // but do not check for any particular resulting value.
-    a1.moveFrom(a1);
-    a3.moveFrom(a3);
+    a1 = std::move(a1);
+    a3 = std::move(a3);
 }
 
 void LocalPointerTest::TestLocalArrayStdUniquePtr() {
@@ -787,9 +788,9 @@ void LocalPointerTest::TestLocalXyzPointerMoveSwap() {
         errln("swap(LocalUNormalizer2Pointer) did not swap back");
     }
     LocalUNormalizer2Pointer f3;
-    f3.moveFrom(f1);
+    f3 = std::move(f1);
     if(f3.getAlias() != p1 || f1.isValid()) {
-        errln("LocalUNormalizer2Pointer.moveFrom() did not move");
+        errln("LocalUNormalizer2Pointer = std::move() did not move");
     }
     infoln("TestLocalXyzPointerMoveSwap() with rvalue references");
     f1 = static_cast<LocalUNormalizer2Pointer &&>(f3);
@@ -803,8 +804,8 @@ void LocalPointerTest::TestLocalXyzPointerMoveSwap() {
     // Move self assignment leaves the object valid but in an undefined state.
     // Do it to make sure there is no crash,
     // but do not check for any particular resulting value.
-    f1.moveFrom(f1);
-    f3.moveFrom(f3);
+    f1 = std::move(f1);
+    f3 = std::move(f3);
 #endif /* !UCONFIG_NO_NORMALIZATION */
 }
 

--- a/icu4c/source/test/intltest/ustrtest.cpp
+++ b/icu4c/source/test/intltest/ustrtest.cpp
@@ -6,6 +6,8 @@
  * others. All Rights Reserved.
  ********************************************************************/
 
+#include <utility>
+
 #include "ustrtest.h"
 #include "unicode/appendable.h"
 #include "unicode/std_string.h"
@@ -2145,19 +2147,19 @@ UnicodeStringTest::TestMoveSwap() {
         errln("swap(UnicodeString) did not swap back");
     }
     UnicodeString s4;
-    s4.moveFrom(s1);
+    s4 = std::move(s1);
     if(s4.getBuffer() != p || s4.length() != 100 || !s1.isBogus()) {
-        errln("UnicodeString.moveFrom(heap) did not move");
+        errln("UnicodeString = std::move(heap) did not move");
     }
     UnicodeString s5;
-    s5.moveFrom(s2);
+    s5 = std::move(s2);
     if(s5 != UNICODE_STRING_SIMPLE("defg")) {
-        errln("UnicodeString.moveFrom(stack) did not move");
+        errln("UnicodeString = std::move(stack) did not move");
     }
     UnicodeString s6;
-    s6.moveFrom(s3);
+    s6 = std::move(s3);
     if(s6.getBuffer() != abc || s6.length() != 3) {
-        errln("UnicodeString.moveFrom(alias) did not move");
+        errln("UnicodeString = std::move(alias) did not move");
     }
     infoln("TestMoveSwap() with rvalue references");
     s1 = static_cast<UnicodeString &&>(s6);
@@ -2172,13 +2174,13 @@ UnicodeStringTest::TestMoveSwap() {
     // Move self assignment leaves the object valid but in an undefined state.
     // Do it to make sure there is no crash,
     // but do not check for any particular resulting value.
-    s1.moveFrom(s1);
-    s2.moveFrom(s2);
-    s3.moveFrom(s3);
-    s4.moveFrom(s4);
-    s5.moveFrom(s5);
-    s6.moveFrom(s6);
-    s7.moveFrom(s7);
+    s1 = std::move(s1);
+    s2 = std::move(s2);
+    s3 = std::move(s3);
+    s4 = std::move(s4);
+    s5 = std::move(s5);
+    s6 = std::move(s6);
+    s7 = std::move(s7);
     // Simple copy assignment must work.
     UnicodeString simple = UNICODE_STRING_SIMPLE("simple");
     s1 = s6 = s4 = s7 = simple;


### PR DESCRIPTION
…since we require C++11 which has std::move()

https://unicode-org.atlassian.net/browse/ICU-13081