### PR TITLE
ICU-20213 deprecate BreakIterator::createTitleInstance()

### DIFF
--- a/icu4c/source/common/unicode/brkiter.h
+++ b/icu4c/source/common/unicode/brkiter.h
@@ -431,12 +431,13 @@ public:
     static BreakIterator* U_EXPORT2
     createSentenceInstance(const Locale& where, UErrorCode& status);
 
+#ifndef U_HIDE_DEPRECATED_API
     /**
      * Create BreakIterator for title-casing breaks using the specified locale
      * Returns an instance of a BreakIterator implementing title breaks.
      * The iterator returned locates title boundaries as described for
      * Unicode 3.2 only. For Unicode 4.0 and above title boundary iteration,
-     * please use Word Boundary iterator.{@link #createWordInstance }
+     * please use a word boundary iterator. See {@link #createWordInstance }.
      *
      * @param where the locale.
      * @param status The error code.
@@ -451,10 +452,11 @@ public:
      * used; neither the requested locale nor any of its fall back locales
      * could be found.
      * The caller owns the returned object and is responsible for deleting it.
-     * @stable ICU 2.1
+     * @deprecated ICU 64 Use createWordInstance instead.
      */
     static BreakIterator* U_EXPORT2
     createTitleInstance(const Locale& where, UErrorCode& status);
+#endif /* U_HIDE_DEPRECATED_API */
 
     /**
      * Get the set of Locales for which TextBoundaries are installed.

--- a/icu4j/main/classes/core/src/com/ibm/icu/text/BreakIterator.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/BreakIterator.java
@@ -576,8 +576,11 @@ public abstract class BreakIterator implements Cloneable
     public static final int KIND_SENTENCE = 3;
     /**
      * {@icu}
-     * @stable ICU 2.4
+     * @see #getTitleInstance
+     * @see #getWordInstance
+     * @deprecated ICU 64 Use {@link #getWordInstance} instead.
      */
+    @Deprecated
     public static final int KIND_TITLE = 4;
 
     /**
@@ -750,8 +753,9 @@ public abstract class BreakIterator implements Cloneable
      * Unicode 3.2 only. For Unicode 4.0 and above title boundary iteration,
      * please use a word boundary iterator. {@link #getWordInstance}
      * @return A new instance of BreakIterator that locates title boundaries.
-     * @stable ICU 2.0
+     * @deprecated ICU 64 Use {@link #getWordInstance} instead.
      */
+    @Deprecated
     public static BreakIterator getTitleInstance()
     {
         return getTitleInstance(ULocale.getDefault());
@@ -765,8 +769,9 @@ public abstract class BreakIterator implements Cloneable
      * @param where A Locale specifying the language of the text being analyzed.
      * @return A new instance of BreakIterator that locates title boundaries.
      * @throws NullPointerException if <code>where</code> is null.
-     * @stable ICU 2.0
+     * @deprecated ICU 64 Use {@link #getWordInstance} instead.
      */
+    @Deprecated
     public static BreakIterator getTitleInstance(Locale where)
     {
         return getBreakInstance(ULocale.forLocale(where), KIND_TITLE);
@@ -780,8 +785,9 @@ public abstract class BreakIterator implements Cloneable
      * @param where A Locale specifying the language of the text being analyzed.
      * @return A new instance of BreakIterator that locates title boundaries.
      * @throws NullPointerException if <code>where</code> is null.
-     * @stable ICU 3.2
-s     */
+     * @deprecated ICU 64 Use {@link #getWordInstance} instead.
+     */
+    @Deprecated
     public static BreakIterator getTitleInstance(ULocale where)
     {
         return getBreakInstance(where, KIND_TITLE);


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-20213