### PR TITLE
ICU-13081 test self-move without clang warning

### DIFF
--- a/icu4c/source/test/intltest/itutil.cpp
+++ b/icu4c/source/test/intltest/itutil.cpp
@@ -486,6 +486,12 @@ void LocalPointerTest::TestLocalPointer() {
     // destructor
 }
 
+// Try to avoid clang -Wself-move warnings from s1 = std::move(s1);
+template<typename T>
+void moveFrom(T &dest, T &src) {
+    dest = std::move(src);
+}
+
 void LocalPointerTest::TestLocalPointerMoveSwap() {
     UnicodeString *p1 = new UnicodeString((UChar)0x61);
     UnicodeString *p2 = new UnicodeString((UChar)0x62);
@@ -517,8 +523,8 @@ void LocalPointerTest::TestLocalPointerMoveSwap() {
     // Move self assignment leaves the object valid but in an undefined state.
     // Do it to make sure there is no crash,
     // but do not check for any particular resulting value.
-    s1 = std::move(s1);
-    s3 = std::move(s3);
+    moveFrom(s1, s1);
+    moveFrom(s3, s3);
 }
 
 void LocalPointerTest::TestLocalPointerStdUniquePtr() {
@@ -623,8 +629,8 @@ void LocalPointerTest::TestLocalArrayMoveSwap() {
     // Move self assignment leaves the object valid but in an undefined state.
     // Do it to make sure there is no crash,
     // but do not check for any particular resulting value.
-    a1 = std::move(a1);
-    a3 = std::move(a3);
+    moveFrom(a1, a1);
+    moveFrom(a3, a3);
 }
 
 void LocalPointerTest::TestLocalArrayStdUniquePtr() {
@@ -804,8 +810,8 @@ void LocalPointerTest::TestLocalXyzPointerMoveSwap() {
     // Move self assignment leaves the object valid but in an undefined state.
     // Do it to make sure there is no crash,
     // but do not check for any particular resulting value.
-    f1 = std::move(f1);
-    f3 = std::move(f3);
+    moveFrom(f1, f1);
+    moveFrom(f3, f3);
 #endif /* !UCONFIG_NO_NORMALIZATION */
 }
 

--- a/icu4c/source/test/intltest/ustrtest.cpp
+++ b/icu4c/source/test/intltest/ustrtest.cpp
@@ -2131,6 +2131,11 @@ UnicodeStringTest::TestSizeofUnicodeString() {
     }
 }
 
+// Try to avoid clang -Wself-move warnings from s1 = std::move(s1);
+void moveFrom(UnicodeString &dest, UnicodeString &src) {
+    dest = std::move(src);
+}
+
 void
 UnicodeStringTest::TestMoveSwap() {
     static const UChar abc[3] = { 0x61, 0x62, 0x63 };  // "abc"
@@ -2174,13 +2179,13 @@ UnicodeStringTest::TestMoveSwap() {
     // Move self assignment leaves the object valid but in an undefined state.
     // Do it to make sure there is no crash,
     // but do not check for any particular resulting value.
-    s1 = std::move(s1);
-    s2 = std::move(s2);
-    s3 = std::move(s3);
-    s4 = std::move(s4);
-    s5 = std::move(s5);
-    s6 = std::move(s6);
-    s7 = std::move(s7);
+    moveFrom(s1, s1);
+    moveFrom(s2, s2);
+    moveFrom(s3, s3);
+    moveFrom(s4, s4);
+    moveFrom(s5, s5);
+    moveFrom(s6, s6);
+    moveFrom(s7, s7);
     // Simple copy assignment must work.
     UnicodeString simple = UNICODE_STRING_SIMPLE("simple");
     s1 = s6 = s4 = s7 = simple;


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-13081