### PR TITLE
ICU-20306 Remove incorrect #ifndef U_HIDE_INTERNAL_API around UTEXT_MAGIC

### DIFF
--- a/icu4c/source/common/unicode/utext.h
+++ b/icu4c/source/common/unicode/utext.h
@@ -1555,7 +1555,7 @@ struct UText {
 U_STABLE UText * U_EXPORT2
 utext_setup(UText *ut, int32_t extraSpace, UErrorCode *status);
 
-#ifndef U_HIDE_INTERNAL_API
+// do not use #ifndef U_HIDE_INTERNAL_API around the following!
 /**
   * @internal
   *  Value used to help identify correctly initialized UText structs.
@@ -1564,7 +1564,6 @@ utext_setup(UText *ut, int32_t extraSpace, UErrorCode *status);
 enum {
     UTEXT_MAGIC = 0x345ad82c
 };
-#endif  /* U_HIDE_INTERNAL_API */
 
 /**
  * initializer to be used with local (stack) instances of a UText


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20306
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included: N/A for functionality, but filed ticket to enhance BRS tests
- [ ] Documentation is changed or added: N/A

Removed incorrect #ifndef U_HIDE_INTERNAL_API around UTEXT_MAGIC (been there since 2011!), which is needed for public UTEXT_INITIALIZER.