### PR TITLE
ICU-20389 Add MSVC Debug build to the Azure CI builds.

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -59,9 +59,9 @@ jobs:
         filename: icu4c/source/allinone/icucheck.bat
         arguments: 'x64 Release'
 #-------------------------------------------------------------------------
-- job: ICU4C_MSVC_x86_Release
-  displayName: 'C: MSVC 32-bit Release (VS 2017)'
-  timeoutInMinutes: 30
+- job: ICU4C_MSVC_x86_Debug
+  displayName: 'C: MSVC 32-bit Debug (VS 2017)'
+  timeoutInMinutes: 45
   pool:
     vmImage: 'vs2017-win2016'
     demands: 
@@ -74,12 +74,12 @@ jobs:
       inputs:
         solution: icu4c/source/allinone/allinone.sln
         platform: Win32
-        configuration: Release
+        configuration: Debug
     - task: BatchScript@1
       displayName: 'Run Tests (icucheck.bat)'
       inputs:
         filename: icu4c/source/allinone/icucheck.bat
-        arguments: 'x86 Release'
+        arguments: 'x86 Debug'
 #-------------------------------------------------------------------------
 # Using a manual install of Python 3, until the vs2015 image has it 
 # by default.


### PR DESCRIPTION
In order to catch issues like [ICU-20388](https://unicode-org.atlassian.net/browse/ICU-20388), this replaces the 32-bit Release build with a 32-bit "Debug" build instead (for the Azure Pipelines CI builds).

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20389
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

