### PR TITLE
ICU-13731 Adding test for default currency symbol.

### DIFF
--- a/icu4c/source/test/intltest/numfmtst.cpp
+++ b/icu4c/source/test/intltest/numfmtst.cpp
@@ -227,6 +227,7 @@ void NumberFormatTest::runIndexedTest( int32_t index, UBool exec, const char* &n
   TESTCASE_AUTO(Test13850_EmptyStringCurrency);
   TESTCASE_AUTO(Test20348_CurrencyPrefixOverride);
   TESTCASE_AUTO(Test20358_GroupingInPattern);
+  TESTCASE_AUTO(Test13731_DefaultCurrency);
   TESTCASE_AUTO_END;
 }
 
@@ -9515,6 +9516,32 @@ void NumberFormatTest::Test20358_GroupingInPattern() {
         fmt->isGroupingUsed());
     assertEquals("Set grouping true format",
         u"54,321", fmt->format(54321, result.remove(), NULL, status));
+}
+
+void NumberFormatTest::Test13731_DefaultCurrency() {
+    IcuTestErrorCode status(*this, "Test13731_DefaultCurrency");
+    UnicodeString result;
+    {
+        LocalPointer<NumberFormat> nf(NumberFormat::createInstance(
+            "en", UNumberFormatStyle::UNUM_CURRENCY, status), status);
+        assertEquals("symbol", u"¤1.10",
+            nf->format(1.1, result.remove(), status));
+        assertEquals("currency", u"XXX", nf->getCurrency());
+    }
+    {
+        LocalPointer<NumberFormat> nf(NumberFormat::createInstance(
+            "en", UNumberFormatStyle::UNUM_CURRENCY_ISO, status), status);
+        assertEquals("iso_code", u"XXX 1.10",
+            nf->format(1.1, result.remove(), status));
+        assertEquals("currency", u"XXX", nf->getCurrency());
+    }
+    {
+        LocalPointer<NumberFormat> nf(NumberFormat::createInstance(
+            "en", UNumberFormatStyle::UNUM_CURRENCY_PLURAL, status), status);
+        assertEquals("plural", u"1.10 (unknown currency)",
+            nf->format(1.1, result.remove(), status));
+        assertEquals("currency", u"XXX", nf->getCurrency());
+    }
 }
 
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/test/intltest/numfmtst.h
+++ b/icu4c/source/test/intltest/numfmtst.h
@@ -292,6 +292,7 @@ class NumberFormatTest: public CalendarTimeZoneTest {
     void Test13850_EmptyStringCurrency();
     void Test20348_CurrencyPrefixOverride();
     void Test20358_GroupingInPattern();
+    void Test13731_DefaultCurrency();
 
  private:
     UBool testFormattableAsUFormattable(const char *file, int line, Formattable &f);

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/NumberFormatTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/NumberFormatTest.java
@@ -6451,4 +6451,23 @@ public class NumberFormatTest extends TestFmwk {
         assertEquals("Set grouping true format",
             "54,321", fmt.format(54321));
     }
+
+    @Test
+    public void test13731_DefaultCurrency() {
+        {
+            NumberFormat nf = NumberFormat.getInstance(ULocale.ENGLISH, NumberFormat.CURRENCYSTYLE);
+            assertEquals("symbol", "¤1.10", nf.format(1.1));
+            assertEquals("currency", "XXX", nf.getCurrency().getCurrencyCode());
+        }
+        {
+            NumberFormat nf = NumberFormat.getInstance(ULocale.ENGLISH, NumberFormat.ISOCURRENCYSTYLE);
+            assertEquals("iso_code", "XXX 1.10", nf.format(1.1));
+            assertEquals("currency", "XXX", nf.getCurrency().getCurrencyCode());
+        }
+        {
+            NumberFormat nf = NumberFormat.getInstance(ULocale.ENGLISH, NumberFormat.PLURALCURRENCYSTYLE);
+            assertEquals("plural", "1.10 (unknown currency)", nf.format(1.1));
+            assertEquals("currency", "XXX", nf.getCurrency().getCurrencyCode());
+        }
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-13731
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

