### PR TITLE
ICU-20413 OOM not handled in initStaticTimeZones() in timezone.cpp

### DIFF
--- a/icu4c/source/test/intltest/tztest.cpp
+++ b/icu4c/source/test/intltest/tztest.cpp
@@ -72,6 +72,7 @@ void TimeZoneTest::runIndexedTest( int32_t index, UBool exec, const char* &name,
     TESTCASE_AUTO(TestGetRegion);
     TESTCASE_AUTO(TestGetAvailableIDsNew);
     TESTCASE_AUTO(TestGetUnknown);
+    TESTCASE_AUTO(TestGetGMT);
     TESTCASE_AUTO(TestGetWindowsID);
     TESTCASE_AUTO(TestGetIDForWindowsID);
     TESTCASE_AUTO_END;
@@ -2418,6 +2419,15 @@ void TimeZoneTest::TestGetUnknown() {
     assertEquals("getUnknown() wrong ID", expectedID, unknown.getID(id));
     assertTrue("getUnknown() wrong offset", 0 == unknown.getRawOffset());
     assertFalse("getUnknown() uses DST", unknown.useDaylightTime());
+}
+
+void TimeZoneTest::TestGetGMT() {
+    const TimeZone *gmt = TimeZone::getGMT();
+    UnicodeString expectedID = UNICODE_STRING_SIMPLE("GMT");
+    UnicodeString id;
+    assertEquals("getGMT() wrong ID", expectedID, gmt->getID(id));
+    assertTrue("getGMT() wrong offset", 0 == gmt->getRawOffset());
+    assertFalse("getGMT() uses DST", gmt->useDaylightTime());
 }
 
 void TimeZoneTest::TestGetWindowsID(void) {

--- a/icu4c/source/test/intltest/tztest.h
+++ b/icu4c/source/test/intltest/tztest.h
@@ -99,6 +99,7 @@ public:
 
     void TestGetRegion(void);
     void TestGetUnknown();
+    void TestGetGMT();
 
     void TestGetWindowsID(void);
     void TestGetIDForWindowsID(void);


### PR DESCRIPTION
We can use static allocated memory and placement new to avoid OOM failures for the GMT and Unknown time zones.

Note: This approach is already used in `static_unicode_sets.cpp` and `number_decimfmtprops.cpp`, so this isn't introducing any new features/dependencies with the use of `alignas` or placement new.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20413
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

