### PR TITLE
ICU-20434 AppVeyor CI builds failing on Cygwin 3.0.0. Use Cygwin 2.11 for now

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,32 +4,43 @@ image: Visual Studio 2017
 platform: x64
 
 # Don't clone the entire repo.
-clone_depth: 3
+clone_depth: 1
 
 # Cache things between builds to speed things up and save bandwidth.
 cache:
   - c:\icu-ci-cache
 
+# Notes:
+#  - The VS2017 build is disabled (commented out) below, as we build both VS2015 and VS2017
+#    on Azure Pipelines instead, since that is much faster.
+#
+#  - For the Cygwin build, the CYG_MIRROR URL below is from the "Cygwin Time Machine" archive,
+#    and that URL maps to the 64-bit version of Cygwin 2.11.2-1 (with timestamp 1550062412).
+#    This was the last release of Cygwin 2.11 before version 3.0.0 was released.
+#    See: http://www.crouchingtigerhiddenfruitbat.org/Cygwin/timemachine.html
+#
+#    Note: The archived Cygwin repo does not keep or retain any file signature files, so we
+#    must use the "-X" or "--no-verify" option below in the setup command.
+
 environment:
   global:
     ICU_CI_CACHE: c:\icu-ci-cache
     CYG_URL: https://cygwin.com/setup-x86_64.exe
-    CYG_MIRROR: http://cygwin.mirror.constant.com
+    CYG_MIRROR: http://ctm.crouchingtigerhiddenfruitbat.org/pub/cygwin/circa/64bit/2019/02/13/045332
     CYG_PACKAGES: automake,gcc-core,gcc-g++,make,pkg-config,perl,python3
     CYG_ROOT: c:\cygwin-root
     CYG_CACHE: '%ICU_CI_CACHE%\cygwin64'
     CYG_CACHED_SETUP: '%CYG_CACHE%\setup.exe'
 
   matrix:
-    - BUILDSYSTEM: VS2017
-      configuration: Release
-      APPVEYOR_CACHE_SKIP_RESTORE: true
-      APPVEYOR_CACHE_SKIP_SAVE: true
-
     - BUILDSYSTEM: cygwin64-gcc
       CC: gcc
       CXX: g++
       APPVEYOR_SAVE_CACHE_ON_ERROR: true
+#    - BUILDSYSTEM: VS2017
+#      configuration: Release
+#      APPVEYOR_CACHE_SKIP_RESTORE: true
+#      APPVEYOR_CACHE_SKIP_SAVE: true
 
 for:
   -
@@ -46,7 +57,7 @@ for:
             Invoke-WebRequest $env:CYG_URL -OutFile $env:CYG_CACHED_SETUP
           }
       - cmd: >-
-          %CYG_CACHED_SETUP% --quiet-mode --no-shortcuts --no-startmenu --no-desktop --upgrade-also --only-site --site "%CYG_MIRROR%" --root "%CYG_ROOT%"  --local-package-dir "%CYG_CACHE%" --packages "%CYG_PACKAGES%"
+          %CYG_CACHED_SETUP% --no-verify --quiet-mode --no-shortcuts --no-startmenu --no-desktop --upgrade-also --only-site --site "%CYG_MIRROR%" --root "%CYG_ROOT%"  --local-package-dir "%CYG_CACHE%" --packages "%CYG_PACKAGES%"
 
     # Check that we have a working Cygwin environment before building.
     before_build:
@@ -56,13 +67,13 @@ for:
     build_script:
       - '%CYG_ROOT%\\bin\\bash -lc "cd $(cygpath ${APPVEYOR_BUILD_FOLDER}) && cd icu4c/source && ./runConfigureICU Cygwin && make check"'
 
-  -
-    matrix:
-      only:
-        - BUILDSYSTEM: VS2017
-
-    build:
-      project: icu4c/source/allinone/allinone.sln
-
-    test_script:
-      - icu4c/source/allinone/icucheck.bat x64 Release
+#  -
+#    matrix:
+#      only:
+#        - BUILDSYSTEM: VS2017
+#
+#    build:
+#      project: icu4c/source/allinone/allinone.sln
+#
+#    test_script:
+#      - icu4c/source/allinone/icucheck.bat x64 Release


### PR DESCRIPTION
[Cygwin 3.0.0](https://cygwin.com/ml/cygwin-announce/2019-02/msg00010.html) was released on Saturday, Feb. 16, 2019 -- and now the AppVeyor CI builds for ICU4C are failing. (Previously, the AppVeyor builds used Cygwin 2.11.2.)

From the build output, it looks like `pkgdata` is failing with the following error:
`Assembly type "-a gcc-mingw64" is unknown.`

This change forces AppVeyor to use the Cygwin 2.11 release (for now) until we can further investigate the build failure on Cygwin 3.0.0

Additionally, this change removes the redundant VS2017 build from AppVeyor, since we have Azure Pipelines for VS, and also limits the git clone depth to 1 -- both in an effort to speed up the already quite slow AppVeyor CI builds.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20434
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

