### PR TITLE
ICU-20419 Export internal StackUResourceBundle helper, so can be used in i18n library.

### DIFF
--- a/icu4c/source/common/uresimp.h
+++ b/icu4c/source/common/uresimp.h
@@ -106,7 +106,7 @@ U_NAMESPACE_BEGIN
  * @see LocalUResourceBundlePointer
  * @internal
  */
-class StackUResourceBundle {
+class U_COMMON_API StackUResourceBundle {
 public:
     // No heap allocation. Use only on the stack.
     static void* U_EXPORT2 operator new(size_t) U_NO_THROW = delete;
@@ -119,6 +119,9 @@ public:
     ~StackUResourceBundle();
 
     UResourceBundle* getAlias() { return &bundle; }
+
+    UResourceBundle& ref() { return bundle; }
+    const UResourceBundle& ref() const { return bundle; }
 
     StackUResourceBundle(const StackUResourceBundle&) = delete;
     StackUResourceBundle& operator=(const StackUResourceBundle&) = delete;

--- a/icu4c/source/common/wintz.cpp
+++ b/icu4c/source/common/wintz.cpp
@@ -86,19 +86,18 @@ uprv_detectWindowsTimeZone()
     }
 
     if (dynamicTZI.TimeZoneKeyName[0] != 0) {
-        UResourceBundle winTZ;
-        ures_initStackObject(&winTZ);
-        ures_getByKey(bundle.getAlias(), dynamicTZKeyName, &winTZ, &status);
-        
+        StackUResourceBundle winTZ;
+        ures_getByKey(bundle.getAlias(), dynamicTZKeyName, winTZ.getAlias(), &status);
+
         if (U_SUCCESS(status)) {
             const UChar* icuTZ = nullptr;
             if (errorCode != 0) {
-                icuTZ = ures_getStringByKey(&winTZ, ISOcode, &len, &status);
+                icuTZ = ures_getStringByKey(winTZ.getAlias(), ISOcode, &len, &status);
             }
             if (errorCode == 0 || icuTZ == nullptr) {
                 /* fallback to default "001" and reset status */
                 status = U_ZERO_ERROR;
-                icuTZ = ures_getStringByKey(&winTZ, "001", &len, &status);
+                icuTZ = ures_getStringByKey(winTZ.getAlias(), "001", &len, &status);
             }
 
             if (U_SUCCESS(status)) {
@@ -111,7 +110,6 @@ uprv_detectWindowsTimeZone()
                 tmpid[index] = '\0';
             }
         }
-        ures_close(&winTZ);
     }
 
     // Copy the timezone ID to icuid to be returned.

--- a/icu4c/source/i18n/coll.cpp
+++ b/icu4c/source/i18n/coll.cpp
@@ -226,27 +226,25 @@ initAvailableLocaleList(UErrorCode &status) {
     U_ASSERT(availableLocaleList == NULL);
     // for now, there is a hardcoded list, so just walk through that list and set it up.
     UResourceBundle *index = NULL;
-    UResourceBundle installed;
+    StackUResourceBundle installed;
     int32_t i = 0;
     
-    ures_initStackObject(&installed);
     index = ures_openDirect(U_ICUDATA_COLL, "res_index", &status);
-    ures_getByKey(index, "InstalledLocales", &installed, &status);
-    
+    ures_getByKey(index, "InstalledLocales", installed.getAlias(), &status);
+
     if(U_SUCCESS(status)) {
-        availableLocaleListCount = ures_getSize(&installed);
+        availableLocaleListCount = ures_getSize(installed.getAlias());
         availableLocaleList = new Locale[availableLocaleListCount];
         
         if (availableLocaleList != NULL) {
-            ures_resetIterator(&installed);
-            while(ures_hasNext(&installed)) {
+            ures_resetIterator(installed.getAlias());
+            while(ures_hasNext(installed.getAlias())) {
                 const char *tempKey = NULL;
-                ures_getNextString(&installed, NULL, &tempKey, &status);
+                ures_getNextString(installed.getAlias(), NULL, &tempKey, &status);
                 availableLocaleList[i++] = Locale(tempKey);
             }
         }
         U_ASSERT(availableLocaleListCount == i);
-        ures_close(&installed);
     }
     ures_close(index);
     ucln_i18n_registerCleanup(UCLN_I18N_COLLATOR, collator_cleanup);

--- a/icu4c/source/i18n/zonemeta.cpp
+++ b/icu4c/source/i18n/zonemeta.cpp
@@ -784,14 +784,13 @@ static void U_CALLCONV initAvailableMetaZoneIDs () {
 
     UResourceBundle *rb = ures_openDirect(NULL, gMetaZones, &status);
     UResourceBundle *bundle = ures_getByKey(rb, gMapTimezonesTag, NULL, &status);
-    UResourceBundle res;
-    ures_initStackObject(&res);
+    StackUResourceBundle res;
     while (U_SUCCESS(status) && ures_hasNext(bundle)) {
-        ures_getNextResource(bundle, &res, &status);
+        ures_getNextResource(bundle, res.getAlias(), &status);
         if (U_FAILURE(status)) {
             break;
         }
-        const char *mzID = ures_getKey(&res);
+        const char *mzID = ures_getKey(res.getAlias());
         int32_t len = static_cast<int32_t>(uprv_strlen(mzID));
         UChar *uMzID = (UChar*)uprv_malloc(sizeof(UChar) * (len + 1));
         if (uMzID == NULL) {
@@ -809,7 +808,6 @@ static void U_CALLCONV initAvailableMetaZoneIDs () {
             delete usMzID;
         }
     }
-    ures_close(&res);
     ures_close(bundle);
     ures_close(rb);
 


### PR DESCRIPTION
[ICU-20249](https://unicode-org.atlassian.net/browse/ICU-20249) added a nice internal RAII helper class for stack allocated `UResourceBundle` objects to the common library.

However, the class is not marked for export, meaning that the class currently cannot be used in the i18n library without getting LINK errors on MSVC.

This change exports the class (with `U_COMMON_API`), and then replaces all current usages of `ures_initStackObject()` in the i18n library with the `StackUResourceBundle` helper class.

(Aside: Another possible alternative would have been to move the constructor/destructor implementation from `uresbund.cpp` file into to the header file `uresimp.h`, making the class "header-only" similar to the `LocalPointer` class.)

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20419
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

