### PR TITLE
ICU-12902 make getInstanceForSkeleton use correct calendar; don't capitalize empty field

### DIFF
--- a/icu4c/source/i18n/datefmt.cpp
+++ b/icu4c/source/i18n/datefmt.cpp
@@ -460,7 +460,12 @@ DateFormat::createInstanceForSkeleton(
         status = U_ILLEGAL_ARGUMENT_ERROR;
         return NULL;
     }
-    DateFormat *result = createInstanceForSkeleton(skeleton, locale, status);
+    Locale localeWithCalendar = locale;
+    localeWithCalendar.setKeywordValue("calendar", calendar->getType(), status);
+    if (U_FAILURE(status)) {
+        return NULL;
+    }
+    DateFormat *result = createInstanceForSkeleton(skeleton, localeWithCalendar, status);
     if (U_FAILURE(status)) {
         return NULL;
     }

--- a/icu4c/source/i18n/smpdtfmt.cpp
+++ b/icu4c/source/i18n/smpdtfmt.cpp
@@ -1950,7 +1950,8 @@ SimpleDateFormat::subFormat(UnicodeString &appendTo,
     }
 #if !UCONFIG_NO_BREAK_ITERATION
     // if first field, check to see whether we need to and are able to titlecase it
-    if (fieldNum == 0 && u_islower(appendTo.char32At(beginOffset)) && fCapitalizationBrkIter != NULL) {
+    if (fieldNum == 0 && fCapitalizationBrkIter != NULL && appendTo.length() > beginOffset &&
+            u_islower(appendTo.char32At(beginOffset))) {
         UBool titlecase = FALSE;
         switch (capitalizationContext) {
             case UDISPCTX_CAPITALIZATION_FOR_BEGINNING_OF_SENTENCE:

--- a/icu4c/source/test/intltest/dtfmrgts.h
+++ b/icu4c/source/test/intltest/dtfmrgts.h
@@ -55,6 +55,7 @@ public:
     void Test5554(void);
     void Test9237(void);
     void TestParsing(void);
+    void Test12902_yWithGregoCalInThaiLoc(void);
     void TestT10334(void);
     void TestT10619(void);
     void TestT10855(void);

--- a/icu4j/main/classes/core/src/com/ibm/icu/text/DateFormat.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/DateFormat.java
@@ -2170,6 +2170,9 @@ public abstract class DateFormat extends UFormat {
      */
     public final static DateFormat getInstanceForSkeleton(
         Calendar cal, String skeleton, ULocale locale) {
+        if (cal != null) {
+            locale = locale.setKeywordValue("calendar", cal.getType());
+        }
         DateTimePatternGenerator generator = DateTimePatternGenerator.getInstance(locale);
         final String bestPattern = generator.getBestPattern(skeleton);
         SimpleDateFormat format = new SimpleDateFormat(bestPattern, locale);

--- a/icu4j/main/classes/core/src/com/ibm/icu/text/SimpleDateFormat.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/SimpleDateFormat.java
@@ -2041,7 +2041,8 @@ public class SimpleDateFormat extends DateFormat {
             break;
         } // switch (patternCharIndex)
 
-        if (fieldNum == 0 && capitalizationContext != null && UCharacter.isLowerCase(buf.codePointAt(bufstart))) {
+        if (fieldNum == 0 && capitalizationContext != null && buf.length() > bufstart &&
+                UCharacter.isLowerCase(buf.codePointAt(bufstart))) {
             boolean titlecase = false;
             switch (capitalizationContext) {
                 case CAPITALIZATION_FOR_BEGINNING_OF_SENTENCE:

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/DateFormatRegressionTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/DateFormatRegressionTest.java
@@ -1239,6 +1239,38 @@ public class DateFormatRegressionTest extends TestFmwk {
     }
 
     @Test
+    public void Test12902_yWithGregoCalInThaiLoc() {
+        final Date testDate = new Date(43200000); // 1970-Jan-01 12:00 GMT
+        final String skeleton = "y";
+        // Note that in locale "th", the availableFormats for skeleton "y" differ by calendar:
+        // for buddhist (default calendar): y{"G y"}
+        // for gregorian: y{"y"}
+        final String expectFormat = "1970"; // format for skeleton y in Thai locale with Gregorian calendar
+
+        GregorianCalendar pureGregorianCalendar = new GregorianCalendar(TimeZone.GMT_ZONE, ULocale.ENGLISH);
+        pureGregorianCalendar.setGregorianChange(new Date(Long.MIN_VALUE)); // Per original bug, but not relevant
+        DateFormat df1 = DateFormat.getPatternInstance(pureGregorianCalendar, skeleton, ULocale.forLanguageTag("th"));
+        try {
+            String getFormat = df1.format(testDate);
+            if (!getFormat.equals(expectFormat)) {
+                errln("Error in DateFormat.format for th with Grego cal, expect: " + expectFormat + ", get: " + getFormat);
+            }
+        } catch (Exception e) {
+            errln("Fail in DateFormat.format for th with Grego cal: " + e);
+        }
+
+        DateFormat df2 = DateFormat.getPatternInstance(skeleton, new ULocale("th-u-ca-gregory"));
+        try {
+            String getFormat = df2.format(testDate);
+            if (!getFormat.equals(expectFormat)) {
+                errln("Error in DateFormat.format for th-u-ca-gregory, expect: " + expectFormat + ", get: " + getFormat);
+            }
+        } catch (Exception e) {
+            errln("Fail in DateFormat.format for th-u-ca-gregory: " + e);
+        }
+    }
+
+    @Test
     public void TestT10110() {
         try {
             SimpleDateFormat formatter = new SimpleDateFormat("Gy年M月d日E", new Locale("zh_Hans"));


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-12902
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added: N/A

Now createInstanceForSkeleton/getInstanceForSkeleton get the type for any passed-in Calendar, and add calendar keyword with that type (or replace an existing one) in the Locale it passes to [Simple]DateFormat.

Also, in DateFormat.subFormat, do not try to capitalize the first field if it is empty.