### PR TITLE
ICU-20273 Resolve inconsistent behavior of "root", "und", "" in locales

### DIFF
--- a/icu4c/source/common/locdispnames.cpp
+++ b/icu4c/source/common/locdispnames.cpp
@@ -26,6 +26,7 @@
 #include "unicode/uloc.h"
 #include "unicode/ures.h"
 #include "unicode/ustring.h"
+#include "charstr.h"
 #include "cmemory.h"
 #include "cstring.h"
 #include "putilimp.h"
@@ -504,6 +505,22 @@ uloc_getDisplayName(const char *locale,
     if(destCapacity<0 || (destCapacity>0 && dest==NULL)) {
         *pErrorCode=U_ILLEGAL_ARGUMENT_ERROR;
         return 0;
+    }
+
+    // For the display name, we treat this as unknown language (ICU-20273).
+    static const char UND[] = "und";
+    CharString und;
+    if (locale != NULL) {
+        if (*locale == '\0') {
+            locale = UND;
+        } else if (*locale == '_') {
+            und.append(UND, *pErrorCode);
+            und.append(locale, *pErrorCode);
+            if (U_FAILURE(*pErrorCode)) {
+                return 0;
+            }
+            locale = und.data();
+        }
     }
 
     {

--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -626,6 +626,19 @@ Locale& Locale::init(const char* localeID, UBool canonicalize)
             variantBegin = (int32_t)(field[variantField] - fullName);
         }
 
+        if (length == 4 && uprv_stricmp(fullName, "root") == 0) {
+            length = 0;
+            variantBegin = 0;
+            language[0] = '\0';
+            fullName[0] = '\0';
+        } else if (length >= 3 && uprv_strnicmp(fullName, "und", 3) == 0 &&
+            (length == 3 || fullName[3] == '_' || fullName[3] == '@')) {
+            length -= 3;
+            variantBegin -= 3;
+            language[0] = '\0';
+            uprv_memmove(fullName, fullName + 3, length + 1);
+        }
+
         err = U_ZERO_ERROR;
         initBaseName(err);
         if (U_FAILURE(err)) {

--- a/icu4c/source/common/loclikely.cpp
+++ b/icu4c/source/common/loclikely.cpp
@@ -1253,16 +1253,17 @@ uloc_isRightToLeft(const char *locale) {
         errorCode = U_ZERO_ERROR;
         char lang[8];
         int32_t langLength = uloc_getLanguage(locale, lang, UPRV_LENGTHOF(lang), &errorCode);
-        if (U_FAILURE(errorCode) || errorCode == U_STRING_NOT_TERMINATED_WARNING ||
-                langLength == 0) {
+        if (U_FAILURE(errorCode) || errorCode == U_STRING_NOT_TERMINATED_WARNING) {
             return FALSE;
         }
-        const char* langPtr = uprv_strstr(LANG_DIR_STRING, lang);
-        if (langPtr != NULL) {
-            switch (langPtr[langLength]) {
-            case '-': return FALSE;
-            case '+': return TRUE;
-            default: break;  // partial match of a longer code
+        if (langLength > 0) {
+            const char* langPtr = uprv_strstr(LANG_DIR_STRING, lang);
+            if (langPtr != NULL) {
+                switch (langPtr[langLength]) {
+                case '-': return FALSE;
+                case '+': return TRUE;
+                default: break;  // partial match of a longer code
+                }
             }
         }
         // Otherwise, find the likely script.

--- a/icu4c/source/i18n/ucol_res.cpp
+++ b/icu4c/source/i18n/ucol_res.cpp
@@ -348,7 +348,7 @@ CollationLoader::loadFromCollations(UErrorCode &errorCode) {
     const char *actualLocale = ures_getLocaleByType(data, ULOC_ACTUAL_LOCALE, &errorCode);
     if(U_FAILURE(errorCode)) { return NULL; }
     const char *vLocale = validLocale.getBaseName();
-    UBool actualAndValidLocalesAreDifferent = uprv_strcmp(actualLocale, vLocale) != 0;
+    UBool actualAndValidLocalesAreDifferent = Locale(actualLocale) != Locale(vLocale);
 
     // Set the collation types on the informational locales,
     // except when they match the default types (for brevity and backwards compatibility).
@@ -410,7 +410,7 @@ CollationLoader::loadFromData(UErrorCode &errorCode) {
 
     const char *actualLocale = locale.getBaseName();  // without type
     const char *vLocale = validLocale.getBaseName();
-    UBool actualAndValidLocalesAreDifferent = uprv_strcmp(actualLocale, vLocale) != 0;
+    UBool actualAndValidLocalesAreDifferent = Locale(actualLocale) != Locale(vLocale);
 
     // For the actual locale, suppress the default type *according to the actual locale*.
     // For example, zh has default=pinyin and contains all of the Chinese tailorings.

--- a/icu4c/source/test/intltest/loctest.h
+++ b/icu4c/source/test/intltest/loctest.h
@@ -118,6 +118,7 @@ public:
 
     void TestAddLikelySubtags();
     void TestMinimizeSubtags();
+    void TestAddLikelyAndMinimizeSubtags();
 
     void TestForLanguageTag();
     void TestToLanguageTag();
@@ -130,6 +131,10 @@ public:
     void TestBug13417VeryLongLanguageTag();
 
     void TestBug11053UnderlineTimeZone();
+
+    void TestUnd();
+    void TestUndScript();
+    void TestUndRegion();
 
 private:
     void _checklocs(const char* label,

--- a/icu4c/source/test/intltest/restest.cpp
+++ b/icu4c/source/test/intltest/restest.cpp
@@ -581,8 +581,8 @@ ResourceBundleTest::TestGetLocaleByType(void)
     } test[] = {
         { "te_IN_BLAH", "string_only_in_te_IN", "te_IN", "te_IN" },
         { "te_IN_BLAH", "string_only_in_te", "te_IN", "te" },
-        { "te_IN_BLAH", "string_only_in_Root", "te_IN", "root" },
-        { "te_IN_BLAH_01234567890_01234567890_01234567890_01234567890_01234567890_01234567890", "array_2d_only_in_Root", "te_IN", "root" },
+        { "te_IN_BLAH", "string_only_in_Root", "te_IN", "" },
+        { "te_IN_BLAH_01234567890_01234567890_01234567890_01234567890_01234567890_01234567890", "array_2d_only_in_Root", "te_IN", "" },
         { "te_IN_BLAH@currency=euro", "array_2d_only_in_te_IN", "te_IN", "te_IN" },
         { "te_IN_BLAH@calendar=thai;collation=phonebook", "array_2d_only_in_te", "te_IN", "te" }
     };

--- a/icu4c/source/test/intltest/svccoll.cpp
+++ b/icu4c/source/test/intltest/svccoll.cpp
@@ -583,7 +583,7 @@ void CollationServiceTest::TestSeparateTree() {
                                                      Locale::createFromName("de"),
                                                      isAvailable, ec);
     assertSuccess("getFunctionalEquivalent", ec);
-    assertEquals("getFunctionalEquivalent(de)", "root", equiv.getName());
+    assertEquals("getFunctionalEquivalent(de)", "", equiv.getName());
     assertTrue("getFunctionalEquivalent(de).isAvailable==TRUE",
                isAvailable == TRUE);
 
@@ -591,7 +591,7 @@ void CollationServiceTest::TestSeparateTree() {
                                               Locale::createFromName("de_DE"),
                                               isAvailable, ec);
     assertSuccess("getFunctionalEquivalent", ec);
-    assertEquals("getFunctionalEquivalent(de_DE)", "root", equiv.getName());
+    assertEquals("getFunctionalEquivalent(de_DE)", "", equiv.getName());
     assertTrue("getFunctionalEquivalent(de_DE).isAvailable==FALSE",
                isAvailable == FALSE);
 

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/LocaleDisplayNamesImpl.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/LocaleDisplayNamesImpl.java
@@ -305,10 +305,9 @@ public class LocaleDisplayNamesImpl extends LocaleDisplayNames {
         String lang = locale.getLanguage();
 
         // Empty basename indicates root locale (keywords are ignored for this).
-        // Our data uses 'root' to access display names for the root locale in the
-        // "Languages" table.
-        if (locale.getBaseName().length() == 0) {
-            lang = "root";
+        // For the display name, we treat this as unknown language (ICU-20273).
+        if (lang.isEmpty()) {
+            lang = "und";
         }
         String script = locale.getScript();
         String country = locale.getCountry();

--- a/icu4j/main/tests/collate/src/com/ibm/icu/dev/test/collator/CollationServiceTest.java
+++ b/icu4j/main/tests/collate/src/com/ibm/icu/dev/test/collator/CollationServiceTest.java
@@ -359,7 +359,7 @@ public class CollationServiceTest extends TestFmwk {
                                                          new ULocale("de"),
                                                          isAvailable);
         if (assertTrue("getFunctionalEquivalent(de)!=null", equiv!=null)) {
-            assertEquals("getFunctionalEquivalent(de)", "root", equiv.toString());
+            assertEquals("getFunctionalEquivalent(de)", "", equiv.toString());
         }
         assertTrue("getFunctionalEquivalent(de).isAvailable==true",
                    isAvailable[0] == true);
@@ -368,7 +368,7 @@ public class CollationServiceTest extends TestFmwk {
                                                  new ULocale("de_DE"),
                                                  isAvailable);
         if (assertTrue("getFunctionalEquivalent(de_DE)!=null", equiv!=null)) {
-            assertEquals("getFunctionalEquivalent(de_DE)", "root", equiv.toString());
+            assertEquals("getFunctionalEquivalent(de_DE)", "", equiv.toString());
         }
         assertTrue("getFunctionalEquivalent(de_DE).isAvailable==false",
                    isAvailable[0] == false);

--- a/icu4j/main/tests/collate/src/com/ibm/icu/dev/test/format/GlobalizationPreferencesTest.java
+++ b/icu4j/main/tests/collate/src/com/ibm/icu/dev/test/format/GlobalizationPreferencesTest.java
@@ -868,8 +868,8 @@ public class GlobalizationPreferencesTest extends TestFmwk {
         gp.setLocale(new ULocale("aar"));
         BreakIterator brk = gp.getBreakIterator(GlobalizationPreferences.BI_LINE);
         String locStr = brk.getLocale(ULocale.VALID_LOCALE).toString();
-        if (!locStr.equals("root")) {
-            errln("FAIL: Line break iterator locale is " + locStr + " Expected: root");
+        if (!locStr.isEmpty()) {
+            errln("FAIL: Line break iterator locale is " + locStr + " Expected: \"\"");
         }
 
         // Set locale - es

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/LocaleMatcherTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/LocaleMatcherTest.java
@@ -377,7 +377,7 @@ public class LocaleMatcherTest extends TestFmwk {
 
         // When it *does* occur in the list, BestMatch returns it, as expected.
         matcher = newLocaleMatcher("it,und");
-        assertEquals("und", matcher.getBestMatch("und").toString());
+        assertEquals("", matcher.getBestMatch("und").toString());
 
         // The unusual part:
         // max("und") = "en_Latn_US", and since matching is based on maximized

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/TestLocaleValidity.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/TestLocaleValidity.java
@@ -105,8 +105,8 @@ public class TestLocaleValidity extends TestFmwk {
 
                 {"OK", "en-u-ca-buddhist-ca-islamic-umalqura-cf-account-co-big5han-cu-adp-fw-fri-hc-h11-ka-noignore-kb-false-kc-false-kf-false-kk-false-kn-false-kr-latn-digit-symbol-ks-identic-kv-currency-nu-ahom-sd-usny-tz-adalv-va-posix"},
 
-                // bad case (for language tag)
-                {"{language, root}", "root"},
+                // root is canonicalized to the root locale (ICU-20273)
+                {"OK", "root"},
 
                 // deprecated, but turned into valid by ULocale.Builder()
                 {"OK", "en-u-ca-islamicc"}, // deprecated

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/ULocaleTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/ULocaleTest.java
@@ -25,6 +25,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -3424,8 +3425,8 @@ public class ULocaleTest extends TestFmwk {
                     "zh_HK"
                 }, {
                     "und_AQ",
-                    "und_Latn_AQ",
-                    "und_AQ"
+                    "_Latn_AQ",
+                    "_AQ"
                 }, {
                     "und_Zzzz",
                     "en_Latn_US",
@@ -3448,8 +3449,8 @@ public class ULocaleTest extends TestFmwk {
                     "zh_HK"
                 }, {
                     "und_Zzzz_AQ",
-                    "und_Latn_AQ",
-                    "und_AQ"
+                    "_Latn_AQ",
+                    "_AQ"
                 }, {
                     "und_Latn",
                     "en_Latn_US",
@@ -3472,8 +3473,8 @@ public class ULocaleTest extends TestFmwk {
                     "zh_Latn_HK"
                 }, {
                     "und_Latn_AQ",
-                    "und_Latn_AQ",
-                    "und_AQ"
+                    "_Latn_AQ",
+                    "_AQ"
                 }, {
                     "und_Hans",
                     "zh_Hans_CN",
@@ -3544,8 +3545,8 @@ public class ULocaleTest extends TestFmwk {
                     "zh_Moon_HK"
                 }, {
                     "und_Moon_AQ",
-                    "und_Moon_AQ",
-                    "und_Moon_AQ"
+                    "_Moon_AQ",
+                    "_Moon_AQ"
                 }, {
                     "es",
                     "es_Latn_ES",
@@ -4272,7 +4273,7 @@ public class ULocaleTest extends TestFmwk {
                 {new ULocale("en__POSIX"), new ULocale("en"), ULocale.ROOT, null},
                 {new ULocale("de_DE@collation=phonebook"), new ULocale("de@collation=phonebook"), new ULocale("@collation=phonebook"), null},
                 {new ULocale("_US_POSIX"), new ULocale("_US"), ULocale.ROOT, null},
-                {new ULocale("root"), ULocale.ROOT, null},
+                {new ULocale("root"), null},
             };
 
         for(ULocale[] chain : TESTLOCALES) {
@@ -4676,7 +4677,6 @@ public class ULocaleTest extends TestFmwk {
                 "th_TH@calendar=gergorian",
                 "th_TH@numbers=latn",
                 "this is a bogus locale id",
-                "und",
                 "zh_CN",
                 "zh_TW",
                 "zh_Hans",
@@ -4889,5 +4889,149 @@ public class ULocaleTest extends TestFmwk {
                 errln("Error: " + pair[0] + " is not equal to " + pair[1]);
             }
         }
+    }
+
+    @Test
+    public void TestUnd() {
+        final String empty = "";
+        final String root = "root";
+        final String und = "und";
+
+        ULocale empty_new = new ULocale(empty);
+        ULocale empty_tag = ULocale.forLanguageTag(empty);
+
+        ULocale root_new = new ULocale(root);
+        ULocale root_tag = ULocale.forLanguageTag(root);
+        ULocale root_build = new Builder().setLanguageTag(root).build();
+
+        ULocale und_new = new ULocale(und);
+        ULocale und_tag = ULocale.forLanguageTag(und);
+        ULocale und_build = new Builder().setLanguageTag(und).build();
+
+        Assert.assertEquals(empty, empty_new.getName());
+        Assert.assertEquals(empty, root_new.getName());
+        Assert.assertEquals(empty, und_new.getName());
+
+        Assert.assertEquals(empty, empty_tag.getName());
+        Assert.assertEquals(empty, root_tag.getName());
+        Assert.assertEquals(empty, und_tag.getName());
+
+        Assert.assertEquals(empty, root_build.getName());
+        Assert.assertEquals(empty, und_build.getName());
+
+        Assert.assertEquals(und, empty_new.toLanguageTag());
+        Assert.assertEquals(und, root_new.toLanguageTag());
+        Assert.assertEquals(und, und_new.toLanguageTag());
+
+        Assert.assertEquals(und, empty_tag.toLanguageTag());
+        Assert.assertEquals(und, root_tag.toLanguageTag());
+        Assert.assertEquals(und, und_tag.toLanguageTag());
+
+        Assert.assertEquals(und, root_build.toLanguageTag());
+        Assert.assertEquals(und, und_build.toLanguageTag());
+
+        Assert.assertEquals(empty_new, empty_tag);
+
+        Assert.assertEquals(root_new, root_tag);
+        Assert.assertEquals(root_new, root_build);
+        Assert.assertEquals(root_tag, root_build);
+
+        Assert.assertEquals(und_new, und_tag);
+        Assert.assertEquals(und_new, und_build);
+        Assert.assertEquals(und_tag, und_build);
+
+        Assert.assertEquals(empty_new, root_new);
+        Assert.assertEquals(empty_new, und_new);
+        Assert.assertEquals(root_new, und_new);
+
+        Assert.assertEquals(empty_tag, root_tag);
+        Assert.assertEquals(empty_tag, und_tag);
+        Assert.assertEquals(root_tag, und_tag);
+
+        Assert.assertEquals(root_build, und_build);
+
+        final ULocale displayLocale = ULocale.ENGLISH;
+        final String displayName = "Unknown language";
+
+        Assert.assertEquals(displayName, empty_new.getDisplayName(displayLocale));
+        Assert.assertEquals(displayName, root_new.getDisplayName(displayLocale));
+        Assert.assertEquals(displayName, und_new.getDisplayName(displayLocale));
+
+        Assert.assertEquals(displayName, empty_tag.getDisplayName(displayLocale));
+        Assert.assertEquals(displayName, root_tag.getDisplayName(displayLocale));
+        Assert.assertEquals(displayName, und_tag.getDisplayName(displayLocale));
+
+        Assert.assertEquals(displayName, root_build.getDisplayName(displayLocale));
+        Assert.assertEquals(displayName, und_build.getDisplayName(displayLocale));
+    }
+
+    @Test
+    public void TestUndScript() {
+        final String id = "_Cyrl";
+        final String tag = "und-Cyrl";
+        final String script = "Cyrl";
+
+        ULocale locale_new = new ULocale(id);
+        ULocale locale_legacy = new ULocale(tag);
+        ULocale locale_tag = ULocale.forLanguageTag(tag);
+        ULocale locale_build = new Builder().setScript(script).build();
+
+        Assert.assertEquals(id, locale_new.getName());
+        Assert.assertEquals(id, locale_legacy.getName());
+        Assert.assertEquals(id, locale_tag.getName());
+        Assert.assertEquals(id, locale_build.getName());
+
+        Assert.assertEquals(tag, locale_new.toLanguageTag());
+        Assert.assertEquals(tag, locale_legacy.toLanguageTag());
+        Assert.assertEquals(tag, locale_tag.toLanguageTag());
+        Assert.assertEquals(tag, locale_build.toLanguageTag());
+
+        Assert.assertEquals(locale_new, locale_legacy);
+        Assert.assertEquals(locale_new, locale_tag);
+        Assert.assertEquals(locale_new, locale_build);
+        Assert.assertEquals(locale_tag, locale_build);
+
+        final ULocale displayLocale = ULocale.ENGLISH;
+        final String displayName = "Unknown language (Cyrillic)";
+
+        Assert.assertEquals(displayName, locale_new.getDisplayName(displayLocale));
+        Assert.assertEquals(displayName, locale_legacy.getDisplayName(displayLocale));
+        Assert.assertEquals(displayName, locale_tag.getDisplayName(displayLocale));
+        Assert.assertEquals(displayName, locale_build.getDisplayName(displayLocale));
+    }
+
+    @Test
+    public void TestUndRegion() {
+        final String id = "_AQ";
+        final String tag = "und-AQ";
+        final String region = "AQ";
+
+        ULocale locale_new = new ULocale(id);
+        ULocale locale_legacy = new ULocale(tag);
+        ULocale locale_tag = ULocale.forLanguageTag(tag);
+        ULocale locale_build = new Builder().setRegion(region).build();
+
+        Assert.assertEquals(id, locale_new.getName());
+        Assert.assertEquals(id, locale_legacy.getName());
+        Assert.assertEquals(id, locale_tag.getName());
+        Assert.assertEquals(id, locale_build.getName());
+
+        Assert.assertEquals(tag, locale_new.toLanguageTag());
+        Assert.assertEquals(tag, locale_legacy.toLanguageTag());
+        Assert.assertEquals(tag, locale_tag.toLanguageTag());
+        Assert.assertEquals(tag, locale_build.toLanguageTag());
+
+        Assert.assertEquals(locale_new, locale_legacy);
+        Assert.assertEquals(locale_new, locale_tag);
+        Assert.assertEquals(locale_new, locale_build);
+        Assert.assertEquals(locale_tag, locale_build);
+
+        final ULocale displayLocale = ULocale.ENGLISH;
+        final String displayName = "Unknown language (Antarctica)";
+
+        Assert.assertEquals(displayName, locale_new.getDisplayName(displayLocale));
+        Assert.assertEquals(displayName, locale_legacy.getDisplayName(displayLocale));
+        Assert.assertEquals(displayName, locale_tag.getDisplayName(displayLocale));
+        Assert.assertEquals(displayName, locale_build.getDisplayName(displayLocale));
     }
 }

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/data/localeMatcherTest.txt
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/data/localeMatcherTest.txt
@@ -763,7 +763,7 @@ fr-FR >> fr
 ja-JP >> fr
 # For a language that doesn't match anything, return the default.
 zu >> en-GB
-root >> fr
+zxx >> fr
 
 @distance=script
 en-GB >> en-GB
@@ -771,7 +771,7 @@ en-US >> en
 fr-FR >> fr
 ja-JP >> fr
 zu >> en-GB
-root >> en
+zxx >> en
 
 ** test: TestExactMatch
 @supported=fr, en-GB, ja, es-ES, es-MX


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-20273

Please start out with reviewing the changes to the unit tests, to make sure that we're all in agreement that these accurately reflect the desired and agreed upon behaviour (before we go into the details of how to achieve this behaviour).