### PR TITLE
ICU-20243 Setup triggers for Exhaustive Tests to only build on master

### DIFF
--- a/.ci-builds/.azure-exhaustive-tests.yml
+++ b/.ci-builds/.azure-exhaustive-tests.yml
@@ -9,6 +9,15 @@ resources:
     lfs: true
     fetchDepth: 1
 
+# Only run the exhaustive tests on the master branch, and batch up
+# any pending changes so that we will only have at most one build
+# running at a given time.
+trigger:
+  batch: true
+  branches:
+    include:
+    - master
+
 jobs:
 #-------------------------------------------------------------------------
 # Note: The exhaustive tests for J take longer than the C tests. They 


### PR DESCRIPTION
It seems that Azure Pipelines recently added support for defining the "triggers" in the YML file, rather than in the Azure DevOps site itself.
This change adds the triggers to the Exhaustive Test file -- only building the master branch, and "batch" up any pending changes, so that we only have at most 1 build running at a time.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20243
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

