### PR TITLE
ICU-13820 ICU4C should use "Etc/Unknown" zone when host TZ detection fails

### DIFF
--- a/icu4c/source/common/putil.cpp
+++ b/icu4c/source/common/putil.cpp
@@ -1068,7 +1068,7 @@ uprv_tzname(int n)
     // the other code path returns a pointer to a heap location.
     // If we don't have a name already, then tzname wouldn't be any
     // better, so just fall back.
-    return uprv_strdup("Etc/UTC");
+    return uprv_strdup("");
 #endif // !U_TZNAME
 
 #else

--- a/icu4c/source/i18n/unicode/timezone.h
+++ b/icu4c/source/i18n/unicode/timezone.h
@@ -277,17 +277,25 @@ public:
 
     /**
      * Creates an instance of TimeZone detected from the current host
-     * system configuration. Note that ICU4C does not change the default
-     * time zone unless TimeZone::adoptDefault(TimeZone*) or
-     * TimeZone::setDefault(const TimeZone&) is explicitly called by a
+     * system configuration. If the host system detection routines fail,
+     * or if they specify a TimeZone or TimeZone offset which is not
+     * recognized, then the special TimeZone "Etc/Unknown" is returned.
+     * 
+     * Note that ICU4C does not change the default time zone unless
+     * `TimeZone::adoptDefault(TimeZone*)` or 
+     * `TimeZone::setDefault(const TimeZone&)` is explicitly called by a
      * user. This method does not update the current ICU's default,
      * and may return a different TimeZone from the one returned by
-     * TimeZone::createDefault().
+     * `TimeZone::createDefault()`.
      *
      * <p>This function is not thread safe.</p>
      *
      * @return  A new instance of TimeZone detected from the current host system
      *          configuration.
+     * @see adoptDefault
+     * @see setDefault
+     * @see createDefault
+     * @see getUnknown
      * @stable ICU 55
      */
     static TimeZone* U_EXPORT2 detectHostTimeZone();
@@ -295,13 +303,14 @@ public:
     /**
      * Creates a new copy of the default TimeZone for this host. Unless the default time
      * zone has already been set using adoptDefault() or setDefault(), the default is
-     * determined by querying the system using methods in TPlatformUtilities. If the
-     * system routines fail, or if they specify a TimeZone or TimeZone offset which is not
-     * recognized, the TimeZone indicated by the ID kLastResortID is instantiated
-     * and made the default.
+     * determined by querying the host system configuration. If the host system detection
+     * routines fail, or if they specify a TimeZone or TimeZone offset which is not
+     * recognized, then the special TimeZone "Etc/Unknown" is instantiated and made the
+     * default.
      *
      * @return   A default TimeZone. Clients are responsible for deleting the time zone
      *           object returned.
+     * @see getUnknown
      * @stable ICU 2.0
      */
     static TimeZone* U_EXPORT2 createDefault(void);
@@ -676,7 +685,7 @@ public:
      * @param locale the locale in which to supply the display name.
      * @param result the human-readable name of this time zone in the given locale
      *               or in the default locale if the given locale is not recognized.
-     * @return       A refence to 'result'.
+     * @return       A reference to 'result'.
      * @stable ICU 2.0
      */
     UnicodeString& getDisplayName(UBool inDaylight, EDisplayType style, const Locale& locale, UnicodeString& result) const;
@@ -926,7 +935,7 @@ private:
         UErrorCode& status);
 
     /**
-     * Returns the normalized custome time zone ID for the given offset fields.
+     * Returns the normalized custom time zone ID for the given offset fields.
      * @param hour offset hours
      * @param min offset minutes
      * @param sec offset seconds

--- a/icu4c/source/i18n/unicode/ucal.h
+++ b/icu4c/source/i18n/unicode/ucal.h
@@ -105,7 +105,7 @@
  * <p>
  * <strong>Note:</strong> for some non-Gregorian calendars, different
  * fields may be necessary for complete disambiguation. For example, a full
- * specification of the historial Arabic astronomical calendar requires year,
+ * specification of the historical Arabic astronomical calendar requires year,
  * month, day-of-month <em>and</em> day-of-week in some cases.
  *
  * <p>
@@ -157,6 +157,7 @@
 
 /**
  * The time zone ID reserved for unknown time zone.
+ * It behaves like the GMT/UTC time zone but has the special ID "Etc/Unknown".
  * @stable ICU 4.8
  */
 #define UCAL_UNKNOWN_ZONE_ID "Etc/Unknown"
@@ -620,8 +621,13 @@ ucal_openCountryTimeZones(const char* country, UErrorCode* ec);
 
 /**
  * Return the default time zone. The default is determined initially
- * by querying the host operating system. It may be changed with
- * ucal_setDefaultTimeZone() or with the C++ TimeZone API.
+ * by querying the host operating system. If the host system detection
+ * routines fail, or if they specify a TimeZone or TimeZone offset
+ * which is not recognized, then the special TimeZone "Etc/Unknown"
+ * is returned.
+ * 
+ * The default may be changed with `ucal_setDefaultTimeZone()` or with
+ * the C++ TimeZone API, `TimeZone::adoptDefault(TimeZone*)`.
  *
  * @param result A buffer to receive the result, or NULL
  *
@@ -631,7 +637,9 @@ ucal_openCountryTimeZones(const char* country, UErrorCode* ec);
  *
  * @return The result string length, not including the terminating
  * null
- *
+ * 
+ * @see #UCAL_UNKNOWN_ZONE_ID
+ * 
  * @stable ICU 2.6
  */
 U_STABLE int32_t U_EXPORT2


### PR DESCRIPTION
Per discussion in the ICU-TC call on 2018-06-06, ICU4C is supposed to be using the special zone "Etc/Unknown" when the host detection fails, and shouldn't be using "Etc/UTC".
This change modifies ICU4C to use the Unknown zone when host detection fails and updates the API docs for the C and C++ APIs to clarify what is returned in failure cases.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-13820
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [x] Documentation is changed or added

