### PR TITLE
ICU-20241 intltest/itformat.cpp build failure on Solaris

### DIFF
--- a/icu4c/source/test/intltest/numbertest.h
+++ b/icu4c/source/test/intltest/numbertest.h
@@ -88,7 +88,7 @@ class NumberFormatterApiTest : public IntlTestWithFieldPosition {
     CurrencyUnit GBP;
     CurrencyUnit CZK;
     CurrencyUnit CAD;
-    CurrencyUnit ESP;
+    CurrencyUnit __ESP;
     CurrencyUnit PTE;
 
     MeasureUnit METER;

--- a/icu4c/source/test/intltest/numbertest_api.cpp
+++ b/icu4c/source/test/intltest/numbertest_api.cpp
@@ -30,7 +30,7 @@ NumberFormatterApiTest::NumberFormatterApiTest(UErrorCode& status)
           GBP(u"GBP", status),
           CZK(u"CZK", status),
           CAD(u"CAD", status),
-          ESP(u"ESP", status),
+          __ESP(u"ESP", status),
           PTE(u"PTE", status),
           FRENCH_SYMBOLS(Locale::getFrench(), status),
           SWISS_SYMBOLS(Locale("de-CH"), status),
@@ -750,7 +750,7 @@ void NumberFormatterApiTest::unitCurrency() {
     assertFormatSingle(
             u"Currency-dependent format (Test)",
             u"currency/ESP unit-width-short",
-            NumberFormatter::with().unit(ESP).unitWidth(UNUM_UNIT_WIDTH_SHORT),
+            NumberFormatter::with().unit(__ESP).unitWidth(UNUM_UNIT_WIDTH_SHORT),
             Locale("ca"),
             444444.55,
             u"₧ 444.445");


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20241
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [NA] Tests included
- [NA] Documentation is changed or added

