### PR TITLE
ICU-20356 Fix compilation warnings 'dllimport' attribute ignored

### DIFF
--- a/icu4c/source/common/hash.h
+++ b/icu4c/source/common/hash.h
@@ -41,7 +41,7 @@ public:
      * @param ignoreKeyCase If true, keys are case insensitive.
      * @param status Error code
     */
-    Hashtable(UBool ignoreKeyCase, UErrorCode& status);
+    inline Hashtable(UBool ignoreKeyCase, UErrorCode& status);
 
     /**
      * Construct a hashtable
@@ -49,7 +49,7 @@ public:
      * @param size initial size allocation
      * @param status Error code
     */
-    Hashtable(UBool ignoreKeyCase, int32_t size, UErrorCode& status);
+    inline Hashtable(UBool ignoreKeyCase, int32_t size, UErrorCode& status);
 
     /**
      * Construct a hashtable
@@ -57,57 +57,57 @@ public:
      * @param valueComp Comparator for comparing the values
      * @param status Error code
     */
-    Hashtable(UKeyComparator *keyComp, UValueComparator *valueComp, UErrorCode& status);
+    inline Hashtable(UKeyComparator *keyComp, UValueComparator *valueComp, UErrorCode& status);
 
     /**
      * Construct a hashtable
      * @param status Error code
     */
-    Hashtable(UErrorCode& status);
+    inline Hashtable(UErrorCode& status);
 
     /**
      * Construct a hashtable, _disregarding any error_.  Use this constructor
      * with caution.
      */
-    Hashtable();
+    inline Hashtable();
 
     /**
      * Non-virtual destructor; make this virtual if Hashtable is subclassed
      * in the future.
      */
-    ~Hashtable();
+    inline ~Hashtable();
 
-    UObjectDeleter *setValueDeleter(UObjectDeleter *fn);
+    inline UObjectDeleter *setValueDeleter(UObjectDeleter *fn);
 
-    int32_t count() const;
+    inline int32_t count() const;
 
-    void* put(const UnicodeString& key, void* value, UErrorCode& status);
+    inline void* put(const UnicodeString& key, void* value, UErrorCode& status);
 
-    int32_t puti(const UnicodeString& key, int32_t value, UErrorCode& status);
+    inline int32_t puti(const UnicodeString& key, int32_t value, UErrorCode& status);
 
-    void* get(const UnicodeString& key) const;
+    inline void* get(const UnicodeString& key) const;
 
-    int32_t geti(const UnicodeString& key) const;
+    inline int32_t geti(const UnicodeString& key) const;
 
-    void* remove(const UnicodeString& key);
+    inline void* remove(const UnicodeString& key);
 
-    int32_t removei(const UnicodeString& key);
+    inline int32_t removei(const UnicodeString& key);
 
-    void removeAll(void);
+    inline void removeAll(void);
 
-    const UHashElement* find(const UnicodeString& key) const;
+    inline const UHashElement* find(const UnicodeString& key) const;
 
     /**
      * @param pos - must be UHASH_FIRST on first call, and untouched afterwards.
      * @see uhash_nextElement
      */
-    const UHashElement* nextElement(int32_t& pos) const;
+    inline const UHashElement* nextElement(int32_t& pos) const;
 
-    UKeyComparator* setKeyComparator(UKeyComparator*keyComp);
+    inline UKeyComparator* setKeyComparator(UKeyComparator*keyComp);
 
-    UValueComparator* setValueComparator(UValueComparator* valueComp);
+    inline UValueComparator* setValueComparator(UValueComparator* valueComp);
 
-    UBool equals(const Hashtable& that) const;
+    inline UBool equals(const Hashtable& that) const;
 private:
     Hashtable(const Hashtable &other); // forbid copying of this class
     Hashtable &operator=(const Hashtable &other); // forbid copying of this class

--- a/icu4c/source/common/unicode/dtintrv.h
+++ b/icu4c/source/common/unicode/dtintrv.h
@@ -53,14 +53,14 @@ public:
      * @return  the from date in dateInterval.
      * @stable ICU 4.0
      */
-    UDate getFromDate() const;
+    inline UDate getFromDate() const;
 
     /** 
      * Get the to date.
      * @return  the to date in dateInterval.
      * @stable ICU 4.0
      */
-    UDate getToDate() const;
+    inline UDate getToDate() const;
 
 
     /**
@@ -114,7 +114,7 @@ public:
      * @return TRUE if the two DateIntervals are not the same
      * @stable ICU 4.0
      */
-    UBool operator!=(const DateInterval& other) const;
+    inline UBool operator!=(const DateInterval& other) const;
 
 
     /**

--- a/icu4c/source/common/unicode/locdspnm.h
+++ b/icu4c/source/common/unicode/locdspnm.h
@@ -49,7 +49,7 @@ public:
      * @return a LocaleDisplayNames instance
      * @stable ICU 4.4
      */
-    static LocaleDisplayNames* U_EXPORT2 createInstance(const Locale& locale);
+    inline static LocaleDisplayNames* U_EXPORT2 createInstance(const Locale& locale);
 
     /**
      * Returns an instance of LocaleDisplayNames that returns names

--- a/icu4c/source/common/unicode/locid.h
+++ b/icu4c/source/common/unicode/locid.h
@@ -340,7 +340,7 @@ public:
      *              otherwise.
      * @stable ICU 2.0
      */
-    UBool   operator!=(const    Locale&     other) const;
+    inline UBool   operator!=(const    Locale&     other) const;
 
     /**
      * Clone this object.
@@ -962,7 +962,7 @@ public:
      * @return FALSE if it is a real locale, TRUE if it is a bogus locale
      * @stable ICU 2.1
      */
-    UBool isBogus(void) const;
+    inline UBool isBogus(void) const;
 
     /**
      * Returns a list of all installed locales.

--- a/icu4c/source/common/unicode/parsepos.h
+++ b/icu4c/source/common/unicode/parsepos.h
@@ -90,21 +90,21 @@ public:
      * Assignment operator
      * @stable ICU 2.0
      */
-    ParsePosition&      operator=(const ParsePosition& copy);
+    inline ParsePosition&      operator=(const ParsePosition& copy);
 
     /**
      * Equality operator.
      * @return TRUE if the two parse positions are equal, FALSE otherwise.
      * @stable ICU 2.0
      */
-    UBool              operator==(const ParsePosition& that) const;
+    inline UBool              operator==(const ParsePosition& that) const;
 
     /**
      * Equality operator.
      * @return TRUE if the two parse positions are not equal, FALSE otherwise.
      * @stable ICU 2.0
      */
-    UBool              operator!=(const ParsePosition& that) const;
+    inline UBool              operator!=(const ParsePosition& that) const;
 
     /**
      * Clone this object.
@@ -126,14 +126,14 @@ public:
      * @return the current index.
      * @stable ICU 2.0
      */
-    int32_t getIndex(void) const;
+    inline int32_t getIndex(void) const;
 
     /**
      * Set the current parse position.
      * @param index the new index.
      * @stable ICU 2.0
      */
-    void setIndex(int32_t index);
+    inline void setIndex(int32_t index);
 
     /**
      * Set the index at which a parse error occurred.  Formatters
@@ -142,14 +142,14 @@ public:
      * set.
      * @stable ICU 2.0
      */
-    void setErrorIndex(int32_t ei);
+    inline void setErrorIndex(int32_t ei);
 
     /**
      * Retrieve the index at which an error occurred, or -1 if the
      * error index has not been set.
      * @stable ICU 2.0
      */
-    int32_t getErrorIndex(void) const;
+    inline int32_t getErrorIndex(void) const;
 
     /**
      * ICU "poor man's RTTI", returns a UClassID for this class.

--- a/icu4c/source/common/unicode/rbbi.h
+++ b/icu4c/source/common/unicode/rbbi.h
@@ -260,7 +260,7 @@ public:
      * @return TRUE if both BreakIterators are not same.
      *  @stable ICU 2.0
      */
-    UBool operator!=(const BreakIterator& that) const;
+    inline UBool operator!=(const BreakIterator& that) const;
 
     /**
      * Returns a newly-constructed RuleBasedBreakIterator with the same

--- a/icu4c/source/common/unicode/uniset.h
+++ b/icu4c/source/common/unicode/uniset.h
@@ -490,7 +490,7 @@ public:
      * <tt>true</tt> if the specified set is not equal to this set.
      * @stable ICU 2.0
      */
-    UBool operator!=(const UnicodeSet& o) const;
+    inline UBool operator!=(const UnicodeSet& o) const;
 
     /**
      * Returns a copy of this object.  All UnicodeFunctor objects have

--- a/icu4c/source/common/unicode/unistr.h
+++ b/icu4c/source/common/unicode/unistr.h
@@ -1915,7 +1915,7 @@ public:
    * @param s2 will get s1's contents and state
    * @stable ICU 56
    */
-  friend U_COMMON_API inline void U_EXPORT2
+  friend inline void U_EXPORT2
   swap(UnicodeString &s1, UnicodeString &s2) U_NOEXCEPT {
     s1.swap(s2);
   }
@@ -1998,7 +1998,7 @@ public:
    * @return a reference to this
    * @stable ICU 2.0
    */
-  UnicodeString& setTo(char16_t srcChar);
+  inline UnicodeString& setTo(char16_t srcChar);
 
   /**
    * Set the characters in the UnicodeString object to the code point
@@ -2008,7 +2008,7 @@ public:
    * @return a reference to this
    * @stable ICU 2.0
    */
-  UnicodeString& setTo(UChar32 srcChar);
+  inline UnicodeString& setTo(UChar32 srcChar);
 
   /**
    * Aliasing setTo() function, analogous to the readonly-aliasing char16_t* constructor.
@@ -2319,7 +2319,7 @@ public:
    * @return a reference to this
    * @stable ICU 2.0
    */
-  UnicodeString& replace(int32_t start,
+  inline UnicodeString& replace(int32_t start,
              int32_t length,
              const UnicodeString& srcText,
              int32_t srcStart,
@@ -2337,7 +2337,7 @@ public:
    * @return a reference to this
    * @stable ICU 2.0
    */
-  UnicodeString& replace(int32_t start,
+  inline UnicodeString& replace(int32_t start,
              int32_t length,
              const UnicodeString& srcText);
 
@@ -2358,7 +2358,7 @@ public:
    * @return a reference to this
    * @stable ICU 2.0
    */
-  UnicodeString& replace(int32_t start,
+  inline UnicodeString& replace(int32_t start,
              int32_t length,
              const char16_t *srcChars,
              int32_t srcStart,

--- a/icu4c/source/common/uvector.h
+++ b/icu4c/source/common/uvector.h
@@ -142,19 +142,19 @@ public:
 
     UBool equals(const UVector &other) const;
 
-    void* firstElement(void) const;
+    inline void* firstElement(void) const;
 
-    void* lastElement(void) const;
+    inline void* lastElement(void) const;
 
-    int32_t lastElementi(void) const;
+    inline int32_t lastElementi(void) const;
 
     int32_t indexOf(void* obj, int32_t startIndex = 0) const;
 
     int32_t indexOf(int32_t obj, int32_t startIndex = 0) const;
 
-    UBool contains(void* obj) const;
+    inline UBool contains(void* obj) const;
 
-    UBool contains(int32_t obj) const;
+    inline UBool contains(int32_t obj) const;
 
     UBool containsAll(const UVector& other) const;
 
@@ -168,9 +168,9 @@ public:
 
     void removeAllElements();
 
-    int32_t size(void) const;
+    inline int32_t size(void) const;
 
-    UBool isEmpty(void) const;
+    inline UBool isEmpty(void) const;
 
     UBool ensureCapacity(int32_t minimumCapacity, UErrorCode &status);
 
@@ -195,7 +195,7 @@ public:
 
     UElementsAreEqual *setComparer(UElementsAreEqual *c);
 
-    void* operator[](int32_t index) const;
+    inline void* operator[](int32_t index) const;
 
     /**
      * Removes the element at the given index from this vector and
@@ -309,19 +309,19 @@ public:
     // It's okay not to have a virtual destructor (in UVector)
     // because UStack has no special cleanup to do.
 
-    UBool empty(void) const;
+    inline UBool empty(void) const;
 
-    void* peek(void) const;
+    inline void* peek(void) const;
 
-    int32_t peeki(void) const;
+    inline int32_t peeki(void) const;
     
     void* pop(void);
     
     int32_t popi(void);
     
-    void* push(void* obj, UErrorCode &status);
+    inline void* push(void* obj, UErrorCode &status);
 
-    int32_t push(int32_t i, UErrorCode &status);
+    inline int32_t push(int32_t i, UErrorCode &status);
 
     /*
     If the object o occurs as an item in this stack,

--- a/icu4c/source/common/uvectr32.h
+++ b/icu4c/source/common/uvectr32.h
@@ -97,21 +97,21 @@ public:
     // java.util.Vector API
     //------------------------------------------------------------
 
-    void addElement(int32_t elem, UErrorCode &status);
+    inline void addElement(int32_t elem, UErrorCode &status);
 
     void setElementAt(int32_t elem, int32_t index);
 
     void insertElementAt(int32_t elem, int32_t index, UErrorCode &status);
     
-    int32_t elementAti(int32_t index) const;
+    inline int32_t elementAti(int32_t index) const;
 
     UBool equals(const UVector32 &other) const;
 
-    int32_t lastElementi(void) const;
+    inline int32_t lastElementi(void) const;
 
     int32_t indexOf(int32_t elem, int32_t startIndex = 0) const;
 
-    UBool contains(int32_t elem) const;
+    inline UBool contains(int32_t elem) const;
 
     UBool containsAll(const UVector32& other) const;
 
@@ -123,9 +123,9 @@ public:
 
     void removeAllElements();
 
-    int32_t size(void) const;
+    inline int32_t size(void) const;
 
-    UBool isEmpty(void) const;
+    inline UBool isEmpty(void) const;
 
     // Inline.  Use this one for speedy size check.
     inline UBool ensureCapacity(int32_t minimumCapacity, UErrorCode &status);
@@ -163,7 +163,7 @@ public:
     /**
      * Returns a pointer to the internal array holding the vector.
      */
-    int32_t *getBuffer() const;
+    inline int32_t *getBuffer() const;
 
     /**
      * Set the maximum allowed buffer capacity for this vector/stack.
@@ -197,16 +197,16 @@ private:
     //  In the original UVector, these were in a separate derived class, UStack.
     //  Here in UVector32, they are all together.
 public:
-    UBool empty(void) const;   // TODO:  redundant, same as empty().  Remove it?
+    inline UBool empty(void) const;   // TODO:  redundant, same as empty().  Remove it?
 
-    int32_t peeki(void) const;
+    inline int32_t peeki(void) const;
     
-    int32_t popi(void);
+    inline int32_t popi(void);
     
-    int32_t push(int32_t i, UErrorCode &status);
+    inline int32_t push(int32_t i, UErrorCode &status);
 
-    int32_t *reserveBlock(int32_t size, UErrorCode &status);
-    int32_t *popFrame(int32_t size);
+    inline int32_t *reserveBlock(int32_t size, UErrorCode &status);
+    inline int32_t *popFrame(int32_t size);
 };
 
 

--- a/icu4c/source/common/uvectr64.h
+++ b/icu4c/source/common/uvectr64.h
@@ -96,17 +96,17 @@ public:
     // subset of java.util.Vector API
     //------------------------------------------------------------
 
-    void addElement(int64_t elem, UErrorCode &status);
+    inline void addElement(int64_t elem, UErrorCode &status);
 
     void setElementAt(int64_t elem, int32_t index);
 
     void insertElementAt(int64_t elem, int32_t index, UErrorCode &status);
     
-    int64_t elementAti(int32_t index) const;
+    inline int64_t elementAti(int32_t index) const;
 
     //UBool equals(const UVector64 &other) const;
 
-    int64_t lastElementi(void) const;
+    inline int64_t lastElementi(void) const;
 
     //int32_t indexOf(int64_t elem, int32_t startIndex = 0) const;
 
@@ -122,7 +122,7 @@ public:
 
     void removeAllElements();
 
-    int32_t size(void) const;
+    inline int32_t size(void) const;
 
     inline UBool isEmpty(void) const { return count == 0; }
 
@@ -152,7 +152,7 @@ public:
     /**
      * Returns a pointer to the internal array holding the vector.
      */
-    int64_t *getBuffer() const;
+    inline int64_t *getBuffer() const;
 
     /**
      * Set the maximum allowed buffer capacity for this vector/stack.
@@ -190,12 +190,12 @@ public:
 
     //int64_t peeki(void) const;
     
-    int64_t popi(void);
+    inline int64_t popi(void);
     
-    int64_t push(int64_t i, UErrorCode &status);
+    inline int64_t push(int64_t i, UErrorCode &status);
 
-    int64_t *reserveBlock(int32_t size, UErrorCode &status);
-    int64_t *popFrame(int32_t size);
+    inline int64_t *reserveBlock(int32_t size, UErrorCode &status);
+    inline int64_t *popFrame(int32_t size);
 };
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: [https://unicode-org.atlassian.net/browse/ICU-20356](https://unicode-org.atlassian.net/browse/ICU-20356)
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

Methods implementead as 'inline' but not declared 'inline' cause clang++
to throw compilation warnings on Windows. This adds 'inline' to the
relevant method declarations.
