### PR TITLE
ICU-20252 Update icu-config with more CLDR locales

### DIFF
--- a/icu4c/source/data/icu-config.xml
+++ b/icu4c/source/data/icu-config.xml
@@ -100,6 +100,8 @@
 		<include locales="ccp_IN"/>
 		<include locales="ce"/>
 		<include locales="ce_RU"/>
+		<include locales="ceb"/>
+		<include locales="ceb_PH"/>
 		<include locales="cgg"/>
 		<include locales="cgg_UG"/>
 		<include locales="chr"/>
@@ -145,6 +147,7 @@
 		<include locales="en"/>
 		<include locales="en_001"/>
 		<include locales="en_150"/>
+		<include locales="en_AE"/>
 		<include locales="en_AG"/>
 		<include locales="en_AI"/>
 		<include locales="en_AS"/>
@@ -250,6 +253,7 @@
 		<include locales="en_ZM"/>
 		<include locales="en_ZW"/>
 		<include locales="eo"/>
+		<include locales="eo_001"/>
 		<include locales="es"/>
 		<include locales="es_003"/>
 		<include locales="es_419"/>
@@ -292,6 +296,19 @@
 		<include locales="ff"/>
 		<include locales="ff_CM"/>
 		<include locales="ff_GN"/>
+		<include locales="ff_Latn"/>
+		<include locales="ff_Latn_BF"/>
+		<include locales="ff_Latn_CM"/>
+		<include locales="ff_Latn_GH"/>
+		<include locales="ff_Latn_GM"/>
+		<include locales="ff_Latn_GN"/>
+		<include locales="ff_Latn_GW"/>
+		<include locales="ff_Latn_LR"/>
+		<include locales="ff_Latn_MR"/>
+		<include locales="ff_Latn_NE"/>
+		<include locales="ff_Latn_NG"/>
+		<include locales="ff_Latn_SL"/>
+		<include locales="ff_Latn_SN"/>
 		<include locales="ff_MR"/>
 		<include locales="ff_SN"/>
 		<include locales="fi"/>
@@ -575,6 +592,7 @@
 		<include locales="pl_PL"/>
 		<include locales="ps"/>
 		<include locales="ps_AF"/>
+		<include locales="ps_PK"/>
 		<include locales="pt"/>
 		<include locales="pt_AO"/>
 		<include locales="pt_BR"/>
@@ -763,10 +781,10 @@
 		<include locales="yo_BJ"/>
 		<include locales="yo_NG"/>
 		<include locales="yue"/>
- 		<include locales="yue_Hans"/>
- 		<include locales="yue_Hans_CN"/>
- 		<include locales="yue_Hant"/>
- 		<include locales="yue_Hant_HK"/>
+		<include locales="yue_Hans"/>
+		<include locales="yue_Hans_CN"/>
+		<include locales="yue_Hant"/>
+		<include locales="yue_Hant_HK"/>
 		<include locales="zgh"/>
 		<include locales="zgh_MA"/>
 		<include locales="zh"/>


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20252
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added: N/A

Update icu-config.xml to include the “real” full locale names for the ff_Latn regional locales (but CLDR also has stub locales for the short names like ff_CM that alias to the full forms, so we do not need to move ff_CM and similar from icu-config.xml  to icu-locale-deprecates.xml. Also add new locales from CLDR in two categories:
- New regional locales for languages already included in ICU, e.g. en_AE
- New language ceb (Cebuano) and its regional locale ceb_PH

None of this will have any effect until I do the CLDR-to-ICU integration over the next few days.