### PR TITLE
ICU-20229 update make dist to use git, not svn

### DIFF
--- a/icu4c/source/config/dist.mk
+++ b/icu4c/source/config/dist.mk
@@ -9,7 +9,7 @@
 #
 # This will only work if subversion is installed.
 # You must checkout ICU4C at the `/icu`  or `/icu/icu4c` level - not just `…/source`
-# also note that `make dist` does NOT reflect any local modifications - it only does a fresh SVN export.
+# also note that `make dist` does NOT reflect any local modifications, but pulls from HEAD.
 
 top_builddir = .
 
@@ -19,21 +19,21 @@ DISTY_DIR=dist
 DISTY_TMP=dist/tmp
 DISTY_ICU=$(DISTY_TMP)/icu
 DISTY_DATA=$(DISTY_ICU)/source/data
+# The following line controls what is removed in the data/ subdirectory for the source tarball.
 DISTY_RMV=brkitr coll curr lang locales mappings rbnf region translit xml zone misc/*.txt misc/*.mk unit
 DISTY_RMDIR=$(DISTY_RMV:%=$(DISTY_DATA)/%)
 DISTY_IN=$(DISTY_DATA)/in
 DOCZIP=icu-docs.zip
 
-SVNTOP=$(top_srcdir)/..
-SVNVER=$(shell svnversion $(SVNTOP) | cut -d: -f1 | tr -cd 'a-zA-Z0-9')
-SVNURL=$(shell svn info $(SVNTOP) | grep '^URL:' | cut -d: -f2-)
+ICU4CTOP=$(top_srcdir)/..
+GITVER=$(shell (cd $(ICU4CTOP) && (git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD)) || echo 'unknown')
 DISTY_VER=$(shell echo $(VERSION) | tr '.' '_' )
 DISTY_PREFIX=icu4c
 DISTY_FILE_DIR=$(shell pwd)/$(DISTY_DIR)
-DISTY_FILE_TGZ=$(DISTY_FILE_DIR)/$(DISTY_PREFIX)-src-$(DISTY_VER)-r$(SVNVER).tgz
-DISTY_FILE_ZIP=$(DISTY_FILE_DIR)/$(DISTY_PREFIX)-src-$(DISTY_VER)-r$(SVNVER).zip
-DISTY_DOC_ZIP=$(DISTY_FILE_DIR)/$(DISTY_PREFIX)-docs-$(DISTY_VER)-r$(SVNVER).zip
-DISTY_DATA_ZIP=$(DISTY_FILE_DIR)/$(DISTY_PREFIX)-data-$(DISTY_VER)-r$(SVNVER).zip
+DISTY_FILE_TGZ=$(DISTY_FILE_DIR)/$(DISTY_PREFIX)-$(DISTY_VER)-$(GITVER)-src.tgz
+DISTY_FILE_ZIP=$(DISTY_FILE_DIR)/$(DISTY_PREFIX)-$(DISTY_VER)-$(GITVER)-src.zip
+DISTY_DOC_ZIP=$(DISTY_FILE_DIR)/$(DISTY_PREFIX)-$(DISTY_VER)-$(GITVER)-docs.zip
+DISTY_DATA_ZIP=$(DISTY_FILE_DIR)/$(DISTY_PREFIX)-$(DISTY_VER)-$(GITVER)-data.zip
 DISTY_DAT:=$(firstword $(wildcard data/out/tmp/icudt$(SO_TARGET_VERSION_MAJOR)*.dat))
 
 DISTY_FILES_SRC=$(DISTY_FILE_TGZ) $(DISTY_FILE_ZIP)
@@ -50,8 +50,9 @@ $(DISTY_TMP):
 $(DISTY_DOC_ZIP):  $(DOCZIP) $(DISTY_FILE_DIR)
 	cp $(DOCZIP) $(DISTY_DOC_ZIP)
 	ln -sf $(shell basename $(DISTY_DOC_ZIP)) $(DISTY_FILE_DIR)/icu4c-docs.zip
+	ln -f $(DISTY_DOC_ZIP) $(DISTY_FILE_DIR)/icu4c-$(DISTY_VER)-docs.zip
 
-$(DISTY_DAT): 
+$(DISTY_DAT):
 	echo Missing $@
 	/bin/false
 
@@ -61,15 +62,10 @@ $(DOCZIP):
 	"$(MAKE)" -C . srcdir="$(srcdir)" top_srcdir="$(top_srcdir)" builddir=. $@
 
 $(DISTY_FILE_TGZ) $(DISTY_FILE_ZIP) $(DISTY_DATA_ZIP):  $(DISTY_DAT) $(DISTY_TMP)
-	@echo "svnversion of $(SVNTOP) is as follows (if this fails, make sure svn is installed..)"
-	svnversion $(SVNTOP)
+	@echo Export icu4c@$(GITVER) to "$(DISTY_TMP)/icu"
 	-$(RMV) $(DISTY_FILE) $(DISTY_TMP)
 	$(MKINSTALLDIRS) $(DISTY_TMP)
-	@echo collecting excludes to $(EXCLUDES_FILE)
-	(cd "$(SVNTOP)" ; svn status --no-ignore  | grep '^I' | cut -c2- > "$(EXCLUDES_FILE)" ) 
-	@echo pseudo-exporting $(SVNVER)
-	@#svn export -r $(shell echo $(SVNVER) | tr -d 'a-zA-Z' ) $(SVNURL) "$(DISTY_TMP)/icu"
-	rsync -a --exclude-from="$(EXCLUDES_FILE)" "$(SVNTOP)" "$(DISTY_TMP)/icu"
+	( cd $(ICU4CTOP)/.. && git archive --format=tar --prefix=icu/ HEAD:icu4c/ ) | ( cd "$(DISTY_TMP)" && tar xf - )
 	( cd $(DISTY_TMP)/icu/source ; zip -rlq $(DISTY_DATA_ZIP) data )
 	$(MKINSTALLDIRS) $(DISTY_IN)
 	echo DISTY_DAT=$(DISTY_DAT)
@@ -82,6 +78,9 @@ $(DISTY_FILE_TGZ) $(DISTY_FILE_ZIP) $(DISTY_DATA_ZIP):  $(DISTY_DAT) $(DISTY_TMP
 	ln -sf $(shell basename $(DISTY_FILE_ZIP)) $(DISTY_FILE_DIR)/icu4c-src.zip
 	ln -sf $(shell basename $(DISTY_FILE_TGZ)) $(DISTY_FILE_DIR)/icu4c-src.tgz
 	ln -sf $(shell basename $(DISTY_DATA_ZIP)) $(DISTY_FILE_DIR)/icu4c-data.zip
+	ln -f $(DISTY_FILE_ZIP) $(DISTY_FILE_DIR)/icu4c-$(DISTY_VER)-src.zip
+	ln -f $(DISTY_FILE_TGZ) $(DISTY_FILE_DIR)/icu4c-$(DISTY_VER)-src.tgz
+	ln -f $(DISTY_DATA_ZIP) $(DISTY_FILE_DIR)/icu4c-$(DISTY_VER)-data.zip
 	ls -l $(DISTY_FILE_TGZ) $(DISTY_FILE_ZIP) $(DISTY_DATA_ZIP)
 
 


### PR DESCRIPTION
- use git instead of svn for versioning
- update generated file names to match official downloads

Example filenames:
- icu4c-63_1-c5749aaf94-src.tgz (includes git hash or tag)
- icu4c-63_1-src.tgz (hard link to above)
- icu4c-src.tgz (symlink)
- icu4c-63_1-c5749aaf94-src.zip (includes git hash or tag)
- icu4c-63_1-src.zip (hard link to above)
- icu4c-src.zip (symlink)
- icu4c-63_1-c5749aaf94-data.zip (includes git hash or tag)
- icu4c-63_1-data.zip (hard link to above)
- icu4c-data.zip (symlink)
- icu4c-63_1-c5749aaf94-docs.zip (includes git hash or tag)
- icu4c-63_1-docs.zip (hard link to above)
- icu4c-docs.zip (symlink)


##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20229
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted

