### PR TITLE
ICU-20280 PluralRules::forLocale() ignore locale extensions

### DIFF
--- a/icu4c/source/i18n/plurrule.cpp
+++ b/icu4c/source/i18n/plurrule.cpp
@@ -703,14 +703,14 @@ PluralRules::getRuleFromResource(const Locale& locale, UPluralType type, UErrorC
         return emptyStr;
     }
     int32_t resLen=0;
-    const char *curLocaleName=locale.getName();
+    const char *curLocaleName=locale.getBaseName();
     const UChar* s = ures_getStringByKey(locRes.getAlias(), curLocaleName, &resLen, &errCode);
 
     if (s == nullptr) {
         // Check parent locales.
         UErrorCode status = U_ZERO_ERROR;
         char parentLocaleName[ULOC_FULLNAME_CAPACITY];
-        const char *curLocaleName2=locale.getName();
+        const char *curLocaleName2=locale.getBaseName();
         uprv_strcpy(parentLocaleName, curLocaleName2);
 
         while (uloc_getParent(parentLocaleName, parentLocaleName,

--- a/icu4c/source/test/intltest/plurults.cpp
+++ b/icu4c/source/test/intltest/plurults.cpp
@@ -55,6 +55,7 @@ void PluralRulesTest::runIndexedTest( int32_t index, UBool exec, const char* &na
     TESTCASE_AUTO(testParseErrors);
     TESTCASE_AUTO(testFixedDecimal);
     TESTCASE_AUTO(testSelectTrailingZeros);
+    TESTCASE_AUTO(testLocaleExtension);
     TESTCASE_AUTO_END;
 }
 
@@ -1036,6 +1037,12 @@ void PluralRulesTest::testSelectTrailingZeros() {
     }
 }
 
-
+void PluralRulesTest::testLocaleExtension() {
+    IcuTestErrorCode errorCode(*this, "testLocaleExtension");
+    LocalPointer<PluralRules> rules(PluralRules::forLocale("pt@calendar=gregorian", errorCode));
+    if (errorCode.errIfFailureAndReset("PluralRules::forLocale()")) { return; }
+    UnicodeString key = rules->select(1);
+    assertEquals("pt@calendar=gregorian select(1)", u"one", key);
+}
 
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/test/intltest/plurults.h
+++ b/icu4c/source/test/intltest/plurults.h
@@ -38,6 +38,7 @@ private:
     void testParseErrors();
     void testFixedDecimal();
     void testSelectTrailingZeros();
+    void testLocaleExtension();
 
     void assertRuleValue(const UnicodeString& rule, double expected);
     void assertRuleKeyValue(const UnicodeString& rule, const UnicodeString& key,

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/PluralRulesTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/PluralRulesTest.java
@@ -527,6 +527,13 @@ public class PluralRulesTest extends TestFmwk {
     }
 
     @Test
+    public void testLocaleExtension() {
+        PluralRules rules = PluralRules.forLocale(new ULocale("pt@calendar=gregorian"));
+        String key = rules.select(1);
+        assertEquals("pt@calendar=gregorian select(1)", "one", key);
+    }
+
+    @Test
     public void testFunctionalEquivalent() {
         // spot check
         ULocale unknown = ULocale.createCanonical("zz_ZZ");


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-20280