### PR TITLE
ICU-20243 Fix exhaustive test CI builds to run cintltst.

### DIFF
--- a/.ci-builds/.azure-exhaustive-tests.yml
+++ b/.ci-builds/.azure-exhaustive-tests.yml
@@ -51,11 +51,9 @@ jobs:
         cd icu4c/source && ./runConfigureICU Linux && make -j2
       displayName: 'Build'
     - script: |
-        cd icu4c/source && make check
+        cd icu4c/source && make check-exhaustive
       displayName: 'Exhaustive Tests'
       env:
-        INTLTEST_OPTS: '-e'
-        CINTLTEST_OPTS: '-e'
         CC: clang
         CXX: clang++
 #-------------------------------------------------------------------------


### PR DESCRIPTION
No actual change to the product code.
This PR simply fixes the YML config file to actually run the exhaustive tests for `cintltst` in the CI builds.

(Thanks to Andy for running the tests manually and noticing the failure!).

Note: The exhaustive test for ICU4C has a failure in cintltst test `/tsutil/cldrtest/VerifyTranslation`.
This is tracked by [ICU-20210](https://unicode-org.atlassian.net/browse/ICU-20210), which needs changes from CLDR.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20243
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

