### PR TITLE
ICU-20470 skip data/rules.mk regen for source tarball

### DIFF
--- a/icu4c/source/configure
+++ b/icu4c/source/configure
@@ -753,7 +753,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -858,7 +857,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1111,15 +1109,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1257,7 +1246,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1410,7 +1399,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -9127,16 +9115,22 @@ if test -z "$PYTHON";
 then
     echo "" > data/rules.mk
 else
-    echo "Spawning Python to generate data/rules.mk..."
-    PYTHONPATH="$srcdir/data" $PYTHON -m buildtool \
-        --mode gnumake \
-        --seqmode parallel \
-        --src_dir "$srcdir/data" \
-        --filter_file "$ICU_DATA_FILTER_FILE" \
-        $BUILDTOOL_OPTS \
-        > data/rules.mk
-    if test "$?" != "0"; then
-        as_fn_error $? "Python failed to run; see above error." "$LINENO" 5
+    if test -f "$srcdir/data/locales/root.txt";
+    then
+        echo "Spawning Python to generate data/rules.mk..."
+        PYTHONPATH="$srcdir/data" $PYTHON -m buildtool \
+            --mode gnumake \
+            --seqmode parallel \
+            --src_dir "$srcdir/data" \
+            --filter_file "$ICU_DATA_FILTER_FILE" \
+            $ICU_DATA_BUILDTOOL_OPTS \
+            > data/rules.mk
+        if test "$?" != "0"; then
+            as_fn_error $? "Python failed to run; see above error." "$LINENO" 5
+        fi
+    else
+      echo "Not rebuilding data/rules.mk, assuming prebuilt data in data/in"
+      touch data/rules.mk
     fi
     echo "Spawning Python to generate test/testdata/rules.mk..."
     PYTHONPATH="$srcdir/test/testdata:$srcdir/data" $PYTHON -m buildtool \

--- a/icu4c/source/configure.ac
+++ b/icu4c/source/configure.ac
@@ -1391,16 +1391,22 @@ if test -z "$PYTHON";
 then
     echo "" > data/rules.mk
 else
-    echo "Spawning Python to generate data/rules.mk..."
-    PYTHONPATH="$srcdir/data" $PYTHON -m buildtool \
-        --mode gnumake \
-        --seqmode parallel \
-        --src_dir "$srcdir/data" \
-        --filter_file "$ICU_DATA_FILTER_FILE" \
-        $ICU_DATA_BUILDTOOL_OPTS \
-        > data/rules.mk
-    if test "$?" != "0"; then
-        AC_MSG_ERROR(Python failed to run; see above error.)
+    if test -f "$srcdir/data/locales/root.txt";
+    then
+        echo "Spawning Python to generate data/rules.mk..."
+        PYTHONPATH="$srcdir/data" $PYTHON -m buildtool \
+            --mode gnumake \
+            --seqmode parallel \
+            --src_dir "$srcdir/data" \
+            --filter_file "$ICU_DATA_FILTER_FILE" \
+            $ICU_DATA_BUILDTOOL_OPTS \
+            > data/rules.mk
+        if test "$?" != "0"; then
+            AC_MSG_ERROR(Python failed to run; see above error.)
+        fi
+    else
+      echo "Not rebuilding data/rules.mk, assuming prebuilt data in data/in"
+      touch data/rules.mk
     fi
     echo "Spawning Python to generate test/testdata/rules.mk..."
     PYTHONPATH="$srcdir/test/testdata:$srcdir/data" $PYTHON -m buildtool \

--- a/icu4c/source/data/Makefile.in
+++ b/icu4c/source/data/Makefile.in
@@ -251,6 +251,7 @@ build-local: $(SO_VERSION_DATA) $(PKGDATA_LIST) $(OS390LIST)
 	echo timestamp > $@
 $(PKGDATA_LIST): $(SRCLISTDEPS) $(ICUDATA_SOURCE_ARCHIVE)
 ifneq ($(ICUDATA_SOURCE_IS_NATIVE_TARGET),YES)
+	$(MKINSTALLDIRS) $(OUTTMPDIR) $(BUILDDIR)
 	@echo "Unpacking $(ICUDATA_SOURCE_ARCHIVE) and generating $@ (list of data files)"
 	@-$(RMV) $@
 	$(INVOKE) $(TOOLBINDIR)/icupkg -d $(BUILDDIR) --list -x \* $(ICUDATA_SOURCE_ARCHIVE) -o $@


### PR DESCRIPTION
Merge in 07df49c9a92c2fcc73b6b2daac5624d477e1b14f to maint branch

- If icu/source/data/locales/root.txt missing, skip
  python rules.mk generation.
- Also, create build directories properly as needed
- Also includes noise changes to configure
  (configure was probably generated using unreleased
   autoconf 2.70 or 2.69 + patches)
- eac8f4b31ab7395abb3a216aa17bafe7af6314ed did not
  regen configure properly, so BUILDTOOL_OPTS is now
  ICU_DATA_BUILDTOOL_OPTS

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20470
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
