### PR TITLE
ICU-13393 Short-term fixes for anyone still using the vendor compiler on Solaris 2.10+

### DIFF
--- a/icu4c/source/i18n/currunit.cpp
+++ b/icu4c/source/i18n/currunit.cpp
@@ -20,7 +20,7 @@
 #include "uinvchar.h"
 #include "charstr.h"
 
-static constexpr char16_t kDefaultCurrency[] = u"XXX";
+static constexpr char16_t* kDefaultCurrency = u"XXX";
 static constexpr char kDefaultCurrency8[] = "XXX";
 
 U_NAMESPACE_BEGIN

--- a/icu4c/source/i18n/number_types.h
+++ b/icu4c/source/i18n/number_types.h
@@ -42,7 +42,7 @@ static constexpr int32_t kMaxIntFracSig = 999;
 static constexpr RoundingMode kDefaultMode = RoundingMode::UNUM_FOUND_HALFEVEN;
 
 // ICU4J Equivalent: Padder.FALLBACK_PADDING_STRING
-static constexpr char16_t kFallbackPaddingString[] = u" ";
+static constexpr char16_t* kFallbackPaddingString = u" ";
 
 // Forward declarations:
 

--- a/icu4c/source/i18n/numparse_compositions.h
+++ b/icu4c/source/i18n/numparse_compositions.h
@@ -31,10 +31,18 @@ class U_I18N_API CompositionMatcher : public NumberParseMatcher {
     CompositionMatcher() = default;
 
     // To be overridden by subclasses (used for iteration):
+#ifndef __SUNPRO_CC
     virtual const NumberParseMatcher* const* begin() const = 0;
+#else
+    virtual const NumberParseMatcher* const* begin() const {return nullptr;};
+#endif
 
     // To be overridden by subclasses (used for iteration):
+#ifndef __SUNPRO_CC
     virtual const NumberParseMatcher* const* end() const = 0;
+#else
+    virtual const NumberParseMatcher* const* end() const {return nullptr;};
+#endif
 };
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-13393
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

Long-term, anyone on Solaris should switch to GCC or Clang; GCC is now the system compiler on all but Oracle Solaris