### PR TITLE
ICU-13393 Fixes for Sun Studio compiler on Oracle Solaris.

### DIFF
--- a/icu4c/source/common/uniset_props.cpp
+++ b/icu4c/source/common/uniset_props.cpp
@@ -105,14 +105,8 @@ static UBool U_CALLCONV uset_cleanup(void) {
     return TRUE;
 }
 
-U_CDECL_END
-
-U_NAMESPACE_BEGIN
-
-namespace {
-
 // Cache some sets for other services -------------------------------------- ***
-void U_CALLCONV createUni32Set(UErrorCode &errorCode) {
+static void U_CALLCONV createUni32Set(UErrorCode &errorCode) {
     U_ASSERT(uni32Singleton == NULL);
     uni32Singleton = new UnicodeSet(UNICODE_STRING_SIMPLE("[:age=3.2:]"), errorCode);
     if(uni32Singleton==NULL) {
@@ -123,13 +117,19 @@ void U_CALLCONV createUni32Set(UErrorCode &errorCode) {
     ucln_common_registerCleanup(UCLN_COMMON_USET, uset_cleanup);
 }
 
-
+// All public C API symbols can only exist at file scope.
+// Blame Oracle. (in a few years dev studio shall be ancient history, i hope.)
 U_CFUNC UnicodeSet *
 uniset_getUnicode32Instance(UErrorCode &errorCode) {
     umtx_initOnce(uni32InitOnce, &createUni32Set, errorCode);
     return uni32Singleton;
 }
 
+U_CDECL_END
+
+U_NAMESPACE_BEGIN
+
+namespace {
 // helper functions for matching of pattern syntax pieces ------------------ ***
 // these functions are parallel to the PERL_OPEN etc. strings above
 

--- a/icu4c/source/i18n/currunit.cpp
+++ b/icu4c/source/i18n/currunit.cpp
@@ -20,7 +20,7 @@
 #include "uinvchar.h"
 #include "charstr.h"
 
-static constexpr char16_t kDefaultCurrency[] = u"XXX";
+static constexpr const char16_t* kDefaultCurrency = u"XXX";
 static constexpr char kDefaultCurrency8[] = "XXX";
 
 U_NAMESPACE_BEGIN

--- a/icu4c/source/i18n/number_types.h
+++ b/icu4c/source/i18n/number_types.h
@@ -42,7 +42,7 @@ static constexpr int32_t kMaxIntFracSig = 999;
 static constexpr RoundingMode kDefaultMode = RoundingMode::UNUM_FOUND_HALFEVEN;
 
 // ICU4J Equivalent: Padder.FALLBACK_PADDING_STRING
-static constexpr char16_t kFallbackPaddingString[] = u" ";
+static constexpr const char16_t* kFallbackPaddingString = u" ";
 
 // Forward declarations:
 


### PR DESCRIPTION
Short-term fix for Sun Studio users. Long term, anyone on Solaris 2.11 should switch to GCC or Clang; on all but Oracle Solaris, [GCC is now the system compiler.](https://illumos.topicbox.com/groups/developer/T87bcf50a95d4efad-M164f2ceb9ebde4bf51c09bd8) 

At this point, the only major C++ codebase that still requires it is Java, as Java _only_ builds with the vendor compiler on all supported platforms (GCC on Linux, Microsoft C++ on Windows, XL C++ on AIX, Clang on Macintosh, DevStudio on Solaris, etc)

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-13393
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

