### PR TITLE
ICU-20474 VS library build Props file ignores command line defines with MSBUILD

### DIFF
--- a/icu4c/source/allinone/Build.Windows.Library.ProjectConfiguration.props
+++ b/icu4c/source/allinone/Build.Windows.Library.ProjectConfiguration.props
@@ -7,6 +7,7 @@
     <ClCompile>
       <!-- ICU does not use exceptions in library code. -->
       <PreprocessorDefinitions>
+        $(DefineConstants);
         _HAS_EXCEPTIONS=0;
         %(PreprocessorDefinitions)
       </PreprocessorDefinitions>


### PR DESCRIPTION
This change/fix allows for setting preprocessor defines on the command line when building with MSBUILD.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20474
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

