### PR TITLE
ICU-20484 Narrow currency symbol should fall back to short symbol.

### DIFF
--- a/icu4c/source/common/ucurr.cpp
+++ b/icu4c/source/common/ucurr.cpp
@@ -690,7 +690,13 @@ ucurr_getName(const UChar* currency,
         key.append("/", ec2);
         key.append(buf, ec2);
         s = ures_getStringByKeyWithFallback(rb.getAlias(), key.data(), len, &ec2);
-    } else {
+        if (ec2 == U_MISSING_RESOURCE_ERROR) {
+            *ec = U_USING_FALLBACK_WARNING;
+            ec2 = U_ZERO_ERROR;
+            choice = UCURR_SYMBOL_NAME;
+        }
+    }
+    if (s == NULL) {
         ures_getByKey(rb.getAlias(), CURRENCIES, rb.getAlias(), &ec2);
         ures_getByKeyWithFallback(rb.getAlias(), buf, rb.getAlias(), &ec2);
         s = ures_getStringByIndex(rb.getAlias(), choice, len, &ec2);

--- a/icu4c/source/test/intltest/numbertest_api.cpp
+++ b/icu4c/source/test/intltest/numbertest_api.cpp
@@ -779,7 +779,7 @@ void NumberFormatterApiTest::unitCurrency() {
             NumberFormatter::with().unit(PTE).unitWidth(UNUM_UNIT_WIDTH_NARROW),
             Locale("pt-PT"),
             444444.55,
-            u"444,444$55 PTE");
+            u"444,444$55 \u200B");
 
     assertFormatSingle(
             u"Currency-dependent symbols (Test ISO Code)",

--- a/icu4c/source/test/intltest/numfmtst.h
+++ b/icu4c/source/test/intltest/numfmtst.h
@@ -153,6 +153,8 @@ class NumberFormatTest: public CalendarTimeZoneTest {
 
     void TestCurrencyNames(void);
 
+    void Test20484_NarrowSymbolFallback(void);
+
     void TestCurrencyAmount(void);
 
     void TestCurrencyUnit(void);

--- a/icu4j/main/classes/core/src/com/ibm/icu/text/CurrencyDisplayNames.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/CurrencyDisplayNames.java
@@ -122,8 +122,8 @@ public abstract class CurrencyDisplayNames {
 
     /**
      * Returns the narrow symbol for the currency with the provided ISO code.
-     * If there is no data for narrow symbol, substitutes isoCode, or returns
-     * null if noSubstitute was set in the factory method.
+     * If there is no data for narrow symbol, substitutes the default symbol,
+     * or returns null if noSubstitute was set in the factory method.
      *
      * @param isoCode the three-letter ISO code.
      * @return the narrow symbol.

--- a/icu4j/main/classes/currdata/src/com/ibm/icu/impl/ICUCurrencyDisplayInfoProvider.java
+++ b/icu4j/main/classes/currdata/src/com/ibm/icu/impl/ICUCurrencyDisplayInfoProvider.java
@@ -95,7 +95,7 @@ public class ICUCurrencyDisplayInfoProvider implements CurrencyDisplayInfoProvid
         /**
          * Cache for symbolMap() and nameMap().
          */
-        private volatile SoftReference<ParsingData> parsingDataCache = new SoftReference<ParsingData>(null);
+        private volatile SoftReference<ParsingData> parsingDataCache = new SoftReference<>(null);
 
         /**
          * Cache for getUnitPatterns().
@@ -124,8 +124,8 @@ public class ICUCurrencyDisplayInfoProvider implements CurrencyDisplayInfoProvid
         }
 
         static class ParsingData {
-            Map<String, String> symbolToIsoCode = new HashMap<String, String>();
-            Map<String, String> nameToIsoCode = new HashMap<String, String>();
+            Map<String, String> symbolToIsoCode = new HashMap<>();
+            Map<String, String> nameToIsoCode = new HashMap<>();
         }
 
         ////////////////////////
@@ -170,9 +170,8 @@ public class ICUCurrencyDisplayInfoProvider implements CurrencyDisplayInfoProvid
             NarrowSymbol narrowSymbol = fetchNarrowSymbol(isoCode);
 
             // Fall back to ISO Code
-            // TODO: Should this fall back to the regular symbol instead of the ISO code?
             if (narrowSymbol.narrowSymbol == null && fallback) {
-                return isoCode;
+                return getSymbol(isoCode);
             }
             return narrowSymbol.narrowSymbol;
         }
@@ -289,7 +288,7 @@ public class ICUCurrencyDisplayInfoProvider implements CurrencyDisplayInfoProvid
                 CurrencySink sink = new CurrencySink(!fallback, CurrencySink.EntrypointTable.TOP);
                 sink.parsingData = result;
                 rb.getAllItemsWithFallback("", sink);
-                parsingDataCache = new SoftReference<ParsingData>(result);
+                parsingDataCache = new SoftReference<>(result);
             }
             return result;
         }
@@ -297,7 +296,7 @@ public class ICUCurrencyDisplayInfoProvider implements CurrencyDisplayInfoProvid
         Map<String, String> fetchUnitPatterns() {
             Map<String, String> result = unitPatternsCache;
             if (result == null) {
-                result = new HashMap<String, String>();
+                result = new HashMap<>();
                 CurrencySink sink = new CurrencySink(!fallback, CurrencySink.EntrypointTable.CURRENCY_UNIT_PATTERNS);
                 sink.unitPatterns = result;
                 rb.getAllItemsWithFallback("CurrencyUnitPatterns", sink);

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
@@ -741,7 +741,7 @@ public class NumberFormatterApiTest {
                 NumberFormatter.with().unit(PTE).unitWidth(UnitWidth.NARROW),
                 ULocale.forLanguageTag("pt-PT"),
                 444444.55,
-                "444,444$55 PTE");
+                "444,444$55 \u200B");
 
         assertFormatSingle(
                 "Currency-dependent symbols (Test)",

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/CurrencyTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/CurrencyTest.java
@@ -239,6 +239,30 @@ public class CurrencyTest extends TestFmwk {
     }
 
     @Test
+    public void test20484_NarrowSymbolFallback() {
+        Object[][] cases = new Object[][] {
+            {"en-US", "CAD", "CA$", "$"},
+            {"en-US", "CDF", "CDF", "CDF"},
+            {"sw-CD", "CDF", "FC", "FC"},
+            {"en-US", "GEL", "GEL", "₾"},
+            {"ka-GE", "GEL", "₾", "₾"},
+            {"ka", "GEL", "₾", "₾"},
+        };
+        for (Object[] cas : cases) {
+            ULocale locale = new ULocale((String) cas[0]);
+            String isoCode = (String) cas[1];
+            String expectedShort = (String) cas[2];
+            String expectedNarrow = (String) cas[3];
+
+            CurrencyDisplayNames cdn = CurrencyDisplayNames.getInstance(locale);
+            assertEquals("Short symbol: " + locale + ": " + isoCode,
+                    expectedShort, cdn.getSymbol(isoCode));
+            assertEquals("Narrow symbol: " + locale + ": " + isoCode,
+                    expectedNarrow, cdn.getNarrowSymbol(isoCode));
+        }
+    }
+
+    @Test
     public void testGetName_Locale_Int_String_BooleanArray() {
         Currency currency = Currency.getInstance(ULocale.CHINA);
         boolean[] isChoiceFormat = new boolean[1];


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20484
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [x] Documentation is changed or added

