### PR TITLE
ICU-12956 fix buffer overrun of UTF-7 and IMAP-mailbox-name

### DIFF
--- a/icu4j/main/classes/charset/src/com/ibm/icu/charset/CharsetUTF7.java
+++ b/icu4j/main/classes/charset/src/com/ibm/icu/charset/CharsetUTF7.java
@@ -28,7 +28,7 @@ class CharsetUTF7 extends CharsetICU {
 
     public CharsetUTF7(String icuCanonicalName, String javaCanonicalName, String[] aliases) {
         super(icuCanonicalName, javaCanonicalName, aliases);
-        maxBytesPerChar=4; /* max 3 bytes per code unit from UTF-7 (base64) */
+        maxBytesPerChar=5; /* max 3 bytes per code unit from UTF-7 (base64) plus SIN SOUT */
         minBytesPerChar=1;
         maxCharsPerByte=1;
 

--- a/icu4j/main/tests/charset/src/com/ibm/icu/dev/test/charset/TestCharset.java
+++ b/icu4j/main/tests/charset/src/com/ibm/icu/dev/test/charset/TestCharset.java
@@ -21,6 +21,7 @@ import java.nio.charset.CodingErrorAction;
 import java.nio.charset.UnsupportedCharsetException;
 import java.nio.charset.spi.CharsetProvider;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.MissingResourceException;
 import java.util.Set;
@@ -3215,6 +3216,28 @@ public class TestCharset extends TestFmwk {
             errln("Overflow buffer while encoding UTF-7 should have occurred.");
         }
         //end of charset encoder code coverage code
+    }
+
+    @Test
+    public void TestBug12956() {
+        final CharsetProvider provider = new CharsetProviderICU();
+        final Charset cs_utf7 = provider.charsetForName("UTF-7");
+        final Charset cs_imap = provider.charsetForName("IMAP-mailbox-name");
+        final String test = "新";
+        final byte[] expected_utf7 = {0x2b, 0x5a, 0x62, 0x41, 0x2d};
+        final byte[] expected_imap = {0x26, 0x5a, 0x62, 0x41, 0x2d};
+
+        byte[] bytes = test.getBytes(cs_utf7);
+        if (!Arrays.equals(bytes, expected_utf7)) {
+            errln("Incorrect UTF-7 conversion. Got " + new String(bytes) + " but expect " +
+                  new String(expected_utf7));
+        }
+
+        bytes = test.getBytes(cs_imap);
+        if (!Arrays.equals(bytes, expected_imap)) {
+            errln("Incorrect IMAP-mailbox-name conversion. Got " + new String(bytes) +
+                  " but expect " + new String(expected_imap));
+        }
     }
 
     //Test Charset ISCII


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-12956
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [X] Tests included
- [X] Documentation is changed or added

