### PR TITLE
ICU-20471 setFormatWidth(0) should cause padding to be ignored in pattern etc.

### DIFF
--- a/icu4c/source/i18n/number_mapper.cpp
+++ b/icu4c/source/i18n/number_mapper.cpp
@@ -182,7 +182,7 @@ MacroProps NumberPropertyMapper::oldToNew(const DecimalFormatProperties& propert
     // PADDING //
     /////////////
 
-    if (properties.formatWidth != -1) {
+    if (properties.formatWidth > 0) {
         macros.padder = Padder::forProperties(properties);
     }
 

--- a/icu4c/source/i18n/number_patternstring.cpp
+++ b/icu4c/source/i18n/number_patternstring.cpp
@@ -781,7 +781,7 @@ UnicodeString PatternStringUtils::propertiesToPatternString(const DecimalFormatP
     sb.append(affixes.getString(AffixPatternProvider::AFFIX_POS_SUFFIX));
 
     // Resolve Padding
-    if (paddingWidth != -1 && !paddingLocation.isNull()) {
+    if (paddingWidth > 0 && !paddingLocation.isNull()) {
         while (paddingWidth - sb.length() > 0) {
             sb.insert(afterPrefixPos, u'#');
             beforeSuffixPos++;

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/PatternStringUtils.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/PatternStringUtils.java
@@ -171,7 +171,7 @@ public class PatternStringUtils {
         sb.append(affixes.getString(AffixPatternProvider.FLAG_POS_SUFFIX));
 
         // Resolve Padding
-        if (paddingWidth != -1) {
+        if (paddingWidth > 0) {
             while (paddingWidth - sb.length() > 0) {
                 sb.insert(afterPrefixPos, '#');
                 beforeSuffixPos++;

--- a/icu4j/main/classes/core/src/com/ibm/icu/number/NumberPropertyMapper.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/number/NumberPropertyMapper.java
@@ -219,7 +219,7 @@ final class NumberPropertyMapper {
         // PADDING //
         /////////////
 
-        if (properties.getFormatWidth() != -1) {
+        if (properties.getFormatWidth() > 0) {
             macros.padder = Padder.forProperties(properties);
         }
 

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/NumberFormatTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/NumberFormatTest.java
@@ -1418,6 +1418,29 @@ public class NumberFormatTest extends TestFmwk {
         expect2(new DecimalFormat("*'😃'####.00", US), 1.1, "😃😃😃1.10");
     }
 
+    @Test
+    public void TestIgnorePadding() {
+        DecimalFormatSymbols dfs = new DecimalFormatSymbols(Locale.US);
+        DecimalFormat fmt = new DecimalFormat("", dfs);
+        fmt.setGroupingUsed(false);
+        fmt.setFormatWidth(0);
+        fmt.setPadCharacter('*');
+        fmt.setPadPosition(0);
+        fmt.setMinimumIntegerDigits(0);
+        fmt.setMaximumIntegerDigits(8);
+        fmt.setMinimumFractionDigits(0);
+        fmt.setMaximumFractionDigits(0);
+        String pattern = fmt.toPattern();
+        if (pattern.startsWith("*")) {
+            errln("ERROR toPattern result should ignore padding but get \"" + pattern + "\"");
+        }
+        fmt.applyPattern(pattern);
+        String format = fmt.format(24);
+        if (!format.equals("24")) {
+             errln("ERROR format result expect 24 but get \"" + format + "\"");
+       }
+    }
+
     /**
      * Upgrade to alphaWorks
      */


### PR DESCRIPTION

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20471
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

Soould treat any formatWidth <= 0  (not just -1) as disabling padding e.g. when generating the pattern string, etc.