### PR TITLE
ICU-20491 u_getDataDirectory shouldn't set path to current dir by default on Windows

### DIFF
--- a/icu4c/source/common/putil.cpp
+++ b/icu4c/source/common/putil.cpp
@@ -1420,12 +1420,7 @@ static void U_CALLCONV dataDirectoryInitFn() {
 
     if(path==NULL) {
         /* It looks really bad, set it to something. */
-#if U_PLATFORM_HAS_WIN32_API
-        // Windows UWP will require icudtl.dat file in same directory as icuuc.dll
-        path = ".\\";
-#else
         path = "";
-#endif
     }
 
     u_setDataDirectory(path);


### PR DESCRIPTION
There's technically no reason why the Windows UWP version should require or limit the icudtl.dat file
to be in the same directory as the icuuc.dll file.

(From looking at the history, this change was originally introduced by commit e9946ec, which itself was a merge of several other UWP related changes).

It is possible that the original comment was intended to say something along the lines of "UWP requires the icudtl.dat file be in the same package as the DLL files", but I'm not sure if it is worth adding that comment buried in some random .cpp file.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20491
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

