### PR TITLE
ICU-20439 Updating double-conversion.

### DIFF
--- a/icu4c/source/i18n/double-conversion.cpp
+++ b/icu4c/source/i18n/double-conversion.cpp
@@ -579,7 +579,7 @@ static bool IsCharacterDigitForRadix(int c, int radix, char a_character) {
 
 // Returns true, when the iterator is equal to end.
 template<class Iterator>
-static bool Advance (Iterator* it, char separator, int base, Iterator& end) {
+static bool Advance (Iterator* it, uc16 separator, int base, Iterator& end) {
   if (separator == StringToDoubleConverter::kNoSeparator) {
     ++(*it);
     return *it == end;
@@ -607,7 +607,7 @@ static bool Advance (Iterator* it, char separator, int base, Iterator& end) {
 template<class Iterator>
 static bool IsHexFloatString(Iterator start,
                              Iterator end,
-                             char separator,
+                             uc16 separator,
                              bool allow_trailing_junk) {
   ASSERT(start != end);
 
@@ -648,7 +648,7 @@ template <int radix_log_2, class Iterator>
 static double RadixStringToIeee(Iterator* current,
                                 Iterator end,
                                 bool sign,
-                                char separator,
+                                uc16 separator,
                                 bool parse_as_hex_float,
                                 bool allow_trailing_junk,
                                 double junk_string_value,

--- a/icu4c/source/i18n/double-conversion.h
+++ b/icu4c/source/i18n/double-conversion.h
@@ -544,9 +544,7 @@ class StringToDoubleConverter {
         junk_string_value_(junk_string_value),
         infinity_symbol_(infinity_symbol),
         nan_symbol_(nan_symbol),
-        // ICU PATCH: Convert the u16 to a char.
-        // This patch should be removed when upstream #89 is fixed.
-        separator_(static_cast<char>(separator)) {
+        separator_(separator) {
   }
 
   // Performs the conversion.
@@ -581,10 +579,7 @@ class StringToDoubleConverter {
   const double junk_string_value_;
   const char* const infinity_symbol_;
   const char* const nan_symbol_;
-
-  // ICU PATCH: Avoid warnings by making this a char instead of a u16.
-  // This patch should be removed when upstream #89 is fixed.
-  const char separator_;
+  const uc16 separator_;
 
   template <class Iterator>
   double StringToIeee(Iterator start_pointer,

--- a/vendor/double-conversion/upstream/CMakeLists.txt
+++ b/vendor/double-conversion/upstream/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-project(double-conversion VERSION 3.1.1)
+project(double-conversion VERSION 3.1.4)
 
 set(headers
     double-conversion/bignum.h

--- a/vendor/double-conversion/upstream/Changelog
+++ b/vendor/double-conversion/upstream/Changelog
@@ -1,3 +1,25 @@
+2019-03-11:
+  Use relative includes in the library. This shouldn't have any visible effect
+  for consumers of the library.
+
+  Update version number.
+
+2019-03-06:
+  Fix typo in test.
+  Update version number.
+
+2019-03-03:
+  Fix separator characters when they they don't fit into 8 bits.
+  Update version number.
+
+2019-02-16:
+  Check correctly for _MSC_VER.
+  Patch by Ben Boeckel
+
+2019-01-17:
+  Allow the library to be compiled for Emscripten.
+  Patch by Tim Paine.
+
 2018-09-15:
   Update version numbers. This also updates the shared-library version number.
 

--- a/vendor/double-conversion/upstream/double-conversion/bignum-dtoa.cc
+++ b/vendor/double-conversion/upstream/double-conversion/bignum-dtoa.cc
@@ -27,10 +27,10 @@
 
 #include <cmath>
 
-#include <double-conversion/bignum-dtoa.h>
+#include "bignum-dtoa.h"
 
-#include <double-conversion/bignum.h>
-#include <double-conversion/ieee.h>
+#include "bignum.h"
+#include "ieee.h"
 
 namespace double_conversion {
 

--- a/vendor/double-conversion/upstream/double-conversion/bignum-dtoa.h
+++ b/vendor/double-conversion/upstream/double-conversion/bignum-dtoa.h
@@ -28,7 +28,7 @@
 #ifndef DOUBLE_CONVERSION_BIGNUM_DTOA_H_
 #define DOUBLE_CONVERSION_BIGNUM_DTOA_H_
 
-#include <double-conversion/utils.h>
+#include "utils.h"
 
 namespace double_conversion {
 

--- a/vendor/double-conversion/upstream/double-conversion/bignum.cc
+++ b/vendor/double-conversion/upstream/double-conversion/bignum.cc
@@ -25,8 +25,8 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <double-conversion/bignum.h>
-#include <double-conversion/utils.h>
+#include "bignum.h"
+#include "utils.h"
 
 namespace double_conversion {
 

--- a/vendor/double-conversion/upstream/double-conversion/bignum.h
+++ b/vendor/double-conversion/upstream/double-conversion/bignum.h
@@ -28,7 +28,7 @@
 #ifndef DOUBLE_CONVERSION_BIGNUM_H_
 #define DOUBLE_CONVERSION_BIGNUM_H_
 
-#include <double-conversion/utils.h>
+#include "utils.h"
 
 namespace double_conversion {
 

--- a/vendor/double-conversion/upstream/double-conversion/cached-powers.cc
+++ b/vendor/double-conversion/upstream/double-conversion/cached-powers.cc
@@ -29,9 +29,9 @@
 #include <cmath>
 #include <cstdarg>
 
-#include <double-conversion/utils.h>
+#include "utils.h"
 
-#include <double-conversion/cached-powers.h>
+#include "cached-powers.h"
 
 namespace double_conversion {
 

--- a/vendor/double-conversion/upstream/double-conversion/cached-powers.h
+++ b/vendor/double-conversion/upstream/double-conversion/cached-powers.h
@@ -28,7 +28,7 @@
 #ifndef DOUBLE_CONVERSION_CACHED_POWERS_H_
 #define DOUBLE_CONVERSION_CACHED_POWERS_H_
 
-#include <double-conversion/diy-fp.h>
+#include "diy-fp.h"
 
 namespace double_conversion {
 

--- a/vendor/double-conversion/upstream/double-conversion/diy-fp.cc
+++ b/vendor/double-conversion/upstream/double-conversion/diy-fp.cc
@@ -26,8 +26,8 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-#include <double-conversion/diy-fp.h>
-#include <double-conversion/utils.h>
+#include "diy-fp.h"
+#include "utils.h"
 
 namespace double_conversion {
 

--- a/vendor/double-conversion/upstream/double-conversion/diy-fp.h
+++ b/vendor/double-conversion/upstream/double-conversion/diy-fp.h
@@ -28,7 +28,7 @@
 #ifndef DOUBLE_CONVERSION_DIY_FP_H_
 #define DOUBLE_CONVERSION_DIY_FP_H_
 
-#include <double-conversion/utils.h>
+#include "utils.h"
 
 namespace double_conversion {
 

--- a/vendor/double-conversion/upstream/double-conversion/double-conversion.cc
+++ b/vendor/double-conversion/upstream/double-conversion/double-conversion.cc
@@ -29,14 +29,14 @@
 #include <locale>
 #include <cmath>
 
-#include <double-conversion/double-conversion.h>
+#include "double-conversion.h"
 
-#include <double-conversion/bignum-dtoa.h>
-#include <double-conversion/fast-dtoa.h>
-#include <double-conversion/fixed-dtoa.h>
-#include <double-conversion/ieee.h>
-#include <double-conversion/strtod.h>
-#include <double-conversion/utils.h>
+#include "bignum-dtoa.h"
+#include "fast-dtoa.h"
+#include "fixed-dtoa.h"
+#include "ieee.h"
+#include "strtod.h"
+#include "utils.h"
 
 namespace double_conversion {
 
@@ -553,7 +553,7 @@ static bool IsCharacterDigitForRadix(int c, int radix, char a_character) {
 
 // Returns true, when the iterator is equal to end.
 template<class Iterator>
-static bool Advance (Iterator* it, char separator, int base, Iterator& end) {
+static bool Advance (Iterator* it, uc16 separator, int base, Iterator& end) {
   if (separator == StringToDoubleConverter::kNoSeparator) {
     ++(*it);
     return *it == end;
@@ -581,7 +581,7 @@ static bool Advance (Iterator* it, char separator, int base, Iterator& end) {
 template<class Iterator>
 static bool IsHexFloatString(Iterator start,
                              Iterator end,
-                             char separator,
+                             uc16 separator,
                              bool allow_trailing_junk) {
   ASSERT(start != end);
 
@@ -622,7 +622,7 @@ template <int radix_log_2, class Iterator>
 static double RadixStringToIeee(Iterator* current,
                                 Iterator end,
                                 bool sign,
-                                char separator,
+                                uc16 separator,
                                 bool parse_as_hex_float,
                                 bool allow_trailing_junk,
                                 double junk_string_value,

--- a/vendor/double-conversion/upstream/double-conversion/double-conversion.h
+++ b/vendor/double-conversion/upstream/double-conversion/double-conversion.h
@@ -28,7 +28,7 @@
 #ifndef DOUBLE_CONVERSION_DOUBLE_CONVERSION_H_
 #define DOUBLE_CONVERSION_DOUBLE_CONVERSION_H_
 
-#include <double-conversion/utils.h>
+#include "utils.h"
 
 namespace double_conversion {
 

--- a/vendor/double-conversion/upstream/double-conversion/fast-dtoa.cc
+++ b/vendor/double-conversion/upstream/double-conversion/fast-dtoa.cc
@@ -25,11 +25,11 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <double-conversion/fast-dtoa.h>
+#include "fast-dtoa.h"
 
-#include <double-conversion/cached-powers.h>
-#include <double-conversion/diy-fp.h>
-#include <double-conversion/ieee.h>
+#include "cached-powers.h"
+#include "diy-fp.h"
+#include "ieee.h"
 
 namespace double_conversion {
 

--- a/vendor/double-conversion/upstream/double-conversion/fast-dtoa.h
+++ b/vendor/double-conversion/upstream/double-conversion/fast-dtoa.h
@@ -28,7 +28,7 @@
 #ifndef DOUBLE_CONVERSION_FAST_DTOA_H_
 #define DOUBLE_CONVERSION_FAST_DTOA_H_
 
-#include <double-conversion/utils.h>
+#include "utils.h"
 
 namespace double_conversion {
 

--- a/vendor/double-conversion/upstream/double-conversion/fixed-dtoa.cc
+++ b/vendor/double-conversion/upstream/double-conversion/fixed-dtoa.cc
@@ -27,8 +27,8 @@
 
 #include <cmath>
 
-#include <double-conversion/fixed-dtoa.h>
-#include <double-conversion/ieee.h>
+#include "fixed-dtoa.h"
+#include "ieee.h"
 
 namespace double_conversion {
 

--- a/vendor/double-conversion/upstream/double-conversion/fixed-dtoa.h
+++ b/vendor/double-conversion/upstream/double-conversion/fixed-dtoa.h
@@ -28,7 +28,7 @@
 #ifndef DOUBLE_CONVERSION_FIXED_DTOA_H_
 #define DOUBLE_CONVERSION_FIXED_DTOA_H_
 
-#include <double-conversion/utils.h>
+#include "utils.h"
 
 namespace double_conversion {
 

--- a/vendor/double-conversion/upstream/double-conversion/ieee.h
+++ b/vendor/double-conversion/upstream/double-conversion/ieee.h
@@ -28,7 +28,7 @@
 #ifndef DOUBLE_CONVERSION_DOUBLE_H_
 #define DOUBLE_CONVERSION_DOUBLE_H_
 
-#include <double-conversion/diy-fp.h>
+#include "diy-fp.h"
 
 namespace double_conversion {
 

--- a/vendor/double-conversion/upstream/double-conversion/strtod.cc
+++ b/vendor/double-conversion/upstream/double-conversion/strtod.cc
@@ -28,10 +28,10 @@
 #include <climits>
 #include <cstdarg>
 
-#include <double-conversion/bignum.h>
-#include <double-conversion/cached-powers.h>
-#include <double-conversion/ieee.h>
-#include <double-conversion/strtod.h>
+#include "bignum.h"
+#include "cached-powers.h"
+#include "ieee.h"
+#include "strtod.h"
 
 namespace double_conversion {
 

--- a/vendor/double-conversion/upstream/double-conversion/strtod.h
+++ b/vendor/double-conversion/upstream/double-conversion/strtod.h
@@ -28,7 +28,7 @@
 #ifndef DOUBLE_CONVERSION_STRTOD_H_
 #define DOUBLE_CONVERSION_STRTOD_H_
 
-#include <double-conversion/utils.h>
+#include "utils.h"
 
 namespace double_conversion {
 


### PR DESCRIPTION
Removes the u16 separator ICU patch.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20439
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added
