### PR TITLE
ICU-20503 Add Python 3 to the CI build PATH, and bump Python version.

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -94,9 +94,12 @@ jobs:
       - visualstudio
       - Cmd
   steps:
-    - powershell: 'Invoke-WebRequest https://www.python.org/ftp/python/3.7.1/python-3.7.1-amd64-webinstall.exe -OutFile c:\py3-setup.exe'
+    - powershell: 'Invoke-WebRequest https://www.python.org/ftp/python/3.7.2/python-3.7.2-amd64-webinstall.exe -OutFile c:\py3-setup.exe'
     - script: |
         c:\py3-setup.exe /quiet PrependPath=1 InstallAllUsers=1 Include_launcher=1 InstallLauncherAllUsers=1 Include_test=0 Include_doc=0 Include_dev=0 Include_debug=0 Include_tcltk=0 TargetDir=c:\py3
+    - script: |
+        @echo ##vso[task.prependpath]C:\py3
+        @echo ##vso[task.prependpath]C:\py3\Scripts
     - script: |
         python --version
         py -3 --version


### PR DESCRIPTION
The VM images used by the Azure Pipelines for VS2015 (not VS2017) are missing Python 3.

In order to work around this, I added a step to the CI build that downloads and installs Python 3 on the build bot (see ICU-20281).

However, it was pointed out on https://github.com/Microsoft/azure-pipelines-image-generation/issues/374 that the Python installer's `PrependPath` option doesn't appear to work on the build machine.

A workaround was found by @mloskot: We can modify the `PATH` to prepend the Python directory ourselves. (Thanks for the tip!)

Also, we should take this opportunity to update the version of the Python installer too (to 3.7.2).

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20503
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

