### PR TITLE
ICU-20439 Updated currency numeric code for YUD to 890.

### DIFF
--- a/icu4c/source/data/misc/currencyNumericCodes.txt
+++ b/icu4c/source/data/misc/currencyNumericCodes.txt
@@ -6,7 +6,7 @@
 // Corporation and others.  All Rights Reserved.
 //---------------------------------------------------------
 // Build tool: com.ibm.icu.dev.tool.currency.NumericCodeData
-// Build date: 2018-09-17T17:52:05Z
+// Build date: 2019-03-20T21:22:05Z
 //---------------------------------------------------------
 // >> !!! >>   THIS IS A MACHINE-GENERATED FILE   << !!! <<
 // >> !!! >>>            DO NOT EDIT             <<< !!! <<
@@ -299,7 +299,7 @@ currencyNumericCodes:table(nofallback){
         XXX:int{999}
         YDD:int{720}
         YER:int{886}
-        YUD:int{891}
+        YUD:int{890}
         YUM:int{891}
         YUN:int{890}
         ZAL:int{991}

--- a/icu4j/main/shared/data/icudata.jar
+++ b/icu4j/main/shared/data/icudata.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bf43c6ef604a31b682026712ec7b66015243dff4fef0beb835412380de789f64
-size 12818986
+oid sha256:bd004f5d8064e047cef4f7d31326b39b7fc43fba685fab2f0d23c154f4dbc637
+size 12818511

--- a/icu4j/main/shared/data/icutzdata.jar
+++ b/icu4j/main/shared/data/icutzdata.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:15ddd5d52c5d9dbd8a4f0d3857ece71bc49c1af42b45caf4df6b6739c6667023
+oid sha256:bad41bf7819eaa9ad2955b5a7600fb61252415f625bab22750bc60412bc83998
 size 94046

--- a/tools/currency/build.xml
+++ b/tools/currency/build.xml
@@ -22,7 +22,7 @@
 <target name="classes" description="Build the Java tool">
     <mkdir dir="${classes.dir}"/>
     <javac srcdir="${src.dir}" destdir="${classes.dir}"
-            target="1.6" encoding="UTF-8" includeAntRuntime="false"/>
+            target="1.7" encoding="UTF-8" includeAntRuntime="false"/>
 </target>
 
 <target name="_checkLocalXml">

--- a/tools/currency/src/com/ibm/icu/dev/tool/currency/NumericCodeData.java
+++ b/tools/currency/src/com/ibm/icu/dev/tool/currency/NumericCodeData.java
@@ -401,7 +401,7 @@ public class NumericCodeData {
         {"XXX", "999"},
         {"YDD", "720"},
         {"YER", "886"},
-        {"YUD", "891"},
+        {"YUD", "890"},
         {"YUM", "891"},
         {"YUN", "890"},
         {"ZAL", "991"},


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20439
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

