### PR TITLE
ICU-20508 Fixing -Wextra-semi in library code.

### DIFF
--- a/icu4c/source/common/cmemory.h
+++ b/icu4c/source/common/cmemory.h
@@ -298,7 +298,7 @@ public:
      */
     MaybeStackArray(int32_t newCapacity) : MaybeStackArray() {
         if (capacity < newCapacity) { resize(newCapacity); }
-    };
+    }
     /**
      * Destructor deletes the array (if owned).
      */

--- a/icu4c/source/common/dictbe.cpp
+++ b/icu4c/source/common/dictbe.cpp
@@ -103,8 +103,8 @@ private:
     int32_t   cpLengths[POSSIBLE_WORD_LIST_MAX];   // Word Lengths, in code points.
 
 public:
-    PossibleWord() : count(0), prefix(0), offset(-1), mark(0), current(0) {};
-    ~PossibleWord() {};
+    PossibleWord() : count(0), prefix(0), offset(-1), mark(0), current(0) {}
+    ~PossibleWord() {}
   
     // Fill the list of candidates if needed, select the longest, and return the number found
     int32_t   candidates( UText *text, DictionaryMatcher *dict, int32_t rangeEnd );
@@ -118,13 +118,13 @@ public:
   
     // Return the longest prefix this candidate location shares with a dictionary word
     // Return value is in code points.
-    int32_t   longestPrefix() { return prefix; };
+    int32_t   longestPrefix() { return prefix; }
   
     // Mark the current candidate as the one we like
-    void      markCurrent() { mark = current; };
+    void      markCurrent() { mark = current; }
     
     // Get length in code points of the marked word.
-    int32_t   markedCPLength() { return cpLengths[mark]; };
+    int32_t   markedCPLength() { return cpLengths[mark]; }
 };
 
 

--- a/icu4c/source/common/dictionarydata.h
+++ b/icu4c/source/common/dictionarydata.h
@@ -68,7 +68,7 @@ public:
  */
 class U_COMMON_API DictionaryMatcher : public UMemory {
 public:
-    DictionaryMatcher() {};
+    DictionaryMatcher() {}
     virtual ~DictionaryMatcher();
     // this should emulate CompactTrieDictionary::matches()
     /*  @param text      The text in which to look for matching words. Matching begins

--- a/icu4c/source/common/rbbi.cpp
+++ b/icu4c/source/common/rbbi.cpp
@@ -720,7 +720,7 @@ struct LookAheadResults {
     int32_t    fPositions[8];
     int16_t    fKeys[8];
 
-    LookAheadResults() : fUsedSlotLimit(0), fPositions(), fKeys() {};
+    LookAheadResults() : fUsedSlotLimit(0), fPositions(), fKeys() {}
 
     int32_t getPosition(int16_t key) {
         for (int32_t i=0; i<fUsedSlotLimit; ++i) {

--- a/icu4c/source/common/rbbi_cache.h
+++ b/icu4c/source/common/rbbi_cache.h
@@ -95,7 +95,7 @@ class RuleBasedBreakIterator::BreakCache: public UMemory {
                                 fTextIdx = fBI->fPosition = fBoundaries[fBufIdx];
                                 fBI->fRuleStatusIndex = fStatuses[fBufIdx];
                             }
-                };
+                }
 
 
     void        nextOL();
@@ -178,7 +178,7 @@ class RuleBasedBreakIterator::BreakCache: public UMemory {
     void dumpCache();
 
   private:
-    static inline int32_t   modChunkSize(int index) { return index & (CACHE_SIZE - 1); };
+    static inline int32_t   modChunkSize(int index) { return index & (CACHE_SIZE - 1); }
 
     static constexpr int32_t CACHE_SIZE = 128;
     static_assert((CACHE_SIZE & (CACHE_SIZE-1)) == 0, "CACHE_SIZE must be power of two.");

--- a/icu4c/source/common/rbbiscan.h
+++ b/icu4c/source/common/rbbiscan.h
@@ -54,7 +54,7 @@ public:
     struct RBBIRuleChar {
         UChar32             fChar;
         UBool               fEscaped;
-        RBBIRuleChar() : fChar(0), fEscaped(FALSE) {};
+        RBBIRuleChar() : fChar(0), fEscaped(FALSE) {}
     };
 
     RBBIRuleScanner(RBBIRuleBuilder  *rb);

--- a/icu4c/source/common/umutex.h
+++ b/icu4c/source/common/umutex.h
@@ -95,8 +95,8 @@ inline int32_t umtx_atomic_dec(u_atomic_int32_t *var) {
 struct UInitOnce {
     u_atomic_int32_t   fState;
     UErrorCode       fErrCode;
-    void reset() {fState = 0;};
-    UBool isReset() {return umtx_loadAcquire(fState) == 0;};
+    void reset() {fState = 0;}
+    UBool isReset() {return umtx_loadAcquire(fState) == 0;}
 // Note: isReset() is used by service registration code.
 //                 Thread safety of this usage needs review.
 };

--- a/icu4c/source/common/unifiedcache.h
+++ b/icu4c/source/common/unifiedcache.h
@@ -137,7 +137,7 @@ class LocaleCacheKey : public CacheKey<T> {
  protected:
    Locale   fLoc;
  public:
-   LocaleCacheKey(const Locale &loc) : fLoc(loc) {};
+   LocaleCacheKey(const Locale &loc) : fLoc(loc) {}
    LocaleCacheKey(const LocaleCacheKey<T> &other)
            : CacheKey<T>(other), fLoc(other.fLoc) { }
    virtual ~LocaleCacheKey() { }

--- a/icu4c/source/i18n/csdetect.cpp
+++ b/icu4c/source/i18n/csdetect.cpp
@@ -36,9 +36,9 @@ U_NAMESPACE_BEGIN
 
 struct CSRecognizerInfo : public UMemory {
     CSRecognizerInfo(CharsetRecognizer *recognizer, UBool isDefaultEnabled)
-        : recognizer(recognizer), isDefaultEnabled(isDefaultEnabled) {};
+        : recognizer(recognizer), isDefaultEnabled(isDefaultEnabled) {}
 
-    ~CSRecognizerInfo() {delete recognizer;};
+    ~CSRecognizerInfo() {delete recognizer;}
 
     CharsetRecognizer *recognizer;
     UBool isDefaultEnabled;

--- a/icu4c/source/i18n/number_decimalquantity.h
+++ b/icu4c/source/i18n/number_decimalquantity.h
@@ -275,7 +275,7 @@ class U_I18N_API DecimalQuantity : public IFixedDecimal, public UMemory {
     inline bool isUsingBytes() { return usingBytes; }
 
     /** Visible for testing */
-    inline bool isExplicitExactDouble() { return explicitExactDouble; };
+    inline bool isExplicitExactDouble() { return explicitExactDouble; }
 
     bool operator==(const DecimalQuantity& other) const;
 

--- a/icu4c/source/i18n/number_patternstring.h
+++ b/icu4c/source/i18n/number_patternstring.h
@@ -98,7 +98,7 @@ struct U_I18N_API ParsedPatternInfo : public AffixPatternProvider, public UMemor
         int32_t offset = 0;
 
         explicit ParserState(const UnicodeString& _pattern)
-                : pattern(_pattern) {};
+                : pattern(_pattern) {}
 
         ParserState& operator=(ParserState&& src) U_NOEXCEPT {
             // Leave pattern reference alone; it will continue to point to the same place in memory,

--- a/icu4c/source/i18n/numparse_types.h
+++ b/icu4c/source/i18n/numparse_types.h
@@ -347,7 +347,7 @@ class U_I18N_API NumberParseMatcher {
      */
     virtual void postProcess(ParsedNumber&) const {
         // Default implementation: no-op
-    };
+    }
 
     // String for debugging
     virtual UnicodeString toString() const = 0;

--- a/icu4c/source/i18n/scriptset.h
+++ b/icu4c/source/i18n/scriptset.h
@@ -40,7 +40,7 @@ class U_I18N_API ScriptSet: public UMemory {
     ~ScriptSet();
 
     UBool operator == (const ScriptSet &other) const;
-    UBool operator != (const ScriptSet &other) const {return !(*this == other);};
+    UBool operator != (const ScriptSet &other) const {return !(*this == other);}
     ScriptSet & operator = (const ScriptSet &other);
 
     UBool      test(UScriptCode script, UErrorCode &status) const;

--- a/icu4c/source/i18n/tzgnames.h
+++ b/icu4c/source/i18n/tzgnames.h
@@ -46,7 +46,7 @@ public:
     static TimeZoneGenericNames* createInstance(const Locale& locale, UErrorCode& status);
 
     virtual UBool operator==(const TimeZoneGenericNames& other) const;
-    virtual UBool operator!=(const TimeZoneGenericNames& other) const {return !operator==(other);};
+    virtual UBool operator!=(const TimeZoneGenericNames& other) const {return !operator==(other);}
     virtual TimeZoneGenericNames* clone() const;
 
     UnicodeString& getDisplayName(const TimeZone& tz, UTimeZoneGenericNameType type,

--- a/icu4c/source/i18n/tznames.cpp
+++ b/icu4c/source/i18n/tznames.cpp
@@ -108,7 +108,7 @@ public:
     virtual ~TimeZoneNamesDelegate();
 
     virtual UBool operator==(const TimeZoneNames& other) const;
-    virtual UBool operator!=(const TimeZoneNames& other) const {return !operator==(other);};
+    virtual UBool operator!=(const TimeZoneNames& other) const {return !operator==(other);}
     virtual TimeZoneNames* clone() const;
 
     StringEnumeration* getAvailableMetaZoneIDs(UErrorCode& status) const;

--- a/icu4c/source/i18n/unicode/alphaindex.h
+++ b/icu4c/source/i18n/unicode/alphaindex.h
@@ -651,7 +651,7 @@ private:
      /**
       *   No assignment.
       */
-     AlphabeticIndex &operator =(const AlphabeticIndex & /*other*/) { return *this;};
+     AlphabeticIndex &operator =(const AlphabeticIndex & /*other*/) { return *this;}
 
     /**
      * No Equality operators.

--- a/icu4c/source/i18n/unicode/dtitvfmt.h
+++ b/icu4c/source/i18n/unicode/dtitvfmt.h
@@ -60,7 +60,7 @@ class U_I18N_API FormattedDateInterval : public UMemory, public FormattedValue {
      * Default constructor; makes an empty FormattedDateInterval.
      * @draft ICU 64
      */
-    FormattedDateInterval() : fData(nullptr), fErrorCode(U_INVALID_STATE_ERROR) {};
+    FormattedDateInterval() : fData(nullptr), fErrorCode(U_INVALID_STATE_ERROR) {}
 
     /**
      * Move constructor: Leaves the source FormattedDateInterval in an undefined state.

--- a/icu4c/source/i18n/unicode/formattedvalue.h
+++ b/icu4c/source/i18n/unicode/formattedvalue.h
@@ -122,7 +122,7 @@ class U_I18N_API ConstrainedFieldPosition : public UMemory {
      */
     inline int32_t getCategory() const {
         return fCategory;
-    };
+    }
 
     /**
      * Gets the field for the current position.
@@ -135,7 +135,7 @@ class U_I18N_API ConstrainedFieldPosition : public UMemory {
      */
     inline int32_t getField() const {
         return fField;
-    };
+    }
 
     /**
      * Gets the INCLUSIVE start index for the current position.
@@ -147,7 +147,7 @@ class U_I18N_API ConstrainedFieldPosition : public UMemory {
      */
     inline int32_t getStart() const {
         return fStart;
-    };
+    }
 
     /**
      * Gets the EXCLUSIVE end index stored for the current position.
@@ -159,7 +159,7 @@ class U_I18N_API ConstrainedFieldPosition : public UMemory {
      */
     inline int32_t getLimit() const {
         return fLimit;
-    };
+    }
 
     ////////////////////////////////////////////////////////////////////
     //// The following methods are for FormattedValue implementers; ////

--- a/icu4c/source/i18n/unicode/listformatter.h
+++ b/icu4c/source/i18n/unicode/listformatter.h
@@ -85,7 +85,7 @@ class U_I18N_API FormattedList : public UMemory, public FormattedValue {
      * Default constructor; makes an empty FormattedList.
      * @draft ICU 64
      */
-    FormattedList() : fData(nullptr), fErrorCode(U_INVALID_STATE_ERROR) {};
+    FormattedList() : fData(nullptr), fErrorCode(U_INVALID_STATE_ERROR) {}
 
     /**
      * Move constructor: Leaves the source FormattedList in an undefined state.

--- a/icu4c/source/i18n/unicode/numberformatter.h
+++ b/icu4c/source/i18n/unicode/numberformatter.h
@@ -2411,7 +2411,7 @@ class U_I18N_API FormattedNumber : public UMemory, public FormattedValue {
      * @draft ICU 64
      */
     FormattedNumber()
-        : fData(nullptr), fErrorCode(U_INVALID_STATE_ERROR) {};
+        : fData(nullptr), fErrorCode(U_INVALID_STATE_ERROR) {}
 
     /**
      * Move constructor: Leaves the source FormattedNumber in an undefined state.

--- a/icu4c/source/i18n/unicode/numberrangeformatter.h
+++ b/icu4c/source/i18n/unicode/numberrangeformatter.h
@@ -481,7 +481,7 @@ class U_I18N_API NumberRangeFormatterSettings {
         }
         fMacros.copyErrorTo(outErrorCode);
         return U_FAILURE(outErrorCode);
-    };
+    }
 
     // NOTE: Uses default copy and move constructors.
 

--- a/icu4c/source/i18n/unicode/reldatefmt.h
+++ b/icu4c/source/i18n/unicode/reldatefmt.h
@@ -264,7 +264,7 @@ class U_I18N_API FormattedRelativeDateTime : public UMemory, public FormattedVal
      * Default constructor; makes an empty FormattedRelativeDateTime.
      * @draft ICU 64
      */
-    FormattedRelativeDateTime() : fData(nullptr), fErrorCode(U_INVALID_STATE_ERROR) {};
+    FormattedRelativeDateTime() : fData(nullptr), fErrorCode(U_INVALID_STATE_ERROR) {}
 
     /**
      * Move constructor: Leaves the source FormattedRelativeDateTime in an undefined state.


### PR DESCRIPTION
More precisely, I added `-Wextra-semi` to my CXXFLAGS and got rid of all the errors according to Clang4.0.1-10.

This fixes the warnings in library code, but I didn't touch test code.

Actually it's probably only important in the public header files, but it was easier to just fix it in the whole library.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20508
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

