### PR TITLE
ICU-20516 Work-around MSVC Warning C4003

### DIFF
--- a/icu4c/source/i18n/number_output.cpp
+++ b/icu4c/source/i18n/number_output.cpp
@@ -16,6 +16,7 @@ namespace number {
 
 UPRV_FORMATTED_VALUE_SUBCLASS_AUTO_IMPL(FormattedNumber)
 
+#define UPRV_NOARG
 
 UBool FormattedNumber::nextFieldPosition(FieldPosition& fieldPosition, UErrorCode& status) const {
     UPRV_FORMATTED_VALUE_METHOD_GUARD(FALSE)
@@ -30,12 +31,12 @@ void FormattedNumber::getAllFieldPositions(FieldPositionIterator& iterator, UErr
 
 void FormattedNumber::getAllFieldPositionsImpl(FieldPositionIteratorHandler& fpih,
                                                UErrorCode& status) const {
-    UPRV_FORMATTED_VALUE_METHOD_GUARD()
+    UPRV_FORMATTED_VALUE_METHOD_GUARD(UPRV_NOARG)
     fData->getStringRef().getAllFieldPositions(fpih, status);
 }
 
 void FormattedNumber::getDecimalQuantity(impl::DecimalQuantity& output, UErrorCode& status) const {
-    UPRV_FORMATTED_VALUE_METHOD_GUARD()
+    UPRV_FORMATTED_VALUE_METHOD_GUARD(UPRV_NOARG)
     output = fData->quantity;
 }
 

--- a/icu4c/source/i18n/numrange_fluent.cpp
+++ b/icu4c/source/i18n/numrange_fluent.cpp
@@ -377,6 +377,7 @@ LocalizedNumberRangeFormatter::getFormatter(UErrorCode& status) const {
 
 UPRV_FORMATTED_VALUE_SUBCLASS_AUTO_IMPL(FormattedNumberRange)
 
+#define UPRV_NOARG
 
 UBool FormattedNumberRange::nextFieldPosition(FieldPosition& fieldPosition, UErrorCode& status) const {
     UPRV_FORMATTED_VALUE_METHOD_GUARD(FALSE)
@@ -391,7 +392,7 @@ void FormattedNumberRange::getAllFieldPositions(FieldPositionIterator& iterator,
 
 void FormattedNumberRange::getAllFieldPositionsImpl(
         FieldPositionIteratorHandler& fpih, UErrorCode& status) const {
-    UPRV_FORMATTED_VALUE_METHOD_GUARD()
+    UPRV_FORMATTED_VALUE_METHOD_GUARD(UPRV_NOARG)
     fData->getStringRef().getAllFieldPositions(fpih, status);
 }
 


### PR DESCRIPTION
Work-around for MSVC not handling empty arguments to a function-like macro.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20516
- [x] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

