### PR TITLE
ICU-20530 icu headers cannot be built within extern "C" scope

### DIFF
--- a/icu4c/source/common/unicode/char16ptr.h
+++ b/icu4c/source/common/unicode/char16ptr.h
@@ -7,8 +7,11 @@
 #ifndef __CHAR16PTR_H__
 #define __CHAR16PTR_H__
 
-#include <cstddef>
 #include "unicode/utypes.h"
+
+U_CXX_BEGIN
+#include <cstddef>
+U_CXX_END
 
 /**
  * \file

--- a/icu4c/source/common/unicode/localpointer.h
+++ b/icu4c/source/common/unicode/localpointer.h
@@ -42,7 +42,9 @@
 
 #if U_SHOW_CPLUSPLUS_API
 
+U_CXX_BEGIN
 #include <memory>
+U_CXX_END
 
 U_NAMESPACE_BEGIN
 

--- a/icu4c/source/common/unicode/std_string.h
+++ b/icu4c/source/common/unicode/std_string.h
@@ -32,6 +32,9 @@
 #if defined(__GLIBCXX__)
 namespace std { class type_info; }
 #endif
+
+U_CXX_BEGIN
 #include <string>
+U_CXX_END
 
 #endif  // __STD_STRING_H__

--- a/icu4c/source/common/unicode/umachine.h
+++ b/icu4c/source/common/unicode/umachine.h
@@ -75,14 +75,39 @@
  * @stable ICU 2.4
  */
 
+/**
+ * \def U_CXX_BEGIN
+ * This is used to begin a C++ block.
+ * When not compiling for C++, it does nothing.
+ * When compiling for C++, it begins an extern "C++" linkage block (to protect
+ * against cases in which an external client includes ICU header files inside
+ * an extern "C" linkage block).
+ *
+ * @draft ICU 65
+ */
+
+/**
+ * \def U_CXX_END
+ * This is used to end a declaration of a C++ API.
+ * When not compiling for C++, it does nothing.
+ * When compiling for C++, it ends the extern "C++" block begun by
+ * U_CXX_BEGIN.
+ *
+ * @draft ICU 65
+ */
+
 #ifdef __cplusplus
 #   define U_CFUNC extern "C"
 #   define U_CDECL_BEGIN extern "C" {
 #   define U_CDECL_END   }
+#   define U_CXX_BEGIN extern "C++" {
+#   define U_CXX_END }
 #else
 #   define U_CFUNC extern
 #   define U_CDECL_BEGIN
 #   define U_CDECL_END
+#   define U_CXX_BEGIN
+#   define U_CXX_END
 #endif
 
 #ifndef U_ATTRIBUTE_DEPRECATED

--- a/icu4c/source/common/unicode/unistr.h
+++ b/icu4c/source/common/unicode/unistr.h
@@ -28,13 +28,16 @@
  * \brief C++ API: Unicode String
  */
 
-#include <cstddef>
 #include "unicode/utypes.h"
 #include "unicode/char16ptr.h"
 #include "unicode/rep.h"
 #include "unicode/std_string.h"
 #include "unicode/stringpiece.h"
 #include "unicode/bytestream.h"
+
+U_CXX_BEGIN
+#include <cstddef>
+U_CXX_END
 
 struct UConverter;          // unicode/ucnv.h
 

--- a/icu4c/source/common/unicode/uversion.h
+++ b/icu4c/source/common/unicode/uversion.h
@@ -64,13 +64,10 @@ typedef uint8_t UVersionInfo[U_MAX_VERSION_LENGTH];
 
 /**
  * \def U_NAMESPACE_BEGIN
- * This is used to begin a declaration of a public ICU C++ API.
+ * This is used to begin a declaration of a public ICU C++ API within
+ * versioned-ICU-namespace block.
  * When not compiling for C++, it does nothing.
- * When compiling for C++, it begins an extern "C++" linkage block (to protect
- * against cases in which an external client includes ICU header files inside
- * an extern "C" linkage block).
  *
- * It also begins a versioned-ICU-namespace block.
  * @stable ICU 2.4
  */
 
@@ -78,10 +75,8 @@ typedef uint8_t UVersionInfo[U_MAX_VERSION_LENGTH];
  * \def U_NAMESPACE_END
  * This is used to end a declaration of a public ICU C++ API.
  * When not compiling for C++, it does nothing.
- * When compiling for C++, it ends the extern "C++" block begun by
- * U_NAMESPACE_BEGIN.
+ * It ends the versioned-ICU-namespace block begun by U_NAMESPACE_BEGIN.
  *
- * It also ends the versioned-ICU-namespace block begun by U_NAMESPACE_BEGIN.
  * @stable ICU 2.4
  */
 
@@ -116,8 +111,8 @@ typedef uint8_t UVersionInfo[U_MAX_VERSION_LENGTH];
         namespace icu = U_ICU_NAMESPACE;
 #   endif
 
-#   define U_NAMESPACE_BEGIN extern "C++" { namespace U_ICU_NAMESPACE {
-#   define U_NAMESPACE_END } }
+#   define U_NAMESPACE_BEGIN U_CXX_BEGIN namespace U_ICU_NAMESPACE {
+#   define U_NAMESPACE_END } U_CXX_END
 #   define U_NAMESPACE_USE using namespace U_ICU_NAMESPACE;
 #   define U_NAMESPACE_QUALIFIER U_ICU_NAMESPACE::
 

--- a/icu4c/source/i18n/unicode/numberrangeformatter.h
+++ b/icu4c/source/i18n/unicode/numberrangeformatter.h
@@ -5,12 +5,15 @@
 #ifndef __NUMBERRANGEFORMATTER_H__
 #define __NUMBERRANGEFORMATTER_H__
 
-#include <atomic>
 #include "unicode/appendable.h"
 #include "unicode/fieldpos.h"
 #include "unicode/formattedvalue.h"
 #include "unicode/fpositer.h"
 #include "unicode/numberformatter.h"
+
+U_CXX_BEGIN
+#include <atomic>
+U_CXX_END
 
 #ifndef U_HIDE_DRAFT_API
 

--- a/icu4c/source/io/unicode/ustream.h
+++ b/icu4c/source/io/unicode/ustream.h
@@ -34,7 +34,9 @@
 namespace std { class type_info; } // WORKAROUND: http://llvm.org/bugs/show_bug.cgi?id=13364
 #endif
 
+U_CXX_BEGIN
 #include <iostream>
+U_CXX_END
 
 U_NAMESPACE_BEGIN
 

--- a/icu4c/source/test/hdrtst/Makefile.in
+++ b/icu4c/source/test/hdrtst/Makefile.in
@@ -53,7 +53,7 @@ E_DEP="[6/$(E_NUM)] Hide Deprecated: "
 E_INT="[7/$(E_NUM)] Hide Internal: "
 E_OBS="[8/$(E_NUM)] Hide Obsolete: "
 
-check: dtest ctest cpptest doclean drafttest deprtest internaltest obsoletetest
+check: dtest ctest cpptest cpptest_extern_c doclean drafttest deprtest internaltest obsoletetest
 ifeq ($(MAKECMDGOALS),check)
 	$(MAKE) clean
 else
@@ -69,6 +69,18 @@ cpptest:
 	  incfile=`basename $$file .h` ; \
 	  echo "$@ unicode/$$incfile.h" ; \
 	  echo '#include "'unicode/$$incfile'.h"' > ht_$$incfile.cpp ; \
+	  echo 'void junk(){}' >> ht_$$incfile.cpp ; \
+          $(COMPILE.cc) -c $(cppflags) ht_$$incfile.cpp || FAIL=1 ; \
+	done ;\
+	exit $$FAIL
+
+cpptest_extern_c:
+	@FAIL=0;for file in `ls $(prefix)/include/unicode/*.h | fgrep -v -f $(srcdir)/pfiles.txt`; do \
+	  incfile=`basename $$file .h` ; \
+	  echo "$@ unicode/$$incfile.h" ; \
+	  echo 'extern "C" {' > ht_$$incfile.cpp ; \
+	  echo '#include "'unicode/$$incfile'.h"' >> ht_$$incfile.cpp ; \
+	  echo '}' >> ht_$$incfile.cpp ; \
 	  echo 'void junk(){}' >> ht_$$incfile.cpp ; \
           $(COMPILE.cc) -c $(cppflags) ht_$$incfile.cpp || FAIL=1 ; \
 	done ;\
@@ -170,5 +182,5 @@ Makefile: $(srcdir)/Makefile.in  $(top_builddir)/config.status
 	cd $(top_builddir) \
 	&& CONFIG_FILES=$(subdir)/$@ CONFIG_HEADERS= $(SHELL) ./config.status
 
-.PHONY:	doclean check all cpptest dtest ctest clean distclean
+.PHONY:	doclean check all cpptest cpptest_extern_c dtest ctest clean distclean
 


### PR DESCRIPTION
Introduce by ICU-20357, commit b7a3571b adding <memory> include without guard.

Fails when compiling within extern "C".

```
a.cxx
---
extern "C" {
 #include <unicode/localpointer.h>
}
---
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/include/g++-v8/memory:84,
                 from /tmp/icu/icu4c/source/common/unicode/localpointer.h:45,
                 from a.cxx:4:
/usr/lib/gcc/x86_64-pc-linux-gnu/8.2.0/include/g++-v8/backward/auto_ptr.h:325:3: error: template with C linkage
   template<typename _Tp, typename _Dp>
   ^~~~~~~~
a.cxx:3:1: note: ‘extern "C"’ linkage started here
 extern "C" {
 ^~~~~~~~~~
---
```

Found by usage of xmlsec.

---

This is an alternative of #603  to remain with the ability to include the ICU headers within `extern "C"` context.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20530
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [x] Documentation is changed or added

