### PR TITLE
ICU-20475 Japanese calendar era calculation should use local time, not UTC (ICU4C)

### DIFF
--- a/icu4c/source/i18n/erarules.cpp
+++ b/icu4c/source/i18n/erarules.cpp
@@ -11,6 +11,7 @@
 #include "unicode/ucal.h"
 #include "unicode/ures.h"
 #include "unicode/ustring.h"
+#include "unicode/timezone.h"
 #include "cmemory.h"
 #include "cstring.h"
 #include "erarules.h"
@@ -290,9 +291,22 @@ int32_t EraRules::getEraIndex(int32_t year, int32_t month, int32_t day, UErrorCo
 }
 
 void EraRules::initCurrentEra() {
-    UDate now = ucal_getNow();
+    // Compute local wall time in millis using ICU's default time zone.
+    UErrorCode ec = U_ZERO_ERROR;
+    UDate localMillis = ucal_getNow();
+
+    int32_t rawOffset, dstOffset;
+    TimeZone* zone = TimeZone::createDefault();
+    // If we failed to create the default time zone, we are in a bad state and don't
+    // really have many options. Carry on using UTC millis as a fallback.
+    if (zone != nullptr) {
+        zone->getOffset(localMillis, FALSE, rawOffset, dstOffset, ec);
+        delete zone;
+        localMillis += (rawOffset + dstOffset);
+    }
+
     int year, month0, dom, dow, doy, mid;
-    Grego::timeToFields(now, year, month0, dom, dow, doy, mid);
+    Grego::timeToFields(localMillis, year, month0, dom, dow, doy, mid);
     int currentEncodedDate = encodeDate(year, month0 + 1 /* changes to 1-base */, dom);
     int eraIdx = numEras - 1;
     while (eraIdx > 0) {
@@ -303,7 +317,8 @@ void EraRules::initCurrentEra() {
     }
     // Note: current era could be before the first era.
     // In this case, this implementation returns the first era index (0).
-    currentEra = eraIdx;}
+    currentEra = eraIdx;
+}
 
 U_NAMESPACE_END
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/i18n/erarules.h
+++ b/icu4c/source/i18n/erarules.h
@@ -75,7 +75,8 @@ public:
 
     /**
      * Gets the current era index. This is calculated only once for an instance of
-     * EraRules.
+     * EraRules. The current era calculation is based on the default time zone at
+     * the time of instantiation.
      *
      * @return era index of current era (or 0, when current date is before the first era)
      */


### PR DESCRIPTION
The Japanese calendar current era calculation uses `ucal_getNow` to determine if new era should start or not.
However, `ucal_getNow` returns the time in UTC, not local time.
This means that the era start time in JST will actually be 9:00 AM instead of 00:00.

This change modifies `erarules.cpp` to use ICU's default time zone offset, so that the era will start relative to local time, not UTC.

Note: This is only for ICU4C, but if this looks okay then similar change should be made for ICU4J too.

ICU4J change: https://github.com/unicode-org/icu/pull/577

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20475
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

