### PR TITLE
ICU-20475 Japanese calendar era calculation should use local time, not UTC (ICU4J)

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/EraRules.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/EraRules.java
@@ -5,6 +5,7 @@ package com.ibm.icu.impl;
 import java.util.Arrays;
 
 import com.ibm.icu.util.ICUException;
+import com.ibm.icu.util.TimeZone;
 import com.ibm.icu.util.UResourceBundle;
 import com.ibm.icu.util.UResourceBundleIterator;
 
@@ -201,7 +202,8 @@ public class EraRules {
 
     /**
      * Gets the current era index. This is calculated only once for an instance of
-     * EraRules.
+     * EraRules. The current era calculation is based on the default time zone at
+     * the time of instantiation.
      *
      * @return era index of current era (or 0, when current date is before the first era)
      */
@@ -210,7 +212,11 @@ public class EraRules {
     }
 
     private void initCurrentEra() {
-        int[] fields = Grego.timeToFields(System.currentTimeMillis(), null);
+        long localMillis = System.currentTimeMillis();
+        TimeZone zone = TimeZone.getDefault();
+        localMillis += zone.getOffset(localMillis);
+
+        int[] fields = Grego.timeToFields(localMillis, null);
         int currentEncodedDate = encodeDate(fields[0], fields[1] + 1 /* changes to 1-base */, fields[2]);
         int eraIdx = numEras - 1;
         while (eraIdx > 0) {


### PR DESCRIPTION
ICU4C change: https://github.com/unicode-org/icu/pull/574

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20475
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

