### PR TITLE
ICU-20526 fix pkgdata where LD_SONAME has a trailing space

### DIFF
--- a/icu4c/source/config/mh-darwin
+++ b/icu4c/source/config/mh-darwin
@@ -31,9 +31,9 @@ SHLIB.cc=	$(CXX) -dynamiclib -dynamic $(CXXFLAGS) $(LDFLAGS) $(LD_SOOPTIONS)
 
 ## Compiler switches to embed a library name and version information
 ifeq ($(ENABLE_RPATH),YES)
-LD_SONAME = -Wl,-compatibility_version -Wl,$(SO_TARGET_VERSION_MAJOR) -Wl,-current_version -Wl,$(SO_TARGET_VERSION) -install_name $(libdir)/$(notdir $(MIDDLE_SO_TARGET))
+LD_SONAME = -Wl,-compatibility_version -Wl,$(SO_TARGET_VERSION_MAJOR) -Wl,-current_version -Wl,$(SO_TARGET_VERSION) -install_name $(libdir)/$(notdir $(MIDDLE_SO_TARGET)) $(PKGDATA_TRAILING_SPACE)
 else
-LD_SONAME = -Wl,-compatibility_version -Wl,$(SO_TARGET_VERSION_MAJOR) -Wl,-current_version -Wl,$(SO_TARGET_VERSION) -install_name $(notdir $(MIDDLE_SO_TARGET))
+LD_SONAME = -Wl,-compatibility_version -Wl,$(SO_TARGET_VERSION_MAJOR) -Wl,-current_version -Wl,$(SO_TARGET_VERSION) -install_name $(notdir $(MIDDLE_SO_TARGET)) $(PKGDATA_TRAILING_SPACE)
 endif
 
 ## Compiler switch to embed a runtime search path

--- a/icu4c/source/config/mh-solaris
+++ b/icu4c/source/config/mh-solaris
@@ -56,7 +56,7 @@ LD_RPATH_PRE=   -R
 #LIBRARY_PATH_PREFIX=/usr/lib/lwp:
 
 ## Compiler switch to embed a library name
-LD_SONAME = -h $(notdir $(MIDDLE_SO_TARGET))
+LD_SONAME = -h $(notdir $(MIDDLE_SO_TARGET)) $(PKGDATA_TRAILING_SPACE)
 
 ## Shared object suffix
 SO=		so

--- a/icu4c/source/config/mh-solaris-gcc
+++ b/icu4c/source/config/mh-solaris-gcc
@@ -25,7 +25,7 @@ LD_RPATH=       -R'$$'ORIGIN
 LD_RPATH_PRE=   -R
 
 ## Compiler switch to embed a library name
-LD_SONAME = -h $(notdir $(MIDDLE_SO_TARGET))
+LD_SONAME = -h $(notdir $(MIDDLE_SO_TARGET)) $(PKGDATA_TRAILING_SPACE)
 
 ## Shared library options
 LD_SOOPTIONS= -Wl,-Bsymbolic

--- a/icu4c/source/config/pkgdataMakefile.in
+++ b/icu4c/source/config/pkgdataMakefile.in
@@ -16,6 +16,7 @@ include $(top_builddir)/icudefs.mk
 
 OUTPUTFILE=pkgdata.inc
 MIDDLE_SO_TARGET=
+PKGDATA_TRAILING_SPACE=" "
 
 all : clean 
 	@echo GENCCODE_ASSEMBLY_TYPE=$(GENCCODE_ASSEMBLY) >> $(OUTPUTFILE)
@@ -35,7 +36,6 @@ all : clean
 	@echo ARFLAGS=$(ARFLAGS) >> $(OUTPUTFILE)
 	@echo RANLIB=$(RANLIB) >> $(OUTPUTFILE)
 	@echo INSTALL_CMD=$(INSTALL-L) >> $(OUTPUTFILE)
-
 
 clean : 
 	$(RMV) $(OUTPUTFILE)

--- a/icu4c/source/data/pkgdataMakefile.in
+++ b/icu4c/source/data/pkgdataMakefile.in
@@ -16,6 +16,7 @@ include $(top_builddir)/icudefs.mk
 
 OUTPUTFILE=icupkg.inc
 MIDDLE_SO_TARGET=
+PKGDATA_TRAILING_SPACE=" "
 
 all : clean 
 	@echo GENCCODE_ASSEMBLY_TYPE=$(GENCCODE_ASSEMBLY) >> $(OUTPUTFILE)
@@ -35,7 +36,6 @@ all : clean
 	@echo ARFLAGS=$(ARFLAGS) >> $(OUTPUTFILE)
 	@echo RANLIB=$(RANLIB) >> $(OUTPUTFILE)
 	@echo INSTALL_CMD=$(INSTALL) >> $(OUTPUTFILE)
-
 
 clean : 
 	$(RMV) $(OUTPUTFILE)

--- a/icu4c/source/extra/uconv/pkgdataMakefile.in
+++ b/icu4c/source/extra/uconv/pkgdataMakefile.in
@@ -14,9 +14,9 @@ top_builddir = ../..
 ## All the flags and other definitions are included here.
 include $(top_builddir)/icudefs.mk
 
-MIDDLE_SO_TARGET=
-
 OUTPUTFILE=pkgdata.inc
+MIDDLE_SO_TARGET=
+PKGDATA_TRAILING_SPACE=" "
 
 all : clean 
 	@echo GENCCODE_ASSEMBLY_TYPE=$(GENCCODE_ASSEMBLY) >> $(OUTPUTFILE)

--- a/icu4c/source/test/testdata/pkgdataMakefile.in
+++ b/icu4c/source/test/testdata/pkgdataMakefile.in
@@ -14,9 +14,9 @@ top_builddir = ../..
 ## All the flags and other definitions are included here.
 include $(top_builddir)/icudefs.mk
 
-MIDDLE_SO_TARGET=
-
 OUTPUTFILE=pkgdata.inc
+MIDDLE_SO_TARGET=
+PKGDATA_TRAILING_SPACE=" "
 
 all : clean 
 	@echo GENCCODE_ASSEMBLY_TYPE=$(GENCCODE_ASSEMBLY) >> $(OUTPUTFILE)

--- a/icu4c/source/tools/pkgdata/pkgdata.cpp
+++ b/icu4c/source/tools/pkgdata/pkgdata.cpp
@@ -504,7 +504,6 @@ main(int argc, char* argv[]) {
     if (o.files != NULL) {
         pkg_deleteList(o.files);
     }
-
     return result;
 }
 
@@ -544,6 +543,7 @@ normal_command_mode:
     int result = system(cmd);
     if (result != 0) {
         fprintf(stderr, "-- return status = %d\n", result);
+        result = 1; // system() result code is platform specific.
     }
 
     if (cmd != cmdBuffer && cmd != command) {


### PR DESCRIPTION
- added `PKGDATA_TRAILING_SPACE` to all of the pkgdataMakefile.in file.
   - NOTE: Users who create their own `pkgdata.inc` /` icupkg.inc` files may need to recreate this `PKGDATA_TRAILING_SPACE` behavior.

- used the above variable, normally undefined, in `mh-*` files that need a trailing space

- Also, fixed use of `system()` in `pkgdata.cpp` per [ICU-20538](https://unicode-org.atlassian.net/browse/ICU-20538). This was causing `pkgdata` to return a zero (success) status even on clang failure, masking this issue.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20526
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted

