### PR TITLE
ICU-20534 Add Japanese era constant for REIWA in ICU4J JapaneseCalendar

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/util/JapaneseCalendar.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/util/JapaneseCalendar.java
@@ -386,6 +386,12 @@ public class JapaneseCalendar extends GregorianCalendar {
      */
     static public final int HEISEI;
 
+    /**
+     * Constant for the era starting on May 1, 2019 AD.
+     * @stable ICU 64
+     */
+    static public final int REIWA;
+
     // We want to make these era constants initialized in a static initializer
     // block to prevent javac to inline these values in a consumer code.
     // By doing so, we can keep better binary compatibility across versions even
@@ -395,6 +401,7 @@ public class JapaneseCalendar extends GregorianCalendar {
         TAISHO = 233;
         SHOWA = 234;
         HEISEI = 235;
+        REIWA = 236;
         CURRENT_ERA = ERA_RULES.getCurrentEraIndex();
     }
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20534
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

