### PR TITLE
ICU-12504 Maint 4.8 fixup of bad merge

### DIFF
--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/calendar/CalendarRegression.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/calendar/CalendarRegression.java
@@ -2242,10 +2242,7 @@ public class CalendarRegression extends com.ibm.icu.dev.test.TestFmwk {
             errln("FAIL: Max week in 2009 in ISO calendar is 53, but got " + maxWeeks);
         }
     }
-}
 
-
-    @Test
     public void TestPersianCalOverflow() {
         String localeID = "bs_Cyrl@calendar=persian";
         Calendar cal = Calendar.getInstance(new ULocale(localeID));


### PR DESCRIPTION
a5fe7b2 had a bad merge:

- extra right curlybracket
- anachronistic `@Test` annotation was backported

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-12504
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included