### PR TITLE
ICU-20537 jaEra: DateIntvFmt to load fmts with G, applyPattern to update Gannen use

### DIFF
--- a/icu4c/source/i18n/dtitvfmt.cpp
+++ b/icu4c/source/i18n/dtitvfmt.cpp
@@ -1130,7 +1130,9 @@ DateIntervalFormat::setSeparateDateTimePtn(
         }
         setIntervalPattern(UCAL_YEAR, skeleton, bestSkeleton, differenceInfo,
                            &extendedSkeleton, &extendedBestSkeleton);
-    } else {
+        setIntervalPattern(UCAL_ERA, skeleton, bestSkeleton, differenceInfo,
+                           &extendedSkeleton, &extendedBestSkeleton);
+     } else {
         setIntervalPattern(UCAL_MINUTE, skeleton, bestSkeleton, differenceInfo);
         setIntervalPattern(UCAL_HOUR, skeleton, bestSkeleton, differenceInfo);
         setIntervalPattern(UCAL_AM_PM, skeleton, bestSkeleton, differenceInfo);

--- a/icu4c/source/i18n/dtitvinf.cpp
+++ b/icu4c/source/i18n/dtitvinf.cpp
@@ -326,7 +326,9 @@ struct DateIntervalInfo::DateIntervalSink : public ResourceSink {
         char c0;
         if ((c0 = patternLetter[0]) != 0 && patternLetter[1] == 0) {
             // Check that the pattern letter is accepted
-            if (c0 == 'y') {
+            if (c0 == 'G') {
+                return UCAL_ERA;
+            } else if (c0 == 'y') {
                 return UCAL_YEAR;
             } else if (c0 == 'M') {
                 return UCAL_MONTH;

--- a/icu4c/source/i18n/smpdtfmt.cpp
+++ b/icu4c/source/i18n/smpdtfmt.cpp
@@ -863,7 +863,7 @@ SimpleDateFormat::initialize(const Locale& locale,
 
     // Simple-minded hack to force Gannen year numbering for ja@calendar=japanese
     // if format is non-numeric (includes 年) and fDateOverride is not already specified.
-    // This does not update if applyPattern subsequently changes the pattern type.
+    // Now this does get updated if applyPattern subsequently changes the pattern type.
     if (fDateOverride.isBogus() && fHasHanYearChar &&
             fCalendar != nullptr && uprv_strcmp(fCalendar->getType(),"japanese") == 0 &&
             uprv_strcmp(fLocale.getLanguage(),"ja") == 0) {
@@ -3885,6 +3885,42 @@ SimpleDateFormat::applyPattern(const UnicodeString& pattern)
 {
     fPattern = pattern;
     parsePattern();
+
+    // Hack to update use of Gannen year numbering for ja@calendar=japanese -
+    // use only if format is non-numeric (includes 年) and no other fDateOverride.
+    if (fCalendar != nullptr && uprv_strcmp(fCalendar->getType(),"japanese") == 0 &&
+            uprv_strcmp(fLocale.getLanguage(),"ja") == 0) {
+        if (fDateOverride==UnicodeString(u"y=jpanyear") && !fHasHanYearChar) {
+            // Gannen numbering is set but new pattern should not use it, unset;
+            // use procedure from adoptNumberFormat to clear overrides
+            if (fSharedNumberFormatters) {
+                freeSharedNumberFormatters(fSharedNumberFormatters);
+                fSharedNumberFormatters = NULL;
+            }
+            fDateOverride.setToBogus(); // record status
+        } else if (fDateOverride.isBogus() && fHasHanYearChar) {
+            // No current override (=> no Gannen numbering) but new pattern needs it;
+            // use procedures from initNUmberFormatters / adoptNumberFormat
+            umtx_lock(LOCK());
+            if (fSharedNumberFormatters == NULL) {
+                fSharedNumberFormatters = allocSharedNumberFormatters();
+            }
+            umtx_unlock(LOCK());
+            if (fSharedNumberFormatters != NULL) {
+                Locale ovrLoc(fLocale.getLanguage(),fLocale.getCountry(),fLocale.getVariant(),"numbers=jpanyear");
+                UErrorCode status = U_ZERO_ERROR;
+                const SharedNumberFormat *snf = NULL;
+                SharedObject::copyPtr(createSharedNumberFormat(ovrLoc, status), snf);
+                if (U_SUCCESS(status)) {
+                    // Now that we have an appropriate number formatter, fill in the
+                    // appropriate slot in the number formatters table.
+                    UDateFormatField patternCharIndex = DateFormatSymbols::getPatternCharIndex(u'y');
+                    SharedObject::copyPtr(snf, fSharedNumberFormatters[patternCharIndex]);
+                    fDateOverride.setTo(u"y=jpanyear", -1); // record status
+                }
+            }
+        }
+    }
 }
 
 //----------------------------------------------------------------------

--- a/icu4c/source/i18n/unicode/udat.h
+++ b/icu4c/source/i18n/unicode/udat.h
@@ -488,19 +488,19 @@ typedef enum UDateFormatStyle {
  * root/English abbreviated version (ASCII-range characters).
  * @internal
  */
-#define JP_ERA_2019_ROOT                "Qqqq"
+#define JP_ERA_2019_ROOT                "Reiwa"
 /**
  * Constant for Unicode string name of new (in 2019) Japanese calendar era,
  * Japanese abbreviated version (Han, or fullwidth Latin for testing).
  * @internal
  */
-#define JP_ERA_2019_JA                  "\\uFF31\\uFF31"
+#define JP_ERA_2019_JA                  "\\u4EE4\\u548C"
 /**
  * Constant for Unicode string name of new (in 2019) Japanese calendar era,
  * root and Japanese narrow version (ASCII-range characters).
  * @internal
  */
-#define JP_ERA_2019_NARROW              "Q"
+#define JP_ERA_2019_NARROW              "R"
 #endif  // U_HIDE_INTERNAL_API
 
 /**

--- a/icu4c/source/test/intltest/dtifmtts.cpp
+++ b/icu4c/source/test/intltest/dtifmtts.cpp
@@ -1064,9 +1064,9 @@ void DateIntervalFormatTest::testFormat() {
 
         "ja-u-ca-japanese", "S 64 01 05 09:00:00", "H 1 01 15 09:00:00",  "GyMMMd", "\\u662D\\u548C64\\u5E741\\u67085\\u65E5\\uFF5E\\u5E73\\u6210\\u5143\\u5E741\\u670815\\u65E5",
 
-        "ja-u-ca-japanese", "S 64 01 05 09:00:00", "H 1 01 15 09:00:00",  "GGGGGyMd", "S64/1/5\\uFF5EH1/1/15", // The GGGGG/G forces inheritance from a different pattern, no padding
+        "ja-u-ca-japanese", "S 64 01 05 09:00:00", "H 1 01 15 09:00:00",  "GGGGGyMd", "S64/01/05\\uFF5EH1/01/15",
 
-        "ja-u-ca-japanese", "H 31 04 15 09:00:00", JP_ERA_2019_NARROW " 1 05 15 09:00:00", "GGGGGyMd", "H31/4/15\\uFF5E" JP_ERA_2019_NARROW "1/5/15",
+        "ja-u-ca-japanese", "H 31 04 15 09:00:00", JP_ERA_2019_NARROW " 1 05 15 09:00:00", "GGGGGyMd", "H31/04/15\\uFF5E" JP_ERA_2019_NARROW "1/05/15",
 
     };
     expect(DATA, UPRV_LENGTHOF(DATA));
@@ -1077,7 +1077,6 @@ void DateIntervalFormatTest::expect(const char** data, int32_t data_length) {
     int32_t i = 0;
     UErrorCode ec = U_ZERO_ERROR;
     UnicodeString str, str2;
-    UBool testNewJpanEra = JapaneseCalendar::enableTentativeEra();
     const char* pattern = data[i++];
 
     while (i<data_length) {
@@ -1093,11 +1092,6 @@ void DateIntervalFormatTest::expect(const char** data, int32_t data_length) {
         }
         const char* calType = defCal->getType();
  
-        if (!testNewJpanEra && uprv_strcmp(calType,"japanese")==0 && uprv_strncmp(datestr_2,JP_ERA_2019_NARROW,1)==0) {
-            i += 2; // skip the rest of the strings for this item
-            continue; // skip tests involving future japanese eras if not enabled by environment variable
-        }
-
         Locale refLoc("root");
         if (calType) {
             refLoc.setKeywordValue("calendar", calType, ec);

--- a/icu4j/main/classes/core/src/com/ibm/icu/text/DateFormat.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/DateFormat.java
@@ -1318,7 +1318,7 @@ public abstract class DateFormat extends UFormat {
      * @deprecated This API is ICU internal only.
      */
     @Deprecated
-    public static final String JP_ERA_2019_ROOT = "Qqqq";
+    public static final String JP_ERA_2019_ROOT = "Reiwa";
 
     /**
      * Constant for Unicode string name of new (in 2019) Japanese calendar era,
@@ -1327,7 +1327,7 @@ public abstract class DateFormat extends UFormat {
      * @deprecated This API is ICU internal only.
      */
     @Deprecated
-    public static final String JP_ERA_2019_JA = "\uFF31\uFF31";
+    public static final String JP_ERA_2019_JA = "\u4EE4\u548C";
 
     /**
      * Constant for Unicode string name of new (in 2019) Japanese calendar era,
@@ -1336,7 +1336,7 @@ public abstract class DateFormat extends UFormat {
      * @deprecated This API is ICU internal only.
      */
     @Deprecated
-    public static final String JP_ERA_2019_NARROW = "Q";
+    public static final String JP_ERA_2019_NARROW = "R";
 
     /**
      * Gets the time formatter with the default formatting style

--- a/icu4j/main/classes/core/src/com/ibm/icu/text/DateIntervalFormat.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/DateIntervalFormat.java
@@ -1804,6 +1804,7 @@ public class DateIntervalFormat extends UFormat {
                 skeleton = skeletons.bestMatchSkeleton;
             }
             genIntervalPattern(Calendar.YEAR, skeleton, bestSkeleton, differenceInfo, intervalPatterns);
+            genIntervalPattern(Calendar.ERA, skeleton, bestSkeleton, differenceInfo, intervalPatterns);
         } else {
             genIntervalPattern(Calendar.MINUTE, skeleton, bestSkeleton, differenceInfo, intervalPatterns);
             genIntervalPattern(Calendar.HOUR, skeleton, bestSkeleton, differenceInfo, intervalPatterns);

--- a/icu4j/main/classes/core/src/com/ibm/icu/text/DateIntervalInfo.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/DateIntervalInfo.java
@@ -426,7 +426,7 @@ public class DateIntervalInfo implements Cloneable, Freezable<DateIntervalInfo>,
          * Calendar.MINUTE
          * Calendar.SECOND
          */
-        private static final String ACCEPTED_PATTERN_LETTERS = "yMdahHms";
+        private static final String ACCEPTED_PATTERN_LETTERS = "GyMdahHms";
 
         // Output data
         DateIntervalInfo dateIntervalInfo;

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/calendar/JapaneseTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/calendar/JapaneseTest.java
@@ -235,30 +235,45 @@ public class JapaneseTest extends CalendarTestFmwk {
     @Test
     public void TestForceGannenNumbering() {
         final String jCalShortPattern = "y/M/d"; // Note: just 'y' doesn't work here.
-        final String jCalGannenDate = "1/5/9"; // A date in the above format after the accession date for Heisei era (Heisei year 1 Jan 8)
-                                               // or the new era in Gregorian 2019 (new era year 1 May 1). If before the accession date,
+        final String jCalGannenDate = "1/5/9"; // A date in the above format after the accession date for Heisei [1989-] era (Heisei year 1 Jan 8)
+                                               // or Reiwa [2019-] era (Reiwa year 1 May 1). If before the accession date,
                                                // the year will be in the previous era.
         ULocale loc = new ULocale("ja_JP@calendar=japanese");
-        DateFormat refFmt = DateFormat.getDateInstance(DateFormat.SHORT, loc);
-        ((SimpleDateFormat)refFmt).applyPattern(jCalShortPattern);
-        ParsePosition pos = new ParsePosition(0);
-        Date refDate = refFmt.parse(jCalGannenDate, pos);
-        final String testSkeleton = "yMMMd";
+        Date refDate = new Date(600336000000L); // 1989 Jan 9 Monday = Heisei 1
+        final String patText = "Gy年M月d日";
+        final String patNumr = "GGGGGy/MM/dd";
+        final String skelText = "yMMMM";
 
         // Test Gannen year forcing
-        DateFormat testFmt1 = DateFormat.getInstanceForSkeleton(testSkeleton, loc);
+        SimpleDateFormat testFmt1 = new SimpleDateFormat(patText, loc);
+        SimpleDateFormat testFmt2 = new SimpleDateFormat(patNumr, loc);
         String testString1 = testFmt1.format(refDate);
         if (testString1.length() < 3 || testString1.charAt(2) != '\u5143') { // 元
-            errln("Formatting year 1 as Gannen, got " + testString1 + " but expected 3rd char to be \u5143");
+            errln("Formatting year 1 in created text style, got " + testString1 + " but expected 3rd char to be \u5143");
+        }
+        String testString2 = testFmt2.format(refDate);
+        if (testString2.length() < 2 || testString2.charAt(1) != '1') {
+            errln("Formatting year 1 in created numeric style, got " + testString2 + " but expected 2nd char to be 1");
+        }
+        // Now switch the patterns and verify that Gannen use follows the pattern
+        testFmt1.applyPattern(patNumr);
+        testString1 = testFmt1.format(refDate);
+        if (testString1.length() < 2 || testString1.charAt(1) != '1') { //
+            errln("Formatting year 1 in applied numeric style, got " + testString1 + " but expected 2nd char to be 1");
+        }
+        testFmt2.applyPattern(patText);
+        testString2 = testFmt2.format(refDate);
+        if (testString2.length() < 3 || testString2.charAt(2) != '\u5143') { // 元
+            errln("Formatting year 1 in applied text style, got " + testString2 + " but expected 3rd char to be \u5143");
         }
 
         // Test disabling of Gannen year forcing
         DateTimePatternGenerator dtpgen = DateTimePatternGenerator.getInstance(loc);
-        String pattern = dtpgen.getBestPattern(testSkeleton);
-        SimpleDateFormat testFmt2 = new SimpleDateFormat(pattern, "", loc); // empty override string to disable Gannen year numbering
-        String testString2 = testFmt2.format(refDate);
-        if (testString2.length() < 3 || testString2.charAt(2) != '1') {
-            errln("Formatting year 1 with Gannen disabled, got " + testString2 + " but expected 3rd char to be 1");
+        String pattern = dtpgen.getBestPattern(skelText);
+        SimpleDateFormat testFmt3 = new SimpleDateFormat(pattern, "", loc); // empty override string to disable Gannen year numbering
+        String testString3 = testFmt3.format(refDate);
+        if (testString3.length() < 3 || testString3.charAt(2) != '1') {
+            errln("Formatting year 1 with Gannen disabled, got " + testString3 + " but expected 3rd char to be 1");
         }
     }
 

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/DateIntervalFormatTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/DateIntervalFormatTest.java
@@ -712,9 +712,9 @@ public class DateIntervalFormatTest extends TestFmwk {
 
                 "ja-u-ca-japanese", "S 64 01 05 09:00:00", "H 1 01 15 09:00:00",  "GyMMMd", "\u662D\u548C64\u5E741\u67085\u65E5\uFF5E\u5E73\u6210\u5143\u5E741\u670815\u65E5",
 
-                "ja-u-ca-japanese", "S 64 01 05 09:00:00", "H 1 01 15 09:00:00",  "GGGGGyMd", "S64\u5E741\u67085\u65E5\uFF5EH\u5143\u5E741\u670815\u65E5", // The GGGGG/G forces inheritance from a different pattern, non-numeric-only
+                "ja-u-ca-japanese", "S 64 01 05 09:00:00", "H 1 01 15 09:00:00",  "GGGGGyMd", "S64/01/05\uFF5EH1/01/15",
 
-                "ja-u-ca-japanese", "H 31 04 15 09:00:00", DateFormat.JP_ERA_2019_NARROW+" 1 05 15 09:00:00", "GGGGGyMd", "H31\u5E744\u670815\u65E5\uFF5E"+DateFormat.JP_ERA_2019_NARROW+"\u5143\u5E745\u670815\u65E5",
+                "ja-u-ca-japanese", "H 31 04 15 09:00:00", DateFormat.JP_ERA_2019_NARROW+" 1 05 15 09:00:00", "GGGGGyMd", "H31/04/15\uFF5E"+DateFormat.JP_ERA_2019_NARROW+"1/05/15",
 
         };
         expect(DATA, DATA.length);
@@ -723,7 +723,6 @@ public class DateIntervalFormatTest extends TestFmwk {
 
     private void expect(String[] data, int data_length) {
         int i = 0;
-        boolean testNewJpanEra = JapaneseCalendar.enableTentativeEra();
         String pattern = data[i++];
  
         while (i<data_length) {
@@ -734,11 +733,6 @@ public class DateIntervalFormatTest extends TestFmwk {
             ULocale loc = new ULocale(locName);
             Calendar defCal = Calendar.getInstance(loc);
             String calType = defCal.getType();
-
-            if (!testNewJpanEra && calType.equals("japanese") && datestr_2.startsWith(DateFormat.JP_ERA_2019_NARROW)) {
-                i += 2; // skip the rest of the strings for this item
-                continue; // skip tests involving future japanese eras if not enabled by environment variable
-            }
 
             ULocale refLoc = ULocale.ROOT.setKeywordValue("calendar", calType);
             SimpleDateFormat ref = new SimpleDateFormat(pattern, refLoc);


### PR DESCRIPTION

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20537
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

This PR does the following:
- Fixes DateIntervalInfo and DateIntervalFormat to load and use the actual intervalFormats with skeletons containing 'G' from the data
- Fixes SimpleDateFormat applyPattern to update use of Gannen year numbering based on the new pattern being applied (previously SimpleDateFormat just set the use of Gannen year numbering from the format it was initialized with)
- Fixes ICU4C TestJapanese3860 to adapt to new Japan eras
- Addes tests for Gannen updating with applyPattern
- Removes the code that skipped some DateIntervalFormatTest cases if the ICU_ENABLE_TENTATIVE_ERA  environment variable was not set
- Updates expected results from DateIntervalFormatTest now that we are loading the correct patterns