### PR TITLE
ICU-20544 Regex, fix min/max match length computation with negative l…

### DIFF
--- a/icu4c/source/i18n/regexcmp.cpp
+++ b/icu4c/source/i18n/regexcmp.cpp
@@ -2328,7 +2328,7 @@ void  RegexCompile::handleCloseParen() {
                 error(U_REGEX_LOOK_BEHIND_LIMIT);
                 break;
             }
-            if (minML == INT32_MAX && maxML == 0) {
+            if (minML == INT32_MAX) {
                 // This condition happens when no match is possible, such as with a
                 // [set] expression containing no elements.
                 // In principle, the generated code to evaluate the expression could be deleted,

--- a/icu4c/source/test/testdata/regextst.txt
+++ b/icu4c/source/test/testdata/regextst.txt
@@ -1439,11 +1439,14 @@
 "[^\u0000-\U0010ffff]"             "a"
 "[^[^\u0000-\U0010ffff]]"          "<0>a</0>"
 
+# Bug ICU-20544. Similar to 20385, above. Assertion failure with a negative look-behind assertion containing
+#                a set with no contents. Look-behind pattern includes more than just the empty set.
+
+"(?<![ⰿ&&m]c)"                     "<0></0>abc"   # note: first 'ⰿ' is \u2c3f, hence empty set.
+"(?<![^\u0000-\U0010ffff]c)"       "<0></0>abc"
 
 #  Random debugging, Temporary
 #
-
-
 
 
 #


### PR DESCRIPTION
…ook-behind patterns.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20544
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

