### PR TITLE
ICU-20550 jaEra: use all valid eras for calendar calculations

### DIFF
--- a/icu4c/source/i18n/japancal.cpp
+++ b/icu4c/source/i18n/japancal.cpp
@@ -250,7 +250,7 @@ int32_t JapaneseCalendar::handleGetLimit(UCalendarDateFields field, ELimitType l
         if (limitType == UCAL_LIMIT_MINIMUM || limitType == UCAL_LIMIT_GREATEST_MINIMUM) {
             return 0;
         }
-        return gCurrentEra;
+        return gJapaneseEraRules->getNumberOfEras() - 1; // max known era, not gCurrentEra
     case UCAL_YEAR:
         {
             switch (limitType) {
@@ -282,7 +282,7 @@ int32_t JapaneseCalendar::getActualMaximum(UCalendarDateFields field, UErrorCode
         if (U_FAILURE(status)) {
             return 0; // error case... any value
         }
-        if (era == gCurrentEra) {
+        if (era == gJapaneseEraRules->getNumberOfEras() - 1) { // max known era, not gCurrentEra
             // TODO: Investigate what value should be used here - revisit after 4.0.
             return handleGetLimit(UCAL_YEAR, UCAL_LIMIT_MAXIMUM);
         } else {


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20550
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

This changes Japanese calendar calculations to include through the last valid era, not just the current one (based on system time). For example, ucal_add UCAL_ERA +1 should not pin the era until in the last valid era.

This PR is just for the ICU4C changes, the ICU4J changes will be in another PR

Note, without the library code fixes, the added test produced the following:
```
    TestJpnCalAddSetNextEra   {
!!    ERROR: set 1 then add ERA 1, expected start year 2019 but get 1989
!!    ERROR: set 2 then add ERA 1, expected start year 2019 but get 1989
    }
```
