### PR TITLE
ICU-20550 jaEra: use all valid eras for calendar calculations (Java p…

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/util/JapaneseCalendar.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/util/JapaneseCalendar.java
@@ -419,7 +419,7 @@ public class JapaneseCalendar extends GregorianCalendar {
             if (limitType == MINIMUM || limitType == GREATEST_MINIMUM) {
                 return 0;
             }
-            return CURRENT_ERA;
+            return ERA_RULES.getNumberOfEras() - 1; // max known era, not always CURRENT_ERA
         case YEAR:
         {
             switch (limitType) {
@@ -466,7 +466,7 @@ public class JapaneseCalendar extends GregorianCalendar {
     public int getActualMaximum(int field) {
         if (field == YEAR) {
             int era = get(Calendar.ERA);
-            if (era == CURRENT_ERA) {
+            if (era == ERA_RULES.getNumberOfEras() - 1) {
                 // TODO: Investigate what value should be used here - revisit after 4.0.
                 return handleGetLimit(YEAR, MAXIMUM);
             } else {

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/calendar/JapaneseTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/calendar/JapaneseTest.java
@@ -450,5 +450,33 @@ public class JapaneseTest extends CalendarTestFmwk {
         doLimitsTest(jcal, null, cal.getTime());
         doTheoreticalLimitsTest(jcal, true);
     }
+
+    // The following currently assumes that Reiwa is the last known/valid era.
+    // Filed ICU-20551 to generalize this when we have more time...
+    @Test
+    public void TestJpnCalAddSetNextEra() {
+        final JapaneseCalendar jCal = new JapaneseCalendar();
+        jCal.clear();   // This sets to 1970 in Showa
+
+        final int sEra = jCal.get(Calendar.ERA);  // Don't assume era number for Showa
+        final int[] startYears = { 1926, 1989, 2019, 0 };    // start years for Show, Heisei, Reiwa; 0 marks invalid era beyond
+
+        for (int iEra = 1; iEra < 3; iEra++) {
+            jCal.clear();
+            jCal.set(Calendar.ERA, sEra + iEra);
+            int eYear = jCal.get(Calendar.EXTENDED_YEAR);
+            if (eYear != startYears[iEra]) {
+                errln("ERROR: set " + iEra + ", expected start year " + startYears[iEra] + " but get " + eYear);
+            } else {
+                jCal.add(Calendar.ERA, 1);
+                eYear = jCal.get(Calendar.EXTENDED_YEAR);
+                int nextEraStart = (startYears[iEra + 1] == 0) ? startYears[iEra] : startYears[iEra + 1];
+                if (eYear != nextEraStart) {
+                    errln("ERROR: set " + iEra + " then add ERA 1, expected start year " + nextEraStart
+                            + " but get " + eYear);
+                }
+            }
+        }
+    }
 }
 


### PR DESCRIPTION
…ort)

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20550
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

