### PR TITLE
ICU-20513 Treat MSVC warnings C4910 and C4003 as errors in library code

### DIFF
--- a/icu4c/source/allinone/Build.Windows.Library.WarningSettings.ProjectConfiguration.props
+++ b/icu4c/source/allinone/Build.Windows.Library.WarningSettings.ProjectConfiguration.props
@@ -17,8 +17,10 @@
           C4005 Macro redifintion.
           C4068 Unknown pragma.
           C4267 Conversion from size_t to type, possible loss of data.
+          C4910 __declspec(dllexport) and extern are incompatible on an explicit instantiation.
+          C4003 Not enough parameters for macro.
       -->
-      <TreatSpecificWarningsAsErrors>4251;4661;4715;4706;4005;4068;4267;%(TreatSpecificWarningsAsErrors)</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>4251;4661;4715;4706;4005;4068;4267;4910;4003;%(TreatSpecificWarningsAsErrors)</TreatSpecificWarningsAsErrors>
     </ClCompile>
   </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20513
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

