### PR TITLE
ICU-20563 fix macosx rpath breakage in the data build

### DIFF
--- a/icu4c/source/config/mh-darwin
+++ b/icu4c/source/config/mh-darwin
@@ -31,7 +31,7 @@ SHLIB.cc=	$(CXX) -dynamiclib -dynamic $(CXXFLAGS) $(LDFLAGS) $(LD_SOOPTIONS)
 
 ## Compiler switches to embed a library name and version information
 ifeq ($(ENABLE_RPATH),YES)
-LD_SONAME = -Wl,-compatibility_version -Wl,$(SO_TARGET_VERSION_MAJOR) -Wl,-current_version -Wl,$(SO_TARGET_VERSION) -install_name $(libdir)/$(notdir $(MIDDLE_SO_TARGET)) $(PKGDATA_TRAILING_SPACE)
+LD_SONAME = -Wl,-compatibility_version -Wl,$(SO_TARGET_VERSION_MAJOR) -Wl,-current_version -Wl,$(SO_TARGET_VERSION) -install_name $(libdir)/$(notdir $(MIDDLE_SO_TARGET))
 else
 LD_SONAME = -Wl,-compatibility_version -Wl,$(SO_TARGET_VERSION_MAJOR) -Wl,-current_version -Wl,$(SO_TARGET_VERSION) -install_name $(notdir $(MIDDLE_SO_TARGET)) $(PKGDATA_TRAILING_SPACE)
 endif


### PR DESCRIPTION
- in the rpath case, we do NOT want a trailing space in LD_SONAME

regression was introduced in ICU-20526 with
 83a0542b5b52a30b7af736f5ef6b0405f6582867 (master)
 b76cb6517efa113739a3ffadda7ff024db0d5689 (in maint-64)

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20563
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted

