### PR TITLE
ICU-11533 Myanmar calendar support - suggestion to add [WIP]

### DIFF
--- a/icu4c/source/data/locales/root.txt
+++ b/icu4c/source/data/locales/root.txt
@@ -3158,6 +3158,34 @@ root{
             monthNames:alias{"/LOCALE/calendar/gregorian/monthNames"}
             quarters:alias{"/LOCALE/calendar/gregorian/quarters"}
         }
+        myanmar{
+            eras{
+                abbreviated{
+                    "ME",
+                }
+            }
+            monthNames{
+                format{
+                    wide{
+                        "Tagu",
+                        "Kason",
+                        "Nayon",
+                        "Waso",
+                        "Second Waso",
+                        "Wagaung",
+                        "Tawthalin",
+                        "Thadingyut",
+                        "Tazaungmon",
+                        "Nadaw",
+                        "Pyatho",
+                        "Tabodwe",
+                        "Tabaung",
+                        "Late Tagu",
+                        "Late Kason",
+                    }
+                }
+            }
+        }
         persian{
             AmPmMarkers:alias{"/LOCALE/calendar/gregorian/AmPmMarkers"}
             AmPmMarkersNarrow:alias{"/LOCALE/calendar/gregorian/AmPmMarkersNarrow"}

--- a/icu4c/source/i18n/calendar.cpp
+++ b/icu4c/source/i18n/calendar.cpp
@@ -50,6 +50,7 @@
 #include "coptccal.h"
 #include "dangical.h"
 #include "ethpccal.h"
+#include "myancal.h"
 #include "unicode/calendar.h"
 #include "cpputils.h"
 #include "servloc.h"
@@ -162,6 +163,7 @@ static const char * const gCalTypes[] = {
     "gregorian",
     "japanese",
     "buddhist",
+    "myanmar",
     "roc",
     "persian",
     "islamic-civil",
@@ -186,6 +188,7 @@ typedef enum ECalType {
     CALTYPE_GREGORIAN = 0,
     CALTYPE_JAPANESE,
     CALTYPE_BUDDHIST,
+    CALTYPE_MYANMAR,
     CALTYPE_ROC,
     CALTYPE_PERSIAN,
     CALTYPE_ISLAMIC_CIVIL,
@@ -322,6 +325,9 @@ static Calendar *createStandardCalendar(ECalType calType, const Locale &loc, UEr
             break;
         case CALTYPE_BUDDHIST:
             cal.adoptInsteadAndCheckErrorCode(new BuddhistCalendar(loc, status), status);
+            break;
+        case CALTYPE_MYANMAR:
+            cal.adoptInsteadAndCheckErrorCode(new MyanmarCalendar(loc, status), status);
             break;
         case CALTYPE_ROC:
             cal.adoptInsteadAndCheckErrorCode(new TaiwanCalendar(loc, status), status);

--- a/icu4c/source/i18n/i18n.vcxproj
+++ b/icu4c/source/i18n/i18n.vcxproj
@@ -185,6 +185,7 @@
     <ClCompile Include="messageformat2_parser.cpp" />
     <ClCompile Include="messageformat2_serializer.cpp" />
     <ClCompile Include="msgfmt.cpp" />
+    <ClCompile Include="myancal.cpp" />
     <ClCompile Include="nfrs.cpp" />
     <ClCompile Include="nfrule.cpp" />
     <ClCompile Include="nfsubs.cpp" />
@@ -400,6 +401,7 @@
     <ClInclude Include="japancal.h" />
     <ClInclude Include="measunit_impl.h" />
     <ClInclude Include="msgfmt_impl.h" />
+    <ClInclude Include="myancal.h" />
     <ClInclude Include="nfrlist.h" />
     <ClInclude Include="nfrs.h" />
     <ClInclude Include="nfrule.h" />

--- a/icu4c/source/i18n/i18n.vcxproj.filters
+++ b/icu4c/source/i18n/i18n.vcxproj.filters
@@ -252,6 +252,9 @@
     <ClCompile Include="msgfmt.cpp">
       <Filter>formatting</Filter>
     </ClCompile>
+    <ClCompile Include="myancal.cpp">
+      <Filter>formatting</Filter>
+    </ClCompile>
     <ClCompile Include="nfrs.cpp">
       <Filter>formatting</Filter>
     </ClCompile>
@@ -906,6 +909,9 @@
       <Filter>formatting</Filter>
     </ClInclude>
     <ClInclude Include="msgfmt_impl.h">
+      <Filter>formatting</Filter>
+    </ClInclude>
+    <ClInclude Include="myancal.h">
       <Filter>formatting</Filter>
     </ClInclude>
     <ClInclude Include="nfrlist.h">

--- a/icu4c/source/i18n/i18n_uwp.vcxproj
+++ b/icu4c/source/i18n/i18n_uwp.vcxproj
@@ -418,6 +418,7 @@
     <ClCompile Include="messageformat2_parser.cpp" />
     <ClCompile Include="messageformat2_serializer.cpp" />
     <ClCompile Include="msgfmt.cpp" />
+    <ClCompile Include="myancal.cpp" />
     <ClCompile Include="nfrs.cpp" />
     <ClCompile Include="nfrule.cpp" />
     <ClCompile Include="nfsubs.cpp" />
@@ -631,6 +632,7 @@
     <ClInclude Include="japancal.h" />
     <ClInclude Include="measunit_impl.h" />
     <ClInclude Include="msgfmt_impl.h" />
+    <ClInclude Include="myancal.h" />
     <ClInclude Include="nfrlist.h" />
     <ClInclude Include="nfrs.h" />
     <ClInclude Include="nfrule.h" />

--- a/icu4c/source/i18n/myancal.cpp
+++ b/icu4c/source/i18n/myancal.cpp
@@ -1,0 +1,487 @@
+// © 2019 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+/*
+ ******************************************************************************
+ *
+ * File MYANCAL.CPP
+ *
+ * Modification History:
+ *
+ *   Date        Name        Description
+ *   12/28/2017  mapmeld     copied from persncal.cpp
+ *   4/9/2019    mapmeld     continuing project
+ *****************************************************************************
+ */
+
+#include "myancal.h"
+
+#if !UCONFIG_NO_FORMATTING
+
+#include "umutex.h"
+#include "gregoimp.h" // Math
+#include <math.h>
+#include <float.h>
+
+static const int32_t kMyanmarCalendarLimits[UCAL_FIELD_COUNT][4] = {
+    // Minimum  Greatest     Least   Maximum
+    //           Minimum   Maximum
+    {        0,        0,        2,        2}, // ERA
+    { -5000000, -5000000,  5000000,  5000000}, // YEAR
+    {        1,        1,       12,       14}, // MONTH
+    {        1,        1,       51,       56}, // WEEK_OF_YEAR
+    {        1,        1,        5,        5}, // WEEK_OF_MONTH
+    {        1,       1,        29,       30}, // DAY_OF_MONTH
+    {        1,       1,       354,      385}, // DAY_OF_YEAR
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // DAY_OF_WEEK
+    {        1,       1,         5,        5}, // DAY_OF_WEEK_IN_MONTH
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // AM_PM
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // HOUR
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // HOUR_OF_DAY
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // MINUTE
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // SECOND
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // MILLISECOND
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // ZONE_OFFSET
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // DST_OFFSET
+    { -5000000, -5000000,  5000000,  5000000}, // YEAR_WOY
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // DOW_LOCAL
+    { -5000000, -5000000,  5000000,  5000000}, // EXTENDED_YEAR
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // JULIAN_DAY
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // MILLISECONDS_IN_DAY
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // IS_LEAP_MONTH
+};
+
+static const int8_t kMyanmarMonthLength[]
+= {29,30,29,30,0,29,30,29,30,29,30,29,30}; // 0-based
+static const int8_t kMyanmarSmallLeapMonthLength[]
+= {29,30,29,30,30,29,30,29,30,29,30,29,30}; // 0-based
+static const int8_t kMyanmarLargeLeapMonthLength[]
+= {29,30,30,30,30,29,30,29,30,29,30,29,30}; // 0-based
+
+static const double SOLAR_YEAR = 1577917828.0 / 4320000.0; //solar year (365.2587565)
+static const double LUNAR_MONTH = 1577917828.0 / 53433336.0; //lunar month (29.53058795)
+static const double MYANMAR_EPOCH = 1954168.050623; //beginning of 0 ME
+
+U_NAMESPACE_BEGIN
+
+// Implementation of the MyanmarCalendar class
+
+//-------------------------------------------------------------------------
+// Constructors...
+//-------------------------------------------------------------------------
+
+const char *MyanmarCalendar::getType() const {
+    return "myanmar";
+}
+
+Calendar* MyanmarCalendar::clone() const {
+    return new MyanmarCalendar(*this);
+}
+
+MyanmarCalendar::MyanmarCalendar(const Locale& aLocale, UErrorCode& success)
+  :   Calendar(TimeZone::createDefault(), aLocale, success)
+{
+    setTimeInMillis(getNow(), success); // Call this again now that the vtable is set up properly.
+}
+
+MyanmarCalendar::MyanmarCalendar(const MyanmarCalendar& other) : Calendar(other) {
+}
+
+MyanmarCalendar::~MyanmarCalendar()
+{
+}
+
+//-------------------------------------------------------------------------
+// Minimum / Maximum access functions
+//-------------------------------------------------------------------------
+
+
+int32_t MyanmarCalendar::handleGetLimit(UCalendarDateFields field, ELimitType limitType) const {
+    return kMyanmarCalendarLimits[field][limitType];
+}
+
+//-------------------------------------------------------------------------
+// Assorted calculation utilities
+//
+
+/**
+ * Determine whether a Myanmar year is a leap year (big or little watat)
+ */
+UBool MyanmarCalendar::isLeapYear(int32_t year)
+{
+    return false;
+}
+
+/**
+ * Return the day # on which the given year starts.  Days are counted
+ * from the Myanmar epoch, origin 0.
+ */
+int32_t MyanmarCalendar::yearStart(int32_t year) {
+    return handleComputeMonthStart(year,1,FALSE);
+}
+
+/**
+ * Return the day # on which the given month starts.  Days are counted
+ * from the Myanmar epoch, origin 0.
+ *
+ * @param year  The Myanmar year
+ * @param month The Myanmar month, 0-based
+ */
+int32_t MyanmarCalendar::monthStart(int32_t year, int32_t month) const {
+    return handleComputeMonthStart(year,month,TRUE);
+}
+
+//----------------------------------------------------------------------
+// Calendar framework
+//----------------------------------------------------------------------
+
+/**
+ * Return the length (in days) of the given month.
+ *
+ * @param year  The Myanmar year
+ * @param month The Myanmar month, 0-based
+ */
+int32_t MyanmarCalendar::handleGetMonthLength(int32_t extendedYear, int32_t month) const {
+    // If the month is out of range, adjust it into range, and
+    // modify the extended year value accordingly.
+    // if (month < 0 || month > 12) {
+    //     extendedYear += ClockMath::floorDivide(month, 13, month);
+    // }
+
+    bool watat_year = isLeapYear(extendedYear);
+    if (watat_year) {
+      return kMyanmarMonthLength[month];
+    } else {
+      return kMyanmarSmallLeapMonthLength[month];
+    } //else if (watat_year == 2) {
+      //return kMyanmarLargeLeapMonthLength[month];
+    //}
+}
+
+/**
+ * Return the number of days in the given Myanmar year
+ */
+int32_t MyanmarCalendar::handleGetYearLength(int32_t extendedYear) const {
+    int32_t leapStatus;
+
+    leapStatus = isLeapYear(extendedYear);
+    if (leapStatus) {
+      return 354;
+    } else { //if (leapStatus == 1) {
+      return 384;
+    }// else if (leapStatus == 2) {
+    //  return 385;
+    //}
+}
+
+void MyanmarCalendar::cal_my(int32_t myan_year, int32_t& myan_year_type, long& startOfTagu, long& full_moon_waso_2, long& addedOffset) const {
+	long prevYears = 0, year_length_diff = 0, prev_year_little_watat, prev_year_full_moon_waso_2, subject_year_little_watat, subject_year_full_moon_waso_2;
+  addedOffset = 0;
+	cal_watat(myan_year, subject_year_little_watat, subject_year_full_moon_waso_2);
+  myan_year_type = subject_year_little_watat;
+	do {
+    prevYears++;
+    cal_watat(myan_year - prevYears, prev_year_little_watat, prev_year_full_moon_waso_2);
+  } while (prev_year_little_watat == 0 && prevYears < 3);
+	if (myan_year_type) {
+		year_length_diff = (subject_year_full_moon_waso_2 - prev_year_full_moon_waso_2) % 354;
+    myan_year_type = long(ClockMath::floorDivide(year_length_diff, 31) + 1);
+		full_moon_waso_2 = subject_year_full_moon_waso_2;
+    if (year_length_diff != 30 && year_length_diff != 31) {
+      addedOffset = 1;
+    }
+	} else {
+    full_moon_waso_2 = prev_year_full_moon_waso_2 + 354 * prevYears;
+  }
+	startOfTagu = prev_year_full_moon_waso_2 + 354 * prevYears - 102;
+}
+
+//-------------------------------------------------------------------------
+// Functions for converting from field values to milliseconds....
+//-------------------------------------------------------------------------
+
+// Return JD of start of given month/year
+int32_t MyanmarCalendar::handleComputeMonthStart(int32_t eyear, int32_t monthOrder, UBool /*useMonth*/) const {
+    // If the month is out of range, adjust it into range, and
+    // modify the extended year value accordingly.
+    // if (month < 0 || month > 12) {
+    //     eyear += ClockMath::floorDivide(month, 13, month);
+    // }
+
+    // convert to mcal month order
+    int32_t month = monthOrder;
+    if (month == 4) {
+      month = 0;
+    } else if (month > 4) {
+      month--;
+    }
+    int32_t myan_day = 1; // first of month
+    int32_t myan_year_type;
+    long b, c, dayOfYear, year_length, monthType;
+    long startOfTagu, full_moon_waso_2, addedOffset;
+    cal_my(long(eyear), myan_year_type, startOfTagu, full_moon_waso_2, addedOffset);//check year
+    monthType = ClockMath::floorDivide(month, 13);
+    month = month % 13 + monthType; // to 1-12 with month type
+    b = ClockMath::floorDivide(myan_year_type, 2);
+    c = 1 - ClockMath::floorDivide(myan_year_type + 1, 2); //if big watat and common year
+    month += 4 - long(ClockMath::floorDivide(month + 15, 16)) * 4
+            + long(ClockMath::floorDivide(month + 12, 16)); //adjust month
+	  dayOfYear = myan_day + ClockMath::floorDivide(int32_t(29.544 * month - 29.26), 1)
+            - c * ClockMath::floorDivide(month + 11, 16) * 30
+            + b * ClockMath::floorDivide(month + 12, 16);
+	  year_length = 354 + (1 - c) * 30 + b;
+    dayOfYear += monthType * year_length;//adjust day count with year length
+	  return (dayOfYear + startOfTagu);
+}
+
+//-------------------------------------------------------------------------
+// Functions for converting from milliseconds to field values
+//-------------------------------------------------------------------------
+
+int32_t MyanmarCalendar::handleGetExtendedYear() {
+    int32_t year;
+    if (newerField(UCAL_EXTENDED_YEAR, UCAL_YEAR) == UCAL_EXTENDED_YEAR) {
+        year = internalGet(UCAL_EXTENDED_YEAR, 1); // Default to year 1
+    } else {
+        year = internalGet(UCAL_YEAR, 1); // Default to year 1
+    }
+    return year;
+}
+
+/**
+ * Override Calendar to compute several fields specific to the Myanmar
+ * calendar system.  These are:
+ *
+ * <ul><li>ERA
+ * <li>YEAR
+ * <li>MONTH
+ * <li>DAY_OF_MONTH
+ * <li>DAY_OF_YEAR
+ * <li>EXTENDED_YEAR</ul>
+ *
+ * The DAY_OF_WEEK and DOW_LOCAL fields are already set when this
+ * method is called.
+ */
+void MyanmarCalendar::handleComputeFields(int32_t julianDay, UErrorCode &/*status*/) {
+    int32_t dayOfYear, year_length, monthType;
+    long startOfTagu, full_moon_waso_2, addedOffset, a, b, c, e, f;
+    int32_t myan_year_type;
+    long myan_year = ClockMath::floorDivide(julianDay - 0.5 - MYANMAR_EPOCH, SOLAR_YEAR); //Myanmar year
+    cal_my(myan_year, myan_year_type, startOfTagu, full_moon_waso_2, addedOffset); //check year
+    dayOfYear = julianDay - startOfTagu + 1;//day count
+    b = ClockMath::floorDivide(myan_year_type, 2);
+    c = ClockMath::floorDivide(1, (myan_year_type + 1)); //big wa and common yr
+    year_length = 354 + (1 - c) * 30 + b;//year length
+    monthType = ClockMath::floorDivide(dayOfYear - 1, year_length); //month type: late =1 or early = 0
+    dayOfYear -= monthType * year_length;
+    a = ClockMath::floorDivide(dayOfYear + 423, 512); //adjust day count and threshold
+    int32_t myan_month = ClockMath::floorDivide(dayOfYear - b * a + c * a * 30 + 29.26, 29.544); //month
+    e = ClockMath::floorDivide(myan_month + 12, 16);
+    f = ClockMath::floorDivide(myan_month + 11, 16);
+    int32_t myan_day = dayOfYear - long(ClockMath::floorDivide(int32_t(29.544 * myan_month - 29.26), 1))
+          - b * e + c * f * 30; //day
+    myan_month += f * 3 - e * 4 + 12 * monthType;
+
+    // adjust myan_month from mcal's order
+    if (myan_month == 0) {
+      myan_month = 4;
+    } else if (myan_month >= 4) {
+      myan_month++;
+    }
+    //myan_month--;
+    //myan_day++;
+
+    internalSet(UCAL_ERA, 0);
+    internalSet(UCAL_YEAR, myan_year);
+    internalSet(UCAL_EXTENDED_YEAR, myan_year);
+    internalSet(UCAL_MONTH, myan_month);
+    internalSet(UCAL_DAY_OF_MONTH, myan_day);
+    internalSet(UCAL_DAY_OF_YEAR, dayOfYear);
+}
+
+// Search first dimension in a 2D array
+// input: (k=key,A=array,u=size)
+// output: (i=index)
+long MyanmarCalendar::bSearch2(int32_t k, long (*A)[2], long u) const {
+	long i = 0;
+  long l = 0;
+  u--;
+	while(u >= l) {
+		i = ClockMath::floorDivide(l + u, 2);
+		if (A[i][0] > k) u = i - 1;
+		else if (A[i][0] < k) l = i + 1;
+		else return i;
+	} return -1;
+}
+//-----------------------------------------------------------------------------
+// Search a 1D array
+// input: (k=key,A=array,u=size)
+// output: (i=index)
+long MyanmarCalendar::bSearch1(int32_t k,long* A, long u) const {
+	long i=0;
+  long l=0;
+  u--;
+	while (u >= l) {
+		i = ClockMath::floorDivide(l + u, 2);
+		if (A[i] > k)  u = i - 1;
+		else if (A[i] < k) l = i + 1;
+		else return i;
+	} return -1;
+}
+
+void MyanmarCalendar::GetMyConst(int32_t myan_year, double& era, double& WO, double& NM, long& EW) const {
+	EW = 0;
+  long (*big_watat)[2];
+  long* wte;
+  long i = -1, uf, uw;
+	// The third era (the era after Independence 1312 ME and after)
+	if (myan_year >= 1312) {
+		era = 3;
+    WO = -0.5;
+    NM = 8;
+		long era_big_watat[][2] = { {1377, 1} };
+		long wte3[] = { 1344, 1345 };
+		big_watat = era_big_watat;
+    wte = wte3;
+		uf = long(sizeof(era_big_watat) / sizeof(era_big_watat[0]));
+		uw = long(sizeof(wte3) / sizeof(wte3[0]));
+	}
+	// The second era (the era under British colony: 1217 ME - 1311 ME)
+	else if (myan_year >= 1217) {
+		era = 2;
+    WO = -1;
+    NM = 4;
+		long era_big_watat[][2] = { {1234, 1},{1261, -1} };
+		long wte2[] = { 1263, 1264 };
+		big_watat = era_big_watat;
+    wte = wte2;
+		uf = long(sizeof(era_big_watat) / sizeof(era_big_watat[0]));
+		uw = long(sizeof(wte2) / sizeof(wte2[0]));
+	}
+	// The first era (the era of Myanmar kings: ME1216 and before)
+	// Thandeikta (ME 1100 - 1216)
+	else if (myan_year >= 1100) {
+		era = 1.3;
+    WO = -0.85;
+    NM = -1;
+		long era_big_watat[][2] = {{1120, 1}, {1126, -1}, {1150, 1}, {1172, -1}, {1207, 1}};
+		long wte13[] = {1201, 1202};
+		big_watat = era_big_watat;
+    wte = wte13;
+		uf = long(sizeof(era_big_watat) / sizeof(era_big_watat[0]));
+		uw = long(sizeof(wte13) / sizeof(wte13[0]));
+	}
+	// Makaranta system 2 (ME 798 - 1099)
+	else if (myan_year >= 798) {
+		era = 1.2;
+    WO = -1.1;
+    NM = -1;
+		long era_big_watat[][2] = {{813, -1}, {849, -1}, {851, -1}, {854, -1}, {927, -1},
+		{933, -1}, {936, -1}, {938, -1}, {949, -1}, {952, -1}, {963, -1}, {968, -1}, {1039, -1}};
+		long wte12[] = {-9999};
+		big_watat = era_big_watat;
+    wte = wte12;
+		uf = long(sizeof(era_big_watat) / sizeof(era_big_watat[0]));
+		uw = long(sizeof(wte12) / sizeof(wte12[0]));
+	}
+	// Makaranta system 1 (ME 0 - 797)
+	else {
+		era = 1.1;
+    WO = -1.1;
+    NM = -1;
+		long era_big_watat[][2] = {{205, 1}, {246, 1}, {471, 1}, {572, -1}, {651, 1},
+		{653, 2}, {656, 1}, {672, 1}, {729, 1}, {767, -1}};
+		long wte11[] = {-9999};
+		big_watat = era_big_watat;
+    wte = wte11;
+		uf = long(sizeof(era_big_watat) / sizeof(era_big_watat[0]));
+		uw = long(sizeof(wte11) / sizeof(wte11[0]));
+	}
+
+	i = bSearch2(myan_year, big_watat, uf);
+  if (i >= 0) WO += big_watat[i][1]; // full moon day offset exceptions
+
+  i = bSearch1(myan_year, wte, uw);
+  if (i >= 0) EW = 1; //correct watat exceptions
+}
+
+void MyanmarCalendar::cal_watat(int32_t myan_year, long& watat, long& full_moon_waso_2) const {//get data for respective era
+	double era, WO, NM, excess_days;
+  long EW;
+	GetMyConst(myan_year, era, WO, NM, EW); // get constants for the corresponding calendar era
+	double TA = (SOLAR_YEAR / 12 - LUNAR_MONTH) * (12 - NM); //threshold to adjust
+  // printf("calculate remainder of solar_year * (%d + 3739) / lunar_month", myan_year);
+	// ClockMath::floorDivide(double(SOLAR_YEAR * (long(myan_year) + 3739)), LUNAR_MONTH, excess_days); // excess days
+  // printf("got excess_days %s instead of %s", excess_days, fmod(SOLAR_YEAR*(long(myan_year)+3739),LUNAR_MONTH));
+  excess_days = fmod(SOLAR_YEAR*(long(myan_year)+3739),LUNAR_MONTH);
+	if (excess_days < TA) {
+    excess_days += LUNAR_MONTH; //adjust excess days
+  }
+	full_moon_waso_2 = long(round(SOLAR_YEAR * long(myan_year) + MYANMAR_EPOCH - excess_days + 4.5 * LUNAR_MONTH + WO));
+  //full moon day of 2nd Waso
+	double TW = 0;
+  watat = 0;//find watat
+	if (era >= 2) {//if 2nd era or later find watat based on excess days
+		TW = LUNAR_MONTH - (SOLAR_YEAR / 12 - LUNAR_MONTH) * NM;
+		if (excess_days >= TW) {
+      watat = 1;
+    }
+	}
+	else {//if 1st era,find watat by 19 years metonic cycle
+	//Myanmar year is divided by 19 and there is intercalary month
+	//if the remainder is 2,5,7,10,13,15,18
+	//https://github.com/kanasimi/CeJS/blob/master/data/date/calendar.js#L2330
+		watat = (long(myan_year) * 7 + 2) % 19;
+    if (watat < 0) {
+      watat += 19;
+    }
+		watat = long(ClockMath::floorDivide(watat, 12));
+	}
+	watat^=EW;//correct watat exceptions
+}
+
+// default century
+
+static UDate           gSystemDefaultCenturyStart       = DBL_MIN;
+static int32_t         gSystemDefaultCenturyStartYear   = -1;
+static icu::UInitOnce  gSystemDefaultCenturyInit        = U_INITONCE_INITIALIZER;
+
+UBool MyanmarCalendar::haveDefaultCentury() const
+{
+    return TRUE;
+}
+
+static void U_CALLCONV initializeSystemDefaultCentury() {
+    // initialize systemDefaultCentury and systemDefaultCenturyYear based
+    // on the current time.  They'll be set to 80 years before
+    // the current time.
+    UErrorCode status = U_ZERO_ERROR;
+    MyanmarCalendar calendar(Locale("@calendar=myanmar"),status);
+   if (U_SUCCESS(status))
+   {
+        calendar.setTime(Calendar::getNow(), status);
+        calendar.add(UCAL_YEAR, -80, status);
+
+        gSystemDefaultCenturyStart = calendar.getTime(status);
+        gSystemDefaultCenturyStartYear = calendar.get(UCAL_YEAR, status);
+   } else {
+     // printf("fail create Myanmar\n");
+   }
+}
+
+UDate MyanmarCalendar::defaultCenturyStart() const {
+    // lazy-evaluate systemDefaultCenturyStart
+    umtx_initOnce(gSystemDefaultCenturyInit, &initializeSystemDefaultCentury);
+    return gSystemDefaultCenturyStart;
+}
+
+int32_t MyanmarCalendar::defaultCenturyStartYear() const {
+    // lazy-evaluate systemDefaultCenturyStartYear
+    umtx_initOnce(gSystemDefaultCenturyInit, &initializeSystemDefaultCentury);
+    return gSystemDefaultCenturyStartYear;
+}
+
+UOBJECT_DEFINE_RTTI_IMPLEMENTATION(MyanmarCalendar)
+
+U_NAMESPACE_END
+
+#endif

--- a/icu4c/source/i18n/myancal.cpp
+++ b/icu4c/source/i18n/myancal.cpp
@@ -151,7 +151,6 @@ int32_t MyanmarCalendar::handleGetMonthLength(int32_t extendedYear, int32_t mont
  * Return the number of days in the given Myanmar year
  */
 int32_t MyanmarCalendar::handleGetYearLength(int32_t extendedYear) const {
-    int32_t leapStatus;
     long watat_type, waso_type;
 
     cal_watat(extendedYear, watat_type, waso_type);
@@ -191,7 +190,7 @@ void MyanmarCalendar::cal_my(int32_t myan_year, int32_t& myan_year_type, long& s
 //-------------------------------------------------------------------------
 
 // Return JD of start of given month/year
-int64_t MyanmarCalendar::handleComputeMonthStart(int32_t eyear, int32_t month, UBool /*useMonth*/, UErrorCode& status) const {
+int64_t MyanmarCalendar::handleComputeMonthStart(int32_t eyear, int32_t month, UBool /*useMonth*/, UErrorCode& /*status*/) const {
     int32_t myan_day_offset = -1;
     int32_t myan_year_type;
     long b, c, dayOfYear, year_length, monthType;
@@ -223,7 +222,7 @@ int64_t MyanmarCalendar::handleComputeMonthStart(int32_t eyear, int32_t month, U
 
     /* 2nd waso correction for non-leap years */
     if (myan_year_type == 0 && month == 4) {
-      return dayOfYear;
+      return startOfTagu;
     }
 
     monthType = long(floor(month / 13));

--- a/icu4c/source/i18n/myancal.cpp
+++ b/icu4c/source/i18n/myancal.cpp
@@ -18,7 +18,6 @@
 
 #include "umutex.h"
 #include "gregoimp.h" // Math
-#include <math.h>
 #include <float.h>
 
 static const int32_t kMyanmarCalendarLimits[UCAL_FIELD_COUNT][4] = {
@@ -26,13 +25,13 @@ static const int32_t kMyanmarCalendarLimits[UCAL_FIELD_COUNT][4] = {
     //           Minimum   Maximum
     {        0,        0,        2,        2}, // ERA
     { -5000000, -5000000,  5000000,  5000000}, // YEAR
-    {        1,        1,       12,       15}, // MONTH
+    {        1,        2,       13,       15}, // MONTH
     {        1,        1,       51,       56}, // WEEK_OF_YEAR
-    {        1,        1,        5,        5}, // WEEK_OF_MONTH
-    {        1,       1,        29,       30}, // DAY_OF_MONTH
+    {        1,        1,        1,        5}, // WEEK_OF_MONTH
+    {        1,       1,         1,       30}, // DAY_OF_MONTH
     {        1,       1,       354,      385}, // DAY_OF_YEAR
     {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // DAY_OF_WEEK
-    {        1,       1,         5,        5}, // DAY_OF_WEEK_IN_MONTH
+    {        1,       1,         1,        5}, // DAY_OF_WEEK_IN_MONTH
     {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // AM_PM
     {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // HOUR
     {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // HOUR_OF_DAY

--- a/icu4c/source/i18n/myancal.cpp
+++ b/icu4c/source/i18n/myancal.cpp
@@ -275,7 +275,7 @@ void MyanmarCalendar::handleComputeFields(int32_t julianDay, UErrorCode &/*statu
     int32_t og_julian = julianDay;
     long myan_year = long(floor((julianDay - 0.5 - MYANMAR_EPOCH) / SOLAR_YEAR)); //Myanmar year
     /* long watat correction from 2015-2018 CE */
-    if (julianDay > 2457190 && julianDay < 2458287) {
+    if (julianDay > 2457190 && julianDay < 2458283) {
       julianDay--;
     }
     cal_my(myan_year, myan_year_type, startOfTagu, full_moon_waso_2, addedOffset); //check year

--- a/icu4c/source/i18n/myancal.cpp
+++ b/icu4c/source/i18n/myancal.cpp
@@ -1,4 +1,4 @@
-// © 2019 and later: Unicode, Inc. and others.
+// © 2023 and later: Unicode, Inc. and others.
 // License & terms of use: http://www.unicode.org/copyright.html
 /*
  ******************************************************************************

--- a/icu4c/source/i18n/myancal.h
+++ b/icu4c/source/i18n/myancal.h
@@ -1,0 +1,248 @@
+// © 2019 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+/*
+ * File MYANCAL.H
+ *
+ */
+
+#ifndef MYANCAL_H
+#define MYANCAL_H
+
+#include "unicode/utypes.h"
+
+#if !UCONFIG_NO_FORMATTING
+
+#include "unicode/calendar.h"
+
+U_NAMESPACE_BEGIN
+
+/**
+ * <code>MyanmarCalendar</code> is a subclass of <code>Calendar</code>
+ * that implements the traditional Buddhist calendar used today in Myanmar (Burma).
+ * <p>
+ * The Myanmar is lunisolar, with months following the lunar cycle (29 or 30 days)
+ * and additional days being inserted on a regular basis to sync with the solar year.
+ * In practice the days of the month can be labeled waxing 1-14, full moon, waning 1-14, and new moon
+ * There are two leap year types: little watat (with a full leap month named 2nd Waso) occurring every 2-3 years,
+ * and big watat (which adds 2nd Waso and one more day in the month of Nayon).
+ * Big Watat is declared officially by the Myanmar government and very rare (once in past 50 years).
+ * <p>
+ * The Myanmar calendar has been recalibrated over the years and has been in its current
+ * era since 1951 CE. Additional months such as Late Tagu / Late Kason, and other concepts are
+ * supported to accommodate older eras.
+ *
+ * @see GregorianCalendar
+ *
+ * @author Nick Doiron
+ * @internal
+ */
+class MyanmarCalendar : public Calendar {
+ public:
+  //-------------------------------------------------------------------------
+  // Constants...
+  //-------------------------------------------------------------------------
+  /**
+   * Constants for the months
+   * @internal
+   */
+  enum EMonths {
+    /**
+     * Months of Myanmar calendar
+     * @internal
+     */
+    TAGU = 1,
+    KASON = 2,
+    NAYON = 3,
+    WASO = 4,
+    SECOND_WASO = 5,
+    WAGAUNG = 6,
+    TAWTHALIN = 7,
+    THADINGYUT = 8,
+    TAZAUNGMON = 9,
+    NADAW = 10,
+    PYATHO = 11,
+    TABODWE = 12,
+    TABAUNG = 13,
+    LATE_TAGU = 14,
+    LATE_KASON = 15,
+    MYANMAR_MONTH_MAX
+  };
+
+
+
+  //-------------------------------------------------------------------------
+  // Constructors...
+  //-------------------------------------------------------------------------
+
+  /**
+   * Constructs a MyanmarCalendar based on the current time in the default time zone
+   * with the given locale.
+   *
+   * @param aLocale  The given locale.
+   * @param success  Indicates the status of MyanmarCalendar object construction.
+   *                 Returns U_ZERO_ERROR if constructed successfully.
+   * @internal
+   */
+  MyanmarCalendar(const Locale& aLocale, UErrorCode &success);
+
+  /**
+   * Copy Constructor
+   * @internal
+   */
+  MyanmarCalendar(const MyanmarCalendar& other);
+
+  /**
+   * Destructor.
+   * @internal
+   */
+  virtual ~MyanmarCalendar();
+
+  // clone
+  virtual Calendar* clone() const;
+
+ private:
+  /**
+   * Determine whether a year is a common, little watat, or big watat year in the Myanmar calendar
+   */
+  static int32_t isLeapYear(int32_t year);
+
+  /**
+   * Return the day # on which the given year starts.  Days are counted
+   * from the Myanmar Era epoch, origin 0.
+   */
+  int32_t yearStart(int32_t year);
+
+  /**
+   * Return the day # on which the given month starts.  Days are counted
+   * from the Myanmar Era epoch, origin 0.
+   *
+   * @param year  The Myanmar year
+   * @param year  The Myanmar month, 1-based
+   */
+  int32_t monthStart(int32_t year, int32_t month) const;
+  long bSearch2(int32_t k, long (*A)[2], long u) const;
+  long bSearch1(int32_t k,long* A, long u) const;
+  void GetMyConst(int32_t my, double& EI, double& WO, double& NM, long& EW) const;
+  void cal_watat(int32_t my, long& watat, long& fm) const;
+  void cal_my(int32_t my, int32_t& myt, long& tg1, long& fm, long& werr) const;
+
+  //----------------------------------------------------------------------
+  // Calendar framework
+  //----------------------------------------------------------------------
+ protected:
+  /**
+   * @internal
+   */
+  virtual int32_t handleGetLimit(UCalendarDateFields field, ELimitType limitType) const;
+
+  /**
+   * Return the length (in days) of the given month.
+   *
+   * @param year  The Myanmar year
+   * @param year  The Myanmar month, 1-based
+   * @internal
+   */
+  virtual int32_t handleGetMonthLength(int32_t extendedYear, int32_t month) const;
+
+  /**
+   * Return the number of days in the given Myanmar year
+   * @internal
+   */
+  virtual int32_t handleGetYearLength(int32_t extendedYear) const;
+
+  //-------------------------------------------------------------------------
+  // Functions for converting from field values to milliseconds....
+  //-------------------------------------------------------------------------
+
+  // Return JD of start of given month/year
+  /**
+   * @internal
+   */
+  virtual int32_t handleComputeMonthStart(int32_t eyear, int32_t month, UBool useMonth) const;
+
+  //-------------------------------------------------------------------------
+  // Functions for converting from milliseconds to field values
+  //-------------------------------------------------------------------------
+
+  /**
+   * @internal
+   */
+  virtual int32_t handleGetExtendedYear();
+
+  /**
+   * Override Calendar to compute several fields specific to the Myanmar
+   * calendar system.  These are:
+   *
+   * <ul><li>ERA
+   * <li>YEAR
+   * <li>MONTH
+   * <li>DAY_OF_MONTH
+   * <li>DAY_OF_YEAR
+   * <li>EXTENDED_YEAR</ul>
+   *
+   * The DAY_OF_WEEK and DOW_LOCAL fields are already set when this
+   * method is called. The getGregorianXxx() methods return Gregorian
+   * calendar equivalents for the given Julian day.
+   * @internal
+   */
+  virtual void handleComputeFields(int32_t julianDay, UErrorCode &status);
+
+  // UObject stuff
+ public:
+  /**
+   * @return   The class ID for this object. All objects of a given class have the
+   *           same class ID. Objects of other classes have different class IDs.
+   * @internal
+   */
+  virtual UClassID getDynamicClassID(void) const;
+
+  /**
+   * Return the class ID for this class. This is useful only for comparing to a return
+   * value from getDynamicClassID(). For example:
+   *
+   *      Base* polymorphic_pointer = createPolymorphicObject();
+   *      if (polymorphic_pointer->getDynamicClassID() ==
+   *          Derived::getStaticClassID()) ...
+   *
+   * @return   The class ID for all objects of this class.
+   * @internal
+   */
+  U_I18N_API static UClassID U_EXPORT2 getStaticClassID(void);
+
+  /**
+   * return the calendar type, "myanmar".
+   *
+   * @return calendar type
+   * @internal
+   */
+  virtual const char * getType() const;
+
+ private:
+  MyanmarCalendar(); // default constructor not implemented
+
+ protected:
+
+  /**
+   * Returns TRUE because the Myanmar Calendar does have a default century
+   * @internal
+   */
+  virtual UBool haveDefaultCentury() const;
+
+  /**
+   * Returns the date of the start of the default century
+   * @return start of century - in milliseconds since epoch, 1970
+   * @internal
+   */
+  virtual UDate defaultCenturyStart() const;
+
+  /**
+   * Returns the year in which the default century begins
+   * @internal
+   */
+  virtual int32_t defaultCenturyStartYear() const;
+};
+
+U_NAMESPACE_END
+
+#endif
+#endif

--- a/icu4c/source/i18n/myancal.h
+++ b/icu4c/source/i18n/myancal.h
@@ -105,13 +105,13 @@ class MyanmarCalendar : public Calendar {
   /**
    * Determine whether a year is either a little watat or big watat year in the Myanmar calendar
    */
-  static bool isLeapYear(int32_t year);
+  bool isLeapYear(int32_t year);
 
   /**
    * Return the day # on which the given year starts.  Days are counted
    * from the Myanmar Era epoch, origin 0.
    */
-  int32_t yearStart(int32_t year);
+  int32_t yearStart(int32_t year, UErrorCode& success);
 
   /**
    * Return the day # on which the given month starts.  Days are counted
@@ -120,7 +120,7 @@ class MyanmarCalendar : public Calendar {
    * @param year  The Myanmar year
    * @param year  The Myanmar month, 1-based
    */
-  int32_t monthStart(int32_t year, int32_t month) const;
+  int32_t monthStart(int32_t year, int32_t month, UErrorCode& success) const;
   long bSearch2(int32_t k, long (*A)[2], long u) const;
   long bSearch1(int32_t k,long* A, long u) const;
   void GetMyConst(int32_t my, double& EI, double& WO, double& NM, long& EW) const;
@@ -140,10 +140,11 @@ class MyanmarCalendar : public Calendar {
    * Return the length (in days) of the given month.
    *
    * @param year  The Myanmar year
-   * @param year  The Myanmar month, 1-based
+   * @param year  The Myanmar month, 0-based
    * @internal
    */
-  virtual int32_t handleGetMonthLength(int32_t extendedYear, int32_t month) const;
+  virtual int32_t handleGetMonthLength(int32_t extendedYear, int32_t month,
+                                                UErrorCode& status) const override;
 
   /**
    * Return the number of days in the given Myanmar year
@@ -159,7 +160,7 @@ class MyanmarCalendar : public Calendar {
   /**
    * @internal
    */
-  virtual int32_t handleComputeMonthStart(int32_t eyear, int32_t month, UBool useMonth) const;
+  virtual int64_t handleComputeMonthStart(int32_t eyear, int32_t month, UBool useMonth, UErrorCode& status) const override;
 
   //-------------------------------------------------------------------------
   // Functions for converting from milliseconds to field values
@@ -168,7 +169,7 @@ class MyanmarCalendar : public Calendar {
   /**
    * @internal
    */
-  virtual int32_t handleGetExtendedYear();
+  virtual int32_t handleGetExtendedYear(UErrorCode& status) override;
 
   /**
    * Override Calendar to compute several fields specific to the Myanmar

--- a/icu4c/source/i18n/myancal.h
+++ b/icu4c/source/i18n/myancal.h
@@ -103,9 +103,9 @@ class MyanmarCalendar : public Calendar {
 
  private:
   /**
-   * Determine whether a year is a common, little watat, or big watat year in the Myanmar calendar
+   * Determine whether a year is either a little watat or big watat year in the Myanmar calendar
    */
-  static int32_t isLeapYear(int32_t year);
+  static bool isLeapYear(int32_t year);
 
   /**
    * Return the day # on which the given year starts.  Days are counted

--- a/icu4c/source/i18n/myancal.h
+++ b/icu4c/source/i18n/myancal.h
@@ -1,4 +1,4 @@
-// © 2019 and later: Unicode, Inc. and others.
+// © 2023 and later: Unicode, Inc. and others.
 // License & terms of use: http://www.unicode.org/copyright.html
 /*
  * File MYANCAL.H
@@ -30,6 +30,7 @@ U_NAMESPACE_BEGIN
  * The Myanmar calendar has been recalibrated over the years and has been in its current
  * era since 1951 CE. Additional months such as Late Tagu / Late Kason, and other concepts are
  * supported to accommodate older eras.
+ * Adapted from a C++ implementation by Yan Naing Aye https://github.com/yan9a/mmcal/tree/master/cpp
  *
  * @see GregorianCalendar
  *

--- a/icu4c/source/i18n/myancal.h
+++ b/icu4c/source/i18n/myancal.h
@@ -123,7 +123,7 @@ class MyanmarCalendar : public Calendar {
   long bSearch1(int32_t k,long* A, long u) const;
   void GetMyConst(int32_t my, double& EI, double& WO, double& NM, long& EW) const;
   void cal_watat(int32_t my, long& watat, long& fm) const;
-  void cal_my(int32_t my, int32_t& myt, long& tg1, long& fm, long& werr) const;
+  void cal_my(int32_t my, int32_t& myt, long& tg1, long& fm) const;
 
   //----------------------------------------------------------------------
   // Calendar framework

--- a/icu4c/source/i18n/myancal.h
+++ b/icu4c/source/i18n/myancal.h
@@ -32,8 +32,6 @@ U_NAMESPACE_BEGIN
  * supported to accommodate older eras.
  * Adapted from a C++ implementation by Yan Naing Aye https://github.com/yan9a/mmcal/tree/master/cpp
  *
- * @see GregorianCalendar
- *
  * @author Nick Doiron
  * @internal
  */
@@ -99,7 +97,7 @@ class MyanmarCalendar : public Calendar {
   virtual ~MyanmarCalendar();
 
   // clone
-  virtual Calendar* clone() const;
+  virtual Calendar* clone() const override;
 
  private:
   /**
@@ -134,7 +132,7 @@ class MyanmarCalendar : public Calendar {
   /**
    * @internal
    */
-  virtual int32_t handleGetLimit(UCalendarDateFields field, ELimitType limitType) const;
+  virtual int32_t handleGetLimit(UCalendarDateFields field, ELimitType limitType) const override;
 
   /**
    * Return the length (in days) of the given month.
@@ -150,7 +148,7 @@ class MyanmarCalendar : public Calendar {
    * Return the number of days in the given Myanmar year
    * @internal
    */
-  virtual int32_t handleGetYearLength(int32_t extendedYear) const;
+  virtual int32_t handleGetYearLength(int32_t extendedYear) const override;
 
   //-------------------------------------------------------------------------
   // Functions for converting from field values to milliseconds....
@@ -187,7 +185,7 @@ class MyanmarCalendar : public Calendar {
    * calendar equivalents for the given Julian day.
    * @internal
    */
-  virtual void handleComputeFields(int32_t julianDay, UErrorCode &status);
+  virtual void handleComputeFields(int32_t julianDay, UErrorCode &status) override;
 
   // UObject stuff
  public:
@@ -196,7 +194,7 @@ class MyanmarCalendar : public Calendar {
    *           same class ID. Objects of other classes have different class IDs.
    * @internal
    */
-  virtual UClassID getDynamicClassID(void) const;
+  virtual UClassID getDynamicClassID(void) const override;
 
   /**
    * Return the class ID for this class. This is useful only for comparing to a return
@@ -217,7 +215,7 @@ class MyanmarCalendar : public Calendar {
    * @return calendar type
    * @internal
    */
-  virtual const char * getType() const;
+  virtual const char * getType() const override;
 
  private:
   MyanmarCalendar(); // default constructor not implemented
@@ -228,20 +226,20 @@ class MyanmarCalendar : public Calendar {
    * Returns TRUE because the Myanmar Calendar does have a default century
    * @internal
    */
-  virtual UBool haveDefaultCentury() const;
+  virtual UBool haveDefaultCentury() const override;
 
   /**
    * Returns the date of the start of the default century
    * @return start of century - in milliseconds since epoch, 1970
    * @internal
    */
-  virtual UDate defaultCenturyStart() const;
+  virtual UDate defaultCenturyStart() const override;
 
   /**
    * Returns the year in which the default century begins
    * @internal
    */
-  virtual int32_t defaultCenturyStartYear() const;
+  virtual int32_t defaultCenturyStartYear() const override;
 };
 
 U_NAMESPACE_END

--- a/icu4c/source/i18n/sources.txt
+++ b/icu4c/source/i18n/sources.txt
@@ -105,6 +105,7 @@ messageformat2_formattable.cpp
 messageformat2_function_registry.cpp
 messageformat2_parser.cpp
 messageformat2_serializer.cpp
+myancal.cpp
 name2uni.cpp
 nfrs.cpp
 nfrule.cpp

--- a/icu4c/source/i18n/ucal.cpp
+++ b/icu4c/source/i18n/ucal.cpp
@@ -710,6 +710,7 @@ static const char * const CAL_TYPES[] = {
         "islamic-umalqura",
         "islamic-tbla",
         "islamic-rgsa",
+        "myanmar",
         nullptr
 };
 

--- a/icu4c/source/test/depstest/dependencies.txt
+++ b/icu4c/source/test/depstest/dependencies.txt
@@ -1083,7 +1083,7 @@ group: formatting
     measfmt.o quantityformatter.o
     # dateformat
     astro.o buddhcal.o calendar.o cecal.o chnsecal.o coptccal.o dangical.o ethpccal.o
-    gregocal.o gregoimp.o hebrwcal.o indiancal.o islamcal.o iso8601cal.o japancal.o persncal.o taiwncal.o
+    gregocal.o gregoimp.o hebrwcal.o indiancal.o islamcal.o iso8601cal.o japancal.o myancal.o persncal.o taiwncal.o
     erarules.o  # mostly for Japanese eras
     ucal.o
     basictz.o olsontz.o rbtz.o simpletz.o timezone.o tzrule.o tztrans.o

--- a/icu4c/source/test/intltest/callimts.cpp
+++ b/icu4c/source/test/intltest/callimts.cpp
@@ -170,7 +170,8 @@ TestCase TestCases[] = {
         {"indian",          false,      DEFAULT_START, DEFAULT_END},
         {"coptic",          false,      DEFAULT_START, DEFAULT_END},
         {"ethiopic",        false,      DEFAULT_START, DEFAULT_END},
-        {"ethiopic-amete-alem", false,  DEFAULT_START, DEFAULT_END}
+        {"ethiopic-amete-alem", false,  DEFAULT_START, DEFAULT_END},
+        {"myanmar",         false,      DEFAULT_START, DEFAULT_END}
 };
     
 struct {

--- a/icu4c/source/test/intltest/incaltst.cpp
+++ b/icu4c/source/test/intltest/incaltst.cpp
@@ -799,23 +799,25 @@ void IntlCalendarTest::TestMyanmar() {
 
     // Test various dates to be sure of validity
     int32_t data[] = {
-        2015, 6, 16, 1377, 3, 30, // extra nayon day, big watat
+        2016, 4, 17, 1378, 1, 10, // first day of 1378
+        2015, 8, 16, 1377, 6, 1, // Wagaung, big watat
         2015, 7, 17, 1377, 5, 1, // 2nd waso, big watat
-        1989, 4, 15, 1350, 1, 10,
+        2015, 6, 17, 1377, 4, 1, // 1st waso, big watat
+        2015, 6, 16, 1377, 3, 30, //  nayon , big watat
+        2015, 6, 15, 1377, 3, 29, //  nayon , big watat
+        2015, 4, 18, 1377, 2, 1, //  kason
+        2015, 4, 3, 1376, 14, 15, //  dagu
+        2015, 3, 20, 1376, 14, 1, //  dagu
+        2015, 3, 19, 1376, 13, 30, //  tabaung
+        1989, 4, 15, 1350, 14, 10, // late dagu
+        1989, 4, 9, 1350, 14, 4,
+        1989, 4, 6, 1350, 14, 1,
         1875, 7, 17, 1237, 4, 15,
         1838, 7, 17, 1200, 4, 26,
         // historic dates via https://github.com/yan9a/mcal/blob/master/javascript/ceMmDateTime.js
         1609, 2, 17,  970, 13,16,
         -1,-1,-1,-1,-1,-1,-1,-1,-1,-1
     };
-
-    // off by 29 days in Unix time
-    // 1377/3/30 <-> 1377/1/2
-    // 1377/5/1 but got 1377/5/3
-    // 1350/1/10 but got 1350/1/11
-    // 1237/4/15 but got 1237/5/17
-    // 1200/4/26 but got 1200/5/28
-    // 970/13/16 but got 970/13/17
 
     Calendar *grego = Calendar::createInstance("en_US@calendar=gregorian", status);
     for (int32_t i=0; data[i]!=-1; ) {
@@ -865,7 +867,7 @@ void IntlCalendarTest::TestMyanmarFormat() {
     UErrorCode status = U_ZERO_ERROR;
 
     // Test simple parse/format with adopt
-    UDate aDate = 608603000000.0;
+    UDate aDate = 608621000000.0;
     SimpleDateFormat *fmt = new SimpleDateFormat(UnicodeString("MMMM d, yyyy G"), Locale("en_US@calendar=myanmar"), status);
     CHECK(status, "creating myanmar date format instance");
     SimpleDateFormat *fmt2 = new SimpleDateFormat(UnicodeString("MMMM d, yyyy G"), Locale("en_US@calendar=gregorian"), status);
@@ -879,7 +881,7 @@ void IntlCalendarTest::TestMyanmarFormat() {
         str.remove();
         fmt->format(aDate, str);
         logln(UnicodeString() + "as Myanmar Calendar: " + escape(str));
-        UnicodeString expected("Tagu 10, 1350 ME");
+        UnicodeString expected("Late Tagu 10, 1350 ME");
         if(str != expected) {
             errln("Expected " + escape(expected) + " but got " + escape(str));
         }

--- a/icu4c/source/test/intltest/incaltst.cpp
+++ b/icu4c/source/test/intltest/incaltst.cpp
@@ -799,9 +799,31 @@ void IntlCalendarTest::TestMyanmar() {
 
     // Test various dates to be sure of validity
     int32_t data[] = {
-        2016, 4, 17, 1378, 1, 10, // first day of 1378
+        2024, 6, 12, 1386, 3, 6, // 2024
+        2019, 4, 17, 1381, 1, 13, // start of 1381
+        2019, 1,  1, 1380, 10, 25,
+        2018, 8,  1, 1380, 5, 20, // second waso after 2015 2018 correction
+        2018, 7, 13, 1380, 5, 1, // start of second waso
+        2018, 7, 12, 1380, 4, 30, // end of first waso
+        2018, 6, 14, 1380, 4, 2,
+        2018, 6, 13, 1380, 4, 1, // start of first waso
+        2018, 6, 12, 1380, 3, 29, // nayon / first waso
+        2018, 6, 11, 1380, 3, 28, 
+        2018, 5,  1, 1380, 2, 17,
+        2018, 4, 17, 1380, 2,  3, // start year in kason
+        2018, 4, 16, 1379, 15, 2, // late kason
+        2018, 4,  1, 1379, 14, 16, // late tagu
+        2017, 7, 24, 1379, 6, 1, // no month 5 / 2nd waso
+        2017, 7, 23, 1379, 4, 30, // no month 5 / 2nd waso
+        2017, 4, 26, 1379, 2, 1,
+        2017, 4, 17, 1379, 1, 21, // start year in tagu
+        2017, 4, 16, 1378, 14, 20, // late tagu
+        2017, 1,  1, 1378, 11, 4,
+        2016, 4, 17, 1378, 1, 10, // first day of 1378, tagu
+        2016, 4, 16, 1377, 14, 9, // last day of 1377, late tagu
         2015, 8, 16, 1377, 6, 1, // Wagaung, big watat
         2015, 7, 17, 1377, 5, 1, // 2nd waso, big watat
+        2015, 6, 18, 1377, 4, 2, // 1st waso, big watat
         2015, 6, 17, 1377, 4, 1, // 1st waso, big watat
         2015, 6, 16, 1377, 3, 30, //  nayon , big watat
         2015, 6, 15, 1377, 3, 29, //  nayon , big watat
@@ -809,13 +831,15 @@ void IntlCalendarTest::TestMyanmar() {
         2015, 4, 3, 1376, 14, 15, //  dagu
         2015, 3, 20, 1376, 14, 1, //  dagu
         2015, 3, 19, 1376, 13, 30, //  tabaung
+
+/* examples of 2nd waso boundaries? */
+
         1989, 4, 15, 1350, 14, 10, // late dagu
-        1989, 4, 9, 1350, 14, 4,
-        1989, 4, 6, 1350, 14, 1,
+        1989, 4, 6, 1350, 14, 1, // start of late dagu
         1875, 7, 17, 1237, 4, 15,
         1838, 7, 17, 1200, 4, 26,
-        // historic dates via https://github.com/yan9a/mcal/blob/master/javascript/ceMmDateTime.js
-        1609, 2, 17,  970, 13,16,
+        1609, 2, 17,  970, 13, 26,
+
         -1,-1,-1,-1,-1,-1,-1,-1,-1,-1
     };
 
@@ -867,7 +891,7 @@ void IntlCalendarTest::TestMyanmarFormat() {
     UErrorCode status = U_ZERO_ERROR;
 
     // Test simple parse/format with adopt
-    UDate aDate = 608621000000.0;
+    UDate aDate = 608626800000.0;
     SimpleDateFormat *fmt = new SimpleDateFormat(UnicodeString("MMMM d, yyyy G"), Locale("en_US@calendar=myanmar"), status);
     CHECK(status, "creating myanmar date format instance");
     SimpleDateFormat *fmt2 = new SimpleDateFormat(UnicodeString("MMMM d, yyyy G"), Locale("en_US@calendar=gregorian"), status);

--- a/icu4c/source/test/intltest/incaltst.cpp
+++ b/icu4c/source/test/intltest/incaltst.cpp
@@ -88,6 +88,8 @@ void IntlCalendarTest::runIndexedTest( int32_t index, UBool exec, const char* &n
     TESTCASE_AUTO(TestPersian);
     TESTCASE_AUTO(TestPersianFormat);
     TESTCASE_AUTO(TestTaiwan);
+    TESTCASE_AUTO(TestMyanmar);
+    TESTCASE_AUTO(TestMyanmarFormat);
     TESTCASE_AUTO(TestConsistencyGregorian);
     TESTCASE_AUTO(TestConsistencyCoptic);
     TESTCASE_AUTO(TestConsistencyEthiopic);
@@ -773,6 +775,129 @@ void IntlCalendarTest::TestForceGannenNumbering()
             }
         }
     }
+}
+
+/**
+ * Verify the Myanmar Calendar.
+ */
+void IntlCalendarTest::TestMyanmar() {
+    UDate timeA = Calendar::getNow();
+
+    Calendar *cal;
+    UErrorCode status = U_ZERO_ERROR;
+    cal = Calendar::createInstance("en_US@calendar=myanmar", status);
+    CHECK(status, UnicodeString("Creating en_US@calendar=myanmar calendar"));
+    // Sanity check the calendar
+    UDate timeB = Calendar::getNow();
+    UDate timeCal = cal->getTime(status);
+
+    if(!(timeA <= timeCal) || !(timeCal <= timeB)) {
+      errln((UnicodeString)"Error: Calendar time " + timeCal +
+            " is not within sampled times [" + timeA + " to " + timeB + "]!");
+    }
+    // end sanity check
+
+    // Test various dates to be sure of validity
+    int32_t data[] = {
+        2015, 6, 16, 1377, 3, 30, // extra nayon day, big watat
+        2015, 7, 17, 1377, 5, 1, // 2nd waso, big watat
+        1989, 4, 15, 1350, 1, 10,
+        1875, 7, 17, 1237, 4, 15,
+        1838, 7, 17, 1200, 4, 26,
+        // historic dates via https://github.com/yan9a/mcal/blob/master/javascript/ceMmDateTime.js
+        1609, 2, 17,  970, 13,16,
+        -1,-1,-1,-1,-1,-1,-1,-1,-1,-1
+    };
+
+    // off by 29 days in Unix time
+    // 1377/3/30 <-> 1377/1/2
+    // 1377/5/1 but got 1377/5/3
+    // 1350/1/10 but got 1350/1/11
+    // 1237/4/15 but got 1237/5/17
+    // 1200/4/26 but got 1200/5/28
+    // 970/13/16 but got 970/13/17
+
+    Calendar *grego = Calendar::createInstance("en_US@calendar=gregorian", status);
+    for (int32_t i=0; data[i]!=-1; ) {
+        int32_t gregYear = data[i++];
+        int32_t gregMonth = data[i++]-1;
+        int32_t gregDay = data[i++];
+        int32_t myYear = data[i++];
+        int32_t myMonth = data[i++]-1;
+        int32_t myDay = data[i++];
+
+        // Test conversion from Myanmar dates
+        grego->clear();
+        grego->set(gregYear, gregMonth, gregDay);
+
+        cal->clear();
+        cal->set(myYear, myMonth, myDay);
+
+        UDate myTime = cal->getTime(status);
+        UDate gregTime = grego->getTime(status);
+
+        if (myTime != gregTime) {
+          errln(UnicodeString("Expected ") + gregTime + " but got " + myTime);
+        }
+
+        // Test conversion to Myanmar dates
+        cal->clear();
+        cal->setTime(gregTime, status);
+
+        int32_t computedYear = cal->get(UCAL_YEAR, status);
+        int32_t computedMonth = cal->get(UCAL_MONTH, status);
+        int32_t computedDay = cal->get(UCAL_DATE, status);
+
+        if ((myYear != computedYear) ||
+            (myMonth != computedMonth) ||
+            (myDay != computedDay)) {
+          errln(UnicodeString("Expected ") + myYear + "/" + (myMonth+1) + "/" + myDay +
+                " but got " +  computedYear + "/" + (computedMonth+1) + "/" + computedDay);
+        }
+
+    }
+
+    delete cal;
+    delete grego;
+}
+
+void IntlCalendarTest::TestMyanmarFormat() {
+    UErrorCode status = U_ZERO_ERROR;
+
+    // Test simple parse/format with adopt
+    UDate aDate = 608603000000.0;
+    SimpleDateFormat *fmt = new SimpleDateFormat(UnicodeString("MMMM d, yyyy G"), Locale("en_US@calendar=myanmar"), status);
+    CHECK(status, "creating myanmar date format instance");
+    SimpleDateFormat *fmt2 = new SimpleDateFormat(UnicodeString("MMMM d, yyyy G"), Locale("en_US@calendar=gregorian"), status);
+    CHECK(status, "creating gregorian date format instance");
+    if(!fmt) {
+        errln("Couldn't create en_US instance");
+    } else {
+        UnicodeString str;
+        fmt2->format(aDate, str);
+        logln(UnicodeString() + "Test Date:" + str);
+        str.remove();
+        fmt->format(aDate, str);
+        logln(UnicodeString() + "as Myanmar Calendar: " + escape(str));
+        UnicodeString expected("Tagu 10, 1350 ME");
+        if(str != expected) {
+            errln("Expected " + escape(expected) + " but got " + escape(str));
+        }
+        UDate otherDate = fmt->parse(expected, status);
+        if(otherDate != aDate) {
+            UnicodeString str3;
+            fmt->format(otherDate, str3);
+            errln("Parse incorrect of " + escape(expected) + " - wanted " + aDate + " but got " +  otherDate + ", " + escape(str3));
+        } else {
+            logln("Parsed OK: " + expected);
+        }
+        delete fmt;
+    }
+    delete fmt2;
+
+    CHECK(status, "Error occurred testing Myanmar Calendar in English ");
+
+    // other languages follow
 }
 
 /**

--- a/icu4c/source/test/intltest/incaltst.cpp
+++ b/icu4c/source/test/intltest/incaltst.cpp
@@ -802,40 +802,60 @@ void IntlCalendarTest::TestMyanmar() {
         2024, 6, 12, 1386, 3, 6, // 2024
         2019, 4, 17, 1381, 1, 13, // start of 1381
         2019, 1,  1, 1380, 10, 25,
+
         2018, 8,  1, 1380, 5, 20, // second waso after 2015 2018 correction
         2018, 7, 13, 1380, 5, 1, // start of second waso
         2018, 7, 12, 1380, 4, 30, // end of first waso
         2018, 6, 14, 1380, 4, 2,
         2018, 6, 13, 1380, 4, 1, // start of first waso
         2018, 6, 12, 1380, 3, 29, // nayon / first waso
-        2018, 6, 11, 1380, 3, 28, 
+        2018, 6, 11, 1380, 3, 28,
         2018, 5,  1, 1380, 2, 17,
         2018, 4, 17, 1380, 2,  3, // start year in kason
         2018, 4, 16, 1379, 15, 2, // late kason
         2018, 4,  1, 1379, 14, 16, // late tagu
+
         2017, 7, 24, 1379, 6, 1, // no month 5 / 2nd waso
         2017, 7, 23, 1379, 4, 30, // no month 5 / 2nd waso
         2017, 4, 26, 1379, 2, 1,
         2017, 4, 17, 1379, 1, 21, // start year in tagu
         2017, 4, 16, 1378, 14, 20, // late tagu
         2017, 1,  1, 1378, 11, 4,
+
         2016, 4, 17, 1378, 1, 10, // first day of 1378, tagu
         2016, 4, 16, 1377, 14, 9, // last day of 1377, late tagu
-        2015, 8, 16, 1377, 6, 1, // Wagaung, big watat
-        2015, 7, 17, 1377, 5, 1, // 2nd waso, big watat
-        2015, 6, 18, 1377, 4, 2, // 1st waso, big watat
-        2015, 6, 17, 1377, 4, 1, // 1st waso, big watat
-        2015, 6, 16, 1377, 3, 30, //  nayon , big watat
-        2015, 6, 15, 1377, 3, 29, //  nayon , big watat
-        2015, 4, 18, 1377, 2, 1, //  kason
-        2015, 4, 3, 1376, 14, 15, //  dagu
-        2015, 3, 20, 1376, 14, 1, //  dagu
+
+        2015, 8, 16, 1377, 6, 1, // start of wagaung, big watat
+        2015, 8, 15, 1377, 5, 30, // end of 2nd waso, big watat
+        2015, 7, 17, 1377, 5, 1, // start of 2nd waso, big watat
+        2015, 7, 16, 1377, 4, 30, // end of first waso, big watat
+        2015, 6, 17, 1377, 4, 1, // start of 1st waso, big watat
+        2015, 6, 16, 1377, 3, 30, // nayon, big watat
+        2015, 6, 15, 1377, 3, 29, // nayon, big watat
+
+        2015, 4, 18, 1377, 2, 1, // kason
+        2015, 4, 17, 1377, 1, 29, // first day of year is single-day tagu
+        2015, 4, 3, 1376, 14, 15, //  late dagu
+        2015, 3, 20, 1376, 14, 1, //  late dagu
         2015, 3, 19, 1376, 13, 30, //  tabaung
 
-/* examples of 2nd waso boundaries? */
+        2014, 7, 27, 1376, 6, 1, // start of waguang, skipping second waso
+        2014, 7, 26, 1376, 4, 30, // end of first waso
+        2014, 6, 27, 1376, 4, 1, // start of first waso
+        2014, 6, 26, 1376, 3, 29, // end of nayon
+
+        2012, 8, 18, 1374, 6, 1, // start of wagaung, little watat
+        2012, 8, 17, 1374, 5, 30, // end of 2nd waso, little watat
+        2012, 7, 19, 1374, 5, 1, // start of 2nd waso, little watat
+        2012, 7, 18, 1374, 4, 30, // end of first waso, little watat
+        2012, 6, 19, 1374, 4, 1, // start of 1st waso, little watat
+        2012, 6, 18, 1374, 3, 29, // nayon, little watat
+        2012, 6, 17, 1374, 3, 28, // nayon, little watat
 
         1989, 4, 15, 1350, 14, 10, // late dagu
         1989, 4, 6, 1350, 14, 1, // start of late dagu
+
+        // history
         1875, 7, 17, 1237, 4, 15,
         1838, 7, 17, 1200, 4, 26,
         1609, 2, 17,  970, 13, 26,

--- a/icu4c/source/test/intltest/incaltst.h
+++ b/icu4c/source/test/intltest/incaltst.h
@@ -1,14 +1,14 @@
 // © 2016 and later: Unicode, Inc. and others.
 // License & terms of use: http://www.unicode.org/copyright.html
 /********************************************************************
- * COPYRIGHT: 
+ * COPYRIGHT:
  * Copyright (c) 1997-2007, International Business Machines Corporation and
  * others. All Rights Reserved.
  ********************************************************************/
 
 #ifndef __IntlCalendarTest__
 #define __IntlCalendarTest__
- 
+
 #include "unicode/utypes.h"
 
 #if !UCONFIG_NO_FORMATTING
@@ -39,7 +39,7 @@ public:
     void TestJapaneseFormat();
     void TestJapanese3860();
     void TestForceGannenNumbering();
-    
+
     void TestPersian();
     void TestPersianFormat();
 
@@ -62,6 +62,8 @@ public:
     void TestConsistencyJapanese();
     void TestIslamicUmalquraCalendarSlow();
     void TestJapaneseLargeEra();
+    void TestMyanmar(void);
+    void TestMyanmarFormat(void);
 
  protected:
     // Test a Gregorian-Like calendar
@@ -70,14 +72,14 @@ public:
     void checkConsistency(const char* locale);
 
     int32_t daysToCheckInConsistency;
- 
+
 public: // package
     // internal routine for checking date
     static UnicodeString value(Calendar* calendar);
- 
+
 };
 
 
 #endif /* #if !UCONFIG_NO_FORMATTING */
- 
+
 #endif // __IntlCalendarTest__

--- a/icu4c/source/test/intltest/uobjtest.cpp
+++ b/icu4c/source/test/intltest/uobjtest.cpp
@@ -243,6 +243,7 @@ UObject *UObjectTest::testClassNoClassID(UObject *obj, const char *className, co
 #include "taiwncal.h"
 #include "indiancal.h"
 #include "chnsecal.h"
+#include "myancal.h"
 #include "windtfmt.h"
 #include "winnmfmt.h"
 #include "ustrenum.h"
@@ -389,6 +390,7 @@ void UObjectTest::testIDs()
     TESTCLASSID_FACTORY(IndianCalendar, Calendar::createInstance(Locale("@calendar=indian"), status));
     TESTCLASSID_FACTORY(ChineseCalendar, Calendar::createInstance(Locale("@calendar=chinese"), status));
     TESTCLASSID_FACTORY(TaiwanCalendar, Calendar::createInstance(Locale("@calendar=roc"), status));
+    TESTCLASSID_FACTORY(MyanmarCalendar, Calendar::createInstance(Locale("@calendar=myanmar"), status));
 #if U_PLATFORM_USES_ONLY_WIN32_API
     TESTCLASSID_FACTORY(Win32DateFormat, DateFormat::createDateInstance(DateFormat::kFull, Locale("@compat=host")));
     TESTCLASSID_FACTORY(Win32NumberFormat, NumberFormat::createInstance(Locale("@compat=host"), status));

--- a/icu4c/source/test/testdata/structLocale.txt
+++ b/icu4c/source/test/testdata/structLocale.txt
@@ -34290,6 +34290,7 @@ structLocale:table(nofallback){
             japanese{""}
             persian{""}
             roc{""}
+            myanmar{""}
         }
         collation{
             big5han{""}


### PR DESCRIPTION
This is still a work in progress, but as an ICU and C++ newbie, I am reaching out for advice. Any help on setup, please contact me here or @mapmeld on Twitter.

Update: earlier I was overwriting BuddhCal.cpp with MyanCal.cpp to get it to run; for the PR to be more legible I have changed them back to separate files

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-11533
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

CLDR ticket: https://unicode-org.atlassian.net/browse/CLDR-8081
Unicode / ICU ticket: https://unicode-org.atlassian.net/browse/ICU-11533

The code implements the Burmese/Myanmar lunisolar calendar for festival / holiday dates.  Some people in Myanmar use this calendar on official documents and forms, e.g. their birthdate, and it is not simple to convert between them.

### Comparing to a working reference

I am using the open source C++ and JS implementations from https://github.com/yan9a/mcal and making changes:
- renaming variables so their meaning is easier to understand
- changing variable type from long to int where a long is not needed (e.g. day / month / year )
- numbering months in chronological order
- using ClockMath.floorDivide instead of importing math.h ... but is this necessary? Following other calendar implementations
Currently the tests appear to have off-by-one errors (1 month and 1 day off) in most cases.

### Help with development

~~As mentioned earlier, development would be better if I can create calendar=myanmar separate from calendar=buddhist. Also~~ I currently run *all* icu4c tests with ```make check``` instead of the ones which I am targeting - Any help on setup, please contact me here or @mapmeld on Twitter.

### CLA

I have signed the CLA. Because the C++ code is based on Yan Naing Aye's repo, I've filed an Issue asking if he would sign the CLA as well.