### PR TITLE
ICU-20558 Fix regression in DateTimePatternGenerator (Backport for 63)

### DIFF
--- a/icu4c/source/test/intltest/dtptngts.cpp
+++ b/icu4c/source/test/intltest/dtptngts.cpp
@@ -20,8 +20,8 @@
 #include "unicode/dtptngen.h"
 #include "unicode/ustring.h"
 #include "cmemory.h"
+#include "cstring.h"
 #include "loctest.h"
-
 
 // This is an API test, not a unit test.  It doesn't test very many cases, and doesn't
 // try to test the full functionality.  It just calls each function in the class and
@@ -38,6 +38,7 @@ void IntlTestDateTimePatternGeneratorAPI::runIndexedTest( int32_t index, UBool e
         TESTCASE(4, testC);
         TESTCASE(5, testSkeletonsWithDayPeriods);
         TESTCASE(6, testGetFieldDisplayNames);
+        TESTCASE(7, testFallbackWithDefaultRootLocale);
         default: name = ""; break;
     }
 }
@@ -1256,6 +1257,33 @@ void IntlTestDateTimePatternGeneratorAPI::testGetFieldDisplayNames() {
             }
             delete dtpg;
         }
+    }
+}
+
+void IntlTestDateTimePatternGeneratorAPI::testFallbackWithDefaultRootLocale() {
+    UErrorCode status = U_ZERO_ERROR;
+    char original[ULOC_FULLNAME_CAPACITY];
+    
+    uprv_strcpy(original, uloc_getDefault());
+    uloc_setDefault("root", &status);
+    if (U_FAILURE(status)) {
+        errln("ERROR: Failed to change the default locale to root! Default is: %s\n", uloc_getDefault());
+    }
+ 
+    DateTimePatternGenerator* dtpg = icu::DateTimePatternGenerator::createInstance("abcdedf", status);
+
+    if (U_FAILURE(status)) {
+        errln("ERROR: expected createInstance with invalid locale to succeed. Status: %s", u_errorName(status));
+    }
+    if (status != U_USING_DEFAULT_WARNING) {
+        errln("ERROR: expected createInstance to return U_USING_DEFAULT_WARNING for invalid locale and default root locale. Status: %s", u_errorName(status));
+    }
+
+    delete dtpg;
+
+    uloc_setDefault(original, &status);
+    if (U_FAILURE(status)) {
+        errln("ERROR: Failed to change the default locale back to %s\n", original);
     }
 }
 

--- a/icu4c/source/test/intltest/dtptngts.h
+++ b/icu4c/source/test/intltest/dtptngts.h
@@ -32,6 +32,7 @@ private:
     void testC();
     void testSkeletonsWithDayPeriods();
     void testGetFieldDisplayNames();
+    void testFallbackWithDefaultRootLocale();
 };
 
 #endif /* #if !UCONFIG_NO_FORMATTING */


### PR DESCRIPTION
Backporting to ICU 63.

This is manually cherry-picked from commit: 693adf3987c192c9ec649bc88e3e41b52f23204d
See pull-request #632.

This fixes a regression introduced by commit
b12a927c9365bb38831afbf76fdd0999f8f33deb for issue [ICU-13778](https://unicode-org.atlassian.net/browse/ICU-13778).

The above commit improved the error checking in the
DateTimePatternGenerator class, adding checks for errors/failures
where there previously was none at all. This was done in order to
catch catastrophic errors like out-of-memory (OOM), and properly
report them to the caller, rather than ignoring/hiding these errors.

However, in doing so it exposed a case where the code was depending
on ignoring errors in order to fall-back to the Gregorian calendar
when the default ICU locale is set to root.

This restores the previous behavior, by allowing the error of
U_MISSING_RESOURCE_ERROR to fall-though and continue without
reporting back an error to the caller.

Note: This regression was technically introduced in ICU 63, and
also effects ICU 64 as well.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20558
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

