### PR TITLE
ICU-20593 Genrb: Remove keys if bundle is empty after filtering.

### DIFF
--- a/icu4c/source/tools/genrb/reslist.cpp
+++ b/icu4c/source/tools/genrb/reslist.cpp
@@ -1371,7 +1371,7 @@ SRBRoot::compactKeys(UErrorCode &errorCode) {
     }
 
     int32_t keysCount = fUsePoolBundle->fKeysCount + fKeysCount;
-    if (U_FAILURE(errorCode) || fKeysCount == 0 || fKeyMap != NULL) {
+    if (U_FAILURE(errorCode) || fKeyMap != NULL) {
         return;
     }
     map = (KeyMapEntry *)uprv_malloc(keysCount * sizeof(KeyMapEntry));


### PR DESCRIPTION
This is a bug fix.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20593
- [x] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

