### PR TITLE
ICU-20593 Consuming ignore_xml_deprecates option in BUILDRULES.py.

### DIFF
--- a/icu4c/source/data/BUILDRULES.py
+++ b/icu4c/source/data/BUILDRULES.py
@@ -518,15 +518,17 @@ def generate_tree(
 
     # Generate res_index file
     synthetic_locales = set()
-    deprecates_xml_path = os.path.join(os.path.dirname(__file__), xml_filename)
-    deprecates_xml = ET.parse(deprecates_xml_path)
-    for child in deprecates_xml.getroot():
-        if child.tag == "alias":
-            synthetic_locales.add(child.attrib["from"])
-        elif child.tag == "emptyLocale":
-            synthetic_locales.add(child.attrib["locale"])
-        else:
-            raise ValueError("Unknown tag in deprecates XML: %s" % child.tag)
+    if not config.ignore_xml_deprecates:
+        deprecates_xml_path = os.path.join(
+            os.path.dirname(__file__), xml_filename)
+        deprecates_xml = ET.parse(deprecates_xml_path)
+        for child in deprecates_xml.getroot():
+            if child.tag == "alias":
+                synthetic_locales.add(child.attrib["from"])
+            elif child.tag == "emptyLocale":
+                synthetic_locales.add(child.attrib["locale"])
+            else:
+                raise ValueError("Unknown tag in deprecates XML: %s" % child.tag)
     index_input_files = []
     for f in input_files:
         file_stem = f.filename[f.filename.rfind("/")+1:-4]


### PR DESCRIPTION
The option was added in b603285, but the option was not being used.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20593
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

