### PR TITLE
ICU-20599 windowsZones.txt: reflect changes for Europe/Volgograd

### DIFF
--- a/icu4c/source/data/misc/windowsZones.txt
+++ b/icu4c/source/data/misc/windowsZones.txt
@@ -500,7 +500,7 @@ windowsZones:table(nofallback){
         }
         "Russian Standard Time"{
             001{"Europe/Moscow"}
-            RU{"Europe/Moscow Europe/Kirov Europe/Volgograd"}
+            RU{"Europe/Moscow Europe/Kirov"}
             UA{"Europe/Simferopol"}
         }
         "SA Eastern Standard Time"{
@@ -730,6 +730,10 @@ windowsZones:table(nofallback){
         "Vladivostok Standard Time"{
             001{"Asia/Vladivostok"}
             RU{"Asia/Vladivostok Asia/Ust-Nera"}
+        }
+        "Volgograd Standard Time"{
+            001{"Europe/Volgograd"}
+            RU{"Europe/Volgograd"}
         }
         "W. Australia Standard Time"{
             001{"Australia/Perth"}


### PR DESCRIPTION
1. The zone Europe/Volgograd since October 28, 2018 is no more a member of
Russian Standard Time (as of tz2018f). Reflect this at Windows timezones.

2. A new Windows time zone "Volgograd Standard Time" has beed added:
https://support.microsoft.com/help/4468323/dst-and-time-zone-changes-in-windows-for-morocco-and-volgograd
Add this definition to ICU timezones.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20599
- [x] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

