### PR TITLE
ICU-20549 Publish Windows build artifacts from CI builds (x64 Release)

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
       env:
         BUILD: ICU4J
     - script: |
-        cat `find out/junit-results -name "*.txt" -exec grep -l FAILED {} \;`
+        cd icu4j && cat `find out/junit-results -name "*.txt" -exec grep -l FAILED {} \;`
       condition: failed() # only run if the build fails.
       displayName: 'List failures (if any)'
 #-------------------------------------------------------------------------
@@ -58,6 +58,18 @@ jobs:
       inputs:
         filename: icu4c/source/allinone/icucheck.bat
         arguments: 'x64 Release'
+    - task: PowerShell@2
+      displayName: 'PowerShell: Distrelease script'
+      inputs:
+        targetType: filePath
+        filePath: 'icu4c/packaging/distrelease.ps1'
+        arguments: '-arch x64'
+        workingDirectory: icu4c
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Artifacts: icu-windows.zip'
+      inputs:
+        PathtoPublish: 'icu4c/source/dist/icu-windows.zip'
+        ArtifactName: '$(Build.BuildNumber)_ICU4C_MSVC_x64_Release'
 #-------------------------------------------------------------------------
 - job: ICU4C_MSVC_x86_Debug
   displayName: 'C: MSVC 32-bit Debug (VS 2017)'


### PR DESCRIPTION
This runs the `distrelease.ps1` script to package up the Windows binaries on the Azure CI build machines (for x64 Release) into a zip file, and then publishes the file as a build "artifact" for the pipline.

This will allow us to use the generated binaries from the CI build machines for the BRS tasks.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20549
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

