### PR TITLE
ICU-20566 Add missing ICU namespace macros for extra files

### DIFF
--- a/icu4c/source/extra/Makefile.in
+++ b/icu4c/source/extra/Makefile.in
@@ -23,7 +23,7 @@ subdir = extra
 ## Files to remove for 'make clean'
 CLEANFILES = *~
 
-SUBDIRS = uconv
+SUBDIRS = scrptrun uconv
 
 ## List of phony targets
 .PHONY : all all-local all-recursive install install-local		\

--- a/icu4c/source/extra/scrptrun/scrptrun.cpp
+++ b/icu4c/source/extra/scrptrun/scrptrun.cpp
@@ -19,6 +19,8 @@
 #include "cmemory.h"
 #include "scrptrun.h"
 
+U_NAMESPACE_BEGIN
+
 const char ScriptRun::fgClassID=0;
 
 UChar32 ScriptRun::pairedChars[] = {
@@ -201,3 +203,4 @@ UBool ScriptRun::next()
     return true;
 }
 
+U_NAMESPACE_END

--- a/icu4c/source/extra/scrptrun/scrptrun.h
+++ b/icu4c/source/extra/scrptrun/scrptrun.h
@@ -20,6 +20,8 @@
 #include "unicode/uobject.h"
 #include "unicode/uscript.h"
 
+U_NAMESPACE_BEGIN
+
 struct ScriptRecord
 {
     UChar32 startChar;
@@ -152,5 +154,6 @@ inline void ScriptRun::reset(const UChar chars[], int32_t start, int32_t length)
     reset(start, length);
 }
 
+U_NAMESPACE_END
 
 #endif

--- a/icu4c/source/extra/scrptrun/srtest.cpp
+++ b/icu4c/source/extra/scrptrun/srtest.cpp
@@ -27,9 +27,9 @@ UChar testChars[] = {
 
 int32_t testLength = UPRV_LENGTHOF(testChars);
 
-void main()
+int main()
 {
-    ScriptRun scriptRun(testChars, 0, testLength);
+    icu::ScriptRun scriptRun(testChars, 0, testLength);
 
     while (scriptRun.next()) {
         int32_t     start = scriptRun.getScriptStart();
@@ -38,4 +38,5 @@ void main()
 
         printf("Script '%s' from %d to %d.\n", uscript_getName(code), start, end);
     }
+    return 0;
 }


### PR DESCRIPTION
ICU-20566: ICU now uses namespaces. When trying to use the scrptrun.h header, the
header cannot compile stand-alone as it is inheriting from UObject which
is namespaced now. Add namespace macros to properly inherit.

This PR might be incomplete.  There is an srtset.cpp file that also needs to be updated but I'm not sure what the right way to do it is.  I was also asked to add these files to the default build but I'm not certain how to as I think they are already part of the build.  Can someone please help me verify this?

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20566
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added