### PR TITLE
ICU-20602 copyErrorTo() functions should be const

### DIFF
--- a/icu4c/source/common/localebuilder.cpp
+++ b/icu4c/source/common/localebuilder.cpp
@@ -433,7 +433,7 @@ Locale LocaleBuilder::build(UErrorCode& errorCode)
     return product;
 }
 
-UBool LocaleBuilder::copyErrorTo(UErrorCode &outErrorCode) {
+UBool LocaleBuilder::copyErrorTo(UErrorCode &outErrorCode) const {
     if (U_FAILURE(outErrorCode)) {
         // Do not overwrite the older error code
         return TRUE;

--- a/icu4c/source/common/unicode/localebuilder.h
+++ b/icu4c/source/common/unicode/localebuilder.h
@@ -288,7 +288,7 @@ public:
      * @return TRUE if U_FAILURE(outErrorCode)
      * @draft ICU 65
      */
-    UBool copyErrorTo(UErrorCode &outErrorCode);
+    UBool copyErrorTo(UErrorCode &outErrorCode) const;
 
 private:
     UErrorCode status_;


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20602
- [X] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

