### PR TITLE
ICU-20647 Fix TimeZone leak in ucal_open if uloc_setKeywordValue fails.

### DIFF
--- a/icu4c/source/i18n/ucal.cpp
+++ b/icu4c/source/i18n/ucal.cpp
@@ -140,8 +140,8 @@ ucal_open(  const UChar*  zoneID,
 
   if(U_FAILURE(*status)) return 0;
   
-  TimeZone* zone = (zoneID==NULL) ? TimeZone::createDefault()
-      : _createTimeZone(zoneID, len, status);
+  LocalPointer<TimeZone> zone( (zoneID==NULL) ? TimeZone::createDefault() 
+      : _createTimeZone(zoneID, len, status), *status);
 
   if (U_FAILURE(*status)) {
       return NULL;
@@ -157,9 +157,9 @@ ucal_open(  const UChar*  zoneID,
       if (U_FAILURE(*status)) {
           return NULL;
       }
-      return (UCalendar*)Calendar::createInstance(zone, Locale(localeBuf), *status);
+      return (UCalendar*)Calendar::createInstance(zone.orphan(), Locale(localeBuf), *status);
   }
-  return (UCalendar*)Calendar::createInstance(zone, Locale(locale), *status);
+  return (UCalendar*)Calendar::createInstance(zone.orphan(), Locale(locale), *status);
 }
 
 U_CAPI void U_EXPORT2


### PR DESCRIPTION
The `ucal_open` API will leak the TimeZone object `zone` if the calendar type is `UCAL_GREGORIAN`  and the `uloc_setKeywordValue` fails (for any reason). 
If we use a LocalPointer for the TimeZone object, then we can prevent the leak.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20647
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

