### PR TITLE
ICU-20652 Adds Makefile.in, a fuzzer driver, and minor changes to in …

### DIFF
--- a/icu4c/source/aclocal.m4
+++ b/icu4c/source/aclocal.m4
@@ -1,6 +1,6 @@
-# generated automatically by aclocal 1.15 -*- Autoconf -*-
+# generated automatically by aclocal 1.15.1 -*- Autoconf -*-
 
-# Copyright (C) 1996-2014 Free Software Foundation, Inc.
+# Copyright (C) 1996-2017 Free Software Foundation, Inc.
 
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -13,7 +13,7 @@
 
 m4_ifndef([AC_CONFIG_MACRO_DIRS], [m4_defun([_AM_CONFIG_MACRO_DIRS], [])m4_defun([AC_CONFIG_MACRO_DIRS], [_AM_CONFIG_MACRO_DIRS($@)])])
 dnl pkg.m4 - Macros to locate and utilise pkg-config.   -*- Autoconf -*-
-dnl serial 11 (pkg-config-0.29.1)
+dnl serial 11 (pkg-config-0.29)
 dnl
 dnl Copyright © 2004 Scott James Remnant <scott@netsplit.com>.
 dnl Copyright © 2012-2015 Dan Nicholson <dbn.lists@gmail.com>
@@ -55,7 +55,7 @@ dnl
 dnl See the "Since" comment for each macro you use to see what version
 dnl of the macros you require.
 m4_defun([PKG_PREREQ],
-[m4_define([PKG_MACROS_VERSION], [0.29.1])
+[m4_define([PKG_MACROS_VERSION], [0.29])
 m4_if(m4_version_compare(PKG_MACROS_VERSION, [$1]), -1,
     [m4_fatal([pkg.m4 version $1 or higher is required but ]PKG_MACROS_VERSION[ found])])
 ])dnl PKG_PREREQ

--- a/icu4c/source/configure
+++ b/icu4c/source/configure
@@ -645,6 +645,8 @@ ICULIBSUFFIX
 DATA_PACKAGING_MODE
 thepkgicudatadir
 pkgicudatadir
+U_HAVE_FUZZER
+FUZZER_TRUE
 U_HAVE_TOOLS
 TOOLS_TRUE
 U_HAVE_LAYOUTEX
@@ -753,6 +755,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -797,6 +800,7 @@ enable_icuio
 enable_layoutex
 enable_layout
 enable_tools
+enable_fuzzer
 with_data_packaging
 with_library_suffix
 enable_tests
@@ -857,6 +861,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1109,6 +1114,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1246,7 +1260,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1399,6 +1413,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1454,6 +1469,7 @@ Optional Features:
             icu-le-hb must be installed via pkg-config. See http://harfbuzz.org
 
   --enable-tools         build ICU's tools default=yes
+  --enable-fuzzer        build ICU's fuzzer test targets default=no
   --enable-tests          build ICU tests default=yes
   --enable-samples        build ICU samples default=yes
 
@@ -7665,6 +7681,28 @@ else
   U_HAVE_TOOLS=0
 fi
 
+# Enable/disable fuzzer target tests.
+# Check whether --enable-fuzzer was given.
+if test "${enable_fuzzer+set}" = set; then :
+  enableval=$enable_fuzzer; case "${enableval}" in
+		yes) fuzzer=true ;;
+		no)  fuzzer=false ;;
+		*) as_fn_error $? "bad value ${enableval} for --enable-fuzzer" "$LINENO" 5 ;;
+		esac
+else
+  fuzzer=false
+fi
+
+
+
+if test "$fuzzer" = true; then
+  FUZZER_TRUE=
+  U_HAVE_FUZZER=1
+else
+  FUZZER_TRUE='#'
+  U_HAVE_FUZZER=0
+fi
+
 
 # Check whether --with-data-packaging was given.
 if test "${with_data_packaging+set}" = set; then :
@@ -7883,7 +7921,7 @@ echo "CXXFLAGS=$CXXFLAGS"
 
 
 # output the Makefiles
-ac_config_files="$ac_config_files icudefs.mk Makefile data/pkgdataMakefile config/Makefile.inc config/icu.pc config/pkgdataMakefile data/Makefile stubdata/Makefile common/Makefile i18n/Makefile layoutex/Makefile io/Makefile extra/Makefile extra/uconv/Makefile extra/uconv/pkgdataMakefile extra/scrptrun/Makefile tools/Makefile tools/ctestfw/Makefile tools/toolutil/Makefile tools/makeconv/Makefile tools/genrb/Makefile tools/genccode/Makefile tools/gencmn/Makefile tools/gencnval/Makefile tools/gendict/Makefile tools/gentest/Makefile tools/gennorm2/Makefile tools/genbrk/Makefile tools/gensprep/Makefile tools/icuinfo/Makefile tools/icupkg/Makefile tools/icuswap/Makefile tools/pkgdata/Makefile tools/tzcode/Makefile tools/gencfu/Makefile tools/escapesrc/Makefile test/Makefile test/compat/Makefile test/testdata/Makefile test/testdata/pkgdataMakefile test/hdrtst/Makefile test/intltest/Makefile test/cintltst/Makefile test/iotest/Makefile test/letest/Makefile test/perf/Makefile test/perf/collationperf/Makefile test/perf/collperf/Makefile test/perf/collperf2/Makefile test/perf/dicttrieperf/Makefile test/perf/ubrkperf/Makefile test/perf/charperf/Makefile test/perf/convperf/Makefile test/perf/normperf/Makefile test/perf/DateFmtPerf/Makefile test/perf/howExpensiveIs/Makefile test/perf/strsrchperf/Makefile test/perf/unisetperf/Makefile test/perf/usetperf/Makefile test/perf/ustrperf/Makefile test/perf/utfperf/Makefile test/perf/utrie2perf/Makefile test/perf/leperf/Makefile samples/Makefile samples/date/Makefile samples/cal/Makefile samples/layout/Makefile"
+ac_config_files="$ac_config_files icudefs.mk Makefile data/pkgdataMakefile config/Makefile.inc config/icu.pc config/pkgdataMakefile data/Makefile stubdata/Makefile common/Makefile i18n/Makefile layoutex/Makefile io/Makefile extra/Makefile extra/uconv/Makefile extra/uconv/pkgdataMakefile extra/scrptrun/Makefile tools/Makefile tools/ctestfw/Makefile tools/toolutil/Makefile tools/makeconv/Makefile tools/genrb/Makefile tools/genccode/Makefile tools/gencmn/Makefile tools/gencnval/Makefile tools/gendict/Makefile tools/gentest/Makefile tools/gennorm2/Makefile tools/genbrk/Makefile tools/gensprep/Makefile tools/icuinfo/Makefile tools/icupkg/Makefile tools/icuswap/Makefile tools/pkgdata/Makefile tools/tzcode/Makefile tools/gencfu/Makefile tools/escapesrc/Makefile test/Makefile test/compat/Makefile test/testdata/Makefile test/testdata/pkgdataMakefile test/hdrtst/Makefile test/intltest/Makefile test/cintltst/Makefile test/iotest/Makefile test/letest/Makefile test/perf/Makefile test/perf/collationperf/Makefile test/perf/collperf/Makefile test/perf/collperf2/Makefile test/perf/dicttrieperf/Makefile test/perf/ubrkperf/Makefile test/perf/charperf/Makefile test/perf/convperf/Makefile test/perf/normperf/Makefile test/perf/DateFmtPerf/Makefile test/perf/howExpensiveIs/Makefile test/perf/strsrchperf/Makefile test/perf/unisetperf/Makefile test/perf/usetperf/Makefile test/perf/ustrperf/Makefile test/perf/utfperf/Makefile test/perf/utrie2perf/Makefile test/perf/leperf/Makefile test/fuzzer/Makefile samples/Makefile samples/date/Makefile samples/cal/Makefile samples/layout/Makefile"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -8656,6 +8694,7 @@ do
     "test/perf/utfperf/Makefile") CONFIG_FILES="$CONFIG_FILES test/perf/utfperf/Makefile" ;;
     "test/perf/utrie2perf/Makefile") CONFIG_FILES="$CONFIG_FILES test/perf/utrie2perf/Makefile" ;;
     "test/perf/leperf/Makefile") CONFIG_FILES="$CONFIG_FILES test/perf/leperf/Makefile" ;;
+    "test/fuzzer/Makefile") CONFIG_FILES="$CONFIG_FILES test/fuzzer/Makefile" ;;
     "samples/Makefile") CONFIG_FILES="$CONFIG_FILES samples/Makefile" ;;
     "samples/date/Makefile") CONFIG_FILES="$CONFIG_FILES samples/date/Makefile" ;;
     "samples/cal/Makefile") CONFIG_FILES="$CONFIG_FILES samples/cal/Makefile" ;;

--- a/icu4c/source/configure.ac
+++ b/icu4c/source/configure.ac
@@ -1124,6 +1124,17 @@ AC_ARG_ENABLE(tools,
 	tools=true)
 ICU_CONDITIONAL(TOOLS, test "$tools" = true)
 
+# Enable/disable fuzzer target tests.
+AC_ARG_ENABLE(fuzzer,
+	[  --enable-fuzzer        build ICU's fuzzer test targets [default=no]],
+	[case "${enableval}" in
+		yes) fuzzer=true ;;
+		no)  fuzzer=false ;;
+		*) AC_MSG_ERROR(bad value ${enableval} for --enable-fuzzer) ;;
+		esac],
+	fuzzer=false)
+ICU_CONDITIONAL(FUZZER, test "$fuzzer" = true)
+
 AC_ARG_WITH(data-packaging,
 	[  --with-data-packaging     specify how to package ICU data. Possible values:
         files    raw files (.res, etc)
@@ -1387,6 +1398,7 @@ AC_CONFIG_FILES([icudefs.mk \
 		test/perf/utfperf/Makefile \
 		test/perf/utrie2perf/Makefile \
 		test/perf/leperf/Makefile \
+		test/fuzzer/Makefile \
 		samples/Makefile samples/date/Makefile \
 		samples/cal/Makefile samples/layout/Makefile])
 AC_OUTPUT

--- a/icu4c/source/test/Makefile.in
+++ b/icu4c/source/test/Makefile.in
@@ -15,6 +15,8 @@ include $(top_builddir)/icudefs.mk
 ## Build directory information
 subdir = test
 
+@FUZZER_TRUE@FUZZER=fuzzer
+
 @ICUIO_TRUE@IOTEST = iotest
 
 # the letest directory depends on layoutex.
@@ -32,7 +34,7 @@ STATUS_FULL = $(shell pwd)/$(STATUS_TMP)
 ## Files to remove for 'make clean'
 CLEANFILES = *~ $(STATUS_TMP)
 
-SUBDIRS = $(TESTDATA) intltest $(IOTEST) cintltst $(LETEST)
+SUBDIRS = $(TESTDATA) intltest $(IOTEST) cintltst $(LETEST) $(FUZZER)
 
 ## List of phony targets
 .PHONY : everything all all-local all-recursive install install-local		\
@@ -139,6 +141,8 @@ $(STATUS_FULL)/status.$(STATUS_NUM).deleteme.%: pcheck_setup
 pcheck: $(STATUS_FILES)
 	@goods=; \
 	bads=; \
+	echo "----------------------------------------"; \
+	echo $SUBDIRS \
 	echo "----------------------------------------"; \
 	for subdir in $(SUBDIRS); do \
 	  if [ -s "$(MYSTATUS_R).$$subdir" ]; then \

--- a/icu4c/source/test/fuzzer/Makefile.in
+++ b/icu4c/source/test/fuzzer/Makefile.in
@@ -1,0 +1,99 @@
+# © 2019 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
+#******************************************************************************
+## Makefile.in for ICU - test/fuzzer
+
+## Source directory information
+srcdir = @srcdir@
+top_srcdir = @top_srcdir@
+
+top_builddir = ../..
+
+## All the flags and other definitions are included here.
+include $(top_builddir)/icudefs.mk
+
+## Build directory information
+subdir = test/fuzzer
+
+## Extra files to remove for 'make clean'
+CLEANFILES = *~ $(DEPS) $(TESTXML)
+
+## Target information
+TARGET = all_fuzzers
+
+BUILDDIR := $(CURR_SRCCODE_FULL_DIR)/../../
+# Simplify the path for Unix
+BUILDDIR := $(BUILDDIR:test/fuzzer/../../=)
+# Simplify the path for Windows
+BUILDDIR := $(BUILDDIR:test\\fuzzer/../../=)
+# Simplify the path for Windows 98
+BUILDDIR := $(BUILDDIR:TEST\\FUZZER/../../=)
+
+CPPFLAGS += -I$(srcdir) -I$(top_srcdir)/common -I$(top_srcdir)/i18n -I$(top_srcdir)/tools/ctestfw -I$(top_srcdir)/io
+DEFS += -D'U_TOPSRCDIR="$(top_srcdir)/"' -D'U_TOPBUILDDIR="$(BUILDDIR)"'
+LIBS = $(LIBCTESTFW) $(LIBICUTOOLUTIL) $(LIBICUIO) $(LIBICUI18N) $(LIBICUUC) $(DEFAULT_LIBS) $(LIB_M)
+
+FUZZER_TARGETS = break_iterator_fuzzer collator_compare_fuzzer converter_fuzzer locale_fuzzer number_format_fuzzer ucasemap_fuzzer uloc_canonicalize_fuzzer uloc_for_language_tag_fuzzer uloc_get_name_fuzzer uloc_is_right_to_left_fuzzer uloc_open_keywords_fuzzer unicode_string_codepage_create_fuzzer uregex_open_fuzzer
+
+OBJECTS = $(FUZZER_TARGETS:%=%.o)
+OBJECTS += fuzzer_driver.o locale_util.o
+
+DEPS = $(OBJECTS:.o=.d)
+
+-include Makefile.local
+
+## List of phony targets
+.PHONY : all all-local install install-local clean clean-local	\
+distclean distclean-local dist dist-local check check-local xcheck	\
+check-exhaustive check-exhaustive-local all_fuzzers
+
+## Clear suffix list
+.SUFFIXES :
+
+## List of standard targets
+all: all-local
+install: install-local
+clean: clean-local
+distclean : distclean-local
+dist: dist-local
+check: all check-local
+xcheck: all xcheck-local
+
+all-local: $(TARGET)
+
+install-local:
+
+dist-local:
+
+clean-local:
+	test -z "$(CLEANFILES)" || $(RMV) $(CLEANFILES)
+	$(RMV) $(OBJECTS) $(TARGET) $(FUZZER_TARGETS)
+
+distclean-local: clean-local
+	$(RMV) Makefile
+
+check-local: all-local
+	$(foreach trgt,$(FUZZER_TARGETS), echo $(trgt); $(INVOKE) ./$(trgt) \
+            $(TEST_OUTPUT_OPTS) || exit \
+            $(IOTEST_OPTS);)
+
+xcheck-local: check-local
+
+Makefile: $(srcdir)/Makefile.in  $(top_builddir)/config.status
+	cd $(top_builddir) \
+	 && CONFIG_FILES=$(subdir)/$@ CONFIG_HEADERS= $(SHELL) ./config.status
+
+all_fuzzers: $(FUZZER_TARGETS)
+
+%_fuzzer: %_fuzzer.o fuzzer_driver.o locale_util.o
+	$(LINK.cc) $(OUTOPT)$@ $^ $(LIBS)
+
+ifeq (,$(MAKECMDGOALS))
+-include $(DEPS)
+else
+ifneq ($(patsubst %clean,,$(MAKECMDGOALS)),)
+ifneq ($(patsubst %install,,$(MAKECMDGOALS)),)
+-include $(DEPS)
+endif
+endif
+endif

--- a/icu4c/source/test/fuzzer/break_iterator_fuzzer.cpp
+++ b/icu4c/source/test/fuzzer/break_iterator_fuzzer.cpp
@@ -1,6 +1,7 @@
 // © 2019 and later: Unicode, Inc. and others.
 // License & terms of use: http://www.unicode.org/copyright.html
 
+#include <cstring>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>

--- a/icu4c/source/test/fuzzer/converter_fuzzer.cpp
+++ b/icu4c/source/test/fuzzer/converter_fuzzer.cpp
@@ -6,6 +6,8 @@
 
 #include <algorithm>
 #include <array>
+#include <cstring>
+#include <functional>
 #include <memory>
 #include <vector>
 

--- a/icu4c/source/test/fuzzer/fuzzer_driver.cpp
+++ b/icu4c/source/test/fuzzer/fuzzer_driver.cpp
@@ -1,0 +1,20 @@
+// © 2019 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "cmemory.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size);
+
+int main(int argc, char* argv[])
+{
+  (void) argc;
+  (void) argv;
+  const char *fuzzer_data = "abc123";
+   
+  LLVMFuzzerTestOneInput((const uint8_t *) fuzzer_data, strlen(fuzzer_data));
+
+  return 0;
+}

--- a/icu4c/source/test/fuzzer/number_format_fuzzer.cpp
+++ b/icu4c/source/test/fuzzer/number_format_fuzzer.cpp
@@ -3,8 +3,10 @@
 
 // Fuzzer for NumberFormat::parse.
 
+#include <cstring>
 #include <stddef.h>
 #include <stdint.h>
+#include <string>
 #include <memory>
 #include "fuzzer_utils.h"
 #include "unicode/numfmt.h"

--- a/icu4c/source/test/fuzzer/ucasemap_fuzzer.cpp
+++ b/icu4c/source/test/fuzzer/ucasemap_fuzzer.cpp
@@ -3,9 +3,11 @@
 
 // Fuzzer for ucasemap.
 
+#include <cstring>
+#include <functional>
+#include <memory>
 #include <stddef.h>
 #include <stdint.h>
-#include <memory>
 #include "fuzzer_utils.h"
 #include "unicode/ucasemap.h"
 

--- a/icu4c/source/test/fuzzer/unicode_string_codepage_create_fuzzer.cpp
+++ b/icu4c/source/test/fuzzer/unicode_string_codepage_create_fuzzer.cpp
@@ -4,6 +4,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <cstring>
 #include <algorithm>
 #include <array>
 #include <vector>

--- a/icu4c/source/test/fuzzer/uregex_open_fuzzer.cpp
+++ b/icu4c/source/test/fuzzer/uregex_open_fuzzer.cpp
@@ -3,6 +3,8 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
+
 
 #include "fuzzer_utils.h"
 #include "unicode/regex.h"
@@ -12,11 +14,13 @@ IcuEnvironment* env = new IcuEnvironment();
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   UParseError pe = { 0 };
   UErrorCode status = U_ZERO_ERROR;
+
   URegularExpression* re = uregex_open(reinterpret_cast<const UChar*>(data),
                                        static_cast<int>(size) / sizeof(UChar),
                                        0, &pe, &status);
+
   if (re)
     uregex_close(re);
-
+ 
   return 0;
 }


### PR DESCRIPTION
…fuzzer

targets to test/fuzzer/ directory. This will enable compilation and
smoke test of fuzzer targets as part of the ICU continuous build.

ICU-20652 Fixed exit-on-error behaviour of fuzzer targets execution.
Minor clean-ups and improvements

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20652
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

