### PR TITLE
ICU-20627 Fixing typo introduced by #670.

### DIFF
--- a/icu4c/source/python/icutools/databuilder/request_types.py
+++ b/icu4c/source/python/icutools/databuilder/request_types.py
@@ -304,7 +304,7 @@ class IndexRequest(AbstractRequest):
                 del self.installed_files[i]
         j = 0
         while j < len(self.alias_files):
-            if filter.match(self.alias_files[i]):
+            if filter.match(self.alias_files[j]):
                 j += 1
             else:
                 del self.alias_files[j]


### PR DESCRIPTION
Small fix, whoops; manifests itself with `--filter_file` is used.  We should probably make a BRS task that checks that code path, or add something to the automated build.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20627
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

