### PR TITLE
ICU-20658 Fix broken Data Filtering on Windows builds. (backport for 64)

### DIFF
--- a/icu4c/source/data/makedata.mak
+++ b/icu4c/source/data/makedata.mak
@@ -239,9 +239,9 @@ $(COREDATA_TS):
 		--tool_dir "$(ICUTOOLS)" \
 		--tool_cfg "$(CFG)" \
 		--out_dir "$(ICUBLD_PKG)" \
-		--tmp_dir "$(ICUTMP)"
+		--tmp_dir "$(ICUTMP)" \
 		--filter_file "$(ICU_DATA_FILTER_FILE)" \
-		$(ICU_DATA_BUILDTOOL_OPTS) \
+		$(ICU_DATA_BUILDTOOL_OPTS)
 	@echo "timestamp" > $(COREDATA_TS)
 
 	


### PR DESCRIPTION
Back-porting to ICU 64. 

(cherry picked from commit d72aa9142925691c3197f60949f42ca67650ae1f)

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20658
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

