### PR TITLE
ICU-20652 Corrects calculation of byte sequence length to prevent buffer

### DIFF
--- a/icu4c/source/test/fuzzer/collator_compare_fuzzer.cpp
+++ b/icu4c/source/test/fuzzer/collator_compare_fuzzer.cpp
@@ -17,10 +17,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     return 0;
 
   std::unique_ptr<char16_t> compbuff1(new char16_t[size/4]);
-  std::memcpy(compbuff1.get(), data, size/2);
+  std::memcpy(compbuff1.get(), data, (size/4)*2);
   data = data + size/2;
   std::unique_ptr<char16_t> compbuff2(new char16_t[size/4]);
-  std::memcpy(compbuff2.get(), data, size/2);
+  std::memcpy(compbuff2.get(), data, (size/4)*2);
 
   icu::LocalPointer<icu::Collator> fuzzCollator(
       icu::Collator::createInstance(icu::Locale::getUS(), status), status);


### PR DESCRIPTION
overflow.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20652
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

