### PR TITLE
ICU-20718 Disable the MSYS2 CI builds for now.

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -163,25 +163,29 @@ jobs:
         filename: icu4c/source/allinone/icucheck.bat
         arguments: 'x64 Release'
 #-------------------------------------------------------------------------
-- job: ICU4C_MSYS2_GCC_x86_64_Release
-  displayName: 'C: MSYS2 GCC x86_64 Release'
-  timeoutInMinutes: 45
-  pool:
-    vmImage: 'vs2017-win2016'
-    demands:
-      - Cmd
-  steps:
-    - script: |
-       choco install -y msys2
-       rem refreshenv
-      displayName: 'Install MSYS2'
-    - script: |
-       c:\tools\msys64\usr\bin\bash.exe -lc "echo 'Hello World' && uname -a"
-       c:\tools\msys64\usr\bin\bash.exe -lc "pacman --noconfirm -S mingw-w64-x86_64-toolchain"
-       c:\tools\msys64\usr\bin\bash.exe -lc "pacman --noconfirm -S make"
-       exit
-      displayName: 'Install mingw-w64-x86_64-toolchain'
-    - script: |
-       set MSYSTEM=MINGW64
-       c:\tools\msys64\usr\bin\bash.exe -lc "cd $BUILD_SOURCESDIRECTORY && cd icu4c/source && ./runConfigureICU MinGW && make -j2 check"
-      displayName: 'Build and Test ICU4C'
+# Temporarily disabled as the MSYS2 builds are failing due to a ADO
+# image/VM update.
+#
+#- job: ICU4C_MSYS2_GCC_x86_64_Release
+#  displayName: 'C: MSYS2 GCC x86_64 Release'
+#  timeoutInMinutes: 45
+#  pool:
+#    vmImage: 'vs2017-win2016'
+#    demands:
+#      - Cmd
+#  steps:
+#    - script: |
+#       choco install -y msys2
+#       rem refreshenv
+#      displayName: 'Install MSYS2'
+#    - script: |
+#       c:\tools\msys64\usr\bin\bash.exe -lc "echo 'Hello World' && uname -a"
+#       c:\tools\msys64\usr\bin\bash.exe -lc "pacman --noconfirm -S mingw-w64-x86_64-toolchain"
+#       c:\tools\msys64\usr\bin\bash.exe -lc "pacman --noconfirm -S make"
+#       exit
+#      displayName: 'Install mingw-w64-x86_64-toolchain'
+#    - script: |
+#       set MSYSTEM=MINGW64
+#       c:\tools\msys64\usr\bin\bash.exe -lc "cd $BUILD_SOURCESDIRECTORY && cd icu4c/source && ./runConfigureICU MinGW && make -j2 check"
+#      displayName: 'Build and Test ICU4C'
+#


### PR DESCRIPTION
It seems that an update to the Azure DevOps images that run the CI builds has caused the MSYS2 build to start failing on the master and maint-64 branches.
I'm not sure what the underlying root cause it, but I'm temporarily disabling this flavor of the CI build to unblock other PRs.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20718
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

