### PR TITLE
ICU-20718 Fix failing MSYS2 build due to current path confusion.

### DIFF
--- a/icu4c/source/config/mh-mingw
+++ b/icu4c/source/config/mh-mingw
@@ -103,13 +103,29 @@ LIBICU = $(STATIC_PREFIX_WHEN_USED)$(ICUPREFIX)
 #SH## with usually. Many applications will want to add ${ICULIBS_I18N} as well. 
 #SH#ICULIBS="${ICULIBS_BASE} ${ICULIBS_I18N} ${ICULIBS_COMMON} ${ICULIBS_DATA} "
 
-# The #M# is used to delete lines for icu-config
-# Current full path directory.
-#CURR_FULL_DIR=$(shell pwd -W)#M# for MSYS
-CURR_FULL_DIR?=$(subst \,/,$(shell cmd /c cd))#M# for Cygwin shell
-# Current full path directory for use in source code in a -D compiler option.
-#CURR_SRCCODE_FULL_DIR=$(subst /,\\\\,$(shell pwd -W))#M# for MSYS
-CURR_SRCCODE_FULL_DIR=$(subst \,/,$(shell cmd /c cd))#M# for Cygwin shell
+# Note: The #M# is used to delete lines for icu-config
+MSYS_VERSION ?= $(if $(findstring Msys, $(shell uname -o)),$(word 1, $(subst ., ,$(shell uname -r))),0)#M#
+$(info Detected MSYS version: $(MSYS_VERSION))
+
+ifeq ($(MSYS_VERSION),$(filter $(MSYS_VERSION),0 1))
+	# Older versions of MSYS don't have cygpath by default. #M#
+	
+	# Current full path directory. #M#
+	#CURR_FULL_DIR=$(shell pwd -W)#M# for MSYS
+	CURR_FULL_DIR?=$(subst \,/,$(shell cmd /c cd))#M# for Cygwin shell 
+
+	# Current full path directory for use in source code in a -D compiler option. #M#
+	#CURR_SRCCODE_FULL_DIR=$(subst /,\\\\,$(shell pwd -W))#M# for MSYS
+	CURR_SRCCODE_FULL_DIR=$(subst \,/,$(shell cmd /c cd))#M# for Cygwin shell
+else
+	# MSYS2 and up have cygpath by default #M#
+
+	# Current full path directory. #M#
+	CURR_FULL_DIR?=$(shell cygpath . -a -m)#M#
+
+	# Current full path directory for use in source code in a -D compiler option. #M#
+	CURR_SRCCODE_FULL_DIR=$(shell cygpath . -a -m)#M#
+endif
 
 ## Compilation rules
 %.$(STATIC_O): $(srcdir)/%.c

--- a/icu4c/source/config/mh-mingw64
+++ b/icu4c/source/config/mh-mingw64
@@ -103,13 +103,29 @@ LIBICU = $(STATIC_PREFIX_WHEN_USED)$(ICUPREFIX)
 #SH## with usually. Many applications will want to add ${ICULIBS_I18N} as well. 
 #SH#ICULIBS="${ICULIBS_BASE} ${ICULIBS_I18N} ${ICULIBS_COMMON} ${ICULIBS_DATA} "
 
-# The #M# is used to delete lines for icu-config
-# Current full path directory.
-#CURR_FULL_DIR=$(shell pwd -W)#M# for MSYS
-CURR_FULL_DIR?=$(subst \,/,$(shell cmd /c cd))#M# for Cygwin shell
-# Current full path directory for use in source code in a -D compiler option.
-#CURR_SRCCODE_FULL_DIR=$(subst /,\\\\,$(shell pwd -W))#M# for MSYS
-CURR_SRCCODE_FULL_DIR=$(subst \,/,$(shell cmd /c cd))#M# for Cygwin shell
+# Note: The #M# is used to delete lines for icu-config
+MSYS_VERSION ?= $(if $(findstring Msys, $(shell uname -o)),$(word 1, $(subst ., ,$(shell uname -r))),0)#M#
+$(info Detected MSYS version: $(MSYS_VERSION))
+
+ifeq ($(MSYS_VERSION),$(filter $(MSYS_VERSION),0 1))
+	# Older versions of MSYS don't have cygpath by default. #M#
+	
+	# Current full path directory. #M#
+	#CURR_FULL_DIR=$(shell pwd -W)#M# for MSYS
+	CURR_FULL_DIR?=$(subst \,/,$(shell cmd /c cd))#M# for Cygwin shell 
+
+	# Current full path directory for use in source code in a -D compiler option. #M#
+	#CURR_SRCCODE_FULL_DIR=$(subst /,\\\\,$(shell pwd -W))#M# for MSYS
+	CURR_SRCCODE_FULL_DIR=$(subst \,/,$(shell cmd /c cd))#M# for Cygwin shell
+else
+	# MSYS2 and up have cygpath by default #M#
+
+	# Current full path directory. #M#
+	CURR_FULL_DIR?=$(shell cygpath . -a -m)#M#
+
+	# Current full path directory for use in source code in a -D compiler option. #M#
+	CURR_SRCCODE_FULL_DIR=$(shell cygpath . -a -m)#M#
+endif
 
 ## Compilation rules
 %.$(STATIC_O): $(srcdir)/%.c


### PR DESCRIPTION
The Azure DevOps VM images that are used in the CI builds recently updated the version of MSYS that is installed, which is causing the MSYS builds to fail. It seems that this new version has issues with using the `shell cmd` method in the makefiles to obtain the current path.
However, we can avoid this entirely by using the `cygpath` utility, which also avoids the overhead of launching a new `cmd` instance just to get the path.
Unfortunately, it seems that older versions of MSYS don't have this utility program included by default, though versions of MSYS 2 and up do have it included by default.
We can continue using the old approach for the older versions and use the `cygpath` approach for new versions.

This PR supplants/replaces PR #709.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20718
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

