### PR TITLE
ICU-20721 Fix typo in API docs about unumf_openForSkeletonAndLocale.

### DIFF
--- a/icu4c/source/i18n/unicode/unum.h
+++ b/icu4c/source/i18n/unicode/unum.h
@@ -409,7 +409,7 @@ typedef enum UNumberFormatFields {
  * respectively.
  *
  * <p><strong>NOTE::</strong> New users with are strongly encouraged to
- * use unumf_openWithSkeletonAndLocale instead of unum_open.
+ * use unumf_openForSkeletonAndLocale instead of unum_open.
  *
  * @param pattern A pattern specifying the format to use. 
  * This parameter is ignored unless the style is


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20721
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

