### PR TITLE
ICU-20747 Change dependency for common_uwp from onecoreuap.lib to onecore.lib

### DIFF
--- a/icu4c/source/common/common_uwp.vcxproj
+++ b/icu4c/source/common/common_uwp.vcxproj
@@ -114,7 +114,7 @@
       </DataExecutionPrevention>
       <TurnOffAssemblyGeneration>true</TurnOffAssemblyGeneration>
       <IgnoreSpecificDefaultLibraries>vccorlib.lib;msvcrt.lib</IgnoreSpecificDefaultLibraries>
-      <AdditionalDependencies>onecoreuap.lib</AdditionalDependencies>
+      <AdditionalDependencies>onecore.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">


### PR DESCRIPTION
onecore.lib is on all devices, while onecoreuap.lib is only on devices that support UWP. Moving down to OneCore.lib means being able to target more devices.
See https://docs.microsoft.com/en-us/windows/win32/apiindex/windows-umbrella-libraries for additional info.

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20747
- [X] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

