### PR TITLE
ICU-20751 Fix xtensa build

### DIFF
--- a/icu4c/source/i18n/double-conversion-utils.h
+++ b/icu4c/source/i18n/double-conversion-utils.h
@@ -103,6 +103,7 @@ int main(int argc, char** argv) {
     defined(__AARCH64EL__) || defined(__aarch64__) || defined(__AARCH64EB__) || \
     defined(__riscv) || \
     defined(__or1k__) || defined(__arc__) || \
+    defined(__XTENSA__) || \
     defined(__EMSCRIPTEN__)
 #define DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS 1
 #elif defined(__mc68000__) || \


### PR DESCRIPTION
Solves build error
In file included from double-conversion.h:42:0,
                 from number_decimalquantity.cpp:19:
double-conversion-utils.h:119:2: error: #error Target architecture was not detected as supported by Double-Conversion.
 #error Target architecture was not detected as supported by Double-Conversion.

detected by buildroot autobuilders:
http://autobuild.buildroot.net/results/e6c/e6c6f826d8280f2bef923b3327d2a9a13ce2f7e1/

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

