### PR TITLE
ICU-20756 add xtensa architecture support to double-conversion-utils.h

### DIFF
--- a/icu4c/source/i18n/double-conversion-utils.h
+++ b/icu4c/source/i18n/double-conversion-utils.h
@@ -103,7 +103,7 @@ int main(int argc, char** argv) {
     defined(__AARCH64EL__) || defined(__aarch64__) || defined(__AARCH64EB__) || \
     defined(__riscv) || \
     defined(__or1k__) || defined(__arc__) || \
-    defined(__EMSCRIPTEN__)
+    defined(__EMSCRIPTEN__) || defined(__xtensa__)
 #define DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS 1
 #elif defined(__mc68000__) || \
     defined(__pnacl__) || defined(__native_client__)


### PR DESCRIPTION
Building of icu4c for the Xtensa architecture currently fails with the
following error message:

  double-conversion-utils.h:120:2: error: #error Target architecture was
  not detected as supported by Double-Conversion.

Xtensa uses 64-bit doubles and passes the test case in the
double-conversion-utils.h. Add it to the list of supported
architectures.

Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [+] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20756
- [+] Updated PR title and link in previous line to include Issue number
- [-] Issue accepted
- [-] Tests included
- [-] Documentation is changed or added

