### PR TITLE
ICU-20601 Remove and add semicolons for consistency

### DIFF
--- a/icu4c/source/common/utrie.h
+++ b/icu4c/source/common/utrie.h
@@ -199,7 +199,7 @@ typedef struct UTrie UTrie;
 
 /** Internal trie getter from a BMP code point, treating a lead surrogate as a normal code point */
 #define _UTRIE_GET_FROM_BMP(trie, data, c16) \
-    _UTRIE_GET_RAW(trie, data, 0xd800<=(c16) && (c16)<=0xdbff ? UTRIE_LEAD_INDEX_DISP : 0, c16);
+    _UTRIE_GET_RAW(trie, data, 0xd800<=(c16) && (c16)<=0xdbff ? UTRIE_LEAD_INDEX_DISP : 0, c16)
 
 /**
  * Internal trie getter from a code point.

--- a/icu4c/source/i18n/tzfmt.cpp
+++ b/icu4c/source/i18n/tzfmt.cpp
@@ -1878,7 +1878,7 @@ TimeZoneFormat::parseOffsetFieldsWithPattern(const UnicodeString& text, int32_t 
                     while (len > 0) {
                         UChar32 ch;
                         int32_t chLen;
-                        U16_GET(patStr, 0, 0, len, ch)
+                        U16_GET(patStr, 0, 0, len, ch);
                         if (PatternProps::isWhiteSpace(ch)) {
                             chLen = U16_LENGTH(ch);
                             len -= chLen;

--- a/icu4c/source/samples/cal/cal.c
+++ b/icu4c/source/samples/cal/cal.c
@@ -697,7 +697,7 @@ print_year(UCalendar *c,
                 if(left_current == 0) {
                     break;
                 }
-            };
+            }
             
             /* If the current day isn't 0, indent to make up for missing
             days at the end of the month */
@@ -745,7 +745,7 @@ print_year(UCalendar *c,
                     break;
                 }
                 
-            };
+            }
             
             /* Output a newline */
             putc('\n', stdout);

--- a/icu4c/source/test/cintltst/callcoll.c
+++ b/icu4c/source/test/cintltst/callcoll.c
@@ -219,7 +219,7 @@ UBool hasCollationElements(const char *locName) {
 
   UErrorCode status = U_ZERO_ERROR;
 
-  UResourceBundle *loc = ures_open(U_ICUDATA_NAME U_TREE_SEPARATOR_STRING "coll", locName, &status);;
+  UResourceBundle *loc = ures_open(U_ICUDATA_NAME U_TREE_SEPARATOR_STRING "coll", locName, &status);
 
   if(U_SUCCESS(status)) {
     status = U_ZERO_ERROR;

--- a/icu4c/source/test/cintltst/capitst.c
+++ b/icu4c/source/test/cintltst/capitst.c
@@ -849,7 +849,7 @@ void TestCloneBinary(){
         ucol_getSortKey(col, t, -1, k2, l2);
         if (strcmp((char *)k1,(char *)k2) != 0){
             log_err("ucol_openBinary - new collator should equal to old one\n");
-        };
+        }
         free(k1);
         free(k2);
     }

--- a/icu4c/source/test/cintltst/cbiapts.c
+++ b/icu4c/source/test/cintltst/cbiapts.c
@@ -99,7 +99,7 @@ static UChar* toUChar(const char *src, void **freeHook) {
     UErrorCode status = U_ZERO_ERROR;
     if (src == NULL) {
         return NULL;
-    };
+    }
 
     cnv = ucnv_open(NULL, &status);
     if(U_FAILURE(status) || cnv == NULL) {
@@ -532,7 +532,7 @@ static UBreakIterator * testOpenRules(char *rules) {
     if (U_FAILURE(status)) {
         log_data_err("FAIL: ubrk_openRules: ICU Error \"%s\" (Are you missing data?)\n", u_errorName(status));
         bi = 0;
-    };
+    }
     freeToUCharStrings(&strCleanUp);
     return bi;
 

--- a/icu4c/source/test/cintltst/ccaltst.c
+++ b/icu4c/source/test/cintltst/ccaltst.c
@@ -935,7 +935,7 @@ static void TestAddRollExtensive()
     
     u_uastrcpy(tzID, "PST");
     /*open the calendar used */
-    cal=ucal_open(tzID, u_strlen(tzID), "en_US", UCAL_GREGORIAN, &status);;
+    cal=ucal_open(tzID, u_strlen(tzID), "en_US", UCAL_GREGORIAN, &status);
     if (U_FAILURE(status)) {
         log_data_err("ucal_open() failed : %s - (Are you missing data?)\n", u_errorName(status)); 
         return; 
@@ -1123,7 +1123,7 @@ static void TestGetLimits()
     
     u_uastrcpy(tzID, "PST");
     /*open the calendar used */
-    cal=ucal_open(tzID, u_strlen(tzID), "en_US", UCAL_GREGORIAN, &status);;
+    cal=ucal_open(tzID, u_strlen(tzID), "en_US", UCAL_GREGORIAN, &status);
     if (U_FAILURE(status)) {
         log_data_err("ucal_open() for gregorian calendar failed in TestGetLimits: %s - (Are you missing data?)\n", u_errorName(status));
         return; 
@@ -1221,7 +1221,7 @@ static void TestDOWProgression()
     char tempMsgBuf[256];
     u_strcpy(tzID, fgGMTID);
     /*open the calendar used */
-    cal=ucal_open(tzID, u_strlen(tzID), "en_US", UCAL_TRADITIONAL, &status);;
+    cal=ucal_open(tzID, u_strlen(tzID), "en_US", UCAL_TRADITIONAL, &status);
     if (U_FAILURE(status)) {
         log_data_err("ucal_open failed: %s - (Are you missing data?)\n", u_errorName(status));
         return; 
@@ -1294,7 +1294,7 @@ static void testZones(int32_t yr, int32_t mo, int32_t dt, int32_t hr, int32_t mn
     char tempMsgBuf[256];
 
     u_strcpy(tzID, fgGMTID);
-    gmtcal=ucal_open(tzID, 3, "en_US", UCAL_TRADITIONAL, &status);;
+    gmtcal=ucal_open(tzID, 3, "en_US", UCAL_TRADITIONAL, &status);
     if (U_FAILURE(status)) {
         log_data_err("ucal_open failed: %s - (Are you missing data?)\n", u_errorName(status)); 
         return; 

--- a/icu4c/source/test/cintltst/cnumtst.c
+++ b/icu4c/source/test/cintltst/cnumtst.c
@@ -498,7 +498,7 @@ free(result);
     pattern=unum_open(UNUM_IGNORE,temp1, u_strlen(temp1), NULL, NULL,&status);
     if(U_FAILURE(status))
     {
-        log_err("error in unum_openPattern(): %s\n", myErrorName(status) );;
+        log_err("error in unum_openPattern(): %s\n", myErrorName(status) );
     }
     else
         log_verbose("Pass: unum_openPattern() works fine\n");
@@ -1323,7 +1323,7 @@ static void TestNumberFormatPadding()
     pattern=unum_open(UNUM_IGNORE,temp1, u_strlen(temp1), "en_US",NULL, &status);
     if(U_FAILURE(status))
     {
-        log_err_status(status, "error in padding unum_openPattern(%s): %s\n", temp1, myErrorName(status) );;
+        log_err_status(status, "error in padding unum_openPattern(%s): %s\n", temp1, myErrorName(status) );
     }
     else {
         log_verbose("Pass: padding unum_openPattern() works fine\n");
@@ -1625,7 +1625,7 @@ static void test_fmt(UNumberFormat* fmt, UBool isDecimal) {
             /* set the default ruleset to the first one found, and retry */
 
             if (len > 0) {
-                for (i = 0; i < len && temp[i] != ';'; ++i){};
+                for (i = 0; i < len && temp[i] != ';'; ++i){}
                 if (i < len) {
                     buffer[i] = 0;
                     unum_setTextAttribute(fmt, UNUM_DEFAULT_RULESET, buffer, -1, &status);

--- a/icu4c/source/test/cintltst/crestst.c
+++ b/icu4c/source/test/cintltst/crestst.c
@@ -534,7 +534,7 @@ TestOpenDirect(void) {
     }
     ures_close(idna_rules);
 
-    errorCode = U_USING_FALLBACK_WARNING;;
+    errorCode = U_USING_FALLBACK_WARNING;
     idna_rules=ures_openDirect("testdata", "idna_rules", &errorCode);
     if(U_FAILURE(errorCode)) {
         log_data_err("ures_openDirect(\"idna_rules\") failed when U_USING_FALLBACK_WARNING was set prior to call: %s\n", u_errorName(errorCode));

--- a/icu4c/source/test/cintltst/cstrtest.c
+++ b/icu4c/source/test/cintltst/cstrtest.c
@@ -117,10 +117,10 @@ static void TestAPI(void)
         log_err("FAIL: uprv_stricmp() where the second string is null failed. Expected: 1, returned %d\n", intValue);
     }
     if((intValue=uprv_stricmp(NULL, NULL)) != 0){
-        log_err("FAIL: uprv_stricmp(NULL, NULL) failed.  Expected:  0, returned %d\n", intValue);;
+        log_err("FAIL: uprv_stricmp(NULL, NULL) failed.  Expected:  0, returned %d\n", intValue);
     }
     if((intValue=uprv_stricmp("", "")) != 0){
-        log_err("FAIL: uprv_stricmp(\"\", \"\") failed.  Expected:  0, returned %d\n", intValue);;
+        log_err("FAIL: uprv_stricmp(\"\", \"\") failed.  Expected:  0, returned %d\n", intValue);
     }
     if((intValue=uprv_stricmp("", "abc")) != -1){
         log_err("FAIL: uprv_stricmp(\"\", \"abc\") failed.  Expected: -1, returned %d\n", intValue);
@@ -146,10 +146,10 @@ static void TestAPI(void)
         log_err("FAIL: uprv_strnicmp() where the second string is null failed. Expected: 1, returned %d\n", intValue);
     }
     if((intValue=uprv_strnicmp(NULL, NULL, 10)) != 0){
-        log_err("FAIL: uprv_strnicmp(NULL, NULL, 10) failed.  Expected:  0, returned %d\n", intValue);;
+        log_err("FAIL: uprv_strnicmp(NULL, NULL, 10) failed.  Expected:  0, returned %d\n", intValue);
     }
     if((intValue=uprv_strnicmp("", "", 10)) != 0){
-        log_err("FAIL: uprv_strnicmp(\"\", \"\") failed.  Expected:  0, returned %d\n", intValue);;
+        log_err("FAIL: uprv_strnicmp(\"\", \"\") failed.  Expected:  0, returned %d\n", intValue);
     }
     if((intValue=uprv_strnicmp("", "abc", 10)) != -1){
         log_err("FAIL: uprv_stricmp(\"\", \"abc\", 10) failed.  Expected: -1, returned %d\n", intValue);

--- a/icu4c/source/test/cintltst/nccbtst.c
+++ b/icu4c/source/test/cintltst/nccbtst.c
@@ -914,7 +914,7 @@ static void TestSkip(int32_t inputsize, int32_t outputsize)
         if(!testConvertToUnicode(sampleText1, UPRV_LENGTHOF(sampleText1),
                  expected1, UPRV_LENGTHOF(expected1),"utf8",
                 UCNV_TO_U_CALLBACK_SKIP, offsets1, NULL, 0 ))
-            log_err("utf8->u with skip did not match.\n");;
+            log_err("utf8->u with skip did not match.\n");
     }
 
     log_verbose("Testing toUnicode for SCSU with UCNV_TO_U_CALLBACK_SKIP \n");
@@ -1330,7 +1330,7 @@ static void TestStop(int32_t inputsize, int32_t outputsize)
         if(!testConvertToUnicode(sampleText1, UPRV_LENGTHOF(sampleText1),
                  expected1, UPRV_LENGTHOF(expected1),"utf8",
                 UCNV_TO_U_CALLBACK_STOP, offsets1, NULL, 0 ))
-            log_err("utf8->u with stop did not match.\n");;
+            log_err("utf8->u with stop did not match.\n");
     }
     log_verbose("Testing toUnicode for SCSU with UCNV_TO_U_CALLBACK_STOP \n");
     {
@@ -1341,7 +1341,7 @@ static void TestStop(int32_t inputsize, int32_t outputsize)
         if(!testConvertToUnicode(sampleText1, UPRV_LENGTHOF(sampleText1),
                  expected1, UPRV_LENGTHOF(expected1),"SCSU",
                 UCNV_TO_U_CALLBACK_STOP, offsets1, NULL, 0 ))
-            log_err("scsu->u with stop did not match.\n");;
+            log_err("scsu->u with stop did not match.\n");
     }
 
 }
@@ -1620,7 +1620,7 @@ static void TestSub(int32_t inputsize, int32_t outputsize)
         if(!testConvertToUnicode(sampleText1, UPRV_LENGTHOF(sampleText1),
                  expected1, UPRV_LENGTHOF(expected1),"utf8",
                 UCNV_TO_U_CALLBACK_SUBSTITUTE, offsets1, NULL, 0 ))
-            log_err("utf8->u with substitute did not match.\n");;
+            log_err("utf8->u with substitute did not match.\n");
     }
     log_verbose("Testing toUnicode for SCSU with UCNV_TO_U_CALLBACK_SUBSTITUTE \n");
     {
@@ -1631,7 +1631,7 @@ static void TestSub(int32_t inputsize, int32_t outputsize)
         if(!testConvertToUnicode(sampleText1, UPRV_LENGTHOF(sampleText1),
                  expected1, UPRV_LENGTHOF(expected1),"SCSU",
                 UCNV_TO_U_CALLBACK_SUBSTITUTE, offsets1, NULL, 0 ))
-            log_err("scsu->u with stop did not match.\n");;
+            log_err("scsu->u with stop did not match.\n");
     }
 
 #if !UCONFIG_NO_LEGACY_CONVERSION

--- a/icu4c/source/test/cintltst/ncnvtst.c
+++ b/icu4c/source/test/cintltst/ncnvtst.c
@@ -968,7 +968,7 @@ static void TestWithBufferSize(int32_t insize, int32_t outsize){
 
         if(!testConvertToU(sampleText1, sizeof(sampleText1),
                  expected1, UPRV_LENGTHOF(expected1),"utf8", UCNV_TO_U_CALLBACK_SUBSTITUTE, offsets1,FALSE))
-            log_err("utf8->u with substitute did not match.\n");;
+            log_err("utf8->u with substitute did not match.\n");
     }
 
 #if !UCONFIG_NO_LEGACY_CONVERSION

--- a/icu4c/source/test/cintltst/reapits.c
+++ b/icu4c/source/test/cintltst/reapits.c
@@ -691,7 +691,7 @@ static void TestRegexCAPI(void) {
         
         
         /* SetRegion(), getRegion() do something  */
-        TEST_SETUP(".*", "0123456789ABCDEF", 0)
+        TEST_SETUP(".*", "0123456789ABCDEF", 0);
         UChar resultString[40];
         TEST_ASSERT(uregex_regionStart(re, &status) == 0);
         TEST_ASSERT(uregex_regionEnd(re, &status) == 16);
@@ -699,7 +699,7 @@ static void TestRegexCAPI(void) {
         TEST_ASSERT(uregex_regionStart(re, &status) == 3);
         TEST_ASSERT(uregex_regionEnd(re, &status) == 6);
         TEST_ASSERT(uregex_findNext(re, &status));
-        TEST_ASSERT(uregex_group(re, 0, resultString, UPRV_LENGTHOF(resultString), &status) == 3)
+        TEST_ASSERT(uregex_group(re, 0, resultString, UPRV_LENGTHOF(resultString), &status) == 3);
         TEST_ASSERT_STRING("345", resultString, TRUE);
         TEST_TEARDOWN;
         
@@ -1322,7 +1322,7 @@ static void TestRegexCAPI(void) {
       *       to be invoked.  The nested '+' operators give exponential time
       *       behavior with increasing string length.
       */
-     TEST_SETUP("((.)+\\2)+x", "aaaaaaaaaaaaaaaaaaab", 0)
+     TEST_SETUP("((.)+\\2)+x", "aaaaaaaaaaaaaaaaaaab", 0);
      callBackContext cbInfo = {4, 0, 0};
      const void     *pContext   = &cbInfo;
      URegexMatchCallback    *returnedFn = &TestCallbackFn;

--- a/icu4c/source/test/cintltst/spooftest.c
+++ b/icu4c/source/test/cintltst/spooftest.c
@@ -319,7 +319,7 @@ static void TestUSpoofCAPI(void) {
          result = uspoof_check(sc, scMixed, -1, NULL, &status);
          TEST_ASSERT_SUCCESS(status);
          TEST_ASSERT_EQ(USPOOF_SINGLE_SCRIPT, result);
-     TEST_TEARDOWN
+     TEST_TEARDOWN;
 
 
     /*
@@ -358,7 +358,7 @@ static void TestUSpoofCAPI(void) {
         /* Default allowed locales list should be empty */
         allowedLocales = uspoof_getAllowedLocales(sc, &status);
         TEST_ASSERT_SUCCESS(status);
-        TEST_ASSERT(strcmp("", allowedLocales) == 0)
+        TEST_ASSERT(strcmp("", allowedLocales) == 0);
 
         /* Allow en and ru, which should enable Latin and Cyrillic only to pass */
         uspoof_setAllowedLocales(sc, "en, ru_RU", &status);

--- a/icu4c/source/test/cintltst/ucnvseltst.c
+++ b/icu4c/source/test/cintltst/ucnvseltst.c
@@ -386,7 +386,7 @@ static void TestSelector()
     return;
   }
   if (!text_open(&text)) {
-    releaseAvailableNames();;
+    releaseAvailableNames();
   }
 
   excluded_sets[0] = uset_openEmpty();

--- a/icu4c/source/test/intltest/utxttest.cpp
+++ b/icu4c/source/test/intltest/utxttest.cpp
@@ -266,7 +266,7 @@ void UTextTest::TestString(const UnicodeString &s) {
     i = 0;   // native utf-8 index
     for (j=0; j<cpCount ; j++) {  // code point number
         u8Map[j].nativeIdx = i;
-        U8_NEXT(u8String, i, u8Len, c)
+        U8_NEXT(u8String, i, u8Len, c);
         u8Map[j].cp = c;
     }
     u8Map[cpCount].nativeIdx = u8Len;   // position following the last char in utf-8 string.


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-20601

These inconsistent uses of statement terminating semicolons were found while working on the macro definitions that trigger -Wextra-semi-stmt in client code. We might just as well clean them up.

ALLOW_MANY_COMMITS=true