### PR TITLE
ICU-20773 Adds an explanation to the pre-flighting.

### DIFF
--- a/icu4c/source/common/unicode/ustring.h
+++ b/icu4c/source/common/unicode/ustring.h
@@ -1277,6 +1277,10 @@ u_strToUTF8(char *dest,
  * @param destCapacity  The size of the buffer (number of UChars). If it is 0, then
  *                      dest may be NULL and the function will only return the length of the 
  *                      result without writing any of the result string (pre-flighting).
+ *                      Note that in the pre-flighting case, passing in a buffer
+ *                      with insufficient capacity will still be flagged as an
+ *                      error, which must then be ignored. The pDestLength will
+ *                      be filled out properly despite the reported error.
  * @param pDestLength   A pointer to receive the number of units written to the destination. If 
  *                      pDestLength!=NULL then *pDestLength is always set to the 
  *                      number of output units corresponding to the transformation of 


### PR DESCRIPTION
A non-obvious feature of the pre-flighting is that it will report a
buffer overflow error code during pre-flighting, while still reporting
the discovered target buffer size correctly.

So in order to pre-flight correctly, one must ignore that particular error
code.  While the documentation is technically correct in that the code will
report overflow when overflow would have happened had we requested a
conversion, it maybe stands to reason to emphasize that this particular
use case need special handling.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20773
- [X] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [X] Documentation is changed or added

