### PR TITLE
ICU-20766 Fix failing TravisCI build for ICU4J due to missing ANT.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,11 @@ matrix:
 
     - name: "j"
       language: java
+      addons:
+        apt:
+          packages:
+            - ant
+            - ant-optional
       env:      BUILD=ICU4J
       before_script:
         - cd icu4j


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20766
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

