### PR TITLE
ICU-20776 Checks for nullness in UMutex::lock()

### DIFF
--- a/icu4c/source/common/umutex.cpp
+++ b/icu4c/source/common/umutex.cpp
@@ -98,6 +98,7 @@ std::mutex *UMutex::getMutex() {
             gListHead = this;
         }
     }
+    U_ASSERT(retPtr != nullptr);
     return retPtr;
 }
 

--- a/icu4c/source/common/umutex.h
+++ b/icu4c/source/common/umutex.h
@@ -240,7 +240,8 @@ private:
     static UMutex *gListHead;
 
     /** Out-of-line function to lazily initialize a UMutex on first use.
-     * Initial fast check is inline, in lock().
+     * Initial fast check is inline, in lock().  The returned value may never
+     * be nullptr.
      */
     std::mutex *getMutex();
 };


### PR DESCRIPTION
Adds `U_ASSERT` check before using `m->lock()` to make allocation issues
more apparent at least in debug builds.

There is probably quite a few places like this, but let's try fixing
broken windows.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20776
- [X] Updated PR title and link in previous line to include Issue number
- [ ] Tests included
- [ ] Issue accepted
- [ ] Documentation is changed or added

