### PR TITLE
ICU-20601 Wrap ICU implementation compound macros in do { } while.

### DIFF
--- a/icu4c/source/common/loclikely.cpp
+++ b/icu4c/source/common/loclikely.cpp
@@ -807,24 +807,24 @@ error:
     return FALSE;
 }
 
-#define CHECK_TRAILING_VARIANT_SIZE(trailing, trailingLength) \
-    {   int32_t count = 0; \
-        int32_t i; \
-        for (i = 0; i < trailingLength; i++) { \
-            if (trailing[i] == '-' || trailing[i] == '_') { \
-                count = 0; \
-                if (count > 8) { \
-                    goto error; \
-                } \
-            } else if (trailing[i] == '@') { \
-                break; \
-            } else if (count > 8) { \
+#define CHECK_TRAILING_VARIANT_SIZE(trailing, trailingLength) UPRV_BLOCK_MACRO_BEGIN { \
+    int32_t count = 0; \
+    int32_t i; \
+    for (i = 0; i < trailingLength; i++) { \
+        if (trailing[i] == '-' || trailing[i] == '_') { \
+            count = 0; \
+            if (count > 8) { \
                 goto error; \
-            } else { \
-                count++; \
             } \
+        } else if (trailing[i] == '@') { \
+            break; \
+        } else if (count > 8) { \
+            goto error; \
+        } else { \
+            count++; \
         } \
-    }
+    } \
+} UPRV_BLOCK_MACRO_END
 
 static void
 _uloc_addLikelySubtags(const char* localeID,

--- a/icu4c/source/common/ubidiimp.h
+++ b/icu4c/source/common/ubidiimp.h
@@ -387,41 +387,49 @@ typedef union {
 } BidiMemoryForAllocation;
 
 /* Macros for initial checks at function entry */
-#define RETURN_IF_NULL_OR_FAILING_ERRCODE(pErrcode, retvalue)   \
-        if((pErrcode)==NULL || U_FAILURE(*pErrcode)) return retvalue
-#define RETURN_IF_NOT_VALID_PARA(bidi, errcode, retvalue)   \
-        if(!IS_VALID_PARA(bidi)) {  \
-            errcode=U_INVALID_STATE_ERROR;  \
-            return retvalue;                \
-        }
-#define RETURN_IF_NOT_VALID_PARA_OR_LINE(bidi, errcode, retvalue)   \
-        if(!IS_VALID_PARA_OR_LINE(bidi)) {  \
-            errcode=U_INVALID_STATE_ERROR;  \
-            return retvalue;                \
-        }
-#define RETURN_IF_BAD_RANGE(arg, start, limit, errcode, retvalue)   \
-        if((arg)<(start) || (arg)>=(limit)) {       \
-            (errcode)=U_ILLEGAL_ARGUMENT_ERROR;     \
-            return retvalue;                        \
-        }
+#define RETURN_IF_NULL_OR_FAILING_ERRCODE(pErrcode, retvalue) UPRV_BLOCK_MACRO_BEGIN { \
+    if((pErrcode)==NULL || U_FAILURE(*pErrcode)) return retvalue; \
+} UPRV_BLOCK_MACRO_END
+#define RETURN_IF_NOT_VALID_PARA(bidi, errcode, retvalue) UPRV_BLOCK_MACRO_BEGIN { \
+    if(!IS_VALID_PARA(bidi)) { \
+        errcode=U_INVALID_STATE_ERROR; \
+        return retvalue; \
+    } \
+} UPRV_BLOCK_MACRO_END
+#define RETURN_IF_NOT_VALID_PARA_OR_LINE(bidi, errcode, retvalue) UPRV_BLOCK_MACRO_BEGIN { \
+    if(!IS_VALID_PARA_OR_LINE(bidi)) { \
+        errcode=U_INVALID_STATE_ERROR; \
+        return retvalue; \
+    } \
+} UPRV_BLOCK_MACRO_END
+#define RETURN_IF_BAD_RANGE(arg, start, limit, errcode, retvalue) UPRV_BLOCK_MACRO_BEGIN { \
+    if((arg)<(start) || (arg)>=(limit)) { \
+        (errcode)=U_ILLEGAL_ARGUMENT_ERROR; \
+        return retvalue; \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define RETURN_VOID_IF_NULL_OR_FAILING_ERRCODE(pErrcode)   \
-        if((pErrcode)==NULL || U_FAILURE(*pErrcode)) return
-#define RETURN_VOID_IF_NOT_VALID_PARA(bidi, errcode)   \
-        if(!IS_VALID_PARA(bidi)) {  \
-            errcode=U_INVALID_STATE_ERROR;  \
-            return;                \
-        }
-#define RETURN_VOID_IF_NOT_VALID_PARA_OR_LINE(bidi, errcode)   \
-        if(!IS_VALID_PARA_OR_LINE(bidi)) {  \
-            errcode=U_INVALID_STATE_ERROR;  \
-            return;                \
-        }
-#define RETURN_VOID_IF_BAD_RANGE(arg, start, limit, errcode)   \
-        if((arg)<(start) || (arg)>=(limit)) {       \
-            (errcode)=U_ILLEGAL_ARGUMENT_ERROR;     \
-            return;                        \
-        }
+#define RETURN_VOID_IF_NULL_OR_FAILING_ERRCODE(pErrcode) UPRV_BLOCK_MACRO_BEGIN { \
+    if((pErrcode)==NULL || U_FAILURE(*pErrcode)) return; \
+} UPRV_BLOCK_MACRO_END
+#define RETURN_VOID_IF_NOT_VALID_PARA(bidi, errcode) UPRV_BLOCK_MACRO_BEGIN { \
+    if(!IS_VALID_PARA(bidi)) { \
+        errcode=U_INVALID_STATE_ERROR; \
+        return; \
+    } \
+} UPRV_BLOCK_MACRO_END
+#define RETURN_VOID_IF_NOT_VALID_PARA_OR_LINE(bidi, errcode) UPRV_BLOCK_MACRO_BEGIN { \
+    if(!IS_VALID_PARA_OR_LINE(bidi)) { \
+        errcode=U_INVALID_STATE_ERROR; \
+        return; \
+    } \
+} UPRV_BLOCK_MACRO_END
+#define RETURN_VOID_IF_BAD_RANGE(arg, start, limit, errcode) UPRV_BLOCK_MACRO_BEGIN { \
+    if((arg)<(start) || (arg)>=(limit)) { \
+        (errcode)=U_ILLEGAL_ARGUMENT_ERROR; \
+        return; \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 /* helper function to (re)allocate memory if allowed */
 U_CFUNC UBool

--- a/icu4c/source/common/ubiditransform.cpp
+++ b/icu4c/source/common/ubiditransform.cpp
@@ -31,11 +31,11 @@
 #define SHAPE_LOGICAL           U_SHAPE_TEXT_DIRECTION_LOGICAL
 #define SHAPE_VISUAL            U_SHAPE_TEXT_DIRECTION_VISUAL_LTR
 
-#define CHECK_LEN(STR, LEN, ERROR) { \
-        if (LEN == 0) return 0; \
-        if (LEN < -1) { *(ERROR) = U_ILLEGAL_ARGUMENT_ERROR; return 0; } \
-        if (LEN == -1) LEN = u_strlen(STR); \
-    } 
+#define CHECK_LEN(STR, LEN, ERROR) UPRV_BLOCK_MACRO_BEGIN { \
+    if (LEN == 0) return 0; \
+    if (LEN < -1) { *(ERROR) = U_ILLEGAL_ARGUMENT_ERROR; return 0; } \
+    if (LEN == -1) LEN = u_strlen(STR); \
+} UPRV_BLOCK_MACRO_END
 
 #define MAX_ACTIONS     7
 

--- a/icu4c/source/common/ucase.cpp
+++ b/icu4c/source/common/ucase.cpp
@@ -116,7 +116,7 @@ static const uint8_t flagsOffset[256]={
  *               moved to the last uint16_t of the value, use +1 for beginning of next slot
  * @param value (out) int32_t or uint32_t output if hasSlot, otherwise not modified
  */
-#define GET_SLOT_VALUE(excWord, idx, pExc16, value) \
+#define GET_SLOT_VALUE(excWord, idx, pExc16, value) UPRV_BLOCK_MACRO_BEGIN { \
     if(((excWord)&UCASE_EXC_DOUBLE_SLOTS)==0) { \
         (pExc16)+=SLOT_OFFSET(excWord, idx); \
         (value)=*pExc16; \
@@ -124,7 +124,8 @@ static const uint8_t flagsOffset[256]={
         (pExc16)+=2*SLOT_OFFSET(excWord, idx); \
         (value)=*pExc16++; \
         (value)=((value)<<16)|*pExc16; \
-    }
+    } \
+} UPRV_BLOCK_MACRO_END
 
 /* simple case mappings ----------------------------------------------------- */
 

--- a/icu4c/source/common/ucnv_lmb.cpp
+++ b/icu4c/source/common/ucnv_lmb.cpp
@@ -1107,11 +1107,13 @@ GetUniFromLMBCSUni(char const ** ppLMBCSin)  /* Called with LMBCS-style Unicode 
    all input as required by ICU converter semantics.
 */
 
-#define CHECK_SOURCE_LIMIT(index) \
-     if (args->source+index > args->sourceLimit){\
-         *err = U_TRUNCATED_CHAR_FOUND;\
-         args->source = args->sourceLimit;\
-         return 0xffff;}
+#define CHECK_SOURCE_LIMIT(index) UPRV_BLOCK_MACRO_BEGIN { \
+    if (args->source+index > args->sourceLimit) { \
+        *err = U_TRUNCATED_CHAR_FOUND; \
+        args->source = args->sourceLimit; \
+        return 0xffff; \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 /* Return the Unicode representation for the current LMBCS character */
 

--- a/icu4c/source/common/ucnvbocu.cpp
+++ b/icu4c/source/common/ucnvbocu.cpp
@@ -202,14 +202,14 @@ bocu1TrailToByte[BOCU1_TRAIL_CONTROLS_COUNT]={
  * @param d Divisor.
  * @param m Output variable for the rest (modulo result).
  */
-#define NEGDIVMOD(n, d, m) { \
+#define NEGDIVMOD(n, d, m) UPRV_BLOCK_MACRO_BEGIN { \
     (m)=(n)%(d); \
     (n)/=(d); \
     if((m)<0) { \
         --(n); \
         (m)+=(d); \
     } \
-}
+} UPRV_BLOCK_MACRO_END
 
 /* Faster versions of packDiff() for single-byte-encoded diff values. */
 

--- a/icu4c/source/common/ucnvhz.cpp
+++ b/icu4c/source/common/ucnvhz.cpp
@@ -38,7 +38,7 @@
 #define ESC_LEN       2
 
 
-#define CONCAT_ESCAPE_MACRO( args, targetIndex,targetLength,strToAppend, err, len,sourceIndex){                             \
+#define CONCAT_ESCAPE_MACRO(args, targetIndex,targetLength,strToAppend, err, len,sourceIndex) UPRV_BLOCK_MACRO_BEGIN {      \
     while(len-->0){                                                                                                         \
         if(targetIndex < targetLength){                                                                                     \
             args->target[targetIndex] = (unsigned char) *strToAppend;                                                       \
@@ -53,7 +53,7 @@
         }                                                                                                                   \
         strToAppend++;                                                                                                      \
     }                                                                                                                       \
-}
+} UPRV_BLOCK_MACRO_END
 
 
 typedef struct{

--- a/icu4c/source/common/ucnvisci.cpp
+++ b/icu4c/source/common/ucnvisci.cpp
@@ -831,7 +831,7 @@ static const uint16_t nuktaSpecialCases[][2]={
 };
 
 
-#define WRITE_TO_TARGET_FROM_U(args,offsets,source,target,targetLimit,targetByteUnit,err){      \
+#define WRITE_TO_TARGET_FROM_U(args,offsets,source,target,targetLimit,targetByteUnit,err) UPRV_BLOCK_MACRO_BEGIN { \
     int32_t offset = (int32_t)(source - args->source-1);                                        \
       /* write the targetUniChar  to target */                                                  \
     if(target < targetLimit){                                                                   \
@@ -884,7 +884,7 @@ static const uint16_t nuktaSpecialCases[][2]={
                         (uint8_t) (targetByteUnit);                                             \
         *err = U_BUFFER_OVERFLOW_ERROR;                                                         \
     }                                                                                           \
-}
+} UPRV_BLOCK_MACRO_END
 
 /* Rules:
  *    Explicit Halant :
@@ -1119,7 +1119,7 @@ static const uint16_t lookupTable[][2]={
     { GURMUKHI,   PNJ_MASK }
 };
 
-#define WRITE_TO_TARGET_TO_U(args,source,target,offsets,offset,targetUniChar,delta, err){\
+#define WRITE_TO_TARGET_TO_U(args,source,target,offsets,offset,targetUniChar,delta, err) UPRV_BLOCK_MACRO_BEGIN { \
     /* add offset to current Indic Block */                                              \
     if(targetUniChar>ASCII_END &&                                                        \
            targetUniChar != ZWJ &&                                                       \
@@ -1140,9 +1140,9 @@ static const uint16_t lookupTable[][2]={
             (UChar)targetUniChar;                                                        \
         *err = U_BUFFER_OVERFLOW_ERROR;                                                  \
     }                                                                                    \
-}
+} UPRV_BLOCK_MACRO_END
 
-#define GET_MAPPING(sourceChar,targetUniChar,data){                                      \
+#define GET_MAPPING(sourceChar,targetUniChar,data) UPRV_BLOCK_MACRO_BEGIN {              \
     targetUniChar = toUnicodeTable[(sourceChar)] ;                                       \
     /* is the code point valid in current script? */                                     \
     if(sourceChar> ASCII_END &&                                                          \
@@ -1153,7 +1153,7 @@ static const uint16_t lookupTable[][2]={
             targetUniChar=missingCharMarker;                                             \
         }                                                                                \
     }                                                                                    \
-}
+} UPRV_BLOCK_MACRO_END
 
 /***********
  *  Rules for ISCII to Unicode converter

--- a/icu4c/source/common/uhash.cpp
+++ b/icu4c/source/common/uhash.cpp
@@ -119,13 +119,14 @@ static const float RESIZE_POLICY_RATIO_TABLE[6] = {
 
 /* This macro expects a UHashTok.pointer as its keypointer and
    valuepointer parameters */
-#define HASH_DELETE_KEY_VALUE(hash, keypointer, valuepointer) \
-            if (hash->keyDeleter != NULL && keypointer != NULL) { \
-                (*hash->keyDeleter)(keypointer); \
-            } \
-            if (hash->valueDeleter != NULL && valuepointer != NULL) { \
-                (*hash->valueDeleter)(valuepointer); \
-            }
+#define HASH_DELETE_KEY_VALUE(hash, keypointer, valuepointer) UPRV_BLOCK_MACRO_BEGIN { \
+    if (hash->keyDeleter != NULL && keypointer != NULL) { \
+        (*hash->keyDeleter)(keypointer); \
+    } \
+    if (hash->valueDeleter != NULL && valuepointer != NULL) { \
+        (*hash->valueDeleter)(valuepointer); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 /*
  * Constants for hinting whether a key or value is an integer

--- a/icu4c/source/common/uloc.cpp
+++ b/icu4c/source/common/uloc.cpp
@@ -482,14 +482,15 @@ static const CanonicalizationMap CANONICALIZE_MAP[] = {
 /* Test if the locale id has BCP47 u extension and does not have '@' */
 #define _hasBCP47Extension(id) (id && uprv_strstr(id, "@") == NULL && getShortestSubtagLength(localeID) == 1)
 /* Converts the BCP47 id to Unicode id. Does nothing to id if conversion fails */
-#define _ConvertBCP47(finalID, id, buffer, length,err) \
-        if (uloc_forLanguageTag(id, buffer, length, NULL, err) <= 0 ||  \
-                U_FAILURE(*err) || *err == U_STRING_NOT_TERMINATED_WARNING) { \
-            finalID=id; \
-            if (*err == U_STRING_NOT_TERMINATED_WARNING) { *err = U_BUFFER_OVERFLOW_ERROR; } \
-        } else { \
-            finalID=buffer; \
-        }
+#define _ConvertBCP47(finalID, id, buffer, length,err) UPRV_BLOCK_MACRO_BEGIN { \
+    if (uloc_forLanguageTag(id, buffer, length, NULL, err) <= 0 || \
+            U_FAILURE(*err) || *err == U_STRING_NOT_TERMINATED_WARNING) { \
+        finalID=id; \
+        if (*err == U_STRING_NOT_TERMINATED_WARNING) { *err = U_BUFFER_OVERFLOW_ERROR; } \
+    } else { \
+        finalID=buffer; \
+    } \
+} UPRV_BLOCK_MACRO_END
 /* Gets the size of the shortest subtag in the given localeID. */
 static int32_t getShortestSubtagLength(const char *localeID) {
     int32_t localeIDLength = static_cast<int32_t>(uprv_strlen(localeID));

--- a/icu4c/source/common/unames.cpp
+++ b/icu4c/source/common/unames.cpp
@@ -212,13 +212,13 @@ isDataLoaded(UErrorCode *pErrorCode) {
     return U_SUCCESS(*pErrorCode);
 }
 
-#define WRITE_CHAR(buffer, bufferLength, bufferPos, c) { \
+#define WRITE_CHAR(buffer, bufferLength, bufferPos, c) UPRV_BLOCK_MACRO_BEGIN { \
     if((bufferLength)>0) { \
         *(buffer)++=c; \
         --(bufferLength); \
     } \
     ++(bufferPos); \
-}
+} UPRV_BLOCK_MACRO_END
 
 #define U_ISO_COMMENT U_CHAR_NAME_CHOICE_COUNT
 

--- a/icu4c/source/common/uniset_props.cpp
+++ b/icu4c/source/common/uniset_props.cpp
@@ -802,7 +802,10 @@ static UBool mungeCharName(char* dst, const char* src, int32_t dstCapacity) {
 // Property set API
 //----------------------------------------------------------------
 
-#define FAIL(ec) {ec=U_ILLEGAL_ARGUMENT_ERROR; return *this;}
+#define FAIL(ec) UPRV_BLOCK_MACRO_BEGIN { \
+    ec=U_ILLEGAL_ARGUMENT_ERROR; \
+    return *this; \
+} UPRV_BLOCK_MACRO_END
 
 UnicodeSet&
 UnicodeSet::applyIntPropertyValue(UProperty prop, int32_t value, UErrorCode& ec) {

--- a/icu4c/source/common/ustring.cpp
+++ b/icu4c/source/common/ustring.cpp
@@ -1428,7 +1428,7 @@ u_unescape(const char *src, UChar *dest, int32_t destCapacity) {
  * NUL-terminate a string no matter what its type.
  * Set warning and error codes accordingly.
  */
-#define __TERMINATE_STRING(dest, destCapacity, length, pErrorCode)      \
+#define __TERMINATE_STRING(dest, destCapacity, length, pErrorCode) UPRV_BLOCK_MACRO_BEGIN { \
     if(pErrorCode!=NULL && U_SUCCESS(*pErrorCode)) {                    \
         /* not a public function, so no complete argument checking */   \
                                                                         \
@@ -1448,7 +1448,8 @@ u_unescape(const char *src, UChar *dest, int32_t destCapacity) {
             /* even the string itself did not fit - set an error code */ \
             *pErrorCode=U_BUFFER_OVERFLOW_ERROR;                        \
         }                                                               \
-    }
+    } \
+} UPRV_BLOCK_MACRO_END
 
 U_CAPI int32_t U_EXPORT2
 u_terminateUChars(UChar *dest, int32_t destCapacity, int32_t length, UErrorCode *pErrorCode) {
@@ -1488,7 +1489,7 @@ u_terminateWChars(wchar_t *dest, int32_t destCapacity, int32_t length, UErrorCod
   the output range. [LIU]
 */
 
-#define STRING_HASH(TYPE, STR, STRLEN, DEREF) \
+#define STRING_HASH(TYPE, STR, STRLEN, DEREF) UPRV_BLOCK_MACRO_BEGIN { \
     uint32_t hash = 0;                        \
     const TYPE *p = (const TYPE*) STR;        \
     if (p != NULL) {                          \
@@ -1500,7 +1501,8 @@ u_terminateWChars(wchar_t *dest, int32_t destCapacity, int32_t length, UErrorCod
             p += inc;                         \
         }                                     \
     }                                         \
-    return static_cast<int32_t>(hash)
+    return static_cast<int32_t>(hash);        \
+} UPRV_BLOCK_MACRO_END
 
 /* Used by UnicodeString to compute its hashcode - Not public API. */
 U_CAPI int32_t U_EXPORT2

--- a/icu4c/source/common/utracimp.h
+++ b/icu4c/source/common/utracimp.h
@@ -144,10 +144,12 @@ U_CDECL_END
  */
 #define UTRACE_ENTRY(fnNumber) \
     int32_t utraceFnNumber=(fnNumber); \
+UPRV_BLOCK_MACRO_BEGIN { \
     if(utrace_getLevel()>=UTRACE_INFO) { \
         utrace_entry(fnNumber); \
         utraceFnNumber |= UTRACE_TRACED_ENTRY; \
-    }
+    } \
+} UPRV_BLOCK_MACRO_END
 
 
 /**
@@ -162,10 +164,12 @@ U_CDECL_END
  */
 #define UTRACE_ENTRY_OC(fnNumber) \
     int32_t utraceFnNumber=(fnNumber); \
+UPRV_BLOCK_MACRO_BEGIN { \
     if(utrace_getLevel()>=UTRACE_OPEN_CLOSE) { \
         utrace_entry(fnNumber); \
         utraceFnNumber |= UTRACE_TRACED_ENTRY; \
-    }
+    } \
+} UPRV_BLOCK_MACRO_END
 
 /**
  * Trace statement for each exit point of a function that has a UTRACE_ENTRY()
@@ -179,10 +183,11 @@ U_CDECL_END
  *
  * @internal
  */
-#define UTRACE_EXIT() \
-    {if(utraceFnNumber & UTRACE_TRACED_ENTRY) { \
+#define UTRACE_EXIT() UPRV_BLOCK_MACRO_BEGIN { \
+    if(utraceFnNumber & UTRACE_TRACED_ENTRY) { \
         utrace_exit(utraceFnNumber & ~UTRACE_TRACED_ENTRY, UTRACE_EXITV_NONE); \
-    }}
+    } \
+} UPRV_BLOCK_MACRO_END
 
 /**
  * Trace statement for each exit point of a function that has a UTRACE_ENTRY()
@@ -192,25 +197,29 @@ U_CDECL_END
  *
  * @internal 
  */
-#define UTRACE_EXIT_VALUE(val) \
-    {if(utraceFnNumber & UTRACE_TRACED_ENTRY) { \
+#define UTRACE_EXIT_VALUE(val) UPRV_BLOCK_MACRO_BEGIN { \
+    if(utraceFnNumber & UTRACE_TRACED_ENTRY) { \
         utrace_exit(utraceFnNumber & ~UTRACE_TRACED_ENTRY, UTRACE_EXITV_I32, val); \
-    }}
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define UTRACE_EXIT_STATUS(status) \
-    {if(utraceFnNumber & UTRACE_TRACED_ENTRY) { \
+#define UTRACE_EXIT_STATUS(status) UPRV_BLOCK_MACRO_BEGIN { \
+    if(utraceFnNumber & UTRACE_TRACED_ENTRY) { \
         utrace_exit(utraceFnNumber & ~UTRACE_TRACED_ENTRY, UTRACE_EXITV_STATUS, status); \
-    }}
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define UTRACE_EXIT_VALUE_STATUS(val, status) \
-    {if(utraceFnNumber & UTRACE_TRACED_ENTRY) { \
+#define UTRACE_EXIT_VALUE_STATUS(val, status) UPRV_BLOCK_MACRO_BEGIN { \
+    if(utraceFnNumber & UTRACE_TRACED_ENTRY) { \
         utrace_exit(utraceFnNumber & ~UTRACE_TRACED_ENTRY, (UTRACE_EXITV_I32 | UTRACE_EXITV_STATUS), val, status); \
-    }}
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define UTRACE_EXIT_PTR_STATUS(ptr, status) \
-    {if(utraceFnNumber & UTRACE_TRACED_ENTRY) { \
+#define UTRACE_EXIT_PTR_STATUS(ptr, status) UPRV_BLOCK_MACRO_BEGIN { \
+    if(utraceFnNumber & UTRACE_TRACED_ENTRY) { \
         utrace_exit(utraceFnNumber & ~UTRACE_TRACED_ENTRY, (UTRACE_EXITV_PTR | UTRACE_EXITV_STATUS), ptr, status); \
-    }}
+    } \
+} UPRV_BLOCK_MACRO_END
 
 /**
  * Trace statement used inside functions that have a UTRACE_ENTRY() statement.
@@ -220,10 +229,11 @@ U_CDECL_END
  * Calls utrace_data() if the level is high enough.
  * @internal
  */
-#define UTRACE_DATA0(level, fmt) \
+#define UTRACE_DATA0(level, fmt) UPRV_BLOCK_MACRO_BEGIN { \
     if(UTRACE_LEVEL(level)) { \
         utrace_data(utraceFnNumber & ~UTRACE_TRACED_ENTRY, (level), (fmt)); \
-    }
+    } \
+} UPRV_BLOCK_MACRO_END
 
 /**
  * Trace statement used inside functions that have a UTRACE_ENTRY() statement.
@@ -233,10 +243,11 @@ U_CDECL_END
  * Calls utrace_data() if the level is high enough.
  * @internal
  */
-#define UTRACE_DATA1(level, fmt, a) \
+#define UTRACE_DATA1(level, fmt, a) UPRV_BLOCK_MACRO_BEGIN { \
     if(UTRACE_LEVEL(level)) { \
         utrace_data(utraceFnNumber & ~UTRACE_TRACED_ENTRY , (level), (fmt), (a)); \
-    }
+    } \
+} UPRV_BLOCK_MACRO_END
 
 /**
  * Trace statement used inside functions that have a UTRACE_ENTRY() statement.
@@ -246,10 +257,11 @@ U_CDECL_END
  * Calls utrace_data() if the level is high enough.
  * @internal
  */
-#define UTRACE_DATA2(level, fmt, a, b) \
+#define UTRACE_DATA2(level, fmt, a, b) UPRV_BLOCK_MACRO_BEGIN { \
     if(UTRACE_LEVEL(level)) { \
         utrace_data(utraceFnNumber & ~UTRACE_TRACED_ENTRY , (level), (fmt), (a), (b)); \
-    }
+    } \
+} UPRV_BLOCK_MACRO_END
 
 /**
  * Trace statement used inside functions that have a UTRACE_ENTRY() statement.
@@ -259,10 +271,11 @@ U_CDECL_END
  * Calls utrace_data() if the level is high enough.
  * @internal
  */
-#define UTRACE_DATA3(level, fmt, a, b, c) \
+#define UTRACE_DATA3(level, fmt, a, b, c) UPRV_BLOCK_MACRO_BEGIN { \
     if(UTRACE_LEVEL(level)) { \
         utrace_data(utraceFnNumber & ~UTRACE_TRACED_ENTRY, (level), (fmt), (a), (b), (c)); \
-    }
+    } \
+} UPRV_BLOCK_MACRO_END
 
 /**
  * Trace statement used inside functions that have a UTRACE_ENTRY() statement.
@@ -272,10 +285,11 @@ U_CDECL_END
  * Calls utrace_data() if the level is high enough.
  * @internal
  */
-#define UTRACE_DATA4(level, fmt, a, b, c, d) \
+#define UTRACE_DATA4(level, fmt, a, b, c, d) UPRV_BLOCK_MACRO_BEGIN { \
     if(UTRACE_LEVEL(level)) { \
         utrace_data(utraceFnNumber & ~UTRACE_TRACED_ENTRY, (level), (fmt), (a), (b), (c), (d)); \
-    }
+    } \
+} UPRV_BLOCK_MACRO_END
 
 /**
  * Trace statement used inside functions that have a UTRACE_ENTRY() statement.
@@ -285,10 +299,11 @@ U_CDECL_END
  * Calls utrace_data() if the level is high enough.
  * @internal
  */
-#define UTRACE_DATA5(level, fmt, a, b, c, d, e) \
+#define UTRACE_DATA5(level, fmt, a, b, c, d, e) UPRV_BLOCK_MACRO_BEGIN { \
     if(UTRACE_LEVEL(level)) { \
         utrace_data(utraceFnNumber & ~UTRACE_TRACED_ENTRY, (level), (fmt), (a), (b), (c), (d), (e)); \
-    }
+    } \
+} UPRV_BLOCK_MACRO_END
 
 /**
  * Trace statement used inside functions that have a UTRACE_ENTRY() statement.
@@ -298,10 +313,11 @@ U_CDECL_END
  * Calls utrace_data() if the level is high enough.
  * @internal
  */
-#define UTRACE_DATA6(level, fmt, a, b, c, d, e, f) \
+#define UTRACE_DATA6(level, fmt, a, b, c, d, e, f) UPRV_BLOCK_MACRO_BEGIN { \
     if(UTRACE_LEVEL(level)) { \
         utrace_data(utraceFnNumber & ~UTRACE_TRACED_ENTRY, (level), (fmt), (a), (b), (c), (d), (e), (f)); \
-    }
+    } \
+} UPRV_BLOCK_MACRO_END
 
 /**
  * Trace statement used inside functions that have a UTRACE_ENTRY() statement.
@@ -311,10 +327,11 @@ U_CDECL_END
  * Calls utrace_data() if the level is high enough.
  * @internal
  */
-#define UTRACE_DATA7(level, fmt, a, b, c, d, e, f, g) \
+#define UTRACE_DATA7(level, fmt, a, b, c, d, e, f, g) UPRV_BLOCK_MACRO_BEGIN { \
     if(UTRACE_LEVEL(level)) { \
         utrace_data(utraceFnNumber & ~UTRACE_TRACED_ENTRY, (level), (fmt), (a), (b), (c), (d), (e), (f), (g)); \
-    }
+    } \
+} UPRV_BLOCK_MACRO_END
 
 /**
  * Trace statement used inside functions that have a UTRACE_ENTRY() statement.
@@ -324,10 +341,11 @@ U_CDECL_END
  * Calls utrace_data() if the level is high enough.
  * @internal
  */
-#define UTRACE_DATA8(level, fmt, a, b, c, d, e, f, g, h) \
+#define UTRACE_DATA8(level, fmt, a, b, c, d, e, f, g, h) UPRV_BLOCK_MACRO_BEGIN { \
     if(UTRACE_LEVEL(level)) { \
         utrace_data(utraceFnNumber & ~UTRACE_TRACED_ENTRY, (level), (fmt), (a), (b), (c), (d), (e), (f), (g), (h)); \
-    }
+    } \
+} UPRV_BLOCK_MACRO_END
 
 /**
  * Trace statement used inside functions that have a UTRACE_ENTRY() statement.
@@ -337,10 +355,11 @@ U_CDECL_END
  * Calls utrace_data() if the level is high enough.
  * @internal
  */
-#define UTRACE_DATA9(level, fmt, a, b, c, d, e, f, g, h, i) \
+#define UTRACE_DATA9(level, fmt, a, b, c, d, e, f, g, h, i) UPRV_BLOCK_MACRO_BEGIN { \
     if(UTRACE_LEVEL(level)) { \
         utrace_data(utraceFnNumber & ~UTRACE_TRACED_ENTRY, (level), (fmt), (a), (b), (c), (d), (e), (f), (g), (h), (i)); \
-    }
+    } \
+} UPRV_BLOCK_MACRO_END
 
 #else
 

--- a/icu4c/source/common/utrie.h
+++ b/icu4c/source/common/utrie.h
@@ -182,7 +182,7 @@ typedef struct UTrie UTrie;
     ]
 
 /** Internal trie getter from a pair of surrogates */
-#define _UTRIE_GET_FROM_PAIR(trie, data, c, c2, result, resultType) { \
+#define _UTRIE_GET_FROM_PAIR(trie, data, c, c2, result, resultType) UPRV_BLOCK_MACRO_BEGIN { \
     int32_t __offset; \
 \
     /* get data for lead surrogate */ \
@@ -195,7 +195,7 @@ typedef struct UTrie UTrie;
     } else { \
         (result)=(resultType)((trie)->initialValue); \
     } \
-}
+} UPRV_BLOCK_MACRO_END
 
 /** Internal trie getter from a BMP code point, treating a lead surrogate as a normal code point */
 #define _UTRIE_GET_FROM_BMP(trie, data, c16) \
@@ -206,7 +206,7 @@ typedef struct UTrie UTrie;
  * Could be faster(?) but longer with
  *   if((c32)<=0xd7ff) { (result)=_UTRIE_GET_RAW(trie, data, 0, c32); }
  */
-#define _UTRIE_GET(trie, data, c32, result, resultType) \
+#define _UTRIE_GET(trie, data, c32, result, resultType) UPRV_BLOCK_MACRO_BEGIN { \
     if((uint32_t)(c32)<=0xffff) { \
         /* BMP code points */ \
         (result)=_UTRIE_GET_FROM_BMP(trie, data, c32); \
@@ -217,10 +217,11 @@ typedef struct UTrie UTrie;
     } else { \
         /* out of range */ \
         (result)=(resultType)((trie)->initialValue); \
-    }
+    } \
+} UPRV_BLOCK_MACRO_END
 
 /** Internal next-post-increment: get the next code point (c, c2) and its data */
-#define _UTRIE_NEXT(trie, data, src, limit, c, c2, result, resultType) { \
+#define _UTRIE_NEXT(trie, data, src, limit, c, c2, result, resultType) UPRV_BLOCK_MACRO_BEGIN { \
     (c)=*(src)++; \
     if(!U16_IS_LEAD(c)) { \
         (c2)=0; \
@@ -233,10 +234,10 @@ typedef struct UTrie UTrie;
         (c2)=0; \
         (result)=_UTRIE_GET_RAW((trie), data, UTRIE_LEAD_INDEX_DISP, (c)); \
     } \
-}
+} UPRV_BLOCK_MACRO_END
 
 /** Internal previous: get the previous code point (c, c2) and its data */
-#define _UTRIE_PREVIOUS(trie, data, start, src, c, c2, result, resultType) { \
+#define _UTRIE_PREVIOUS(trie, data, start, src, c, c2, result, resultType) UPRV_BLOCK_MACRO_BEGIN { \
     (c)=*--(src); \
     if(!U16_IS_SURROGATE(c)) { \
         (c2)=0; \
@@ -257,7 +258,7 @@ typedef struct UTrie UTrie;
         (c2)=0; \
         (result)=_UTRIE_GET_RAW((trie), data, UTRIE_LEAD_INDEX_DISP, (c)); \
     } \
-}
+} UPRV_BLOCK_MACRO_END
 
 /* Public UTrie API ---------------------------------------------------------*/
 

--- a/icu4c/source/common/utrie2.h
+++ b/icu4c/source/common/utrie2.h
@@ -871,7 +871,7 @@ utrie2_internalU8PrevIndex(const UTrie2 *trie, UChar32 c,
     (trie)->data[_UTRIE2_INDEX_FROM_CP(trie, asciiOffset, c)]
 
 /** Internal next-post-increment: get the next code point (c) and its data. */
-#define _UTRIE2_U16_NEXT(trie, data, src, limit, c, result) { \
+#define _UTRIE2_U16_NEXT(trie, data, src, limit, c, result) UPRV_BLOCK_MACRO_BEGIN { \
     { \
         uint16_t __c2; \
         (c)=*(src)++; \
@@ -885,10 +885,10 @@ utrie2_internalU8PrevIndex(const UTrie2 *trie, UChar32 c,
             (result)=_UTRIE2_GET_FROM_SUPP((trie), data, (c)); \
         } \
     } \
-}
+} UPRV_BLOCK_MACRO_END
 
 /** Internal pre-decrement-previous: get the previous code point (c) and its data */
-#define _UTRIE2_U16_PREV(trie, data, start, src, c, result) { \
+#define _UTRIE2_U16_PREV(trie, data, start, src, c, result) UPRV_BLOCK_MACRO_BEGIN { \
     { \
         uint16_t __c2; \
         (c)=*--(src); \
@@ -900,10 +900,10 @@ utrie2_internalU8PrevIndex(const UTrie2 *trie, UChar32 c,
             (result)=_UTRIE2_GET_FROM_SUPP((trie), data, (c)); \
         } \
     } \
-}
+} UPRV_BLOCK_MACRO_END
 
 /** Internal UTF-8 next-post-increment: get the next code point's data. */
-#define _UTRIE2_U8_NEXT(trie, ascii, data, src, limit, result) { \
+#define _UTRIE2_U8_NEXT(trie, ascii, data, src, limit, result) UPRV_BLOCK_MACRO_BEGIN { \
     uint8_t __lead=(uint8_t)*(src)++; \
     if(U8_IS_SINGLE(__lead)) { \
         (result)=(trie)->ascii[__lead]; \
@@ -935,10 +935,10 @@ utrie2_internalU8PrevIndex(const UTrie2 *trie, UChar32 c,
             (result)=(trie)->data[__index>>3]; \
         } \
     } \
-}
+} UPRV_BLOCK_MACRO_END
 
 /** Internal UTF-8 pre-decrement-previous: get the previous code point's data. */
-#define _UTRIE2_U8_PREV(trie, ascii, data, start, src, result) { \
+#define _UTRIE2_U8_PREV(trie, ascii, data, start, src, result) UPRV_BLOCK_MACRO_BEGIN { \
     uint8_t __b=(uint8_t)*--(src); \
     if(U8_IS_SINGLE(__b)) { \
         (result)=(trie)->ascii[__b]; \
@@ -948,7 +948,7 @@ utrie2_internalU8PrevIndex(const UTrie2 *trie, UChar32 c,
         (src)-=__index&7; \
         (result)=(trie)->data[__index>>3]; \
     } \
-}
+} UPRV_BLOCK_MACRO_END
 
 U_CDECL_END
 

--- a/icu4c/source/i18n/bocsu.h
+++ b/icu4c/source/i18n/bocsu.h
@@ -144,14 +144,14 @@ U_NAMESPACE_END
  * yields negative modulo results and quotients that are one more than
  * what we need here.
  */
-#define NEGDIVMOD(n, d, m) { \
+#define NEGDIVMOD(n, d, m) UPRV_BLOCK_MACRO_BEGIN { \
     (m)=(n)%(d); \
     (n)/=(d); \
     if((m)<0) { \
         --(n); \
         (m)+=(d); \
     } \
-}
+} UPRV_BLOCK_MACRO_END
 
 U_CFUNC UChar32
 u_writeIdenticalLevelRun(UChar32 prev, const UChar *s, int32_t length, icu::ByteSink &sink);

--- a/icu4c/source/i18n/decNumberLocal.h
+++ b/icu4c/source/i18n/decNumberLocal.h
@@ -259,7 +259,7 @@
   /* 2,000,000,000 (as is needed for negative exponents of            */
   /* subnormals).  The unsigned integer pow is used as a temporary    */
   /* variable. */
-  #define TODIGIT(u, cut, c, pow) {       \
+  #define TODIGIT(u, cut, c, pow) UPRV_BLOCK_MACRO_BEGIN { \
     *(c)='0';                             \
     pow=DECPOWERS[cut]*2;                 \
     if ((u)>pow) {                        \
@@ -272,7 +272,7 @@
     if ((u)>=pow) {(u)-=pow; *(c)+=2;}    \
     pow/=2;                               \
     if ((u)>=pow) {(u)-=pow; *(c)+=1;}    \
-    }
+    } UPRV_BLOCK_MACRO_END
 
   /* ---------------------------------------------------------------- */
   /* Definitions for fixed-precision modules (only valid after        */

--- a/icu4c/source/i18n/dtitvinf.cpp
+++ b/icu4c/source/i18n/dtitvinf.cpp
@@ -42,7 +42,9 @@ U_NAMESPACE_BEGIN
 
 
 #ifdef DTITVINF_DEBUG
-#define PRINTMESG(msg) { std::cout << "(" << __FILE__ << ":" << __LINE__ << ") " << msg << "\n"; }
+#define PRINTMESG(msg) UPRV_BLOCK_MACRO_BEGIN { \
+    std::cout << "(" << __FILE__ << ":" << __LINE__ << ") " << msg << "\n"; \
+} UPRV_BLOCK_MACRO_END
 #endif
 
 UOBJECT_DEFINE_RTTI_IMPLEMENTATION(DateIntervalInfo)

--- a/icu4c/source/i18n/number_skeletons.cpp
+++ b/icu4c/source/i18n/number_skeletons.cpp
@@ -120,17 +120,17 @@ inline void appendMultiple(UnicodeString& sb, UChar32 cp, int32_t count) {
 
 
 #define CHECK_NULL(seen, field, status) (void)(seen); /* for auto-format line wrapping */ \
-{ \
+UPRV_BLOCK_MACRO_BEGIN { \
     if ((seen).field) { \
         (status) = U_NUMBER_SKELETON_SYNTAX_ERROR; \
         return STATE_NULL; \
     } \
     (seen).field = true; \
-}
+} UPRV_BLOCK_MACRO_END
 
 
 #define SKELETON_UCHAR_TO_CHAR(dest, src, start, end, status) (void)(dest); \
-{ \
+UPRV_BLOCK_MACRO_BEGIN { \
     UErrorCode conversionStatus = U_ZERO_ERROR; \
     (dest).appendInvariantChars({FALSE, (src).getBuffer() + (start), (end) - (start)}, conversionStatus); \
     if (conversionStatus == U_INVARIANT_CONVERSION_ERROR) { \
@@ -141,7 +141,7 @@ inline void appendMultiple(UnicodeString& sb, UChar32 cp, int32_t count) {
         (status) = conversionStatus; \
         return; \
     } \
-}
+} UPRV_BLOCK_MACRO_END
 
 
 } // anonymous namespace

--- a/icu4c/source/i18n/rbnf.cpp
+++ b/icu4c/source/i18n/rbnf.cpp
@@ -355,10 +355,16 @@ private:
 };
 
 #ifdef RBNF_DEBUG
-#define ERROR(msg) parseError(msg); return NULL;
+#define ERROR(msg) UPRV_BLOCK_MACRO_BEGIN { \
+    parseError(msg); \
+    return NULL; \
+} UPRV_BLOCK_MACRO_END
 #define EXPLANATION_ARG explanationArg
 #else
-#define ERROR(msg) parseError(NULL); return NULL;
+#define ERROR(msg) UPRV_BLOCK_MACRO_BEGIN { \
+    parseError(NULL); \
+    return NULL; \
+} UPRV_BLOCK_MACRO_END
 #define EXPLANATION_ARG
 #endif
         

--- a/icu4c/source/tools/genrb/rle.c
+++ b/icu4c/source/tools/genrb/rle.c
@@ -91,14 +91,14 @@ encodeRunByte(uint16_t* buffer,uint16_t* bufLimit, uint8_t value, int32_t length
     return buffer;
 }
 
-#define APPEND( buffer, bufLimit, value, num, status){  \
+#define APPEND( buffer, bufLimit, value, num, status) UPRV_BLOCK_MACRO_BEGIN { \
     if(buffer<bufLimit){                    \
         *buffer++=(value);                  \
     }else{                                  \
         *status = U_BUFFER_OVERFLOW_ERROR;  \
     }                                       \
     num++;                                  \
-}
+} UPRV_BLOCK_MACRO_END
 
 /**
  * Encode a run, possibly a degenerate run (of < 4 values).

--- a/icu4c/source/tools/genrb/ustr.h
+++ b/icu4c/source/tools/genrb/ustr.h
@@ -22,7 +22,7 @@
 
 #include "unicode/utypes.h"
 
-#define U_APPEND_CHAR32(c,target,len) {                         \
+#define U_APPEND_CHAR32(c,target,len) UPRV_BLOCK_MACRO_BEGIN {  \
     if (c <= 0xffff)                                            \
     {                                                           \
         *(target)++ = (UChar) c;                                \
@@ -35,9 +35,9 @@
         len=2;                                                  \
         target +=2;                                             \
     }                                                           \
-}
+} UPRV_BLOCK_MACRO_END
 
-#define U_APPEND_CHAR32_ONLY(c,target) {                             \
+#define U_APPEND_CHAR32_ONLY(c,target) UPRV_BLOCK_MACRO_BEGIN { \
     if (c <= 0xffff)                                            \
     {                                                           \
         *(target)++ = (UChar) c;                                \
@@ -48,7 +48,7 @@
         target[1] = U16_TRAIL(c);                               \
         target +=2;                                             \
     }                                                           \
-}
+} UPRV_BLOCK_MACRO_END
 
 /* A C representation of a string "object" (to avoid realloc all the time) */
 struct UString {


### PR DESCRIPTION
This does the same for the ICU implementation code as was done for the public ICU API in PR #759.

This is not necessary to do in order to enable users of ICU to use -Wextra-semi-stmt when building their own code (that has now already been resolved), but it will make it possible to use this warning when building ICU itself which is useful both to weed out mistakes in the ICU code itself and to prevent future changes that cause this warning to creep in into the public ICU API. It'll also make macro definitions consistent in ICU between API and implementation code.