### PR TITLE
ICU-20601 Wrap ICU test compound macros in do { } while.

### DIFF
--- a/icu4c/source/test/cintltst/bocu1tst.c
+++ b/icu4c/source/test/cintltst/bocu1tst.c
@@ -212,14 +212,14 @@ bocu1TrailToByte[BOCU1_TRAIL_CONTROLS_COUNT]={
  * @param d Divisor.
  * @param m Output variable for the rest (modulo result).
  */
-#define NEGDIVMOD(n, d, m) { \
+#define NEGDIVMOD(n, d, m) UPRV_BLOCK_MACRO_BEGIN { \
     (m)=(n)%(d); \
     (n)/=(d); \
     if((m)<0) { \
         --(n); \
         (m)+=(d); \
     } \
-}
+} UPRV_BLOCK_MACRO_END
 
 /* State for BOCU-1 decoder function. */
 struct Bocu1Rx {

--- a/icu4c/source/test/cintltst/cbiapts.c
+++ b/icu4c/source/test/cintltst/cbiapts.c
@@ -35,11 +35,17 @@
 #include "cbiapts.h"
 #include "cmemory.h"
 
-#define TEST_ASSERT_SUCCESS(status) {if (U_FAILURE(status)) { \
-log_data_err("Failure at file %s, line %d, error = %s (Are you missing data?)\n", __FILE__, __LINE__, u_errorName(status));}}
+#define TEST_ASSERT_SUCCESS(status) UPRV_BLOCK_MACRO_BEGIN { \
+    if (U_FAILURE(status)) { \
+        log_data_err("Failure at file %s, line %d, error = %s (Are you missing data?)\n", __FILE__, __LINE__, u_errorName(status)); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define TEST_ASSERT(expr) {if ((expr)==FALSE) { \
-log_data_err("Test Failure at file %s, line %d (Are you missing data?)\n", __FILE__, __LINE__);}}
+#define TEST_ASSERT(expr) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((expr)==FALSE) { \
+        log_data_err("Test Failure at file %s, line %d (Are you missing data?)\n", __FILE__, __LINE__); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 #if !UCONFIG_NO_FILE_IO
 static void TestBreakIteratorSafeClone(void);

--- a/icu4c/source/test/cintltst/cbiditst.c
+++ b/icu4c/source/test/cintltst/cbiditst.c
@@ -1287,11 +1287,12 @@ _testReordering(UBiDi *pBiDi, int testNumber) {
     }
 }
 
-#define RETURN_IF_BAD_ERRCODE(x)    \
+#define RETURN_IF_BAD_ERRCODE(x) UPRV_BLOCK_MACRO_BEGIN { \
     if (U_FAILURE(errorCode)) {      \
         log_err("\nbad errorCode %d at %s\n", errorCode, (x));  \
         return;     \
     }               \
+} UPRV_BLOCK_MACRO_END
 
 #define STRING_TEST_CASE(s) { (s), UPRV_LENGTHOF(s) }
 

--- a/icu4c/source/test/cintltst/crestst.c
+++ b/icu4c/source/test/cintltst/crestst.c
@@ -55,9 +55,23 @@ enum E_Where
 typedef enum E_Where E_Where;
 /*****************************************************************************/
 
-#define CONFIRM_EQ(actual,expected) if (u_strcmp(expected,actual)==0){ record_pass(); } else { record_fail(); log_err("%s  returned  %s  instead of %s\n", action, austrdup(actual), austrdup(expected)); }
+#define CONFIRM_EQ(actual,expected) UPRV_BLOCK_MACRO_BEGIN { \
+    if (u_strcmp(expected,actual)==0) { \
+        record_pass(); \
+    } else { \
+        record_fail(); \
+        log_err("%s  returned  %s  instead of %s\n", action, austrdup(actual), austrdup(expected)); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define CONFIRM_ErrorCode(actual,expected) if ((expected)==(actual)) { record_pass(); } else { record_fail();  log_err("%s returned  %s  instead of %s\n", action, myErrorName(actual), myErrorName(expected)); }
+#define CONFIRM_ErrorCode(actual,expected) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((expected)==(actual)) { \
+        record_pass(); \
+    } else { \
+        record_fail(); \
+        log_err("%s returned  %s  instead of %s\n", action, myErrorName(actual), myErrorName(expected)); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 
 /* Array of our test objects */

--- a/icu4c/source/test/cintltst/creststn.c
+++ b/icu4c/source/test/cintltst/creststn.c
@@ -132,10 +132,38 @@ enum E_Where
 typedef enum E_Where E_Where;
 /*****************************************************************************/
 
-#define CONFIRM_EQ(actual,expected) if (u_strcmp(expected,actual)==0){ record_pass(); } else { record_fail(); log_err("%s  returned  %s  instead of %s\n", action, austrdup(actual), austrdup(expected)); }
-#define CONFIRM_INT_EQ(actual,expected) if ((expected)==(actual)) { record_pass(); } else { record_fail(); log_err("%s returned %d instead of %d\n",  action, actual, expected); }
-#define CONFIRM_INT_GE(actual,expected) if ((actual)>=(expected)) { record_pass(); } else { record_fail(); log_err("%s returned %d instead of x >= %d\n",  action, actual, expected); }
-#define CONFIRM_INT_NE(actual,expected) if ((expected)!=(actual)) { record_pass(); } else { record_fail(); log_err("%s returned %d instead of x != %d\n",  action, actual, expected); }
+#define CONFIRM_EQ(actual,expected) UPRV_BLOCK_MACRO_BEGIN { \
+    if (u_strcmp(expected,actual)==0) { \
+        record_pass(); \
+    } else { \
+        record_fail(); \
+        log_err("%s  returned  %s  instead of %s\n", action, austrdup(actual), austrdup(expected)); \
+    } \
+} UPRV_BLOCK_MACRO_END
+#define CONFIRM_INT_EQ(actual,expected) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((expected)==(actual)) { \
+        record_pass(); \
+    } else { \
+        record_fail(); \
+        log_err("%s returned %d instead of %d\n",  action, actual, expected); \
+    } \
+} UPRV_BLOCK_MACRO_END
+#define CONFIRM_INT_GE(actual,expected) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((actual)>=(expected)) { \
+        record_pass(); \
+    } else { \
+        record_fail(); \
+        log_err("%s returned %d instead of x >= %d\n",  action, actual, expected); \
+    } \
+} UPRV_BLOCK_MACRO_END
+#define CONFIRM_INT_NE(actual,expected) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((expected)!=(actual)) { \
+        record_pass(); \
+    } else { \
+        record_fail(); \
+        log_err("%s returned %d instead of x != %d\n",  action, actual, expected); \
+    } \
+} UPRV_BLOCK_MACRO_END
 /*#define CONFIRM_ErrorCode(actual,expected) if ((expected)==(actual)) { record_pass(); } else { record_fail();  log_err("%s returned  %s  instead of %s\n", action, myErrorName(actual), myErrorName(expected)); } */
 static void 
 CONFIRM_ErrorCode(UErrorCode actual,UErrorCode expected) 

--- a/icu4c/source/test/cintltst/hpmufn.c
+++ b/icu4c/source/test/cintltst/hpmufn.c
@@ -42,17 +42,20 @@ addHeapMutexTest(TestNode** root)
 
 static int32_t gMutexFailures = 0;
 
-#define TEST_STATUS(status, expected) \
-if (status != expected) { \
-log_err_status(status, "FAIL at  %s:%d. Actual status = \"%s\";  Expected status = \"%s\"\n", \
-  __FILE__, __LINE__, u_errorName(status), u_errorName(expected)); gMutexFailures++; }
+#define TEST_STATUS(status, expected) UPRV_BLOCK_MACRO_BEGIN { \
+    if (status != expected) { \
+        log_err_status(status, "FAIL at  %s:%d. Actual status = \"%s\";  Expected status = \"%s\"\n", \
+                       __FILE__, __LINE__, u_errorName(status), u_errorName(expected)); gMutexFailures++; \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 
-#define TEST_ASSERT(expr) \
-if (!(expr)) { \
-    log_err("FAILED Assertion \"" #expr "\" at  %s:%d.\n", __FILE__, __LINE__); \
-    gMutexFailures++; \
-}
+#define TEST_ASSERT(expr) UPRV_BLOCK_MACRO_BEGIN { \
+    if (!(expr)) { \
+        log_err("FAILED Assertion \"" #expr "\" at  %s:%d.\n", __FILE__, __LINE__); \
+        gMutexFailures++; \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 
 /*  These tests do cleanup and reinitialize ICU in the course of their operation.

--- a/icu4c/source/test/cintltst/reapits.c
+++ b/icu4c/source/test/cintltst/reapits.c
@@ -33,11 +33,17 @@
 #include "cintltst.h"
 #include "cmemory.h"
 
-#define TEST_ASSERT_SUCCESS(status) {if (U_FAILURE(status)) { \
-log_data_err("Failure at file %s:%d - error = %s (Are you missing data?)\n", __FILE__, __LINE__, u_errorName(status));}}
+#define TEST_ASSERT_SUCCESS(status) UPRV_BLOCK_MACRO_BEGIN { \
+    if (U_FAILURE(status)) { \
+        log_data_err("Failure at file %s:%d - error = %s (Are you missing data?)\n", __FILE__, __LINE__, u_errorName(status)); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define TEST_ASSERT(expr) {if ((expr)==FALSE) { \
-log_err("Test Failure at file %s:%d - ASSERT(%s) failed.\n", __FILE__, __LINE__, #expr);}}
+#define TEST_ASSERT(expr) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((expr)==FALSE) { \
+        log_err("Test Failure at file %s:%d - ASSERT(%s) failed.\n", __FILE__, __LINE__, #expr); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 /*
  *   TEST_SETUP and TEST_TEARDOWN
@@ -50,7 +56,7 @@ log_err("Test Failure at file %s:%d - ASSERT(%s) failed.\n", __FILE__, __LINE__,
  *         Put arbitrary test code between SETUP and TEARDOWN.
  *         're" is the compiled, ready-to-go  regular expression.
  */
-#define TEST_SETUP(pattern, testString, flags) {  \
+#define TEST_SETUP(pattern, testString, flags) UPRV_BLOCK_MACRO_BEGIN { \
     UChar   *srcString = NULL;  \
     status = U_ZERO_ERROR; \
     re = uregex_openC(pattern, flags, NULL, &status);  \
@@ -60,14 +66,15 @@ log_err("Test Failure at file %s:%d - ASSERT(%s) failed.\n", __FILE__, __LINE__,
     u_uastrncpy(srcString, testString, testStringLen + 1); \
     uregex_setText(re, srcString, -1, &status); \
     TEST_ASSERT_SUCCESS(status);  \
-    if (U_SUCCESS(status)) {
-    
+    if (U_SUCCESS(status)) { \
+        UPRV_BLOCK_MACRO_BEGIN {} UPRV_BLOCK_MACRO_END
+
 #define TEST_TEARDOWN  \
     }  \
     TEST_ASSERT_SUCCESS(status);  \
     uregex_close(re);  \
     free(srcString);   \
-    }
+} UPRV_BLOCK_MACRO_END
 
 
 /**

--- a/icu4c/source/test/cintltst/spooftest.c
+++ b/icu4c/source/test/cintltst/spooftest.c
@@ -31,19 +31,31 @@
 #include "cintltst.h"
 #include "cmemory.h"
 
-#define TEST_ASSERT_SUCCESS(status) {if (U_FAILURE(status)) { \
-    log_err_status(status, "Failure at file %s, line %d, error = %s\n", __FILE__, __LINE__, u_errorName(status));}}
+#define TEST_ASSERT_SUCCESS(status) UPRV_BLOCK_MACRO_BEGIN { \
+    if (U_FAILURE(status)) { \
+        log_err_status(status, "Failure at file %s, line %d, error = %s\n", __FILE__, __LINE__, u_errorName(status)); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define TEST_ASSERT(expr) {if ((expr)==FALSE) { \
-log_err("Test Failure at file %s, line %d: \"%s\" is false.\n", __FILE__, __LINE__, #expr);}}
+#define TEST_ASSERT(expr) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((expr)==FALSE) { \
+        log_err("Test Failure at file %s, line %d: \"%s\" is false.\n", __FILE__, __LINE__, #expr); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define TEST_ASSERT_EQ(a, b) { if ((a) != (b)) { \
-    log_err("Test Failure at file %s, line %d: \"%s\" (%d) != \"%s\" (%d) \n", \
-             __FILE__, __LINE__, #a, (a), #b, (b)); }}
+#define TEST_ASSERT_EQ(a, b) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((a) != (b)) { \
+        log_err("Test Failure at file %s, line %d: \"%s\" (%d) != \"%s\" (%d) \n", \
+                __FILE__, __LINE__, #a, (a), #b, (b)); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define TEST_ASSERT_NE(a, b) { if ((a) == (b)) { \
-    log_err("Test Failure at file %s, line %d: \"%s\" (%d) == \"%s\" (%d) \n", \
-             __FILE__, __LINE__, #a, (a), #b, (b)); }}
+#define TEST_ASSERT_NE(a, b) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((a) == (b)) { \
+        log_err("Test Failure at file %s, line %d: \"%s\" (%d) == \"%s\" (%d) \n", \
+                __FILE__, __LINE__, #a, (a), #b, (b)); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 
 /*
@@ -52,7 +64,7 @@ log_err("Test Failure at file %s, line %d: \"%s\" is false.\n", __FILE__, __LINE
  *         Put arbitrary test code between SETUP and TEARDOWN.
  *         "sc" is the ready-to-go  SpoofChecker for use in the tests.
  */
-#define TEST_SETUP {  \
+#define TEST_SETUP UPRV_BLOCK_MACRO_BEGIN { \
     UErrorCode status = U_ZERO_ERROR; \
     USpoofChecker *sc;     \
     sc = uspoof_open(&status);  \
@@ -63,7 +75,7 @@ log_err("Test Failure at file %s, line %d: \"%s\" is false.\n", __FILE__, __LINE
     }  \
     TEST_ASSERT_SUCCESS(status);  \
     uspoof_close(sc);  \
-}
+} UPRV_BLOCK_MACRO_END
 
 static void TestOpenFromSource(void);
 static void TestUSpoofCAPI(void);

--- a/icu4c/source/test/cintltst/tracetst.c
+++ b/icu4c/source/test/cintltst/tracetst.c
@@ -49,10 +49,11 @@ addUTraceTest(TestNode** root)
 /*
  * Macro for assert style tests.
  */
-#define TEST_ASSERT(expr) \
-if (!(expr)) { \
-    log_err("FAILED Assertion \"" #expr "\" at  %s:%d.\n", __FILE__, __LINE__); \
-}
+#define TEST_ASSERT(expr) UPRV_BLOCK_MACRO_BEGIN { \
+    if (!(expr)) { \
+        log_err("FAILED Assertion \"" #expr "\" at  %s:%d.\n", __FILE__, __LINE__); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 
 /*

--- a/icu4c/source/test/cintltst/usrchtst.c
+++ b/icu4c/source/test/cintltst/usrchtst.c
@@ -2506,9 +2506,11 @@ exitTestForwardBackward :
     }
 }
 
-#define TEST_ASSERT(x) \
-   {if (U_FAILURE(x)) {log_err_status(x, "%s:%d: FAIL: test assertion failure \n", __FILE__, __LINE__);\
-   }}
+#define TEST_ASSERT(x) UPRV_BLOCK_MACRO_BEGIN { \
+    if (U_FAILURE(x)) { \
+        log_err_status(x, "%s:%d: FAIL: test assertion failure \n", __FILE__, __LINE__); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 static void TestSearchForNull(void) {
     UCollator *coll;

--- a/icu4c/source/test/cintltst/utexttst.c
+++ b/icu4c/source/test/cintltst/utexttst.c
@@ -34,17 +34,21 @@ addUTextTest(TestNode** root)
 }
 
 
-#define TEST_ASSERT(x) \
-   {if ((x)==FALSE) {log_err("Test failure in file %s at line %d\n", __FILE__, __LINE__);\
-                     gFailed = TRUE;\
-   }}
+#define TEST_ASSERT(x) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((x)==FALSE) { \
+        log_err("Test failure in file %s at line %d\n", __FILE__, __LINE__); \
+        gFailed = TRUE; \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 
-#define TEST_SUCCESS(status) \
-   {if (U_FAILURE(status)) {log_err("Test failure in file %s at line %d. Error = \"%s\"\n", \
-       __FILE__, __LINE__, u_errorName(status)); \
-       gFailed = TRUE;\
-   }}
+#define TEST_SUCCESS(status) UPRV_BLOCK_MACRO_BEGIN { \
+    if (U_FAILURE(status)) { \
+        log_err("Test failure in file %s at line %d. Error = \"%s\"\n", \
+                __FILE__, __LINE__, u_errorName(status)); \
+        gFailed = TRUE; \
+   } \
+} UPRV_BLOCK_MACRO_END
 
 
 

--- a/icu4c/source/test/cintltst/utf8tst.c
+++ b/icu4c/source/test/cintltst/utf8tst.c
@@ -35,7 +35,7 @@
  * the macros below do not attempt to assemble such pairs.
  */
 
-#define L8_NEXT(s, i, length, c) { \
+#define L8_NEXT(s, i, length, c) UPRV_BLOCK_MACRO_BEGIN { \
     (c)=(uint8_t)(s)[(i)++]; \
     if((c)>=0x80) { \
         if(U8_IS_LEAD(c)) { \
@@ -44,9 +44,9 @@
             (c)=U_SENTINEL; \
         } \
     } \
-}
+} UPRV_BLOCK_MACRO_END
 
-#define L8_PREV(s, start, i, c) { \
+#define L8_PREV(s, start, i, c) UPRV_BLOCK_MACRO_BEGIN { \
     (c)=(uint8_t)(s)[--(i)]; \
     if((c)>=0x80) { \
         if((c)<=0xbf) { \
@@ -55,7 +55,7 @@
             (c)=U_SENTINEL; \
         } \
     } \
-}
+} UPRV_BLOCK_MACRO_END
 
 /* -------------------------------------------------------------------------- */
 

--- a/icu4c/source/test/intltest/alphaindextst.cpp
+++ b/icu4c/source/test/intltest/alphaindextst.cpp
@@ -71,10 +71,19 @@ void AlphabeticIndexTest::runIndexedTest( int32_t index, UBool exec, const char*
     TESTCASE_AUTO_END;
 }
 
-#define TEST_CHECK_STATUS {if (U_FAILURE(status)) {dataerrln("%s:%d: Test failure.  status=%s", \
-                                                              __FILE__, __LINE__, u_errorName(status)); return;}}
+#define TEST_CHECK_STATUS UPRV_BLOCK_MACRO_BEGIN { \
+    if (U_FAILURE(status)) { \
+        dataerrln("%s:%d: Test failure.  status=%s", \
+                  __FILE__, __LINE__, u_errorName(status)); \
+        return; \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define TEST_ASSERT(expr) {if ((expr)==FALSE) {errln("%s:%d: Test failure \n", __FILE__, __LINE__);}}
+#define TEST_ASSERT(expr) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((expr)==FALSE) { \
+        errln("%s:%d: Test failure \n", __FILE__, __LINE__); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 //
 //  APITest.   Invoke every function at least once, and check that it does something.

--- a/icu4c/source/test/intltest/astrotst.cpp
+++ b/icu4c/source/test/intltest/astrotst.cpp
@@ -44,7 +44,12 @@ void AstroTest::runIndexedTest( int32_t index, UBool exec, const char* &name, ch
 
 #undef CASE
 
-#define ASSERT_OK(x)   if(U_FAILURE(x)) { dataerrln("%s:%d: %s\n", __FILE__, __LINE__, u_errorName(x)); return; }
+#define ASSERT_OK(x) UPRV_BLOCK_MACRO_BEGIN { \
+    if(U_FAILURE(x)) { \
+        dataerrln("%s:%d: %s\n", __FILE__, __LINE__, u_errorName(x)); \
+        return; \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 
 void AstroTest::initAstro(UErrorCode &status) {

--- a/icu4c/source/test/intltest/caltest.cpp
+++ b/icu4c/source/test/intltest/caltest.cpp
@@ -25,23 +25,33 @@
 
 #define mkcstr(U) u_austrcpy(calloc(8, u_strlen(U) + 1), U)
 
-#define TEST_CHECK_STATUS { \
+#define TEST_CHECK_STATUS UPRV_BLOCK_MACRO_BEGIN { \
     if (U_FAILURE(status)) { \
         if (status == U_MISSING_RESOURCE_ERROR) { \
             dataerrln("%s:%d: Test failure.  status=%s", __FILE__, __LINE__, u_errorName(status)); \
         } else { \
             errln("%s:%d: Test failure.  status=%s", __FILE__, __LINE__, u_errorName(status)); \
-        } return;}}
+        } \
+        return; \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define TEST_CHECK_STATUS_LOCALE(testlocale) { \
+#define TEST_CHECK_STATUS_LOCALE(testlocale) UPRV_BLOCK_MACRO_BEGIN { \
     if (U_FAILURE(status)) { \
         if (status == U_MISSING_RESOURCE_ERROR) { \
             dataerrln("%s:%d: Test failure, locale %s.  status=%s", __FILE__, __LINE__, testlocale, u_errorName(status)); \
         } else { \
             errln("%s:%d: Test failure, locale %s.  status=%s", __FILE__, __LINE__, testlocale, u_errorName(status)); \
-        } return;}}
+        } \
+        return; \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define TEST_ASSERT(expr) {if ((expr)==FALSE) {errln("%s:%d: Test failure \n", __FILE__, __LINE__);}}
+#define TEST_ASSERT(expr) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((expr)==FALSE) { \
+        errln("%s:%d: Test failure \n", __FILE__, __LINE__); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 // *****************************************************************************
 // class CalendarTest
@@ -1747,11 +1757,12 @@ CalendarTest::marchByDelta(Calendar* cal, int32_t delta)
     delete cur;
 }
 
-#define CHECK(status, msg) \
+#define CHECK(status, msg) UPRV_BLOCK_MACRO_BEGIN { \
     if (U_FAILURE(status)) { \
         errcheckln(status, msg); \
         return; \
-    }
+    } \
+} UPRV_BLOCK_MACRO_END
 
 void CalendarTest::TestWOY(void) {
     /*

--- a/icu4c/source/test/intltest/csdetest.cpp
+++ b/icu4c/source/test/intltest/csdetest.cpp
@@ -33,12 +33,18 @@
 #define CH_SPACE 0x0020
 #define CH_SLASH 0x002F
 
-#define TEST_ASSERT(x) {if (!(x)) { \
-    errln("Failure in file %s, line %d", __FILE__, __LINE__);}}
+#define TEST_ASSERT(x) UPRV_BLOCK_MACRO_BEGIN { \
+    if (!(x)) { \
+        errln("Failure in file %s, line %d", __FILE__, __LINE__); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define TEST_ASSERT_SUCCESS(errcode) { if (U_FAILURE(errcode)) { \
-    errcheckln(errcode, "Failure in file %s, line %d, status = \"%s\"", __FILE__, __LINE__, u_errorName(errcode));\
-    return;}}
+#define TEST_ASSERT_SUCCESS(errcode) UPRV_BLOCK_MACRO_BEGIN { \
+    if (U_FAILURE(errcode)) { \
+        errcheckln(errcode, "Failure in file %s, line %d, status = \"%s\"", __FILE__, __LINE__, u_errorName(errcode)); \
+        return; \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 
 //---------------------------------------------------------------------------

--- a/icu4c/source/test/intltest/dcfmapts.cpp
+++ b/icu4c/source/test/intltest/dcfmapts.cpp
@@ -642,14 +642,15 @@ void IntlTestDecimalFormatAPI::TestScale()
 }
 
 
-#define ASSERT_EQUAL(expect, actual) { \
+#define ASSERT_EQUAL(expect, actual) UPRV_BLOCK_MACRO_BEGIN { \
     /* ICU-20080: Use temporary variables to avoid strange compiler behaviour \
        (with the nice side-effect of avoiding repeated function calls too). */ \
     auto lhs = (expect); \
     auto rhs = (actual); \
     char tmp[200]; \
     sprintf(tmp, "(%g==%g)", (double)lhs, (double)rhs); \
-    assertTrue(tmp, (lhs==rhs), FALSE, TRUE, __FILE__, __LINE__); }
+    assertTrue(tmp, (lhs==rhs), FALSE, TRUE, __FILE__, __LINE__); \
+} UPRV_BLOCK_MACRO_END
 
 #if defined(_MSC_VER)
 // Ignore the noisy warning 4805 (comparisons between int and bool) in the function below as we use the ICU TRUE/FALSE macros

--- a/icu4c/source/test/intltest/dcfmtest.cpp
+++ b/icu4c/source/test/intltest/dcfmtest.cpp
@@ -79,21 +79,41 @@ void DecimalFormatTest::runIndexedTest( int32_t index, UBool exec, const char* &
 //   Error Checking / Reporting macros used in all of the tests.
 //
 //---------------------------------------------------------------------------
-#define DF_CHECK_STATUS {if (U_FAILURE(status)) \
-    {dataerrln("DecimalFormatTest failure at line %d.  status=%s", \
-    __LINE__, u_errorName(status)); return 0;}}
+#define DF_CHECK_STATUS UPRV_BLOCK_MACRO_BEGIN { \
+    if (U_FAILURE(status)) { \
+        dataerrln("DecimalFormatTest failure at line %d.  status=%s", \
+                  __LINE__, u_errorName(status)); \
+        return 0; \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define DF_ASSERT(expr) {if ((expr)==FALSE) {errln("DecimalFormatTest failure at line %d.\n", __LINE__);}}
+#define DF_ASSERT(expr) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((expr)==FALSE) { \
+        errln("DecimalFormatTest failure at line %d.\n", __LINE__); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define DF_ASSERT_FAIL(expr, errcode) {UErrorCode status=U_ZERO_ERROR; (expr);\
-if (status!=errcode) {dataerrln("DecimalFormatTest failure at line %d.  Expected status=%s, got %s", \
-    __LINE__, u_errorName(errcode), u_errorName(status));}}
+#define DF_ASSERT_FAIL(expr, errcode) UPRV_BLOCK_MACRO_BEGIN { \
+    UErrorCode status=U_ZERO_ERROR; \
+    (expr); \
+    if (status!=errcode) { \
+        dataerrln("DecimalFormatTest failure at line %d.  Expected status=%s, got %s", \
+                  __LINE__, u_errorName(errcode), u_errorName(status)); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define DF_CHECK_STATUS_L(line) {if (U_FAILURE(status)) {errln( \
-    "DecimalFormatTest failure at line %d, from %d.  status=%d\n",__LINE__, (line), status); }}
+#define DF_CHECK_STATUS_L(line) UPRV_BLOCK_MACRO_BEGIN { \
+    if (U_FAILURE(status)) { \
+        errln("DecimalFormatTest failure at line %d, from %d.  status=%d\n",__LINE__, (line), status); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define DF_ASSERT_L(expr, line) {if ((expr)==FALSE) { \
-    errln("DecimalFormatTest failure at line %d, from %d.", __LINE__, (line)); return;}}
+#define DF_ASSERT_L(expr, line) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((expr)==FALSE) { \
+        errln("DecimalFormatTest failure at line %d, from %d.", __LINE__, (line)); \
+        return; \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 
 

--- a/icu4c/source/test/intltest/dtfmttst.cpp
+++ b/icu4c/source/test/intltest/dtfmttst.cpp
@@ -29,7 +29,12 @@
 #include "windttst.h"
 #endif
 
-#define ASSERT_OK(status)  if(U_FAILURE(status)) {errcheckln(status, #status " = %s @ %s:%d", u_errorName(status), __FILE__, __LINE__); return; }
+#define ASSERT_OK(status) UPRV_BLOCK_MACRO_BEGIN { \
+    if(U_FAILURE(status)) { \
+        errcheckln(status, #status " = %s @ %s:%d", u_errorName(status), __FILE__, __LINE__); \
+        return; \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 // *****************************************************************************
 // class DateFormatTest

--- a/icu4c/source/test/intltest/incaltst.cpp
+++ b/icu4c/source/test/intltest/incaltst.cpp
@@ -22,11 +22,12 @@
 #include <stdio.h>
 #include "caltest.h"
 
-#define CHECK(status, msg) \
+#define CHECK(status, msg) UPRV_BLOCK_MACRO_BEGIN { \
     if (U_FAILURE(status)) { \
-      dataerrln((UnicodeString(u_errorName(status)) + UnicodeString(" : " ) )+ msg); \
+        dataerrln((UnicodeString(u_errorName(status)) + UnicodeString(" : " ) )+ msg); \
         return; \
-    }
+    } \
+} UPRV_BLOCK_MACRO_END
 
 
 static UnicodeString escape( const UnicodeString&src)

--- a/icu4c/source/test/intltest/intltest.h
+++ b/icu4c/source/test/intltest/intltest.h
@@ -87,7 +87,7 @@ UnicodeString toString(UBool b);
 //|     TESTCASE_AUTO_END;
 //| }
 #define TESTCASE_AUTO_BEGIN \
-    for(;;) { \
+    do { \
         int32_t testCaseAutoNumber = 0
 
 #define TESTCASE_AUTO(test) \
@@ -99,7 +99,7 @@ UnicodeString toString(UBool b);
                 test(); \
             } \
             break; \
-        }
+        } else (void)0
 
 #define TESTCASE_AUTO_CLASS(TestClass) \
         if (index == testCaseAutoNumber++) { \
@@ -111,7 +111,7 @@ UnicodeString toString(UBool b);
                 callTest(test, par); \
             } \
             break; \
-        }
+        } else (void)0
 
 #define TESTCASE_AUTO_CREATE_CLASS(TestClass) \
         if (index == testCaseAutoNumber++) { \
@@ -123,12 +123,12 @@ UnicodeString toString(UBool b);
                 callTest(*test, par); \
             } \
             break; \
-        }
+        } else (void)0
 
 #define TESTCASE_AUTO_END \
         name = ""; \
         break; \
-    }
+    } while (TRUE)
 
 
 // WHERE Macro yields a literal string of the form "source_file_name:line number "

--- a/icu4c/source/test/intltest/itspoof.cpp
+++ b/icu4c/source/test/intltest/itspoof.cpp
@@ -29,22 +29,37 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#define TEST_ASSERT_SUCCESS(status) {if (U_FAILURE(status)) { \
-    errcheckln(status, "Failure at file %s, line %d, error = %s", __FILE__, __LINE__, u_errorName(status));}}
+#define TEST_ASSERT_SUCCESS(status) UPRV_BLOCK_MACRO_BEGIN { \
+    if (U_FAILURE(status)) { \
+        errcheckln(status, "Failure at file %s, line %d, error = %s", __FILE__, __LINE__, u_errorName(status)); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define TEST_ASSERT(expr) {if ((expr)==FALSE) { \
-    errln("Test Failure at file %s, line %d: \"%s\" is false.", __FILE__, __LINE__, #expr);}}
+#define TEST_ASSERT(expr) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((expr)==FALSE) { \
+        errln("Test Failure at file %s, line %d: \"%s\" is false.", __FILE__, __LINE__, #expr); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define TEST_ASSERT_MSG(expr, msg) {if ((expr)==FALSE) { \
-    dataerrln("Test Failure at file %s, line %d, %s: \"%s\" is false.", __FILE__, __LINE__, msg, #expr);}}
+#define TEST_ASSERT_MSG(expr, msg) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((expr)==FALSE) { \
+        dataerrln("Test Failure at file %s, line %d, %s: \"%s\" is false.", __FILE__, __LINE__, msg, #expr); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define TEST_ASSERT_EQ(a, b) { if ((a) != (b)) { \
-    errln("Test Failure at file %s, line %d: \"%s\" (%d) != \"%s\" (%d)", \
-             __FILE__, __LINE__, #a, (a), #b, (b)); }}
+#define TEST_ASSERT_EQ(a, b) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((a) != (b)) { \
+        errln("Test Failure at file %s, line %d: \"%s\" (%d) != \"%s\" (%d)", \
+              __FILE__, __LINE__, #a, (a), #b, (b)); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define TEST_ASSERT_NE(a, b) { if ((a) == (b)) { \
-    errln("Test Failure at file %s, line %d: \"%s\" (%d) == \"%s\" (%d)", \
-             __FILE__, __LINE__, #a, (a), #b, (b)); }}
+#define TEST_ASSERT_NE(a, b) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((a) == (b)) { \
+        errln("Test Failure at file %s, line %d: \"%s\" (%d) == \"%s\" (%d)", \
+              __FILE__, __LINE__, #a, (a), #b, (b)); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 /*
  *   TEST_SETUP and TEST_TEARDOWN
@@ -52,7 +67,7 @@
  *         Put arbitrary test code between SETUP and TEARDOWN.
  *         "sc" is the ready-to-go  SpoofChecker for use in the tests.
  */
-#define TEST_SETUP {  \
+#define TEST_SETUP UPRV_BLOCK_MACRO_BEGIN { \
     UErrorCode status = U_ZERO_ERROR; \
     USpoofChecker *sc;     \
     sc = uspoof_open(&status);  \
@@ -67,7 +82,7 @@
     TEST_ASSERT_SUCCESS(status);  \
     uspoof_closeCheckResult(checkResult); \
     uspoof_close(sc);  \
-}
+} UPRV_BLOCK_MACRO_END
 
 
 
@@ -128,9 +143,9 @@ void IntlTestSpoof::testSpoofAPI() {
 }
 
 
-#define CHECK_SKELETON(type, input, expected) { \
+#define CHECK_SKELETON(type, input, expected) UPRV_BLOCK_MACRO_BEGIN { \
     checkSkeleton(sc, type, input, expected, __LINE__); \
-    }
+} UPRV_BLOCK_MACRO_END
 
 
 // testSkeleton.   Spot check a number of confusable skeleton substitutions from the 

--- a/icu4c/source/test/intltest/locnmtst.cpp
+++ b/icu4c/source/test/intltest/locnmtst.cpp
@@ -20,13 +20,12 @@
    the macro is ugly but makes the tests pretty.
 */
 
-#define test_assert(test) \
-    { \
-        if(!(test)) \
-            errln("FAIL: " #test " was not true. In " __FILE__ " on line %d", __LINE__ ); \
-        else \
-            logln("PASS: asserted " #test); \
-    }
+#define test_assert(test) UPRV_BLOCK_MACRO_BEGIN { \
+    if(!(test)) \
+        errln("FAIL: " #test " was not true. In " __FILE__ " on line %d", __LINE__ ); \
+    else \
+        logln("PASS: asserted " #test); \
+} UPRV_BLOCK_MACRO_END
 
 /*
  Usage:
@@ -38,25 +37,25 @@
    the macro is ugly but makes the tests pretty.
 */
 
-#define test_assert_print(test,print) \
-    { \
-        if(!(test)) \
-            errln("FAIL: " #test " was not true. " + UnicodeString(print) ); \
-        else \
-            logln("PASS: asserted " #test "-> " + UnicodeString(print)); \
-    }
+#define test_assert_print(test,print) UPRV_BLOCK_MACRO_BEGIN { \
+    if(!(test)) \
+        errln("FAIL: " #test " was not true. " + UnicodeString(print) ); \
+    else \
+        logln("PASS: asserted " #test "-> " + UnicodeString(print)); \
+} UPRV_BLOCK_MACRO_END
 
-#define test_assert_equal(target,value) \
-  { \
+#define test_assert_equal(target,value) UPRV_BLOCK_MACRO_BEGIN { \
     if (UnicodeString(target)!=(value)) { \
-      logln("unexpected value '" + (value) + "'"); \
-      dataerrln("FAIL: " #target " == " #value " was not true. In " __FILE__ " on line %d", __LINE__); \
+        logln("unexpected value '" + (value) + "'"); \
+        dataerrln("FAIL: " #target " == " #value " was not true. In " __FILE__ " on line %d", __LINE__); \
     } else { \
-      logln("PASS: asserted " #target " == " #value); \
+        logln("PASS: asserted " #target " == " #value); \
     } \
-  }
+} UPRV_BLOCK_MACRO_END
 
-#define test_dumpLocale(l) { logln(#l " = " + UnicodeString(l.getName(), "")); }
+#define test_dumpLocale(l) UPRV_BLOCK_MACRO_BEGIN { \
+    logln(#l " = " + UnicodeString(l.getName(), "")); \
+} UPRV_BLOCK_MACRO_END
 
 LocaleDisplayNamesTest::LocaleDisplayNamesTest() {
 }

--- a/icu4c/source/test/intltest/loctest.cpp
+++ b/icu4c/source/test/intltest/loctest.cpp
@@ -146,13 +146,12 @@ static const char* const rawData[33][8] = {
    the macro is ugly but makes the tests pretty.
 */
 
-#define test_assert(test) \
-    { \
-        if(!(test)) \
-            errln("FAIL: " #test " was not true. In " __FILE__ " on line %d", __LINE__ ); \
-        else \
-            logln("PASS: asserted " #test); \
-    }
+#define test_assert(test) UPRV_BLOCK_MACRO_BEGIN { \
+    if(!(test)) \
+        errln("FAIL: " #test " was not true. In " __FILE__ " on line %d", __LINE__ ); \
+    else \
+        logln("PASS: asserted " #test); \
+} UPRV_BLOCK_MACRO_END
 
 /*
  Usage:
@@ -164,16 +163,17 @@ static const char* const rawData[33][8] = {
    the macro is ugly but makes the tests pretty.
 */
 
-#define test_assert_print(test,print) \
-    { \
-        if(!(test)) \
-            errln("FAIL: " #test " was not true. " + UnicodeString(print) ); \
-        else \
-            logln("PASS: asserted " #test "-> " + UnicodeString(print)); \
-    }
+#define test_assert_print(test,print) UPRV_BLOCK_MACRO_BEGIN { \
+    if(!(test)) \
+        errln("FAIL: " #test " was not true. " + UnicodeString(print) ); \
+    else \
+        logln("PASS: asserted " #test "-> " + UnicodeString(print)); \
+} UPRV_BLOCK_MACRO_END
 
 
-#define test_dumpLocale(l) { logln(#l " = " + UnicodeString(l.getName(), "")); }
+#define test_dumpLocale(l) UPRV_BLOCK_MACRO_BEGIN { \
+    logln(#l " = " + UnicodeString(l.getName(), "")); \
+} UPRV_BLOCK_MACRO_END
 
 LocaleTest::LocaleTest()
 : dataTable(NULL)

--- a/icu4c/source/test/intltest/numbertest_api.cpp
+++ b/icu4c/source/test/intltest/numbertest_api.cpp
@@ -2820,7 +2820,7 @@ void NumberFormatterApiTest::validRanges() {
 
 #define EXPECTED_MAX_INT_FRAC_SIG 999
 
-#define VALID_RANGE_ASSERT(status, method, lowerBound, argument) { \
+#define VALID_RANGE_ASSERT(status, method, lowerBound, argument) UPRV_BLOCK_MACRO_BEGIN { \
     UErrorCode expectedStatus = ((lowerBound <= argument) && (argument <= EXPECTED_MAX_INT_FRAC_SIG)) \
         ? U_ZERO_ERROR \
         : U_NUMBER_ARG_OUTOFBOUNDS_ERROR; \
@@ -2829,17 +2829,17 @@ void NumberFormatterApiTest::validRanges() {
             + Int64ToUnicodeString(argument), \
         expectedStatus, \
         status); \
-}
+} UPRV_BLOCK_MACRO_END
 
-#define VALID_RANGE_ONEARG(setting, method, lowerBound) { \
+#define VALID_RANGE_ONEARG(setting, method, lowerBound) UPRV_BLOCK_MACRO_BEGIN { \
     for (int32_t argument = -2; argument <= EXPECTED_MAX_INT_FRAC_SIG + 2; argument++) { \
         UErrorCode status = U_ZERO_ERROR; \
         NumberFormatter::with().setting(method(argument)).copyErrorTo(status); \
         VALID_RANGE_ASSERT(status, method, lowerBound, argument); \
     } \
-}
+} UPRV_BLOCK_MACRO_END
 
-#define VALID_RANGE_TWOARGS(setting, method, lowerBound) { \
+#define VALID_RANGE_TWOARGS(setting, method, lowerBound) UPRV_BLOCK_MACRO_BEGIN { \
     for (int32_t argument = -2; argument <= EXPECTED_MAX_INT_FRAC_SIG + 2; argument++) { \
         UErrorCode status = U_ZERO_ERROR; \
         /* Pass EXPECTED_MAX_INT_FRAC_SIG as the second argument so arg1 <= arg2 in expected cases */ \
@@ -2855,7 +2855,7 @@ void NumberFormatterApiTest::validRanges() {
             U_NUMBER_ARG_OUTOFBOUNDS_ERROR, \
             status); \
     } \
-}
+} UPRV_BLOCK_MACRO_END
 
     VALID_RANGE_ONEARG(precision, Precision::fixedFraction, 0);
     VALID_RANGE_ONEARG(precision, Precision::minFraction, 0);

--- a/icu4c/source/test/intltest/numfmtst.cpp
+++ b/icu4c/source/test/intltest/numfmtst.cpp
@@ -81,8 +81,18 @@ static const UChar ISO_CURRENCY_USD[] = {0x55, 0x53, 0x44, 0}; // "USD"
 // class NumberFormatTest
 // *****************************************************************************
 
-#define CHECK(status,str) if (U_FAILURE(status)) { errcheckln(status, UnicodeString("FAIL: ") + str + " - " + u_errorName(status)); return; }
-#define CHECK_DATA(status,str) if (U_FAILURE(status)) { dataerrln(UnicodeString("FAIL: ") + str + " - " + u_errorName(status)); return; }
+#define CHECK(status,str) UPRV_BLOCK_MACRO_BEGIN { \
+    if (U_FAILURE(status)) { \
+        errcheckln(status, UnicodeString("FAIL: ") + str + " - " + u_errorName(status)); \
+        return; \
+    } \
+} UPRV_BLOCK_MACRO_END
+#define CHECK_DATA(status,str) UPRV_BLOCK_MACRO_BEGIN { \
+    if (U_FAILURE(status)) { \
+        dataerrln(UnicodeString("FAIL: ") + str + " - " + u_errorName(status)); \
+        return; \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 void NumberFormatTest::runIndexedTest( int32_t index, UBool exec, const char* &name, char* /*par*/ )
 {
@@ -6744,12 +6754,12 @@ const char* attrString(int32_t attrId) {
 //      API test, not a comprehensive test.
 //      See DecimalFormatTest/DataDrivenTests
 //
-#define ASSERT_SUCCESS(status) { \
+#define ASSERT_SUCCESS(status) UPRV_BLOCK_MACRO_BEGIN { \
     assertSuccess(UnicodeString("file ") + __FILE__ + ", line " + __LINE__, (status)); \
-}
-#define ASSERT_EQUALS(expected, actual) { \
+} UPRV_BLOCK_MACRO_END
+#define ASSERT_EQUALS(expected, actual) UPRV_BLOCK_MACRO_BEGIN { \
     assertEquals(UnicodeString("file ") + __FILE__ + ", line " + __LINE__, (expected), (actual)); \
-}
+} UPRV_BLOCK_MACRO_END
 
 void NumberFormatTest::TestDecimal() {
     {

--- a/icu4c/source/test/intltest/numrgts.cpp
+++ b/icu4c/source/test/intltest/numrgts.cpp
@@ -2734,27 +2734,28 @@ void NumberFormatRegressionTest::TestJ691(void) {
 //   Error Checking / Reporting macros
 //
 //---------------------------------------------------------------------------
-#define TEST_CHECK_STATUS(status) { \
+#define TEST_CHECK_STATUS(status) UPRV_BLOCK_MACRO_BEGIN { \
     if (U_FAILURE(status)) { \
         if (status == U_MISSING_RESOURCE_ERROR) { \
             dataerrln("File %s, Line %d: status=%s", __FILE__, __LINE__, u_errorName(status)); \
         } else { \
             errln("File %s, Line %d: status=%s", __FILE__, __LINE__, u_errorName(status)); \
         } return; \
-    }}
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define TEST_ASSERT(expr) \
+#define TEST_ASSERT(expr) UPRV_BLOCK_MACRO_BEGIN { \
     if ((expr)==FALSE) {\
         errln("File %s, line %d: Assertion Failed: " #expr "\n", __FILE__, __LINE__);\
-    }
-#define TEST_ASSERT_EQUALS(x,y)                  \
-    {                                                                     \
+    } \
+} UPRV_BLOCK_MACRO_END
+#define TEST_ASSERT_EQUALS(x,y) UPRV_BLOCK_MACRO_BEGIN { \
       char _msg[1000]; \
       int32_t len = sprintf (_msg,"File %s, line %d: " #x "==" #y, __FILE__, __LINE__); \
       (void)len;                                                         \
       U_ASSERT(len < (int32_t) sizeof(_msg));                            \
       assertEquals((const char*) _msg, x,y);                             \
-    }
+} UPRV_BLOCK_MACRO_END
 
 
 // Ticket 8199:  Parse failure for numbers in the range of 1E10 - 1E18

--- a/icu4c/source/test/intltest/rbbiapts.cpp
+++ b/icu4c/source/test/intltest/rbbiapts.cpp
@@ -34,11 +34,17 @@
  */
 
 
-#define TEST_ASSERT_SUCCESS(status) {if (U_FAILURE(status)) {\
-dataerrln("Failure at file %s, line %d, error = %s", __FILE__, __LINE__, u_errorName(status));}}
+#define TEST_ASSERT_SUCCESS(status) UPRV_BLOCK_MACRO_BEGIN { \
+    if (U_FAILURE(status)) { \
+        dataerrln("Failure at file %s, line %d, error = %s", __FILE__, __LINE__, u_errorName(status)); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define TEST_ASSERT(expr) {if ((expr) == FALSE) { \
-    errln("Test Failure at file %s, line %d: \"%s\" is false.\n", __FILE__, __LINE__, #expr);}}
+#define TEST_ASSERT(expr) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((expr) == FALSE) { \
+        errln("Test Failure at file %s, line %d: \"%s\" is false.\n", __FILE__, __LINE__, #expr); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 void RBBIAPITest::TestCloneEquals()
 {

--- a/icu4c/source/test/intltest/rbbimonkeytest.cpp
+++ b/icu4c/source/test/intltest/rbbimonkeytest.cpp
@@ -660,12 +660,12 @@ void RBBIMonkeyImpl::join() {
 }
 
 
-#define MONKEY_ERROR(msg, index) { \
+#define MONKEY_ERROR(msg, index) UPRV_BLOCK_MACRO_BEGIN { \
     IntlTest::gTest->errln("%s:%d %s at index %d. Parameters to reproduce: @rules=%s,seed=%u,loop=1,verbose ", \
                     __FILE__, __LINE__, msg, index, fRuleFileName, fTestData->fRandomSeed); \
     if (fVerbose) { fTestData->dump(index); } \
     status = U_INVALID_STATE_ERROR;  \
-}
+} UPRV_BLOCK_MACRO_END
 
 void RBBIMonkeyImpl::runTest() {
     UErrorCode status = U_ZERO_ERROR;

--- a/icu4c/source/test/intltest/rbbitst.cpp
+++ b/icu4c/source/test/intltest/rbbitst.cpp
@@ -51,11 +51,17 @@
 #include "unicode/filteredbrk.h"
 #endif // !UCONFIG_NO_FILTERED_BREAK_ITERATION
 
-#define TEST_ASSERT(x) {if (!(x)) { \
-    errln("Failure in file %s, line %d", __FILE__, __LINE__);}}
+#define TEST_ASSERT(x) UPRV_BLOCK_MACRO_BEGIN { \
+    if (!(x)) { \
+        errln("Failure in file %s, line %d", __FILE__, __LINE__); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define TEST_ASSERT_SUCCESS(errcode) { if (U_FAILURE(errcode)) { \
-    errcheckln(errcode, "Failure in file %s, line %d, status = \"%s\"", __FILE__, __LINE__, u_errorName(errcode));}}
+#define TEST_ASSERT_SUCCESS(errcode) UPRV_BLOCK_MACRO_BEGIN { \
+    if (U_FAILURE(errcode)) { \
+        errcheckln(errcode, "Failure in file %s, line %d, status = \"%s\"", __FILE__, __LINE__, u_errorName(errcode)); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 //---------------------------------------------
 // runIndexedTest

--- a/icu4c/source/test/intltest/regextst.cpp
+++ b/icu4c/source/test/intltest/regextst.cpp
@@ -177,29 +177,56 @@ const char* RegexTest::extractToAssertBuf(const UnicodeString& message) {
   return ASSERT_BUF;
 }
 
-#define REGEX_VERBOSE_TEXT(text) {char buf[200];utextToPrintable(buf,UPRV_LENGTHOF(buf),text);logln("%s:%d: UText %s=\"%s\"", __FILE__, __LINE__, #text, buf);}
+#define REGEX_VERBOSE_TEXT(text) UPRV_BLOCK_MACRO_BEGIN { \
+    char buf[200]; \
+    utextToPrintable(buf,UPRV_LENGTHOF(buf),text); \
+    logln("%s:%d: UText %s=\"%s\"", __FILE__, __LINE__, #text, buf); \
+} UPRV_BLOCK_MACRO_END
 
-#define REGEX_CHECK_STATUS {if (U_FAILURE(status)) {dataerrln("%s:%d: RegexTest failure.  status=%s", \
-                                                              __FILE__, __LINE__, u_errorName(status)); return;}}
+#define REGEX_CHECK_STATUS UPRV_BLOCK_MACRO_BEGIN { \
+    if (U_FAILURE(status)) { \
+        dataerrln("%s:%d: RegexTest failure.  status=%s", \
+                  __FILE__, __LINE__, u_errorName(status)); \
+        return; \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define REGEX_ASSERT(expr) {if ((expr)==FALSE) {errln("%s:%d: RegexTest failure: REGEX_ASSERT(%s) failed \n", __FILE__, __LINE__, #expr);}}
+#define REGEX_ASSERT(expr) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((expr)==FALSE) { \
+        errln("%s:%d: RegexTest failure: REGEX_ASSERT(%s) failed \n", __FILE__, __LINE__, #expr); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define REGEX_ASSERT_FAIL(expr, errcode) {UErrorCode status=U_ZERO_ERROR; (expr);\
-if (status!=errcode) {dataerrln("RegexTest failure at line %d.  Expected status=%s, got %s", \
-    __LINE__, u_errorName(errcode), u_errorName(status));}}
+#define REGEX_ASSERT_FAIL(expr, errcode) UPRV_BLOCK_MACRO_BEGIN { \
+    UErrorCode status=U_ZERO_ERROR; \
+    (expr); \
+    if (status!=errcode) { \
+        dataerrln("RegexTest failure at line %d.  Expected status=%s, got %s", \
+                  __LINE__, u_errorName(errcode), u_errorName(status)); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define REGEX_CHECK_STATUS_L(line) {if (U_FAILURE(status)) {errln( \
-    "RegexTest failure at line %d, from %d.  status=%d\n",__LINE__, (line), status); }}
+#define REGEX_CHECK_STATUS_L(line) UPRV_BLOCK_MACRO_BEGIN { \
+    if (U_FAILURE(status)) { \
+        errln("RegexTest failure at line %d, from %d.  status=%d\n",__LINE__, (line), status); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define REGEX_ASSERT_L(expr, line) {if ((expr)==FALSE) { \
-    errln("RegexTest failure at line %d, from %d.", __LINE__, (line)); return;}}
+#define REGEX_ASSERT_L(expr, line) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((expr)==FALSE) { \
+        errln("RegexTest failure at line %d, from %d.", __LINE__, (line)); \
+        return; \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 // expected: const char * , restricted to invariant characters.
 // actual: const UnicodeString &
-#define REGEX_ASSERT_UNISTR(expected, actual) { \
+#define REGEX_ASSERT_UNISTR(expected, actual) UPRV_BLOCK_MACRO_BEGIN { \
     if (UnicodeString(expected, -1, US_INV) != (actual)) { \
         errln("%s:%d: RegexTest failure: REGEX_ASSERT_UNISTR(%s, %s) failed \n",  \
-                __FILE__, __LINE__, expected, extractToAssertBuf(actual));}}
+              __FILE__, __LINE__, expected, extractToAssertBuf(actual)); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 
 static UBool testUTextEqual(UText *uta, UText *utb) {
@@ -329,7 +356,10 @@ static UText* regextst_openUTF8FromInvariant(UText *ut, const char *inv, int64_t
 //
 //---------------------------------------------------------------------------
 
-#define REGEX_TESTLM(pat, text, looking, match) {doRegexLMTest(pat, text, looking, match, __LINE__);doRegexLMTestUTF8(pat, text, looking, match, __LINE__);}
+#define REGEX_TESTLM(pat, text, looking, match) UPRV_BLOCK_MACRO_BEGIN { \
+    doRegexLMTest(pat, text, looking, match, __LINE__); \
+    doRegexLMTestUTF8(pat, text, looking, match, __LINE__); \
+} UPRV_BLOCK_MACRO_END
 
 UBool RegexTest::doRegexLMTest(const char *pat, const char *text, UBool looking, UBool match, int32_t line) {
     const UnicodeString pattern(pat, -1, US_INV);

--- a/icu4c/source/test/intltest/restest.cpp
+++ b/icu4c/source/test/intltest/restest.cpp
@@ -37,11 +37,35 @@ enum E_Where
 
 //***************************************************************************************
 
-#define CONFIRM_EQ(actual, expected, myAction) if ((expected)==(actual)) { record_pass(myAction); } else { record_fail(myAction + (UnicodeString)" returned " + (actual) + (UnicodeString)" instead of " + (expected) + "\n");}
-#define CONFIRM_GE(actual, expected, myAction) if ((actual)>=(expected)) { record_pass(myAction); } else { record_fail(myAction + (UnicodeString)" returned " + (actual) + (UnicodeString)" instead of x >= " + (expected) + "\n");}
-#define CONFIRM_NE(actual, expected, myAction) if ((expected)!=(actual)) { record_pass(myAction); } else { record_fail(myAction + (UnicodeString)" returned " + (actual) + (UnicodeString)" instead of x != " + (expected) + "\n");}
+#define CONFIRM_EQ(actual, expected, myAction) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((expected)==(actual)) { \
+        record_pass(myAction); \
+    } else { \
+        record_fail(myAction + (UnicodeString)" returned " + (actual) + (UnicodeString)" instead of " + (expected) + "\n"); \
+    } \
+} UPRV_BLOCK_MACRO_END
+#define CONFIRM_GE(actual, expected, myAction) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((actual)>=(expected)) { \
+        record_pass(myAction); \
+    } else { \
+        record_fail(myAction + (UnicodeString)" returned " + (actual) + (UnicodeString)" instead of x >= " + (expected) + "\n"); \
+    } \
+} UPRV_BLOCK_MACRO_END
+#define CONFIRM_NE(actual, expected, myAction) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((expected)!=(actual)) { \
+        record_pass(myAction); \
+    } else { \
+        record_fail(myAction + (UnicodeString)" returned " + (actual) + (UnicodeString)" instead of x != " + (expected) + "\n"); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define CONFIRM_UErrorCode(actual, expected, myAction) if ((expected)==(actual)) { record_pass(myAction); } else { record_fail(myAction + (UnicodeString)" returned " + u_errorName(actual) + " instead of " + u_errorName(expected) + "\n"); }
+#define CONFIRM_UErrorCode(actual, expected, myAction) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((expected)==(actual)) { \
+        record_pass(myAction); \
+    } else { \
+        record_fail(myAction + (UnicodeString)" returned " + u_errorName(actual) + " instead of " + u_errorName(expected) + "\n"); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 //***************************************************************************************
 

--- a/icu4c/source/test/intltest/restsnew.cpp
+++ b/icu4c/source/test/intltest/restsnew.cpp
@@ -66,11 +66,39 @@ enum E_Where
 
 //***************************************************************************************
 
-#define CONFIRM_EQ(actual,expected) if ((expected)==(actual)) { record_pass(); } else { record_fail(); errln(action + (UnicodeString)" returned " + (actual) + (UnicodeString)" instead of " + (expected)); }
-#define CONFIRM_GE(actual,expected) if ((actual)>=(expected)) { record_pass(); } else { record_fail(); errln(action + (UnicodeString)" returned " + (actual) + (UnicodeString)" instead of x >= " + (expected)); }
-#define CONFIRM_NE(actual,expected) if ((expected)!=(actual)) { record_pass(); } else { record_fail(); errln(action + (UnicodeString)" returned " + (actual) + (UnicodeString)" instead of x != " + (expected)); }
+#define CONFIRM_EQ(actual,expected) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((expected)==(actual)) { \
+        record_pass(); \
+    } else { \
+        record_fail(); \
+        errln(action + (UnicodeString)" returned " + (actual) + (UnicodeString)" instead of " + (expected)); \
+    } \
+} UPRV_BLOCK_MACRO_END
+#define CONFIRM_GE(actual,expected) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((actual)>=(expected)) { \
+        record_pass(); \
+    } else { \
+        record_fail(); \
+        errln(action + (UnicodeString)" returned " + (actual) + (UnicodeString)" instead of x >= " + (expected)); \
+    } \
+} UPRV_BLOCK_MACRO_END
+#define CONFIRM_NE(actual,expected) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((expected)!=(actual)) { \
+        record_pass(); \
+    } else { \
+        record_fail(); \
+        errln(action + (UnicodeString)" returned " + (actual) + (UnicodeString)" instead of x != " + (expected)); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define CONFIRM_UErrorCode(actual,expected) if ((expected)==(actual)) { record_pass(); } else { record_fail(); errln(action + (UnicodeString)" returned " + (UnicodeString)u_errorName(actual) + (UnicodeString)" instead of " + (UnicodeString)u_errorName(expected)); }
+#define CONFIRM_UErrorCode(actual,expected) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((expected)==(actual)) { \
+        record_pass(); \
+    } else { \
+        record_fail(); \
+        errln(action + (UnicodeString)" returned " + (UnicodeString)u_errorName(actual) + (UnicodeString)" instead of " + (UnicodeString)u_errorName(expected)); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 //***************************************************************************************
 
@@ -1211,17 +1239,17 @@ NewResourceBundleTest::TestGetByFallback() {
 }
 
 
-#define REQUIRE_SUCCESS(status) { \
+#define REQUIRE_SUCCESS(status) UPRV_BLOCK_MACRO_BEGIN { \
     if (status.errIfFailureAndReset("line %d", __LINE__)) { \
         return; \
     } \
-}
+} UPRV_BLOCK_MACRO_END
 
-#define REQUIRE_ERROR(expected, status) { \
+#define REQUIRE_ERROR(expected, status) UPRV_BLOCK_MACRO_BEGIN { \
     if (!status.expectErrorAndReset(expected, "line %d", __LINE__)) { \
         return; \
     } \
-}
+} UPRV_BLOCK_MACRO_END
 
 /**
  * Tests the --filterDir option in genrb.

--- a/icu4c/source/test/intltest/selfmts.cpp
+++ b/icu4c/source/test/intltest/selfmts.cpp
@@ -23,8 +23,13 @@
 #define EXP_FORMAT_RESULT_DATA 12
 #define NUM_OF_FORMAT_ARGS 3
 
-#define VERBOSE_INT(x) {logln("%s:%d:  int %s=%d\n", __FILE__, __LINE__, #x, (x));}
-#define VERBOSE_USTRING(text) {logln("%s:%d: UnicodeString %s(%d) = ", __FILE__, __LINE__, #text, text.length()); logln(UnicodeString(" \"")+text+UnicodeString("\";"));}
+#define VERBOSE_INT(x) UPRV_BLOCK_MACRO_BEGIN { \
+    logln("%s:%d:  int %s=%d\n", __FILE__, __LINE__, #x, (x)); \
+} UPRV_BLOCK_MACRO_END
+#define VERBOSE_USTRING(text) UPRV_BLOCK_MACRO_BEGIN { \
+    logln("%s:%d: UnicodeString %s(%d) = ", __FILE__, __LINE__, #text, text.length()); \
+    logln(UnicodeString(" \"")+text+UnicodeString("\";")); \
+} UPRV_BLOCK_MACRO_END
 
 
 void SelectFormatTest::runIndexedTest( int32_t index, UBool exec, const char* &name, char* /*par*/ )

--- a/icu4c/source/test/intltest/ssearch.cpp
+++ b/icu4c/source/test/intltest/ssearch.cpp
@@ -32,15 +32,25 @@
 
 char testId[100];
 
-#define TEST_ASSERT(x) {if (!(x)) { \
-    errln("Failure in file %s, line %d, test ID = \"%s\"", __FILE__, __LINE__, testId);}}
+#define TEST_ASSERT(x) UPRV_BLOCK_MACRO_BEGIN { \
+    if (!(x)) { \
+        errln("Failure in file %s, line %d, test ID = \"%s\"", __FILE__, __LINE__, testId); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define TEST_ASSERT_M(x, m) {if (!(x)) { \
-    dataerrln("Failure in file %s, line %d.   \"%s\"", __FILE__, __LINE__, m);return;}}
+#define TEST_ASSERT_M(x, m) UPRV_BLOCK_MACRO_BEGIN { \
+    if (!(x)) { \
+        dataerrln("Failure in file %s, line %d.   \"%s\"", __FILE__, __LINE__, m); \
+        return; \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define TEST_ASSERT_SUCCESS(errcode) {if (U_FAILURE(errcode)) { \
-    dataerrln("Failure in file %s, line %d, test ID \"%s\", status = \"%s\"", \
-          __FILE__, __LINE__, testId, u_errorName(errcode));}}
+#define TEST_ASSERT_SUCCESS(errcode) UPRV_BLOCK_MACRO_BEGIN { \
+    if (U_FAILURE(errcode)) { \
+        dataerrln("Failure in file %s, line %d, test ID \"%s\", status = \"%s\"", \
+                  __FILE__, __LINE__, testId, u_errorName(errcode)); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 #define NEW_ARRAY(type, count) (type *) uprv_malloc((count) * sizeof(type))
 #define DELETE_ARRAY(array) uprv_free((void *) (array))

--- a/icu4c/source/test/intltest/transapi.cpp
+++ b/icu4c/source/test/intltest/transapi.cpp
@@ -915,8 +915,12 @@ void TransliteratorAPITest::doTest(const UnicodeString& message, const UnicodeSt
 //                    transliterator, just to verify that they don't fail in some
 //                    destructive way.
 //
-#define CEASSERT(a) {if (!(a)) { \
-errln("FAIL at line %d from line %d: %s", __LINE__, line, #a);  return; }}
+#define CEASSERT(a) UPRV_BLOCK_MACRO_BEGIN { \
+    if (!(a)) { \
+        errln("FAIL at line %d from line %d: %s", __LINE__, line, #a); \
+        return; \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 void TransliteratorAPITest::callEverything(const Transliterator *tr, int line) {
     Transliterator *clonedTR = tr->clone();

--- a/icu4c/source/test/intltest/transrt.cpp
+++ b/icu4c/source/test/intltest/transrt.cpp
@@ -1034,11 +1034,14 @@ void TransliteratorRoundTripTest::TestHangul() {
 }
 
 
-#define ASSERT_SUCCESS(status) {if (U_FAILURE(status)) { \
-     errcheckln(status, "error at file %s, line %d, status = %s", __FILE__, __LINE__, \
-         u_errorName(status)); \
-         return;}}
-    
+#define ASSERT_SUCCESS(status) UPRV_BLOCK_MACRO_BEGIN { \
+    if (U_FAILURE(status)) { \
+        errcheckln(status, "error at file %s, line %d, status = %s", __FILE__, __LINE__, \
+                   u_errorName(status)); \
+        return; \
+    } \
+} UPRV_BLOCK_MACRO_END
+
 
 static void writeStringInU8(FILE *out, const UnicodeString &s) {
     int i;

--- a/icu4c/source/test/intltest/transtst.cpp
+++ b/icu4c/source/test/intltest/transtst.cpp
@@ -4066,7 +4066,7 @@ void TransliteratorTest::TestAllCodepoints(){
 
 } 
 
-#define TEST_TRANSLIT_ID(id, cls) { \
+#define TEST_TRANSLIT_ID(id, cls) UPRV_BLOCK_MACRO_BEGIN { \
   UErrorCode ec = U_ZERO_ERROR; \
   Transliterator* t = Transliterator::createInstance(id, UTRANS_FORWARD, ec); \
   if (U_FAILURE(ec)) { \
@@ -4078,9 +4078,9 @@ void TransliteratorTest::TestAllCodepoints(){
     /* *t = *t; */ /*can't do this: coverage test for assignment op*/ \
   } \
   delete t; \
-}
+} UPRV_BLOCK_MACRO_END
 
-#define TEST_TRANSLIT_RULE(rule, cls) { \
+#define TEST_TRANSLIT_RULE(rule, cls) UPRV_BLOCK_MACRO_BEGIN { \
   UErrorCode ec = U_ZERO_ERROR; \
   UParseError pe; \
   Transliterator* t = Transliterator::createFromRules("_", rule, UTRANS_FORWARD, pe, ec); \
@@ -4093,7 +4093,7 @@ void TransliteratorTest::TestAllCodepoints(){
     /* *t = *t; */ /*can't do this: coverage test for assignment op*/ \
   } \
   delete t; \
-}
+} UPRV_BLOCK_MACRO_END
 
 void TransliteratorTest::TestBoilerplate() {
     TEST_TRANSLIT_ID("Any-Latin", AnyTransliterator);

--- a/icu4c/source/test/intltest/uobjtest.cpp
+++ b/icu4c/source/test/intltest/uobjtest.cpp
@@ -48,53 +48,53 @@
 
 #define TESTCLASSID_NONE_DEFAULT(c) \
     delete testClassNoClassID(new c, #c, "new " #c)
-#define TESTCLASSID_NONE_CTOR(c, x) { \
+#define TESTCLASSID_NONE_CTOR(c, x) UPRV_BLOCK_MACRO_BEGIN { \
     delete testClassNoClassID(new c x, #c, "new " #c #x); \
     if(U_FAILURE(status)) { \
         dataerrln(UnicodeString(#c " - new " #x " - got err status ") + UnicodeString(u_errorName(status))); \
         status = U_ZERO_ERROR; \
     } \
-}
-#define TESTCLASSID_NONE_FACTORY(c, f) { \
+} UPRV_BLOCK_MACRO_END
+#define TESTCLASSID_NONE_FACTORY(c, f) UPRV_BLOCK_MACRO_BEGIN { \
     delete testClassNoClassID(f, #c, #f); \
     if(U_FAILURE(status)) { \
         dataerrln(UnicodeString(#c " - " #f " - got err status ") + UnicodeString(u_errorName(status))); \
         status = U_ZERO_ERROR; \
     } \
-}
-#define TESTCLASSID_FACTORY(c, f) { \
+} UPRV_BLOCK_MACRO_END
+#define TESTCLASSID_FACTORY(c, f) UPRV_BLOCK_MACRO_BEGIN { \
     delete testClass(f, #c, #f, c ::getStaticClassID()); \
     if(U_FAILURE(status)) { \
         dataerrln(UnicodeString(#c " - " #f " - got err status ") + UnicodeString(u_errorName(status))); \
         status = U_ZERO_ERROR; \
     } \
-}
-#define TESTCLASSID_TRANSLIT(c, t) { \
+} UPRV_BLOCK_MACRO_END
+#define TESTCLASSID_TRANSLIT(c, t) UPRV_BLOCK_MACRO_BEGIN { \
     delete testClass(Transliterator::createInstance(UnicodeString(t), UTRANS_FORWARD,parseError,status), #c, "Transliterator: " #t, c ::getStaticClassID()); \
     if(U_FAILURE(status)) { \
         dataerrln(UnicodeString(#c " - Transliterator: " #t " - got err status ") + UnicodeString(u_errorName(status))); \
         status = U_ZERO_ERROR; \
     } \
-}
-#define TESTCLASSID_CTOR(c, x) { \
+} UPRV_BLOCK_MACRO_END
+#define TESTCLASSID_CTOR(c, x) UPRV_BLOCK_MACRO_BEGIN { \
     delete testClass(new c x, #c, "new " #c #x, c ::getStaticClassID()); \
     if(U_FAILURE(status)) { \
         dataerrln(UnicodeString(#c " - new " #x " - got err status ") + UnicodeString(u_errorName(status))); \
         status = U_ZERO_ERROR; \
     } \
-}
+} UPRV_BLOCK_MACRO_END
 #define TESTCLASSID_DEFAULT(c) \
     delete testClass(new c, #c, "new " #c , c::getStaticClassID())
 #define TESTCLASSID_ABSTRACT(c) \
     testClass(NULL, #c, NULL, c::getStaticClassID())
-#define TESTCLASSID_FACTORY_HIDDEN(c, f) { \
+#define TESTCLASSID_FACTORY_HIDDEN(c, f) UPRV_BLOCK_MACRO_BEGIN { \
     UObject *objVar = f; \
     delete testClass(objVar, #c, #f, objVar!=NULL? objVar->getDynamicClassID(): NULL); \
     if(U_FAILURE(status)) { \
         dataerrln(UnicodeString(#c " - " #f " - got err status ")  + UnicodeString(u_errorName(status))); \
         status = U_ZERO_ERROR; \
     } \
-}
+} UPRV_BLOCK_MACRO_END
 
 #define MAX_CLASS_ID 200
 

--- a/icu4c/source/test/intltest/usettest.cpp
+++ b/icu4c/source/test/intltest/usettest.cpp
@@ -29,12 +29,18 @@
 #include "cmemory.h"
 #include "hash.h"
 
-#define TEST_ASSERT_SUCCESS(status) {if (U_FAILURE(status)) { \
-    dataerrln("fail in file \"%s\", line %d: \"%s\"", __FILE__, __LINE__, \
-    u_errorName(status));}}
+#define TEST_ASSERT_SUCCESS(status) UPRV_BLOCK_MACRO_BEGIN { \
+    if (U_FAILURE(status)) { \
+        dataerrln("fail in file \"%s\", line %d: \"%s\"", __FILE__, __LINE__, \
+                  u_errorName(status)); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
-#define TEST_ASSERT(expr) {if (!(expr)) { \
-    dataerrln("fail in file \"%s\", line %d", __FILE__, __LINE__); }}
+#define TEST_ASSERT(expr) UPRV_BLOCK_MACRO_BEGIN { \
+    if (!(expr)) { \
+        dataerrln("fail in file \"%s\", line %d", __FILE__, __LINE__); \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 UnicodeString operator+(const UnicodeString& left, const UnicodeSet& set) {
     UnicodeString pat;

--- a/icu4c/source/test/intltest/utxttest.cpp
+++ b/icu4c/source/test/intltest/utxttest.cpp
@@ -29,17 +29,21 @@ static int    gTestNum = 0;
 // Forward decl
 UText *openFragmentedUnicodeString(UText *ut, UnicodeString *s, UErrorCode *status);
 
-#define TEST_ASSERT(x) \
-{ if ((x)==FALSE) {errln("Test #%d failure in file %s at line %d\n", gTestNum, __FILE__, __LINE__);\
-                     gFailed = TRUE;\
-   }}
+#define TEST_ASSERT(x) UPRV_BLOCK_MACRO_BEGIN { \
+    if ((x)==FALSE) { \
+        errln("Test #%d failure in file %s at line %d\n", gTestNum, __FILE__, __LINE__); \
+        gFailed = TRUE; \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 
-#define TEST_SUCCESS(status) \
-{ if (U_FAILURE(status)) {errln("Test #%d failure in file %s at line %d. Error = \"%s\"\n", \
-       gTestNum, __FILE__, __LINE__, u_errorName(status)); \
-       gFailed = TRUE;\
-   }}
+#define TEST_SUCCESS(status) UPRV_BLOCK_MACRO_BEGIN { \
+    if (U_FAILURE(status)) { \
+        errln("Test #%d failure in file %s at line %d. Error = \"%s\"\n", \
+              gTestNum, __FILE__, __LINE__, u_errorName(status)); \
+        gFailed = TRUE; \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 UTextTest::UTextTest() {
 }

--- a/icu4c/source/test/intltest/uvectest.cpp
+++ b/icu4c/source/test/intltest/uvectest.cpp
@@ -57,16 +57,18 @@ void UVectorTest::runIndexedTest( int32_t index, UBool exec, const char* &name, 
 //   Error Checking / Reporting macros used in all of the tests.
 //
 //---------------------------------------------------------------------------
-#define TEST_CHECK_STATUS(status) \
+#define TEST_CHECK_STATUS(status) UPRV_BLOCK_MACRO_BEGIN {\
     if (U_FAILURE(status)) {\
         errln("UVectorTest failure at line %d.  status=%s\n", __LINE__, u_errorName(status));\
         return;\
-    }
+    }\
+} UPRV_BLOCK_MACRO_END
 
-#define TEST_ASSERT(expr) \
+#define TEST_ASSERT(expr) UPRV_BLOCK_MACRO_BEGIN {\
     if ((expr)==FALSE) {\
         errln("UVectorTest failure at line %d.\n", __LINE__);\
-    }
+    }\
+} UPRV_BLOCK_MACRO_END
 
 static int8_t U_CALLCONV
 UVectorTest_compareInt32(UElement key1, UElement key2) {

--- a/icu4c/source/test/intltest/v32test.cpp
+++ b/icu4c/source/test/intltest/v32test.cpp
@@ -57,16 +57,18 @@ void UVector32Test::runIndexedTest( int32_t index, UBool exec, const char* &name
 //   Error Checking / Reporting macros used in all of the tests.
 //
 //---------------------------------------------------------------------------
-#define TEST_CHECK_STATUS(status) \
+#define TEST_CHECK_STATUS(status) UPRV_BLOCK_MACRO_BEGIN {\
     if (U_FAILURE(status)) {\
         errln("UVector32Test failure at line %d.  status=%s\n", __LINE__, u_errorName(status));\
         return;\
-    }
+    }\
+} UPRV_BLOCK_MACRO_END
 
-#define TEST_ASSERT(expr) \
+#define TEST_ASSERT(expr) UPRV_BLOCK_MACRO_BEGIN {\
     if ((expr)==FALSE) {\
         errln("UVector32Test failure at line %d.\n", __LINE__);\
-    }
+    }\
+} UPRV_BLOCK_MACRO_END
 
 //---------------------------------------------------------------------------
 //

--- a/icu4c/source/test/iotest/filetst.c
+++ b/icu4c/source/test/iotest/filetst.c
@@ -1120,7 +1120,7 @@ static void TestFilePrintCompatibility(void) {
 }
 #endif
 
-#define TestFPrintFormat(uFormat, uValue, cFormat, cValue) \
+#define TestFPrintFormat(uFormat, uValue, cFormat, cValue) UPRV_BLOCK_MACRO_BEGIN { \
     myFile = u_fopen(STANDARD_TEST_FILE, "w", STANDARD_TEST_LOCALE, NULL);\
     if (myFile == NULL) {\
         log_err("Can't write test file for %s.\n", uFormat);\
@@ -1146,6 +1146,7 @@ static void TestFilePrintCompatibility(void) {
     if (buffer[uNumPrinted+1] != '*') {\
         log_err("%" uFormat " too much stored\n");\
     }\
+} UPRV_BLOCK_MACRO_END
 
 #if !UCONFIG_NO_FORMATTING
 static void TestFprintfFormat(void) {

--- a/icu4c/source/test/iotest/strtst.c
+++ b/icu4c/source/test/iotest/strtst.c
@@ -313,7 +313,7 @@ static void TestLocalizedString(void) {
 }
 
 #if !UCONFIG_NO_FORMATTING
-#define Test_u_snprintf(limit, format, value, expectedSize, expectedStr) \
+#define Test_u_snprintf(limit, format, value, expectedSize, expectedStr) UPRV_BLOCK_MACRO_BEGIN { \
     u_uastrncpy(testStr, "xxxxxxxxxxxxxx", UPRV_LENGTHOF(testStr));\
     size = u_snprintf(testStr, limit, format, value);\
     u_austrncpy(cTestResult, testStr, UPRV_LENGTHOF(cTestResult));\
@@ -324,6 +324,7 @@ static void TestLocalizedString(void) {
     else {\
         log_verbose("Got: %s\n", cTestResult);\
     }\
+} UPRV_BLOCK_MACRO_END
 
 #endif
 
@@ -358,7 +359,7 @@ static void TestSnprintf(void) {
 #endif
 }
 
-#define TestSPrintFormat(uFormat, uValue, cFormat, cValue) \
+#define TestSPrintFormat(uFormat, uValue, cFormat, cValue) UPRV_BLOCK_MACRO_BEGIN { \
     /* Reinitialize the buffer to verify null termination works. */\
     u_memset(uBuffer, 0x2a, UPRV_LENGTHOF(uBuffer));\
     memset(buffer, '*', UPRV_LENGTHOF(buffer));\
@@ -375,6 +376,7 @@ static void TestSnprintf(void) {
     if (buffer[uNumPrinted+1] != '*') {\
         log_err("%" uFormat " too much stored\n");\
     }\
+} UPRV_BLOCK_MACRO_END
 
 static void TestSprintfFormat(void) {
 #if !UCONFIG_NO_FORMATTING


### PR DESCRIPTION
This does the same for the ICU test code as was done for the public ICU API in PR #759.

This is in no way necessary to do, but it enables building all ICU source code with -Wextra-semi-stmt which was most helpful for testing the other changes done for ICU-20601 and it can surely be useful to prevent mistakes being made in the future, and it does make the test code consistent with the implementation code.

(The test case configuration macros in intltest.h have a rather peculiar structure, depending on being able to break out of an encompassing loop, so they can't be handled using the UPRV_BLOCK_MACRO_BEGIN / UPRV_BLOCK_MACRO_END macros.)