### PR TITLE
ICU-20783 use C++ covariant return types

### DIFF
--- a/icu4c/source/common/unicode/unifilt.h
+++ b/icu4c/source/common/unicode/unifilt.h
@@ -72,6 +72,14 @@ public:
     virtual ~UnicodeFilter();
 
     /**
+     * Clones this object polymorphically.
+     * The caller owns the result and should delete it when done.
+     * @return clone, or nullptr if an error occurred
+     * @stable ICU 2.4
+     */
+    virtual UnicodeFilter* clone() const = 0;
+
+    /**
      * Returns <tt>true</tt> for characters that are in the selected
      * subset.  In other words, if a character is <b>to be
      * filtered</b>, then <tt>contains()</tt> returns

--- a/icu4c/source/common/unisetspan.cpp
+++ b/icu4c/source/common/unisetspan.cpp
@@ -400,7 +400,7 @@ UnicodeSetStringSpan::UnicodeSetStringSpan(const UnicodeSetStringSpan &otherStri
     if(otherStringSpan.pSpanNotSet==&otherStringSpan.spanSet) {
         pSpanNotSet=&spanSet;
     } else {
-        pSpanNotSet=(UnicodeSet *)otherStringSpan.pSpanNotSet->clone();
+        pSpanNotSet=otherStringSpan.pSpanNotSet->clone();
     }
 
     // Allocate a block of meta data.
@@ -436,7 +436,7 @@ void UnicodeSetStringSpan::addToSpanNotSet(UChar32 c) {
         if(spanSet.contains(c)) {
             return;  // Nothing to do.
         }
-        UnicodeSet *newSet=(UnicodeSet *)spanSet.cloneAsThawed();
+        UnicodeSet *newSet=spanSet.cloneAsThawed();
         if(newSet==NULL) {
             return;  // Out of memory.
         } else {

--- a/icu4c/source/i18n/alphaindex.cpp
+++ b/icu4c/source/i18n/alphaindex.cpp
@@ -260,8 +260,7 @@ AlphabeticIndex::ImmutableIndex *AlphabeticIndex::buildImmutableIndex(UErrorCode
     // but that would be worth it only if this method is called multiple times,
     // or called after using the old-style bucket iterator API.
     LocalPointer<BucketList> immutableBucketList(createBucketList(errorCode));
-    LocalPointer<RuleBasedCollator> coll(
-        static_cast<RuleBasedCollator *>(collatorPrimaryOnly_->clone()));
+    LocalPointer<RuleBasedCollator> coll(collatorPrimaryOnly_->clone());
     if (immutableBucketList.isNull() || coll.isNull()) {
         errorCode = U_MEMORY_ALLOCATION_ERROR;
         return NULL;
@@ -907,7 +906,7 @@ void AlphabeticIndex::init(const Locale *locale, UErrorCode &status) {
             return;
         }
     }
-    collatorPrimaryOnly_ = static_cast<RuleBasedCollator *>(collator_->clone());
+    collatorPrimaryOnly_ = collator_->clone();
     if (collatorPrimaryOnly_ == NULL) {
         status = U_MEMORY_ALLOCATION_ERROR;
         return;

--- a/icu4c/source/i18n/calendar.cpp
+++ b/icu4c/source/i18n/calendar.cpp
@@ -2595,7 +2595,7 @@ Calendar::isWeekend(UDate date, UErrorCode &status) const
         return FALSE;
     }
     // clone the calendar so we don't mess with the real one.
-    Calendar *work = (Calendar*)this->clone();
+    Calendar *work = this->clone();
     if (work == NULL) {
         status = U_MEMORY_ALLOCATION_ERROR;
         return FALSE;
@@ -2755,7 +2755,7 @@ Calendar::getActualMinimum(UCalendarDateFields field, UErrorCode& status) const
 
     // clone the calendar so we don't mess with the real one, and set it to
     // accept anything for the field values
-    Calendar *work = (Calendar*)this->clone();
+    Calendar *work = this->clone();
     if (work == NULL) {
         status = U_MEMORY_ALLOCATION_ERROR;
         return 0;

--- a/icu4c/source/i18n/datefmt.cpp
+++ b/icu4c/source/i18n/datefmt.cpp
@@ -154,7 +154,7 @@ DateFormat& DateFormat::operator=(const DateFormat& other)
           fCalendar = NULL;
         }
         if(other.fNumberFormat) {
-          fNumberFormat = (NumberFormat*)other.fNumberFormat->clone();
+          fNumberFormat = other.fNumberFormat->clone();
         } else {
           fNumberFormat = NULL;
         }
@@ -598,7 +598,7 @@ DateFormat::adoptNumberFormat(NumberFormat* newNumberFormat)
 void
 DateFormat::setNumberFormat(const NumberFormat& newNumberFormat)
 {
-    NumberFormat* newNumFmtClone = (NumberFormat*)newNumberFormat.clone();
+    NumberFormat* newNumFmtClone = newNumberFormat.clone();
     if (newNumFmtClone != NULL) {
         adoptNumberFormat(newNumFmtClone);
     }

--- a/icu4c/source/i18n/dtitvfmt.cpp
+++ b/icu4c/source/i18n/dtitvfmt.cpp
@@ -170,7 +170,7 @@ DateIntervalFormat::operator=(const DateIntervalFormat& itvfmt) {
         {
             Mutex lock(&gFormatterMutex);
             if ( itvfmt.fDateFormat ) {
-                fDateFormat = (SimpleDateFormat*)itvfmt.fDateFormat->clone();
+                fDateFormat = itvfmt.fDateFormat->clone();
             } else {
                 fDateFormat = NULL;
             }
@@ -196,9 +196,9 @@ DateIntervalFormat::operator=(const DateIntervalFormat& itvfmt) {
             fIntervalPatterns[i] = itvfmt.fIntervalPatterns[i];
         }
         fLocale = itvfmt.fLocale;
-        fDatePattern    = (itvfmt.fDatePattern)?    (UnicodeString*)itvfmt.fDatePattern->clone(): NULL;
-        fTimePattern    = (itvfmt.fTimePattern)?    (UnicodeString*)itvfmt.fTimePattern->clone(): NULL;
-        fDateTimeFormat = (itvfmt.fDateTimeFormat)? (UnicodeString*)itvfmt.fDateTimeFormat->clone(): NULL;
+        fDatePattern    = (itvfmt.fDatePattern)?    itvfmt.fDatePattern->clone(): NULL;
+        fTimePattern    = (itvfmt.fTimePattern)?    itvfmt.fTimePattern->clone(): NULL;
+        fDateTimeFormat = (itvfmt.fDateTimeFormat)? itvfmt.fDateTimeFormat->clone(): NULL;
     }
     return *this;
 }

--- a/icu4c/source/i18n/measure.cpp
+++ b/icu4c/source/i18n/measure.cpp
@@ -43,7 +43,7 @@ Measure& Measure::operator=(const Measure& other) {
     if (this != &other) {
         delete unit;
         number = other.number;
-        unit = (MeasureUnit*) other.unit->clone();
+        unit = other.unit->clone();
     }
     return *this;
 }

--- a/icu4c/source/i18n/numfmt.cpp
+++ b/icu4c/source/i18n/numfmt.cpp
@@ -569,7 +569,7 @@ NumberFormat::format(const Formattable& obj,
     if(arg.wasCurrency() && u_strcmp(iso, getCurrency())) {
       // trying to format a different currency.
       // Right now, we clone.
-      LocalPointer<NumberFormat> cloneFmt((NumberFormat*)this->clone());
+      LocalPointer<NumberFormat> cloneFmt(this->clone());
       cloneFmt->setCurrency(iso, status);
       // next line should NOT recurse, because n is numeric whereas obj was a wrapper around currency amount.
       return cloneFmt->format(*n, appendTo, pos, status);
@@ -624,7 +624,7 @@ NumberFormat::format(const Formattable& obj,
     if(arg.wasCurrency() && u_strcmp(iso, getCurrency())) {
       // trying to format a different currency.
       // Right now, we clone.
-      LocalPointer<NumberFormat> cloneFmt((NumberFormat*)this->clone());
+      LocalPointer<NumberFormat> cloneFmt(this->clone());
       cloneFmt->setCurrency(iso, status);
       // next line should NOT recurse, because n is numeric whereas obj was a wrapper around currency amount.
       return cloneFmt->format(*n, appendTo, posIter, status);
@@ -1059,7 +1059,7 @@ NumberFormat::createInstance(const Locale& loc, UNumberFormatStyle kind, UErrorC
     if (U_FAILURE(status)) {
         return NULL;
     }
-    NumberFormat *result = static_cast<NumberFormat *>((*shared)->clone());
+    NumberFormat *result = (*shared)->clone();
     shared->removeRef();
     if (result == NULL) {
         status = U_MEMORY_ALLOCATION_ERROR;

--- a/icu4c/source/i18n/olsontz.cpp
+++ b/icu4c/source/i18n/olsontz.cpp
@@ -287,8 +287,7 @@ OlsonTimeZone& OlsonTimeZone::operator=(const OlsonTimeZone& other) {
     typeMapData = other.typeMapData;
 
     delete finalZone;
-    finalZone = (other.finalZone != 0) ?
-        (SimpleTimeZone*) other.finalZone->clone() : 0;
+    finalZone = (other.finalZone != 0) ? other.finalZone->clone() : 0;
 
     finalStartYear = other.finalStartYear;
     finalStartMillis = other.finalStartMillis;
@@ -816,7 +815,7 @@ OlsonTimeZone::initTransitionRules(UErrorCode& status) {
              * For now, we do not set the valid start year when the construction time
              * and create a clone and set the start year when extracting rules.
              */
-            finalZoneWithStartYear = (SimpleTimeZone*)finalZone->clone();
+            finalZoneWithStartYear = finalZone->clone();
             // Check to make sure finalZone was actually cloned.
             if (finalZoneWithStartYear == NULL) {
                 status = U_MEMORY_ALLOCATION_ERROR;
@@ -837,7 +836,7 @@ OlsonTimeZone::initTransitionRules(UErrorCode& status) {
             startTime = tzt.getTime();
         } else {
             // final rule with no transitions
-            finalZoneWithStartYear = (SimpleTimeZone*)finalZone->clone();
+            finalZoneWithStartYear = finalZone->clone();
             // Check to make sure finalZone was actually cloned.
             if (finalZoneWithStartYear == NULL) {
                 status = U_MEMORY_ALLOCATION_ERROR;

--- a/icu4c/source/i18n/plurfmt.cpp
+++ b/icu4c/source/i18n/plurfmt.cpp
@@ -159,7 +159,7 @@ PluralFormat::copyObjects(const PluralFormat& other) {
     if (other.numberFormat == NULL) {
         numberFormat = NumberFormat::createInstance(locale, status);
     } else {
-        numberFormat = (NumberFormat*)other.numberFormat->clone();
+        numberFormat = other.numberFormat->clone();
     }
     if (other.pluralRulesWrapper.pluralRules == NULL) {
         pluralRulesWrapper.pluralRules = PluralRules::forLocale(locale, status);
@@ -353,7 +353,7 @@ PluralFormat::setNumberFormat(const NumberFormat* format, UErrorCode& status) {
     if (U_FAILURE(status)) {
         return;
     }
-    NumberFormat* nf = (NumberFormat*)format->clone();
+    NumberFormat* nf = format->clone();
     if (nf != NULL) {
         delete numberFormat;
         numberFormat = nf;

--- a/icu4c/source/i18n/rbt_pars.cpp
+++ b/icu4c/source/i18n/rbt_pars.cpp
@@ -1111,7 +1111,7 @@ void TransliteratorParser::parseRules(const UnicodeString& rule,
             int32_t p = UHASH_FIRST;
             const UHashElement* he = variableNames.nextElement(p);
             while (he != NULL) {
-                UnicodeString* tempus = (UnicodeString*)(((UnicodeString*)(he->value.pointer))->clone());
+                UnicodeString* tempus = ((UnicodeString*)(he->value.pointer))->clone();
                 if (tempus == NULL) {
                     status = U_MEMORY_ALLOCATION_ERROR;
                     return;

--- a/icu4c/source/i18n/rbt_rule.cpp
+++ b/icu4c/source/i18n/rbt_rule.cpp
@@ -180,13 +180,13 @@ TransliterationRule::TransliterationRule(TransliterationRule& other) :
     }
 
     if (other.anteContext != NULL) {
-        anteContext = (StringMatcher*) other.anteContext->clone();
+        anteContext = other.anteContext->clone();
     }
     if (other.key != NULL) {
-        key = (StringMatcher*) other.key->clone();
+        key = other.key->clone();
     }
     if (other.postContext != NULL) {
-        postContext = (StringMatcher*) other.postContext->clone();
+        postContext = other.postContext->clone();
     }
     output = other.output->clone();
 }

--- a/icu4c/source/i18n/reldtfmt.cpp
+++ b/icu4c/source/i18n/reldtfmt.cpp
@@ -51,7 +51,7 @@ RelativeDateFormat::RelativeDateFormat(const RelativeDateFormat& other) :
  fCapitalizationBrkIter(NULL)
 {
     if(other.fDateTimeFormatter != NULL) {
-        fDateTimeFormatter = (SimpleDateFormat*)other.fDateTimeFormatter->clone();
+        fDateTimeFormatter = other.fDateTimeFormatter->clone();
     }
     if(other.fCombinedFormat != NULL) {
         fCombinedFormat = new SimpleFormatter(*other.fCombinedFormat);

--- a/icu4c/source/i18n/remtrans.cpp
+++ b/icu4c/source/i18n/remtrans.cpp
@@ -51,7 +51,7 @@ RemoveTransliterator::~RemoveTransliterator() {}
 RemoveTransliterator* RemoveTransliterator::clone() const {
     RemoveTransliterator* result = new RemoveTransliterator();
     if (result != NULL && getFilter() != 0) {
-        result->adoptFilter((UnicodeFilter*)(getFilter()->clone()));
+        result->adoptFilter(getFilter()->clone());
     }
     return result;
 }

--- a/icu4c/source/i18n/smpdtfmt.cpp
+++ b/icu4c/source/i18n/smpdtfmt.cpp
@@ -2108,7 +2108,7 @@ SimpleDateFormat::zeroPaddingNumber(
     // Fall back to slow path (clone and mutate the NumberFormat)
     if (currentNumberFormat != nullptr) {
         FieldPosition pos(FieldPosition::DONT_CARE);
-        LocalPointer<NumberFormat> nf(dynamic_cast<NumberFormat*>(currentNumberFormat->clone()));
+        LocalPointer<NumberFormat> nf(currentNumberFormat->clone());
         nf->setMinimumIntegerDigits(minDigits);
         nf->setMaximumIntegerDigits(maxDigits);
         nf->format(value, appendTo, pos);  // 3rd arg is there to speed up processing
@@ -3771,7 +3771,7 @@ void SimpleDateFormat::parseInt(const UnicodeString& text,
     auto* fmtAsDF = dynamic_cast<const DecimalFormat*>(fmt);
     LocalPointer<DecimalFormat> df;
     if (!allowNegative && fmtAsDF != nullptr) {
-        df.adoptInstead(dynamic_cast<DecimalFormat*>(fmtAsDF->clone()));
+        df.adoptInstead(fmtAsDF->clone());
         if (df.isNull()) {
             // Memory allocation error
             return;

--- a/icu4c/source/i18n/tmutfmt.cpp
+++ b/icu4c/source/i18n/tmutfmt.cpp
@@ -685,7 +685,7 @@ TimeUnitFormat::setNumberFormat(const NumberFormat& format, UErrorCode& status){
     if (U_FAILURE(status)) {
         return;
     }
-    adoptNumberFormat((NumberFormat *)format.clone(), status);
+    adoptNumberFormat(format.clone(), status);
 }
 
 
@@ -721,8 +721,8 @@ TimeUnitFormat::copyHash(const Hashtable* source, Hashtable* target, UErrorCode&
             const UHashTok valueTok = element->value;
             const MessageFormat** value = (const MessageFormat**)valueTok.pointer;
             MessageFormat** newVal = (MessageFormat**)uprv_malloc(UTMUTFMT_FORMAT_STYLE_COUNT*sizeof(MessageFormat*));
-            newVal[0] = (MessageFormat*)value[0]->clone();
-            newVal[1] = (MessageFormat*)value[1]->clone();
+            newVal[0] = value[0]->clone();
+            newVal[1] = value[1]->clone();
             target->put(UnicodeString(*key), newVal, status);
             if ( U_FAILURE(status) ) {
                 delete newVal[0];

--- a/icu4c/source/i18n/translit.cpp
+++ b/icu4c/source/i18n/translit.cpp
@@ -158,7 +158,7 @@ Transliterator::Transliterator(const Transliterator& other) :
 
     if (other.filter != 0) {
         // We own the filter, so we must have our own copy
-        filter = (UnicodeFilter*) other.filter->clone();
+        filter = other.filter->clone();
     }
 }
 
@@ -175,7 +175,7 @@ Transliterator& Transliterator::operator=(const Transliterator& other) {
     ID.getTerminatedBuffer();
 
     maximumContextLength = other.maximumContextLength;
-    adoptFilter((other.filter == 0) ? 0 : (UnicodeFilter*) other.filter->clone());
+    adoptFilter((other.filter == 0) ? 0 : other.filter->clone());
     return *this;
 }
 

--- a/icu4c/source/i18n/transreg.cpp
+++ b/icu4c/source/i18n/transreg.cpp
@@ -131,7 +131,7 @@ Transliterator* TransliteratorAlias::create(UParseError& pe,
             return 0;
         }
         if (compoundFilter != 0)
-            t->adoptFilter((UnicodeSet*)compoundFilter->clone());
+            t->adoptFilter(compoundFilter->clone());
         break;
     case COMPOUND:
         {
@@ -173,8 +173,8 @@ Transliterator* TransliteratorAlias::create(UParseError& pe,
 
             if (U_SUCCESS(ec)) {
                 t = new CompoundTransliterator(ID, transliterators,
-                    (compoundFilter ? (UnicodeSet*)(compoundFilter->clone()) : 0),
-                    anonymousRBTs, pe, ec);
+                        (compoundFilter ? compoundFilter->clone() : nullptr),
+                        anonymousRBTs, pe, ec);
                 if (t == 0) {
                     ec = U_MEMORY_ALLOCATION_ERROR;
                     return 0;
@@ -946,7 +946,7 @@ void TransliteratorRegistry::registerEntry(const UnicodeString& ID,
     if (visible) {
         registerSTV(source, target, variant);
         if (!availableIDs.contains((void*) &ID)) {
-            UnicodeString *newID = (UnicodeString *)ID.clone();
+            UnicodeString *newID = ID.clone();
             // Check to make sure newID was created.
             if (newID != NULL) {
                 // NUL-terminate the ID string

--- a/icu4c/source/i18n/unicode/basictz.h
+++ b/icu4c/source/i18n/unicode/basictz.h
@@ -44,6 +44,14 @@ public:
     virtual ~BasicTimeZone();
 
     /**
+     * Clones this object polymorphically.
+     * The caller owns the result and should delete it when done.
+     * @return clone, or nullptr if an error occurred
+     * @stable ICU 3.8
+     */
+    virtual BasicTimeZone* clone() const = 0;
+
+    /**
      * Gets the first time zone transition after the base time.
      * @param base      The base time.
      * @param inclusive Whether the base time is inclusive or not.

--- a/icu4c/source/i18n/unicode/datefmt.h
+++ b/icu4c/source/i18n/unicode/datefmt.h
@@ -224,6 +224,14 @@ public:
     virtual ~DateFormat();
 
     /**
+     * Clones this object polymorphically.
+     * The caller owns the result and should delete it when done.
+     * @return clone, or nullptr if an error occurred
+     * @stable ICU 2.0
+     */
+    virtual DateFormat* clone() const = 0;
+
+    /**
      * Equality operator.  Returns true if the two formats have the same behavior.
      * @stable ICU 2.0
      */

--- a/icu4c/source/i18n/unicode/numfmt.h
+++ b/icu4c/source/i18n/unicode/numfmt.h
@@ -263,6 +263,14 @@ public:
     virtual ~NumberFormat();
 
     /**
+     * Clones this object polymorphically.
+     * The caller owns the result and should delete it when done.
+     * @return clone, or nullptr if an error occurred
+     * @stable ICU 2.0
+     */
+    virtual NumberFormat* clone() const = 0;
+
+    /**
      * Return true if the given Format objects are semantically equal.
      * Objects of different subclasses are considered unequal.
      * @return    true if the given Format objects are semantically equal.

--- a/icu4c/source/i18n/uspoof.cpp
+++ b/icu4c/source/i18n/uspoof.cpp
@@ -349,7 +349,7 @@ uspoof_setAllowedUnicodeSet(USpoofChecker *sc, const UnicodeSet *chars, UErrorCo
         *status = U_ILLEGAL_ARGUMENT_ERROR;
         return;
     }
-    UnicodeSet *clonedSet = static_cast<UnicodeSet *>(chars->clone());
+    UnicodeSet *clonedSet = chars->clone();
     if (clonedSet == NULL || clonedSet->isBogus()) {
         *status = U_MEMORY_ALLOCATION_ERROR;
         return;

--- a/icu4c/source/i18n/uspoof_impl.cpp
+++ b/icu4c/source/i18n/uspoof_impl.cpp
@@ -82,7 +82,7 @@ SpoofImpl::SpoofImpl(const SpoofImpl &src, UErrorCode &status)  :
     if (src.fSpoofData != NULL) {
         fSpoofData = src.fSpoofData->addReference();
     }
-    fAllowedCharsSet = static_cast<const UnicodeSet *>(src.fAllowedCharsSet->clone());
+    fAllowedCharsSet = src.fAllowedCharsSet->clone();
     fAllowedLocales = uprv_strdup(src.fAllowedLocales);
     if (fAllowedCharsSet == NULL || fAllowedLocales == NULL) {
         status = U_MEMORY_ALLOCATION_ERROR;
@@ -193,7 +193,7 @@ void SpoofImpl::setAllowedLocales(const char *localesList, UErrorCode &status) {
     }
 
     // Store the updated spoof checker state.
-    tmpSet = static_cast<UnicodeSet *>(allowedChars.clone());
+    tmpSet = allowedChars.clone();
     const char *tmpLocalesList = uprv_strdup(localesList);
     if (tmpSet == NULL || tmpLocalesList == NULL) {
         status = U_MEMORY_ALLOCATION_ERROR;

--- a/icu4c/source/i18n/vtzone.cpp
+++ b/icu4c/source/i18n/vtzone.cpp
@@ -965,7 +965,7 @@ VTimeZone::VTimeZone(const VTimeZone& source)
     tzurl(source.tzurl), lastmod(source.lastmod),
     olsonzid(source.olsonzid), icutzver(source.icutzver) {
     if (source.tz != NULL) {
-        tz = (BasicTimeZone*)source.tz->clone();
+        tz = source.tz->clone();
     }
     if (source.vtzlines != NULL) {
         UErrorCode status = U_ZERO_ERROR;
@@ -1007,7 +1007,7 @@ VTimeZone::operator=(const VTimeZone& right) {
             tz = NULL;
         }
         if (right.tz != NULL) {
-            tz = (BasicTimeZone*)right.tz->clone();
+            tz = right.tz->clone();
         }
         if (vtzlines != NULL) {
             delete vtzlines;
@@ -1092,7 +1092,7 @@ VTimeZone::createVTimeZoneFromBasicTimeZone(const BasicTimeZone& basic_time_zone
         status = U_MEMORY_ALLOCATION_ERROR;
         return NULL;
     }
-    vtz->tz = (BasicTimeZone *)basic_time_zone.clone();
+    vtz->tz = basic_time_zone.clone();
     if (vtz->tz == NULL) {
         status = U_MEMORY_ALLOCATION_ERROR;
         delete vtz;
@@ -1957,7 +1957,7 @@ VTimeZone::writeZone(VTZWriter& w, BasicTimeZone& basictz,
                 && (atzrule = dynamic_cast<const AnnualTimeZoneRule *>(tzt.getTo())) != NULL
                 && atzrule->getEndYear() == AnnualTimeZoneRule::MAX_YEAR
             ) {
-                finalDstRule = (AnnualTimeZoneRule*)tzt.getTo()->clone();
+                finalDstRule = atzrule->clone();
             }
             if (dstCount > 0) {
                 if (year == dstStartYear + dstCount
@@ -2008,7 +2008,7 @@ VTimeZone::writeZone(VTZWriter& w, BasicTimeZone& basictz,
                 && (atzrule = dynamic_cast<const AnnualTimeZoneRule *>(tzt.getTo())) != NULL
                 && atzrule->getEndYear() == AnnualTimeZoneRule::MAX_YEAR
             ) {
-                finalStdRule = (AnnualTimeZoneRule*)tzt.getTo()->clone();
+                finalStdRule = atzrule->clone();
             }
             if (stdCount > 0) {
                 if (year == stdStartYear + stdCount

--- a/icu4c/source/samples/citer/citer.cpp
+++ b/icu4c/source/samples/citer/citer.cpp
@@ -59,7 +59,7 @@ void Test::TestUChariter() {
     const UChar *testText = testString.getTerminatedBuffer();
 
     UCharCharacterIterator iter(testText, u_strlen(testText));
-    UCharCharacterIterator* test2 = (UCharCharacterIterator*)iter.clone();
+    UCharCharacterIterator* test2 = iter.clone();
 
     u_fprintf(out, "testText = %s", testChars);
 
@@ -126,7 +126,7 @@ void Test::TestStringiter() {
     const UChar *testText    = testString.getTerminatedBuffer();
 
     StringCharacterIterator iter(testText, u_strlen(testText));
-    StringCharacterIterator* test2 = (StringCharacterIterator*)iter.clone();
+    StringCharacterIterator* test2 = iter.clone();
 
     if (iter != *test2 ) {
         u_fprintf(out, "clone() or equals() failed: Two clones tested unequal\n");

--- a/icu4c/source/test/intltest/apicoll.cpp
+++ b/icu4c/source/test/intltest/apicoll.cpp
@@ -2345,7 +2345,7 @@ void CollationAPITest::TestClone() {
     dump("c1", c1, status);
     
     logln("\ninit c2");
-    RuleBasedCollator* c2 = (RuleBasedCollator*)c1->clone();
+    RuleBasedCollator* c2 = c1->clone();
     val = c2->getAttribute(UCOL_CASE_FIRST, status);
     if(val == UCOL_LOWER_FIRST){
         c2->setAttribute(UCOL_CASE_FIRST, UCOL_UPPER_FIRST, status);

--- a/icu4c/source/test/intltest/calregts.cpp
+++ b/icu4c/source/test/intltest/calregts.cpp
@@ -193,7 +193,7 @@ CalendarRegressionTest::test4028518()
       return;
     }
     failure(status, "new GregorianCalendar");
-    GregorianCalendar *cal2 = (GregorianCalendar*) cal1->clone() ;
+    GregorianCalendar *cal2 = cal1->clone() ;
 
     printdate(cal1, "cal1: ") ;
     printdate(cal2, "cal2 - cloned(): ") ;
@@ -1521,7 +1521,7 @@ void CalendarRegressionTest::test4141665()
       delete cal;
       return;
     }
-    GregorianCalendar *cal2 = (GregorianCalendar*)cal->clone();
+    GregorianCalendar *cal2 = cal->clone();
     UDate cut = cal->getGregorianChange();
     UDate cut2 = cut + 100*24*60*60*1000.0; // 100 days later
     if (*cal != *cal2) {
@@ -1937,7 +1937,7 @@ CalendarRegressionTest::Test4167060()
 
             if(U_FAILURE(status))
                 errln("setGregorianChange() failed");
-            format->adoptCalendar((Calendar*)calendar->clone());
+            format->adoptCalendar(calendar->clone());
 
             UDate dateBefore = calendar->getTime(status);
             if(U_FAILURE(status))

--- a/icu4c/source/test/intltest/caltest.cpp
+++ b/icu4c/source/test/intltest/caltest.cpp
@@ -750,7 +750,7 @@ CalendarTest::TestClonesUnique908()
     UErrorCode status = U_ZERO_ERROR;
     Calendar *c = Calendar::createInstance(status);
     if (failure(status, "Calendar::createInstance", TRUE)) return;
-    Calendar *d = (Calendar*) c->clone();
+    Calendar *d = c->clone();
     c->set(UCAL_MILLISECOND, 123);
     d->set(UCAL_MILLISECOND, 456);
     if (c->get(UCAL_MILLISECOND, status) != 123 ||
@@ -1732,7 +1732,7 @@ void
 CalendarTest::marchByDelta(Calendar* cal, int32_t delta)
 {
     UErrorCode status = U_ZERO_ERROR;
-    Calendar *cur = (Calendar*) cal->clone();
+    Calendar *cur = cal->clone();
     int32_t initialDOW = cur->get(UCAL_DAY_OF_WEEK, status);
     if (U_FAILURE(status)) { errln("Calendar::get failed"); return; }
     int32_t DOW, newDOW = initialDOW;

--- a/icu4c/source/test/intltest/citrtest.cpp
+++ b/icu4c/source/test/intltest/citrtest.cpp
@@ -198,7 +198,7 @@ void CharIterTest::TestConstructionAndEquality() {
     UnicodeString  testText2("Don't bother using this string.");
     UnicodeString result1, result2, result3;
 
-    CharacterIterator* test1 = new StringCharacterIterator(testText);
+    StringCharacterIterator* test1 = new StringCharacterIterator(testText);
     CharacterIterator* test1b= new StringCharacterIterator(testText, -1);
     CharacterIterator* test1c= new StringCharacterIterator(testText, 100);
     CharacterIterator* test1d= new StringCharacterIterator(testText, -2, 100, 5);
@@ -257,7 +257,7 @@ void CharIterTest::TestConstructionAndEquality() {
    
     StringCharacterIterator* testChar1=new StringCharacterIterator(testText);
     StringCharacterIterator* testChar2=new StringCharacterIterator(testText2);
-    StringCharacterIterator* testChar3=(StringCharacterIterator*)test1->clone();
+    StringCharacterIterator* testChar3=test1->clone();
 
     testChar1->getText(result1);
     testChar2->getText(result2);
@@ -292,7 +292,7 @@ void CharIterTest::TestConstructionAndEqualityUChariter() {
     UCharCharacterIterator* test2 = new UCharCharacterIterator(testText, u_strlen(testText), 5);
     UCharCharacterIterator* test3 = new UCharCharacterIterator(testText, u_strlen(testText), 2, 20, 5);
     UCharCharacterIterator* test4 = new UCharCharacterIterator(testText2, u_strlen(testText2));
-    UCharCharacterIterator* test5 = (UCharCharacterIterator*)test1->clone();
+    UCharCharacterIterator* test5 = test1->clone();
     UCharCharacterIterator* test6 = new UCharCharacterIterator(*test1);
 
     // j785: length=-1 will use u_strlen()

--- a/icu4c/source/test/intltest/cpdtrtst.cpp
+++ b/icu4c/source/test/intltest/cpdtrtst.cpp
@@ -159,10 +159,10 @@ void CompoundTransliteratorTest::TestCloneEqual(){
         errln("Error: =operator or copy constructor failed");
     }
 
-    CompoundTransliterator *clonect1a=(CompoundTransliterator*)ct1->clone();
-    CompoundTransliterator *clonect1b=(CompoundTransliterator*)equalct1.clone();
-    CompoundTransliterator *clonect2a=(CompoundTransliterator*)ct2->clone();
-    CompoundTransliterator *clonect2b=(CompoundTransliterator*)copyct2->clone();
+    CompoundTransliterator *clonect1a=ct1->clone();
+    CompoundTransliterator *clonect1b=equalct1.clone();
+    CompoundTransliterator *clonect2a=ct2->clone();
+    CompoundTransliterator *clonect2b=copyct2->clone();
 
 
     if(clonect1a->getID()  != ct1->getID()       || clonect1a->getCount() != ct1->getCount()        ||

--- a/icu4c/source/test/intltest/dtfmapts.cpp
+++ b/icu4c/source/test/intltest/dtfmapts.cpp
@@ -235,7 +235,7 @@ if (fr != NULL && it != NULL && de != NULL)
     }
 
     const NumberFormat *nf = def->getNumberFormat();
-    NumberFormat *newNf = (NumberFormat*) nf->clone();
+    NumberFormat *newNf = nf->clone();
     de->adoptNumberFormat(newNf);   
     it->setNumberFormat(*newNf);
     if( *(de->getNumberFormat()) != *(it->getNumberFormat())) {

--- a/icu4c/source/test/intltest/dtifmtts.cpp
+++ b/icu4c/source/test/intltest/dtifmtts.cpp
@@ -132,7 +132,7 @@ void DateIntervalFormatTest::testAPI() {
     status = U_ZERO_ERROR;
     logln("Testing DateIntervalFormat clone");
 
-    DateIntervalFormat* another = (DateIntervalFormat*)dtitvfmt->clone();
+    DateIntervalFormat* another = dtitvfmt->clone();
     if ( (*another) != (*dtitvfmt) ) {
         dataerrln("%s:%d ERROR: clone failed", __FILE__, __LINE__);
     }
@@ -224,7 +224,7 @@ void DateIntervalFormatTest::testAPI() {
     }
 
     status = U_ZERO_ERROR;
-    DateFormat* nonConstFmt = (DateFormat*)fmt->clone();
+    DateFormat* nonConstFmt = fmt->clone();
     dtitvfmt->adoptDateFormat(nonConstFmt, status);
     anotherFmt = dtitvfmt->getDateFormat();
     if ( (*fmt) != (*anotherFmt) || U_FAILURE(status) ) {
@@ -250,7 +250,7 @@ void DateIntervalFormatTest::testAPI() {
     logln("Testing DateIntervalFormat constructor and assigment operator");
     status = U_ZERO_ERROR;
 
-    DateFormat* constFmt = (constFmt*)dtitvfmt->getDateFormat()->clone();
+    DateFormat* constFmt = dtitvfmt->getDateFormat()->clone();
     inf = dtitvfmt->getDateIntervalInfo()->clone();
 
 
@@ -1483,7 +1483,7 @@ void DateIntervalFormatTest::stress(const char** data, int32_t data_length,
                 GregorianCalendar* gregCal = new GregorianCalendar(loc, ec);
                 if (!assertSuccess("GregorianCalendar()", ec)) return;
                 const DateFormat* dformat = dtitvfmt->getDateFormat();
-                DateFormat* newOne = (DateFormat*)dformat->clone();
+                DateFormat* newOne = dformat->clone();
                 newOne->adoptCalendar(gregCal);
                 //dtitvfmt->adoptDateFormat(newOne, ec);
                 dtitvfmt->setDateFormat(*newOne, ec);
@@ -1640,7 +1640,7 @@ void DateIntervalFormatTest::testTicket12065() {
         dataerrln("FAIL: DateIntervalFormat::createInstance failed for Locale::getEnglish()");
         return;
     }
-    LocalPointer<DateIntervalFormat> clone(dynamic_cast<DateIntervalFormat *>(formatter->clone()));
+    LocalPointer<DateIntervalFormat> clone(formatter->clone());
     if (*formatter != *clone) {
         errln("%s:%d DateIntervalFormat and clone are not equal.", __FILE__, __LINE__);
         return;

--- a/icu4c/source/test/intltest/itrbnf.cpp
+++ b/icu4c/source/test/intltest/itrbnf.cpp
@@ -166,7 +166,7 @@ IntlTestRBNF::TestAPI() {
   // test clone
   {
     logln("Testing Clone");
-    RuleBasedNumberFormat* rbnfClone = (RuleBasedNumberFormat *)formatter->clone();
+    RuleBasedNumberFormat* rbnfClone = formatter->clone();
     if(rbnfClone != NULL) {
       if(!(*rbnfClone == *formatter)) {
         errln("Clone should be semantically equivalent to the original!");

--- a/icu4c/source/test/intltest/measfmttest.cpp
+++ b/icu4c/source/test/intltest/measfmttest.cpp
@@ -1543,7 +1543,7 @@ void MeasureFormatTest::TestBasic() {
     if (!(*ptr1 != *ptr3)) {
         errln("Expect != to work.");
     }
-    MeasureUnit *ptr4 = (MeasureUnit *) ptr1->clone();
+    MeasureUnit *ptr4 = ptr1->clone();
     if (*ptr1 != *ptr4) {
         errln("Expect clone to work.");
     }
@@ -1874,7 +1874,7 @@ void MeasureFormatTest::TestFormatPeriodEn() {
         return;
     }
     nf->setMaximumFractionDigits(4);
-    MeasureFormat mf(en, UMEASFMT_WIDTH_WIDE, (NumberFormat *) nf->clone(), status);
+    MeasureFormat mf(en, UMEASFMT_WIDTH_WIDE, nf->clone(), status);
     if (!assertSuccess("Error creating measure format en WIDE", status)) {
         return;
     }
@@ -1887,21 +1887,21 @@ void MeasureFormatTest::TestFormatPeriodEn() {
     }
     // exercise clone
     {
-        MeasureFormat *mf3 = (MeasureFormat *) mf.clone();
+        MeasureFormat *mf3 = mf.clone();
         verifyFormat("en WIDE copy", *mf3, fullData, UPRV_LENGTHOF(fullData));
         delete mf3;
     }
-    mf = MeasureFormat(en, UMEASFMT_WIDTH_SHORT, (NumberFormat *) nf->clone(), status);
+    mf = MeasureFormat(en, UMEASFMT_WIDTH_SHORT, nf->clone(), status);
     if (!assertSuccess("Error creating measure format en SHORT", status)) {
         return;
     }
     verifyFormat("en SHORT", mf, abbrevData, UPRV_LENGTHOF(abbrevData));
-    mf = MeasureFormat(en, UMEASFMT_WIDTH_NARROW, (NumberFormat *) nf->clone(), status);
+    mf = MeasureFormat(en, UMEASFMT_WIDTH_NARROW, nf->clone(), status);
     if (!assertSuccess("Error creating measure format en NARROW", status)) {
         return;
     }
     verifyFormat("en NARROW", mf, narrowData, UPRV_LENGTHOF(narrowData));
-    mf = MeasureFormat(en, UMEASFMT_WIDTH_NUMERIC, (NumberFormat *) nf->clone(), status);
+    mf = MeasureFormat(en, UMEASFMT_WIDTH_NUMERIC, nf->clone(), status);
     if (!assertSuccess("Error creating measure format en NUMERIC", status)) {
         return;
     }
@@ -1913,12 +1913,12 @@ void MeasureFormatTest::TestFormatPeriodEn() {
         return;
     }
     nf->setMaximumFractionDigits(4);
-    mf = MeasureFormat(de, UMEASFMT_WIDTH_WIDE, (NumberFormat *) nf->clone(), status);
+    mf = MeasureFormat(de, UMEASFMT_WIDTH_WIDE, nf->clone(), status);
     if (!assertSuccess("Error creating measure format de WIDE", status)) {
         return;
     }
     verifyFormat("de WIDE", mf, fullDataDe, UPRV_LENGTHOF(fullDataDe));
-    mf = MeasureFormat(de, UMEASFMT_WIDTH_NUMERIC, (NumberFormat *) nf->clone(), status);
+    mf = MeasureFormat(de, UMEASFMT_WIDTH_NUMERIC, nf->clone(), status);
     if (!assertSuccess("Error creating measure format de NUMERIC", status)) {
         return;
     }
@@ -1930,7 +1930,7 @@ void MeasureFormatTest::TestFormatPeriodEn() {
         return;
     }
     nf->setMaximumFractionDigits(4);
-    mf = MeasureFormat(bengali, UMEASFMT_WIDTH_NUMERIC, (NumberFormat *) nf->clone(), status);
+    mf = MeasureFormat(bengali, UMEASFMT_WIDTH_NUMERIC, nf->clone(), status);
     if (!assertSuccess("Error creating measure format bn NUMERIC", status)) {
         return;
     }
@@ -1942,7 +1942,7 @@ void MeasureFormatTest::TestFormatPeriodEn() {
         return;
     }
     nf->setMaximumFractionDigits(4);
-    mf = MeasureFormat(bengaliLatin, UMEASFMT_WIDTH_NUMERIC, (NumberFormat *) nf->clone(), status);
+    mf = MeasureFormat(bengaliLatin, UMEASFMT_WIDTH_NUMERIC, nf->clone(), status);
     if (!assertSuccess("Error creating measure format bn-u-nu-latn NUMERIC", status)) {
         return;
     }
@@ -2248,7 +2248,7 @@ void MeasureFormatTest::helperTestSimplePer(
     if (!assertSuccess("Error creating format object", status)) {
         return;
     }
-    Measure measure(value, (MeasureUnit *) unit.clone(), status);
+    Measure measure(value, unit.clone(), status);
     if (!assertSuccess("Error creating measure object", status)) {
         return;
     }

--- a/icu4c/source/test/intltest/nmfmapts.cpp
+++ b/icu4c/source/test/intltest/nmfmapts.cpp
@@ -274,7 +274,7 @@ public:
     virtual NumberFormat* createFormat(const Locale& /* loc */, UNumberFormatStyle formatType)
     {
         if (formatType == UNUM_CURRENCY) {
-            return (NumberFormat*)currencyStyle->clone();
+            return currencyStyle->clone();
         }
         return NULL;
     }

--- a/icu4c/source/test/intltest/numfmtst.cpp
+++ b/icu4c/source/test/intltest/numfmtst.cpp
@@ -321,7 +321,7 @@ public:
         static char classID = 0;
         return (UClassID)&classID;
     }
-    virtual Format* clone() const {return NULL;}
+    virtual StubNumberFormat* clone() const {return NULL;}
 };
 
 void
@@ -2224,7 +2224,7 @@ void NumberFormatTest::TestCurrencyUnit(void){
         errln("CurrencyUnit copy constructed object should be same");
     }
 
-    CurrencyUnit * cu3 = (CurrencyUnit *)cu.clone();
+    CurrencyUnit * cu3 = cu.clone();
     if (!(*cu3 == cu)){
         errln("CurrencyUnit cloned object should be same");
     }
@@ -2292,7 +2292,7 @@ void NumberFormatTest::TestCurrencyAmount(void){
         errln("CurrencyAmount assigned object should be same");
     }
 
-    CurrencyAmount *ca3 = (CurrencyAmount *)ca.clone();
+    CurrencyAmount *ca3 = ca.clone();
     if (!(*ca3 == ca)){
         errln("CurrencyAmount cloned object should be same");
     }
@@ -3183,7 +3183,7 @@ void NumberFormatTest::TestCurrencyFormat()
         dataerrln("FAIL: Status %s", u_errorName(status));
         return;
     }
-    cloneObj = (MeasureFormat *)measureObj->clone();
+    cloneObj = measureObj->clone();
     if (cloneObj == NULL) {
         errln("Clone doesn't work");
         return;
@@ -3493,7 +3493,7 @@ void NumberFormatTest::TestNumberingSystems() {
             continue;
         }
         // Clone to test ticket #10682
-        NumberFormat *fmt = (NumberFormat *) origFmt->clone();
+        NumberFormat *fmt = origFmt->clone();
         delete origFmt;
 
 
@@ -8088,7 +8088,7 @@ void NumberFormatTest::TestEquality() {
     	return;
     }
 
-    DecimalFormat* fmtClone = (DecimalFormat*)fmtBase.clone();
+    DecimalFormat* fmtClone = fmtBase.clone();
     fmtClone->setFormatWidth(fmtBase.getFormatWidth() + 32);
     if (*fmtClone == fmtBase) {
         errln("Error: DecimalFormat == does not distinguish objects that differ only in FormatWidth");

--- a/icu4c/source/test/intltest/numrgts.cpp
+++ b/icu4c/source/test/intltest/numrgts.cpp
@@ -78,7 +78,7 @@ public:
     {
         NumberFormat::parse(text, result, status);
     }
-    virtual Format* clone() const 
+    virtual MyNumberFormatTest* clone() const 
     { return NULL; }
 
     virtual UnicodeString& format(int32_t, 

--- a/icu4c/source/test/intltest/plurfmts.cpp
+++ b/icu4c/source/test/intltest/plurfmts.cpp
@@ -124,7 +124,7 @@ void PluralFormatTest::pluralFormatBasicTest(/*char *par*/)
     }
 
     if ( U_SUCCESS(status[1]) ) {
-        plFmt[2] = (PluralFormat*) plFmt[1]->clone();
+        plFmt[2] = plFmt[1]->clone();
 
         if (plFmt[1]!=NULL) {
             if ( *plFmt[1] != *plFmt[2] ) {

--- a/icu4c/source/test/intltest/rbbiapts.cpp
+++ b/icu4c/source/test/intltest/rbbiapts.cpp
@@ -132,8 +132,8 @@ void RBBIAPITest::TestCloneEquals()
 
 
     logln((UnicodeString)"Testing clone()");
-    RuleBasedBreakIterator* bi1clone = dynamic_cast<RuleBasedBreakIterator *>(bi1->clone());
-    RuleBasedBreakIterator* bi2clone = dynamic_cast<RuleBasedBreakIterator *>(bi2->clone());
+    RuleBasedBreakIterator* bi1clone = bi1->clone();
+    RuleBasedBreakIterator* bi2clone = bi2->clone();
 
     if(*bi1clone != *bi1 || *bi1clone  != *biequal  ||
       *bi1clone == *bi3 || *bi1clone == *bi2)
@@ -203,7 +203,7 @@ void RBBIAPITest::TestgetRules()
     UnicodeString text(u"Hello there");
     bi1->setText(text);
 
-    LocalPointer <RuleBasedBreakIterator> bi3((RuleBasedBreakIterator*)bi1->clone());
+    LocalPointer <RuleBasedBreakIterator> bi3(bi1->clone());
 
     UnicodeString temp=bi1->getRules();
     UnicodeString temp2=bi2->getRules();
@@ -238,8 +238,8 @@ void RBBIAPITest::TestHashCode()
     bi2->setText((UnicodeString)"Hash code");
     bi3->setText((UnicodeString)"Hash code");
 
-    RuleBasedBreakIterator* bi1clone= (RuleBasedBreakIterator*)bi1->clone();
-    RuleBasedBreakIterator* bi2clone= (RuleBasedBreakIterator*)bi2->clone();
+    RuleBasedBreakIterator* bi1clone= bi1->clone();
+    RuleBasedBreakIterator* bi2clone= bi2->clone();
 
     if(bi1->hashCode() != bi1clone->hashCode() ||  bi1->hashCode() != bi3->hashCode() ||
         bi1clone->hashCode() != bi3->hashCode() || bi2->hashCode() != bi2clone->hashCode())
@@ -300,7 +300,7 @@ void RBBIAPITest::TestGetSetAdoptText()
     TEST_ASSERT(tstr == str1);
 
 
-    LocalPointer<RuleBasedBreakIterator> rb((RuleBasedBreakIterator*)wordIter1->clone());
+    LocalPointer<RuleBasedBreakIterator> rb(wordIter1->clone());
     rb->adoptText(text1);
     if(rb->getText() != *text1)
         errln((UnicodeString)"ERROR:1 error in adoptText ");

--- a/icu4c/source/test/intltest/rbbitst.cpp
+++ b/icu4c/source/test/intltest/rbbitst.cpp
@@ -4432,11 +4432,11 @@ void RBBITest::TestBug12519() {
     assertTrue(WHERE, Locale::getFrench() == biFr->getLocale(ULOC_VALID_LOCALE, status));
     assertTrue(WHERE "Locales do not participate in BreakIterator equality.", *biEn == *biFr);
 
-    LocalPointer<RuleBasedBreakIterator>cloneEn((RuleBasedBreakIterator *)biEn->clone());
+    LocalPointer<RuleBasedBreakIterator>cloneEn(biEn->clone());
     assertTrue(WHERE, *biEn == *cloneEn);
     assertTrue(WHERE, Locale::getEnglish() == cloneEn->getLocale(ULOC_VALID_LOCALE, status));
 
-    LocalPointer<RuleBasedBreakIterator>cloneFr((RuleBasedBreakIterator *)biFr->clone());
+    LocalPointer<RuleBasedBreakIterator>cloneFr(biFr->clone());
     assertTrue(WHERE, *biFr == *cloneFr);
     assertTrue(WHERE, Locale::getFrench() == cloneFr->getLocale(ULOC_VALID_LOCALE, status));
 

--- a/icu4c/source/test/intltest/regcoll.cpp
+++ b/icu4c/source/test/intltest/regcoll.cpp
@@ -142,7 +142,7 @@ void CollationRegressionTest::Test4054238(/* char* par */)
 {
     const UChar chars3[] = {0x61, 0x00FC, 0x62, 0x65, 0x63, 0x6b, 0x20, 0x47, 0x72, 0x00F6, 0x00DF, 0x65, 0x20, 0x4c, 0x00FC, 0x62, 0x63, 0x6b, 0};
     const UnicodeString test3(chars3);
-    RuleBasedCollator *c = (RuleBasedCollator *) en_us->clone();
+    RuleBasedCollator *c = en_us->clone();
 
     // NOTE: The Java code uses en_us to create the CollationElementIterators
     // but I'm pretty sure that's wrong, so I've changed this to use c.
@@ -184,7 +184,7 @@ void CollationRegressionTest::Test4054734(/* char* par */)
 
 
     UErrorCode status = U_ZERO_ERROR;
-    RuleBasedCollator *c = (RuleBasedCollator *) en_us->clone();
+    RuleBasedCollator *c = en_us->clone();
 
     c->setStrength(Collator::IDENTICAL);
 
@@ -201,7 +201,7 @@ void CollationRegressionTest::Test4054734(/* char* par */)
 void CollationRegressionTest::Test4054736(/* char* par */)
 {
     UErrorCode status = U_ZERO_ERROR;
-    RuleBasedCollator *c = (RuleBasedCollator *) en_us->clone();
+    RuleBasedCollator *c = en_us->clone();
 
     c->setStrength(Collator::SECONDARY);
     c->setAttribute(UCOL_NORMALIZATION_MODE, UCOL_ON, status);
@@ -425,11 +425,11 @@ void CollationRegressionTest::Test4066189(/* char* par */)
     // NOTE: The java code used en_us to create the
     // CollationElementIterator's. I'm pretty sure that
     // was wrong, so I've change the code to use c1 and c2
-    RuleBasedCollator *c1 = (RuleBasedCollator *) en_us->clone();
+    RuleBasedCollator *c1 = en_us->clone();
     c1->setAttribute(UCOL_NORMALIZATION_MODE, UCOL_ON, status);
     CollationElementIterator *i1 = c1->createCollationElementIterator(test1);
 
-    RuleBasedCollator *c2 = (RuleBasedCollator *) en_us->clone();
+    RuleBasedCollator *c2 = en_us->clone();
     c2->setAttribute(UCOL_NORMALIZATION_MODE, UCOL_OFF, status);
     CollationElementIterator *i2 = c2->createCollationElementIterator(test2);
 
@@ -495,7 +495,7 @@ void CollationRegressionTest::Test4076676(/* char* par */)
     static const UChar s1[] = {0x41, 0x0301, 0x0302, 0x0300, 0};
     static const UChar s2[] = {0x41, 0x0302, 0x0300, 0x0301, 0};
 
-    RuleBasedCollator *c = (RuleBasedCollator *) en_us->clone();
+    RuleBasedCollator *c = en_us->clone();
     c->setStrength(Collator::TERTIARY);
 
     if (c->compare(s1,s2) == 0)
@@ -573,7 +573,7 @@ void CollationRegressionTest::Test4081866(/* char* par */)
     static const UChar s2[] = {0x41, 0x0327, 0x0316, 0x0315, 0x0300, 0};
 
     UErrorCode status = U_ZERO_ERROR;
-    RuleBasedCollator *c = (RuleBasedCollator *) en_us->clone();
+    RuleBasedCollator *c = en_us->clone();
     c->setStrength(Collator::TERTIARY);
 
     // Now that the default collators are set to NO_DECOMPOSITION
@@ -628,7 +628,7 @@ void CollationRegressionTest::Test4087241(/* char* par */)
 //
 void CollationRegressionTest::Test4087243(/* char* par */)
 {
-    RuleBasedCollator *c = (RuleBasedCollator *) en_us->clone();
+    RuleBasedCollator *c = en_us->clone();
     c->setStrength(Collator::TERTIARY);
 
     static const UChar tests[][CollationRegressionTest::MAX_TOKEN_LEN] =
@@ -738,7 +738,7 @@ void CollationRegressionTest::Test4101940(/* char* par */)
 //
 void CollationRegressionTest::Test4103436(/* char* par */)
 {
-    RuleBasedCollator *c = (RuleBasedCollator *) en_us->clone();
+    RuleBasedCollator *c = en_us->clone();
     c->setStrength(Collator::TERTIARY);
 
     static const UChar tests[][CollationRegressionTest::MAX_TOKEN_LEN] =
@@ -759,7 +759,7 @@ void CollationRegressionTest::Test4103436(/* char* par */)
 void CollationRegressionTest::Test4114076(/* char* par */)
 {
     UErrorCode status = U_ZERO_ERROR;
-    RuleBasedCollator *c = (RuleBasedCollator *) en_us->clone();
+    RuleBasedCollator *c = en_us->clone();
     c->setStrength(Collator::TERTIARY);
 
     //
@@ -884,7 +884,7 @@ void CollationRegressionTest::Test4114077(/* char* par */)
     // as we do with it on....
 
     UErrorCode status = U_ZERO_ERROR;
-    RuleBasedCollator *c = (RuleBasedCollator *) en_us->clone();
+    RuleBasedCollator *c = en_us->clone();
     c->setStrength(Collator::TERTIARY);
 
     static const UChar test1[][CollationRegressionTest::MAX_TOKEN_LEN] =
@@ -1253,7 +1253,7 @@ void CollationRegressionTest::TestT7189() {
 }
 
 void CollationRegressionTest::TestCaseFirstCompression() {
-    RuleBasedCollator *col = (RuleBasedCollator *) en_us->clone();
+    RuleBasedCollator *col = en_us->clone();
     UErrorCode status = U_ZERO_ERROR;
 
     // default

--- a/icu4c/source/test/intltest/reldatefmttest.cpp
+++ b/icu4c/source/test/intltest/reldatefmttest.cpp
@@ -988,7 +988,7 @@ void RelativeDateTimeFormatterTest::TestCustomNumberFormat() {
                     "Failure creating format object - %s", u_errorName(status));
             return;
         }
-        nf = (NumberFormat *) fmt.getNumberFormat().clone();
+        nf = fmt.getNumberFormat().clone();
     }
     nf->setMinimumFractionDigits(1);
     nf->setMaximumFractionDigits(1);

--- a/icu4c/source/test/intltest/reptest.cpp
+++ b/icu4c/source/test/intltest/reptest.cpp
@@ -71,7 +71,7 @@ public:
         this->styles = s;
     }
 
-    virtual Replaceable *clone() const {
+    virtual TestReplaceable *clone() const {
         return new TestReplaceable(chars, styles);
     }
 
@@ -289,7 +289,7 @@ void ReplaceableTest::check(const UnicodeString& transliteratorName,
                                             pe, status);
 
         // test clone()
-        TestReplaceable *tr2 = (TestReplaceable *)tr->clone();
+        TestReplaceable *tr2 = tr->clone();
         if(tr2 != NULL) {
             delete tr;
             tr = tr2;

--- a/icu4c/source/test/intltest/selfmts.cpp
+++ b/icu4c/source/test/intltest/selfmts.cpp
@@ -235,7 +235,7 @@ void SelectFormatTest::selectFormatAPITest(/*char *par*/)
     // ======= Test clone && == operator.
     logln("SelectFormat API test: Testing clone and == operator ...");
     if ( U_SUCCESS(status[0])  ) {
-        selFmt[1] = (SelectFormat*)selFmt[0]->clone();
+        selFmt[1] = selFmt[0]->clone();
         if (selFmt[1]!=NULL) {
             if ( *selFmt[1] != *selFmt[0] ) {
                 errln("ERROR: SelectFormat API test clone test failed!");

--- a/icu4c/source/test/intltest/srchtest.cpp
+++ b/icu4c/source/test/intltest/srchtest.cpp
@@ -769,7 +769,7 @@ void StringSearchTest::TestInitialization()
     }
     delete copy;
 
-    copy = (StringSearch *)result->safeClone();
+    copy = result->safeClone();
     if (*(copy->getCollator()) != *(result->getCollator()) ||
         copy->getBreakIterator() != result->getBreakIterator() ||
         copy->getMatchedLength() != result->getMatchedLength() ||

--- a/icu4c/source/test/intltest/tchcfmt.cpp
+++ b/icu4c/source/test/intltest/tchcfmt.cpp
@@ -311,7 +311,7 @@ TestChoiceFormat::TestComplexExample( void )
             it_errln("***  operator!=");
         }
 
-        ChoiceFormat* form_A3 = (ChoiceFormat*) form_A->clone();
+        ChoiceFormat* form_A3 = form_A->clone();
         if (!form_A3) {
             it_errln("***  ChoiceFormat->clone is nil.");
         }else{

--- a/icu4c/source/test/intltest/tmsgfmt.cpp
+++ b/icu4c/source/test/intltest/tmsgfmt.cpp
@@ -921,7 +921,7 @@ void TestMessageFormat::testClone()
     MessageFormat *x = new MessageFormat("There are {0} files on {1}", success);
     MessageFormat *z = new MessageFormat("There are {0} files on {1} created", success);
     MessageFormat *y = 0;
-    y = (MessageFormat*)x->clone();
+    y = x->clone();
     if ( (*x == *y) && 
          (*x != *z) && 
          (*y != *z) )
@@ -1433,8 +1433,8 @@ static void _testCopyConstructor2()
         goto cleanup;
     }
 
-    fmt3 = (MessageFormat*) fmt1->clone();
-    fmt4 = (MessageFormat*) fmt2->clone();
+    fmt3 = fmt1->clone();
+    fmt4 = fmt2->clone();
 
     if (fmt3 == NULL) {
         it_err("testCopyConstructor2: (fmt3 != NULL)");

--- a/icu4c/source/test/intltest/transapi.cpp
+++ b/icu4c/source/test/intltest/transapi.cpp
@@ -712,7 +712,7 @@ int gTestFilter3ClassID = 0;
  */
 class TestFilter1 : public UnicodeFilter {
     UClassID getDynamicClassID()const { return &gTestFilter1ClassID; }
-    virtual UnicodeFunctor* clone() const {
+    virtual TestFilter1* clone() const {
         return new TestFilter1(*this);
     }
     virtual UBool contains(UChar32 c) const {
@@ -733,7 +733,7 @@ class TestFilter1 : public UnicodeFilter {
 };
 class TestFilter2 : public UnicodeFilter {
     UClassID getDynamicClassID()const { return &gTestFilter2ClassID; }
-    virtual UnicodeFunctor* clone() const {
+    virtual TestFilter2* clone() const {
         return new TestFilter2(*this);
     }
     virtual UBool contains(UChar32 c) const {
@@ -754,7 +754,7 @@ class TestFilter2 : public UnicodeFilter {
 };
 class TestFilter3 : public UnicodeFilter {
     UClassID getDynamicClassID()const { return &gTestFilter3ClassID; }
-    virtual UnicodeFunctor* clone() const {
+    virtual TestFilter3* clone() const {
         return new TestFilter3(*this);
     }
     virtual UBool contains(UChar32 c) const {

--- a/icu4c/source/test/intltest/transtst.cpp
+++ b/icu4c/source/test/intltest/transtst.cpp
@@ -657,7 +657,7 @@ int gTestFilterClassID = 0;
  * Used by TestFiltering().
  */
 class TestFilter : public UnicodeFilter {
-    virtual UnicodeFunctor* clone() const {
+    virtual TestFilter* clone() const {
         return new TestFilter(*this);
     }
     virtual UBool contains(UChar32 c) const {

--- a/icu4c/source/test/intltest/tstnorm.cpp
+++ b/icu4c/source/test/intltest/tstnorm.cpp
@@ -1369,7 +1369,7 @@ initExpectedSkippables(UnicodeSet skipSets[UNORM_MODE_COUNT], UErrorCode &errorC
     // We need not look at control codes, Han characters nor Hangul LVT syllables because they
     // do not combine forward. LV syllables are already removed.
     UnicodeSet notInteresting("[[:C:][:Unified_Ideograph:][:HST=LVT:]]", errorCode);
-    LocalPointer<UnicodeSet> unsure(&((UnicodeSet *)(skipSets[UNORM_NFC].clone()))->removeAll(notInteresting));
+    LocalPointer<UnicodeSet> unsure(&(skipSets[UNORM_NFC].clone())->removeAll(notInteresting));
     // System.out.format("unsure.size()=%d\n", unsure.size());
 
     // For each character about which we are unsure, see if it changes when we add

--- a/icu4c/source/test/intltest/tufmtts.cpp
+++ b/icu4c/source/test/intltest/tufmtts.cpp
@@ -171,7 +171,7 @@ void TimeUnitTest::testAPI() {
     TimeUnit* tmunit = TimeUnit::createInstance(TimeUnit::UTIMEUNIT_YEAR, status);
     if (!assertSuccess("TimeUnit::createInstance", status)) return;
 
-    TimeUnit* another = (TimeUnit*)tmunit->clone();
+    TimeUnit* another = tmunit->clone();
     TimeUnit third(*tmunit);
     TimeUnit fourth = third;
 
@@ -239,7 +239,7 @@ void TimeUnitTest::testAPI() {
 
     TimeUnitAmount second(tma);
     TimeUnitAmount third_tma = tma;
-    TimeUnitAmount* fourth_tma = (TimeUnitAmount*)tma.clone();
+    TimeUnitAmount* fourth_tma = tma.clone();
 
     assertTrue("orig and copy are equal", (second == tma));
     assertTrue("clone and assigned are equal", (third_tma == *fourth_tma));
@@ -266,7 +266,7 @@ void TimeUnitTest::testAPI() {
     TimeUnitFormat tmf_copy(tmf_fr);
     assertTrue("TimeUnitFormat: orig and copy are equal", (tmf_fr == tmf_copy));
 
-    TimeUnitFormat* tmf_clone = (TimeUnitFormat*)tmf_en->clone();
+    TimeUnitFormat* tmf_clone = tmf_en->clone();
     assertTrue("TimeUnitFormat: orig and clone are equal", (*tmf_en == *tmf_clone));
     delete tmf_clone;
 

--- a/icu4c/source/test/intltest/tzregts.cpp
+++ b/icu4c/source/test/intltest/tzregts.cpp
@@ -352,7 +352,7 @@ UBool
 TimeZoneRegressionTest::checkCalendar314(GregorianCalendar *testCal, TimeZone *testTZ) 
 {
     UErrorCode status = U_ZERO_ERROR;
-    // GregorianCalendar testCal = (GregorianCalendar)aCal.clone(); 
+    // GregorianCalendar testCal = aCal.clone(); 
 
     int32_t tzOffset, tzRawOffset; 
     float tzOffsetFloat,tzRawOffsetFloat; 

--- a/icu4c/source/test/intltest/tzrulets.cpp
+++ b/icu4c/source/test/intltest/tzrulets.cpp
@@ -266,7 +266,7 @@ TimeZoneRuleTest::TestSimpleRuleBasedTimeZone(void) {
     if (rbtz1->hasSameRules(*rbtz3)) {
         errln("FAIL: rbtz1 and rbtz3 have different rules, but returned true.");
     }
-    RuleBasedTimeZone *rbtz1c = (RuleBasedTimeZone*)rbtz1->clone();
+    RuleBasedTimeZone *rbtz1c = rbtz1->clone();
     if (!rbtz1->hasSameRules(*rbtz1c)) {
         errln("FAIL: Cloned RuleBasedTimeZone must have the same rules with the original.");
     }
@@ -548,7 +548,7 @@ TimeZoneRuleTest::TestHistoricalRuleBasedTimeZone(void) {
     if (ny->hasSameRules(*rbtz) || rbtz->hasSameRules(*ny)) {
         errln("FAIL: hasSameRules must return false");
     }
-    RuleBasedTimeZone *rbtzc = (RuleBasedTimeZone*)rbtz->clone();
+    RuleBasedTimeZone *rbtzc = rbtz->clone();
     if (!rbtz->hasSameRules(*rbtzc) || !rbtz->hasEquivalentTransitions(*rbtzc, jan1_1950, jan1_2010, TRUE, status)) {
         errln("FAIL: hasSameRules/hasEquivalentTransitions must return true for cloned RBTZs");
     }
@@ -742,7 +742,7 @@ TimeZoneRuleTest::TestHasEquivalentTransitions(void) {
     }
 
     // Cloned TimeZone
-    BasicTimeZone *newyork2 = (BasicTimeZone*)newyork->clone();
+    BasicTimeZone *newyork2 = newyork->clone();
     if (!newyork->hasEquivalentTransitions(*newyork2, jan1_1971, jan1_2011, FALSE, status)) {
         errln("FAIL: Cloned TimeZone must have the same transitions");
     }
@@ -1695,7 +1695,7 @@ TimeZoneRuleTest::TestVTimeZoneCoverage(void) {
 
     // setRawOffset
     const int32_t RAW = -10*HOUR;
-    VTimeZone *tmpvtz = (VTimeZone*)vtz->clone();
+    VTimeZone *tmpvtz = vtz->clone();
     tmpvtz->setRawOffset(RAW);
     if (tmpvtz->getRawOffset() != RAW) {
         logln("setRawOffset is implemented in VTimeZone");

--- a/icu4c/source/test/intltest/usettest.cpp
+++ b/icu4c/source/test/intltest/usettest.cpp
@@ -364,8 +364,8 @@ UnicodeSetTest::TestCloneEqualHash(void) {
     }
 
     logln("Testing clone()");
-    UnicodeSet *set1clone=(UnicodeSet*)set1->clone();
-    UnicodeSet *set2clone=(UnicodeSet*)set2->clone();
+    UnicodeSet *set1clone=set1->clone();
+    UnicodeSet *set2clone=set2->clone();
     if(*set1clone != *set1 || *set1clone != *set1copy || *set1clone != set1equal || 
         *set2clone != *set2 || *set2clone == *set1copy || *set2clone != set2equal || 
         *set2clone == *set1 || *set2clone == set1equal || *set2clone == *set1clone){
@@ -2255,7 +2255,7 @@ void UnicodeSetTest::TestFreezable() {
         errln("FAIL: copying a frozen set results in a thawed one");
     }
 
-    UnicodeSet *cloned=(UnicodeSet *)frozen.clone();
+    UnicodeSet *cloned=frozen.clone();
     if(!cloned->isFrozen() || *cloned!=frozen || cloned->containsSome(0xd802, 0xd805)) {
         errln("FAIL: clone() failed");
     }
@@ -2265,7 +2265,7 @@ void UnicodeSetTest::TestFreezable() {
     }
     delete cloned;
 
-    UnicodeSet *thawed=(UnicodeSet *)frozen.cloneAsThawed();
+    UnicodeSet *thawed=frozen.cloneAsThawed();
     if(thawed->isFrozen() || *thawed!=frozen || thawed->containsSome(0xd802, 0xd805)) {
         errln("FAIL: cloneAsThawed() failed");
     }
@@ -3692,11 +3692,11 @@ void UnicodeSetTest::TestSpan() {
             // Intermediate set: Test cloning of a frozen set.
             UnicodeSet *fast=new UnicodeSet(*sets[SLOW]);
             fast->freeze();
-            sets[FAST]=(UnicodeSet *)fast->clone();
+            sets[FAST]=fast->clone();
             delete fast;
             UnicodeSet *fastNot=new UnicodeSet(*sets[SLOW_NOT]);
             fastNot->freeze();
-            sets[FAST_NOT]=(UnicodeSet *)fastNot->clone();
+            sets[FAST_NOT]=fastNot->clone();
             delete fastNot;
 
             for(j=0; j<SET_COUNT; ++j) {

--- a/icu4c/source/test/intltest/ustrtest.cpp
+++ b/icu4c/source/test/intltest/ustrtest.cpp
@@ -77,7 +77,7 @@ UnicodeStringTest::TestBasicManipulation()
     UnicodeString   expectedValue;
     UnicodeString   *c;
 
-    c=(UnicodeString *)test1.clone();
+    c=test1.clone();
     test1.insert(24, "good ");
     expectedValue = "Now is the time for all good men to come swiftly to the aid of the party.\n";
     if (test1 != expectedValue)
@@ -1254,7 +1254,7 @@ UnicodeStringTest::TestStackAllocation()
         errln("UnicodeString.setTo(readonly alias) does not alias correctly");
     }
 
-    UnicodeString *c=(UnicodeString *)test->clone();
+    UnicodeString *c=test->clone();
 
     workingBuffer[1] = 0x109;
     if(test->charAt(1) != 0x109) {


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-20783

Remove pointer casts that are redundant with covariant return types.

Add explicit covariant clone() declarations to abstract, intermediate classes that inherit base class clone(): UnicodeFilter, BasicTimeZone, DateFormat, NumberFormat

Make unit test class clone() functions covariant where they were broken by additional covariant clone() functions.