### PR TITLE
ICU-20782 Enable Windows icucheck.bat for ARM/ARM64.

### DIFF
--- a/icu4c/source/allinone/icucheck.bat
+++ b/icu4c/source/allinone/icucheck.bat
@@ -11,7 +11,7 @@ set ICU_ARCH=%1
 set ICU_DBRL=%2
 
 if "%1" == "" (
-echo Usage: %0 "x86 or x64"  "Debug or Release"
+echo Usage: %0 "x86 or x64 or ARM or ARM64"  "Debug or Release"
 exit /b 1
 )
 
@@ -25,9 +25,13 @@ set ICU_OPATH=%PATH%
 set ICU_ICUDIR="%~dp0"\..\..
 
 if "%ICU_ARCH%" == "x64" (
-set ICU_BINDIR=%~dp0\..\..\bin64
+    set ICU_BINDIR=%~dp0\..\..\bin64
+) else if "%ICU_ARCH%" == "ARM64" (
+    set ICU_BINDIR=%~dp0\..\..\binARM64
+) else if "%ICU_ARCH%" == "ARM" (
+    set ICU_BINDIR=%~dp0\..\..\binARM
 ) else (
-set ICU_BINDIR=%~dp0\..\..\bin
+    set ICU_BINDIR=%~dp0\..\..\bin
 )
 
 set PATH=%ICU_BINDIR%;%PATH%


### PR DESCRIPTION
This is a follow-up from PR #768. 
This allows for running the ICU Test Suite (`icucheck.bat`) with ARM and ARM64.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20782
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

