### PR TITLE
ICU-20789 Clean-up the VS "clean" target for the Makedata project.

### DIFF
--- a/icu4c/source/data/makedata.mak
+++ b/icu4c/source/data/makedata.mak
@@ -412,7 +412,7 @@ icu4j-data-install :
 !ENDIF
 
 "$(ARM_CROSSBUILD_TS)" : $(COMMON_ICUDATA_DEPENDENCIES) "$(ICU_LIB_TARGET)"
-    @echo Building ICU data for "$(ARM_CROSS_BUILD)" from x64
+	@echo Building ICU data for "$(ARM_CROSS_BUILD)" from x64
 	cd "$(ICUBLD_PKG)"
 	"$(ICUPBIN)\pkgdata" $(COMMON_ICUDATA_ARGUMENTS) $(ICUTMP)\icudata.lst
 	-@erase "$(ICU_LIB_TARGET)"
@@ -421,7 +421,7 @@ icu4j-data-install :
 	-@erase "$(U_ICUDATA_NAME).dll"
 	copy "$(ICUTMP)\$(ICUPKG).dat" "$(ICUOUT)\$(U_ICUDATA_NAME)$(U_ICUDATA_ENDIAN_SUFFIX).dat"
 	-@erase "$(ICUTMP)\$(ICUPKG).dat"
-    @echo "timestamp" > $(ARM_CROSSBUILD_TS)
+	@echo "timestamp" > $(ARM_CROSSBUILD_TS)
 
 # utility target to create missing directories
 # Most directories are made by Python, but still create ICUTMP
@@ -431,6 +431,7 @@ CREATE_DIRS :
 	@if not exist "$(ICUTMP)\$(NULL)" mkdir "$(ICUTMP)"
 	@if not exist "$(ICUOUT)\build\$(NULL)" mkdir "$(ICUOUT)\build"
 	@if not exist "$(ICUBLD_PKG)\$(NULL)" mkdir "$(ICUBLD_PKG)"
+	@if not exist "$(TESTDATAOUT)" mkdir "$(TESTDATAOUT)"
 
 # utility target to send us to the right dir
 GODATA : CREATE_DIRS
@@ -439,53 +440,11 @@ GODATA : CREATE_DIRS
 # This is to remove all the data files
 CLEAN : GODATA
 	@echo Cleaning up the data files.
-	@cd "$(ICUBLD_PKG)"
-	-@erase "*.cnv"
-	-@erase "*.exp"
-	-@erase "*.icu"
-	-@erase "*.lib"
-	-@erase "*.nrm"
-	-@erase "*.res"
-	-@erase "*.spp"
-	-@erase "*.txt"
-	-@erase "*.cfu"
-	-@erase "curr\*.res"
-	-@erase "curr\*.txt"
-	-@erase "lang\*.res"
-	-@erase "lang\*.txt"
-	-@erase "region\*.res"
-	-@erase "region\*.txt"
-	-@erase "zone\*.res"
-	-@erase "zone\*.txt"
-	-@erase "$(ICUBRK)\*.brk"
-	-@erase "$(ICUBRK)\*.res"
-	-@erase "$(ICUBRK)\*.txt"
-	-@erase "$(ICUBRK)\*.dict"
-	-@erase "$(ICUCOL)\*.res"
-	-@erase "$(ICUCOL)\*.txt"
-	-@erase "$(ICURBNF)\*.res"
-	-@erase "$(ICURBNF)\*.txt"
-	-@erase "$(ICUTRNS)\*.res"
+	@cd "$(ICUOUT)"
 	-@erase "$(ICUOUT)\*.dat"
-	-@erase "$(ICUTMP)\*.html"
-	-@erase "$(ICUTMP)\*.lst"
-	-@erase "$(ICUTMP)\*.mak"
-	-@erase "$(ICUTMP)\*.obj"
-	-@erase "$(ICUTMP)\*.res"
-	-@erase "$(ICUTMP)\*.timestamp"
-	-@erase "$(TESTDATABLD)\*.cnv"
-	-@erase "$(TESTDATABLD)\*.icu"
-	-@erase "$(TESTDATABLD)\*.mak"
-	-@erase "$(TESTDATABLD)\*.nrm"
-	-@erase "$(TESTDATABLD)\*.res"
-	-@erase "$(TESTDATABLD)\*.spp"
-	-@erase "$(TESTDATABLD)\*.txt"
-	-@erase "$(TESTDATAOUT)\*.dat"
-	-@erase "$(TESTDATAOUT)\testdata\*.typ"
-	-@erase "$(TESTDATAOUT)\testdata\*.res"
-	-@erase "$(TESTDATAOUT)\testdata\*.txt"
-	-@erase "$(TESTDATAOUT)\testdata\*.lst"
-
+	@rmdir $(ICUBLD) /s /q
+	@rmdir $(ICUTMP) /s /q
+	@rmdir $(TESTDATAOUT) /s /q
 
 # DLL version information
 # If you modify this, modify winmode.c in pkgdata.

--- a/icu4c/source/data/makedata.vcxproj
+++ b/icu4c/source/data/makedata.vcxproj
@@ -38,7 +38,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <BuildLog>
-      <Path>$(OutDir)$(Configuration)BuildLog.html</Path>
+      <Path>.\data\log\$(Platform)\$(Configuration)BuildLog.html</Path>
     </BuildLog>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
I noticed this while working on PR #768.

The VS `makedata` project currently deletes *individual files* inside the ICU4C data `build` and `tmp` folders.

This would be much simpler and faster if we just delete the build/tmp folders directly. 

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20789
- [x] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

