### PR TITLE
ICU-20620 cap UNUM_MAX_FRACTION_DIGITS setting at 999

### DIFF
--- a/icu4c/source/i18n/decimfmt.cpp
+++ b/icu4c/source/i18n/decimfmt.cpp
@@ -1388,6 +1388,10 @@ void DecimalFormat::setMinimumIntegerDigits(int32_t newValue) {
 void DecimalFormat::setMaximumFractionDigits(int32_t newValue) {
     if (fields == nullptr) { return; }
     if (newValue == fields->properties.maximumFractionDigits) { return; }
+    // cap for backward compatibility, formerly 340, now 999
+    if (newValue > kMaxIntFracSig) {
+        newValue = kMaxIntFracSig;
+    }
     // For backwards compatibility, conflicting min/max need to keep the most recent setting.
     int32_t min = fields->properties.minimumFractionDigits;
     if (min >= 0 && min > newValue) {


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20620
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

The test is plain C, matching the compatibility issue as actually reported.