### PR TITLE
ICU-20396 add RelativeDateTimeFormatter test for af

### DIFF
--- a/icu4c/source/test/intltest/reldatefmttest.cpp
+++ b/icu4c/source/test/intltest/reldatefmttest.cpp
@@ -746,6 +746,26 @@ static WithQuantityExpectedRelativeDateTimeUnit kEnglishFormat[] = {
         {-2.0, UDAT_REL_UNIT_SATURDAY, "2 Saturdays ago"}
 };
 
+static WithQuantityExpected kAfrikaans[] = {
+        {1.0, UDAT_DIRECTION_NEXT, UDAT_RELATIVE_MONTHS, "oor 1 maand"},
+        {2.0, UDAT_DIRECTION_NEXT, UDAT_RELATIVE_MONTHS, "oor 2 maande"},
+        {1.0, UDAT_DIRECTION_LAST, UDAT_RELATIVE_MONTHS, "1 maand gelede"},
+        {2.0, UDAT_DIRECTION_LAST, UDAT_RELATIVE_MONTHS, "2 maande gelede"},
+};
+
+static WithoutQuantityExpected kAfrikaansNoQuantity[] = {
+        {UDAT_DIRECTION_NEXT, UDAT_ABSOLUTE_MONTH, "volgende maand"},
+        {UDAT_DIRECTION_LAST, UDAT_ABSOLUTE_MONTH, "verlede maand"},
+};
+
+static WithQuantityExpectedRelativeDateTimeUnit kAfrikaansFormatNumeric[] = {
+        {0.0, UDAT_REL_UNIT_MONTH, "oor 0 maande"},
+        {1.0, UDAT_REL_UNIT_MONTH, "oor 1 maand"},
+        {2.0, UDAT_REL_UNIT_MONTH, "oor 2 maande"},
+        {-0.0, UDAT_REL_UNIT_MONTH, "0 maande gelede"},
+        {-1.0, UDAT_REL_UNIT_MONTH, "1 maand gelede"},
+        {-2.0, UDAT_REL_UNIT_MONTH, "2 maande gelede"},
+};
 
 class RelativeDateTimeFormatterTest : public IntlTestWithFieldPosition {
 public:
@@ -765,6 +785,7 @@ private:
     void TestEnglishNoQuantityShort();
     void TestEnglishNoQuantityNarrow();
     void TestSpanishNoQuantity();
+    void TestAfrikaans();
     void TestFormatWithQuantityIllegalArgument();
     void TestFormatWithoutQuantityIllegalArgument();
     void TestCustomNumberFormat();
@@ -857,6 +878,7 @@ void RelativeDateTimeFormatterTest::runIndexedTest(
     TESTCASE_AUTO(TestEnglishNoQuantityShort);
     TESTCASE_AUTO(TestEnglishNoQuantityNarrow);
     TESTCASE_AUTO(TestSpanishNoQuantity);
+    TESTCASE_AUTO(TestAfrikaans);
     TESTCASE_AUTO(TestFormatWithQuantityIllegalArgument);
     TESTCASE_AUTO(TestFormatWithoutQuantityIllegalArgument);
     TESTCASE_AUTO(TestCustomNumberFormat);
@@ -953,6 +975,12 @@ void RelativeDateTimeFormatterTest::TestEnglishNoQuantityNarrow() {
 
 void RelativeDateTimeFormatterTest::TestSpanishNoQuantity() {
     RunTest("es", kSpanishNoQuantity, UPRV_LENGTHOF(kSpanishNoQuantity));
+}
+
+void RelativeDateTimeFormatterTest::TestAfrikaans() {
+    RunTest("af", kAfrikaans, UPRV_LENGTHOF(kAfrikaans));
+    RunTest("af", kAfrikaansNoQuantity, UPRV_LENGTHOF(kAfrikaansNoQuantity));
+    RunTest("af", kAfrikaansFormatNumeric, UPRV_LENGTHOF(kAfrikaansFormatNumeric), true);
 }
 
 void RelativeDateTimeFormatterTest::TestFormatWithQuantityIllegalArgument() {


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20396
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

Just added an ICU4C test that RelativeDateTimeFormatter now works in Afrikaans
