### PR TITLE
ICU-13764 Add a MacOSX CI build with Warnings-as-Errors

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -256,3 +256,16 @@ jobs:
        set MSYSTEM=MINGW64
        c:\tools\msys64\usr\bin\bash.exe -lc "cd $BUILD_SOURCESDIRECTORY && cd icu4c/source && ./runConfigureICU MinGW && make -j2 check"
       displayName: 'Build and Test ICU4C'
+#-------------------------------------------------------------------------
+- job: ICU4C_Clang_MacOSX_WarningsAsErrors
+  displayName: 'C: macOSX Clang WarningsAsErrors (Mojave 10.14)'
+  timeoutInMinutes: 30
+  pool:
+    vmImage: 'macOS-10.14'
+  steps:
+    - script: |
+        export CPPFLAGS="-Werror -Wall -Wextra -Wextra-semi" && cd icu4c/source && ./runConfigureICU MacOSX && make -j2 tests
+      displayName: 'Build only (WarningsAsErrors)'
+      env:
+        CC: clang
+        CXX: clang++


### PR DESCRIPTION
This adds another build bot that builds ICU4C on MacOSX 10.14 using Clang with Warnings-as-Errors, in order to have additional coverage.

cc: @jungshik as FYI.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-13764
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

