### PR TITLE
ICU-20795 Add comment to ICU4C Readme.html about U_SHOW_CPLUSPLUS_API.

### DIFF
--- a/icu4c/readme.html
+++ b/icu4c/readme.html
@@ -744,7 +744,8 @@
         across library and compiler versions is very hard to achieve.
         Most ICU C++ APIs are in header files that contain a comment with
         <code>\brief C++ API</code>.
-        Consider not installing these header files.</li>
+        Consider not installing these header files, or define <code>U_SHOW_CPLUSPLUS_API</code>
+        to be <code>0</code> by modifying unicode/utypes.h before installing it.</li>
       <li><b>Disable renaming:</b> By default, ICU library entry point names
         have an ICU version suffix. Turn this off for a system-level installation,
         to enable upgrading ICU without breaking applications. For example:<br />


### PR DESCRIPTION
Probably worth adding a note to the README.html file that all of the public C++ headers are now guarded with the macro "`U_SHOW_CPLUSPLUS_API`".

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20795
- [x] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [x] Documentation is changed or added

