### PR TITLE
ICU-20701 Add more PluralRules tests for locales with keywords

### DIFF
--- a/icu4c/source/test/intltest/plurults.cpp
+++ b/icu4c/source/test/intltest/plurults.cpp
@@ -1037,12 +1037,34 @@ void PluralRulesTest::testSelectTrailingZeros() {
     }
 }
 
+void PluralRulesTest::compareLocaleResults(const char* loc1, const char* loc2, const char* loc3) {
+    UErrorCode status = U_ZERO_ERROR;
+    LocalPointer<PluralRules> rules1(PluralRules::forLocale(loc1, status));
+    LocalPointer<PluralRules> rules2(PluralRules::forLocale(loc2, status));
+    LocalPointer<PluralRules> rules3(PluralRules::forLocale(loc3, status));
+    if (U_FAILURE(status)) {
+        dataerrln("Failed to create PluralRules for one of %s, %s, %s: %s\n", loc1, loc2, loc3, u_errorName(status));
+        return;
+    }
+    for (int32_t value = 0; value <= 12; value++) {
+        UnicodeString result1 = rules1->select(value);
+        UnicodeString result2 = rules2->select(value);
+        UnicodeString result3 = rules3->select(value);
+        if (result1 != result2 || result1 != result3) {
+            errln("PluralRules.select(%d) does not return the same values for %s, %s, %s\n", value, loc1, loc2, loc3);
+        }
+    }
+}
+
 void PluralRulesTest::testLocaleExtension() {
     IcuTestErrorCode errorCode(*this, "testLocaleExtension");
     LocalPointer<PluralRules> rules(PluralRules::forLocale("pt@calendar=gregorian", errorCode));
     if (errorCode.errIfFailureAndReset("PluralRules::forLocale()")) { return; }
     UnicodeString key = rules->select(1);
     assertEquals("pt@calendar=gregorian select(1)", u"one", key);
+    compareLocaleResults("ar", "ar_SA", "ar_SA@calendar=gregorian");
+    compareLocaleResults("ru", "ru_UA", "ru-u-cu-RUB");
+    compareLocaleResults("fr", "fr_CH", "fr@ms=uksystem");
 }
 
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/test/intltest/plurults.h
+++ b/icu4c/source/test/intltest/plurults.h
@@ -45,6 +45,7 @@ private:
                             double expected);
     void checkSelect(const LocalPointer<PluralRules> &rules, UErrorCode &status, 
                                   int32_t line, const char *keyword, ...);
+    void compareLocaleResults(const char* loc1, const char* loc2, const char* loc3);
 };
 
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/PluralRulesTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/PluralRulesTest.java
@@ -526,11 +526,29 @@ public class PluralRulesTest extends TestFmwk {
         }
     }
 
+    private void compareLocaleResults(String loc1, String loc2, String loc3) {
+        PluralRules rules1 = PluralRules.forLocale(new ULocale(loc1));
+        PluralRules rules2 = PluralRules.forLocale(new ULocale(loc2));
+        PluralRules rules3 = PluralRules.forLocale(new ULocale(loc3));
+        for (int value = 0; value <= 12; value++) {
+            String result1 = rules1.select(value);
+            String result2 = rules2.select(value);
+            String result3 = rules3.select(value);
+            if (!result1.equals(result2) || !result1.equals(result3)) {
+                errln("PluralRules.select(" + value + ") does not return the same values for "
+                        + loc1 + ", " + loc2 + ", " + loc3);
+            }
+        }
+    }
+
     @Test
     public void testLocaleExtension() {
         PluralRules rules = PluralRules.forLocale(new ULocale("pt@calendar=gregorian"));
         String key = rules.select(1);
         assertEquals("pt@calendar=gregorian select(1)", "one", key);
+        compareLocaleResults("ar", "ar_SA", "ar_SA@calendar=gregorian");
+        compareLocaleResults("ru", "ru_UA", "ru-u-cu-RUB");
+        compareLocaleResults("fr", "fr_CH", "fr@ms=uksystem");
     }
 
     @Test


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20701
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

The original problem appears to have been already fixed in ICU 64.1 with https://github.com/unicode-org/icu/pull/471, so all I am doing here is adding more tests.