### PR TITLE
ICU-20797 fix UBS compilation error and UBS in test code

### DIFF
--- a/icu4c/source/i18n/collationtailoring.h
+++ b/icu4c/source/i18n/collationtailoring.h
@@ -92,7 +92,7 @@ private:
     CollationTailoring(const CollationTailoring &other);
 };
 
-struct CollationCacheEntry : public SharedObject {
+struct U_I18N_API CollationCacheEntry : public SharedObject {
     CollationCacheEntry(const Locale &loc, const CollationTailoring *t)
             : validLocale(loc), tailoring(t) {
         if(t != NULL) {

--- a/icu4c/source/i18n/numparse_affixes.h
+++ b/icu4c/source/i18n/numparse_affixes.h
@@ -28,7 +28,7 @@ using ::icu::number::impl::TokenConsumer;
 using ::icu::number::impl::CurrencySymbols;
 
 
-class CodePointMatcher : public NumberParseMatcher, public UMemory {
+class U_I18N_API CodePointMatcher : public NumberParseMatcher, public UMemory {
   public:
     CodePointMatcher() = default;  // WARNING: Leaves the object in an unusable state
 

--- a/icu4c/source/test/intltest/numberformattesttuple.cpp
+++ b/icu4c/source/test/intltest/numberformattesttuple.cpp
@@ -16,7 +16,9 @@
 #include "cstring.h"
 #include "cmemory.h"
 
-static NumberFormatTestTuple *gNullPtr = NULL;
+static NumberFormatTestTuple emptyObject;
+
+static NumberFormatTestTuple *gNullPtr = &emptyObject;
 
 #define FIELD_OFFSET(fieldName) ((int32_t) (((char *) &gNullPtr->fieldName) - ((char *) gNullPtr)))
 #define FIELD_FLAG_OFFSET(fieldName) ((int32_t) (((char *) &gNullPtr->fieldName##Flag) - ((char *) gNullPtr)))


### PR DESCRIPTION
[ICU-20797]

Two issues here:

- fix 2 build issue in i18n when compiling with clang++ -fsanitize=undefined
the following two symbols were not exported (and they should be):
  typeinfo for icu::CollationCacheEntry
  typeinfo for icu::numparse::impl::CodePointMatcher

- remove undefined behavior warning in NumberFormatTestTuple.. minor, but very annoying
when repeated many times during every test run. Tends to mask real errors.

> numberformattesttuple.cpp:319:5: runtime error: member access within null pointer of type 'NumberFormatTestTuple'

- [ ] Issue accepted (not yet)


[ICU-20797]: https://unicode-org.atlassian.net/browse/ICU-20797