### PR TITLE
ICU-20693 Fix weird bug in Maven pom file and add comments

### DIFF
--- a/tools/cldr/cldr-to-icu/pom.xml
+++ b/tools/cldr/cldr-to-icu/pom.xml
@@ -79,6 +79,7 @@
     </repositories>
 
     <dependencies>
+        <!-- Local dependencies (see lib/README.txt). -->
         <dependency>
             <groupId>org.unicode.cldr</groupId>
             <artifactId>cldr-api</artifactId>
@@ -89,16 +90,31 @@
             <artifactId>icu-utilities</artifactId>
             <version>0.1-SNAPSHOT</version>
         </dependency>
+
+        <!-- ICU4J - which should be kept as up-to-date as possible. -->
         <dependency>
             <groupId>com.ibm.icu</groupId>
             <artifactId>icu4j</artifactId>
-            <version>65.1</version>
+            <version>64.2</version>
         </dependency>
+
+        <!-- Useful common libraries. Note that some of the code in the CLDR library is also
+             built against a version of Guava that might not be as recent as this, so they
+             be kept approximately in sync for good measure. -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>27.1-jre</version>
         </dependency>
+
+        <!-- Ant: Only used for running the conversion tool, not compiling it. -->
+        <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant</artifactId>
+            <version>1.10.6</version>
+        </dependency>
+
+        <!-- Testing only dependencies. -->
         <dependency>
             <groupId>com.google.truth</groupId>
             <artifactId>truth</artifactId>
@@ -110,11 +126,6 @@
             <artifactId>truth-java8-extension</artifactId>
             <version>1.0</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant</artifactId>
-            <version>1.10.6</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
I have no idea why, but my Maven setup had used version 65.1 of the ICU4J dependency in the pom file. Perhaps it was configured locally (e.g. my setup or in Google) for some reason but it stopped working abruptly for me tonight (Maven would not build and could not resolve the dependency). I set it back to 64.2 and added some comments, and everything appears to work again. Very odd.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20693
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

