### PR TITLE
ICU-20807 BRS65: Environment test failure in cintltst-timezone

### DIFF
--- a/icu4c/source/test/cintltst/ccaltst.c
+++ b/icu4c/source/test/cintltst/ccaltst.c
@@ -114,7 +114,8 @@ static void TestCalendar()
     UChar *result = 0;
     int32_t resultlength, resultlengthneeded;
     char tempMsgBuf[1024];  // u_austrcpy() of some formatted dates & times.
-    UChar zone1[32], zone2[32];
+    char tempMsgBuf2[256];  // u_austrcpy() of some formatted dates & times.
+    UChar zone1[64], zone2[64];
     const char *tzver = 0;
     UChar canonicalID[64];
     UBool isSystemID = FALSE;
@@ -231,7 +232,7 @@ static void TestCalendar()
     /*Test ucal_set/getDefaultTimeZone and ucal_getHostTimeZone */
     status = U_ZERO_ERROR;
     i = ucal_getDefaultTimeZone(zone1, UPRV_LENGTHOF(zone1), &status);
-    if (U_FAILURE(status)) {
+    if (U_FAILURE(status) || status == U_STRING_NOT_TERMINATED_WARNING) {
         log_err("FAIL: ucal_getDefaultTimeZone() => %s\n",
                 u_errorName(status));
     } else {
@@ -250,11 +251,12 @@ static void TestCalendar()
                 } else {
                     // Redetect the host timezone, it should be the same as zone1 even though ICU's default timezone has been changed.
                     i = ucal_getHostTimeZone(zone2, UPRV_LENGTHOF(zone2), &status);
-                    if (U_FAILURE(status)) {
+                    if (U_FAILURE(status) || status == U_STRING_NOT_TERMINATED_WARNING) {
                         log_err("FAIL: ucal_getHostTimeZone() => %s\n", u_errorName(status));
                     } else {
                         if (u_strcmp(zone1, zone2) != 0) {
-                            log_err("FAIL: ucal_getHostTimeZone() should give the same host timezone even if the default changed.\n");
+                            log_err("FAIL: ucal_getHostTimeZone() should give the same host timezone even if the default changed. (Got '%s', Expected '%s').\n",
+                                u_austrcpy(tempMsgBuf, zone2), u_austrcpy(tempMsgBuf2, zone1));
                         }
                     }
                 }


### PR DESCRIPTION
The issue was found by Norbert while running the Environment tests for the ICU 65 BRS.

It looks like the test case for the C wrapper I added in ICU 65 (`ucal_getHostTimeZone`) exposed a latent issue in the cintltst test code.

The cintltst fails for "America/Argentina/ComodRivadavia", which has length of 32, the same as the buffer that the test is using.
This results in the string being not terminated with a NUL, leading to the new test case failing.

This PR increases the buffer size used by the test, and also checks for the string not terminated warning.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20807
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

