### PR TITLE
ICU-20795 add LocaleMatcher to API docs index

### DIFF
--- a/icu4c/source/common/unicode/docmain.h
+++ b/icu4c/source/common/unicode/docmain.h
@@ -99,7 +99,7 @@
  *   </tr>
  *   <tr>
  *     <td>Codepage Conversion</td>
- *     <td>ucnv.h, ucnvsel.hb</td>
+ *     <td>ucnv.h, ucnvsel.h</td>
  *     <td>C API</td>
  *   </tr>
  *   <tr>
@@ -115,7 +115,7 @@
  *   <tr>
  *     <td>Locales </td>
  *     <td>uloc.h</a></td>
- *     <td>icu::Locale, icu::LocaleBuilder</td>
+ *     <td>icu::Locale, icu::LocaleBuilder, icu::LocaleMatcher</td>
  *   </tr>
  *   <tr>
  *     <td>Resource Bundles</td>


### PR DESCRIPTION
For ICU 65rc: https://unicode-org.atlassian.net/browse/ICU-20795