### PR TITLE
ICU-20795 BRS test without data task: Adds a status check after Local…

### DIFF
--- a/icu4c/source/test/intltest/dtfmttst.cpp
+++ b/icu4c/source/test/intltest/dtfmttst.cpp
@@ -5551,6 +5551,7 @@ void DateFormatTest::TestAdoptCalendarLeak() {
                "hours=h23;lb=strict;lw=normal;measure=metric;numbers=latn;"
                "rg=atzzzz;sd=atat1;ss=none;timezone=Europe/Vienna"),
         status);
+    ASSERT_OK(status);
     sdf.adoptCalendar(Calendar::createInstance(status));
 }
 


### PR DESCRIPTION
…e instance

creation. Test causes segmentation fault if it tries to continue beyond failed
instance creation.
segmentation fault if instance creation fails

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20795
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

