### PR TITLE
ICU-20795 BRS test without data task: Adds a status check after Plura…

### DIFF
--- a/icu4c/source/test/intltest/quantityformattertest.cpp
+++ b/icu4c/source/test/intltest/quantityformattertest.cpp
@@ -17,6 +17,12 @@
 #include "unicode/numfmt.h"
 #include "unicode/plurrule.h"
 
+#define ASSERT_OK(status) UPRV_BLOCK_MACRO_BEGIN { \
+    if(U_FAILURE(status)) { \
+        errcheckln(status, #status " = %s @ %s:%d", u_errorName(status), __FILE__, __LINE__); \
+        return; \
+    } \
+} UPRV_BLOCK_MACRO_END
 
 class QuantityFormatterTest : public IntlTest {
 public:
@@ -117,6 +123,7 @@ void QuantityFormatterTest::TestBasic() {
                 NumberFormat::createInstance(Locale::getEnglish(), status));
         LocalPointer<PluralRules> plurrule(
                 PluralRules::forLocale("en", status));
+        ASSERT_OK(status);
         FieldPosition pos(FieldPosition::DONT_CARE);
         UnicodeString appendTo;
         assertEquals(


### PR DESCRIPTION
…lRules

instance creation. Test causes segmentation fault later if instance creation
fails.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20795
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

