### PR TITLE
ICU-20795 update APIChangeReport for ICU4C 65.1

### DIFF
--- a/icu4c/APIChangeReport.html
+++ b/icu4c/APIChangeReport.html
@@ -5,100 +5,96 @@
 	-->
 <head>
 <META http-equiv="Content-Type" content="text/html; charset=utf-8">
-<title>ICU4C API Comparison: ICU 63 with ICU 64 (update #1: 64.2)</title>
+<title>ICU4C API Comparison: ICU 64 (update #1: 64.2) with ICU 65</title>
 <link type="text/css" href="icu4c.css" rel="stylesheet">
 </head>
 <body>
 <a name="#_top"></a>
-<h1>ICU4C API Comparison: ICU 63 with ICU 64 (update #1: 64.2)</h1>
+<h1>ICU4C API Comparison: ICU 64 (update #1: 64.2) with ICU 65</h1>
 <div id="toc">
 <ul>
 <li>
-<a href="#removed">Removed from ICU 63</a>
+<a href="#removed">Removed from ICU 64</a>
 </li>
 <li>
-<a href="#deprecated">Deprecated or Obsoleted in ICU 64</a>
+<a href="#deprecated">Deprecated or Obsoleted in ICU 65</a>
 </li>
 <li>
-<a href="#changed">Changed in  ICU 64</a>
+<a href="#changed">Changed in  ICU 65</a>
 </li>
 <li>
-<a href="#promoted">Promoted to stable in ICU 64</a>
+<a href="#promoted">Promoted to stable in ICU 65</a>
 </li>
 <li>
-<a href="#added">Added in ICU 64</a>
+<a href="#added">Added in ICU 65</a>
 </li>
 <li>
-<a href="#other">Other existing drafts in ICU 64</a>
+<a href="#other">Other existing drafts in ICU 65</a>
 </li>
 <li>
-<a href="#purevirtual">Signature Simplifications</a><sup style="background-color: yellow; font-size: smallest;">(new)</sup>
+<a href="#purevirtual">Signature Simplifications</a>
 </li>
 </ul>
 <hr>
 </div>
 <a name="removed"></a>
-<h2>Removed from ICU 63</h2>
+<h2>Removed from ICU 64</h2>
 <table BORDER="1" class="genTable">
 <THEAD>
 <tr>
-<th>File</th><th>API</th><th>ICU 63</th><th>ICU 64</th>
+<th>File</th><th>API</th><th>ICU 64</th><th>ICU 65</th>
 </tr>
 </THEAD>
 <tr class="row1">
-<td class="file">localpointer.h</td><td class="proto">LocalArray&lt;T&gt;&amp; icu::LocalArray&lt; T &gt;::moveFrom(LocalArray&lt; T &gt;&amp;)</td><td class="">Draft<br>ICU 56</td><td>(missing)<br>
+<td class="file">decimfmt.h</td><td class="proto">const number::LocalizedNumberFormatter&amp; icu::DecimalFormat::toNumberFormatter() const</td><td class="">Deprecated<br>ICU 64</td><td>(missing)<br>
 <span class=""><span></span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">localpointer.h</td><td class="proto">LocalPointer&lt;T&gt;&amp; icu::LocalPointer&lt; T &gt;::moveFrom(LocalPointer&lt; T &gt;&amp;)</td><td class="">Draft<br>ICU 56</td><td>(missing)<br>
+<td class="file">edits.h</td><td class="proto">UBool icu::Edits::copyErrorTo(UErrorCode&amp;)</td><td class="stabchange">Stable<br>ICU 59</td><td>(missing)<br>
 <span class=""><span></span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">numberformatter.h</td><td class="proto">Appendable&amp; icu::number::FormattedNumber::appendTo(Appendable&amp;)</td><td class="">Deprecated<br>ICU 62</td><td>(missing)<br>
+<td class="file">platform.h</td><td class="proto"><tt>#define</tt> __has_attribute</td><td class="">Internal</td><td>(missing)<br>
 <span class=""><span></span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">numberformatter.h</td><td class="proto">Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::rounding(const Rounder&amp;) const&amp;</td><td class="">Deprecated<br>ICU 62</td><td>(missing)<br>
+<td class="file">platform.h</td><td class="proto"><tt>#define</tt> __has_builtin</td><td class="">Internal</td><td>(missing)<br>
 <span class=""><span></span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">numberformatter.h</td><td class="proto">Precision icu::number::Precision::withMode(UNumberFormatRoundingMode) const</td><td class="">Deprecated<br>ICU 62</td><td>(missing)<br>
+<td class="file">platform.h</td><td class="proto"><tt>#define</tt> __has_cpp_attribute</td><td class="">Internal</td><td>(missing)<br>
 <span class=""><span></span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">numberformatter.h</td><td class="proto">UnicodeString icu::number::FormattedNumber::toString() const</td><td class="">Deprecated<br>ICU 62</td><td>(missing)<br>
+<td class="file">platform.h</td><td class="proto"><tt>#define</tt> __has_declspec_attribute</td><td class="">Internal</td><td>(missing)<br>
 <span class=""><span></span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> SignificantDigitsPrecision icu::number::Precision::fixedDigits(int32_t)</td><td class="">Deprecated<br>ICU 62</td><td>(missing)<br>
+<td class="file">platform.h</td><td class="proto"><tt>#define</tt> __has_extension</td><td class="">Internal</td><td>(missing)<br>
 <span class=""><span></span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> SignificantDigitsPrecision icu::number::Precision::maxDigits(int32_t)</td><td class="">Deprecated<br>ICU 62</td><td>(missing)<br>
+<td class="file">platform.h</td><td class="proto"><tt>#define</tt> __has_feature</td><td class="">Internal</td><td>(missing)<br>
 <span class=""><span></span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> SignificantDigitsPrecision icu::number::Precision::minDigits(int32_t)</td><td class="">Deprecated<br>ICU 62</td><td>(missing)<br>
+<td class="file">platform.h</td><td class="proto"><tt>#define</tt> __has_warning</td><td class="">Internal</td><td>(missing)<br>
 <span class=""><span></span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> SignificantDigitsPrecision icu::number::Precision::minMaxDigits(int32_t, int32_t)</td><td class="">Deprecated<br>ICU 62</td><td>(missing)<br>
+<td class="file">uversion.h</td><td class="proto"><tt>#define</tt> U_NAMESPACE_BEGIN</td><td class="stabchange">Stable<br>ICU 2.4</td><td>(missing)<br>
 <span class=""><span></span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">numberformatter.h</td><td class="proto">void icu::number::FormattedNumber::populateFieldPosition(FieldPosition&amp;, UErrorCode&amp;)</td><td class="">Deprecated<br>ICU 62</td><td>(missing)<br>
+<td class="file">uversion.h</td><td class="proto"><tt>#define</tt> U_NAMESPACE_END</td><td class="stabchange">Stable<br>ICU 2.4</td><td>(missing)<br>
 <span class=""><span></span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">numberformatter.h</td><td class="proto">void icu::number::FormattedNumber::populateFieldPositionIterator(FieldPositionIterator&amp;, UErrorCode&amp;)</td><td class="">Deprecated<br>ICU 62</td><td>(missing)<br>
+<td class="file">uversion.h</td><td class="proto"><tt>#define</tt> U_NAMESPACE_QUALIFIER</td><td class="stabchange">Stable<br>ICU 2.4</td><td>(missing)<br>
 <span class=""><span></span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">numsys.h</td><td class="proto"><tt>#define</tt> NUMSYS_NAME_CAPACITY</td><td class="">Internal</td><td>(missing)<br>
-<span class=""><span></span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">unistr.h</td><td class="proto">UnicodeString&amp; icu::UnicodeString::moveFrom(UnicodeString&amp;)</td><td class="">Draft<br>ICU 56</td><td>(missing)<br>
+<td class="file">uversion.h</td><td class="proto"><tt>#define</tt> U_NAMESPACE_USE</td><td class="stabchange">Stable<br>ICU 2.4</td><td>(missing)<br>
 <span class=""><span></span></span></td>
 </tr>
 </table>
@@ -106,1769 +102,1361 @@
 <a href="#_top">(jump back to top)</a>
 <hr>
 <a name="deprecated"></a>
-<h2>Deprecated or Obsoleted in ICU 64</h2>
+<h2>Deprecated or Obsoleted in ICU 65</h2>
 <table BORDER="1" class="genTable">
 <THEAD>
 <tr>
-<th>File</th><th>API</th><th>ICU 63</th><th>ICU 64</th>
+<th>File</th><th>API</th><th>ICU 64</th><th>ICU 65</th>
 </tr>
 </THEAD>
-<tr class="row1">
-<td class="file">brkiter.h</td><td class="proto"><tt>static</tt> BreakIterator* icu::BreakIterator::createTitleInstance(const Locale&amp;, UErrorCode&amp;)</td><td class="stabchange">Stable<br>ICU 2.1</td><td>Deprecated<br>
-<span class="verchange"><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">decimfmt.h</td><td class="proto">const number::LocalizedNumberFormatter&amp; icu::DecimalFormat::toNumberFormatter() const</td><td class="">Draft<br>ICU 62</td><td>Deprecated<br>
-<span class="verchange"><span>ICU 64</span></span></td>
-</tr>
 </table>
 <P></P>
 <a href="#_top">(jump back to top)</a>
 <hr>
 <a name="changed"></a>
-<h2>Changed in  ICU 64 (old, new)</h2>
+<h2>Changed in  ICU 65 (old, new)</h2>
 <table BORDER="1" class="genTable">
 <THEAD>
 <tr>
-<th>File</th><th>API</th><th>ICU 63</th><th>ICU 64</th>
+<th>File</th><th>API</th><th>ICU 64</th><th>ICU 65</th>
 </tr>
 </THEAD>
 <tr class="row1">
-<td class="file">brkiter.h</td><td class="proto"><tt>static</tt> BreakIterator* icu::BreakIterator::createTitleInstance(const Locale&amp;, UErrorCode&amp;)</td><td class="stabchange">Stable<br>ICU 2.1</td><td>Deprecated<br>
-<span class="verchange"><span>ICU 64</span></span></td>
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createAtmosphere(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 63</td>
 </tr>
 <tr class="row0">
-<td class="file">decimfmt.h</td><td class="proto">UBool icu::DecimalFormat::isFormatFailIfMoreThanMaxDigits() const</td><td class="">Internal</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createPercent(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 63</td>
 </tr>
 <tr class="row1">
-<td class="file">decimfmt.h</td><td class="proto">UBool icu::DecimalFormat::isParseCaseSensitive() const</td><td class="">Internal</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createPermille(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 63</td>
 </tr>
 <tr class="row0">
-<td class="file">decimfmt.h</td><td class="proto">UBool icu::DecimalFormat::isParseNoExponent() const</td><td class="">Internal</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">decimfmt.h</td><td class="proto">UBool icu::DecimalFormat::isSignAlwaysShown() const</td><td class="">Internal</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">decimfmt.h</td><td class="proto">const number::LocalizedNumberFormatter&amp; icu::DecimalFormat::toNumberFormatter() const</td><td class="">Draft<br>ICU 62</td><td>Deprecated<br>
-<span class="verchange"><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">decimfmt.h</td><td class="proto">int32_t icu::DecimalFormat::getMinimumGroupingDigits() const</td><td class="">Internal</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">decimfmt.h</td><td class="proto">void icu::DecimalFormat::setFormatFailIfMoreThanMaxDigits(UBool)</td><td class="">Internal</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">decimfmt.h</td><td class="proto">void icu::DecimalFormat::setMinimumGroupingDigits(int32_t)</td><td class="">Internal</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">decimfmt.h</td><td class="proto">void icu::DecimalFormat::setParseCaseSensitive(UBool)</td><td class="">Internal</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">decimfmt.h</td><td class="proto">void icu::DecimalFormat::setParseNoExponent(UBool)</td><td class="">Internal</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">decimfmt.h</td><td class="proto">void icu::DecimalFormat::setSignAlwaysShown(UBool)</td><td class="">Internal</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">dtptngen.h</td><td class="proto">UnicodeString icu::DateTimePatternGenerator::getFieldDisplayName(UDateTimePatternField, UDateTimePGDisplayWidth) const</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 61</td>
-</tr>
-<tr class="row0">
-<td class="file">ucurr.h</td><td class="proto"><tt>enum</tt> UCurrNameStyle::UCURR_NARROW_SYMBOL_NAME</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 61</td>
-</tr>
-<tr class="row1">
-<td class="file">udatpg.h</td><td class="proto"><tt>enum</tt> UDateTimePGDisplayWidth::UDATPG_ABBREVIATED</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 61</td>
-</tr>
-<tr class="row0">
-<td class="file">udatpg.h</td><td class="proto"><tt>enum</tt> UDateTimePGDisplayWidth::UDATPG_NARROW</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 61</td>
-</tr>
-<tr class="row1">
-<td class="file">udatpg.h</td><td class="proto"><tt>enum</tt> UDateTimePGDisplayWidth::UDATPG_WIDE</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 61</td>
-</tr>
-<tr class="row0">
-<td class="file">udatpg.h</td><td class="proto">int32_t udatpg_getFieldDisplayName(const UDateTimePatternGenerator*, UDateTimePatternField, UDateTimePGDisplayWidth, UChar*, int32_t, UErrorCode*)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 61</td>
-</tr>
-<tr class="row1">
-<td class="file">unum.h</td><td class="proto"><tt>enum</tt> UNumberFormatAttribute::UNUM_MINIMUM_GROUPING_DIGITS</td><td class="">Internal</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">unum.h</td><td class="proto"><tt>enum</tt> UNumberFormatAttribute::UNUM_PARSE_CASE_SENSITIVE</td><td class="">Internal</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">unum.h</td><td class="proto"><tt>enum</tt> UNumberFormatAttribute::UNUM_SIGN_ALWAYS_SHOWN</td><td class="">Internal</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">unumberformatter.h</td><td class="proto">UBool unumf_resultNextFieldPosition(const UFormattedNumber*, UFieldPosition*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 62</td>
-</tr>
-<tr class="row1">
-<td class="file">unumberformatter.h</td><td class="proto">UFormattedNumber* unumf_openResult(UErrorCode*)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 62</td>
-</tr>
-<tr class="row0">
-<td class="file">unumberformatter.h</td><td class="proto">UNumberFormatter* unumf_openForSkeletonAndLocale(const UChar*, int32_t, const char*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 62</td>
-</tr>
-<tr class="row1">
-<td class="file">unumberformatter.h</td><td class="proto">int32_t unumf_resultToString(const UFormattedNumber*, UChar*, int32_t, UErrorCode*)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 62</td>
-</tr>
-<tr class="row0">
-<td class="file">unumberformatter.h</td><td class="proto">void unumf_close(UNumberFormatter*)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 62</td>
-</tr>
-<tr class="row1">
-<td class="file">unumberformatter.h</td><td class="proto">void unumf_closeResult(UFormattedNumber*)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 62</td>
-</tr>
-<tr class="row0">
-<td class="file">unumberformatter.h</td><td class="proto">void unumf_formatDecimal(const UNumberFormatter*, const char*, int32_t, UFormattedNumber*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 62</td>
-</tr>
-<tr class="row1">
-<td class="file">unumberformatter.h</td><td class="proto">void unumf_formatDouble(const UNumberFormatter*, double, UFormattedNumber*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 62</td>
-</tr>
-<tr class="row0">
-<td class="file">unumberformatter.h</td><td class="proto">void unumf_formatInt(const UNumberFormatter*, int64_t, UFormattedNumber*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 62</td>
-</tr>
-<tr class="row1">
-<td class="file">unumberformatter.h</td><td class="proto">void unumf_resultGetAllFieldPositions(const UFormattedNumber*, UFieldPositionIterator*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 62</td>
-</tr>
-<tr class="row0">
-<td class="file">utf8.h</td><td class="proto"><tt>#define</tt> U8_TRUNCATE_IF_INCOMPLETE</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 61</td>
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createPetabyte(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 63</td>
 </tr>
 </table>
 <P></P>
 <a href="#_top">(jump back to top)</a>
 <hr>
 <a name="promoted"></a>
-<h2>Promoted to stable in ICU 64</h2>
+<h2>Promoted to stable in ICU 65</h2>
 <table BORDER="1" class="genTable">
 <THEAD>
 <tr>
-<th>File</th><th>API</th><th>ICU 63</th><th>ICU 64</th>
+<th>File</th><th>API</th><th>ICU 64</th><th>ICU 65</th>
 </tr>
 </THEAD>
 <tr class="row1">
-<td class="file">dtptngen.h</td><td class="proto">UnicodeString icu::DateTimePatternGenerator::getFieldDisplayName(UDateTimePatternField, UDateTimePGDisplayWidth) const</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 61</td>
+<td class="file">basictz.h</td><td class="proto">void* icu::BasicTimeZone::clone() const</td><td class="">(missing)</td><td>Stable<br>
+<span class=""><span>ICU 3.8</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">uchar.h</td><td class="proto"><tt>enum</tt> UBlockCode::UBLOCK_EGYPTIAN_HIEROGLYPH_FORMAT_CONTROLS</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
+<td class="file">datefmt.h</td><td class="proto">void* icu::DateFormat::clone() const</td><td class="">(missing)</td><td>Stable<br>
+<span class=""><span>ICU 2.0</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">uchar.h</td><td class="proto"><tt>enum</tt> UBlockCode::UBLOCK_ELYMAIC</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
+<td class="file">edits.h</td><td class="proto">UBool icu::Edits::copyErrorTo(UErrorCode&amp;) const</td><td class="">(missing)</td><td>Stable<br>
+<span class=""><span>ICU 59</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">uchar.h</td><td class="proto"><tt>enum</tt> UBlockCode::UBLOCK_NANDINAGARI</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createAtmosphere(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 63</td>
 </tr>
 <tr class="row1">
-<td class="file">uchar.h</td><td class="proto"><tt>enum</tt> UBlockCode::UBLOCK_NYIAKENG_PUACHUE_HMONG</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createPercent(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 63</td>
 </tr>
 <tr class="row0">
-<td class="file">uchar.h</td><td class="proto"><tt>enum</tt> UBlockCode::UBLOCK_OTTOMAN_SIYAQ_NUMBERS</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createPermille(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 63</td>
 </tr>
 <tr class="row1">
-<td class="file">uchar.h</td><td class="proto"><tt>enum</tt> UBlockCode::UBLOCK_SMALL_KANA_EXTENSION</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createPetabyte(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 63</td>
 </tr>
 <tr class="row0">
-<td class="file">uchar.h</td><td class="proto"><tt>enum</tt> UBlockCode::UBLOCK_SYMBOLS_AND_PICTOGRAPHS_EXTENDED_A</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
+<td class="file">numfmt.h</td><td class="proto">void* icu::NumberFormat::clone() const</td><td class="">(missing)</td><td>Stable<br>
+<span class=""><span>ICU 2.0</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">uchar.h</td><td class="proto"><tt>enum</tt> UBlockCode::UBLOCK_TAMIL_SUPPLEMENT</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
+<td class="file">unifilt.h</td><td class="proto">void* icu::UnicodeFilter::clone() const</td><td class="">(missing)</td><td>Stable<br>
+<span class=""><span>ICU 2.4</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">uchar.h</td><td class="proto"><tt>enum</tt> UBlockCode::UBLOCK_WANCHO</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
+<td class="file">utrace.h</td><td class="proto"><tt>enum</tt> UTraceFunctionNumber::UTRACE_UDATA_BUNDLE</td><td class="">(missing)</td><td>Stable<br>
+<span class=""><span>ICU 2.8</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">ucurr.h</td><td class="proto"><tt>enum</tt> UCurrNameStyle::UCURR_NARROW_SYMBOL_NAME</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 61</td>
-</tr>
-<tr class="row0">
-<td class="file">udatpg.h</td><td class="proto"><tt>enum</tt> UDateTimePGDisplayWidth::UDATPG_ABBREVIATED</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 61</td>
-</tr>
-<tr class="row1">
-<td class="file">udatpg.h</td><td class="proto"><tt>enum</tt> UDateTimePGDisplayWidth::UDATPG_NARROW</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 61</td>
-</tr>
-<tr class="row0">
-<td class="file">udatpg.h</td><td class="proto"><tt>enum</tt> UDateTimePGDisplayWidth::UDATPG_WIDE</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 61</td>
-</tr>
-<tr class="row1">
-<td class="file">udatpg.h</td><td class="proto">int32_t udatpg_getFieldDisplayName(const UDateTimePatternGenerator*, UDateTimePatternField, UDateTimePGDisplayWidth, UChar*, int32_t, UErrorCode*)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 61</td>
-</tr>
-<tr class="row0">
-<td class="file">unumberformatter.h</td><td class="proto">UBool unumf_resultNextFieldPosition(const UFormattedNumber*, UFieldPosition*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 62</td>
-</tr>
-<tr class="row1">
-<td class="file">unumberformatter.h</td><td class="proto">UFormattedNumber* unumf_openResult(UErrorCode*)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 62</td>
-</tr>
-<tr class="row0">
-<td class="file">unumberformatter.h</td><td class="proto">UNumberFormatter* unumf_openForSkeletonAndLocale(const UChar*, int32_t, const char*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 62</td>
-</tr>
-<tr class="row1">
-<td class="file">unumberformatter.h</td><td class="proto">int32_t unumf_resultToString(const UFormattedNumber*, UChar*, int32_t, UErrorCode*)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 62</td>
-</tr>
-<tr class="row0">
-<td class="file">unumberformatter.h</td><td class="proto">void unumf_close(UNumberFormatter*)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 62</td>
-</tr>
-<tr class="row1">
-<td class="file">unumberformatter.h</td><td class="proto">void unumf_closeResult(UFormattedNumber*)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 62</td>
-</tr>
-<tr class="row0">
-<td class="file">unumberformatter.h</td><td class="proto">void unumf_formatDecimal(const UNumberFormatter*, const char*, int32_t, UFormattedNumber*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 62</td>
-</tr>
-<tr class="row1">
-<td class="file">unumberformatter.h</td><td class="proto">void unumf_formatDouble(const UNumberFormatter*, double, UFormattedNumber*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 62</td>
-</tr>
-<tr class="row0">
-<td class="file">unumberformatter.h</td><td class="proto">void unumf_formatInt(const UNumberFormatter*, int64_t, UFormattedNumber*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 62</td>
-</tr>
-<tr class="row1">
-<td class="file">unumberformatter.h</td><td class="proto">void unumf_resultGetAllFieldPositions(const UFormattedNumber*, UFieldPositionIterator*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 62</td>
-</tr>
-<tr class="row0">
-<td class="file">uscript.h</td><td class="proto"><tt>enum</tt> UScriptCode::USCRIPT_ELYMAIC</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
-</tr>
-<tr class="row1">
-<td class="file">uscript.h</td><td class="proto"><tt>enum</tt> UScriptCode::USCRIPT_NANDINAGARI</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
-</tr>
-<tr class="row0">
-<td class="file">uscript.h</td><td class="proto"><tt>enum</tt> UScriptCode::USCRIPT_NYIAKENG_PUACHUE_HMONG</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
-</tr>
-<tr class="row1">
-<td class="file">uscript.h</td><td class="proto"><tt>enum</tt> UScriptCode::USCRIPT_WANCHO</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
-</tr>
-<tr class="row0">
-<td class="file">utf8.h</td><td class="proto"><tt>#define</tt> U8_TRUNCATE_IF_INCOMPLETE</td><td class="" colspan="2" align="center">Draft&rarr;Stable<br>ICU 61</td>
-</tr>
-<tr class="row1">
-<td class="file">utypes.h</td><td class="proto"><tt>enum</tt> UErrorCode::U_NUMBER_ARG_OUTOFBOUNDS_ERROR</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 61</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">utypes.h</td><td class="proto"><tt>enum</tt> UErrorCode::U_NUMBER_SKELETON_SYNTAX_ERROR</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 62</span></span></td>
+<td class="file">utrace.h</td><td class="proto"><tt>enum</tt> UTraceFunctionNumber::UTRACE_UDATA_RESOURCE</td><td class="">(missing)</td><td>Stable<br>
+<span class=""><span>ICU 2.8</span></span></td>
 </tr>
 </table>
 <P></P>
 <a href="#_top">(jump back to top)</a>
 <hr>
 <a name="added"></a>
-<h2>Added in ICU 64</h2>
+<h2>Added in ICU 65</h2>
 <table BORDER="1" class="genTable">
 <THEAD>
 <tr>
-<th>File</th><th>API</th><th>ICU 63</th><th>ICU 64</th>
+<th>File</th><th>API</th><th>ICU 64</th><th>ICU 65</th>
 </tr>
 </THEAD>
 <tr class="row1">
-<td class="file">currunit.h</td><td class="proto">icu::CurrencyUnit::CurrencyUnit(StringPiece, UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">basictz.h</td><td class="proto">void* icu::BasicTimeZone::clone() const</td><td class="">(missing)</td><td>Stable<br>
+<span class=""><span>ICU 3.8</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">decimfmt.h</td><td class="proto">const number::LocalizedNumberFormatter* icu::DecimalFormat::toNumberFormatter(UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">bytestrie.h</td><td class="proto">BytesTrie&amp; icu::BytesTrie::resetToState64(uint64_t)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">dtitvfmt.h</td><td class="proto">Appendable&amp; icu::FormattedDateInterval::appendTo(Appendable&amp;, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">bytestrie.h</td><td class="proto">uint64_t icu::BytesTrie::getState64() const</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">dtitvfmt.h</td><td class="proto">FormattedDateInterval icu::DateIntervalFormat::formatToValue(Calendar&amp;, Calendar&amp;, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">datefmt.h</td><td class="proto">void* icu::DateFormat::clone() const</td><td class="">(missing)</td><td>Stable<br>
+<span class=""><span>ICU 2.0</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">dtitvfmt.h</td><td class="proto">FormattedDateInterval icu::DateIntervalFormat::formatToValue(const DateInterval&amp;, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">edits.h</td><td class="proto">UBool icu::Edits::copyErrorTo(UErrorCode&amp;) const</td><td class="">(missing)</td><td>Stable<br>
+<span class=""><span>ICU 59</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">dtitvfmt.h</td><td class="proto">FormattedDateInterval&amp; icu::FormattedDateInterval::operator=(FormattedDateInterval&amp;&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">localebuilder.h</td><td class="proto">UBool icu::LocaleBuilder::copyErrorTo(UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">dtitvfmt.h</td><td class="proto">FormattedDateInterval&amp; icu::FormattedDateInterval::operator=(const FormattedDateInterval&amp;)=delete</td><td class="">(missing)</td><td>
-<br>
-<span class=""><span></span>
-<br>
-<b class="bigwarn" title="A new API was introduced that was not tagged.">(untagged)</b></span></td>
+<td class="file">localematcher.h</td><td class="proto">Builder&amp; icu::LocaleMatcher::Builder::addSupportedLocale(const Locale&amp;)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">dtitvfmt.h</td><td class="proto">UBool icu::FormattedDateInterval::nextPosition(ConstrainedFieldPosition&amp;, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">localematcher.h</td><td class="proto">Builder&amp; icu::LocaleMatcher::Builder::operator=(Builder&amp;&amp;)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">dtitvfmt.h</td><td class="proto">UnicodeString icu::FormattedDateInterval::toString(UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">localematcher.h</td><td class="proto">Builder&amp; icu::LocaleMatcher::Builder::setDefaultLocale(const Locale*)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">dtitvfmt.h</td><td class="proto">UnicodeString icu::FormattedDateInterval::toTempString(UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">localematcher.h</td><td class="proto">Builder&amp; icu::LocaleMatcher::Builder::setDemotionPerDesiredLocale(ULocMatchDemotion)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">dtitvfmt.h</td><td class="proto">icu::FormattedDateInterval::FormattedDateInterval()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">localematcher.h</td><td class="proto">Builder&amp; icu::LocaleMatcher::Builder::setFavorSubtag(ULocMatchFavorSubtag)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">dtitvfmt.h</td><td class="proto">icu::FormattedDateInterval::FormattedDateInterval(FormattedDateInterval&amp;&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">localematcher.h</td><td class="proto">Builder&amp; icu::LocaleMatcher::Builder::setSupportedLocales(Iter, Iter)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">dtitvfmt.h</td><td class="proto">icu::FormattedDateInterval::FormattedDateInterval(const FormattedDateInterval&amp;)=delete</td><td class="">(missing)</td><td>
-<br>
-<span class=""><span></span>
-<br>
-<b class="bigwarn" title="A new API was introduced that was not tagged.">(untagged)</b></span></td>
+<td class="file">localematcher.h</td><td class="proto">Builder&amp; icu::LocaleMatcher::Builder::setSupportedLocales(Locale::Iterator&amp;)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">dtitvfmt.h</td><td class="proto">icu::FormattedDateInterval::~FormattedDateInterval()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">localematcher.h</td><td class="proto">Builder&amp; icu::LocaleMatcher::Builder::setSupportedLocalesFromListString(StringPiece)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">formattedvalue.h</td><td class="proto">Appendable&amp; icu::FormattedValue::appendTo(Appendable&amp;, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">localematcher.h</td><td class="proto">Builder&amp; icu::LocaleMatcher::Builder::setSupportedLocalesViaConverter(Iter, Iter, Conv)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">formattedvalue.h</td><td class="proto">UBool icu::ConstrainedFieldPosition::matchesField(int32_t, int32_t) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">localematcher.h</td><td class="proto">Locale icu::LocaleMatcher::Result::makeResolvedLocale(UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">formattedvalue.h</td><td class="proto">UBool icu::FormattedValue::nextPosition(ConstrainedFieldPosition&amp;, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">localematcher.h</td><td class="proto">LocaleMatcher icu::LocaleMatcher::Builder::build(UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">formattedvalue.h</td><td class="proto">UnicodeString icu::FormattedValue::toString(UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">localematcher.h</td><td class="proto">LocaleMatcher&amp; icu::LocaleMatcher::operator=(LocaleMatcher&amp;&amp;)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">formattedvalue.h</td><td class="proto">UnicodeString icu::FormattedValue::toTempString(UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">localematcher.h</td><td class="proto">Result icu::LocaleMatcher::getBestMatchResult(Locale::Iterator&amp;, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">formattedvalue.h</td><td class="proto">icu::ConstrainedFieldPosition::ConstrainedFieldPosition()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">localematcher.h</td><td class="proto">Result icu::LocaleMatcher::getBestMatchResult(const Locale&amp;, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">formattedvalue.h</td><td class="proto">icu::ConstrainedFieldPosition::~ConstrainedFieldPosition()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">localematcher.h</td><td class="proto">Result&amp; icu::LocaleMatcher::Result::operator=(Result&amp;&amp;)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">formattedvalue.h</td><td class="proto">icu::FormattedValue::~FormattedValue()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">localematcher.h</td><td class="proto">UBool icu::LocaleMatcher::Builder::copyErrorTo(UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">formattedvalue.h</td><td class="proto">int32_t icu::ConstrainedFieldPosition::getCategory() const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">localematcher.h</td><td class="proto">const Locale* icu::LocaleMatcher::Result::getDesiredLocale() const</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">formattedvalue.h</td><td class="proto">int32_t icu::ConstrainedFieldPosition::getField() const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">localematcher.h</td><td class="proto">const Locale* icu::LocaleMatcher::Result::getSupportedLocale() const</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">formattedvalue.h</td><td class="proto">int32_t icu::ConstrainedFieldPosition::getLimit() const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">localematcher.h</td><td class="proto">const Locale* icu::LocaleMatcher::getBestMatch(Locale::Iterator&amp;, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">formattedvalue.h</td><td class="proto">int32_t icu::ConstrainedFieldPosition::getStart() const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">localematcher.h</td><td class="proto">const Locale* icu::LocaleMatcher::getBestMatch(const Locale&amp;, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">formattedvalue.h</td><td class="proto">int64_t icu::ConstrainedFieldPosition::getInt64IterationContext() const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">localematcher.h</td><td class="proto">const Locale* icu::LocaleMatcher::getBestMatchForListString(StringPiece, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">formattedvalue.h</td><td class="proto">void icu::ConstrainedFieldPosition::constrainCategory(int32_t)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">formattedvalue.h</td><td class="proto">void icu::ConstrainedFieldPosition::constrainField(int32_t, int32_t)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">formattedvalue.h</td><td class="proto">void icu::ConstrainedFieldPosition::reset()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">formattedvalue.h</td><td class="proto">void icu::ConstrainedFieldPosition::setInt64IterationContext(int64_t)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">formattedvalue.h</td><td class="proto">void icu::ConstrainedFieldPosition::setState(int32_t, int32_t, int32_t, int32_t)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">listformatter.h</td><td class="proto">Appendable&amp; icu::FormattedList::appendTo(Appendable&amp;, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">listformatter.h</td><td class="proto">FormattedList icu::ListFormatter::formatStringsToValue(const UnicodeString items[], int32_t, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">listformatter.h</td><td class="proto">FormattedList&amp; icu::FormattedList::operator=(FormattedList&amp;&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">listformatter.h</td><td class="proto">FormattedList&amp; icu::FormattedList::operator=(const FormattedList&amp;)=delete</td><td class="">(missing)</td><td>
-<br>
-<span class=""><span></span>
-<br>
-<b class="bigwarn" title="A new API was introduced that was not tagged.">(untagged)</b></span></td>
-</tr>
-<tr class="row1">
-<td class="file">listformatter.h</td><td class="proto">UBool icu::FormattedList::nextPosition(ConstrainedFieldPosition&amp;, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">listformatter.h</td><td class="proto">UnicodeString icu::FormattedList::toString(UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">listformatter.h</td><td class="proto">UnicodeString icu::FormattedList::toTempString(UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">listformatter.h</td><td class="proto">icu::FormattedList::FormattedList()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">listformatter.h</td><td class="proto">icu::FormattedList::FormattedList(FormattedList&amp;&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">listformatter.h</td><td class="proto">icu::FormattedList::FormattedList(const FormattedList&amp;)=delete</td><td class="">(missing)</td><td>
-<br>
-<span class=""><span></span>
-<br>
-<b class="bigwarn" title="A new API was introduced that was not tagged.">(untagged)</b></span></td>
-</tr>
-<tr class="row1">
-<td class="file">listformatter.h</td><td class="proto">icu::FormattedList::~FormattedList()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">localebuilder.h</td><td class="proto">Locale icu::LocaleBuilder::build(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::addUnicodeLocaleAttribute(StringPiece)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::clear()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::clearExtensions()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::removeUnicodeLocaleAttribute(StringPiece)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::setExtension(char, StringPiece)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::setLanguage(StringPiece)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::setLanguageTag(StringPiece)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::setLocale(const Locale&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::setRegion(StringPiece)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::setScript(StringPiece)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::setUnicodeLocaleKeyword(StringPiece, StringPiece)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::setVariant(StringPiece)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">localebuilder.h</td><td class="proto">icu::LocaleBuilder::LocaleBuilder()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">localebuilder.h</td><td class="proto">icu::LocaleBuilder::~LocaleBuilder()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">localpointer.h</td><td class="proto">LocalArray&lt;T&gt;&amp; icu::LocalArray&lt; T &gt;::operator=(std::unique_ptr&lt; T[]&gt;&amp;&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">localpointer.h</td><td class="proto">LocalPointer&lt;T&gt;&amp; icu::LocalPointer&lt; T &gt;::operator=(std::unique_ptr&lt; T &gt;&amp;&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">localpointer.h</td><td class="proto">icu::LocalArray&lt; T &gt;::LocalArray(std::unique_ptr&lt; T[]&gt;&amp;&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">localpointer.h</td><td class="proto">icu::LocalArray&lt; T &gt;::operator std::unique_ptr&lt; T[]&gt;() &amp;&amp;</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">localpointer.h</td><td class="proto">icu::LocalPointer&lt; T &gt;::LocalPointer(std::unique_ptr&lt; T &gt;&amp;&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">localpointer.h</td><td class="proto">icu::LocalPointer&lt; T &gt;::operator std::unique_ptr&lt; T &gt;() &amp;&amp;</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">localpointer.h</td><td class="proto"><tt>static</tt> void* icu::LocalPointerBase&lt; T &gt;::operator new(size_t)=delete</td><td class="">(missing)</td><td>
-<br>
-<span class=""><span></span>
-<br>
-<b class="bigwarn" title="A new API was introduced that was not tagged.">(untagged)</b></span></td>
-</tr>
-<tr class="row0">
-<td class="file">localpointer.h</td><td class="proto"><tt>static</tt> void* icu::LocalPointerBase&lt; T &gt;::operator new[](size_t)=delete</td><td class="">(missing)</td><td>
-<br>
-<span class=""><span></span>
-<br>
-<b class="bigwarn" title="A new API was introduced that was not tagged.">(untagged)</b></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getAcre()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getAcreFoot()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getAmpere()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getArcMinute()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getArcSecond()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getAstronomicalUnit()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getAtmosphere()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getBarrel()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getBit()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getBritishThermalUnit()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getBushel()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getByte()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCalorie()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCarat()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCelsius()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCentiliter()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCentimeter()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCentury()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCubicCentimeter()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCubicFoot()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCubicInch()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCubicKilometer()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCubicMeter()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCubicMile()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCubicYard()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCup()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCupMetric()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getDalton()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getDay()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getDayPerson()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getDeciliter()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getDecimeter()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getDegree()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getDunam()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getEarthMass()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getElectronvolt()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getFahrenheit()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getFathom()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getFluidOunce()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getFluidOunceImperial()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getFoodcalorie()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getFoot()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getFurlong()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getGForce()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getGallon()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getGallonImperial()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getGenericTemperature()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getGigabit()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getGigabyte()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getGigahertz()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getGigawatt()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getGram()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getHectare()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getHectoliter()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getHectopascal()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getHertz()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getHorsepower()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getHour()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getInch()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getInchHg()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getJoule()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKarat()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKelvin()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKilobit()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKilobyte()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKilocalorie()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKilogram()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKilohertz()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKilojoule()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKilometer()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKilometerPerHour()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKilopascal()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKilowatt()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKilowattHour()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKnot()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getLightYear()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getLiter()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getLiterPer100Kilometers()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getLiterPerKilometer()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getLux()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMegabit()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMegabyte()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMegahertz()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMegaliter()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMegapascal()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMegawatt()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMeter()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMeterPerSecond()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMeterPerSecondSquared()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMetricTon()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMicrogram()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMicrometer()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMicrosecond()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMile()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMilePerGallon()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMilePerGallonImperial()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMilePerHour()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMileScandinavian()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMilliampere()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMillibar()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMilligram()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMilligramPerDeciliter()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMilliliter()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMillimeter()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMillimeterOfMercury()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMillimolePerLiter()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMillisecond()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMilliwatt()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMinute()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMole()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMonth()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMonthPerson()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getNanometer()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getNanosecond()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getNauticalMile()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getNewton()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getNewtonMeter()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getOhm()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getOunce()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getOunceTroy()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getParsec()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPartPerMillion()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPercent()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPermille()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPermyriad()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPetabyte()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPicometer()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPint()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPintMetric()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPoint()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPound()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPoundFoot()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPoundForce()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPoundPerSquareInch()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getQuart()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getRadian()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getRevolutionAngle()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getSecond()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getSolarLuminosity()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getSolarMass()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getSolarRadius()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getSquareCentimeter()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getSquareFoot()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getSquareInch()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getSquareKilometer()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getSquareMeter()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getSquareMile()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getSquareYard()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getStone()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getTablespoon()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getTeaspoon()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getTerabit()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getTerabyte()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getTon()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getVolt()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getWatt()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getWeek()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getWeekPerson()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getYard()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getYear()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getYearPerson()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createBarrel(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createBritishThermalUnit(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createDalton(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createDayPerson(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createDunam(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createEarthMass(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createElectronvolt(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createFluidOunceImperial(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createKilopascal(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createMegapascal(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createMole(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createMonthPerson(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createNewton(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createNewtonMeter(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createPermyriad(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createPoundFoot(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createPoundForce(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createSolarLuminosity(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createSolarMass(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createSolarRadius(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createWeekPerson(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createYearPerson(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">numberformatter.h</td><td class="proto">LocalPointer&lt;Derived&gt; icu::number::NumberFormatterSettings&lt; Derived &gt;::clone() &amp;&amp;</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">numberformatter.h</td><td class="proto">LocalPointer&lt;Derived&gt; icu::number::NumberFormatterSettings&lt; Derived &gt;::clone() const &amp;</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">numberformatter.h</td><td class="proto">UBool icu::number::FormattedNumber::nextPosition(ConstrainedFieldPosition&amp;, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">numberformatter.h</td><td class="proto">UnicodeString icu::number::FormattedNumber::toTempString(UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">numberformatter.h</td><td class="proto">icu::number::FormattedNumber::FormattedNumber()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> UnlocalizedNumberFormatter icu::number::NumberFormatter::forSkeleton(const UnicodeString&amp;, UParseError&amp;, UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">numberrangeformatter.h</td><td class="proto">LocalPointer&lt;Derived&gt; icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::clone() &amp;&amp;</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">numberrangeformatter.h</td><td class="proto">LocalPointer&lt;Derived&gt; icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::clone() const &amp;</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">numberrangeformatter.h</td><td class="proto">UBool icu::number::FormattedNumberRange::nextPosition(ConstrainedFieldPosition&amp;, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">numberrangeformatter.h</td><td class="proto">UnicodeString icu::number::FormattedNumberRange::toTempString(UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">numfmt.h</td><td class="proto"><tt>enum</tt> 
-							icu::NumberFormat::EAlignmentFields::kCompactField</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">numfmt.h</td><td class="proto"><tt>enum</tt> 
-							icu::NumberFormat::EAlignmentFields::kMeasureUnitField</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">plurrule.h</td><td class="proto">UnicodeString icu::PluralRules::select(const number::FormattedNumber&amp;, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">reldatefmt.h</td><td class="proto">Appendable&amp; icu::FormattedRelativeDateTime::appendTo(Appendable&amp;, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">reldatefmt.h</td><td class="proto">FormattedRelativeDateTime icu::RelativeDateTimeFormatter::formatNumericToValue(double, URelativeDateTimeUnit, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">reldatefmt.h</td><td class="proto">FormattedRelativeDateTime icu::RelativeDateTimeFormatter::formatToValue(UDateDirection, UDateAbsoluteUnit, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">reldatefmt.h</td><td class="proto">FormattedRelativeDateTime icu::RelativeDateTimeFormatter::formatToValue(double, UDateDirection, UDateRelativeUnit, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">reldatefmt.h</td><td class="proto">FormattedRelativeDateTime icu::RelativeDateTimeFormatter::formatToValue(double, URelativeDateTimeUnit, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">reldatefmt.h</td><td class="proto">FormattedRelativeDateTime&amp; icu::FormattedRelativeDateTime::operator=(FormattedRelativeDateTime&amp;&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">reldatefmt.h</td><td class="proto">FormattedRelativeDateTime&amp; icu::FormattedRelativeDateTime::operator=(const FormattedRelativeDateTime&amp;)=delete</td><td class="">(missing)</td><td>
-<br>
-<span class=""><span></span>
-<br>
-<b class="bigwarn" title="A new API was introduced that was not tagged.">(untagged)</b></span></td>
-</tr>
-<tr class="row0">
-<td class="file">reldatefmt.h</td><td class="proto">UBool icu::FormattedRelativeDateTime::nextPosition(ConstrainedFieldPosition&amp;, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">reldatefmt.h</td><td class="proto">UnicodeString icu::FormattedRelativeDateTime::toString(UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">reldatefmt.h</td><td class="proto">UnicodeString icu::FormattedRelativeDateTime::toTempString(UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">reldatefmt.h</td><td class="proto">icu::FormattedRelativeDateTime::FormattedRelativeDateTime()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">reldatefmt.h</td><td class="proto">icu::FormattedRelativeDateTime::FormattedRelativeDateTime(FormattedRelativeDateTime&amp;&amp;)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">reldatefmt.h</td><td class="proto">icu::FormattedRelativeDateTime::FormattedRelativeDateTime(const FormattedRelativeDateTime&amp;)=delete</td><td class="">(missing)</td><td>
-<br>
-<span class=""><span></span>
-<br>
-<b class="bigwarn" title="A new API was introduced that was not tagged.">(untagged)</b></span></td>
-</tr>
-<tr class="row0">
-<td class="file">reldatefmt.h</td><td class="proto">icu::FormattedRelativeDateTime::~FormattedRelativeDateTime()</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">simpleformatter.h</td><td class="proto">UnicodeString icu::SimpleFormatter::getTextWithNoArguments(int32_t*, int32_t) const</td><td class="">(missing)</td><td>Internal<br>
-<span class=""><span></span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">uchar.h</td><td class="proto"><tt>enum</tt> UBlockCode::UBLOCK_EGYPTIAN_HIEROGLYPH_FORMAT_CONTROLS</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
-</tr>
-<tr class="row1">
-<td class="file">uchar.h</td><td class="proto"><tt>enum</tt> UBlockCode::UBLOCK_ELYMAIC</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
-</tr>
-<tr class="row0">
-<td class="file">uchar.h</td><td class="proto"><tt>enum</tt> UBlockCode::UBLOCK_NANDINAGARI</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
-</tr>
-<tr class="row1">
-<td class="file">uchar.h</td><td class="proto"><tt>enum</tt> UBlockCode::UBLOCK_NYIAKENG_PUACHUE_HMONG</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
-</tr>
-<tr class="row0">
-<td class="file">uchar.h</td><td class="proto"><tt>enum</tt> UBlockCode::UBLOCK_OTTOMAN_SIYAQ_NUMBERS</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
-</tr>
-<tr class="row1">
-<td class="file">uchar.h</td><td class="proto"><tt>enum</tt> UBlockCode::UBLOCK_SMALL_KANA_EXTENSION</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
-</tr>
-<tr class="row0">
-<td class="file">uchar.h</td><td class="proto"><tt>enum</tt> UBlockCode::UBLOCK_SYMBOLS_AND_PICTOGRAPHS_EXTENDED_A</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
-</tr>
-<tr class="row1">
-<td class="file">uchar.h</td><td class="proto"><tt>enum</tt> UBlockCode::UBLOCK_TAMIL_SUPPLEMENT</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
-</tr>
-<tr class="row0">
-<td class="file">uchar.h</td><td class="proto"><tt>enum</tt> UBlockCode::UBLOCK_WANCHO</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
-</tr>
-<tr class="row1">
-<td class="file">uconfig.h</td><td class="proto"><tt>#define</tt> UCONFIG_USE_WINDOWS_LCID_MAPPING_API</td><td class="">(missing)</td><td>Internal<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">udat.h</td><td class="proto"><tt>#define</tt> JP_ERA_2019_JA</td><td class="">(missing)</td><td>Internal<br>
+<td class="file">localematcher.h</td><td class="proto">double icu::LocaleMatcher::internalMatch(const Locale&amp;, const Locale&amp;, UErrorCode&amp;) const</td><td class="">(missing)</td><td>Internal<br>
 <span class=""><span></span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">udat.h</td><td class="proto"><tt>#define</tt> JP_ERA_2019_NARROW</td><td class="">(missing)</td><td>Internal<br>
+<td class="file">localematcher.h</td><td class="proto"><tt>enum</tt> ULocMatchDemotion::ULOCMATCH_DEMOTION_NONE</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">localematcher.h</td><td class="proto"><tt>enum</tt> ULocMatchDemotion::ULOCMATCH_DEMOTION_REGION</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">localematcher.h</td><td class="proto"><tt>enum</tt> ULocMatchFavorSubtag::ULOCMATCH_FAVOR_LANGUAGE</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">localematcher.h</td><td class="proto"><tt>enum</tt> ULocMatchFavorSubtag::ULOCMATCH_FAVOR_SCRIPT</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">localematcher.h</td><td class="proto">icu::LocaleMatcher::Builder::Builder()</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">localematcher.h</td><td class="proto">icu::LocaleMatcher::Builder::Builder(Builder&amp;&amp;)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">localematcher.h</td><td class="proto">icu::LocaleMatcher::Builder::~Builder()</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">localematcher.h</td><td class="proto">icu::LocaleMatcher::LocaleMatcher(LocaleMatcher&amp;&amp;)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">localematcher.h</td><td class="proto">icu::LocaleMatcher::Result::Result(Result&amp;&amp;)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">localematcher.h</td><td class="proto">icu::LocaleMatcher::Result::~Result()</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">localematcher.h</td><td class="proto">icu::LocaleMatcher::~LocaleMatcher()</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">localematcher.h</td><td class="proto">int32_t icu::LocaleMatcher::Result::getDesiredIndex() const</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">localematcher.h</td><td class="proto">int32_t icu::LocaleMatcher::Result::getSupportedIndex() const</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">locid.h</td><td class="proto">UBool icu::Locale::ConvertingIterator&lt; Iter, Conv &gt;::hasNext() const override</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">locid.h</td><td class="proto">UBool icu::Locale::Iterator::hasNext() const</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">locid.h</td><td class="proto">UBool icu::Locale::RangeIterator&lt; Iter &gt;::hasNext() const override</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">locid.h</td><td class="proto">const Locale&amp; icu::Locale::ConvertingIterator&lt; Iter, Conv &gt;::next() override</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">locid.h</td><td class="proto">const Locale&amp; icu::Locale::Iterator::next()</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">locid.h</td><td class="proto">const Locale&amp; icu::Locale::RangeIterator&lt; Iter &gt;::next() override</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">locid.h</td><td class="proto">icu::Locale::ConvertingIterator&lt; Iter, Conv &gt;::ConvertingIterator(Iter, Iter, Conv)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">locid.h</td><td class="proto">icu::Locale::Iterator::~Iterator()</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">locid.h</td><td class="proto">icu::Locale::RangeIterator&lt; Iter &gt;::RangeIterator(Iter, Iter)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getBar()</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getDecade()</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getDotPerCentimeter()</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getDotPerInch()</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getEm()</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMegapixel()</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPascal()</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPixel()</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPixelPerCentimeter()</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPixelPerInch()</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getThermUs()</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createBar(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createDecade(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createDotPerCentimeter(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createDotPerInch(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createEm(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createMegapixel(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createPascal(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createPixel(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createPixelPerCentimeter(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createPixelPerInch(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createThermUs(UErrorCode&amp;)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">numberformatter.h</td><td class="proto">StringClass icu::number::FormattedNumber::toDecimalNumber(UErrorCode&amp;) const</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
+</tr>
+<tr class="row0">
+<td class="file">numfmt.h</td><td class="proto">void* icu::NumberFormat::clone() const</td><td class="">(missing)</td><td>Stable<br>
+<span class=""><span>ICU 2.0</span></span></td>
+</tr>
+<tr class="row1">
+<td class="file">platform.h</td><td class="proto"><tt>#define</tt> UPRV_HAS_ATTRIBUTE</td><td class="">(missing)</td><td>Internal<br>
 <span class=""><span></span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">udat.h</td><td class="proto"><tt>#define</tt> JP_ERA_2019_ROOT</td><td class="">(missing)</td><td>Internal<br>
+<td class="file">platform.h</td><td class="proto"><tt>#define</tt> UPRV_HAS_BUILTIN</td><td class="">(missing)</td><td>Internal<br>
 <span class=""><span></span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">udateintervalformat.h</td><td class="proto">UFormattedDateInterval* udtitvfmt_openResult(UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">udateintervalformat.h</td><td class="proto">const UFormattedValue* udtitvfmt_resultAsValue(const UFormattedDateInterval*, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">udateintervalformat.h</td><td class="proto">void udtitvfmt_closeResult(UFormattedDateInterval*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">udateintervalformat.h</td><td class="proto">void udtitvfmt_formatToResult(const UDateIntervalFormat*, UFormattedDateInterval*, UDate, UDate, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">uformattedvalue.h</td><td class="proto">UBool ucfpos_matchesField(const UConstrainedFieldPosition*, int32_t, int32_t, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">uformattedvalue.h</td><td class="proto">UBool ufmtval_nextPosition(const UFormattedValue*, UConstrainedFieldPosition*, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">uformattedvalue.h</td><td class="proto">UConstrainedFieldPosition* ucfpos_open(UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">uformattedvalue.h</td><td class="proto">const UChar* ufmtval_getString(const UFormattedValue*, int32_t*, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">uformattedvalue.h</td><td class="proto"><tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_COUNT</td><td class="">(missing)</td><td>Internal<br>
+<td class="file">platform.h</td><td class="proto"><tt>#define</tt> UPRV_HAS_CPP_ATTRIBUTE</td><td class="">(missing)</td><td>Internal<br>
 <span class=""><span></span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">uformattedvalue.h</td><td class="proto"><tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_DATE_INTERVAL_SPAN</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">platform.h</td><td class="proto"><tt>#define</tt> UPRV_HAS_DECLSPEC_ATTRIBUTE</td><td class="">(missing)</td><td>Internal<br>
+<span class=""><span></span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">uformattedvalue.h</td><td class="proto"><tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_DATE_INTERVAL</td><td class="">(missing)</td><td>Internal<br>
+<td class="file">platform.h</td><td class="proto"><tt>#define</tt> UPRV_HAS_EXTENSION</td><td class="">(missing)</td><td>Internal<br>
 <span class=""><span></span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">uformattedvalue.h</td><td class="proto"><tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_DATE</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">platform.h</td><td class="proto"><tt>#define</tt> UPRV_HAS_FEATURE</td><td class="">(missing)</td><td>Internal<br>
+<span class=""><span></span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">uformattedvalue.h</td><td class="proto"><tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_LIST_SPAN</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">platform.h</td><td class="proto"><tt>#define</tt> UPRV_HAS_WARNING</td><td class="">(missing)</td><td>Internal<br>
+<span class=""><span></span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">uformattedvalue.h</td><td class="proto"><tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_LIST</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">platform.h</td><td class="proto"><tt>#define</tt> U_PF_EMSCRIPTEN</td><td class="">(missing)</td><td>Internal<br>
+<span class=""><span></span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">uformattedvalue.h</td><td class="proto"><tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_NUMBER</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">reldatefmt.h</td><td class="proto"><tt>enum</tt> UDateAbsoluteUnit::UDAT_ABSOLUTE_HOUR</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">uformattedvalue.h</td><td class="proto"><tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_RELATIVE_DATETIME</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">reldatefmt.h</td><td class="proto"><tt>enum</tt> UDateAbsoluteUnit::UDAT_ABSOLUTE_MINUTE</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">uformattedvalue.h</td><td class="proto"><tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_UNDEFINED</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">stringpiece.h</td><td class="proto">icu::StringPiece::StringPiece(T)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">uformattedvalue.h</td><td class="proto">int32_t ucfpos_getCategory(const UConstrainedFieldPosition*, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">ucal.h</td><td class="proto">int32_t ucal_getHostTimeZone(UChar*, int32_t, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">uformattedvalue.h</td><td class="proto">int32_t ucfpos_getField(const UConstrainedFieldPosition*, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">ucharstrie.h</td><td class="proto">UCharsTrie&amp; icu::UCharsTrie::resetToState64(uint64_t)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">uformattedvalue.h</td><td class="proto">int64_t ucfpos_getInt64IterationContext(const UConstrainedFieldPosition*, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">ucharstrie.h</td><td class="proto">uint64_t icu::UCharsTrie::getState64() const</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">uformattedvalue.h</td><td class="proto">void ucfpos_close(UConstrainedFieldPosition*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">uloc.h</td><td class="proto">UEnumeration* uloc_openAvailableByType(ULocAvailableType, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">uformattedvalue.h</td><td class="proto">void ucfpos_constrainCategory(UConstrainedFieldPosition*, int32_t, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">uloc.h</td><td class="proto"><tt>enum</tt> ULocAvailableType::ULOC_AVAILABLE_COUNT</td><td class="">(missing)</td><td>Internal<br>
+<span class=""><span></span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">uformattedvalue.h</td><td class="proto">void ucfpos_constrainField(UConstrainedFieldPosition*, int32_t, int32_t, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">uloc.h</td><td class="proto"><tt>enum</tt> ULocAvailableType::ULOC_AVAILABLE_DEFAULT</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">uformattedvalue.h</td><td class="proto">void ucfpos_getIndexes(const UConstrainedFieldPosition*, int32_t*, int32_t*, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">uloc.h</td><td class="proto"><tt>enum</tt> ULocAvailableType::ULOC_AVAILABLE_ONLY_LEGACY_ALIASES</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">uformattedvalue.h</td><td class="proto">void ucfpos_reset(UConstrainedFieldPosition*, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">uloc.h</td><td class="proto"><tt>enum</tt> ULocAvailableType::ULOC_AVAILABLE_WITH_LEGACY_ALIASES</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">uformattedvalue.h</td><td class="proto">void ucfpos_setInt64IterationContext(UConstrainedFieldPosition*, int64_t, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">umachine.h</td><td class="proto"><tt>#define</tt> UPRV_BLOCK_MACRO_BEGIN</td><td class="">(missing)</td><td>Internal<br>
+<span class=""><span></span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">uformattedvalue.h</td><td class="proto">void ucfpos_setState(UConstrainedFieldPosition*, int32_t, int32_t, int32_t, int32_t, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">umachine.h</td><td class="proto"><tt>#define</tt> UPRV_BLOCK_MACRO_END</td><td class="">(missing)</td><td>Internal<br>
+<span class=""><span></span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">ulistformatter.h</td><td class="proto">UFormattedList* ulistfmt_openResult(UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">unifilt.h</td><td class="proto">void* icu::UnicodeFilter::clone() const</td><td class="">(missing)</td><td>Stable<br>
+<span class=""><span>ICU 2.4</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">ulistformatter.h</td><td class="proto">const UFormattedValue* ulistfmt_resultAsValue(const UFormattedList*, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">utrace.h</td><td class="proto"><tt>enum</tt> UTraceFunctionNumber::UTRACE_RES_DATA_LIMIT</td><td class="">(missing)</td><td>Internal<br>
+<span class=""><span></span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">ulistformatter.h</td><td class="proto">void ulistfmt_closeResult(UFormattedList*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">utrace.h</td><td class="proto"><tt>enum</tt> UTraceFunctionNumber::UTRACE_UDATA_BUNDLE</td><td class="">(missing)</td><td>Stable<br>
+<span class=""><span>ICU 2.8</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">ulistformatter.h</td><td class="proto">void ulistfmt_formatStringsToResult(const UListFormatter*, const UChar* const strings[], const int32_t*, int32_t, UFormattedList*, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">utrace.h</td><td class="proto"><tt>enum</tt> UTraceFunctionNumber::UTRACE_UDATA_DATA_FILE</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">unum.h</td><td class="proto"><tt>enum</tt> UNumberFormatFields::UNUM_COMPACT_FIELD</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">utrace.h</td><td class="proto"><tt>enum</tt> UTraceFunctionNumber::UTRACE_UDATA_RESOURCE</td><td class="">(missing)</td><td>Stable<br>
+<span class=""><span>ICU 2.8</span></span></td>
 </tr>
 <tr class="row1">
-<td class="file">unum.h</td><td class="proto"><tt>enum</tt> UNumberFormatFields::UNUM_MEASURE_UNIT_FIELD</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
+<td class="file">utrace.h</td><td class="proto"><tt>enum</tt> UTraceFunctionNumber::UTRACE_UDATA_RES_FILE</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 <tr class="row0">
-<td class="file">unumberformatter.h</td><td class="proto">UNumberFormatter* unumf_openForSkeletonAndLocaleWithError(const UChar*, int32_t, const char*, UParseError*, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">unumberformatter.h</td><td class="proto">const UFormattedValue* unumf_resultAsValue(const UFormattedNumber*, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">upluralrules.h</td><td class="proto">int32_t uplrules_selectFormatted(const UPluralRules*, const struct UFormattedNumber*, UChar*, int32_t, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">ureldatefmt.h</td><td class="proto">UFormattedRelativeDateTime* ureldatefmt_openResult(UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">ureldatefmt.h</td><td class="proto">const UFormattedValue* ureldatefmt_resultAsValue(const UFormattedRelativeDateTime*, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">ureldatefmt.h</td><td class="proto"><tt>enum</tt> URelativeDateTimeFormatterField::UDAT_REL_LITERAL_FIELD</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">ureldatefmt.h</td><td class="proto"><tt>enum</tt> URelativeDateTimeFormatterField::UDAT_REL_NUMERIC_FIELD</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">ureldatefmt.h</td><td class="proto">void ureldatefmt_closeResult(UFormattedRelativeDateTime*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">ureldatefmt.h</td><td class="proto">void ureldatefmt_formatNumericToResult(const URelativeDateTimeFormatter*, double, URelativeDateTimeUnit, UFormattedRelativeDateTime*, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">ureldatefmt.h</td><td class="proto">void ureldatefmt_formatToResult(const URelativeDateTimeFormatter*, double, URelativeDateTimeUnit, UFormattedRelativeDateTime*, UErrorCode*)</td><td class="">(missing)</td><td>Draft<br>
-<span class=""><span>ICU 64</span></span></td>
-</tr>
-<tr class="row0">
-<td class="file">uscript.h</td><td class="proto"><tt>enum</tt> UScriptCode::USCRIPT_ELYMAIC</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
-</tr>
-<tr class="row1">
-<td class="file">uscript.h</td><td class="proto"><tt>enum</tt> UScriptCode::USCRIPT_NANDINAGARI</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
-</tr>
-<tr class="row0">
-<td class="file">uscript.h</td><td class="proto"><tt>enum</tt> UScriptCode::USCRIPT_NYIAKENG_PUACHUE_HMONG</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
-</tr>
-<tr class="row1">
-<td class="file">uscript.h</td><td class="proto"><tt>enum</tt> UScriptCode::USCRIPT_WANCHO</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 64</span></span></td><td class="bornstable"><b class="bigwarn" title="A new API was introduced as stable in $rightVer.">(Born Stable)</b></td>
-</tr>
-<tr class="row0">
-<td class="file">utypes.h</td><td class="proto"><tt>enum</tt> UErrorCode::U_NUMBER_ARG_OUTOFBOUNDS_ERROR</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 61</span></span></td>
-</tr>
-<tr class="row1">
-<td class="file">utypes.h</td><td class="proto"><tt>enum</tt> UErrorCode::U_NUMBER_SKELETON_SYNTAX_ERROR</td><td class="">(missing)</td><td>Stable<br>
-<span class=""><span>ICU 62</span></span></td>
+<td class="file">utrace.h</td><td class="proto"><tt>enum</tt> UTraceFunctionNumber::UTRACE_UDATA_START</td><td class="">(missing)</td><td>Draft<br>
+<span class=""><span>ICU 65</span></span></td>
 </tr>
 </table>
 <P></P>
 <a href="#_top">(jump back to top)</a>
 <hr>
 <a name="other"></a>
-<h2>Other existing drafts in ICU 64</h2>
+<h2>Other existing drafts in ICU 65</h2>
 <div class="other">
 <table BORDER="1" class="genTable">
 <THEAD>
 <tr>
-<th>File</th><th>API</th><th>ICU 63</th><th>ICU 64</th>
+<th>File</th><th>API</th><th>ICU 64</th><th>ICU 65</th>
 </tr>
 </THEAD>
 <tr class="row1">
+<td class="file">currunit.h</td><td class="proto">icu::CurrencyUnit::CurrencyUnit(StringPiece, UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">decimfmt.h</td><td class="proto">UBool icu::DecimalFormat::isFormatFailIfMoreThanMaxDigits() const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">decimfmt.h</td><td class="proto">UBool icu::DecimalFormat::isParseCaseSensitive() const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">decimfmt.h</td><td class="proto">UBool icu::DecimalFormat::isParseNoExponent() const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">decimfmt.h</td><td class="proto">UBool icu::DecimalFormat::isSignAlwaysShown() const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">decimfmt.h</td><td class="proto">const number::LocalizedNumberFormatter* icu::DecimalFormat::toNumberFormatter(UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">decimfmt.h</td><td class="proto">int32_t icu::DecimalFormat::getMinimumGroupingDigits() const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
 <td class="file">decimfmt.h</td><td class="proto">int32_t icu::DecimalFormat::getMultiplierScale() const</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
 </tr>
+<tr class="row1">
+<td class="file">decimfmt.h</td><td class="proto">void icu::DecimalFormat::setFormatFailIfMoreThanMaxDigits(UBool)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
 <tr class="row0">
+<td class="file">decimfmt.h</td><td class="proto">void icu::DecimalFormat::setMinimumGroupingDigits(int32_t)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
 <td class="file">decimfmt.h</td><td class="proto">void icu::DecimalFormat::setMultiplierScale(int32_t)</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
 </tr>
+<tr class="row0">
+<td class="file">decimfmt.h</td><td class="proto">void icu::DecimalFormat::setParseCaseSensitive(UBool)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
 <tr class="row1">
+<td class="file">decimfmt.h</td><td class="proto">void icu::DecimalFormat::setParseNoExponent(UBool)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">decimfmt.h</td><td class="proto">void icu::DecimalFormat::setSignAlwaysShown(UBool)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">dtitvfmt.h</td><td class="proto">Appendable&amp; icu::FormattedDateInterval::appendTo(Appendable&amp;, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">dtitvfmt.h</td><td class="proto">FormattedDateInterval icu::DateIntervalFormat::formatToValue(Calendar&amp;, Calendar&amp;, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">dtitvfmt.h</td><td class="proto">FormattedDateInterval icu::DateIntervalFormat::formatToValue(const DateInterval&amp;, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">dtitvfmt.h</td><td class="proto">FormattedDateInterval&amp; icu::FormattedDateInterval::operator=(FormattedDateInterval&amp;&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">dtitvfmt.h</td><td class="proto">UBool icu::FormattedDateInterval::nextPosition(ConstrainedFieldPosition&amp;, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">dtitvfmt.h</td><td class="proto">UnicodeString icu::FormattedDateInterval::toString(UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">dtitvfmt.h</td><td class="proto">UnicodeString icu::FormattedDateInterval::toTempString(UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">dtitvfmt.h</td><td class="proto">icu::FormattedDateInterval::FormattedDateInterval()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">dtitvfmt.h</td><td class="proto">icu::FormattedDateInterval::FormattedDateInterval(FormattedDateInterval&amp;&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">dtitvfmt.h</td><td class="proto">icu::FormattedDateInterval::~FormattedDateInterval()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">formattedvalue.h</td><td class="proto">Appendable&amp; icu::FormattedValue::appendTo(Appendable&amp;, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">formattedvalue.h</td><td class="proto">UBool icu::ConstrainedFieldPosition::matchesField(int32_t, int32_t) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">formattedvalue.h</td><td class="proto">UBool icu::FormattedValue::nextPosition(ConstrainedFieldPosition&amp;, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">formattedvalue.h</td><td class="proto">UnicodeString icu::FormattedValue::toString(UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">formattedvalue.h</td><td class="proto">UnicodeString icu::FormattedValue::toTempString(UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">formattedvalue.h</td><td class="proto">icu::ConstrainedFieldPosition::ConstrainedFieldPosition()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">formattedvalue.h</td><td class="proto">icu::ConstrainedFieldPosition::~ConstrainedFieldPosition()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">formattedvalue.h</td><td class="proto">icu::FormattedValue::~FormattedValue()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">formattedvalue.h</td><td class="proto">int32_t icu::ConstrainedFieldPosition::getCategory() const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">formattedvalue.h</td><td class="proto">int32_t icu::ConstrainedFieldPosition::getField() const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">formattedvalue.h</td><td class="proto">int32_t icu::ConstrainedFieldPosition::getLimit() const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">formattedvalue.h</td><td class="proto">int32_t icu::ConstrainedFieldPosition::getStart() const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">formattedvalue.h</td><td class="proto">int64_t icu::ConstrainedFieldPosition::getInt64IterationContext() const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">formattedvalue.h</td><td class="proto">void icu::ConstrainedFieldPosition::constrainCategory(int32_t)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">formattedvalue.h</td><td class="proto">void icu::ConstrainedFieldPosition::constrainField(int32_t, int32_t)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">formattedvalue.h</td><td class="proto">void icu::ConstrainedFieldPosition::setInt64IterationContext(int64_t)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">formattedvalue.h</td><td class="proto">void icu::ConstrainedFieldPosition::setState(int32_t, int32_t, int32_t, int32_t)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">listformatter.h</td><td class="proto">Appendable&amp; icu::FormattedList::appendTo(Appendable&amp;, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">listformatter.h</td><td class="proto">FormattedList icu::ListFormatter::formatStringsToValue(const UnicodeString items[], int32_t, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">listformatter.h</td><td class="proto">FormattedList&amp; icu::FormattedList::operator=(FormattedList&amp;&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">listformatter.h</td><td class="proto">UBool icu::FormattedList::nextPosition(ConstrainedFieldPosition&amp;, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">listformatter.h</td><td class="proto">UnicodeString icu::FormattedList::toString(UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">listformatter.h</td><td class="proto">UnicodeString icu::FormattedList::toTempString(UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
 <td class="file">listformatter.h</td><td class="proto">UnicodeString&amp; icu::ListFormatter::format(const UnicodeString items[], int32_t, UnicodeString&amp;, FieldPositionIterator*, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
+<tr class="row1">
+<td class="file">listformatter.h</td><td class="proto">icu::FormattedList::FormattedList()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
 <tr class="row0">
+<td class="file">listformatter.h</td><td class="proto">icu::FormattedList::FormattedList(FormattedList&amp;&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">listformatter.h</td><td class="proto">icu::FormattedList::~FormattedList()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">localebuilder.h</td><td class="proto">Locale icu::LocaleBuilder::build(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::addUnicodeLocaleAttribute(StringPiece)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::clear()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::clearExtensions()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::removeUnicodeLocaleAttribute(StringPiece)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::setExtension(char, StringPiece)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::setLanguage(StringPiece)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::setLanguageTag(StringPiece)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::setLocale(const Locale&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::setRegion(StringPiece)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::setScript(StringPiece)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::setUnicodeLocaleKeyword(StringPiece, StringPiece)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">localebuilder.h</td><td class="proto">LocaleBuilder&amp; icu::LocaleBuilder::setVariant(StringPiece)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">localebuilder.h</td><td class="proto">icu::LocaleBuilder::LocaleBuilder()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">localebuilder.h</td><td class="proto">icu::LocaleBuilder::~LocaleBuilder()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">localpointer.h</td><td class="proto">LocalArray&lt;T&gt;&amp; icu::LocalArray&lt; T &gt;::operator=(std::unique_ptr&lt; T[]&gt;&amp;&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">localpointer.h</td><td class="proto">LocalPointer&lt;T&gt;&amp; icu::LocalPointer&lt; T &gt;::operator=(std::unique_ptr&lt; T &gt;&amp;&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">localpointer.h</td><td class="proto">icu::LocalArray&lt; T &gt;::LocalArray(std::unique_ptr&lt; T[]&gt;&amp;&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">localpointer.h</td><td class="proto">icu::LocalArray&lt; T &gt;::operator std::unique_ptr&lt; T[]&gt;() &amp;&amp;</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">localpointer.h</td><td class="proto">icu::LocalPointer&lt; T &gt;::LocalPointer(std::unique_ptr&lt; T &gt;&amp;&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">localpointer.h</td><td class="proto">icu::LocalPointer&lt; T &gt;::operator std::unique_ptr&lt; T &gt;() &amp;&amp;</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
 <td class="file">locid.h</td><td class="proto">Locale&amp; icu::Locale::operator=(Locale&amp;&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">locid.h</td><td class="proto">StringClass icu::Locale::getKeywordValue(StringPiece, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">locid.h</td><td class="proto">StringClass icu::Locale::getUnicodeKeywordValue(StringPiece, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">locid.h</td><td class="proto">StringClass icu::Locale::toLanguageTag(UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">locid.h</td><td class="proto">StringEnumeration* icu::Locale::createUnicodeKeywords(UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">locid.h</td><td class="proto">icu::Locale::Locale(Locale&amp;&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">locid.h</td><td class="proto"><tt>static</tt> Locale icu::Locale::forLanguageTag(StringPiece, UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">locid.h</td><td class="proto">void icu::Locale::addLikelySubtags(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">locid.h</td><td class="proto">void icu::Locale::getKeywordValue(StringPiece, ByteSink&amp;, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">locid.h</td><td class="proto">void icu::Locale::getKeywords(OutputIterator, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">locid.h</td><td class="proto">void icu::Locale::getUnicodeKeywordValue(StringPiece, ByteSink&amp;, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">locid.h</td><td class="proto">void icu::Locale::getUnicodeKeywords(OutputIterator, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">locid.h</td><td class="proto">void icu::Locale::minimizeSubtags(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">locid.h</td><td class="proto">void icu::Locale::setKeywordValue(StringPiece, StringPiece, UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">locid.h</td><td class="proto">void icu::Locale::setUnicodeKeywordValue(StringPiece, StringPiece, UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">locid.h</td><td class="proto">void icu::Locale::toLanguageTag(ByteSink&amp;, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">measfmt.h</td><td class="proto">void icu::MeasureFormat::parseObject(const UnicodeString&amp;, Formattable&amp;, ParsePosition&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 53</td>
 </tr>
-<tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createAtmosphere(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
-</tr>
 <tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createPercent(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getAcre()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
 </tr>
 <tr class="row1">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createPermille(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getAcreFoot()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
 </tr>
 <tr class="row0">
-<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createPetabyte(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getAmpere()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getArcMinute()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getArcSecond()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getAstronomicalUnit()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getAtmosphere()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getBarrel()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getBit()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getBritishThermalUnit()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getBushel()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getByte()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCalorie()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCarat()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCelsius()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCentiliter()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCentimeter()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCentury()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCubicCentimeter()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCubicFoot()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCubicInch()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCubicKilometer()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCubicMeter()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCubicMile()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCubicYard()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCup()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getCupMetric()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getDalton()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getDay()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getDayPerson()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getDeciliter()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getDecimeter()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getDegree()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getDunam()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getEarthMass()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getElectronvolt()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getFahrenheit()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getFathom()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getFluidOunce()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getFluidOunceImperial()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getFoodcalorie()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getFoot()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getFurlong()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getGForce()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getGallon()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getGallonImperial()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getGenericTemperature()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getGigabit()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getGigabyte()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getGigahertz()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getGigawatt()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getGram()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getHectare()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getHectoliter()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getHectopascal()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getHertz()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getHorsepower()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getHour()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getInch()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getInchHg()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getJoule()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKarat()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKelvin()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKilobit()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKilobyte()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKilocalorie()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKilogram()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKilohertz()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKilojoule()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKilometer()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKilometerPerHour()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKilopascal()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKilowatt()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKilowattHour()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getKnot()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getLightYear()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getLiter()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getLiterPer100Kilometers()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getLiterPerKilometer()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getLux()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMegabit()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMegabyte()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMegahertz()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMegaliter()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMegapascal()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMegawatt()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMeter()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMeterPerSecond()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMeterPerSecondSquared()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMetricTon()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMicrogram()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMicrometer()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMicrosecond()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMile()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMilePerGallon()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMilePerGallonImperial()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMilePerHour()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMileScandinavian()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMilliampere()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMillibar()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMilligram()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMilligramPerDeciliter()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMilliliter()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMillimeter()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMillimeterOfMercury()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMillimolePerLiter()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMillisecond()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMilliwatt()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMinute()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMole()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMonth()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getMonthPerson()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getNanometer()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getNanosecond()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getNauticalMile()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getNewton()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getNewtonMeter()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getOhm()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getOunce()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getOunceTroy()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getParsec()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPartPerMillion()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPercent()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPermille()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPermyriad()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPetabyte()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPicometer()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPint()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPintMetric()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPoint()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPound()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPoundFoot()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPoundForce()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getPoundPerSquareInch()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getQuart()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getRadian()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getRevolutionAngle()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getSecond()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getSolarLuminosity()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getSolarMass()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getSolarRadius()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getSquareCentimeter()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getSquareFoot()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getSquareInch()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getSquareKilometer()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getSquareMeter()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getSquareMile()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getSquareYard()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getStone()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getTablespoon()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getTeaspoon()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getTerabit()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getTerabyte()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getTon()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getVolt()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getWatt()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getWeek()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getWeekPerson()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getYard()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getYear()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit icu::MeasureUnit::getYearPerson()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createBarrel(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createBritishThermalUnit(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createDalton(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createDayPerson(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createDunam(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createEarthMass(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createElectronvolt(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createFluidOunceImperial(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createKilopascal(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createMegapascal(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createMole(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createMonthPerson(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createNewton(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createNewtonMeter(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createPermyriad(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createPoundFoot(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createPoundForce(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createSolarLuminosity(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createSolarMass(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createSolarRadius(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createWeekPerson(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">measunit.h</td><td class="proto"><tt>static</tt> MeasureUnit* icu::MeasureUnit::createYearPerson(UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
 </tr>
 <tr class="row1">
 <td class="file">nounit.h</td><td class="proto">UClassID icu::NoUnit::getDynamicClassID() const</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
 <tr class="row0">
-<td class="file">nounit.h</td><td class="proto">UObject* icu::NoUnit::clone() const</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
-</tr>
-<tr class="row1">
 <td class="file">nounit.h</td><td class="proto">icu::NoUnit::NoUnit(const NoUnit&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">nounit.h</td><td class="proto">icu::NoUnit::~NoUnit()</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">nounit.h</td><td class="proto"><tt>static</tt> NoUnit icu::NoUnit::base()</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">nounit.h</td><td class="proto"><tt>static</tt> NoUnit icu::NoUnit::percent()</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">nounit.h</td><td class="proto"><tt>static</tt> NoUnit icu::NoUnit::permille()</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">nounit.h</td><td class="proto"><tt>static</tt> UClassID icu::NoUnit::getStaticClassID()</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
+</tr>
+<tr class="row0">
+<td class="file">nounit.h</td><td class="proto">void* icu::NoUnit::clone() const</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
 <tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto">Appendable&amp; icu::number::FormattedNumber::appendTo(Appendable&amp;, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
@@ -1982,6 +1570,12 @@
 <td class="file">numberformatter.h</td><td class="proto">IntegerWidth icu::number::IntegerWidth::truncateAt(int32_t)</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
 <tr class="row0">
+<td class="file">numberformatter.h</td><td class="proto">LocalPointer&lt;Derived&gt; icu::number::NumberFormatterSettings&lt; Derived &gt;::clone() &amp;&amp;</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">numberformatter.h</td><td class="proto">LocalPointer&lt;Derived&gt; icu::number::NumberFormatterSettings&lt; Derived &gt;::clone() const &amp;</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
 <td class="file">numberformatter.h</td><td class="proto">LocalizedNumberFormatter icu::number::UnlocalizedNumberFormatter::locale(const icu::Locale&amp;) const&amp;</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
 <tr class="row1">
@@ -2021,10 +1615,16 @@
 <td class="file">numberformatter.h</td><td class="proto">UBool icu::number::FormattedNumber::nextFieldPosition(FieldPosition&amp;, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
 </tr>
 <tr class="row1">
-<td class="file">numberformatter.h</td><td class="proto">UBool icu::number::NumberFormatterSettings&lt; Derived &gt;::copyErrorTo(UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
+<td class="file">numberformatter.h</td><td class="proto">UBool icu::number::FormattedNumber::nextPosition(ConstrainedFieldPosition&amp;, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
 </tr>
 <tr class="row0">
+<td class="file">numberformatter.h</td><td class="proto">UBool icu::number::NumberFormatterSettings&lt; Derived &gt;::copyErrorTo(UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
+</tr>
+<tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto">UnicodeString icu::number::FormattedNumber::toString(UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
+</tr>
+<tr class="row0">
+<td class="file">numberformatter.h</td><td class="proto">UnicodeString icu::number::FormattedNumber::toTempString(UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
 </tr>
 <tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto">UnicodeString icu::number::NumberFormatterSettings&lt; Derived &gt;::toSkeleton(UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
@@ -2036,115 +1636,121 @@
 <td class="file">numberformatter.h</td><td class="proto">UnlocalizedNumberFormatter&amp; icu::number::UnlocalizedNumberFormatter::operator=(const UnlocalizedNumberFormatter&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
 </tr>
 <tr class="row0">
+<td class="file">numberformatter.h</td><td class="proto">icu::number::FormattedNumber::FormattedNumber()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto">icu::number::FormattedNumber::FormattedNumber(FormattedNumber&amp;&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">numberformatter.h</td><td class="proto">icu::number::FormattedNumber::~FormattedNumber()</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto">icu::number::LocalizedNumberFormatter::LocalizedNumberFormatter()=default</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">numberformatter.h</td><td class="proto">icu::number::LocalizedNumberFormatter::LocalizedNumberFormatter(LocalizedNumberFormatter&amp;&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto">icu::number::LocalizedNumberFormatter::LocalizedNumberFormatter(const LocalizedNumberFormatter&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">numberformatter.h</td><td class="proto">icu::number::LocalizedNumberFormatter::~LocalizedNumberFormatter()</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto">icu::number::Scale::Scale(Scale&amp;&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">numberformatter.h</td><td class="proto">icu::number::Scale::Scale(const Scale&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto">icu::number::Scale::~Scale()</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">numberformatter.h</td><td class="proto">icu::number::UnlocalizedNumberFormatter::UnlocalizedNumberFormatter()=default</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto">icu::number::UnlocalizedNumberFormatter::UnlocalizedNumberFormatter(UnlocalizedNumberFormatter&amp;&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">numberformatter.h</td><td class="proto">icu::number::UnlocalizedNumberFormatter::UnlocalizedNumberFormatter(const UnlocalizedNumberFormatter&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> CompactNotation icu::number::Notation::compactLong()</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> CompactNotation icu::number::Notation::compactShort()</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> CurrencyPrecision icu::number::Precision::currency(UCurrencyUsage)</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> FractionPrecision icu::number::Precision::fixedFraction(int32_t)</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> FractionPrecision icu::number::Precision::integer()</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> FractionPrecision icu::number::Precision::maxFraction(int32_t)</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> FractionPrecision icu::number::Precision::minFraction(int32_t)</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> FractionPrecision icu::number::Precision::minMaxFraction(int32_t, int32_t)</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> IncrementPrecision icu::number::Precision::increment(double)</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> IntegerWidth icu::number::IntegerWidth::zeroFillTo(int32_t)</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> LocalizedNumberFormatter icu::number::NumberFormatter::withLocale(const Locale&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> Precision icu::number::Precision::unlimited()</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> Scale icu::number::Scale::byDecimal(StringPiece)</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> Scale icu::number::Scale::byDouble(double)</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> Scale icu::number::Scale::byDoubleAndPowerOfTen(double, int32_t)</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> Scale icu::number::Scale::none()</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> Scale icu::number::Scale::powerOfTen(int32_t)</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> ScientificNotation icu::number::Notation::engineering()</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> ScientificNotation icu::number::Notation::scientific()</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> SignificantDigitsPrecision icu::number::Precision::fixedSignificantDigits(int32_t)</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> SignificantDigitsPrecision icu::number::Precision::maxSignificantDigits(int32_t)</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> SignificantDigitsPrecision icu::number::Precision::minMaxSignificantDigits(int32_t, int32_t)</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> SignificantDigitsPrecision icu::number::Precision::minSignificantDigits(int32_t)</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> SimpleNotation icu::number::Notation::simple()</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> UnlocalizedNumberFormatter icu::number::NumberFormatter::forSkeleton(const UnicodeString&amp;, UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
+</tr>
+<tr class="row0">
+<td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> UnlocalizedNumberFormatter icu::number::NumberFormatter::forSkeleton(const UnicodeString&amp;, UParseError&amp;, UErrorCode&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
 </tr>
 <tr class="row1">
 <td class="file">numberformatter.h</td><td class="proto"><tt>static</tt> UnlocalizedNumberFormatter icu::number::NumberFormatter::with()</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
@@ -2210,6 +1816,12 @@
 <td class="file">numberrangeformatter.h</td><td class="proto">FormattedNumberRange&amp; icu::number::FormattedNumberRange::operator=(FormattedNumberRange&amp;&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
 <tr class="row0">
+<td class="file">numberrangeformatter.h</td><td class="proto">LocalPointer&lt;Derived&gt; icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::clone() &amp;&amp;</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">numberrangeformatter.h</td><td class="proto">LocalPointer&lt;Derived&gt; icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::clone() const &amp;</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
 <td class="file">numberrangeformatter.h</td><td class="proto">LocalizedNumberRangeFormatter icu::number::UnlocalizedNumberRangeFormatter::locale(const icu::Locale&amp;) const&amp;</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
 <tr class="row1">
@@ -2225,19 +1837,25 @@
 <td class="file">numberrangeformatter.h</td><td class="proto">UBool icu::number::FormattedNumberRange::nextFieldPosition(FieldPosition&amp;, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
 <tr class="row1">
+<td class="file">numberrangeformatter.h</td><td class="proto">UBool icu::number::FormattedNumberRange::nextPosition(ConstrainedFieldPosition&amp;, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
 <td class="file">numberrangeformatter.h</td><td class="proto">UBool icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::copyErrorTo(UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">numberrangeformatter.h</td><td class="proto">UNumberRangeIdentityResult icu::number::FormattedNumberRange::getIdentityResult(UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">numberrangeformatter.h</td><td class="proto">UnicodeString icu::number::FormattedNumberRange::getFirstDecimal(UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">numberrangeformatter.h</td><td class="proto">UnicodeString icu::number::FormattedNumberRange::getSecondDecimal(UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">numberrangeformatter.h</td><td class="proto">UnicodeString icu::number::FormattedNumberRange::toString(UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
+</tr>
+<tr class="row1">
+<td class="file">numberrangeformatter.h</td><td class="proto">UnicodeString icu::number::FormattedNumberRange::toTempString(UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
 </tr>
 <tr class="row0">
 <td class="file">numberrangeformatter.h</td><td class="proto">UnlocalizedNumberRangeFormatter&amp; icu::number::UnlocalizedNumberRangeFormatter::operator=(UnlocalizedNumberRangeFormatter&amp;&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
@@ -2315,112 +1933,244 @@
 <td class="file">numberrangeformatter.h</td><td class="proto">void icu::number::FormattedNumberRange::getAllFieldPositions(FieldPositionIterator&amp;, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
 <tr class="row1">
+<td class="file">numfmt.h</td><td class="proto"><tt>enum</tt>  							icu::NumberFormat::EAlignmentFields::kCompactField</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">numfmt.h</td><td class="proto"><tt>enum</tt>  							icu::NumberFormat::EAlignmentFields::kMeasureUnitField</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">plurrule.h</td><td class="proto">UnicodeString icu::PluralRules::select(const number::FormattedNumber&amp;, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">reldatefmt.h</td><td class="proto">Appendable&amp; icu::FormattedRelativeDateTime::appendTo(Appendable&amp;, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">reldatefmt.h</td><td class="proto">FormattedRelativeDateTime icu::RelativeDateTimeFormatter::formatNumericToValue(double, URelativeDateTimeUnit, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">reldatefmt.h</td><td class="proto">FormattedRelativeDateTime icu::RelativeDateTimeFormatter::formatToValue(UDateDirection, UDateAbsoluteUnit, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">reldatefmt.h</td><td class="proto">FormattedRelativeDateTime icu::RelativeDateTimeFormatter::formatToValue(double, UDateDirection, UDateRelativeUnit, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">reldatefmt.h</td><td class="proto">FormattedRelativeDateTime icu::RelativeDateTimeFormatter::formatToValue(double, URelativeDateTimeUnit, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">reldatefmt.h</td><td class="proto">FormattedRelativeDateTime&amp; icu::FormattedRelativeDateTime::operator=(FormattedRelativeDateTime&amp;&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">reldatefmt.h</td><td class="proto">UBool icu::FormattedRelativeDateTime::nextPosition(ConstrainedFieldPosition&amp;, UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">reldatefmt.h</td><td class="proto">UnicodeString icu::FormattedRelativeDateTime::toString(UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">reldatefmt.h</td><td class="proto">UnicodeString icu::FormattedRelativeDateTime::toTempString(UErrorCode&amp;) const</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
 <td class="file">reldatefmt.h</td><td class="proto"><tt>enum</tt> UDateAbsoluteUnit::UDAT_ABSOLUTE_QUARTER</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
 <tr class="row0">
+<td class="file">reldatefmt.h</td><td class="proto">icu::FormattedRelativeDateTime::FormattedRelativeDateTime()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">reldatefmt.h</td><td class="proto">icu::FormattedRelativeDateTime::FormattedRelativeDateTime(FormattedRelativeDateTime&amp;&amp;)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">reldatefmt.h</td><td class="proto">icu::FormattedRelativeDateTime::~FormattedRelativeDateTime()</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
 <td class="file">uchar.h</td><td class="proto">const UCPMap* u_getIntPropertyMap(UProperty, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">uchar.h</td><td class="proto">const USet* u_getBinaryPropertySet(UProperty, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">ucpmap.h</td><td class="proto">UChar32 ucpmap_getRange(const UCPMap*, UChar32, UCPMapRangeOption, uint32_t, UCPMapValueFilter*, const void*, uint32_t*)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">ucpmap.h</td><td class="proto"><tt>enum</tt> UCPMapRangeOption::UCPMAP_RANGE_FIXED_ALL_SURROGATES</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">ucpmap.h</td><td class="proto"><tt>enum</tt> UCPMapRangeOption::UCPMAP_RANGE_FIXED_LEAD_SURROGATES</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">ucpmap.h</td><td class="proto"><tt>enum</tt> UCPMapRangeOption::UCPMAP_RANGE_NORMAL</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">ucpmap.h</td><td class="proto">uint32_t ucpmap_get(const UCPMap*, UChar32)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">ucptrie.h</td><td class="proto"><tt>#define</tt> UCPTRIE_16</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">ucptrie.h</td><td class="proto"><tt>#define</tt> UCPTRIE_32</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">ucptrie.h</td><td class="proto"><tt>#define</tt> UCPTRIE_8</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">ucptrie.h</td><td class="proto"><tt>#define</tt> UCPTRIE_ASCII_GET</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">ucptrie.h</td><td class="proto"><tt>#define</tt> UCPTRIE_FAST_BMP_GET</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">ucptrie.h</td><td class="proto"><tt>#define</tt> UCPTRIE_FAST_GET</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">ucptrie.h</td><td class="proto"><tt>#define</tt> UCPTRIE_FAST_SUPP_GET</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">ucptrie.h</td><td class="proto"><tt>#define</tt> UCPTRIE_FAST_U16_NEXT</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">ucptrie.h</td><td class="proto"><tt>#define</tt> UCPTRIE_FAST_U16_PREV</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">ucptrie.h</td><td class="proto"><tt>#define</tt> UCPTRIE_FAST_U8_NEXT</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">ucptrie.h</td><td class="proto"><tt>#define</tt> UCPTRIE_FAST_U8_PREV</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">ucptrie.h</td><td class="proto"><tt>#define</tt> UCPTRIE_SMALL_GET</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">ucptrie.h</td><td class="proto">UCPTrie* ucptrie_openFromBinary(UCPTrieType, UCPTrieValueWidth, const void*, int32_t, int32_t*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">ucptrie.h</td><td class="proto">UCPTrieType ucptrie_getType(const UCPTrie*)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">ucptrie.h</td><td class="proto">UCPTrieValueWidth ucptrie_getValueWidth(const UCPTrie*)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">ucptrie.h</td><td class="proto">UChar32 ucptrie_getRange(const UCPTrie*, UChar32, UCPMapRangeOption, uint32_t, UCPMapValueFilter*, const void*, uint32_t*)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">ucptrie.h</td><td class="proto"><tt>enum</tt> UCPTrieType::UCPTRIE_TYPE_ANY</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">ucptrie.h</td><td class="proto"><tt>enum</tt> UCPTrieType::UCPTRIE_TYPE_FAST</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">ucptrie.h</td><td class="proto"><tt>enum</tt> UCPTrieType::UCPTRIE_TYPE_SMALL</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">ucptrie.h</td><td class="proto"><tt>enum</tt> UCPTrieValueWidth::UCPTRIE_VALUE_BITS_16</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">ucptrie.h</td><td class="proto"><tt>enum</tt> UCPTrieValueWidth::UCPTRIE_VALUE_BITS_32</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">ucptrie.h</td><td class="proto"><tt>enum</tt> UCPTrieValueWidth::UCPTRIE_VALUE_BITS_8</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">ucptrie.h</td><td class="proto"><tt>enum</tt> UCPTrieValueWidth::UCPTRIE_VALUE_BITS_ANY</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">ucptrie.h</td><td class="proto">int32_t ucptrie_toBinary(const UCPTrie*, void*, int32_t, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">ucptrie.h</td><td class="proto">uint32_t ucptrie_get(const UCPTrie*, UChar32)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">ucptrie.h</td><td class="proto">void ucptrie_close(UCPTrie*)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
+</tr>
+<tr class="row0">
+<td class="file">udateintervalformat.h</td><td class="proto">UFormattedDateInterval* udtitvfmt_openResult(UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">udateintervalformat.h</td><td class="proto">const UFormattedValue* udtitvfmt_resultAsValue(const UFormattedDateInterval*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">udateintervalformat.h</td><td class="proto">void udtitvfmt_closeResult(UFormattedDateInterval*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">udateintervalformat.h</td><td class="proto">void udtitvfmt_formatToResult(const UDateIntervalFormat*, UFormattedDateInterval*, UDate, UDate, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">uformattedvalue.h</td><td class="proto">UBool ucfpos_matchesField(const UConstrainedFieldPosition*, int32_t, int32_t, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">uformattedvalue.h</td><td class="proto">UBool ufmtval_nextPosition(const UFormattedValue*, UConstrainedFieldPosition*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">uformattedvalue.h</td><td class="proto">UConstrainedFieldPosition* ucfpos_open(UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">uformattedvalue.h</td><td class="proto">const UChar* ufmtval_getString(const UFormattedValue*, int32_t*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">uformattedvalue.h</td><td class="proto"><tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_DATE_INTERVAL_SPAN</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">uformattedvalue.h</td><td class="proto"><tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_DATE</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">uformattedvalue.h</td><td class="proto"><tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_LIST_SPAN</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">uformattedvalue.h</td><td class="proto"><tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_LIST</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">uformattedvalue.h</td><td class="proto"><tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_NUMBER</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">uformattedvalue.h</td><td class="proto"><tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_RELATIVE_DATETIME</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">uformattedvalue.h</td><td class="proto"><tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_UNDEFINED</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">uformattedvalue.h</td><td class="proto">int32_t ucfpos_getCategory(const UConstrainedFieldPosition*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">uformattedvalue.h</td><td class="proto">int32_t ucfpos_getField(const UConstrainedFieldPosition*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">uformattedvalue.h</td><td class="proto">int64_t ucfpos_getInt64IterationContext(const UConstrainedFieldPosition*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">uformattedvalue.h</td><td class="proto">void ucfpos_close(UConstrainedFieldPosition*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">uformattedvalue.h</td><td class="proto">void ucfpos_constrainCategory(UConstrainedFieldPosition*, int32_t, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">uformattedvalue.h</td><td class="proto">void ucfpos_constrainField(UConstrainedFieldPosition*, int32_t, int32_t, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">uformattedvalue.h</td><td class="proto">void ucfpos_getIndexes(const UConstrainedFieldPosition*, int32_t*, int32_t*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">uformattedvalue.h</td><td class="proto">void ucfpos_reset(UConstrainedFieldPosition*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">uformattedvalue.h</td><td class="proto">void ucfpos_setInt64IterationContext(UConstrainedFieldPosition*, int64_t, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">uformattedvalue.h</td><td class="proto">void ucfpos_setState(UConstrainedFieldPosition*, int32_t, int32_t, int32_t, int32_t, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">ulistformatter.h</td><td class="proto">UFormattedList* ulistfmt_openResult(UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">ulistformatter.h</td><td class="proto">const UFormattedValue* ulistfmt_resultAsValue(const UFormattedList*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
 </tr>
 <tr class="row1">
 <td class="file">ulistformatter.h</td><td class="proto"><tt>enum</tt> UListFormatterField::ULISTFMT_ELEMENT_FIELD</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
 <tr class="row0">
 <td class="file">ulistformatter.h</td><td class="proto"><tt>enum</tt> UListFormatterField::ULISTFMT_LITERAL_FIELD</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
+</tr>
+<tr class="row1">
+<td class="file">ulistformatter.h</td><td class="proto">void ulistfmt_closeResult(UFormattedList*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">ulistformatter.h</td><td class="proto">void ulistfmt_formatStringsToResult(const UListFormatter*, const UChar* const strings[], const int32_t*, int32_t, UFormattedList*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
 </tr>
 <tr class="row1">
 <td class="file">umutablecptrie.h</td><td class="proto">UCPTrie* umutablecptrie_buildImmutable(UMutableCPTrie*, UCPTrieType, UCPTrieValueWidth, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
@@ -2453,66 +2203,111 @@
 <td class="file">umutablecptrie.h</td><td class="proto">void umutablecptrie_setRange(UMutableCPTrie*, UChar32, UChar32, uint32_t, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 63</td>
 </tr>
 <tr class="row1">
+<td class="file">unum.h</td><td class="proto"><tt>enum</tt> UNumberFormatAttribute::UNUM_MINIMUM_GROUPING_DIGITS</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">unum.h</td><td class="proto"><tt>enum</tt> UNumberFormatAttribute::UNUM_PARSE_CASE_SENSITIVE</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">unum.h</td><td class="proto"><tt>enum</tt> UNumberFormatAttribute::UNUM_SIGN_ALWAYS_SHOWN</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">unum.h</td><td class="proto"><tt>enum</tt> UNumberFormatFields::UNUM_COMPACT_FIELD</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">unum.h</td><td class="proto"><tt>enum</tt> UNumberFormatFields::UNUM_MEASURE_UNIT_FIELD</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">unumberformatter.h</td><td class="proto">UNumberFormatter* unumf_openForSkeletonAndLocaleWithError(const UChar*, int32_t, const char*, UParseError*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">unumberformatter.h</td><td class="proto">const UFormattedValue* unumf_resultAsValue(const UFormattedNumber*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
 <td class="file">unumberformatter.h</td><td class="proto"><tt>enum</tt> UNumberDecimalSeparatorDisplay::UNUM_DECIMAL_SEPARATOR_ALWAYS</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">unumberformatter.h</td><td class="proto"><tt>enum</tt> UNumberDecimalSeparatorDisplay::UNUM_DECIMAL_SEPARATOR_AUTO</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">unumberformatter.h</td><td class="proto"><tt>enum</tt> UNumberGroupingStrategy::UNUM_GROUPING_AUTO</td><td class="" colspan="2" align="center">Draft<br>ICU 61</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">unumberformatter.h</td><td class="proto"><tt>enum</tt> UNumberGroupingStrategy::UNUM_GROUPING_MIN2</td><td class="" colspan="2" align="center">Draft<br>ICU 61</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">unumberformatter.h</td><td class="proto"><tt>enum</tt> UNumberGroupingStrategy::UNUM_GROUPING_OFF</td><td class="" colspan="2" align="center">Draft<br>ICU 61</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">unumberformatter.h</td><td class="proto"><tt>enum</tt> UNumberGroupingStrategy::UNUM_GROUPING_ON_ALIGNED</td><td class="" colspan="2" align="center">Draft<br>ICU 61</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">unumberformatter.h</td><td class="proto"><tt>enum</tt> UNumberGroupingStrategy::UNUM_GROUPING_THOUSANDS</td><td class="" colspan="2" align="center">Draft<br>ICU 61</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">unumberformatter.h</td><td class="proto"><tt>enum</tt> UNumberSignDisplay::UNUM_SIGN_ACCOUNTING_ALWAYS</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">unumberformatter.h</td><td class="proto"><tt>enum</tt> UNumberSignDisplay::UNUM_SIGN_ACCOUNTING_EXCEPT_ZERO</td><td class="" colspan="2" align="center">Draft<br>ICU 61</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">unumberformatter.h</td><td class="proto"><tt>enum</tt> UNumberSignDisplay::UNUM_SIGN_ACCOUNTING</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">unumberformatter.h</td><td class="proto"><tt>enum</tt> UNumberSignDisplay::UNUM_SIGN_ALWAYS</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">unumberformatter.h</td><td class="proto"><tt>enum</tt> UNumberSignDisplay::UNUM_SIGN_AUTO</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">unumberformatter.h</td><td class="proto"><tt>enum</tt> UNumberSignDisplay::UNUM_SIGN_EXCEPT_ZERO</td><td class="" colspan="2" align="center">Draft<br>ICU 61</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">unumberformatter.h</td><td class="proto"><tt>enum</tt> UNumberSignDisplay::UNUM_SIGN_NEVER</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">unumberformatter.h</td><td class="proto"><tt>enum</tt> UNumberUnitWidth::UNUM_UNIT_WIDTH_FULL_NAME</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">unumberformatter.h</td><td class="proto"><tt>enum</tt> UNumberUnitWidth::UNUM_UNIT_WIDTH_HIDDEN</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">unumberformatter.h</td><td class="proto"><tt>enum</tt> UNumberUnitWidth::UNUM_UNIT_WIDTH_ISO_CODE</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row0">
+<tr class="row1">
 <td class="file">unumberformatter.h</td><td class="proto"><tt>enum</tt> UNumberUnitWidth::UNUM_UNIT_WIDTH_NARROW</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
 </tr>
-<tr class="row1">
+<tr class="row0">
 <td class="file">unumberformatter.h</td><td class="proto"><tt>enum</tt> UNumberUnitWidth::UNUM_UNIT_WIDTH_SHORT</td><td class="" colspan="2" align="center">Draft<br>ICU 60</td>
+</tr>
+<tr class="row1">
+<td class="file">upluralrules.h</td><td class="proto">int32_t uplrules_selectFormatted(const UPluralRules*, const struct UFormattedNumber*, UChar*, int32_t, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
 </tr>
 <tr class="row0">
 <td class="file">uregex.h</td><td class="proto"><tt>enum</tt> URegexpFlag::UREGEX_CANON_EQ</td><td class="" colspan="2" align="center">Draft<br>ICU 2.4</td>
 </tr>
 <tr class="row1">
+<td class="file">ureldatefmt.h</td><td class="proto">UFormattedRelativeDateTime* ureldatefmt_openResult(UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">ureldatefmt.h</td><td class="proto">const UFormattedValue* ureldatefmt_resultAsValue(const UFormattedRelativeDateTime*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">ureldatefmt.h</td><td class="proto"><tt>enum</tt> URelativeDateTimeFormatterField::UDAT_REL_LITERAL_FIELD</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">ureldatefmt.h</td><td class="proto"><tt>enum</tt> URelativeDateTimeFormatterField::UDAT_REL_NUMERIC_FIELD</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">ureldatefmt.h</td><td class="proto">void ureldatefmt_closeResult(UFormattedRelativeDateTime*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
+<td class="file">ureldatefmt.h</td><td class="proto">void ureldatefmt_formatNumericToResult(const URelativeDateTimeFormatter*, double, URelativeDateTimeUnit, UFormattedRelativeDateTime*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row1">
+<td class="file">ureldatefmt.h</td><td class="proto">void ureldatefmt_formatToResult(const URelativeDateTimeFormatter*, double, URelativeDateTimeUnit, UFormattedRelativeDateTime*, UErrorCode*)</td><td class="" colspan="2" align="center">Draft<br>ICU 64</td>
+</tr>
+<tr class="row0">
 <td class="file">uspoof.h</td><td class="proto"><tt>enum</tt> USpoofChecks::USPOOF_HIDDEN_OVERLAY</td><td class="" colspan="2" align="center">Draft<br>ICU 62</td>
 </tr>
 </table>
@@ -2525,13 +2320,146 @@
 <i>This section shows cases where the signature was "simplified" for the sake of comparison. The simplified form is in bold, followed by
     	all possible variations in "original" form.</i>
 <div class="other">
-<ul></ul>
+<ul>
+<li>
+<b>void* icu::ChoiceFormat::clone() const</b>
+<br>ChoiceFormat* icu::ChoiceFormat::clone() const<br>Format* icu::ChoiceFormat::clone() const<br>
+</li>
+<li>
+<b>void* icu::CompactDecimalFormat::clone() const</b>
+<br>CompactDecimalFormat* icu::CompactDecimalFormat::clone() const U_OVERRIDE<br>Format* icu::CompactDecimalFormat::clone() const U_OVERRIDE<br>
+</li>
+<li>
+<b>void* icu::CurrencyAmount::clone() const</b>
+<br>CurrencyAmount* icu::CurrencyAmount::clone() const<br>UObject* icu::CurrencyAmount::clone() const<br>
+</li>
+<li>
+<b>void* icu::CurrencyUnit::clone() const</b>
+<br>CurrencyUnit* icu::CurrencyUnit::clone() const<br>UObject* icu::CurrencyUnit::clone() const<br>
+</li>
+<li>
+<b>void* icu::DateIntervalFormat::clone() const</b>
+<br>DateIntervalFormat* icu::DateIntervalFormat::clone() const<br>Format* icu::DateIntervalFormat::clone() const<br>
+</li>
+<li>
+<b>void* icu::DecimalFormat::clone() const</b>
+<br>DecimalFormat* icu::DecimalFormat::clone() const U_OVERRIDE<br>Format* icu::DecimalFormat::clone() const U_OVERRIDE<br>
+</li>
+<li>
+<b>void* icu::GregorianCalendar::clone() const</b>
+<br>Calendar* icu::GregorianCalendar::clone() const<br>GregorianCalendar* icu::GregorianCalendar::clone() const<br>
+</li>
+<li>
+<b>void* icu::Measure::clone() const</b>
+<br>Measure* icu::Measure::clone() const<br>UObject* icu::Measure::clone() const<br>
+</li>
+<li>
+<b>void* icu::MeasureFormat::clone() const</b>
+<br>Format* icu::MeasureFormat::clone() const<br>MeasureFormat* icu::MeasureFormat::clone() const<br>
+</li>
+<li>
+<b>void* icu::MeasureUnit::clone() const</b>
+<br>MeasureUnit* icu::MeasureUnit::clone() const<br>UObject* icu::MeasureUnit::clone() const<br>
+</li>
+<li>
+<b>void* icu::MessageFormat::clone() const</b>
+<br>Format* icu::MessageFormat::clone() const<br>MessageFormat* icu::MessageFormat::clone() const<br>
+</li>
+<li>
+<b>void* icu::NoUnit::clone() const</b>
+<br>NoUnit* icu::NoUnit::clone() const<br>UObject* icu::NoUnit::clone() const<br>
+</li>
+<li>
+<b>void* icu::PluralFormat::clone() const</b>
+<br>Format* icu::PluralFormat::clone() const<br>PluralFormat* icu::PluralFormat::clone() const<br>
+</li>
+<li>
+<b>void* icu::RuleBasedBreakIterator::clone() const</b>
+<br>BreakIterator* icu::RuleBasedBreakIterator::clone() const<br>RuleBasedBreakIterator* icu::RuleBasedBreakIterator::clone() const<br>
+</li>
+<li>
+<b>void* icu::RuleBasedBreakIterator::createBufferClone(void*, int32_t&amp;, UErrorCode&amp;)</b>
+<br>BreakIterator* icu::RuleBasedBreakIterator::createBufferClone(void*, int32_t&amp;, UErrorCode&amp;)<br>RuleBasedBreakIterator* icu::RuleBasedBreakIterator::createBufferClone(void*, int32_t&amp;, UErrorCode&amp;)<br>
+</li>
+<li>
+<b>void* icu::RuleBasedCollator::clone() const</b>
+<br>Collator* icu::RuleBasedCollator::clone() const<br>RuleBasedCollator* icu::RuleBasedCollator::clone() const<br>
+</li>
+<li>
+<b>void* icu::RuleBasedNumberFormat::clone() const</b>
+<br>Format* icu::RuleBasedNumberFormat::clone() const<br>RuleBasedNumberFormat* icu::RuleBasedNumberFormat::clone() const<br>
+</li>
+<li>
+<b>void* icu::RuleBasedTimeZone::clone() const</b>
+<br>RuleBasedTimeZone* icu::RuleBasedTimeZone::clone() const<br>TimeZone* icu::RuleBasedTimeZone::clone() const<br>
+</li>
+<li>
+<b>void* icu::SelectFormat::clone() const</b>
+<br>Format* icu::SelectFormat::clone() const<br>SelectFormat* icu::SelectFormat::clone() const<br>
+</li>
+<li>
+<b>void* icu::SimpleDateFormat::clone() const</b>
+<br>Format* icu::SimpleDateFormat::clone() const<br>SimpleDateFormat* icu::SimpleDateFormat::clone() const<br>
+</li>
+<li>
+<b>void* icu::SimpleTimeZone::clone() const</b>
+<br>SimpleTimeZone* icu::SimpleTimeZone::clone() const<br>TimeZone* icu::SimpleTimeZone::clone() const<br>
+</li>
+<li>
+<b>void* icu::StringCharacterIterator::clone() const</b>
+<br>CharacterIterator* icu::StringCharacterIterator::clone() const<br>StringCharacterIterator* icu::StringCharacterIterator::clone() const<br>
+</li>
+<li>
+<b>void* icu::StringSearch::safeClone() const</b>
+<br>SearchIterator* icu::StringSearch::safeClone() const<br>StringSearch* icu::StringSearch::safeClone() const<br>
+</li>
+<li>
+<b>void* icu::TimeUnit::clone() const</b>
+<br>TimeUnit* icu::TimeUnit::clone() const<br>UObject* icu::TimeUnit::clone() const<br>
+</li>
+<li>
+<b>void* icu::TimeUnitAmount::clone() const</b>
+<br>TimeUnitAmount* icu::TimeUnitAmount::clone() const<br>UObject* icu::TimeUnitAmount::clone() const<br>
+</li>
+<li>
+<b>void* icu::TimeUnitFormat::clone() const</b>
+<br>Format* icu::TimeUnitFormat::clone() const<br>TimeUnitFormat* icu::TimeUnitFormat::clone() const<br>
+</li>
+<li>
+<b>void* icu::TimeZoneFormat::clone() const</b>
+<br>Format* icu::TimeZoneFormat::clone() const<br>TimeZoneFormat* icu::TimeZoneFormat::clone() const<br>
+</li>
+<li>
+<b>void* icu::UCharCharacterIterator::clone() const</b>
+<br>CharacterIterator* icu::UCharCharacterIterator::clone() const<br>UCharCharacterIterator* icu::UCharCharacterIterator::clone() const<br>
+</li>
+<li>
+<b>void* icu::UnicodeSet::clone() const</b>
+<br>UnicodeFunctor* icu::UnicodeSet::clone() const<br>UnicodeSet* icu::UnicodeSet::clone() const<br>
+</li>
+<li>
+<b>void* icu::UnicodeSet::cloneAsThawed() const</b>
+<br>UnicodeFunctor* icu::UnicodeSet::cloneAsThawed() const<br>UnicodeSet* icu::UnicodeSet::cloneAsThawed() const<br>
+</li>
+<li>
+<b>void* icu::UnicodeSet::freeze()</b>
+<br>UnicodeFunctor* icu::UnicodeSet::freeze()<br>UnicodeSet* icu::UnicodeSet::freeze()<br>
+</li>
+<li>
+<b>void* icu::UnicodeString::clone() const</b>
+<br>Replaceable* icu::UnicodeString::clone() const<br>UnicodeString* icu::UnicodeString::clone() const<br>
+</li>
+<li>
+<b>void* icu::VTimeZone::clone() const</b>
+<br>TimeZone* icu::VTimeZone::clone() const<br>VTimeZone* icu::VTimeZone::clone() const<br>
+</li>
+</ul>
 </div>
 <P></P>
 <a href="#_top">(jump back to top)</a>
 <hr>
 <p>
-<i><font size="-1">Contents generated by StableAPI tool on Fri Apr 05 10:36:27 PDT 2019<br>Copyright (C) 2019, International Business Machines Corporation, All Rights Reserved.</font></i>
+<i><font size="-1">Contents generated by StableAPI tool on Fri Sep 06 20:08:13 EDT 2019<br>Copyright (C) 2019, International Business Machines Corporation, All Rights Reserved.</font></i>
 </p>
 </body>
 </html>

--- a/icu4c/APIChangeReport.md
+++ b/icu4c/APIChangeReport.md
@@ -1,0 +1,870 @@
+
+
+<!--
+ Copyright (C) 2016 and later: Unicode, Inc. and others.
+ License &amp; terms of use: http://www.unicode.org/copyright.html
+-->
+
+
+# ICU4C API Comparison: ICU 64 (update #1: 64.2) with ICU 65
+
+> _Note_ Markdown format of this document is new for ICU 65.
+
+- [Removed from ICU 64](#removed)
+- [Deprecated or Obsoleted in ICU 65](#deprecated)
+- [Changed in  ICU 65](#changed)
+- [Promoted to stable in ICU 65](#promoted)
+- [Added in ICU 65](#added)
+- [Other existing drafts in ICU 65](#other)
+- [Signature Simplifications](#simplifications)
+
+## Removed
+
+Removed from ICU 64
+  
+| File | API | ICU 64 | ICU 65 |
+|---|---|---|---|
+| decimfmt.h | const number::LocalizedNumberFormatter&amp; icu::DecimalFormat::toNumberFormatter() const |  DeprecatedICU 64 | (missing)
+| edits.h | UBool icu::Edits::copyErrorTo(UErrorCode&amp;) |  StableICU 59 | (missing)
+| platform.h | <tt>#define</tt> __has_attribute |  Internal | (missing)
+| platform.h | <tt>#define</tt> __has_builtin |  Internal | (missing)
+| platform.h | <tt>#define</tt> __has_cpp_attribute |  Internal | (missing)
+| platform.h | <tt>#define</tt> __has_declspec_attribute |  Internal | (missing)
+| platform.h | <tt>#define</tt> __has_extension |  Internal | (missing)
+| platform.h | <tt>#define</tt> __has_feature |  Internal | (missing)
+| platform.h | <tt>#define</tt> __has_warning |  Internal | (missing)
+| uversion.h | <tt>#define</tt> U_NAMESPACE_BEGIN |  StableICU 2.4 | (missing)
+| uversion.h | <tt>#define</tt> U_NAMESPACE_END |  StableICU 2.4 | (missing)
+| uversion.h | <tt>#define</tt> U_NAMESPACE_QUALIFIER |  StableICU 2.4 | (missing)
+| uversion.h | <tt>#define</tt> U_NAMESPACE_USE |  StableICU 2.4 | (missing)
+
+## Deprecated
+
+Deprecated or Obsoleted in ICU 65
+  
+| File | API | ICU 64 | ICU 65 |
+|---|---|---|---|
+
+## Changed
+
+Changed in  ICU 65 (old, new)
+
+
+  
+| File | API | ICU 64 | ICU 65 |
+|---|---|---|---|
+| measunit.h | <tt>static</tt> MeasureUnit* icu::MeasureUnit::createAtmosphere(UErrorCode&amp;) |  Draft→StableICU 63
+| measunit.h | <tt>static</tt> MeasureUnit* icu::MeasureUnit::createPercent(UErrorCode&amp;) |  Draft→StableICU 63
+| measunit.h | <tt>static</tt> MeasureUnit* icu::MeasureUnit::createPermille(UErrorCode&amp;) |  Draft→StableICU 63
+| measunit.h | <tt>static</tt> MeasureUnit* icu::MeasureUnit::createPetabyte(UErrorCode&amp;) |  Draft→StableICU 63
+
+## Promoted
+
+Promoted to stable in ICU 65
+  
+| File | API | ICU 64 | ICU 65 |
+|---|---|---|---|
+| basictz.h | void* icu::BasicTimeZone::clone() const |  (missing) | StableICU 3.8
+| datefmt.h | void* icu::DateFormat::clone() const |  (missing) | StableICU 2.0
+| edits.h | UBool icu::Edits::copyErrorTo(UErrorCode&amp;) const |  (missing) | StableICU 59
+| measunit.h | <tt>static</tt> MeasureUnit* icu::MeasureUnit::createAtmosphere(UErrorCode&amp;) |  Draft→StableICU 63
+| measunit.h | <tt>static</tt> MeasureUnit* icu::MeasureUnit::createPercent(UErrorCode&amp;) |  Draft→StableICU 63
+| measunit.h | <tt>static</tt> MeasureUnit* icu::MeasureUnit::createPermille(UErrorCode&amp;) |  Draft→StableICU 63
+| measunit.h | <tt>static</tt> MeasureUnit* icu::MeasureUnit::createPetabyte(UErrorCode&amp;) |  Draft→StableICU 63
+| numfmt.h | void* icu::NumberFormat::clone() const |  (missing) | StableICU 2.0
+| unifilt.h | void* icu::UnicodeFilter::clone() const |  (missing) | StableICU 2.4
+| utrace.h | <tt>enum</tt> UTraceFunctionNumber::UTRACE_UDATA_BUNDLE |  (missing) | StableICU 2.8
+| utrace.h | <tt>enum</tt> UTraceFunctionNumber::UTRACE_UDATA_RESOURCE |  (missing) | StableICU 2.8
+
+## Added
+
+Added in ICU 65
+  
+| File | API | ICU 64 | ICU 65 |
+|---|---|---|---|
+| basictz.h | void* icu::BasicTimeZone::clone() const |  (missing) | StableICU 3.8
+| bytestrie.h | BytesTrie&amp; icu::BytesTrie::resetToState64(uint64_t) |  (missing) | DraftICU 65
+| bytestrie.h | uint64_t icu::BytesTrie::getState64() const |  (missing) | DraftICU 65
+| datefmt.h | void* icu::DateFormat::clone() const |  (missing) | StableICU 2.0
+| edits.h | UBool icu::Edits::copyErrorTo(UErrorCode&amp;) const |  (missing) | StableICU 59
+| localebuilder.h | UBool icu::LocaleBuilder::copyErrorTo(UErrorCode&amp;) const |  (missing) | DraftICU 65
+| localematcher.h | Builder&amp; icu::LocaleMatcher::Builder::addSupportedLocale(const Locale&amp;) |  (missing) | DraftICU 65
+| localematcher.h | Builder&amp; icu::LocaleMatcher::Builder::operator=(Builder&amp;&amp;) |  (missing) | DraftICU 65
+| localematcher.h | Builder&amp; icu::LocaleMatcher::Builder::setDefaultLocale(const Locale*) |  (missing) | DraftICU 65
+| localematcher.h | Builder&amp; icu::LocaleMatcher::Builder::setDemotionPerDesiredLocale(ULocMatchDemotion) |  (missing) | DraftICU 65
+| localematcher.h | Builder&amp; icu::LocaleMatcher::Builder::setFavorSubtag(ULocMatchFavorSubtag) |  (missing) | DraftICU 65
+| localematcher.h | Builder&amp; icu::LocaleMatcher::Builder::setSupportedLocales(Iter, Iter) |  (missing) | DraftICU 65
+| localematcher.h | Builder&amp; icu::LocaleMatcher::Builder::setSupportedLocales(Locale::Iterator&amp;) |  (missing) | DraftICU 65
+| localematcher.h | Builder&amp; icu::LocaleMatcher::Builder::setSupportedLocalesFromListString(StringPiece) |  (missing) | DraftICU 65
+| localematcher.h | Builder&amp; icu::LocaleMatcher::Builder::setSupportedLocalesViaConverter(Iter, Iter, Conv) |  (missing) | DraftICU 65
+| localematcher.h | Locale icu::LocaleMatcher::Result::makeResolvedLocale(UErrorCode&amp;) const |  (missing) | DraftICU 65
+| localematcher.h | LocaleMatcher icu::LocaleMatcher::Builder::build(UErrorCode&amp;) const |  (missing) | DraftICU 65
+| localematcher.h | LocaleMatcher&amp; icu::LocaleMatcher::operator=(LocaleMatcher&amp;&amp;) |  (missing) | DraftICU 65
+| localematcher.h | Result icu::LocaleMatcher::getBestMatchResult(Locale::Iterator&amp;, UErrorCode&amp;) const |  (missing) | DraftICU 65
+| localematcher.h | Result icu::LocaleMatcher::getBestMatchResult(const Locale&amp;, UErrorCode&amp;) const |  (missing) | DraftICU 65
+| localematcher.h | Result&amp; icu::LocaleMatcher::Result::operator=(Result&amp;&amp;) |  (missing) | DraftICU 65
+| localematcher.h | UBool icu::LocaleMatcher::Builder::copyErrorTo(UErrorCode&amp;) const |  (missing) | DraftICU 65
+| localematcher.h | const Locale* icu::LocaleMatcher::Result::getDesiredLocale() const |  (missing) | DraftICU 65
+| localematcher.h | const Locale* icu::LocaleMatcher::Result::getSupportedLocale() const |  (missing) | DraftICU 65
+| localematcher.h | const Locale* icu::LocaleMatcher::getBestMatch(Locale::Iterator&amp;, UErrorCode&amp;) const |  (missing) | DraftICU 65
+| localematcher.h | const Locale* icu::LocaleMatcher::getBestMatch(const Locale&amp;, UErrorCode&amp;) const |  (missing) | DraftICU 65
+| localematcher.h | const Locale* icu::LocaleMatcher::getBestMatchForListString(StringPiece, UErrorCode&amp;) const |  (missing) | DraftICU 65
+| localematcher.h | double icu::LocaleMatcher::internalMatch(const Locale&amp;, const Locale&amp;, UErrorCode&amp;) const |  (missing) | Internal
+| localematcher.h | <tt>enum</tt> ULocMatchDemotion::ULOCMATCH_DEMOTION_NONE |  (missing) | DraftICU 65
+| localematcher.h | <tt>enum</tt> ULocMatchDemotion::ULOCMATCH_DEMOTION_REGION |  (missing) | DraftICU 65
+| localematcher.h | <tt>enum</tt> ULocMatchFavorSubtag::ULOCMATCH_FAVOR_LANGUAGE |  (missing) | DraftICU 65
+| localematcher.h | <tt>enum</tt> ULocMatchFavorSubtag::ULOCMATCH_FAVOR_SCRIPT |  (missing) | DraftICU 65
+| localematcher.h | icu::LocaleMatcher::Builder::Builder() |  (missing) | DraftICU 65
+| localematcher.h | icu::LocaleMatcher::Builder::Builder(Builder&amp;&amp;) |  (missing) | DraftICU 65
+| localematcher.h | icu::LocaleMatcher::Builder::~Builder() |  (missing) | DraftICU 65
+| localematcher.h | icu::LocaleMatcher::LocaleMatcher(LocaleMatcher&amp;&amp;) |  (missing) | DraftICU 65
+| localematcher.h | icu::LocaleMatcher::Result::Result(Result&amp;&amp;) |  (missing) | DraftICU 65
+| localematcher.h | icu::LocaleMatcher::Result::~Result() |  (missing) | DraftICU 65
+| localematcher.h | icu::LocaleMatcher::~LocaleMatcher() |  (missing) | DraftICU 65
+| localematcher.h | int32_t icu::LocaleMatcher::Result::getDesiredIndex() const |  (missing) | DraftICU 65
+| localematcher.h | int32_t icu::LocaleMatcher::Result::getSupportedIndex() const |  (missing) | DraftICU 65
+| locid.h | UBool icu::Locale::ConvertingIterator&lt; Iter, Conv &gt;::hasNext() const override |  (missing) | DraftICU 65
+| locid.h | UBool icu::Locale::Iterator::hasNext() const |  (missing) | DraftICU 65
+| locid.h | UBool icu::Locale::RangeIterator&lt; Iter &gt;::hasNext() const override |  (missing) | DraftICU 65
+| locid.h | const Locale&amp; icu::Locale::ConvertingIterator&lt; Iter, Conv &gt;::next() override |  (missing) | DraftICU 65
+| locid.h | const Locale&amp; icu::Locale::Iterator::next() |  (missing) | DraftICU 65
+| locid.h | const Locale&amp; icu::Locale::RangeIterator&lt; Iter &gt;::next() override |  (missing) | DraftICU 65
+| locid.h | icu::Locale::ConvertingIterator&lt; Iter, Conv &gt;::ConvertingIterator(Iter, Iter, Conv) |  (missing) | DraftICU 65
+| locid.h | icu::Locale::Iterator::~Iterator() |  (missing) | DraftICU 65
+| locid.h | icu::Locale::RangeIterator&lt; Iter &gt;::RangeIterator(Iter, Iter) |  (missing) | DraftICU 65
+| measunit.h | <tt>static</tt> MeasureUnit icu::MeasureUnit::getBar() |  (missing) | DraftICU 65
+| measunit.h | <tt>static</tt> MeasureUnit icu::MeasureUnit::getDecade() |  (missing) | DraftICU 65
+| measunit.h | <tt>static</tt> MeasureUnit icu::MeasureUnit::getDotPerCentimeter() |  (missing) | DraftICU 65
+| measunit.h | <tt>static</tt> MeasureUnit icu::MeasureUnit::getDotPerInch() |  (missing) | DraftICU 65
+| measunit.h | <tt>static</tt> MeasureUnit icu::MeasureUnit::getEm() |  (missing) | DraftICU 65
+| measunit.h | <tt>static</tt> MeasureUnit icu::MeasureUnit::getMegapixel() |  (missing) | DraftICU 65
+| measunit.h | <tt>static</tt> MeasureUnit icu::MeasureUnit::getPascal() |  (missing) | DraftICU 65
+| measunit.h | <tt>static</tt> MeasureUnit icu::MeasureUnit::getPixel() |  (missing) | DraftICU 65
+| measunit.h | <tt>static</tt> MeasureUnit icu::MeasureUnit::getPixelPerCentimeter() |  (missing) | DraftICU 65
+| measunit.h | <tt>static</tt> MeasureUnit icu::MeasureUnit::getPixelPerInch() |  (missing) | DraftICU 65
+| measunit.h | <tt>static</tt> MeasureUnit icu::MeasureUnit::getThermUs() |  (missing) | DraftICU 65
+| measunit.h | <tt>static</tt> MeasureUnit* icu::MeasureUnit::createBar(UErrorCode&amp;) |  (missing) | DraftICU 65
+| measunit.h | <tt>static</tt> MeasureUnit* icu::MeasureUnit::createDecade(UErrorCode&amp;) |  (missing) | DraftICU 65
+| measunit.h | <tt>static</tt> MeasureUnit* icu::MeasureUnit::createDotPerCentimeter(UErrorCode&amp;) |  (missing) | DraftICU 65
+| measunit.h | <tt>static</tt> MeasureUnit* icu::MeasureUnit::createDotPerInch(UErrorCode&amp;) |  (missing) | DraftICU 65
+| measunit.h | <tt>static</tt> MeasureUnit* icu::MeasureUnit::createEm(UErrorCode&amp;) |  (missing) | DraftICU 65
+| measunit.h | <tt>static</tt> MeasureUnit* icu::MeasureUnit::createMegapixel(UErrorCode&amp;) |  (missing) | DraftICU 65
+| measunit.h | <tt>static</tt> MeasureUnit* icu::MeasureUnit::createPascal(UErrorCode&amp;) |  (missing) | DraftICU 65
+| measunit.h | <tt>static</tt> MeasureUnit* icu::MeasureUnit::createPixel(UErrorCode&amp;) |  (missing) | DraftICU 65
+| measunit.h | <tt>static</tt> MeasureUnit* icu::MeasureUnit::createPixelPerCentimeter(UErrorCode&amp;) |  (missing) | DraftICU 65
+| measunit.h | <tt>static</tt> MeasureUnit* icu::MeasureUnit::createPixelPerInch(UErrorCode&amp;) |  (missing) | DraftICU 65
+| measunit.h | <tt>static</tt> MeasureUnit* icu::MeasureUnit::createThermUs(UErrorCode&amp;) |  (missing) | DraftICU 65
+| numberformatter.h | StringClass icu::number::FormattedNumber::toDecimalNumber(UErrorCode&amp;) const |  (missing) | DraftICU 65
+| numfmt.h | void* icu::NumberFormat::clone() const |  (missing) | StableICU 2.0
+| platform.h | <tt>#define</tt> UPRV_HAS_ATTRIBUTE |  (missing) | Internal
+| platform.h | <tt>#define</tt> UPRV_HAS_BUILTIN |  (missing) | Internal
+| platform.h | <tt>#define</tt> UPRV_HAS_CPP_ATTRIBUTE |  (missing) | Internal
+| platform.h | <tt>#define</tt> UPRV_HAS_DECLSPEC_ATTRIBUTE |  (missing) | Internal
+| platform.h | <tt>#define</tt> UPRV_HAS_EXTENSION |  (missing) | Internal
+| platform.h | <tt>#define</tt> UPRV_HAS_FEATURE |  (missing) | Internal
+| platform.h | <tt>#define</tt> UPRV_HAS_WARNING |  (missing) | Internal
+| platform.h | <tt>#define</tt> U_PF_EMSCRIPTEN |  (missing) | Internal
+| reldatefmt.h | <tt>enum</tt> UDateAbsoluteUnit::UDAT_ABSOLUTE_HOUR |  (missing) | DraftICU 65
+| reldatefmt.h | <tt>enum</tt> UDateAbsoluteUnit::UDAT_ABSOLUTE_MINUTE |  (missing) | DraftICU 65
+| stringpiece.h | icu::StringPiece::StringPiece(T) |  (missing) | DraftICU 65
+| ucal.h | int32_t ucal_getHostTimeZone(UChar*, int32_t, UErrorCode*) |  (missing) | DraftICU 65
+| ucharstrie.h | UCharsTrie&amp; icu::UCharsTrie::resetToState64(uint64_t) |  (missing) | DraftICU 65
+| ucharstrie.h | uint64_t icu::UCharsTrie::getState64() const |  (missing) | DraftICU 65
+| uloc.h | UEnumeration* uloc_openAvailableByType(ULocAvailableType, UErrorCode*) |  (missing) | DraftICU 65
+| uloc.h | <tt>enum</tt> ULocAvailableType::ULOC_AVAILABLE_COUNT |  (missing) | Internal
+| uloc.h | <tt>enum</tt> ULocAvailableType::ULOC_AVAILABLE_DEFAULT |  (missing) | DraftICU 65
+| uloc.h | <tt>enum</tt> ULocAvailableType::ULOC_AVAILABLE_ONLY_LEGACY_ALIASES |  (missing) | DraftICU 65
+| uloc.h | <tt>enum</tt> ULocAvailableType::ULOC_AVAILABLE_WITH_LEGACY_ALIASES |  (missing) | DraftICU 65
+| umachine.h | <tt>#define</tt> UPRV_BLOCK_MACRO_BEGIN |  (missing) | Internal
+| umachine.h | <tt>#define</tt> UPRV_BLOCK_MACRO_END |  (missing) | Internal
+| unifilt.h | void* icu::UnicodeFilter::clone() const |  (missing) | StableICU 2.4
+| utrace.h | <tt>enum</tt> UTraceFunctionNumber::UTRACE_RES_DATA_LIMIT |  (missing) | Internal
+| utrace.h | <tt>enum</tt> UTraceFunctionNumber::UTRACE_UDATA_BUNDLE |  (missing) | StableICU 2.8
+| utrace.h | <tt>enum</tt> UTraceFunctionNumber::UTRACE_UDATA_DATA_FILE |  (missing) | DraftICU 65
+| utrace.h | <tt>enum</tt> UTraceFunctionNumber::UTRACE_UDATA_RESOURCE |  (missing) | StableICU 2.8
+| utrace.h | <tt>enum</tt> UTraceFunctionNumber::UTRACE_UDATA_RES_FILE |  (missing) | DraftICU 65
+| utrace.h | <tt>enum</tt> UTraceFunctionNumber::UTRACE_UDATA_START |  (missing) | DraftICU 65
+
+## Other
+
+Other existing drafts in ICU 65
+
+| File | API | ICU 64 | ICU 65 |
+|---|---|---|---|
+| currunit.h |  icu::CurrencyUnit::CurrencyUnit(StringPiece, UErrorCode&amp;) | DraftICU 64 | 
+| decimfmt.h |  UBool icu::DecimalFormat::isFormatFailIfMoreThanMaxDigits() const | DraftICU 64 | 
+| decimfmt.h |  UBool icu::DecimalFormat::isParseCaseSensitive() const | DraftICU 64 | 
+| decimfmt.h |  UBool icu::DecimalFormat::isParseNoExponent() const | DraftICU 64 | 
+| decimfmt.h |  UBool icu::DecimalFormat::isSignAlwaysShown() const | DraftICU 64 | 
+| decimfmt.h |  const number::LocalizedNumberFormatter* icu::DecimalFormat::toNumberFormatter(UErrorCode&amp;) const | DraftICU 64 | 
+| decimfmt.h |  int32_t icu::DecimalFormat::getMinimumGroupingDigits() const | DraftICU 64 | 
+| decimfmt.h |  int32_t icu::DecimalFormat::getMultiplierScale() const | DraftICU 62 | 
+| decimfmt.h |  void icu::DecimalFormat::setFormatFailIfMoreThanMaxDigits(UBool) | DraftICU 64 | 
+| decimfmt.h |  void icu::DecimalFormat::setMinimumGroupingDigits(int32_t) | DraftICU 64 | 
+| decimfmt.h |  void icu::DecimalFormat::setMultiplierScale(int32_t) | DraftICU 62 | 
+| decimfmt.h |  void icu::DecimalFormat::setParseCaseSensitive(UBool) | DraftICU 64 | 
+| decimfmt.h |  void icu::DecimalFormat::setParseNoExponent(UBool) | DraftICU 64 | 
+| decimfmt.h |  void icu::DecimalFormat::setSignAlwaysShown(UBool) | DraftICU 64 | 
+| dtitvfmt.h |  Appendable&amp; icu::FormattedDateInterval::appendTo(Appendable&amp;, UErrorCode&amp;) const | DraftICU 64 | 
+| dtitvfmt.h |  FormattedDateInterval icu::DateIntervalFormat::formatToValue(Calendar&amp;, Calendar&amp;, UErrorCode&amp;) const | DraftICU 64 | 
+| dtitvfmt.h |  FormattedDateInterval icu::DateIntervalFormat::formatToValue(const DateInterval&amp;, UErrorCode&amp;) const | DraftICU 64 | 
+| dtitvfmt.h |  FormattedDateInterval&amp; icu::FormattedDateInterval::operator=(FormattedDateInterval&amp;&amp;) | DraftICU 64 | 
+| dtitvfmt.h |  UBool icu::FormattedDateInterval::nextPosition(ConstrainedFieldPosition&amp;, UErrorCode&amp;) const | DraftICU 64 | 
+| dtitvfmt.h |  UnicodeString icu::FormattedDateInterval::toString(UErrorCode&amp;) const | DraftICU 64 | 
+| dtitvfmt.h |  UnicodeString icu::FormattedDateInterval::toTempString(UErrorCode&amp;) const | DraftICU 64 | 
+| dtitvfmt.h |  icu::FormattedDateInterval::FormattedDateInterval() | DraftICU 64 | 
+| dtitvfmt.h |  icu::FormattedDateInterval::FormattedDateInterval(FormattedDateInterval&amp;&amp;) | DraftICU 64 | 
+| dtitvfmt.h |  icu::FormattedDateInterval::~FormattedDateInterval() | DraftICU 64 | 
+| formattedvalue.h |  Appendable&amp; icu::FormattedValue::appendTo(Appendable&amp;, UErrorCode&amp;) const | DraftICU 64 | 
+| formattedvalue.h |  UBool icu::ConstrainedFieldPosition::matchesField(int32_t, int32_t) const | DraftICU 64 | 
+| formattedvalue.h |  UBool icu::FormattedValue::nextPosition(ConstrainedFieldPosition&amp;, UErrorCode&amp;) const | DraftICU 64 | 
+| formattedvalue.h |  UnicodeString icu::FormattedValue::toString(UErrorCode&amp;) const | DraftICU 64 | 
+| formattedvalue.h |  UnicodeString icu::FormattedValue::toTempString(UErrorCode&amp;) const | DraftICU 64 | 
+| formattedvalue.h |  icu::ConstrainedFieldPosition::ConstrainedFieldPosition() | DraftICU 64 | 
+| formattedvalue.h |  icu::ConstrainedFieldPosition::~ConstrainedFieldPosition() | DraftICU 64 | 
+| formattedvalue.h |  icu::FormattedValue::~FormattedValue() | DraftICU 64 | 
+| formattedvalue.h |  int32_t icu::ConstrainedFieldPosition::getCategory() const | DraftICU 64 | 
+| formattedvalue.h |  int32_t icu::ConstrainedFieldPosition::getField() const | DraftICU 64 | 
+| formattedvalue.h |  int32_t icu::ConstrainedFieldPosition::getLimit() const | DraftICU 64 | 
+| formattedvalue.h |  int32_t icu::ConstrainedFieldPosition::getStart() const | DraftICU 64 | 
+| formattedvalue.h |  int64_t icu::ConstrainedFieldPosition::getInt64IterationContext() const | DraftICU 64 | 
+| formattedvalue.h |  void icu::ConstrainedFieldPosition::constrainCategory(int32_t) | DraftICU 64 | 
+| formattedvalue.h |  void icu::ConstrainedFieldPosition::constrainField(int32_t, int32_t) | DraftICU 64 | 
+| formattedvalue.h |  void icu::ConstrainedFieldPosition::setInt64IterationContext(int64_t) | DraftICU 64 | 
+| formattedvalue.h |  void icu::ConstrainedFieldPosition::setState(int32_t, int32_t, int32_t, int32_t) | DraftICU 64 | 
+| listformatter.h |  Appendable&amp; icu::FormattedList::appendTo(Appendable&amp;, UErrorCode&amp;) const | DraftICU 64 | 
+| listformatter.h |  FormattedList icu::ListFormatter::formatStringsToValue(const UnicodeString items[], int32_t, UErrorCode&amp;) const | DraftICU 64 | 
+| listformatter.h |  FormattedList&amp; icu::FormattedList::operator=(FormattedList&amp;&amp;) | DraftICU 64 | 
+| listformatter.h |  UBool icu::FormattedList::nextPosition(ConstrainedFieldPosition&amp;, UErrorCode&amp;) const | DraftICU 64 | 
+| listformatter.h |  UnicodeString icu::FormattedList::toString(UErrorCode&amp;) const | DraftICU 64 | 
+| listformatter.h |  UnicodeString icu::FormattedList::toTempString(UErrorCode&amp;) const | DraftICU 64 | 
+| listformatter.h |  UnicodeString&amp; icu::ListFormatter::format(const UnicodeString items[], int32_t, UnicodeString&amp;, FieldPositionIterator*, UErrorCode&amp;) const | DraftICU 63 | 
+| listformatter.h |  icu::FormattedList::FormattedList() | DraftICU 64 | 
+| listformatter.h |  icu::FormattedList::FormattedList(FormattedList&amp;&amp;) | DraftICU 64 | 
+| listformatter.h |  icu::FormattedList::~FormattedList() | DraftICU 64 | 
+| localebuilder.h |  Locale icu::LocaleBuilder::build(UErrorCode&amp;) | DraftICU 64 | 
+| localebuilder.h |  LocaleBuilder&amp; icu::LocaleBuilder::addUnicodeLocaleAttribute(StringPiece) | DraftICU 64 | 
+| localebuilder.h |  LocaleBuilder&amp; icu::LocaleBuilder::clear() | DraftICU 64 | 
+| localebuilder.h |  LocaleBuilder&amp; icu::LocaleBuilder::clearExtensions() | DraftICU 64 | 
+| localebuilder.h |  LocaleBuilder&amp; icu::LocaleBuilder::removeUnicodeLocaleAttribute(StringPiece) | DraftICU 64 | 
+| localebuilder.h |  LocaleBuilder&amp; icu::LocaleBuilder::setExtension(char, StringPiece) | DraftICU 64 | 
+| localebuilder.h |  LocaleBuilder&amp; icu::LocaleBuilder::setLanguage(StringPiece) | DraftICU 64 | 
+| localebuilder.h |  LocaleBuilder&amp; icu::LocaleBuilder::setLanguageTag(StringPiece) | DraftICU 64 | 
+| localebuilder.h |  LocaleBuilder&amp; icu::LocaleBuilder::setLocale(const Locale&amp;) | DraftICU 64 | 
+| localebuilder.h |  LocaleBuilder&amp; icu::LocaleBuilder::setRegion(StringPiece) | DraftICU 64 | 
+| localebuilder.h |  LocaleBuilder&amp; icu::LocaleBuilder::setScript(StringPiece) | DraftICU 64 | 
+| localebuilder.h |  LocaleBuilder&amp; icu::LocaleBuilder::setUnicodeLocaleKeyword(StringPiece, StringPiece) | DraftICU 64 | 
+| localebuilder.h |  LocaleBuilder&amp; icu::LocaleBuilder::setVariant(StringPiece) | DraftICU 64 | 
+| localebuilder.h |  icu::LocaleBuilder::LocaleBuilder() | DraftICU 64 | 
+| localebuilder.h |  icu::LocaleBuilder::~LocaleBuilder() | DraftICU 64 | 
+| localpointer.h |  LocalArray&lt;T&gt;&amp; icu::LocalArray&lt; T &gt;::operator=(std::unique_ptr&lt; T[]&gt;&amp;&amp;) | DraftICU 64 | 
+| localpointer.h |  LocalPointer&lt;T&gt;&amp; icu::LocalPointer&lt; T &gt;::operator=(std::unique_ptr&lt; T &gt;&amp;&amp;) | DraftICU 64 | 
+| localpointer.h |  icu::LocalArray&lt; T &gt;::LocalArray(std::unique_ptr&lt; T[]&gt;&amp;&amp;) | DraftICU 64 | 
+| localpointer.h |  icu::LocalArray&lt; T &gt;::operator std::unique_ptr&lt; T[]&gt;() &amp;&amp; | DraftICU 64 | 
+| localpointer.h |  icu::LocalPointer&lt; T &gt;::LocalPointer(std::unique_ptr&lt; T &gt;&amp;&amp;) | DraftICU 64 | 
+| localpointer.h |  icu::LocalPointer&lt; T &gt;::operator std::unique_ptr&lt; T &gt;() &amp;&amp; | DraftICU 64 | 
+| locid.h |  Locale&amp; icu::Locale::operator=(Locale&amp;&amp;) | DraftICU 63 | 
+| locid.h |  StringClass icu::Locale::getKeywordValue(StringPiece, UErrorCode&amp;) const | DraftICU 63 | 
+| locid.h |  StringClass icu::Locale::getUnicodeKeywordValue(StringPiece, UErrorCode&amp;) const | DraftICU 63 | 
+| locid.h |  StringClass icu::Locale::toLanguageTag(UErrorCode&amp;) const | DraftICU 63 | 
+| locid.h |  StringEnumeration* icu::Locale::createUnicodeKeywords(UErrorCode&amp;) const | DraftICU 63 | 
+| locid.h |  icu::Locale::Locale(Locale&amp;&amp;) | DraftICU 63 | 
+| locid.h |  <tt>static</tt> Locale icu::Locale::forLanguageTag(StringPiece, UErrorCode&amp;) | DraftICU 63 | 
+| locid.h |  void icu::Locale::addLikelySubtags(UErrorCode&amp;) | DraftICU 63 | 
+| locid.h |  void icu::Locale::getKeywordValue(StringPiece, ByteSink&amp;, UErrorCode&amp;) const | DraftICU 63 | 
+| locid.h |  void icu::Locale::getKeywords(OutputIterator, UErrorCode&amp;) const | DraftICU 63 | 
+| locid.h |  void icu::Locale::getUnicodeKeywordValue(StringPiece, ByteSink&amp;, UErrorCode&amp;) const | DraftICU 63 | 
+| locid.h |  void icu::Locale::getUnicodeKeywords(OutputIterator, UErrorCode&amp;) const | DraftICU 63 | 
+| locid.h |  void icu::Locale::minimizeSubtags(UErrorCode&amp;) | DraftICU 63 | 
+| locid.h |  void icu::Locale::setKeywordValue(StringPiece, StringPiece, UErrorCode&amp;) | DraftICU 63 | 
+| locid.h |  void icu::Locale::setUnicodeKeywordValue(StringPiece, StringPiece, UErrorCode&amp;) | DraftICU 63 | 
+| locid.h |  void icu::Locale::toLanguageTag(ByteSink&amp;, UErrorCode&amp;) const | DraftICU 63 | 
+| measfmt.h |  void icu::MeasureFormat::parseObject(const UnicodeString&amp;, Formattable&amp;, ParsePosition&amp;) const | DraftICU 53 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getAcre() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getAcreFoot() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getAmpere() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getArcMinute() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getArcSecond() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getAstronomicalUnit() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getAtmosphere() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getBarrel() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getBit() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getBritishThermalUnit() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getBushel() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getByte() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getCalorie() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getCarat() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getCelsius() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getCentiliter() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getCentimeter() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getCentury() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getCubicCentimeter() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getCubicFoot() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getCubicInch() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getCubicKilometer() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getCubicMeter() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getCubicMile() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getCubicYard() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getCup() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getCupMetric() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getDalton() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getDay() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getDayPerson() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getDeciliter() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getDecimeter() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getDegree() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getDunam() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getEarthMass() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getElectronvolt() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getFahrenheit() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getFathom() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getFluidOunce() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getFluidOunceImperial() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getFoodcalorie() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getFoot() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getFurlong() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getGForce() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getGallon() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getGallonImperial() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getGenericTemperature() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getGigabit() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getGigabyte() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getGigahertz() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getGigawatt() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getGram() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getHectare() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getHectoliter() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getHectopascal() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getHertz() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getHorsepower() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getHour() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getInch() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getInchHg() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getJoule() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getKarat() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getKelvin() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getKilobit() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getKilobyte() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getKilocalorie() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getKilogram() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getKilohertz() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getKilojoule() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getKilometer() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getKilometerPerHour() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getKilopascal() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getKilowatt() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getKilowattHour() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getKnot() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getLightYear() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getLiter() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getLiterPer100Kilometers() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getLiterPerKilometer() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getLux() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMegabit() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMegabyte() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMegahertz() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMegaliter() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMegapascal() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMegawatt() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMeter() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMeterPerSecond() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMeterPerSecondSquared() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMetricTon() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMicrogram() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMicrometer() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMicrosecond() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMile() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMilePerGallon() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMilePerGallonImperial() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMilePerHour() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMileScandinavian() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMilliampere() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMillibar() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMilligram() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMilligramPerDeciliter() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMilliliter() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMillimeter() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMillimeterOfMercury() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMillimolePerLiter() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMillisecond() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMilliwatt() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMinute() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMole() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMonth() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getMonthPerson() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getNanometer() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getNanosecond() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getNauticalMile() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getNewton() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getNewtonMeter() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getOhm() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getOunce() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getOunceTroy() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getParsec() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getPartPerMillion() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getPercent() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getPermille() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getPermyriad() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getPetabyte() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getPicometer() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getPint() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getPintMetric() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getPoint() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getPound() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getPoundFoot() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getPoundForce() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getPoundPerSquareInch() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getQuart() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getRadian() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getRevolutionAngle() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getSecond() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getSolarLuminosity() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getSolarMass() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getSolarRadius() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getSquareCentimeter() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getSquareFoot() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getSquareInch() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getSquareKilometer() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getSquareMeter() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getSquareMile() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getSquareYard() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getStone() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getTablespoon() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getTeaspoon() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getTerabit() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getTerabyte() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getTon() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getVolt() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getWatt() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getWeek() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getWeekPerson() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getYard() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getYear() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit icu::MeasureUnit::getYearPerson() | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit* icu::MeasureUnit::createBarrel(UErrorCode&amp;) | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit* icu::MeasureUnit::createBritishThermalUnit(UErrorCode&amp;) | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit* icu::MeasureUnit::createDalton(UErrorCode&amp;) | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit* icu::MeasureUnit::createDayPerson(UErrorCode&amp;) | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit* icu::MeasureUnit::createDunam(UErrorCode&amp;) | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit* icu::MeasureUnit::createEarthMass(UErrorCode&amp;) | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit* icu::MeasureUnit::createElectronvolt(UErrorCode&amp;) | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit* icu::MeasureUnit::createFluidOunceImperial(UErrorCode&amp;) | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit* icu::MeasureUnit::createKilopascal(UErrorCode&amp;) | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit* icu::MeasureUnit::createMegapascal(UErrorCode&amp;) | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit* icu::MeasureUnit::createMole(UErrorCode&amp;) | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit* icu::MeasureUnit::createMonthPerson(UErrorCode&amp;) | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit* icu::MeasureUnit::createNewton(UErrorCode&amp;) | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit* icu::MeasureUnit::createNewtonMeter(UErrorCode&amp;) | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit* icu::MeasureUnit::createPermyriad(UErrorCode&amp;) | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit* icu::MeasureUnit::createPoundFoot(UErrorCode&amp;) | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit* icu::MeasureUnit::createPoundForce(UErrorCode&amp;) | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit* icu::MeasureUnit::createSolarLuminosity(UErrorCode&amp;) | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit* icu::MeasureUnit::createSolarMass(UErrorCode&amp;) | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit* icu::MeasureUnit::createSolarRadius(UErrorCode&amp;) | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit* icu::MeasureUnit::createWeekPerson(UErrorCode&amp;) | DraftICU 64 | 
+| measunit.h |  <tt>static</tt> MeasureUnit* icu::MeasureUnit::createYearPerson(UErrorCode&amp;) | DraftICU 64 | 
+| nounit.h |  UClassID icu::NoUnit::getDynamicClassID() const | DraftICU 60 | 
+| nounit.h |  icu::NoUnit::NoUnit(const NoUnit&amp;) | DraftICU 60 | 
+| nounit.h |  icu::NoUnit::~NoUnit() | DraftICU 60 | 
+| nounit.h |  <tt>static</tt> NoUnit icu::NoUnit::base() | DraftICU 60 | 
+| nounit.h |  <tt>static</tt> NoUnit icu::NoUnit::percent() | DraftICU 60 | 
+| nounit.h |  <tt>static</tt> NoUnit icu::NoUnit::permille() | DraftICU 60 | 
+| nounit.h |  <tt>static</tt> UClassID icu::NoUnit::getStaticClassID() | DraftICU 60 | 
+| nounit.h |  void* icu::NoUnit::clone() const | DraftICU 60 | 
+| numberformatter.h |  Appendable&amp; icu::number::FormattedNumber::appendTo(Appendable&amp;, UErrorCode&amp;) const | DraftICU 62 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::adoptPerUnit(icu::MeasureUnit*) const&amp; | DraftICU 61 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::adoptPerUnit(icu::MeasureUnit*)&amp;&amp; | DraftICU 62 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::adoptSymbols(NumberingSystem*) const&amp; | DraftICU 60 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::adoptSymbols(NumberingSystem*)&amp;&amp; | DraftICU 62 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::adoptUnit(icu::MeasureUnit*) const&amp; | DraftICU 60 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::adoptUnit(icu::MeasureUnit*)&amp;&amp; | DraftICU 62 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::decimal(UNumberDecimalSeparatorDisplay) const&amp; | DraftICU 60 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::decimal(UNumberDecimalSeparatorDisplay)&amp;&amp; | DraftICU 62 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::grouping(UNumberGroupingStrategy) const&amp; | DraftICU 61 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::grouping(UNumberGroupingStrategy)&amp;&amp; | DraftICU 62 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::integerWidth(const IntegerWidth&amp;) const&amp; | DraftICU 60 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::integerWidth(const IntegerWidth&amp;)&amp;&amp; | DraftICU 62 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::notation(const Notation&amp;) const&amp; | DraftICU 60 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::notation(const Notation&amp;)&amp;&amp; | DraftICU 62 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::perUnit(const icu::MeasureUnit&amp;) const&amp; | DraftICU 61 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::perUnit(const icu::MeasureUnit&amp;)&amp;&amp; | DraftICU 62 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::precision(const Precision&amp;) const&amp; | DraftICU 62 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::precision(const Precision&amp;)&amp;&amp; | DraftICU 62 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::roundingMode(UNumberFormatRoundingMode) const&amp; | DraftICU 62 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::roundingMode(UNumberFormatRoundingMode)&amp;&amp; | DraftICU 62 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::scale(const Scale&amp;) const&amp; | DraftICU 62 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::scale(const Scale&amp;)&amp;&amp; | DraftICU 62 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::sign(UNumberSignDisplay) const&amp; | DraftICU 60 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::sign(UNumberSignDisplay)&amp;&amp; | DraftICU 62 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::symbols(const DecimalFormatSymbols&amp;) const&amp; | DraftICU 60 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::symbols(const DecimalFormatSymbols&amp;)&amp;&amp; | DraftICU 62 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::unit(const icu::MeasureUnit&amp;) const&amp; | DraftICU 60 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::unit(const icu::MeasureUnit&amp;)&amp;&amp; | DraftICU 62 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::unitWidth(UNumberUnitWidth) const&amp; | DraftICU 60 | 
+| numberformatter.h |  Derived icu::number::NumberFormatterSettings&lt; Derived &gt;::unitWidth(UNumberUnitWidth)&amp;&amp; | DraftICU 62 | 
+| numberformatter.h |  Format* icu::number::LocalizedNumberFormatter::toFormat(UErrorCode&amp;) const | DraftICU 62 | 
+| numberformatter.h |  FormattedNumber icu::number::LocalizedNumberFormatter::formatDecimal(StringPiece, UErrorCode&amp;) const | DraftICU 60 | 
+| numberformatter.h |  FormattedNumber icu::number::LocalizedNumberFormatter::formatDouble(double, UErrorCode&amp;) const | DraftICU 60 | 
+| numberformatter.h |  FormattedNumber icu::number::LocalizedNumberFormatter::formatInt(int64_t, UErrorCode&amp;) const | DraftICU 60 | 
+| numberformatter.h |  FormattedNumber&amp; icu::number::FormattedNumber::operator=(FormattedNumber&amp;&amp;) | DraftICU 62 | 
+| numberformatter.h |  IntegerWidth icu::number::IntegerWidth::truncateAt(int32_t) | DraftICU 60 | 
+| numberformatter.h |  LocalPointer&lt;Derived&gt; icu::number::NumberFormatterSettings&lt; Derived &gt;::clone() &amp;&amp; | DraftICU 64 | 
+| numberformatter.h |  LocalPointer&lt;Derived&gt; icu::number::NumberFormatterSettings&lt; Derived &gt;::clone() const &amp; | DraftICU 64 | 
+| numberformatter.h |  LocalizedNumberFormatter icu::number::UnlocalizedNumberFormatter::locale(const icu::Locale&amp;) const&amp; | DraftICU 60 | 
+| numberformatter.h |  LocalizedNumberFormatter icu::number::UnlocalizedNumberFormatter::locale(const icu::Locale&amp;)&amp;&amp; | DraftICU 62 | 
+| numberformatter.h |  LocalizedNumberFormatter&amp; icu::number::LocalizedNumberFormatter::operator=(LocalizedNumberFormatter&amp;&amp;) | DraftICU 62 | 
+| numberformatter.h |  LocalizedNumberFormatter&amp; icu::number::LocalizedNumberFormatter::operator=(const LocalizedNumberFormatter&amp;) | DraftICU 62 | 
+| numberformatter.h |  Precision icu::number::CurrencyPrecision::withCurrency(const CurrencyUnit&amp;) const | DraftICU 60 | 
+| numberformatter.h |  Precision icu::number::FractionPrecision::withMaxDigits(int32_t) const | DraftICU 60 | 
+| numberformatter.h |  Precision icu::number::FractionPrecision::withMinDigits(int32_t) const | DraftICU 60 | 
+| numberformatter.h |  Precision icu::number::IncrementPrecision::withMinFraction(int32_t) const | DraftICU 60 | 
+| numberformatter.h |  Scale&amp; icu::number::Scale::operator=(Scale&amp;&amp;) | DraftICU 62 | 
+| numberformatter.h |  Scale&amp; icu::number::Scale::operator=(const Scale&amp;) | DraftICU 62 | 
+| numberformatter.h |  ScientificNotation icu::number::ScientificNotation::withExponentSignDisplay(UNumberSignDisplay) const | DraftICU 60 | 
+| numberformatter.h |  ScientificNotation icu::number::ScientificNotation::withMinExponentDigits(int32_t) const | DraftICU 60 | 
+| numberformatter.h |  UBool icu::number::FormattedNumber::nextFieldPosition(FieldPosition&amp;, UErrorCode&amp;) const | DraftICU 62 | 
+| numberformatter.h |  UBool icu::number::FormattedNumber::nextPosition(ConstrainedFieldPosition&amp;, UErrorCode&amp;) const | DraftICU 64 | 
+| numberformatter.h |  UBool icu::number::NumberFormatterSettings&lt; Derived &gt;::copyErrorTo(UErrorCode&amp;) const | DraftICU 60 | 
+| numberformatter.h |  UnicodeString icu::number::FormattedNumber::toString(UErrorCode&amp;) const | DraftICU 62 | 
+| numberformatter.h |  UnicodeString icu::number::FormattedNumber::toTempString(UErrorCode&amp;) const | DraftICU 64 | 
+| numberformatter.h |  UnicodeString icu::number::NumberFormatterSettings&lt; Derived &gt;::toSkeleton(UErrorCode&amp;) const | DraftICU 62 | 
+| numberformatter.h |  UnlocalizedNumberFormatter&amp; icu::number::UnlocalizedNumberFormatter::operator=(UnlocalizedNumberFormatter&amp;&amp;) | DraftICU 62 | 
+| numberformatter.h |  UnlocalizedNumberFormatter&amp; icu::number::UnlocalizedNumberFormatter::operator=(const UnlocalizedNumberFormatter&amp;) | DraftICU 62 | 
+| numberformatter.h |  icu::number::FormattedNumber::FormattedNumber() | DraftICU 64 | 
+| numberformatter.h |  icu::number::FormattedNumber::FormattedNumber(FormattedNumber&amp;&amp;) | DraftICU 62 | 
+| numberformatter.h |  icu::number::FormattedNumber::~FormattedNumber() | DraftICU 60 | 
+| numberformatter.h |  icu::number::LocalizedNumberFormatter::LocalizedNumberFormatter()=default | DraftICU 62 | 
+| numberformatter.h |  icu::number::LocalizedNumberFormatter::LocalizedNumberFormatter(LocalizedNumberFormatter&amp;&amp;) | DraftICU 62 | 
+| numberformatter.h |  icu::number::LocalizedNumberFormatter::LocalizedNumberFormatter(const LocalizedNumberFormatter&amp;) | DraftICU 60 | 
+| numberformatter.h |  icu::number::LocalizedNumberFormatter::~LocalizedNumberFormatter() | DraftICU 60 | 
+| numberformatter.h |  icu::number::Scale::Scale(Scale&amp;&amp;) | DraftICU 62 | 
+| numberformatter.h |  icu::number::Scale::Scale(const Scale&amp;) | DraftICU 62 | 
+| numberformatter.h |  icu::number::Scale::~Scale() | DraftICU 62 | 
+| numberformatter.h |  icu::number::UnlocalizedNumberFormatter::UnlocalizedNumberFormatter()=default | DraftICU 62 | 
+| numberformatter.h |  icu::number::UnlocalizedNumberFormatter::UnlocalizedNumberFormatter(UnlocalizedNumberFormatter&amp;&amp;) | DraftICU 62 | 
+| numberformatter.h |  icu::number::UnlocalizedNumberFormatter::UnlocalizedNumberFormatter(const UnlocalizedNumberFormatter&amp;) | DraftICU 60 | 
+| numberformatter.h |  <tt>static</tt> CompactNotation icu::number::Notation::compactLong() | DraftICU 60 | 
+| numberformatter.h |  <tt>static</tt> CompactNotation icu::number::Notation::compactShort() | DraftICU 60 | 
+| numberformatter.h |  <tt>static</tt> CurrencyPrecision icu::number::Precision::currency(UCurrencyUsage) | DraftICU 60 | 
+| numberformatter.h |  <tt>static</tt> FractionPrecision icu::number::Precision::fixedFraction(int32_t) | DraftICU 60 | 
+| numberformatter.h |  <tt>static</tt> FractionPrecision icu::number::Precision::integer() | DraftICU 60 | 
+| numberformatter.h |  <tt>static</tt> FractionPrecision icu::number::Precision::maxFraction(int32_t) | DraftICU 60 | 
+| numberformatter.h |  <tt>static</tt> FractionPrecision icu::number::Precision::minFraction(int32_t) | DraftICU 60 | 
+| numberformatter.h |  <tt>static</tt> FractionPrecision icu::number::Precision::minMaxFraction(int32_t, int32_t) | DraftICU 60 | 
+| numberformatter.h |  <tt>static</tt> IncrementPrecision icu::number::Precision::increment(double) | DraftICU 60 | 
+| numberformatter.h |  <tt>static</tt> IntegerWidth icu::number::IntegerWidth::zeroFillTo(int32_t) | DraftICU 60 | 
+| numberformatter.h |  <tt>static</tt> LocalizedNumberFormatter icu::number::NumberFormatter::withLocale(const Locale&amp;) | DraftICU 60 | 
+| numberformatter.h |  <tt>static</tt> Precision icu::number::Precision::unlimited() | DraftICU 60 | 
+| numberformatter.h |  <tt>static</tt> Scale icu::number::Scale::byDecimal(StringPiece) | DraftICU 62 | 
+| numberformatter.h |  <tt>static</tt> Scale icu::number::Scale::byDouble(double) | DraftICU 62 | 
+| numberformatter.h |  <tt>static</tt> Scale icu::number::Scale::byDoubleAndPowerOfTen(double, int32_t) | DraftICU 62 | 
+| numberformatter.h |  <tt>static</tt> Scale icu::number::Scale::none() | DraftICU 62 | 
+| numberformatter.h |  <tt>static</tt> Scale icu::number::Scale::powerOfTen(int32_t) | DraftICU 62 | 
+| numberformatter.h |  <tt>static</tt> ScientificNotation icu::number::Notation::engineering() | DraftICU 60 | 
+| numberformatter.h |  <tt>static</tt> ScientificNotation icu::number::Notation::scientific() | DraftICU 60 | 
+| numberformatter.h |  <tt>static</tt> SignificantDigitsPrecision icu::number::Precision::fixedSignificantDigits(int32_t) | DraftICU 62 | 
+| numberformatter.h |  <tt>static</tt> SignificantDigitsPrecision icu::number::Precision::maxSignificantDigits(int32_t) | DraftICU 62 | 
+| numberformatter.h |  <tt>static</tt> SignificantDigitsPrecision icu::number::Precision::minMaxSignificantDigits(int32_t, int32_t) | DraftICU 62 | 
+| numberformatter.h |  <tt>static</tt> SignificantDigitsPrecision icu::number::Precision::minSignificantDigits(int32_t) | DraftICU 62 | 
+| numberformatter.h |  <tt>static</tt> SimpleNotation icu::number::Notation::simple() | DraftICU 60 | 
+| numberformatter.h |  <tt>static</tt> UnlocalizedNumberFormatter icu::number::NumberFormatter::forSkeleton(const UnicodeString&amp;, UErrorCode&amp;) | DraftICU 62 | 
+| numberformatter.h |  <tt>static</tt> UnlocalizedNumberFormatter icu::number::NumberFormatter::forSkeleton(const UnicodeString&amp;, UParseError&amp;, UErrorCode&amp;) | DraftICU 64 | 
+| numberformatter.h |  <tt>static</tt> UnlocalizedNumberFormatter icu::number::NumberFormatter::with() | DraftICU 60 | 
+| numberformatter.h |  void icu::number::FormattedNumber::getAllFieldPositions(FieldPositionIterator&amp;, UErrorCode&amp;) const | DraftICU 62 | 
+| numberrangeformatter.h |  Appendable&amp; icu::number::FormattedNumberRange::appendTo(Appendable&amp;, UErrorCode&amp;) const | DraftICU 63 | 
+| numberrangeformatter.h |  Derived icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::collapse(UNumberRangeCollapse) const&amp; | DraftICU 63 | 
+| numberrangeformatter.h |  Derived icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::collapse(UNumberRangeCollapse)&amp;&amp; | DraftICU 63 | 
+| numberrangeformatter.h |  Derived icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::identityFallback(UNumberRangeIdentityFallback) const&amp; | DraftICU 63 | 
+| numberrangeformatter.h |  Derived icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::identityFallback(UNumberRangeIdentityFallback)&amp;&amp; | DraftICU 63 | 
+| numberrangeformatter.h |  Derived icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::numberFormatterBoth(UnlocalizedNumberFormatter&amp;&amp;) const&amp; | DraftICU 63 | 
+| numberrangeformatter.h |  Derived icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::numberFormatterBoth(UnlocalizedNumberFormatter&amp;&amp;)&amp;&amp; | DraftICU 63 | 
+| numberrangeformatter.h |  Derived icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::numberFormatterBoth(const UnlocalizedNumberFormatter&amp;) const&amp; | DraftICU 63 | 
+| numberrangeformatter.h |  Derived icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::numberFormatterBoth(const UnlocalizedNumberFormatter&amp;)&amp;&amp; | DraftICU 63 | 
+| numberrangeformatter.h |  Derived icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::numberFormatterFirst(UnlocalizedNumberFormatter&amp;&amp;) const&amp; | DraftICU 63 | 
+| numberrangeformatter.h |  Derived icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::numberFormatterFirst(UnlocalizedNumberFormatter&amp;&amp;)&amp;&amp; | DraftICU 63 | 
+| numberrangeformatter.h |  Derived icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::numberFormatterFirst(const UnlocalizedNumberFormatter&amp;) const&amp; | DraftICU 63 | 
+| numberrangeformatter.h |  Derived icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::numberFormatterFirst(const UnlocalizedNumberFormatter&amp;)&amp;&amp; | DraftICU 63 | 
+| numberrangeformatter.h |  Derived icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::numberFormatterSecond(UnlocalizedNumberFormatter&amp;&amp;) const&amp; | DraftICU 63 | 
+| numberrangeformatter.h |  Derived icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::numberFormatterSecond(UnlocalizedNumberFormatter&amp;&amp;)&amp;&amp; | DraftICU 63 | 
+| numberrangeformatter.h |  Derived icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::numberFormatterSecond(const UnlocalizedNumberFormatter&amp;) const&amp; | DraftICU 63 | 
+| numberrangeformatter.h |  Derived icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::numberFormatterSecond(const UnlocalizedNumberFormatter&amp;)&amp;&amp; | DraftICU 63 | 
+| numberrangeformatter.h |  FormattedNumberRange icu::number::LocalizedNumberRangeFormatter::formatFormattableRange(const Formattable&amp;, const Formattable&amp;, UErrorCode&amp;) const | DraftICU 63 | 
+| numberrangeformatter.h |  FormattedNumberRange&amp; icu::number::FormattedNumberRange::operator=(FormattedNumberRange&amp;&amp;) | DraftICU 63 | 
+| numberrangeformatter.h |  LocalPointer&lt;Derived&gt; icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::clone() &amp;&amp; | DraftICU 64 | 
+| numberrangeformatter.h |  LocalPointer&lt;Derived&gt; icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::clone() const &amp; | DraftICU 64 | 
+| numberrangeformatter.h |  LocalizedNumberRangeFormatter icu::number::UnlocalizedNumberRangeFormatter::locale(const icu::Locale&amp;) const&amp; | DraftICU 63 | 
+| numberrangeformatter.h |  LocalizedNumberRangeFormatter icu::number::UnlocalizedNumberRangeFormatter::locale(const icu::Locale&amp;)&amp;&amp; | DraftICU 63 | 
+| numberrangeformatter.h |  LocalizedNumberRangeFormatter&amp; icu::number::LocalizedNumberRangeFormatter::operator=(LocalizedNumberRangeFormatter&amp;&amp;) | DraftICU 63 | 
+| numberrangeformatter.h |  LocalizedNumberRangeFormatter&amp; icu::number::LocalizedNumberRangeFormatter::operator=(const LocalizedNumberRangeFormatter&amp;) | DraftICU 63 | 
+| numberrangeformatter.h |  UBool icu::number::FormattedNumberRange::nextFieldPosition(FieldPosition&amp;, UErrorCode&amp;) const | DraftICU 63 | 
+| numberrangeformatter.h |  UBool icu::number::FormattedNumberRange::nextPosition(ConstrainedFieldPosition&amp;, UErrorCode&amp;) const | DraftICU 64 | 
+| numberrangeformatter.h |  UBool icu::number::NumberRangeFormatterSettings&lt; Derived &gt;::copyErrorTo(UErrorCode&amp;) const | DraftICU 63 | 
+| numberrangeformatter.h |  UNumberRangeIdentityResult icu::number::FormattedNumberRange::getIdentityResult(UErrorCode&amp;) const | DraftICU 63 | 
+| numberrangeformatter.h |  UnicodeString icu::number::FormattedNumberRange::getFirstDecimal(UErrorCode&amp;) const | DraftICU 63 | 
+| numberrangeformatter.h |  UnicodeString icu::number::FormattedNumberRange::getSecondDecimal(UErrorCode&amp;) const | DraftICU 63 | 
+| numberrangeformatter.h |  UnicodeString icu::number::FormattedNumberRange::toString(UErrorCode&amp;) const | DraftICU 63 | 
+| numberrangeformatter.h |  UnicodeString icu::number::FormattedNumberRange::toTempString(UErrorCode&amp;) const | DraftICU 64 | 
+| numberrangeformatter.h |  UnlocalizedNumberRangeFormatter&amp; icu::number::UnlocalizedNumberRangeFormatter::operator=(UnlocalizedNumberRangeFormatter&amp;&amp;) | DraftICU 63 | 
+| numberrangeformatter.h |  UnlocalizedNumberRangeFormatter&amp; icu::number::UnlocalizedNumberRangeFormatter::operator=(const UnlocalizedNumberRangeFormatter&amp;) | DraftICU 63 | 
+| numberrangeformatter.h |  <tt>enum</tt> UNumberRangeCollapse::UNUM_RANGE_COLLAPSE_ALL | DraftICU 63 | 
+| numberrangeformatter.h |  <tt>enum</tt> UNumberRangeCollapse::UNUM_RANGE_COLLAPSE_AUTO | DraftICU 63 | 
+| numberrangeformatter.h |  <tt>enum</tt> UNumberRangeCollapse::UNUM_RANGE_COLLAPSE_NONE | DraftICU 63 | 
+| numberrangeformatter.h |  <tt>enum</tt> UNumberRangeCollapse::UNUM_RANGE_COLLAPSE_UNIT | DraftICU 63 | 
+| numberrangeformatter.h |  <tt>enum</tt> UNumberRangeIdentityFallback::UNUM_IDENTITY_FALLBACK_APPROXIMATELY_OR_SINGLE_VALUE | DraftICU 63 | 
+| numberrangeformatter.h |  <tt>enum</tt> UNumberRangeIdentityFallback::UNUM_IDENTITY_FALLBACK_APPROXIMATELY | DraftICU 63 | 
+| numberrangeformatter.h |  <tt>enum</tt> UNumberRangeIdentityFallback::UNUM_IDENTITY_FALLBACK_RANGE | DraftICU 63 | 
+| numberrangeformatter.h |  <tt>enum</tt> UNumberRangeIdentityFallback::UNUM_IDENTITY_FALLBACK_SINGLE_VALUE | DraftICU 63 | 
+| numberrangeformatter.h |  <tt>enum</tt> UNumberRangeIdentityResult::UNUM_IDENTITY_RESULT_EQUAL_AFTER_ROUNDING | DraftICU 63 | 
+| numberrangeformatter.h |  <tt>enum</tt> UNumberRangeIdentityResult::UNUM_IDENTITY_RESULT_EQUAL_BEFORE_ROUNDING | DraftICU 63 | 
+| numberrangeformatter.h |  <tt>enum</tt> UNumberRangeIdentityResult::UNUM_IDENTITY_RESULT_NOT_EQUAL | DraftICU 63 | 
+| numberrangeformatter.h |  icu::number::FormattedNumberRange::FormattedNumberRange(FormattedNumberRange&amp;&amp;) | DraftICU 63 | 
+| numberrangeformatter.h |  icu::number::FormattedNumberRange::~FormattedNumberRange() | DraftICU 63 | 
+| numberrangeformatter.h |  icu::number::LocalizedNumberRangeFormatter::LocalizedNumberRangeFormatter()=default | DraftICU 63 | 
+| numberrangeformatter.h |  icu::number::LocalizedNumberRangeFormatter::LocalizedNumberRangeFormatter(LocalizedNumberRangeFormatter&amp;&amp;) | DraftICU 63 | 
+| numberrangeformatter.h |  icu::number::LocalizedNumberRangeFormatter::LocalizedNumberRangeFormatter(const LocalizedNumberRangeFormatter&amp;) | DraftICU 63 | 
+| numberrangeformatter.h |  icu::number::LocalizedNumberRangeFormatter::~LocalizedNumberRangeFormatter() | DraftICU 63 | 
+| numberrangeformatter.h |  icu::number::UnlocalizedNumberRangeFormatter::UnlocalizedNumberRangeFormatter()=default | DraftICU 63 | 
+| numberrangeformatter.h |  icu::number::UnlocalizedNumberRangeFormatter::UnlocalizedNumberRangeFormatter(UnlocalizedNumberRangeFormatter&amp;&amp;) | DraftICU 63 | 
+| numberrangeformatter.h |  icu::number::UnlocalizedNumberRangeFormatter::UnlocalizedNumberRangeFormatter(const UnlocalizedNumberRangeFormatter&amp;) | DraftICU 63 | 
+| numberrangeformatter.h |  <tt>static</tt> LocalizedNumberRangeFormatter icu::number::NumberRangeFormatter::withLocale(const Locale&amp;) | DraftICU 63 | 
+| numberrangeformatter.h |  <tt>static</tt> UnlocalizedNumberRangeFormatter icu::number::NumberRangeFormatter::with() | DraftICU 63 | 
+| numberrangeformatter.h |  void icu::number::FormattedNumberRange::getAllFieldPositions(FieldPositionIterator&amp;, UErrorCode&amp;) const | DraftICU 63 | 
+| numfmt.h |  <tt>enum</tt>  							icu::NumberFormat::EAlignmentFields::kCompactField | DraftICU 64 | 
+| numfmt.h |  <tt>enum</tt>  							icu::NumberFormat::EAlignmentFields::kMeasureUnitField | DraftICU 64 | 
+| plurrule.h |  UnicodeString icu::PluralRules::select(const number::FormattedNumber&amp;, UErrorCode&amp;) const | DraftICU 64 | 
+| reldatefmt.h |  Appendable&amp; icu::FormattedRelativeDateTime::appendTo(Appendable&amp;, UErrorCode&amp;) const | DraftICU 64 | 
+| reldatefmt.h |  FormattedRelativeDateTime icu::RelativeDateTimeFormatter::formatNumericToValue(double, URelativeDateTimeUnit, UErrorCode&amp;) const | DraftICU 64 | 
+| reldatefmt.h |  FormattedRelativeDateTime icu::RelativeDateTimeFormatter::formatToValue(UDateDirection, UDateAbsoluteUnit, UErrorCode&amp;) const | DraftICU 64 | 
+| reldatefmt.h |  FormattedRelativeDateTime icu::RelativeDateTimeFormatter::formatToValue(double, UDateDirection, UDateRelativeUnit, UErrorCode&amp;) const | DraftICU 64 | 
+| reldatefmt.h |  FormattedRelativeDateTime icu::RelativeDateTimeFormatter::formatToValue(double, URelativeDateTimeUnit, UErrorCode&amp;) const | DraftICU 64 | 
+| reldatefmt.h |  FormattedRelativeDateTime&amp; icu::FormattedRelativeDateTime::operator=(FormattedRelativeDateTime&amp;&amp;) | DraftICU 64 | 
+| reldatefmt.h |  UBool icu::FormattedRelativeDateTime::nextPosition(ConstrainedFieldPosition&amp;, UErrorCode&amp;) const | DraftICU 64 | 
+| reldatefmt.h |  UnicodeString icu::FormattedRelativeDateTime::toString(UErrorCode&amp;) const | DraftICU 64 | 
+| reldatefmt.h |  UnicodeString icu::FormattedRelativeDateTime::toTempString(UErrorCode&amp;) const | DraftICU 64 | 
+| reldatefmt.h |  <tt>enum</tt> UDateAbsoluteUnit::UDAT_ABSOLUTE_QUARTER | DraftICU 63 | 
+| reldatefmt.h |  icu::FormattedRelativeDateTime::FormattedRelativeDateTime() | DraftICU 64 | 
+| reldatefmt.h |  icu::FormattedRelativeDateTime::FormattedRelativeDateTime(FormattedRelativeDateTime&amp;&amp;) | DraftICU 64 | 
+| reldatefmt.h |  icu::FormattedRelativeDateTime::~FormattedRelativeDateTime() | DraftICU 64 | 
+| uchar.h |  const UCPMap* u_getIntPropertyMap(UProperty, UErrorCode*) | DraftICU 63 | 
+| uchar.h |  const USet* u_getBinaryPropertySet(UProperty, UErrorCode*) | DraftICU 63 | 
+| ucpmap.h |  UChar32 ucpmap_getRange(const UCPMap*, UChar32, UCPMapRangeOption, uint32_t, UCPMapValueFilter*, const void*, uint32_t*) | DraftICU 63 | 
+| ucpmap.h |  <tt>enum</tt> UCPMapRangeOption::UCPMAP_RANGE_FIXED_ALL_SURROGATES | DraftICU 63 | 
+| ucpmap.h |  <tt>enum</tt> UCPMapRangeOption::UCPMAP_RANGE_FIXED_LEAD_SURROGATES | DraftICU 63 | 
+| ucpmap.h |  <tt>enum</tt> UCPMapRangeOption::UCPMAP_RANGE_NORMAL | DraftICU 63 | 
+| ucpmap.h |  uint32_t ucpmap_get(const UCPMap*, UChar32) | DraftICU 63 | 
+| ucptrie.h |  <tt>#define</tt> UCPTRIE_16 | DraftICU 63 | 
+| ucptrie.h |  <tt>#define</tt> UCPTRIE_32 | DraftICU 63 | 
+| ucptrie.h |  <tt>#define</tt> UCPTRIE_8 | DraftICU 63 | 
+| ucptrie.h |  <tt>#define</tt> UCPTRIE_ASCII_GET | DraftICU 63 | 
+| ucptrie.h |  <tt>#define</tt> UCPTRIE_FAST_BMP_GET | DraftICU 63 | 
+| ucptrie.h |  <tt>#define</tt> UCPTRIE_FAST_GET | DraftICU 63 | 
+| ucptrie.h |  <tt>#define</tt> UCPTRIE_FAST_SUPP_GET | DraftICU 63 | 
+| ucptrie.h |  <tt>#define</tt> UCPTRIE_FAST_U16_NEXT | DraftICU 63 | 
+| ucptrie.h |  <tt>#define</tt> UCPTRIE_FAST_U16_PREV | DraftICU 63 | 
+| ucptrie.h |  <tt>#define</tt> UCPTRIE_FAST_U8_NEXT | DraftICU 63 | 
+| ucptrie.h |  <tt>#define</tt> UCPTRIE_FAST_U8_PREV | DraftICU 63 | 
+| ucptrie.h |  <tt>#define</tt> UCPTRIE_SMALL_GET | DraftICU 63 | 
+| ucptrie.h |  UCPTrie* ucptrie_openFromBinary(UCPTrieType, UCPTrieValueWidth, const void*, int32_t, int32_t*, UErrorCode*) | DraftICU 63 | 
+| ucptrie.h |  UCPTrieType ucptrie_getType(const UCPTrie*) | DraftICU 63 | 
+| ucptrie.h |  UCPTrieValueWidth ucptrie_getValueWidth(const UCPTrie*) | DraftICU 63 | 
+| ucptrie.h |  UChar32 ucptrie_getRange(const UCPTrie*, UChar32, UCPMapRangeOption, uint32_t, UCPMapValueFilter*, const void*, uint32_t*) | DraftICU 63 | 
+| ucptrie.h |  <tt>enum</tt> UCPTrieType::UCPTRIE_TYPE_ANY | DraftICU 63 | 
+| ucptrie.h |  <tt>enum</tt> UCPTrieType::UCPTRIE_TYPE_FAST | DraftICU 63 | 
+| ucptrie.h |  <tt>enum</tt> UCPTrieType::UCPTRIE_TYPE_SMALL | DraftICU 63 | 
+| ucptrie.h |  <tt>enum</tt> UCPTrieValueWidth::UCPTRIE_VALUE_BITS_16 | DraftICU 63 | 
+| ucptrie.h |  <tt>enum</tt> UCPTrieValueWidth::UCPTRIE_VALUE_BITS_32 | DraftICU 63 | 
+| ucptrie.h |  <tt>enum</tt> UCPTrieValueWidth::UCPTRIE_VALUE_BITS_8 | DraftICU 63 | 
+| ucptrie.h |  <tt>enum</tt> UCPTrieValueWidth::UCPTRIE_VALUE_BITS_ANY | DraftICU 63 | 
+| ucptrie.h |  int32_t ucptrie_toBinary(const UCPTrie*, void*, int32_t, UErrorCode*) | DraftICU 63 | 
+| ucptrie.h |  uint32_t ucptrie_get(const UCPTrie*, UChar32) | DraftICU 63 | 
+| ucptrie.h |  void ucptrie_close(UCPTrie*) | DraftICU 63 | 
+| udateintervalformat.h |  UFormattedDateInterval* udtitvfmt_openResult(UErrorCode*) | DraftICU 64 | 
+| udateintervalformat.h |  const UFormattedValue* udtitvfmt_resultAsValue(const UFormattedDateInterval*, UErrorCode*) | DraftICU 64 | 
+| udateintervalformat.h |  void udtitvfmt_closeResult(UFormattedDateInterval*) | DraftICU 64 | 
+| udateintervalformat.h |  void udtitvfmt_formatToResult(const UDateIntervalFormat*, UFormattedDateInterval*, UDate, UDate, UErrorCode*) | DraftICU 64 | 
+| uformattedvalue.h |  UBool ucfpos_matchesField(const UConstrainedFieldPosition*, int32_t, int32_t, UErrorCode*) | DraftICU 64 | 
+| uformattedvalue.h |  UBool ufmtval_nextPosition(const UFormattedValue*, UConstrainedFieldPosition*, UErrorCode*) | DraftICU 64 | 
+| uformattedvalue.h |  UConstrainedFieldPosition* ucfpos_open(UErrorCode*) | DraftICU 64 | 
+| uformattedvalue.h |  const UChar* ufmtval_getString(const UFormattedValue*, int32_t*, UErrorCode*) | DraftICU 64 | 
+| uformattedvalue.h |  <tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_DATE_INTERVAL_SPAN | DraftICU 64 | 
+| uformattedvalue.h |  <tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_DATE | DraftICU 64 | 
+| uformattedvalue.h |  <tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_LIST_SPAN | DraftICU 64 | 
+| uformattedvalue.h |  <tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_LIST | DraftICU 64 | 
+| uformattedvalue.h |  <tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_NUMBER | DraftICU 64 | 
+| uformattedvalue.h |  <tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_RELATIVE_DATETIME | DraftICU 64 | 
+| uformattedvalue.h |  <tt>enum</tt> UFieldCategory::UFIELD_CATEGORY_UNDEFINED | DraftICU 64 | 
+| uformattedvalue.h |  int32_t ucfpos_getCategory(const UConstrainedFieldPosition*, UErrorCode*) | DraftICU 64 | 
+| uformattedvalue.h |  int32_t ucfpos_getField(const UConstrainedFieldPosition*, UErrorCode*) | DraftICU 64 | 
+| uformattedvalue.h |  int64_t ucfpos_getInt64IterationContext(const UConstrainedFieldPosition*, UErrorCode*) | DraftICU 64 | 
+| uformattedvalue.h |  void ucfpos_close(UConstrainedFieldPosition*) | DraftICU 64 | 
+| uformattedvalue.h |  void ucfpos_constrainCategory(UConstrainedFieldPosition*, int32_t, UErrorCode*) | DraftICU 64 | 
+| uformattedvalue.h |  void ucfpos_constrainField(UConstrainedFieldPosition*, int32_t, int32_t, UErrorCode*) | DraftICU 64 | 
+| uformattedvalue.h |  void ucfpos_getIndexes(const UConstrainedFieldPosition*, int32_t*, int32_t*, UErrorCode*) | DraftICU 64 | 
+| uformattedvalue.h |  void ucfpos_reset(UConstrainedFieldPosition*, UErrorCode*) | DraftICU 64 | 
+| uformattedvalue.h |  void ucfpos_setInt64IterationContext(UConstrainedFieldPosition*, int64_t, UErrorCode*) | DraftICU 64 | 
+| uformattedvalue.h |  void ucfpos_setState(UConstrainedFieldPosition*, int32_t, int32_t, int32_t, int32_t, UErrorCode*) | DraftICU 64 | 
+| ulistformatter.h |  UFormattedList* ulistfmt_openResult(UErrorCode*) | DraftICU 64 | 
+| ulistformatter.h |  const UFormattedValue* ulistfmt_resultAsValue(const UFormattedList*, UErrorCode*) | DraftICU 64 | 
+| ulistformatter.h |  <tt>enum</tt> UListFormatterField::ULISTFMT_ELEMENT_FIELD | DraftICU 63 | 
+| ulistformatter.h |  <tt>enum</tt> UListFormatterField::ULISTFMT_LITERAL_FIELD | DraftICU 63 | 
+| ulistformatter.h |  void ulistfmt_closeResult(UFormattedList*) | DraftICU 64 | 
+| ulistformatter.h |  void ulistfmt_formatStringsToResult(const UListFormatter*, const UChar* const strings[], const int32_t*, int32_t, UFormattedList*, UErrorCode*) | DraftICU 64 | 
+| umutablecptrie.h |  UCPTrie* umutablecptrie_buildImmutable(UMutableCPTrie*, UCPTrieType, UCPTrieValueWidth, UErrorCode*) | DraftICU 63 | 
+| umutablecptrie.h |  UMutableCPTrie* umutablecptrie_clone(const UMutableCPTrie*, UErrorCode*) | DraftICU 63 | 
+| umutablecptrie.h |  UMutableCPTrie* umutablecptrie_fromUCPMap(const UCPMap*, UErrorCode*) | DraftICU 63 | 
+| umutablecptrie.h |  UMutableCPTrie* umutablecptrie_fromUCPTrie(const UCPTrie*, UErrorCode*) | DraftICU 63 | 
+| umutablecptrie.h |  UMutableCPTrie* umutablecptrie_open(uint32_t, uint32_t, UErrorCode*) | DraftICU 63 | 
+| umutablecptrie.h |  UChar32 umutablecptrie_getRange(const UMutableCPTrie*, UChar32, UCPMapRangeOption, uint32_t, UCPMapValueFilter*, const void*, uint32_t*) | DraftICU 63 | 
+| umutablecptrie.h |  uint32_t umutablecptrie_get(const UMutableCPTrie*, UChar32) | DraftICU 63 | 
+| umutablecptrie.h |  void umutablecptrie_close(UMutableCPTrie*) | DraftICU 63 | 
+| umutablecptrie.h |  void umutablecptrie_set(UMutableCPTrie*, UChar32, uint32_t, UErrorCode*) | DraftICU 63 | 
+| umutablecptrie.h |  void umutablecptrie_setRange(UMutableCPTrie*, UChar32, UChar32, uint32_t, UErrorCode*) | DraftICU 63 | 
+| unum.h |  <tt>enum</tt> UNumberFormatAttribute::UNUM_MINIMUM_GROUPING_DIGITS | DraftICU 64 | 
+| unum.h |  <tt>enum</tt> UNumberFormatAttribute::UNUM_PARSE_CASE_SENSITIVE | DraftICU 64 | 
+| unum.h |  <tt>enum</tt> UNumberFormatAttribute::UNUM_SIGN_ALWAYS_SHOWN | DraftICU 64 | 
+| unum.h |  <tt>enum</tt> UNumberFormatFields::UNUM_COMPACT_FIELD | DraftICU 64 | 
+| unum.h |  <tt>enum</tt> UNumberFormatFields::UNUM_MEASURE_UNIT_FIELD | DraftICU 64 | 
+| unumberformatter.h |  UNumberFormatter* unumf_openForSkeletonAndLocaleWithError(const UChar*, int32_t, const char*, UParseError*, UErrorCode*) | DraftICU 64 | 
+| unumberformatter.h |  const UFormattedValue* unumf_resultAsValue(const UFormattedNumber*, UErrorCode*) | DraftICU 64 | 
+| unumberformatter.h |  <tt>enum</tt> UNumberDecimalSeparatorDisplay::UNUM_DECIMAL_SEPARATOR_ALWAYS | DraftICU 60 | 
+| unumberformatter.h |  <tt>enum</tt> UNumberDecimalSeparatorDisplay::UNUM_DECIMAL_SEPARATOR_AUTO | DraftICU 60 | 
+| unumberformatter.h |  <tt>enum</tt> UNumberGroupingStrategy::UNUM_GROUPING_AUTO | DraftICU 61 | 
+| unumberformatter.h |  <tt>enum</tt> UNumberGroupingStrategy::UNUM_GROUPING_MIN2 | DraftICU 61 | 
+| unumberformatter.h |  <tt>enum</tt> UNumberGroupingStrategy::UNUM_GROUPING_OFF | DraftICU 61 | 
+| unumberformatter.h |  <tt>enum</tt> UNumberGroupingStrategy::UNUM_GROUPING_ON_ALIGNED | DraftICU 61 | 
+| unumberformatter.h |  <tt>enum</tt> UNumberGroupingStrategy::UNUM_GROUPING_THOUSANDS | DraftICU 61 | 
+| unumberformatter.h |  <tt>enum</tt> UNumberSignDisplay::UNUM_SIGN_ACCOUNTING_ALWAYS | DraftICU 60 | 
+| unumberformatter.h |  <tt>enum</tt> UNumberSignDisplay::UNUM_SIGN_ACCOUNTING_EXCEPT_ZERO | DraftICU 61 | 
+| unumberformatter.h |  <tt>enum</tt> UNumberSignDisplay::UNUM_SIGN_ACCOUNTING | DraftICU 60 | 
+| unumberformatter.h |  <tt>enum</tt> UNumberSignDisplay::UNUM_SIGN_ALWAYS | DraftICU 60 | 
+| unumberformatter.h |  <tt>enum</tt> UNumberSignDisplay::UNUM_SIGN_AUTO | DraftICU 60 | 
+| unumberformatter.h |  <tt>enum</tt> UNumberSignDisplay::UNUM_SIGN_EXCEPT_ZERO | DraftICU 61 | 
+| unumberformatter.h |  <tt>enum</tt> UNumberSignDisplay::UNUM_SIGN_NEVER | DraftICU 60 | 
+| unumberformatter.h |  <tt>enum</tt> UNumberUnitWidth::UNUM_UNIT_WIDTH_FULL_NAME | DraftICU 60 | 
+| unumberformatter.h |  <tt>enum</tt> UNumberUnitWidth::UNUM_UNIT_WIDTH_HIDDEN | DraftICU 60 | 
+| unumberformatter.h |  <tt>enum</tt> UNumberUnitWidth::UNUM_UNIT_WIDTH_ISO_CODE | DraftICU 60 | 
+| unumberformatter.h |  <tt>enum</tt> UNumberUnitWidth::UNUM_UNIT_WIDTH_NARROW | DraftICU 60 | 
+| unumberformatter.h |  <tt>enum</tt> UNumberUnitWidth::UNUM_UNIT_WIDTH_SHORT | DraftICU 60 | 
+| upluralrules.h |  int32_t uplrules_selectFormatted(const UPluralRules*, const struct UFormattedNumber*, UChar*, int32_t, UErrorCode*) | DraftICU 64 | 
+| uregex.h |  <tt>enum</tt> URegexpFlag::UREGEX_CANON_EQ | DraftICU 2.4 | 
+| ureldatefmt.h |  UFormattedRelativeDateTime* ureldatefmt_openResult(UErrorCode*) | DraftICU 64 | 
+| ureldatefmt.h |  const UFormattedValue* ureldatefmt_resultAsValue(const UFormattedRelativeDateTime*, UErrorCode*) | DraftICU 64 | 
+| ureldatefmt.h |  <tt>enum</tt> URelativeDateTimeFormatterField::UDAT_REL_LITERAL_FIELD | DraftICU 64 | 
+| ureldatefmt.h |  <tt>enum</tt> URelativeDateTimeFormatterField::UDAT_REL_NUMERIC_FIELD | DraftICU 64 | 
+| ureldatefmt.h |  void ureldatefmt_closeResult(UFormattedRelativeDateTime*) | DraftICU 64 | 
+| ureldatefmt.h |  void ureldatefmt_formatNumericToResult(const URelativeDateTimeFormatter*, double, URelativeDateTimeUnit, UFormattedRelativeDateTime*, UErrorCode*) | DraftICU 64 | 
+| ureldatefmt.h |  void ureldatefmt_formatToResult(const URelativeDateTimeFormatter*, double, URelativeDateTimeUnit, UFormattedRelativeDateTime*, UErrorCode*) | DraftICU 64 | 
+| uspoof.h |  <tt>enum</tt> USpoofChecks::USPOOF_HIDDEN_OVERLAY | DraftICU 62 | 
+
+## Simplifications
+
+This section shows cases where the signature was "simplified" for the sake of comparison. The simplified form is in bold, followed by
+    all possible variations in "original" form.
+
+- **`void* icu::ChoiceFormat::clone() const`**
+  - `ChoiceFormat* icu::ChoiceFormat::clone() const`
+  - `Format* icu::ChoiceFormat::clone() const`
+- **`void* icu::CompactDecimalFormat::clone() const`**
+  - `CompactDecimalFormat* icu::CompactDecimalFormat::clone() const U_OVERRIDE`
+  - `Format* icu::CompactDecimalFormat::clone() const U_OVERRIDE`
+- **`void* icu::CurrencyAmount::clone() const`**
+  - `CurrencyAmount* icu::CurrencyAmount::clone() const`
+  - `UObject* icu::CurrencyAmount::clone() const`
+- **`void* icu::CurrencyUnit::clone() const`**
+  - `CurrencyUnit* icu::CurrencyUnit::clone() const`
+  - `UObject* icu::CurrencyUnit::clone() const`
+- **`void* icu::DateIntervalFormat::clone() const`**
+  - `DateIntervalFormat* icu::DateIntervalFormat::clone() const`
+  - `Format* icu::DateIntervalFormat::clone() const`
+- **`void* icu::DecimalFormat::clone() const`**
+  - `DecimalFormat* icu::DecimalFormat::clone() const U_OVERRIDE`
+  - `Format* icu::DecimalFormat::clone() const U_OVERRIDE`
+- **`void* icu::GregorianCalendar::clone() const`**
+  - `Calendar* icu::GregorianCalendar::clone() const`
+  - `GregorianCalendar* icu::GregorianCalendar::clone() const`
+- **`void* icu::Measure::clone() const`**
+  - `Measure* icu::Measure::clone() const`
+  - `UObject* icu::Measure::clone() const`
+- **`void* icu::MeasureFormat::clone() const`**
+  - `Format* icu::MeasureFormat::clone() const`
+  - `MeasureFormat* icu::MeasureFormat::clone() const`
+- **`void* icu::MeasureUnit::clone() const`**
+  - `MeasureUnit* icu::MeasureUnit::clone() const`
+  - `UObject* icu::MeasureUnit::clone() const`
+- **`void* icu::MessageFormat::clone() const`**
+  - `Format* icu::MessageFormat::clone() const`
+  - `MessageFormat* icu::MessageFormat::clone() const`
+- **`void* icu::NoUnit::clone() const`**
+  - `NoUnit* icu::NoUnit::clone() const`
+  - `UObject* icu::NoUnit::clone() const`
+- **`void* icu::PluralFormat::clone() const`**
+  - `Format* icu::PluralFormat::clone() const`
+  - `PluralFormat* icu::PluralFormat::clone() const`
+- **`void* icu::RuleBasedBreakIterator::clone() const`**
+  - `BreakIterator* icu::RuleBasedBreakIterator::clone() const`
+  - `RuleBasedBreakIterator* icu::RuleBasedBreakIterator::clone() const`
+- **`void* icu::RuleBasedBreakIterator::createBufferClone(void*, int32_t&, UErrorCode&)`**
+  - `BreakIterator* icu::RuleBasedBreakIterator::createBufferClone(void*, int32_t&, UErrorCode&)`
+  - `RuleBasedBreakIterator* icu::RuleBasedBreakIterator::createBufferClone(void*, int32_t&, UErrorCode&)`
+- **`void* icu::RuleBasedCollator::clone() const`**
+  - `Collator* icu::RuleBasedCollator::clone() const`
+  - `RuleBasedCollator* icu::RuleBasedCollator::clone() const`
+- **`void* icu::RuleBasedNumberFormat::clone() const`**
+  - `Format* icu::RuleBasedNumberFormat::clone() const`
+  - `RuleBasedNumberFormat* icu::RuleBasedNumberFormat::clone() const`
+- **`void* icu::RuleBasedTimeZone::clone() const`**
+  - `RuleBasedTimeZone* icu::RuleBasedTimeZone::clone() const`
+  - `TimeZone* icu::RuleBasedTimeZone::clone() const`
+- **`void* icu::SelectFormat::clone() const`**
+  - `Format* icu::SelectFormat::clone() const`
+  - `SelectFormat* icu::SelectFormat::clone() const`
+- **`void* icu::SimpleDateFormat::clone() const`**
+  - `Format* icu::SimpleDateFormat::clone() const`
+  - `SimpleDateFormat* icu::SimpleDateFormat::clone() const`
+- **`void* icu::SimpleTimeZone::clone() const`**
+  - `SimpleTimeZone* icu::SimpleTimeZone::clone() const`
+  - `TimeZone* icu::SimpleTimeZone::clone() const`
+- **`void* icu::StringCharacterIterator::clone() const`**
+  - `CharacterIterator* icu::StringCharacterIterator::clone() const`
+  - `StringCharacterIterator* icu::StringCharacterIterator::clone() const`
+- **`void* icu::StringSearch::safeClone() const`**
+  - `SearchIterator* icu::StringSearch::safeClone() const`
+  - `StringSearch* icu::StringSearch::safeClone() const`
+- **`void* icu::TimeUnit::clone() const`**
+  - `TimeUnit* icu::TimeUnit::clone() const`
+  - `UObject* icu::TimeUnit::clone() const`
+- **`void* icu::TimeUnitAmount::clone() const`**
+  - `TimeUnitAmount* icu::TimeUnitAmount::clone() const`
+  - `UObject* icu::TimeUnitAmount::clone() const`
+- **`void* icu::TimeUnitFormat::clone() const`**
+  - `Format* icu::TimeUnitFormat::clone() const`
+  - `TimeUnitFormat* icu::TimeUnitFormat::clone() const`
+- **`void* icu::TimeZoneFormat::clone() const`**
+  - `Format* icu::TimeZoneFormat::clone() const`
+  - `TimeZoneFormat* icu::TimeZoneFormat::clone() const`
+- **`void* icu::UCharCharacterIterator::clone() const`**
+  - `CharacterIterator* icu::UCharCharacterIterator::clone() const`
+  - `UCharCharacterIterator* icu::UCharCharacterIterator::clone() const`
+- **`void* icu::UnicodeSet::clone() const`**
+  - `UnicodeFunctor* icu::UnicodeSet::clone() const`
+  - `UnicodeSet* icu::UnicodeSet::clone() const`
+- **`void* icu::UnicodeSet::cloneAsThawed() const`**
+  - `UnicodeFunctor* icu::UnicodeSet::cloneAsThawed() const`
+  - `UnicodeSet* icu::UnicodeSet::cloneAsThawed() const`
+- **`void* icu::UnicodeSet::freeze()`**
+  - `UnicodeFunctor* icu::UnicodeSet::freeze()`
+  - `UnicodeSet* icu::UnicodeSet::freeze()`
+- **`void* icu::UnicodeString::clone() const`**
+  - `Replaceable* icu::UnicodeString::clone() const`
+  - `UnicodeString* icu::UnicodeString::clone() const`
+- **`void* icu::VTimeZone::clone() const`**
+  - `TimeZone* icu::VTimeZone::clone() const`
+  - `VTimeZone* icu::VTimeZone::clone() const`
+
+## Colophon
+
+Contents generated by StableAPI tool on Fri Sep 06 20:08:19 EDT 2019
+
+Copyright (C) 2016-2019, Unicode, Inc. and others.
+License & terms of use: http://www.unicode.org/copyright.html
+  


### PR DESCRIPTION
[ICU-20795]

- API promotions are in a subsequent commit (#808)
- new Markdown format added
- See https://github.com/unicode-org/icu/pull/807 for the tool change which built this report.


[ICU-20795]: https://unicode-org.atlassian.net/browse/ICU-20795