### PR TITLE
ICU-20795 ICU4C 65.1 API promotion - locid.h fix

### DIFF
--- a/icu4c/source/common/unicode/locid.h
+++ b/icu4c/source/common/unicode/locid.h
@@ -1159,7 +1159,6 @@ Locale::operator!=(const    Locale&     other) const
     return !operator==(other);
 }
 
-#ifndef U_HIDE_DRAFT_API
 template<typename StringClass> inline StringClass
 Locale::toLanguageTag(UErrorCode& status) const
 {
@@ -1168,7 +1167,6 @@ Locale::toLanguageTag(UErrorCode& status) const
     toLanguageTag(sink, status);
     return result;
 }
-#endif  // U_HIDE_DRAFT_API
 
 inline const char *
 Locale::getCountry() const
@@ -1199,8 +1197,6 @@ Locale::getName() const
 {
     return fullName;
 }
-
-#ifndef U_HIDE_DRAFT_API
 
 template<typename StringClass, typename OutputIterator> inline void
 Locale::getKeywords(OutputIterator iterator, UErrorCode& status) const
@@ -1253,8 +1249,6 @@ Locale::getUnicodeKeywordValue(StringPiece keywordName, UErrorCode& status) cons
     getUnicodeKeywordValue(keywordName, sink, status);
     return result;
 }
-
-#endif  // U_HIDE_DRAFT_API
 
 inline UBool
 Locale::isBogus(void) const {


### PR DESCRIPTION
[ICU-20795]

- fixup some functions in locid.h that were incorrectly guarded as draft
- Error was in:
   - 5a3ea669aaf3f2c3984e1a10b3998d4b736621bf
   - https://github.com/unicode-org/icu/pull/808


[ICU-20795]: https://unicode-org.atlassian.net/browse/ICU-20795