### PR TITLE
ICU-20819 Correct placement of parentheses in preprocessor macro.

### DIFF
--- a/icu4c/source/test/intltest/caltest.cpp
+++ b/icu4c/source/test/intltest/caltest.cpp
@@ -354,7 +354,7 @@ void CalendarTest::runIndexedTest( int32_t index, UBool exec, const char* &name,
 
 UnicodeString CalendarTest::fieldName(UCalendarDateFields f) {
     switch (f) {
-#define FIELD_NAME_STR(x) case x: return (#x+5)
+#define FIELD_NAME_STR(x) case x: return (#x)+5
       FIELD_NAME_STR( UCAL_ERA );
       FIELD_NAME_STR( UCAL_YEAR );
       FIELD_NAME_STR( UCAL_MONTH );


### PR DESCRIPTION
The purpose of the FIELD_NAME_STR() macro is to create a string literal
by using the # preprocessing operator and then skip the first 5 chars of
this string by using the +5 pointer arithmetic. This is all intentional,
but if the parentheses are misplaced the compiler might think that this
is a mistake, a failed string concatenation (-Wstring-plus-int).