### PR TITLE
ICU-20831 Eliminate a data race in SimpleDateFormat::format.

### DIFF
--- a/icu4c/source/i18n/smpdtfmt.cpp
+++ b/icu4c/source/i18n/smpdtfmt.cpp
@@ -1981,9 +1981,11 @@ SimpleDateFormat::subFormat(UnicodeString &appendTo,
                 break;
         }
         if (titlecase) {
+            BreakIterator* const mutableCapitalizationBrkIter = fCapitalizationBrkIter->clone();
             UnicodeString firstField(appendTo, beginOffset);
-            firstField.toTitle(fCapitalizationBrkIter, fLocale, U_TITLECASE_NO_LOWERCASE | U_TITLECASE_NO_BREAK_ADJUSTMENT);
+            firstField.toTitle(mutableCapitalizationBrkIter, fLocale, U_TITLECASE_NO_LOWERCASE | U_TITLECASE_NO_BREAK_ADJUSTMENT);
             appendTo.replaceBetween(beginOffset, appendTo.length(), firstField);
+            delete mutableCapitalizationBrkIter;
         }
     }
 #endif

--- a/icu4c/source/i18n/unicode/smpdtfmt.h
+++ b/icu4c/source/i18n/unicode/smpdtfmt.h
@@ -1645,7 +1645,7 @@ private:
 
     UBool fHaveDefaultCentury;
 
-    BreakIterator* fCapitalizationBrkIter;
+    const BreakIterator* fCapitalizationBrkIter;
 };
 
 inline UDate


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20831
- [x] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

##### A note regarding testing.
The issue at hand is a fairly rare data race; the only way I found to reliably reproduce it in a unit test was to add a 20 millisecond sleep in [`rbbi_cache.cpp`](https://github.com/unicode-org/icu/blob/c78d9fa13762b7ae1ee9aec623d0b818d02a9956/icu4c/source/common/rbbi_cache.cpp#L434-L435), and to then simultaneously call `format` with different values from many threads on a `SimpleDateFormat` created as follows.
```C++
  icu::ErrorCode error;
  // NOTE: The choice of pattern and locale here is important: the resulting
  // date must start with a lowercase letter in its default capitalization, so
  // that we actually go through the capitalization code.
  icu::Locale french("fr_FR");
  icu::SimpleDateFormat simple_date_format(icu::UnicodeString::fromUTF8("cccc"),
                                           french,
                                           error);
  simple_date_format.setContext(UDISPCTX_CAPITALIZATION_FOR_STANDALONE, error);
```
The calls to `format` will then produce such results as `{ "DimanChe", "DimancChe", "DimancHe", "Dimanche", "Jeudi", "Lundi", "Mardi", "MercrEdi", "MercreDi", "Mercredi", "SamedI", "Samedi", "VendrEdi", "VendreDi", "VendreEdi", "Vendredi" }`, with the oddly-capitalized (and sometimes oddly-spelled) values exhibiting the data race.

Unfortunately, since the test is only effective when adding sleep statements in ICU internals, I cannot really include it in this pull request.