### PR TITLE
ICU-20832 use uint32_t instead of uint16_t to avoid overflows for very long strings

### DIFF
--- a/icu4c/source/i18n/usearch.cpp
+++ b/icu4c/source/i18n/usearch.cpp
@@ -317,7 +317,7 @@ inline uint16_t initializePatternCETable(UStringSearch *strsrch,
         uprv_free(pattern->ces);
     }
 
-    uint16_t  offset      = 0;
+    uint32_t  offset      = 0;
     uint16_t  result      = 0;
     int32_t   ce;
 
@@ -388,7 +388,7 @@ inline uint16_t initializePatternPCETable(UStringSearch *strsrch,
         uprv_free(pattern->pces);
     }
 
-    uint16_t  offset = 0;
+    uint32_t  offset = 0;
     uint16_t  result = 0;
     int64_t   pce;
 

--- a/icu4c/source/test/cintltst/usrchtst.c
+++ b/icu4c/source/test/cintltst/usrchtst.c
@@ -2894,6 +2894,43 @@ exit:
    return;
 }
 
+static void TestUInt16Overflow(void) {
+    const int32_t uint16_overflow = UINT16_MAX + 1;
+    UChar* pattern = (UChar*)uprv_malloc(uint16_overflow * sizeof(UChar));
+    if (pattern == NULL)
+    {
+        log_err("Err: uprv_malloc returned NULL\n");
+        return;
+    }
+    u_memset(pattern, 'A', uint16_overflow);
+    UChar text[] = { 'B' };
+
+    UErrorCode errorCode = U_ZERO_ERROR;
+    UStringSearch* usearch = usearch_open(pattern, uint16_overflow, text, 1, "en-US", NULL, &errorCode);
+
+    if (U_SUCCESS(errorCode))
+    {
+        int32_t match = usearch_first(usearch, &errorCode);
+
+        if (U_SUCCESS(errorCode))
+        {
+            if (match != USEARCH_DONE)
+            {
+                log_err("Err: match was not expected, got %d\n", match);
+            }
+        }
+        else
+        {
+            log_err("usearch_first error %s\n", u_errorName(errorCode));
+        }
+        usearch_close(usearch);
+    }
+    else
+    {
+        log_err("usearch_open error %s\n", u_errorName(errorCode));
+    }
+    uprv_free(pattern);
+}
 
 static void TestPCEBuffer_100df(void) {
   UChar search[] =
@@ -3070,6 +3107,7 @@ void addSearchTest(TestNode** root)
     addTest(root, &TestPCEBuffer_2surr, "tscoll/usrchtst/TestPCEBuffer/2_dfff");
     addTest(root, &TestMatchFollowedByIgnorables, "tscoll/usrchtst/TestMatchFollowedByIgnorables");
     addTest(root, &TestIndicPrefixMatch, "tscoll/usrchtst/TestIndicPrefixMatch");
+    addTest(root, &TestUInt16Overflow, "tscoll/usrchtst/TestUInt16Overflow");
 }
 
 #endif /* #if !UCONFIG_NO_COLLATION */


### PR DESCRIPTION

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20832
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

