### PR TITLE
ICU-20813 Fix Multi-line comment in umachine.h

### DIFF
--- a/icu4c/source/common/unicode/umachine.h
+++ b/icu4c/source/common/unicode/umachine.h
@@ -155,8 +155,9 @@
 // such code the wrapper is itself defined as macros so that it's possible to
 // build ICU 65 and later with the old macro behaviour, like this:
 //
-// CPPFLAGS='-DUPRV_BLOCK_MACRO_BEGIN="" -DUPRV_BLOCK_MACRO_END=""' \
+// export CPPFLAGS='-DUPRV_BLOCK_MACRO_BEGIN="" -DUPRV_BLOCK_MACRO_END=""'
 // runConfigureICU ...
+//
 
 /**
  * \def UPRV_BLOCK_MACRO_BEGIN


### PR DESCRIPTION
[ICU-20813]
- This comment failed on gcc. Split it into two lines.


[ICU-20813]: https://unicode-org.atlassian.net/browse/ICU-20813