### PR TITLE
ICU-20693 No arbitrary ordering in path/value visitation for new API

### DIFF
--- a/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/mapper/Bcp47Mapper.java
+++ b/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/mapper/Bcp47Mapper.java
@@ -7,7 +7,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static org.unicode.cldr.api.AttributeKey.keyOf;
-import static org.unicode.cldr.api.CldrData.PathOrder.ARBITRARY;
+import static org.unicode.cldr.api.CldrData.PathOrder.DTD;
 import static org.unicode.cldr.api.CldrDataType.BCP47;
 
 import java.util.LinkedHashMap;
@@ -88,7 +88,7 @@ public final class Bcp47Mapper {
     @VisibleForTesting // It's easier to supply a fake data instance than a fake supplier.
     static ImmutableList<IcuData> process(CldrData cldrData) {
         Bcp47Visitor visitor = new Bcp47Visitor();
-        cldrData.accept(ARBITRARY, visitor);
+        cldrData.accept(DTD, visitor);
         visitor.addKeyMapValues();
         return ImmutableList.of(visitor.keyTypeData.icuData, visitor.tzData.icuData);
     }

--- a/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/mapper/BreakIteratorMapper.java
+++ b/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/mapper/BreakIteratorMapper.java
@@ -3,7 +3,6 @@
 package org.unicode.icu.tool.cldrtoicu.mapper;
 
 import static org.unicode.cldr.api.AttributeKey.keyOf;
-import static org.unicode.cldr.api.CldrData.PathOrder.ARBITRARY;
 import static org.unicode.cldr.api.CldrData.PathOrder.DTD;
 import static org.unicode.cldr.api.CldrDataSupplier.CldrResolution.UNRESOLVED;
 
@@ -68,7 +67,7 @@ public final class BreakIteratorMapper {
     @VisibleForTesting // It's easier to supply a fake data instance than a fake supplier.
     static IcuData process(String localeId, CldrData cldrData, Optional<CldrData> icuSpecialData) {
         BreakIteratorMapper mapper = new BreakIteratorMapper(localeId);
-        icuSpecialData.ifPresent(s -> s.accept(ARBITRARY, mapper::addSpecials));
+        icuSpecialData.ifPresent(s -> s.accept(DTD, mapper::addSpecials));
         cldrData.accept(DTD, mapper::addSuppression);
         return mapper.icuData;
     }

--- a/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/mapper/CollationMapper.java
+++ b/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/mapper/CollationMapper.java
@@ -4,7 +4,7 @@ package org.unicode.icu.tool.cldrtoicu.mapper;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.unicode.cldr.api.AttributeKey.keyOf;
-import static org.unicode.cldr.api.CldrData.PathOrder.ARBITRARY;
+import static org.unicode.cldr.api.CldrData.PathOrder.DTD;
 import static org.unicode.cldr.api.CldrDataSupplier.CldrResolution.UNRESOLVED;
 
 import java.util.Optional;
@@ -75,8 +75,8 @@ public final class CollationMapper {
     @VisibleForTesting // It's easier to supply a fake data instance than a fake supplier.
     static IcuData process(String localeId, CldrData cldrData, Optional<CldrData> icuSpecialData) {
         CollationVisitor visitor = new CollationVisitor(localeId);
-        icuSpecialData.ifPresent(s -> s.accept(ARBITRARY, visitor));
-        cldrData.accept(ARBITRARY, visitor);
+        icuSpecialData.ifPresent(s -> s.accept(DTD, visitor));
+        cldrData.accept(DTD, visitor);
         return visitor.icuData;
     }
 

--- a/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/mapper/DayPeriodsMapper.java
+++ b/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/mapper/DayPeriodsMapper.java
@@ -3,7 +3,7 @@
 package org.unicode.icu.tool.cldrtoicu.mapper;
 
 import static org.unicode.cldr.api.AttributeKey.keyOf;
-import static org.unicode.cldr.api.CldrData.PathOrder.ARBITRARY;
+import static org.unicode.cldr.api.CldrData.PathOrder.NESTED_GROUPING;
 import static org.unicode.cldr.api.CldrDataType.SUPPLEMENTAL;
 
 import java.util.Optional;
@@ -54,7 +54,7 @@ public final class DayPeriodsMapper {
     @VisibleForTesting // It's easier to supply a fake data instance than a fake supplier.
     static IcuData process(CldrData data) {
         RuleSetVisitor mapper = new RuleSetVisitor();
-        data.accept(ARBITRARY, mapper);
+        data.accept(NESTED_GROUPING, mapper);
         return mapper.icuData;
     }
 

--- a/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/mapper/PluralRangesMapper.java
+++ b/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/mapper/PluralRangesMapper.java
@@ -4,7 +4,7 @@ package org.unicode.icu.tool.cldrtoicu.mapper;
 
 import static com.google.common.base.Preconditions.checkState;
 import static org.unicode.cldr.api.AttributeKey.keyOf;
-import static org.unicode.cldr.api.CldrData.PathOrder.ARBITRARY;
+import static org.unicode.cldr.api.CldrData.PathOrder.NESTED_GROUPING;
 import static org.unicode.cldr.api.CldrDataType.SUPPLEMENTAL;
 
 import org.unicode.cldr.api.AttributeKey;
@@ -59,7 +59,7 @@ public final class PluralRangesMapper {
     @VisibleForTesting // It's easier to supply a fake data instance than a fake supplier.
     static IcuData process(CldrData data) {
         PluralRangesVisitor visitor = new PluralRangesVisitor();
-        data.accept(ARBITRARY, visitor);
+        data.accept(NESTED_GROUPING, visitor);
         return visitor.icuData;
     }
 

--- a/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/mapper/PluralsMapper.java
+++ b/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/mapper/PluralsMapper.java
@@ -5,7 +5,7 @@ package org.unicode.icu.tool.cldrtoicu.mapper;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static org.unicode.cldr.api.AttributeKey.keyOf;
-import static org.unicode.cldr.api.CldrData.PathOrder.ARBITRARY;
+import static org.unicode.cldr.api.CldrData.PathOrder.NESTED_GROUPING;
 import static org.unicode.cldr.api.CldrDataType.SUPPLEMENTAL;
 
 import java.util.ArrayList;
@@ -65,8 +65,8 @@ public final class PluralsMapper {
         // affects the set indices we generate during processing. Ideally this would all be immune
         // to ordering (or just enforce DTD ordering) but right now it's very dependent on
         // mimicking the order of the existing code to get identical output.
-        data.accept(ARBITRARY, visitor.setType("cardinal"));
-        data.accept(ARBITRARY, visitor.setType("ordinal"));
+        data.accept(NESTED_GROUPING, visitor.setType("cardinal"));
+        data.accept(NESTED_GROUPING, visitor.setType("ordinal"));
         return visitor.icuData;
     }
 

--- a/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/mapper/SupplementalMapper.java
+++ b/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/mapper/SupplementalMapper.java
@@ -53,8 +53,8 @@ public final class SupplementalMapper extends AbstractPathValueMapper {
 
     @Override
     void addResults() {
-        // DTD and NESTED_GROUPING order differ because of how the magic <FIFO> label works (it
-        // basically enforces "encounter order" onto things in unlabeled sequences, which matches
+        // NESTED_GROUPING and DTD order differ because of how the magic <FIFO> label works (it
+        // basically enforces "encounter order" onto things in unlabelled sequences, which matches
         // the old behaviour). If it wouldn't break anything, it might be worth moving to DTD order
         // to remove any lingering implicit dependencies on the CLDR data behaviour.
         getCldrData().accept(NESTED_GROUPING, this::visit);


### PR DESCRIPTION
This is an optional, but very "nice to have" PR which removes all non-test use of the "ARBITRARY" order. As soon as everything is in and we're happy to change ICU files a bit, I will remove all ability to control path ordering from the API and go with DTD order everything (this will change supplemental data order a lot). This isolates ICU from any XML file ordering, which seems like a good thing. This PR is just me getting rid of the really egregious case ("arbitrary ordering") first since it really doesn't have any need to exist any more.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20693
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [x] Documentation is changed or added

