### PR TITLE
ICU-20709 Tweak SignDisplay EXCEPT_ZERO semantics for ECMAScript.

### DIFF
--- a/icu4c/source/i18n/number_compact.cpp
+++ b/icu4c/source/i18n/number_compact.cpp
@@ -316,6 +316,7 @@ void CompactHandler::processQuantity(DecimalQuantity &quantity, MicroProps &micr
         ParsedPatternInfo &patternInfo = const_cast<CompactHandler *>(this)->unsafePatternInfo;
         PatternParser::parseToPatternInfo(UnicodeString(patternString), patternInfo, status);
         unsafePatternModifier->setPatternInfo(&unsafePatternInfo, UNUM_COMPACT_FIELD);
+        unsafePatternModifier->setNumberProperties(quantity.signum(), StandardPlural::Form::COUNT);
         micros.modMiddle = unsafePatternModifier;
     }
 

--- a/icu4c/source/i18n/number_compact.h
+++ b/icu4c/source/i18n/number_compact.h
@@ -56,10 +56,16 @@ struct CompactModInfo {
 
 class CompactHandler : public MicroPropsGenerator, public UMemory {
   public:
-    CompactHandler(CompactStyle compactStyle, const Locale &locale, const char *nsName,
-                   CompactType compactType, const PluralRules *rules,
-                   MutablePatternModifier *buildReference, const MicroPropsGenerator *parent,
-                   UErrorCode &status);
+    CompactHandler(
+            CompactStyle compactStyle,
+            const Locale &locale,
+            const char *nsName,
+            CompactType compactType,
+            const PluralRules *rules,
+            MutablePatternModifier *buildReference,
+            bool safe,
+            const MicroPropsGenerator *parent,
+            UErrorCode &status);
 
     ~CompactHandler() U_OVERRIDE;
 
@@ -74,6 +80,7 @@ class CompactHandler : public MicroPropsGenerator, public UMemory {
     int32_t precomputedModsLength = 0;
     CompactData data;
     ParsedPatternInfo unsafePatternInfo;
+    MutablePatternModifier* unsafePatternModifier;
     UBool safe;
 
     /** Used by the safe code path */

--- a/icu4c/source/i18n/number_decimalquantity.cpp
+++ b/icu4c/source/i18n/number_decimalquantity.cpp
@@ -319,10 +319,14 @@ bool DecimalQuantity::isNegative() const {
 }
 
 Signum DecimalQuantity::signum() const {
-    if (isNegative()) {
+    bool isZero = (isZeroish() && !isInfinite());
+    bool isNeg = isNegative();
+    if (isZero && isNeg) {
+        return SIGNUM_NEG_ZERO;
+    } else if (isZero) {
+        return SIGNUM_POS_ZERO;
+    } else if (isNeg) {
         return SIGNUM_NEG;
-    } else if (isZeroish() && !isInfinite()) {
-        return SIGNUM_ZERO;
     } else {
         return SIGNUM_POS;
     }

--- a/icu4c/source/i18n/number_formatimpl.cpp
+++ b/icu4c/source/i18n/number_formatimpl.cpp
@@ -410,8 +410,6 @@ NumberFormatterImpl::macrosToMicroGenerator(const MacroProps& macros, bool safe,
     }
 
     // Compact notation
-    // NOTE: Compact notation can (but might not) override the middle modifier and rounding.
-    // It therefore needs to go at the end of the chain.
     if (macros.notation.fType == Notation::NTN_COMPACT) {
         CompactType compactType = (isCurrency && unitWidth != UNUM_UNIT_WIDTH_FULL_NAME)
                                   ? CompactType::TYPE_CURRENCY : CompactType::TYPE_DECIMAL;
@@ -433,6 +431,7 @@ NumberFormatterImpl::macrosToMicroGenerator(const MacroProps& macros, bool safe,
         chain = fCompactHandler.getAlias();
     }
 
+    // Always add the pattern modifier as the last element of the chain.
     if (safe) {
         fImmutablePatternModifier->addToChain(chain);
         chain = fImmutablePatternModifier.getAlias();

--- a/icu4c/source/i18n/number_formatimpl.cpp
+++ b/icu4c/source/i18n/number_formatimpl.cpp
@@ -111,6 +111,7 @@ void NumberFormatterImpl::preProcess(DecimalQuantity& inValue, MicroProps& micro
         return;
     }
     fMicroPropsGenerator->processQuantity(inValue, microsOut, status);
+    microsOut.integerWidth.apply(inValue, status);
 }
 
 MicroProps& NumberFormatterImpl::preProcessUnsafe(DecimalQuantity& inValue, UErrorCode& status) {
@@ -122,6 +123,7 @@ MicroProps& NumberFormatterImpl::preProcessUnsafe(DecimalQuantity& inValue, UErr
         return fMicros; // must always return a value
     }
     fMicroPropsGenerator->processQuantity(inValue, fMicros, status);
+    fMicros.integerWidth.apply(inValue, status);
     return fMicros;
 }
 

--- a/icu4c/source/i18n/number_formatimpl.h
+++ b/icu4c/source/i18n/number_formatimpl.h
@@ -95,7 +95,7 @@ class NumberFormatterImpl : public UMemory {
     LocalPointer<const ParsedPatternInfo> fPatternInfo;
     LocalPointer<const ScientificHandler> fScientificHandler;
     LocalPointer<MutablePatternModifier> fPatternModifier;
-    LocalPointer<const ImmutablePatternModifier> fImmutablePatternModifier;
+    LocalPointer<ImmutablePatternModifier> fImmutablePatternModifier;
     LocalPointer<const LongNameHandler> fLongNameHandler;
     LocalPointer<const CompactHandler> fCompactHandler;
 

--- a/icu4c/source/i18n/number_integerwidth.cpp
+++ b/icu4c/source/i18n/number_integerwidth.cpp
@@ -40,6 +40,9 @@ IntegerWidth IntegerWidth::truncateAt(int32_t maxInt) {
 }
 
 void IntegerWidth::apply(impl::DecimalQuantity& quantity, UErrorCode& status) const {
+    if (isBogus()) {
+        return;
+    }
     if (fHasError) {
         status = U_ILLEGAL_ARGUMENT_ERROR;
     } else if (fUnion.minMaxInt.fMaxInt == -1) {

--- a/icu4c/source/i18n/number_integerwidth.cpp
+++ b/icu4c/source/i18n/number_integerwidth.cpp
@@ -40,9 +40,6 @@ IntegerWidth IntegerWidth::truncateAt(int32_t maxInt) {
 }
 
 void IntegerWidth::apply(impl::DecimalQuantity& quantity, UErrorCode& status) const {
-    if (isBogus()) {
-        return;
-    }
     if (fHasError) {
         status = U_ILLEGAL_ARGUMENT_ERROR;
     } else if (fUnion.minMaxInt.fMaxInt == -1) {

--- a/icu4c/source/i18n/number_longnames.cpp
+++ b/icu4c/source/i18n/number_longnames.cpp
@@ -308,7 +308,7 @@ void LongNameHandler::simpleFormatsToModifiers(const UnicodeString *simpleFormat
         if (U_FAILURE(status)) { return; }
         SimpleFormatter compiledFormatter(simpleFormat, 0, 1, status);
         if (U_FAILURE(status)) { return; }
-        fModifiers[i] = SimpleModifier(compiledFormatter, field, false, {this, SIGNUM_ZERO, plural});
+        fModifiers[i] = SimpleModifier(compiledFormatter, field, false, {this, SIGNUM_POS_ZERO, plural});
     }
 }
 
@@ -325,7 +325,7 @@ void LongNameHandler::multiSimpleFormatsToModifiers(const UnicodeString *leadFor
         if (U_FAILURE(status)) { return; }
         SimpleFormatter compoundCompiled(compoundFormat, 0, 1, status);
         if (U_FAILURE(status)) { return; }
-        fModifiers[i] = SimpleModifier(compoundCompiled, field, false, {this, SIGNUM_ZERO, plural});
+        fModifiers[i] = SimpleModifier(compoundCompiled, field, false, {this, SIGNUM_POS_ZERO, plural});
     }
 }
 

--- a/icu4c/source/i18n/number_microprops.h
+++ b/icu4c/source/i18n/number_microprops.h
@@ -35,10 +35,10 @@ struct MicroProps : public MicroPropsGenerator {
     char nsName[9];
 
     // Note: This struct has no direct ownership of the following pointers.
-    const DecimalFormatSymbols* symbols;
-    const Modifier* modOuter;
-    const Modifier* modMiddle;
-    const Modifier* modInner;
+    const DecimalFormatSymbols* symbols = nullptr;
+    const Modifier* modOuter = nullptr;
+    const Modifier* modMiddle = nullptr;
+    const Modifier* modInner = nullptr;
 
     // The following "helper" fields may optionally be used during the MicroPropsGenerator.
     // They live here to retain memory.

--- a/icu4c/source/i18n/number_microprops.h
+++ b/icu4c/source/i18n/number_microprops.h
@@ -35,10 +35,10 @@ struct MicroProps : public MicroPropsGenerator {
     char nsName[9];
 
     // Note: This struct has no direct ownership of the following pointers.
-    const DecimalFormatSymbols* symbols = nullptr;
-    const Modifier* modOuter = nullptr;
+    const DecimalFormatSymbols* symbols;
+    const Modifier* modOuter;
     const Modifier* modMiddle = nullptr;
-    const Modifier* modInner = nullptr;
+    const Modifier* modInner;
 
     // The following "helper" fields may optionally be used during the MicroPropsGenerator.
     // They live here to retain memory.

--- a/icu4c/source/i18n/number_modifiers.h
+++ b/icu4c/source/i18n/number_modifiers.h
@@ -322,9 +322,9 @@ class U_I18N_API AdoptingModifierStore : public ModifierStore, public UMemory {
     const Modifier *mods[4 * StandardPlural::COUNT] = {};
 
     inline static int32_t getModIndex(Signum signum, StandardPlural::Form plural) {
-        U_ASSERT(signum >= -2 && signum <= 1);
+        U_ASSERT(signum >= 0 && signum <= 3);
         U_ASSERT(plural >= 0 && plural < StandardPlural::COUNT);
-        return static_cast<int32_t>(plural) * 4 + (signum + 2);
+        return static_cast<int32_t>(plural) * 4 + signum;
     }
 };
 

--- a/icu4c/source/i18n/number_modifiers.h
+++ b/icu4c/source/i18n/number_modifiers.h
@@ -324,7 +324,7 @@ class U_I18N_API AdoptingModifierStore : public ModifierStore, public UMemory {
     inline static int32_t getModIndex(Signum signum, StandardPlural::Form plural) {
         U_ASSERT(signum >= -2 && signum <= 1);
         U_ASSERT(plural >= 0 && plural < StandardPlural::COUNT);
-        return static_cast<int32_t>(plural) * 4 + (signum + 1);
+        return static_cast<int32_t>(plural) * 4 + (signum + 2);
     }
 };
 

--- a/icu4c/source/i18n/number_modifiers.h
+++ b/icu4c/source/i18n/number_modifiers.h
@@ -319,12 +319,12 @@ class U_I18N_API AdoptingModifierStore : public ModifierStore, public UMemory {
 
   private:
     // NOTE: mods is zero-initialized (to nullptr)
-    const Modifier *mods[3 * StandardPlural::COUNT] = {};
+    const Modifier *mods[4 * StandardPlural::COUNT] = {};
 
     inline static int32_t getModIndex(Signum signum, StandardPlural::Form plural) {
-        U_ASSERT(signum >= -1 && signum <= 1);
+        U_ASSERT(signum >= -2 && signum <= 1);
         U_ASSERT(plural >= 0 && plural < StandardPlural::COUNT);
-        return static_cast<int32_t>(plural) * 3 + (signum + 1);
+        return static_cast<int32_t>(plural) * 4 + (signum + 1);
     }
 };
 

--- a/icu4c/source/i18n/number_patternmodifier.cpp
+++ b/icu4c/source/i18n/number_patternmodifier.cpp
@@ -125,7 +125,6 @@ void ImmutablePatternModifier::processQuantity(DecimalQuantity& quantity, MicroP
                                                UErrorCode& status) const {
     parent->processQuantity(quantity, micros, status);
     micros.rounder.apply(quantity, status);
-    micros.integerWidth.apply(quantity, status);
     if (micros.modMiddle != nullptr) {
         return;
     }
@@ -165,7 +164,6 @@ void MutablePatternModifier::processQuantity(DecimalQuantity& fq, MicroProps& mi
                                              UErrorCode& status) const {
     fParent->processQuantity(fq, micros, status);
     micros.rounder.apply(fq, status);
-    micros.integerWidth.apply(fq, status);
     if (micros.modMiddle != nullptr) {
         return;
     }
@@ -274,7 +272,12 @@ int32_t MutablePatternModifier::insertSuffix(FormattedStringBuilder& sb, int pos
 /** This method contains the heart of the logic for rendering LDML affix strings. */
 void MutablePatternModifier::prepareAffix(bool isPrefix) {
     PatternStringUtils::patternInfoToStringBuilder(
-            *fPatternInfo, isPrefix, fSignum, fSignDisplay, fPlural, fPerMilleReplacesPercent, currentAffix);
+            *fPatternInfo,
+            isPrefix,
+            PatternStringUtils::resolveSignDisplay(fSignDisplay, fSignum),
+            fPlural,
+            fPerMilleReplacesPercent,
+            currentAffix);
 }
 
 UnicodeString MutablePatternModifier::getSymbol(AffixPatternType type) const {

--- a/icu4c/source/i18n/number_patternmodifier.cpp
+++ b/icu4c/source/i18n/number_patternmodifier.cpp
@@ -81,8 +81,10 @@ MutablePatternModifier::createImmutableAndChain(const MicroPropsGenerator* paren
         for (StandardPlural::Form plural : STANDARD_PLURAL_VALUES) {
             setNumberProperties(SIGNUM_POS, plural);
             pm->adoptModifier(SIGNUM_POS, plural, createConstantModifier(status));
-            setNumberProperties(SIGNUM_ZERO, plural);
-            pm->adoptModifier(SIGNUM_ZERO, plural, createConstantModifier(status));
+            setNumberProperties(SIGNUM_NEG_ZERO, plural);
+            pm->adoptModifier(SIGNUM_NEG_ZERO, plural, createConstantModifier(status));
+            setNumberProperties(SIGNUM_POS_ZERO, plural);
+            pm->adoptModifier(SIGNUM_POS_ZERO, plural, createConstantModifier(status));
             setNumberProperties(SIGNUM_NEG, plural);
             pm->adoptModifier(SIGNUM_NEG, plural, createConstantModifier(status));
         }
@@ -95,8 +97,10 @@ MutablePatternModifier::createImmutableAndChain(const MicroPropsGenerator* paren
         // Faster path when plural keyword is not needed.
         setNumberProperties(SIGNUM_POS, StandardPlural::Form::COUNT);
         pm->adoptModifierWithoutPlural(SIGNUM_POS, createConstantModifier(status));
-        setNumberProperties(SIGNUM_ZERO, StandardPlural::Form::COUNT);
-        pm->adoptModifierWithoutPlural(SIGNUM_ZERO, createConstantModifier(status));
+        setNumberProperties(SIGNUM_NEG_ZERO, StandardPlural::Form::COUNT);
+        pm->adoptModifierWithoutPlural(SIGNUM_NEG_ZERO, createConstantModifier(status));
+        setNumberProperties(SIGNUM_POS_ZERO, StandardPlural::Form::COUNT);
+        pm->adoptModifierWithoutPlural(SIGNUM_POS_ZERO, createConstantModifier(status));
         setNumberProperties(SIGNUM_NEG, StandardPlural::Form::COUNT);
         pm->adoptModifierWithoutPlural(SIGNUM_NEG, createConstantModifier(status));
         if (U_FAILURE(status)) {

--- a/icu4c/source/i18n/number_patternmodifier.cpp
+++ b/icu4c/source/i18n/number_patternmodifier.cpp
@@ -126,9 +126,10 @@ void ImmutablePatternModifier::processQuantity(DecimalQuantity& quantity, MicroP
     parent->processQuantity(quantity, micros, status);
     micros.rounder.apply(quantity, status);
     micros.integerWidth.apply(quantity, status);
-    if (micros.modMiddle == nullptr) {
-        applyToMicros(micros, quantity, status);
+    if (micros.modMiddle != nullptr) {
+        return;
     }
+    applyToMicros(micros, quantity, status);
 }
 
 void ImmutablePatternModifier::applyToMicros(
@@ -165,6 +166,9 @@ void MutablePatternModifier::processQuantity(DecimalQuantity& fq, MicroProps& mi
     fParent->processQuantity(fq, micros, status);
     micros.rounder.apply(fq, status);
     micros.integerWidth.apply(fq, status);
+    if (micros.modMiddle != nullptr) {
+        return;
+    }
     // The unsafe code path performs self-mutation, so we need a const_cast.
     // This method needs to be const because it overrides a const method in the parent class.
     auto nonConstThis = const_cast<MutablePatternModifier*>(this);

--- a/icu4c/source/i18n/number_patternmodifier.cpp
+++ b/icu4c/source/i18n/number_patternmodifier.cpp
@@ -55,12 +55,6 @@ bool MutablePatternModifier::needsPlurals() const {
 }
 
 ImmutablePatternModifier* MutablePatternModifier::createImmutable(UErrorCode& status) {
-    return createImmutableAndChain(nullptr, status);
-}
-
-ImmutablePatternModifier*
-MutablePatternModifier::createImmutableAndChain(const MicroPropsGenerator* parent, UErrorCode& status) {
-
     // TODO: Move StandardPlural VALUES to standardplural.h
     static const StandardPlural::Form STANDARD_PLURAL_VALUES[] = {
             StandardPlural::Form::ZERO,
@@ -92,7 +86,7 @@ MutablePatternModifier::createImmutableAndChain(const MicroPropsGenerator* paren
             delete pm;
             return nullptr;
         }
-        return new ImmutablePatternModifier(pm, fRules, parent);  // adopts pm
+        return new ImmutablePatternModifier(pm, fRules);  // adopts pm
     } else {
         // Faster path when plural keyword is not needed.
         setNumberProperties(SIGNUM_POS, StandardPlural::Form::COUNT);
@@ -107,7 +101,7 @@ MutablePatternModifier::createImmutableAndChain(const MicroPropsGenerator* paren
             delete pm;
             return nullptr;
         }
-        return new ImmutablePatternModifier(pm, nullptr, parent);  // adopts pm
+        return new ImmutablePatternModifier(pm, nullptr);  // adopts pm
     }
 }
 
@@ -124,14 +118,17 @@ ConstantMultiFieldModifier* MutablePatternModifier::createConstantModifier(UErro
     }
 }
 
-ImmutablePatternModifier::ImmutablePatternModifier(AdoptingModifierStore* pm, const PluralRules* rules,
-                                                   const MicroPropsGenerator* parent)
-        : pm(pm), rules(rules), parent(parent) {}
+ImmutablePatternModifier::ImmutablePatternModifier(AdoptingModifierStore* pm, const PluralRules* rules)
+        : pm(pm), rules(rules), parent(nullptr) {}
 
 void ImmutablePatternModifier::processQuantity(DecimalQuantity& quantity, MicroProps& micros,
                                                UErrorCode& status) const {
     parent->processQuantity(quantity, micros, status);
-    applyToMicros(micros, quantity, status);
+    micros.rounder.apply(quantity, status);
+    micros.integerWidth.apply(quantity, status);
+    if (micros.modMiddle == nullptr) {
+        applyToMicros(micros, quantity, status);
+    }
 }
 
 void ImmutablePatternModifier::applyToMicros(
@@ -152,6 +149,10 @@ const Modifier* ImmutablePatternModifier::getModifier(Signum signum, StandardPlu
     }
 }
 
+void ImmutablePatternModifier::addToChain(const MicroPropsGenerator* parent) {
+    this->parent = parent;
+}
+
 
 /** Used by the unsafe code path. */
 MicroPropsGenerator& MutablePatternModifier::addToChain(const MicroPropsGenerator* parent) {
@@ -162,6 +163,8 @@ MicroPropsGenerator& MutablePatternModifier::addToChain(const MicroPropsGenerato
 void MutablePatternModifier::processQuantity(DecimalQuantity& fq, MicroProps& micros,
                                              UErrorCode& status) const {
     fParent->processQuantity(fq, micros, status);
+    micros.rounder.apply(fq, status);
+    micros.integerWidth.apply(fq, status);
     // The unsafe code path performs self-mutation, so we need a const_cast.
     // This method needs to be const because it overrides a const method in the parent class.
     auto nonConstThis = const_cast<MutablePatternModifier*>(this);

--- a/icu4c/source/i18n/number_patternmodifier.h
+++ b/icu4c/source/i18n/number_patternmodifier.h
@@ -50,9 +50,11 @@ class U_I18N_API ImmutablePatternModifier : public MicroPropsGenerator, public U
 
     const Modifier* getModifier(Signum signum, StandardPlural::Form plural) const;
 
+    // Non-const method:
+    void addToChain(const MicroPropsGenerator* parent);
+
   private:
-    ImmutablePatternModifier(AdoptingModifierStore* pm, const PluralRules* rules,
-                             const MicroPropsGenerator* parent);
+    ImmutablePatternModifier(AdoptingModifierStore* pm, const PluralRules* rules);
 
     const LocalPointer<AdoptingModifierStore> pm;
     const PluralRules* rules;
@@ -164,21 +166,6 @@ class U_I18N_API MutablePatternModifier
      * @return An immutable that supports both positive and negative numbers.
      */
     ImmutablePatternModifier *createImmutable(UErrorCode &status);
-
-    /**
-     * Creates a new quantity-dependent Modifier that behaves the same as the current instance, but which is immutable
-     * and can be saved for future use. The number properties in the current instance are mutated; all other properties
-     * are left untouched.
-     *
-     * <p>
-     * CREATES A NEW HEAP OBJECT; THE CALLER GETS OWNERSHIP.
-     *
-     * @param parent
-     *            The QuantityChain to which to chain this immutable.
-     * @return An immutable that supports both positive and negative numbers.
-     */
-    ImmutablePatternModifier *
-    createImmutableAndChain(const MicroPropsGenerator *parent, UErrorCode &status);
 
     MicroPropsGenerator &addToChain(const MicroPropsGenerator *parent);
 

--- a/icu4c/source/i18n/number_patternstring.cpp
+++ b/icu4c/source/i18n/number_patternstring.cpp
@@ -1000,12 +1000,9 @@ PatternStringUtils::convertLocalized(const UnicodeString& input, const DecimalFo
 }
 
 void PatternStringUtils::patternInfoToStringBuilder(const AffixPatternProvider& patternInfo, bool isPrefix,
-                                                    Signum signum, UNumberSignDisplay signDisplay,
+                                                    PatternSignType patternSignType,
                                                     StandardPlural::Form plural,
                                                     bool perMilleReplacesPercent, UnicodeString& output) {
-
-    // Resolve which of the three options to use for displaying the sign.
-    PatternSignType patternSignType = resolveSignDisplay(signDisplay, signum);
 
     // Should the output render '+' where '-' would normally appear in the pattern?
     bool plusReplacesMinusSign = (patternSignType == PATTERN_SIGN_TYPE_POS_SIGN)

--- a/icu4c/source/i18n/number_patternstring.h
+++ b/icu4c/source/i18n/number_patternstring.h
@@ -22,6 +22,15 @@ namespace impl {
 // Forward declaration
 class PatternParser;
 
+enum PatternSignType {
+    // Render using negative subpattern rules
+    PATTERN_SIGN_TYPE_NEG,
+    // Render using normal positive subpattern rules
+    PATTERN_SIGN_TYPE_POS,
+    // Render using rules to force the display of a plus sign
+    PATTERN_SIGN_TYPE_POS_SIGN
+};
+
 // Exported as U_I18N_API because it is a public member field of exported ParsedSubpatternInfo
 struct U_I18N_API Endpoints {
     int32_t start = 0;
@@ -303,6 +312,8 @@ class U_I18N_API PatternStringUtils {
     /** @return The number of chars inserted. */
     static int escapePaddingString(UnicodeString input, UnicodeString& output, int startIndex,
                                    UErrorCode& status);
+
+    static PatternSignType resolveSignDisplay(UNumberSignDisplay signDisplay, Signum signum);
 };
 
 } // namespace impl

--- a/icu4c/source/i18n/number_patternstring.h
+++ b/icu4c/source/i18n/number_patternstring.h
@@ -22,13 +22,16 @@ namespace impl {
 // Forward declaration
 class PatternParser;
 
+// Note: the order of fields in this enum matters for parsing.
 enum PatternSignType {
-    // Render using negative subpattern rules
-    PATTERN_SIGN_TYPE_NEG,
-    // Render using normal positive subpattern rules
+    /** Render using normal positive subpattern rules */
     PATTERN_SIGN_TYPE_POS,
-    // Render using rules to force the display of a plus sign
-    PATTERN_SIGN_TYPE_POS_SIGN
+    /** Render using rules to force the display of a plus sign */
+    PATTERN_SIGN_TYPE_POS_SIGN,
+    /** Render using negative subpattern rules */
+    PATTERN_SIGN_TYPE_NEG,
+    /** Count for looping over the possibilities */
+    PATTERN_SIGN_TYPE_COUNT
 };
 
 // Exported as U_I18N_API because it is a public member field of exported ParsedSubpatternInfo
@@ -304,16 +307,16 @@ class U_I18N_API PatternStringUtils {
      * substitution, and plural forms for CurrencyPluralInfo.
      */
     static void patternInfoToStringBuilder(const AffixPatternProvider& patternInfo, bool isPrefix,
-                                           Signum signum, UNumberSignDisplay signDisplay,
+                                           PatternSignType patternSignType,
                                            StandardPlural::Form plural, bool perMilleReplacesPercent,
                                            UnicodeString& output);
+
+    static PatternSignType resolveSignDisplay(UNumberSignDisplay signDisplay, Signum signum);
 
   private:
     /** @return The number of chars inserted. */
     static int escapePaddingString(UnicodeString input, UnicodeString& output, int startIndex,
                                    UErrorCode& status);
-
-    static PatternSignType resolveSignDisplay(UNumberSignDisplay signDisplay, Signum signum);
 };
 
 } // namespace impl

--- a/icu4c/source/i18n/number_rounding.cpp
+++ b/icu4c/source/i18n/number_rounding.cpp
@@ -294,9 +294,7 @@ RoundingImpl::RoundingImpl(const Precision& precision, UNumberFormatRoundingMode
 }
 
 RoundingImpl RoundingImpl::passThrough() {
-    RoundingImpl retval;
-    retval.fPassThrough = true;
-    return retval;
+    return {};
 }
 
 bool RoundingImpl::isSignificantDigits() const {

--- a/icu4c/source/i18n/number_roundingutils.h
+++ b/icu4c/source/i18n/number_roundingutils.h
@@ -150,7 +150,7 @@ digits_t doubleFractionLength(double input, int8_t* singleDigit);
  */
 class RoundingImpl {
   public:
-    RoundingImpl() = default;  // default constructor: leaves object in undefined state
+    RoundingImpl() = default;  // defaults to pass-through rounder
 
     RoundingImpl(const Precision& precision, UNumberFormatRoundingMode roundingMode,
                  const CurrencyUnit& currency, UErrorCode& status);
@@ -186,7 +186,7 @@ class RoundingImpl {
   private:
     Precision fPrecision;
     UNumberFormatRoundingMode fRoundingMode;
-    bool fPassThrough;
+    bool fPassThrough = true;  // default value
 };
 
 

--- a/icu4c/source/i18n/number_types.h
+++ b/icu4c/source/i18n/number_types.h
@@ -92,10 +92,10 @@ enum CompactType {
 };
 
 enum Signum {
-    SIGNUM_NEG = -2,
-    SIGNUM_NEG_ZERO = -1,
-    SIGNUM_POS_ZERO = 0,
-    SIGNUM_POS = 1
+    SIGNUM_NEG = 0,
+    SIGNUM_NEG_ZERO = 1,
+    SIGNUM_POS_ZERO = 2,
+    SIGNUM_POS = 3
 };
 
 

--- a/icu4c/source/i18n/number_types.h
+++ b/icu4c/source/i18n/number_types.h
@@ -92,8 +92,9 @@ enum CompactType {
 };
 
 enum Signum {
-    SIGNUM_NEG = -1,
-    SIGNUM_ZERO = 0,
+    SIGNUM_NEG = -2,
+    SIGNUM_NEG_ZERO = -1,
+    SIGNUM_POS_ZERO = 0,
     SIGNUM_POS = 1
 };
 

--- a/icu4c/source/i18n/unicode/numberformatter.h
+++ b/icu4c/source/i18n/unicode/numberformatter.h
@@ -157,6 +157,8 @@ class DecNum;
 class NumberRangeFormatterImpl;
 struct RangeMacroProps;
 struct UFormattedNumberImpl;
+class MutablePatternModifier;
+class ImmutablePatternModifier;
 
 /**
  * Used for NumberRangeFormatter and implemented in numrange_fluent.cpp.
@@ -982,8 +984,12 @@ class U_I18N_API IntegerWidth : public UMemory {
     friend struct impl::MacroProps;
     friend struct impl::MicroProps;
 
-    // To allow NumberFormatterImpl to access isBogus() and perform other operations:
+    // To allow NumberFormatterImpl to access isBogus():
     friend class impl::NumberFormatterImpl;
+
+    // To allow the use of this class when formatting:
+    friend class impl::MutablePatternModifier;
+    friend class impl::ImmutablePatternModifier;
 
     // So that NumberPropertyMapper can create instances
     friend class impl::NumberPropertyMapper;

--- a/icu4c/source/test/intltest/numbertest.h
+++ b/icu4c/source/test/intltest/numbertest.h
@@ -68,6 +68,7 @@ class NumberFormatterApiTest : public IntlTestWithFieldPosition {
     // TODO: Add this method if currency symbols override support is added.
     //void symbolsOverride();
     void sign();
+    void signNearZero();
     void signCoverage();
     void decimal();
     void scale();

--- a/icu4c/source/test/intltest/numbertest_api.cpp
+++ b/icu4c/source/test/intltest/numbertest_api.cpp
@@ -1695,6 +1695,57 @@ void NumberFormatterApiTest::integerWidth() {
             u"00.008765",
             u"00");
 
+    assertFormatDescending(
+            u"Integer Width Compact",
+            u"compact-short integer-width/000",
+            NumberFormatter::with()
+                .notation(Notation::compactShort())
+                .integerWidth(IntegerWidth::zeroFillTo(3).truncateAt(3)),
+            Locale::getEnglish(),
+            u"088K",
+            u"008.8K",
+            u"876",
+            u"088",
+            u"008.8",
+            u"000.88",
+            u"000.088",
+            u"000.0088",
+            u"000");
+
+    assertFormatDescending(
+            u"Integer Width Scientific",
+            u"scientific integer-width/000",
+            NumberFormatter::with()
+                .notation(Notation::scientific())
+                .integerWidth(IntegerWidth::zeroFillTo(3).truncateAt(3)),
+            Locale::getEnglish(),
+            u"008.765E4",
+            u"008.765E3",
+            u"008.765E2",
+            u"008.765E1",
+            u"008.765E0",
+            u"008.765E-1",
+            u"008.765E-2",
+            u"008.765E-3",
+            u"000E0");
+
+    assertFormatDescending(
+            u"Integer Width Engineering",
+            u"engineering integer-width/000",
+            NumberFormatter::with()
+                .notation(Notation::engineering())
+                .integerWidth(IntegerWidth::zeroFillTo(3).truncateAt(3)),
+            Locale::getEnglish(),
+            u"087.65E3",
+            u"008.765E3",
+            u"876.5E0",
+            u"087.65E0",
+            u"008.765E0",
+            u"876.5E-3",
+            u"087.65E-3",
+            u"008.765E-3",
+            u"000E0");
+
     assertFormatSingle(
             u"Integer Width Remove All A",
             u"integer-width/00",

--- a/icu4c/source/test/intltest/numbertest_patternmodifier.cpp
+++ b/icu4c/source/test/intltest/numbertest_patternmodifier.cpp
@@ -82,9 +82,8 @@ void PatternModifierTest::testBasic() {
     assertEquals("Pattern a0b;c-0d", u"c-", getPrefix(mod, status));
     assertEquals("Pattern a0b;c-0d", u"d", getSuffix(mod, status));
     mod.setPatternAttributes(UNUM_SIGN_NEVER, false);
-    // TODO: What should this behavior be?
-    assertEquals("Pattern a0b;c-0d", u"c-", getPrefix(mod, status));
-    assertEquals("Pattern a0b;c-0d", u"d", getSuffix(mod, status));
+    assertEquals("Pattern a0b;c-0d", u"a", getPrefix(mod, status));
+    assertEquals("Pattern a0b;c-0d", u"b", getSuffix(mod, status));
     assertSuccess("Spot 5", status);
 }
 

--- a/icu4c/source/test/intltest/numbertest_patternmodifier.cpp
+++ b/icu4c/source/test/intltest/numbertest_patternmodifier.cpp
@@ -41,7 +41,10 @@ void PatternModifierTest::testBasic() {
     mod.setPatternAttributes(UNUM_SIGN_ALWAYS, false);
     assertEquals("Pattern a0b", u"+a", getPrefix(mod, status));
     assertEquals("Pattern a0b", u"b", getSuffix(mod, status));
-    mod.setNumberProperties(SIGNUM_ZERO, StandardPlural::Form::COUNT);
+    mod.setNumberProperties(SIGNUM_NEG_ZERO, StandardPlural::Form::COUNT);
+    assertEquals("Pattern a0b", u"-a", getPrefix(mod, status));
+    assertEquals("Pattern a0b", u"b", getSuffix(mod, status));
+    mod.setNumberProperties(SIGNUM_POS_ZERO, StandardPlural::Form::COUNT);
     assertEquals("Pattern a0b", u"+a", getPrefix(mod, status));
     assertEquals("Pattern a0b", u"b", getSuffix(mod, status));
     mod.setPatternAttributes(UNUM_SIGN_EXCEPT_ZERO, false);
@@ -66,7 +69,10 @@ void PatternModifierTest::testBasic() {
     mod.setPatternAttributes(UNUM_SIGN_ALWAYS, false);
     assertEquals("Pattern a0b;c-0d", u"c+", getPrefix(mod, status));
     assertEquals("Pattern a0b;c-0d", u"d", getSuffix(mod, status));
-    mod.setNumberProperties(SIGNUM_ZERO, StandardPlural::Form::COUNT);
+    mod.setNumberProperties(SIGNUM_NEG_ZERO, StandardPlural::Form::COUNT);
+    assertEquals("Pattern a0b;c-0d", u"c-", getPrefix(mod, status));
+    assertEquals("Pattern a0b;c-0d", u"d", getSuffix(mod, status));
+    mod.setNumberProperties(SIGNUM_POS_ZERO, StandardPlural::Form::COUNT);
     assertEquals("Pattern a0b;c-0d", u"c+", getPrefix(mod, status));
     assertEquals("Pattern a0b;c-0d", u"d", getSuffix(mod, status));
     mod.setPatternAttributes(UNUM_SIGN_EXCEPT_ZERO, false);

--- a/icu4c/source/test/testdata/numberpermutationtest.txt
+++ b/icu4c/source/test/testdata/numberpermutationtest.txt
@@ -2273,15 +2273,15 @@ compact-short precision-integer sign-accounting-except-zero
   es-MX
     0
     +92 k
-    -0
+    0
   zh-TW
     0
     +9萬
-    -0
+    0
   bn-BD
     ০
     +৯২ হা
-    -০
+    ০
 
 compact-short .000 sign-accounting-except-zero
   es-MX
@@ -4849,15 +4849,15 @@ percent precision-integer sign-accounting-except-zero
   es-MX
     0 %
     +91,827 %
-    -0 %
+    0 %
   zh-TW
     0%
     +91,827%
-    -0%
+    0%
   bn-BD
     ০%
     +৯১,৮২৭%
-    -০%
+    ০%
 
 percent .000 sign-accounting-except-zero
   es-MX
@@ -4905,15 +4905,15 @@ currency/EUR precision-integer sign-accounting-except-zero
   es-MX
     EUR 0
     +EUR 91,827
-    -EUR 0
+    EUR 0
   zh-TW
     €0
     +€91,827
-    (€0)
+    €0
   bn-BD
     ০€
     +৯১,৮২৭€
-    (০ €)
+    ০€
 
 currency/EUR .000 sign-accounting-except-zero
   es-MX
@@ -4961,15 +4961,15 @@ measure-unit/length-furlong precision-integer sign-accounting-except-zero
   es-MX
     0 fur
     +91,827 fur
-    -0 fur
+    0 fur
   zh-TW
     0 化朗
     +91,827 化朗
-    -0 化朗
+    0 化朗
   bn-BD
     ০ ফার্লং
     +৯১,৮২৭ ফার্লং
-    -০ ফার্লং
+    ০ ফার্লং
 
 measure-unit/length-furlong .000 sign-accounting-except-zero
   es-MX
@@ -6627,15 +6627,15 @@ unit-width-narrow precision-integer sign-accounting-except-zero
   es-MX
     0
     +91,827
-    -0
+    0
   zh-TW
     0
     +91,827
-    -0
+    0
   bn-BD
     ০
     +৯১,৮২৭
-    -০
+    ০
 
 unit-width-narrow .000 sign-accounting-except-zero
   es-MX
@@ -6683,15 +6683,15 @@ unit-width-full-name precision-integer sign-accounting-except-zero
   es-MX
     0
     +91,827
-    -0
+    0
   zh-TW
     0
     +91,827
-    -0
+    0
   bn-BD
     ০
     +৯১,৮২৭
-    -০
+    ০
 
 unit-width-full-name .000 sign-accounting-except-zero
   es-MX
@@ -7943,15 +7943,15 @@ precision-integer integer-width/##00 sign-accounting-except-zero
   es-MX
     00
     +1827
-    -00
+    00
   zh-TW
     00
     +1,827
-    -00
+    00
   bn-BD
     ০০
     +১,৮২৭
-    -০০
+    ০০
 
 .000 integer-width/##00 sign-accounting-except-zero
   es-MX
@@ -8167,15 +8167,15 @@ precision-integer scale/0.5 sign-accounting-except-zero
   es-MX
     0
     +45,914
-    -0
+    0
   zh-TW
     0
     +45,914
-    -0
+    0
   bn-BD
     ০
     +৪৫,৯১৪
-    -০
+    ০
 
 .000 scale/0.5 sign-accounting-except-zero
   es-MX
@@ -8335,15 +8335,15 @@ precision-integer group-on-aligned sign-accounting-except-zero
   es-MX
     0
     +91,827
-    -0
+    0
   zh-TW
     0
     +91,827
-    -0
+    0
   bn-BD
     ০
     +৯১,৮২৭
-    -০
+    ০
 
 .000 group-on-aligned sign-accounting-except-zero
   es-MX
@@ -8447,15 +8447,15 @@ precision-integer latin sign-accounting-except-zero
   es-MX
     0
     +91,827
-    -0
+    0
   zh-TW
     0
     +91,827
-    -0
+    0
   bn-BD
     0
     +91,827
-    -0
+    0
 
 .000 latin sign-accounting-except-zero
   es-MX
@@ -8559,15 +8559,15 @@ precision-integer sign-accounting-except-zero decimal-always
   es-MX
     0.
     +91,827.
-    -0.
+    0.
   zh-TW
     0.
     +91,827.
-    -0.
+    0.
   bn-BD
     ০.
     +৯১,৮২৭.
-    -০.
+    ০.
 
 .000 sign-accounting-except-zero decimal-always
   es-MX

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/AdoptingModifierStore.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/AdoptingModifierStore.java
@@ -3,6 +3,7 @@
 package com.ibm.icu.impl.number;
 
 import com.ibm.icu.impl.StandardPlural;
+import com.ibm.icu.impl.number.Modifier.Signum;
 
 /**
  * This implementation of ModifierStore adopts references to Modifiers.
@@ -11,7 +12,8 @@ import com.ibm.icu.impl.StandardPlural;
  */
 public class AdoptingModifierStore implements ModifierStore {
     private final Modifier positive;
-    private final Modifier zero;
+    private final Modifier posZero;
+    private final Modifier negZero;
     private final Modifier negative;
     final Modifier[] mods;
     boolean frozen;
@@ -22,9 +24,10 @@ public class AdoptingModifierStore implements ModifierStore {
      * <p>
      * If this constructor is used, a plural form CANNOT be passed to {@link #getModifier}.
      */
-    public AdoptingModifierStore(Modifier positive, Modifier zero, Modifier negative) {
+    public AdoptingModifierStore(Modifier positive, Modifier posZero, Modifier negZero, Modifier negative) {
         this.positive = positive;
-        this.zero = zero;
+        this.posZero = posZero;
+        this.negZero = negZero;
         this.negative = negative;
         this.mods = null;
         this.frozen = true;
@@ -39,13 +42,14 @@ public class AdoptingModifierStore implements ModifierStore {
      */
     public AdoptingModifierStore() {
         this.positive = null;
-        this.zero = null;
+        this.posZero = null;
+        this.negZero = null;
         this.negative = null;
-        this.mods = new Modifier[3 * StandardPlural.COUNT];
+        this.mods = new Modifier[4 * StandardPlural.COUNT];
         this.frozen = false;
     }
 
-    public void setModifier(int signum, StandardPlural plural, Modifier mod) {
+    public void setModifier(Signum signum, StandardPlural plural, Modifier mod) {
         assert !frozen;
         mods[getModIndex(signum, plural)] = mod;
     }
@@ -54,21 +58,34 @@ public class AdoptingModifierStore implements ModifierStore {
         frozen = true;
     }
 
-    public Modifier getModifierWithoutPlural(int signum) {
+    public Modifier getModifierWithoutPlural(Signum signum) {
         assert frozen;
         assert mods == null;
-        return signum == 0 ? zero : signum < 0 ? negative : positive;
+        assert signum != null;
+        switch (signum) {
+            case POS:
+                return positive;
+            case POS_ZERO:
+                return posZero;
+            case NEG_ZERO:
+                return negZero;
+            case NEG:
+                return negative;
+            default:
+                throw new AssertionError("Unreachable");
+        }
     }
 
-    public Modifier getModifier(int signum, StandardPlural plural) {
+    @Override
+    public Modifier getModifier(Signum signum, StandardPlural plural) {
         assert frozen;
         assert positive == null;
         return mods[getModIndex(signum, plural)];
     }
 
-    private static int getModIndex(int signum, StandardPlural plural) {
-        assert signum >= -1 && signum <= 1;
+    private static int getModIndex(Signum signum, StandardPlural plural) {
+        assert signum != null;
         assert plural != null;
-        return plural.ordinal() * 3 + (signum + 1);
+        return plural.ordinal() * 4 + signum.ordinal();
     }
 }

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/DecimalQuantity.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/DecimalQuantity.java
@@ -7,6 +7,7 @@ import java.math.MathContext;
 import java.text.FieldPosition;
 
 import com.ibm.icu.impl.StandardPlural;
+import com.ibm.icu.impl.number.Modifier.Signum;
 import com.ibm.icu.text.PluralRules;
 import com.ibm.icu.text.UFieldPosition;
 
@@ -130,8 +131,8 @@ public interface DecimalQuantity extends PluralRules.IFixedDecimal {
     /** @return Whether the value represented by this {@link DecimalQuantity} is less than zero. */
     public boolean isNegative();
 
-    /** @return -1 if the value is negative; 1 if positive; or 0 if zero. */
-    public int signum();
+    /** @return The appropriate value from the Signum enum. */
+    public Signum signum();
 
     /** @return Whether the value represented by this {@link DecimalQuantity} is infinite. */
     @Override

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/DecimalQuantity_AbstractBCD.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/DecimalQuantity_AbstractBCD.java
@@ -9,6 +9,7 @@ import java.text.FieldPosition;
 
 import com.ibm.icu.impl.StandardPlural;
 import com.ibm.icu.impl.Utility;
+import com.ibm.icu.impl.number.Modifier.Signum;
 import com.ibm.icu.text.PluralRules;
 import com.ibm.icu.text.PluralRules.Operand;
 import com.ibm.icu.text.UFieldPosition;
@@ -303,8 +304,18 @@ public abstract class DecimalQuantity_AbstractBCD implements DecimalQuantity {
     }
 
     @Override
-    public int signum() {
-        return isNegative() ? -1 : (isZeroish() && !isInfinite()) ? 0 : 1;
+    public Signum signum() {
+        boolean isZero = (isZeroish() && !isInfinite());
+        boolean isNeg = isNegative();
+        if (isZero && isNeg) {
+            return Signum.NEG_ZERO;
+        } else if (isZero) {
+            return Signum.POS_ZERO;
+        } else if (isNeg) {
+            return Signum.NEG;
+        } else {
+            return Signum.POS;
+        }
     }
 
     @Override

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/LongNameHandler.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/LongNameHandler.java
@@ -12,6 +12,7 @@ import com.ibm.icu.impl.ICUResourceBundle;
 import com.ibm.icu.impl.SimpleFormatterImpl;
 import com.ibm.icu.impl.StandardPlural;
 import com.ibm.icu.impl.UResource;
+import com.ibm.icu.impl.number.Modifier.Signum;
 import com.ibm.icu.number.NumberFormatter.UnitWidth;
 import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.text.PluralRules;
@@ -262,7 +263,7 @@ public class LongNameHandler implements MicroPropsGenerator, ModifierStore {
             String compiled = SimpleFormatterImpl.compileToStringMinMaxArguments(simpleFormat, sb, 0, 1);
             Modifier.Parameters parameters = new Modifier.Parameters();
             parameters.obj = this;
-            parameters.signum = 0;
+            parameters.signum = null;// Signum ignored
             parameters.plural = plural;
             modifiers.put(plural, new SimpleModifier(compiled, field, false, parameters));
         }
@@ -281,7 +282,7 @@ public class LongNameHandler implements MicroPropsGenerator, ModifierStore {
                     .compileToStringMinMaxArguments(compoundFormat, sb, 0, 1);
             Modifier.Parameters parameters = new Modifier.Parameters();
             parameters.obj = this;
-            parameters.signum = 0;
+            parameters.signum = null; // Signum ignored
             parameters.plural = plural;
             modifiers.put(plural, new SimpleModifier(compoundCompiled, field, false, parameters));
         }
@@ -296,7 +297,8 @@ public class LongNameHandler implements MicroPropsGenerator, ModifierStore {
     }
 
     @Override
-    public Modifier getModifier(int signum, StandardPlural plural) {
+    public Modifier getModifier(Signum signum, StandardPlural plural) {
+        // Signum ignored
         return modifiers.get(plural);
     }
 }

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/Modifier.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/Modifier.java
@@ -17,6 +17,13 @@ import com.ibm.icu.impl.StandardPlural;
  */
 public interface Modifier {
 
+    static enum Signum {
+        NEG,
+        NEG_ZERO,
+        POS_ZERO,
+        POS
+    };
+
     /**
      * Apply this Modifier to the string builder.
      *
@@ -65,7 +72,7 @@ public interface Modifier {
      */
     public static class Parameters {
         public ModifierStore obj;
-        public int signum;
+        public Signum signum;
         public StandardPlural plural;
     }
 

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/ModifierStore.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/ModifierStore.java
@@ -3,6 +3,7 @@
 package com.ibm.icu.impl.number;
 
 import com.ibm.icu.impl.StandardPlural;
+import com.ibm.icu.impl.number.Modifier.Signum;
 
 /**
  * This is *not* a modifier; rather, it is an object that can return modifiers
@@ -14,5 +15,5 @@ public interface ModifierStore {
     /**
      * Returns a Modifier with the given parameters (best-effort).
      */
-    Modifier getModifier(int signum, StandardPlural plural);
+    Modifier getModifier(Signum signum, StandardPlural plural);
 }

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/MutablePatternModifier.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/MutablePatternModifier.java
@@ -226,7 +226,7 @@ public class MutablePatternModifier implements Modifier, SymbolProvider, MicroPr
     public static class ImmutablePatternModifier implements MicroPropsGenerator {
         final AdoptingModifierStore pm;
         final PluralRules rules;
-        final MicroPropsGenerator parent;
+        /* final */ MicroPropsGenerator parent;
 
         ImmutablePatternModifier(
                 AdoptingModifierStore pm,
@@ -237,9 +237,17 @@ public class MutablePatternModifier implements Modifier, SymbolProvider, MicroPr
             this.parent = parent;
         }
 
+        public ImmutablePatternModifier addToChain(MicroPropsGenerator parent) {
+            this.parent = parent;
+            return this;
+        }
+
         @Override
         public MicroProps processQuantity(DecimalQuantity quantity) {
             MicroProps micros = parent.processQuantity(quantity);
+            if (micros.modMiddle != null) {
+                return micros;
+            }
             applyToMicros(micros, quantity);
             return micros;
         }
@@ -274,6 +282,9 @@ public class MutablePatternModifier implements Modifier, SymbolProvider, MicroPr
     @Override
     public MicroProps processQuantity(DecimalQuantity fq) {
         MicroProps micros = parent.processQuantity(fq);
+        if (micros.modMiddle != null) {
+            return micros;
+        }
         if (needsPlurals()) {
             StandardPlural pluralForm = RoundingUtils.getPluralSafe(micros.rounder, rules, fq);
             setNumberProperties(fq.signum(), pluralForm);

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/MutablePatternModifier.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/MutablePatternModifier.java
@@ -245,6 +245,9 @@ public class MutablePatternModifier implements Modifier, SymbolProvider, MicroPr
         @Override
         public MicroProps processQuantity(DecimalQuantity quantity) {
             MicroProps micros = parent.processQuantity(quantity);
+            if (micros.rounder != null) {
+                micros.rounder.apply(quantity);
+            }
             if (micros.modMiddle != null) {
                 return micros;
             }
@@ -282,6 +285,9 @@ public class MutablePatternModifier implements Modifier, SymbolProvider, MicroPr
     @Override
     public MicroProps processQuantity(DecimalQuantity fq) {
         MicroProps micros = parent.processQuantity(fq);
+        if (micros.rounder != null) {
+            micros.rounder.apply(fq);
+        }
         if (micros.modMiddle != null) {
             return micros;
         }

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/MutablePatternModifier.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/MutablePatternModifier.java
@@ -155,19 +155,6 @@ public class MutablePatternModifier implements Modifier, SymbolProvider, MicroPr
      * @return An immutable that supports both positive and negative numbers.
      */
     public ImmutablePatternModifier createImmutable() {
-        return createImmutableAndChain(null);
-    }
-
-    /**
-     * Creates a new quantity-dependent Modifier that behaves the same as the current instance, but which
-     * is immutable and can be saved for future use. The number properties in the current instance are
-     * mutated; all other properties are left untouched.
-     *
-     * @param parent
-     *            The QuantityChain to which to chain this immutable.
-     * @return An immutable that supports both positive and negative numbers.
-     */
-    public ImmutablePatternModifier createImmutableAndChain(MicroPropsGenerator parent) {
         FormattedStringBuilder a = new FormattedStringBuilder();
         FormattedStringBuilder b = new FormattedStringBuilder();
         if (needsPlurals()) {
@@ -184,7 +171,7 @@ public class MutablePatternModifier implements Modifier, SymbolProvider, MicroPr
                 pm.setModifier(Signum.NEG, plural, createConstantModifier(a, b));
             }
             pm.freeze();
-            return new ImmutablePatternModifier(pm, rules, parent);
+            return new ImmutablePatternModifier(pm, rules);
         } else {
             // Faster path when plural keyword is not needed.
             setNumberProperties(Signum.POS, null);
@@ -196,7 +183,7 @@ public class MutablePatternModifier implements Modifier, SymbolProvider, MicroPr
             setNumberProperties(Signum.NEG, null);
             Modifier negative = createConstantModifier(a, b);
             AdoptingModifierStore pm = new AdoptingModifierStore(positive, posZero, negZero, negative);
-            return new ImmutablePatternModifier(pm, null, parent);
+            return new ImmutablePatternModifier(pm, null);
         }
     }
 
@@ -230,11 +217,10 @@ public class MutablePatternModifier implements Modifier, SymbolProvider, MicroPr
 
         ImmutablePatternModifier(
                 AdoptingModifierStore pm,
-                PluralRules rules,
-                MicroPropsGenerator parent) {
+                PluralRules rules) {
             this.pm = pm;
             this.rules = rules;
-            this.parent = parent;
+            this.parent = null;
         }
 
         public ImmutablePatternModifier addToChain(MicroPropsGenerator parent) {

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/PatternStringUtils.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/PatternStringUtils.java
@@ -5,6 +5,7 @@ package com.ibm.icu.impl.number;
 import java.math.BigDecimal;
 
 import com.ibm.icu.impl.StandardPlural;
+import com.ibm.icu.impl.number.Modifier.Signum;
 import com.ibm.icu.impl.number.Padder.PadPosition;
 import com.ibm.icu.number.NumberFormatter.SignDisplay;
 import com.ibm.icu.text.DecimalFormatSymbols;
@@ -13,6 +14,18 @@ import com.ibm.icu.text.DecimalFormatSymbols;
  * Assorted utilities relating to decimal formatting pattern strings.
  */
 public class PatternStringUtils {
+
+    // Note: the order of fields in this enum matters for parsing.
+    public static enum PatternSignType {
+        // Render using normal positive subpattern rules
+        POS,
+        // Render using rules to force the display of a plus sign
+        POS_SIGN,
+        // Render using negative subpattern rules
+        NEG;
+
+        public static final PatternSignType[] VALUES = PatternSignType.values();
+    };
 
     /**
      * Determine whether a given roundingIncrement should be ignored for formatting
@@ -23,7 +36,7 @@ public class PatternStringUtils {
      * it should not be ignored if maxFrac is 2 or more (but a roundingIncrement of
      * 0.005 is treated like 0.001 for significance).
      *
-     * This test is needed for both NumberPropertyMapper.oldToNew and 
+     * This test is needed for both NumberPropertyMapper.oldToNew and
      * PatternStringUtils.propertiesToPatternString, but NumberPropertyMapper
      * is package-private so we have it here.
      *
@@ -416,25 +429,19 @@ public class PatternStringUtils {
     public static void patternInfoToStringBuilder(
             AffixPatternProvider patternInfo,
             boolean isPrefix,
-            int signum,
-            SignDisplay signDisplay,
+            PatternSignType patternSignType,
             StandardPlural plural,
             boolean perMilleReplacesPercent,
             StringBuilder output) {
 
-        // Should the output render '+' where '-' would normally appear in the pattern?
-        boolean plusReplacesMinusSign = signum != -1
-                && (signDisplay == SignDisplay.ALWAYS
-                        || signDisplay == SignDisplay.ACCOUNTING_ALWAYS
-                        || (signum == 1
-                                && (signDisplay == SignDisplay.EXCEPT_ZERO
-                                        || signDisplay == SignDisplay.ACCOUNTING_EXCEPT_ZERO)))
-                && patternInfo.positiveHasPlusSign() == false;
+        boolean plusReplacesMinusSign = (patternSignType == PatternSignType.POS_SIGN)
+                && !patternInfo.positiveHasPlusSign();
 
-        // Should we use the affix from the negative subpattern? (If not, we will use the positive
-        // subpattern.)
+        // Should we use the affix from the negative subpattern?
+        // (If not, we will use the positive subpattern.)
         boolean useNegativeAffixPattern = patternInfo.hasNegativeSubpattern()
-                && (signum == -1 || (patternInfo.negativeHasMinusSign() && plusReplacesMinusSign));
+                && (patternSignType == PatternSignType.NEG
+                    || (patternInfo.negativeHasMinusSign() && plusReplacesMinusSign));
 
         // Resolve the flags for the affix pattern.
         int flags = 0;
@@ -453,8 +460,8 @@ public class PatternStringUtils {
         boolean prependSign;
         if (!isPrefix || useNegativeAffixPattern) {
             prependSign = false;
-        } else if (signum == -1) {
-            prependSign = signDisplay != SignDisplay.NEVER;
+        } else if (patternSignType == PatternSignType.NEG) {
+            prependSign = true;
         } else {
             prependSign = plusReplacesMinusSign;
         }
@@ -481,6 +488,55 @@ public class PatternStringUtils {
             }
             output.append(candidate);
         }
+    }
+
+    public static PatternSignType resolveSignDisplay(SignDisplay signDisplay, Signum signum) {
+        switch (signDisplay) {
+            case AUTO:
+            case ACCOUNTING:
+                switch (signum) {
+                    case NEG:
+                    case NEG_ZERO:
+                        return PatternSignType.NEG;
+                    case POS_ZERO:
+                    case POS:
+                        return PatternSignType.POS;
+                }
+                break;
+
+            case ALWAYS:
+            case ACCOUNTING_ALWAYS:
+                switch (signum) {
+                    case NEG:
+                    case NEG_ZERO:
+                        return PatternSignType.NEG;
+                    case POS_ZERO:
+                    case POS:
+                        return PatternSignType.POS_SIGN;
+                }
+                break;
+
+            case EXCEPT_ZERO:
+            case ACCOUNTING_EXCEPT_ZERO:
+                switch (signum) {
+                    case NEG:
+                        return PatternSignType.NEG;
+                    case NEG_ZERO:
+                    case POS_ZERO:
+                        return PatternSignType.POS;
+                    case POS:
+                        return PatternSignType.POS_SIGN;
+                }
+                break;
+
+            case NEVER:
+                return PatternSignType.POS;
+
+            default:
+                break;
+        }
+
+        throw new AssertionError("Unreachable");
     }
 
 }

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/RoundingUtils.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/RoundingUtils.java
@@ -228,6 +228,9 @@ public class RoundingUtils {
      */
     public static StandardPlural getPluralSafe(
             Precision rounder, PluralRules rules, DecimalQuantity dq) {
+        if (rounder == null) {
+            return dq.getStandardPlural(rules);
+        }
         // TODO(ICU-20500): Avoid the copy?
         DecimalQuantity copy = dq.createCopy();
         rounder.apply(copy);

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/parse/AffixMatcher.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/parse/AffixMatcher.java
@@ -95,16 +95,14 @@ public class AffixMatcher implements NumberParseMatcher {
         AffixPatternMatcher posSuffix = null;
 
         // Pre-process the affix strings to resolve LDML rules like sign display.
-        for (PatternSignType patternSignType : PatternSignType.VALUES) {
-            boolean isPosPattern = patternSignType == PatternSignType.POS;
-            boolean isPosSignPattern = patternSignType == PatternSignType.POS_SIGN;
+        for (PatternSignType type : PatternSignType.VALUES) {
 
             // Skip affixes in some cases
-            if (isPosPattern
+            if (type == PatternSignType.POS
                     && 0 != (parseFlags & ParsingUtils.PARSE_FLAG_PLUS_SIGN_ALLOWED)) {
                 continue;
             }
-            if (isPosSignPattern
+            if (type == PatternSignType.POS_SIGN
                     && 0 == (parseFlags & ParsingUtils.PARSE_FLAG_PLUS_SIGN_ALLOWED)) {
                 continue;
             }
@@ -112,7 +110,7 @@ public class AffixMatcher implements NumberParseMatcher {
             // Generate Prefix
             PatternStringUtils.patternInfoToStringBuilder(patternInfo,
                     true,
-                    patternSignType,
+                    type,
                     StandardPlural.OTHER,
                     false,
                     sb);
@@ -122,14 +120,14 @@ public class AffixMatcher implements NumberParseMatcher {
             // Generate Suffix
             PatternStringUtils.patternInfoToStringBuilder(patternInfo,
                     false,
-                    patternSignType,
+                    type,
                     StandardPlural.OTHER,
                     false,
                     sb);
             AffixPatternMatcher suffix = AffixPatternMatcher
                     .fromAffixPattern(sb.toString(), factory, parseFlags);
 
-            if (isPosPattern) {
+            if (type == PatternSignType.POS) {
                 posPrefix = prefix;
                 posSuffix = suffix;
             } else if (Objects.equals(prefix, posPrefix) && Objects.equals(suffix, posSuffix)) {
@@ -138,17 +136,17 @@ public class AffixMatcher implements NumberParseMatcher {
             }
 
             // Flags for setting in the ParsedNumber; the token matchers may add more.
-            int flags = (patternSignType == PatternSignType.NEG) ? ParsedNumber.FLAG_NEGATIVE : 0;
+            int flags = (type == PatternSignType.NEG) ? ParsedNumber.FLAG_NEGATIVE : 0;
 
             // Note: it is indeed possible for posPrefix and posSuffix to both be null.
             // We still need to add that matcher for strict mode to work.
             matchers.add(getInstance(prefix, suffix, flags));
             if (includeUnpaired && prefix != null && suffix != null) {
                 // The following if statements are designed to prevent adding two identical matchers.
-                if (isPosPattern || !Objects.equals(prefix, posPrefix)) {
+                if (type == PatternSignType.POS || !Objects.equals(prefix, posPrefix)) {
                     matchers.add(getInstance(prefix, null, flags));
                 }
-                if (isPosPattern || !Objects.equals(suffix, posSuffix)) {
+                if (type == PatternSignType.POS || !Objects.equals(suffix, posSuffix)) {
                     matchers.add(getInstance(null, suffix, flags));
                 }
             }

--- a/icu4j/main/classes/core/src/com/ibm/icu/number/CompactNotation.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/number/CompactNotation.java
@@ -66,9 +66,10 @@ public class CompactNotation extends Notation {
             CompactType compactType,
             PluralRules rules,
             MutablePatternModifier buildReference,
+            boolean safe,
             MicroPropsGenerator parent) {
         // TODO: Add a data cache? It would be keyed by locale, nsName, compact type, and compact style.
-        return new CompactHandler(this, locale, nsName, compactType, rules, buildReference, parent);
+        return new CompactHandler(this, locale, nsName, compactType, rules, buildReference, safe, parent);
     }
 
     private static class CompactHandler implements MicroPropsGenerator {
@@ -76,6 +77,7 @@ public class CompactNotation extends Notation {
         final PluralRules rules;
         final MicroPropsGenerator parent;
         final Map<String, ImmutablePatternModifier> precomputedMods;
+        final MutablePatternModifier unsafePatternModifier;
         final CompactData data;
 
         private CompactHandler(
@@ -85,6 +87,7 @@ public class CompactNotation extends Notation {
                 CompactType compactType,
                 PluralRules rules,
                 MutablePatternModifier buildReference,
+                boolean safe,
                 MicroPropsGenerator parent) {
             this.rules = rules;
             this.parent = parent;
@@ -94,13 +97,15 @@ public class CompactNotation extends Notation {
             } else {
                 data.populate(notation.compactCustomData);
             }
-            if (buildReference != null) {
+            if (safe) {
                 // Safe code path
                 precomputedMods = new HashMap<>();
                 precomputeAllModifiers(buildReference);
+                unsafePatternModifier = null;
             } else {
                 // Unsafe code path
                 precomputedMods = null;
+                unsafePatternModifier = buildReference;
             }
         }
 
@@ -145,9 +150,10 @@ public class CompactNotation extends Notation {
             } else {
                 // Unsafe code path.
                 // Overwrite the PatternInfo in the existing modMiddle.
-                assert micros.modMiddle instanceof MutablePatternModifier;
                 ParsedPatternInfo patternInfo = PatternStringParser.parseToPatternInfo(patternString);
-                ((MutablePatternModifier) micros.modMiddle).setPatternInfo(patternInfo, NumberFormat.Field.COMPACT);
+                unsafePatternModifier.setPatternInfo(patternInfo, NumberFormat.Field.COMPACT);
+                unsafePatternModifier.setNumberProperties(quantity.signum(), null);
+                micros.modMiddle = unsafePatternModifier;
             }
 
             // We already performed rounding. Do not perform it again.

--- a/icu4j/main/classes/core/src/com/ibm/icu/number/CompactNotation.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/number/CompactNotation.java
@@ -157,7 +157,7 @@ public class CompactNotation extends Notation {
             }
 
             // We already performed rounding. Do not perform it again.
-            micros.rounder = Precision.constructPassThrough();
+            micros.rounder = null;
 
             return micros;
         }

--- a/icu4j/main/classes/core/src/com/ibm/icu/number/NumberFormatterImpl.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/number/NumberFormatterImpl.java
@@ -98,7 +98,6 @@ class NumberFormatterImpl {
      */
     public MicroProps preProcess(DecimalQuantity inValue) {
         MicroProps micros = microPropsGenerator.processQuantity(inValue);
-        micros.rounder.apply(inValue);
         if (micros.integerWidth.maxInt == -1) {
             inValue.setMinInteger(micros.integerWidth.minInt);
         } else {
@@ -112,7 +111,6 @@ class NumberFormatterImpl {
         MicroProps micros = new MicroProps(false);
         MicroPropsGenerator microPropsGenerator = macrosToMicroGenerator(macros, micros, false);
         micros = microPropsGenerator.processQuantity(inValue);
-        micros.rounder.apply(inValue);
         if (micros.integerWidth.maxInt == -1) {
             inValue.setMinInteger(micros.integerWidth.minInt);
         } else {

--- a/icu4j/main/classes/core/src/com/ibm/icu/number/Precision.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/number/Precision.java
@@ -384,8 +384,6 @@ public abstract class Precision implements Cloneable {
     static final CurrencyRounderImpl MONETARY_STANDARD = new CurrencyRounderImpl(CurrencyUsage.STANDARD);
     static final CurrencyRounderImpl MONETARY_CASH = new CurrencyRounderImpl(CurrencyUsage.CASH);
 
-    static final PassThroughRounderImpl PASS_THROUGH = new PassThroughRounderImpl();
-
     static Precision constructInfinite() {
         return NONE;
     }
@@ -472,10 +470,6 @@ public abstract class Precision implements Cloneable {
             returnValue = constructFraction(minMaxFrac, minMaxFrac);
         }
         return returnValue.withMode(base.mathContext);
-    }
-
-    static Precision constructPassThrough() {
-        return PASS_THROUGH;
     }
 
     /**
@@ -710,17 +704,6 @@ public abstract class Precision implements Cloneable {
         public void apply(DecimalQuantity value) {
             // Call .withCurrency() before .apply()!
             throw new AssertionError();
-        }
-    }
-
-    static class PassThroughRounderImpl extends Precision {
-
-        public PassThroughRounderImpl() {
-        }
-
-        @Override
-        public void apply(DecimalQuantity value) {
-            // TODO: Assert that value has already been rounded
         }
     }
 

--- a/icu4j/main/classes/core/src/com/ibm/icu/number/ScientificNotation.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/number/ScientificNotation.java
@@ -196,7 +196,7 @@ public class ScientificNotation extends Notation implements Cloneable {
             }
 
             // We already performed rounding. Do not perform it again.
-            micros.rounder = Precision.constructPassThrough();
+            micros.rounder = null;
 
             return micros;
         }

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/data/numberpermutationtest.txt
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/data/numberpermutationtest.txt
@@ -1,4 +1,4 @@
-# © 2017 and later: Unicode, Inc. and others.
+# © 2019 and later: Unicode, Inc. and others.
 # License & terms of use: http://www.unicode.org/copyright.html
 
 compact-short percent unit-width-narrow
@@ -2273,15 +2273,15 @@ compact-short precision-integer sign-accounting-except-zero
   es-MX
     0
     +92 k
-    -0
+    0
   zh-TW
     0
     +9萬
-    -0
+    0
   bn-BD
     ০
     +৯২ হা
-    -০
+    ০
 
 compact-short .000 sign-accounting-except-zero
   es-MX
@@ -4849,15 +4849,15 @@ percent precision-integer sign-accounting-except-zero
   es-MX
     0 %
     +91,827 %
-    -0 %
+    0 %
   zh-TW
     0%
     +91,827%
-    -0%
+    0%
   bn-BD
     ০%
     +৯১,৮২৭%
-    -০%
+    ০%
 
 percent .000 sign-accounting-except-zero
   es-MX
@@ -4905,15 +4905,15 @@ currency/EUR precision-integer sign-accounting-except-zero
   es-MX
     EUR 0
     +EUR 91,827
-    -EUR 0
+    EUR 0
   zh-TW
     €0
     +€91,827
-    (€0)
+    €0
   bn-BD
     ০€
     +৯১,৮২৭€
-    (০ €)
+    ০€
 
 currency/EUR .000 sign-accounting-except-zero
   es-MX
@@ -4961,15 +4961,15 @@ measure-unit/length-furlong precision-integer sign-accounting-except-zero
   es-MX
     0 fur
     +91,827 fur
-    -0 fur
+    0 fur
   zh-TW
     0 化朗
     +91,827 化朗
-    -0 化朗
+    0 化朗
   bn-BD
     ০ ফার্লং
     +৯১,৮২৭ ফার্লং
-    -০ ফার্লং
+    ০ ফার্লং
 
 measure-unit/length-furlong .000 sign-accounting-except-zero
   es-MX
@@ -6627,15 +6627,15 @@ unit-width-narrow precision-integer sign-accounting-except-zero
   es-MX
     0
     +91,827
-    -0
+    0
   zh-TW
     0
     +91,827
-    -0
+    0
   bn-BD
     ০
     +৯১,৮২৭
-    -০
+    ০
 
 unit-width-narrow .000 sign-accounting-except-zero
   es-MX
@@ -6683,15 +6683,15 @@ unit-width-full-name precision-integer sign-accounting-except-zero
   es-MX
     0
     +91,827
-    -0
+    0
   zh-TW
     0
     +91,827
-    -0
+    0
   bn-BD
     ০
     +৯১,৮২৭
-    -০
+    ০
 
 unit-width-full-name .000 sign-accounting-except-zero
   es-MX
@@ -7943,15 +7943,15 @@ precision-integer integer-width/##00 sign-accounting-except-zero
   es-MX
     00
     +1827
-    -00
+    00
   zh-TW
     00
     +1,827
-    -00
+    00
   bn-BD
     ০০
     +১,৮২৭
-    -০০
+    ০০
 
 .000 integer-width/##00 sign-accounting-except-zero
   es-MX
@@ -8167,15 +8167,15 @@ precision-integer scale/0.5 sign-accounting-except-zero
   es-MX
     0
     +45,914
-    -0
+    0
   zh-TW
     0
     +45,914
-    -0
+    0
   bn-BD
     ০
     +৪৫,৯১৪
-    -০
+    ০
 
 .000 scale/0.5 sign-accounting-except-zero
   es-MX
@@ -8335,15 +8335,15 @@ precision-integer group-on-aligned sign-accounting-except-zero
   es-MX
     0
     +91,827
-    -0
+    0
   zh-TW
     0
     +91,827
-    -0
+    0
   bn-BD
     ০
     +৯১,৮২৭
-    -০
+    ০
 
 .000 group-on-aligned sign-accounting-except-zero
   es-MX
@@ -8447,15 +8447,15 @@ precision-integer latin sign-accounting-except-zero
   es-MX
     0
     +91,827
-    -0
+    0
   zh-TW
     0
     +91,827
-    -0
+    0
   bn-BD
     0
     +91,827
-    -0
+    0
 
 .000 latin sign-accounting-except-zero
   es-MX
@@ -8559,15 +8559,15 @@ precision-integer sign-accounting-except-zero decimal-always
   es-MX
     0.
     +91,827.
-    -0.
+    0.
   zh-TW
     0.
     +91,827.
-    -0.
+    0.
   bn-BD
     ০.
     +৯১,৮২৭.
-    -০.
+    ০.
 
 .000 sign-accounting-except-zero decimal-always
   es-MX

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/impl/number/DecimalQuantity_SimpleStorage.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/impl/number/DecimalQuantity_SimpleStorage.java
@@ -9,6 +9,7 @@ import java.text.FieldPosition;
 
 import com.ibm.icu.impl.StandardPlural;
 import com.ibm.icu.impl.number.DecimalQuantity;
+import com.ibm.icu.impl.number.Modifier.Signum;
 import com.ibm.icu.text.PluralRules;
 import com.ibm.icu.text.PluralRules.Operand;
 import com.ibm.icu.text.UFieldPosition;
@@ -517,8 +518,18 @@ public class DecimalQuantity_SimpleStorage implements DecimalQuantity {
   }
 
   @Override
-  public int signum() {
-      return isNegative() ? -1 : isZeroish() ? 0 : 1;
+  public Signum signum() {
+      boolean isZero = (isZeroish() && !isInfinite());
+      boolean isNeg = isNegative();
+      if (isZero && isNeg) {
+          return Signum.NEG_ZERO;
+      } else if (isZero) {
+          return Signum.POS_ZERO;
+      } else if (isNeg) {
+          return Signum.NEG;
+      } else {
+          return Signum.POS;
+      }
   }
 
   private void setNegative(boolean isNegative) {

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/MutablePatternModifierTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/MutablePatternModifierTest.java
@@ -12,6 +12,7 @@ import com.ibm.icu.impl.FormattedStringBuilder;
 import com.ibm.icu.impl.number.DecimalQuantity;
 import com.ibm.icu.impl.number.DecimalQuantity_DualStorageBCD;
 import com.ibm.icu.impl.number.MicroProps;
+import com.ibm.icu.impl.number.Modifier.Signum;
 import com.ibm.icu.impl.number.MutablePatternModifier;
 import com.ibm.icu.impl.number.PatternStringParser;
 import com.ibm.icu.number.NumberFormatter.SignDisplay;
@@ -32,19 +33,22 @@ public class MutablePatternModifierTest {
                 UnitWidth.SHORT,
                 null);
 
-        mod.setNumberProperties(1, null);
+        mod.setNumberProperties(Signum.POS, null);
         assertEquals("a", getPrefix(mod));
         assertEquals("b", getSuffix(mod));
         mod.setPatternAttributes(SignDisplay.ALWAYS, false);
         assertEquals("+a", getPrefix(mod));
         assertEquals("b", getSuffix(mod));
-        mod.setNumberProperties(0, null);
+        mod.setNumberProperties(Signum.POS_ZERO, null);
         assertEquals("+a", getPrefix(mod));
+        assertEquals("b", getSuffix(mod));
+        mod.setNumberProperties(Signum.NEG_ZERO, null);
+        assertEquals("-a", getPrefix(mod));
         assertEquals("b", getSuffix(mod));
         mod.setPatternAttributes(SignDisplay.EXCEPT_ZERO, false);
         assertEquals("a", getPrefix(mod));
         assertEquals("b", getSuffix(mod));
-        mod.setNumberProperties(-1, null);
+        mod.setNumberProperties(Signum.NEG, null);
         assertEquals("-a", getPrefix(mod));
         assertEquals("b", getSuffix(mod));
         mod.setPatternAttributes(SignDisplay.NEVER, false);
@@ -53,24 +57,27 @@ public class MutablePatternModifierTest {
 
         mod.setPatternInfo(PatternStringParser.parseToPatternInfo("a0b;c-0d"), null);
         mod.setPatternAttributes(SignDisplay.AUTO, false);
-        mod.setNumberProperties(1, null);
+        mod.setNumberProperties(Signum.POS, null);
         assertEquals("a", getPrefix(mod));
         assertEquals("b", getSuffix(mod));
         mod.setPatternAttributes(SignDisplay.ALWAYS, false);
         assertEquals("c+", getPrefix(mod));
         assertEquals("d", getSuffix(mod));
-        mod.setNumberProperties(0, null);
+        mod.setNumberProperties(Signum.POS_ZERO, null);
         assertEquals("c+", getPrefix(mod));
+        assertEquals("d", getSuffix(mod));
+        mod.setNumberProperties(Signum.NEG_ZERO, null);
+        assertEquals("c-", getPrefix(mod));
         assertEquals("d", getSuffix(mod));
         mod.setPatternAttributes(SignDisplay.EXCEPT_ZERO, false);
         assertEquals("a", getPrefix(mod));
         assertEquals("b", getSuffix(mod));
-        mod.setNumberProperties(-1, null);
+        mod.setNumberProperties(Signum.NEG, null);
         assertEquals("c-", getPrefix(mod));
         assertEquals("d", getSuffix(mod));
         mod.setPatternAttributes(SignDisplay.NEVER, false);
-        assertEquals("c-", getPrefix(mod)); // TODO: What should this behavior be?
-        assertEquals("d", getSuffix(mod));
+        assertEquals("a", getPrefix(mod));
+        assertEquals("b", getSuffix(mod));
     }
 
     @Test
@@ -112,7 +119,7 @@ public class MutablePatternModifierTest {
                 Currency.getInstance("USD"),
                 UnitWidth.SHORT,
                 null);
-        mod.setNumberProperties(1, null);
+        mod.setNumberProperties(Signum.POS_ZERO, null);
 
         // Unsafe Code Path
         FormattedStringBuilder nsb = new FormattedStringBuilder();

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
@@ -2098,8 +2098,8 @@ public class NumberFormatterApiTest {
             { SignDisplay.ALWAYS, -1.1, "-1" },
             { SignDisplay.EXCEPT_ZERO,  1.1, "+1" },
             { SignDisplay.EXCEPT_ZERO,  0.9, "+1" },
-// TODO     { SignDisplay.EXCEPT_ZERO,  0.1, "0" }, // interesting case
-// TODO     { SignDisplay.EXCEPT_ZERO, -0.1, "0" }, // interesting case
+            { SignDisplay.EXCEPT_ZERO,  0.1, "0" }, // interesting case
+            { SignDisplay.EXCEPT_ZERO, -0.1, "0" }, // interesting case
             { SignDisplay.EXCEPT_ZERO, -0.9, "-1" },
             { SignDisplay.EXCEPT_ZERO, -1.1, "-1" },
         };

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberPermutationTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberPermutationTest.java
@@ -96,7 +96,7 @@ public class NumberPermutationTest extends TestFmwk {
 
         // Build up the golden data string as we evaluate all permutations
         ArrayList<String> resultLines = new ArrayList<>();
-        resultLines.add("# © 2017 and later: Unicode, Inc. and others.");
+        resultLines.add("# © 2019 and later: Unicode, Inc. and others.");
         resultLines.add("# License & terms of use: http://www.unicode.org/copyright.html");
         resultLines.add("");
 


### PR DESCRIPTION
As discussed in the ticket, we have had more in-depth discussion about what would be the best semantics for SignDisplay.EXCEPT_ZERO.  I would like to make these semantics the default behavior in ICU.  The changes involve numbers very close to zero.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20709
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

