### PR TITLE
ICU-20836 ICU4C header plurrule.h needs to include utypes.h before using U_SHOW_CPLUSPLUS_API

### DIFF
--- a/icu4c/source/i18n/unicode/plurrule.h
+++ b/icu4c/source/i18n/unicode/plurrule.h
@@ -18,9 +18,9 @@
 #ifndef PLURRULE
 #define PLURRULE
 
-#if U_SHOW_CPLUSPLUS_API
-
 #include "unicode/utypes.h"
+
+#if U_SHOW_CPLUSPLUS_API
 
 /**
  * \file


### PR DESCRIPTION
I checked all the public header files and this is the only header with code that uses `U_SHOW_CPLUSPLUS_API` before including `utypes.h`.

I'll file a separate ticket for after ICU 65 to add an automated test to the hdrtest.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20836
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

