### PR TITLE
ICU-20709 Change EXCEPT_ZERO to check sign after rounding.

### DIFF
--- a/icu4c/source/i18n/number_compact.cpp
+++ b/icu4c/source/i18n/number_compact.cpp
@@ -215,19 +215,25 @@ void CompactData::CompactDataSink::put(const char *key, ResourceValue &value, UB
 /// END OF CompactData.java; BEGIN CompactNotation.java ///
 ///////////////////////////////////////////////////////////
 
-CompactHandler::CompactHandler(CompactStyle compactStyle, const Locale &locale, const char *nsName,
-                               CompactType compactType, const PluralRules *rules,
-                               MutablePatternModifier *buildReference, const MicroPropsGenerator *parent,
-                               UErrorCode &status)
-        : rules(rules), parent(parent) {
+CompactHandler::CompactHandler(
+        CompactStyle compactStyle,
+        const Locale &locale,
+        const char *nsName,
+        CompactType compactType,
+        const PluralRules *rules,
+        MutablePatternModifier *buildReference,
+        bool safe,
+        const MicroPropsGenerator *parent,
+        UErrorCode &status)
+        : rules(rules), parent(parent), safe(safe) {
     data.populate(locale, nsName, compactStyle, compactType, status);
-    if (buildReference != nullptr) {
+    if (safe) {
         // Safe code path
         precomputeAllModifiers(*buildReference, status);
-        safe = TRUE;
     } else {
         // Unsafe code path
-        safe = FALSE;
+        // Store the MutablePatternModifier reference.
+        unsafePatternModifier = buildReference;
     }
 }
 
@@ -309,8 +315,9 @@ void CompactHandler::processQuantity(DecimalQuantity &quantity, MicroProps &micr
         // C++ Note: Use unsafePatternInfo for proper lifecycle.
         ParsedPatternInfo &patternInfo = const_cast<CompactHandler *>(this)->unsafePatternInfo;
         PatternParser::parseToPatternInfo(UnicodeString(patternString), patternInfo, status);
-        static_cast<MutablePatternModifier*>(const_cast<Modifier*>(micros.modMiddle))
-            ->setPatternInfo(&patternInfo, UNUM_COMPACT_FIELD);
+        unsafePatternModifier->setPatternInfo(&unsafePatternInfo, UNUM_COMPACT_FIELD);
+        unsafePatternModifier->setNumberProperties(quantity.signum(), StandardPlural::Form::COUNT);
+        micros.modMiddle = unsafePatternModifier;
     }
 
     // We already performed rounding. Do not perform it again.

--- a/icu4c/source/i18n/number_compact.h
+++ b/icu4c/source/i18n/number_compact.h
@@ -56,10 +56,16 @@ struct CompactModInfo {
 
 class CompactHandler : public MicroPropsGenerator, public UMemory {
   public:
-    CompactHandler(CompactStyle compactStyle, const Locale &locale, const char *nsName,
-                   CompactType compactType, const PluralRules *rules,
-                   MutablePatternModifier *buildReference, const MicroPropsGenerator *parent,
-                   UErrorCode &status);
+    CompactHandler(
+            CompactStyle compactStyle,
+            const Locale &locale,
+            const char *nsName,
+            CompactType compactType,
+            const PluralRules *rules,
+            MutablePatternModifier *buildReference,
+            bool safe,
+            const MicroPropsGenerator *parent,
+            UErrorCode &status);
 
     ~CompactHandler() U_OVERRIDE;
 
@@ -74,6 +80,7 @@ class CompactHandler : public MicroPropsGenerator, public UMemory {
     int32_t precomputedModsLength = 0;
     CompactData data;
     ParsedPatternInfo unsafePatternInfo;
+    MutablePatternModifier* unsafePatternModifier;
     UBool safe;
 
     /** Used by the safe code path */

--- a/icu4c/source/i18n/number_decimalquantity.cpp
+++ b/icu4c/source/i18n/number_decimalquantity.cpp
@@ -319,10 +319,14 @@ bool DecimalQuantity::isNegative() const {
 }
 
 Signum DecimalQuantity::signum() const {
-    if (isNegative()) {
+    bool isZero = (isZeroish() && !isInfinite());
+    bool isNeg = isNegative();
+    if (isZero && isNeg) {
+        return SIGNUM_NEG_ZERO;
+    } else if (isZero) {
+        return SIGNUM_POS_ZERO;
+    } else if (isNeg) {
         return SIGNUM_NEG;
-    } else if (isZeroish() && !isInfinite()) {
-        return SIGNUM_ZERO;
     } else {
         return SIGNUM_POS;
     }

--- a/icu4c/source/i18n/number_formatimpl.cpp
+++ b/icu4c/source/i18n/number_formatimpl.cpp
@@ -111,7 +111,6 @@ void NumberFormatterImpl::preProcess(DecimalQuantity& inValue, MicroProps& micro
         return;
     }
     fMicroPropsGenerator->processQuantity(inValue, microsOut, status);
-    microsOut.rounder.apply(inValue, status);
     microsOut.integerWidth.apply(inValue, status);
 }
 
@@ -124,7 +123,6 @@ MicroProps& NumberFormatterImpl::preProcessUnsafe(DecimalQuantity& inValue, UErr
         return fMicros; // must always return a value
     }
     fMicroPropsGenerator->processQuantity(inValue, fMicros, status);
-    fMicros.rounder.apply(inValue, status);
     fMicros.integerWidth.apply(inValue, status);
     return fMicros;
 }

--- a/icu4c/source/i18n/number_formatimpl.h
+++ b/icu4c/source/i18n/number_formatimpl.h
@@ -95,7 +95,7 @@ class NumberFormatterImpl : public UMemory {
     LocalPointer<const ParsedPatternInfo> fPatternInfo;
     LocalPointer<const ScientificHandler> fScientificHandler;
     LocalPointer<MutablePatternModifier> fPatternModifier;
-    LocalPointer<const ImmutablePatternModifier> fImmutablePatternModifier;
+    LocalPointer<ImmutablePatternModifier> fImmutablePatternModifier;
     LocalPointer<const LongNameHandler> fLongNameHandler;
     LocalPointer<const CompactHandler> fCompactHandler;
 

--- a/icu4c/source/i18n/number_longnames.cpp
+++ b/icu4c/source/i18n/number_longnames.cpp
@@ -308,7 +308,7 @@ void LongNameHandler::simpleFormatsToModifiers(const UnicodeString *simpleFormat
         if (U_FAILURE(status)) { return; }
         SimpleFormatter compiledFormatter(simpleFormat, 0, 1, status);
         if (U_FAILURE(status)) { return; }
-        fModifiers[i] = SimpleModifier(compiledFormatter, field, false, {this, SIGNUM_ZERO, plural});
+        fModifiers[i] = SimpleModifier(compiledFormatter, field, false, {this, SIGNUM_POS_ZERO, plural});
     }
 }
 
@@ -325,7 +325,7 @@ void LongNameHandler::multiSimpleFormatsToModifiers(const UnicodeString *leadFor
         if (U_FAILURE(status)) { return; }
         SimpleFormatter compoundCompiled(compoundFormat, 0, 1, status);
         if (U_FAILURE(status)) { return; }
-        fModifiers[i] = SimpleModifier(compoundCompiled, field, false, {this, SIGNUM_ZERO, plural});
+        fModifiers[i] = SimpleModifier(compoundCompiled, field, false, {this, SIGNUM_POS_ZERO, plural});
     }
 }
 

--- a/icu4c/source/i18n/number_microprops.h
+++ b/icu4c/source/i18n/number_microprops.h
@@ -37,7 +37,7 @@ struct MicroProps : public MicroPropsGenerator {
     // Note: This struct has no direct ownership of the following pointers.
     const DecimalFormatSymbols* symbols;
     const Modifier* modOuter;
-    const Modifier* modMiddle;
+    const Modifier* modMiddle = nullptr;
     const Modifier* modInner;
 
     // The following "helper" fields may optionally be used during the MicroPropsGenerator.

--- a/icu4c/source/i18n/number_modifiers.h
+++ b/icu4c/source/i18n/number_modifiers.h
@@ -319,12 +319,12 @@ class U_I18N_API AdoptingModifierStore : public ModifierStore, public UMemory {
 
   private:
     // NOTE: mods is zero-initialized (to nullptr)
-    const Modifier *mods[3 * StandardPlural::COUNT] = {};
+    const Modifier *mods[4 * StandardPlural::COUNT] = {};
 
     inline static int32_t getModIndex(Signum signum, StandardPlural::Form plural) {
-        U_ASSERT(signum >= -1 && signum <= 1);
+        U_ASSERT(signum >= 0 && signum <= 3);
         U_ASSERT(plural >= 0 && plural < StandardPlural::COUNT);
-        return static_cast<int32_t>(plural) * 3 + (signum + 1);
+        return static_cast<int32_t>(plural) * 4 + signum;
     }
 };
 

--- a/icu4c/source/i18n/number_modifiers.h
+++ b/icu4c/source/i18n/number_modifiers.h
@@ -322,9 +322,9 @@ class U_I18N_API AdoptingModifierStore : public ModifierStore, public UMemory {
     const Modifier *mods[4 * StandardPlural::COUNT] = {};
 
     inline static int32_t getModIndex(Signum signum, StandardPlural::Form plural) {
-        U_ASSERT(signum >= 0 && signum <= 3);
+        U_ASSERT(signum >= 0 && signum < SIGNUM_COUNT);
         U_ASSERT(plural >= 0 && plural < StandardPlural::COUNT);
-        return static_cast<int32_t>(plural) * 4 + signum;
+        return static_cast<int32_t>(plural) * SIGNUM_COUNT + signum;
     }
 };
 

--- a/icu4c/source/i18n/number_patternmodifier.cpp
+++ b/icu4c/source/i18n/number_patternmodifier.cpp
@@ -81,8 +81,10 @@ MutablePatternModifier::createImmutableAndChain(const MicroPropsGenerator* paren
         for (StandardPlural::Form plural : STANDARD_PLURAL_VALUES) {
             setNumberProperties(SIGNUM_POS, plural);
             pm->adoptModifier(SIGNUM_POS, plural, createConstantModifier(status));
-            setNumberProperties(SIGNUM_ZERO, plural);
-            pm->adoptModifier(SIGNUM_ZERO, plural, createConstantModifier(status));
+            setNumberProperties(SIGNUM_NEG_ZERO, plural);
+            pm->adoptModifier(SIGNUM_NEG_ZERO, plural, createConstantModifier(status));
+            setNumberProperties(SIGNUM_POS_ZERO, plural);
+            pm->adoptModifier(SIGNUM_POS_ZERO, plural, createConstantModifier(status));
             setNumberProperties(SIGNUM_NEG, plural);
             pm->adoptModifier(SIGNUM_NEG, plural, createConstantModifier(status));
         }
@@ -95,8 +97,10 @@ MutablePatternModifier::createImmutableAndChain(const MicroPropsGenerator* paren
         // Faster path when plural keyword is not needed.
         setNumberProperties(SIGNUM_POS, StandardPlural::Form::COUNT);
         pm->adoptModifierWithoutPlural(SIGNUM_POS, createConstantModifier(status));
-        setNumberProperties(SIGNUM_ZERO, StandardPlural::Form::COUNT);
-        pm->adoptModifierWithoutPlural(SIGNUM_ZERO, createConstantModifier(status));
+        setNumberProperties(SIGNUM_NEG_ZERO, StandardPlural::Form::COUNT);
+        pm->adoptModifierWithoutPlural(SIGNUM_NEG_ZERO, createConstantModifier(status));
+        setNumberProperties(SIGNUM_POS_ZERO, StandardPlural::Form::COUNT);
+        pm->adoptModifierWithoutPlural(SIGNUM_POS_ZERO, createConstantModifier(status));
         setNumberProperties(SIGNUM_NEG, StandardPlural::Form::COUNT);
         pm->adoptModifierWithoutPlural(SIGNUM_NEG, createConstantModifier(status));
         if (U_FAILURE(status)) {
@@ -263,7 +267,12 @@ int32_t MutablePatternModifier::insertSuffix(FormattedStringBuilder& sb, int pos
 /** This method contains the heart of the logic for rendering LDML affix strings. */
 void MutablePatternModifier::prepareAffix(bool isPrefix) {
     PatternStringUtils::patternInfoToStringBuilder(
-            *fPatternInfo, isPrefix, fSignum, fSignDisplay, fPlural, fPerMilleReplacesPercent, currentAffix);
+            *fPatternInfo,
+            isPrefix,
+            PatternStringUtils::resolveSignDisplay(fSignDisplay, fSignum),
+            fPlural,
+            fPerMilleReplacesPercent,
+            currentAffix);
 }
 
 UnicodeString MutablePatternModifier::getSymbol(AffixPatternType type) const {

--- a/icu4c/source/i18n/number_patternmodifier.cpp
+++ b/icu4c/source/i18n/number_patternmodifier.cpp
@@ -124,6 +124,7 @@ ImmutablePatternModifier::ImmutablePatternModifier(AdoptingModifierStore* pm, co
 void ImmutablePatternModifier::processQuantity(DecimalQuantity& quantity, MicroProps& micros,
                                                UErrorCode& status) const {
     parent->processQuantity(quantity, micros, status);
+    micros.rounder.apply(quantity, status);
     if (micros.modMiddle != nullptr) {
         return;
     }
@@ -162,6 +163,7 @@ MicroPropsGenerator& MutablePatternModifier::addToChain(const MicroPropsGenerato
 void MutablePatternModifier::processQuantity(DecimalQuantity& fq, MicroProps& micros,
                                              UErrorCode& status) const {
     fParent->processQuantity(fq, micros, status);
+    micros.rounder.apply(fq, status);
     if (micros.modMiddle != nullptr) {
         return;
     }

--- a/icu4c/source/i18n/number_patternmodifier.h
+++ b/icu4c/source/i18n/number_patternmodifier.h
@@ -50,9 +50,11 @@ class U_I18N_API ImmutablePatternModifier : public MicroPropsGenerator, public U
 
     const Modifier* getModifier(Signum signum, StandardPlural::Form plural) const;
 
+    // Non-const method:
+    void addToChain(const MicroPropsGenerator* parent);
+
   private:
-    ImmutablePatternModifier(AdoptingModifierStore* pm, const PluralRules* rules,
-                             const MicroPropsGenerator* parent);
+    ImmutablePatternModifier(AdoptingModifierStore* pm, const PluralRules* rules);
 
     const LocalPointer<AdoptingModifierStore> pm;
     const PluralRules* rules;
@@ -164,21 +166,6 @@ class U_I18N_API MutablePatternModifier
      * @return An immutable that supports both positive and negative numbers.
      */
     ImmutablePatternModifier *createImmutable(UErrorCode &status);
-
-    /**
-     * Creates a new quantity-dependent Modifier that behaves the same as the current instance, but which is immutable
-     * and can be saved for future use. The number properties in the current instance are mutated; all other properties
-     * are left untouched.
-     *
-     * <p>
-     * CREATES A NEW HEAP OBJECT; THE CALLER GETS OWNERSHIP.
-     *
-     * @param parent
-     *            The QuantityChain to which to chain this immutable.
-     * @return An immutable that supports both positive and negative numbers.
-     */
-    ImmutablePatternModifier *
-    createImmutableAndChain(const MicroPropsGenerator *parent, UErrorCode &status);
 
     MicroPropsGenerator &addToChain(const MicroPropsGenerator *parent);
 

--- a/icu4c/source/i18n/number_patternstring.cpp
+++ b/icu4c/source/i18n/number_patternstring.cpp
@@ -1072,6 +1072,8 @@ PatternSignType PatternStringUtils::resolveSignDisplay(UNumberSignDisplay signDi
                 case SIGNUM_POS_ZERO:
                 case SIGNUM_POS:
                     return PATTERN_SIGN_TYPE_POS;
+                default:
+                    break;
             }
             break;
 
@@ -1084,6 +1086,8 @@ PatternSignType PatternStringUtils::resolveSignDisplay(UNumberSignDisplay signDi
                 case SIGNUM_POS_ZERO:
                 case SIGNUM_POS:
                     return PATTERN_SIGN_TYPE_POS_SIGN;
+                default:
+                    break;
             }
             break;
 
@@ -1097,6 +1101,8 @@ PatternSignType PatternStringUtils::resolveSignDisplay(UNumberSignDisplay signDi
                     return PATTERN_SIGN_TYPE_POS;
                 case SIGNUM_POS:
                     return PATTERN_SIGN_TYPE_POS_SIGN;
+                default:
+                    break;
             }
             break;
 

--- a/icu4c/source/i18n/number_patternstring.cpp
+++ b/icu4c/source/i18n/number_patternstring.cpp
@@ -1000,23 +1000,19 @@ PatternStringUtils::convertLocalized(const UnicodeString& input, const DecimalFo
 }
 
 void PatternStringUtils::patternInfoToStringBuilder(const AffixPatternProvider& patternInfo, bool isPrefix,
-                                                    Signum signum, UNumberSignDisplay signDisplay,
+                                                    PatternSignType patternSignType,
                                                     StandardPlural::Form plural,
                                                     bool perMilleReplacesPercent, UnicodeString& output) {
 
     // Should the output render '+' where '-' would normally appear in the pattern?
-    bool plusReplacesMinusSign = signum != -1 && (
-            signDisplay == UNUM_SIGN_ALWAYS || signDisplay == UNUM_SIGN_ACCOUNTING_ALWAYS || (
-                    signum == 1 && (
-                            signDisplay == UNUM_SIGN_EXCEPT_ZERO ||
-                            signDisplay == UNUM_SIGN_ACCOUNTING_EXCEPT_ZERO))) &&
-                                 patternInfo.positiveHasPlusSign() == false;
+    bool plusReplacesMinusSign = (patternSignType == PATTERN_SIGN_TYPE_POS_SIGN)
+        && !patternInfo.positiveHasPlusSign();
 
-    // Should we use the affix from the negative subpattern? (If not, we will use the positive
-    // subpattern.)
-    // TODO: Deal with signum
-    bool useNegativeAffixPattern = patternInfo.hasNegativeSubpattern() && (
-            signum == -1 || (patternInfo.negativeHasMinusSign() && plusReplacesMinusSign));
+    // Should we use the affix from the negative subpattern?
+    // (If not, we will use the positive subpattern.)
+    bool useNegativeAffixPattern = patternInfo.hasNegativeSubpattern()
+        && (patternSignType == PATTERN_SIGN_TYPE_NEG
+            || (patternInfo.negativeHasMinusSign() && plusReplacesMinusSign));
 
     // Resolve the flags for the affix pattern.
     int flags = 0;
@@ -1035,8 +1031,8 @@ void PatternStringUtils::patternInfoToStringBuilder(const AffixPatternProvider& 
     bool prependSign;
     if (!isPrefix || useNegativeAffixPattern) {
         prependSign = false;
-    } else if (signum == -1) {
-        prependSign = signDisplay != UNUM_SIGN_NEVER;
+    } else if (patternSignType == PATTERN_SIGN_TYPE_NEG) {
+        prependSign = true;
     } else {
         prependSign = plusReplacesMinusSign;
     }
@@ -1063,6 +1059,56 @@ void PatternStringUtils::patternInfoToStringBuilder(const AffixPatternProvider& 
         }
         output.append(candidate);
     }
+}
+
+PatternSignType PatternStringUtils::resolveSignDisplay(UNumberSignDisplay signDisplay, Signum signum) {
+    switch (signDisplay) {
+        case UNUM_SIGN_AUTO:
+        case UNUM_SIGN_ACCOUNTING:
+            switch (signum) {
+                case SIGNUM_NEG:
+                case SIGNUM_NEG_ZERO:
+                    return PATTERN_SIGN_TYPE_NEG;
+                case SIGNUM_POS_ZERO:
+                case SIGNUM_POS:
+                    return PATTERN_SIGN_TYPE_POS;
+            }
+            break;
+
+        case UNUM_SIGN_ALWAYS:
+        case UNUM_SIGN_ACCOUNTING_ALWAYS:
+            switch (signum) {
+                case SIGNUM_NEG:
+                case SIGNUM_NEG_ZERO:
+                    return PATTERN_SIGN_TYPE_NEG;
+                case SIGNUM_POS_ZERO:
+                case SIGNUM_POS:
+                    return PATTERN_SIGN_TYPE_POS_SIGN;
+            }
+            break;
+
+        case UNUM_SIGN_EXCEPT_ZERO:
+        case UNUM_SIGN_ACCOUNTING_EXCEPT_ZERO:
+            switch (signum) {
+                case SIGNUM_NEG:
+                    return PATTERN_SIGN_TYPE_NEG;
+                case SIGNUM_NEG_ZERO:
+                case SIGNUM_POS_ZERO:
+                    return PATTERN_SIGN_TYPE_POS;
+                case SIGNUM_POS:
+                    return PATTERN_SIGN_TYPE_POS_SIGN;
+            }
+            break;
+
+        case UNUM_SIGN_NEVER:
+            return PATTERN_SIGN_TYPE_POS;
+
+        default:
+            break;
+    }
+
+    UPRV_UNREACHABLE;
+    return PATTERN_SIGN_TYPE_POS;
 }
 
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/i18n/number_patternstring.h
+++ b/icu4c/source/i18n/number_patternstring.h
@@ -22,6 +22,18 @@ namespace impl {
 // Forward declaration
 class PatternParser;
 
+// Note: the order of fields in this enum matters for parsing.
+enum PatternSignType {
+    /** Render using normal positive subpattern rules */
+    PATTERN_SIGN_TYPE_POS,
+    /** Render using rules to force the display of a plus sign */
+    PATTERN_SIGN_TYPE_POS_SIGN,
+    /** Render using negative subpattern rules */
+    PATTERN_SIGN_TYPE_NEG,
+    /** Count for looping over the possibilities */
+    PATTERN_SIGN_TYPE_COUNT
+};
+
 // Exported as U_I18N_API because it is a public member field of exported ParsedSubpatternInfo
 struct U_I18N_API Endpoints {
     int32_t start = 0;
@@ -295,9 +307,11 @@ class U_I18N_API PatternStringUtils {
      * substitution, and plural forms for CurrencyPluralInfo.
      */
     static void patternInfoToStringBuilder(const AffixPatternProvider& patternInfo, bool isPrefix,
-                                           Signum signum, UNumberSignDisplay signDisplay,
+                                           PatternSignType patternSignType,
                                            StandardPlural::Form plural, bool perMilleReplacesPercent,
                                            UnicodeString& output);
+
+    static PatternSignType resolveSignDisplay(UNumberSignDisplay signDisplay, Signum signum);
 
   private:
     /** @return The number of chars inserted. */

--- a/icu4c/source/i18n/number_rounding.cpp
+++ b/icu4c/source/i18n/number_rounding.cpp
@@ -294,9 +294,7 @@ RoundingImpl::RoundingImpl(const Precision& precision, UNumberFormatRoundingMode
 }
 
 RoundingImpl RoundingImpl::passThrough() {
-    RoundingImpl retval;
-    retval.fPassThrough = true;
-    return retval;
+    return {};
 }
 
 bool RoundingImpl::isSignificantDigits() const {

--- a/icu4c/source/i18n/number_roundingutils.h
+++ b/icu4c/source/i18n/number_roundingutils.h
@@ -150,7 +150,7 @@ digits_t doubleFractionLength(double input, int8_t* singleDigit);
  */
 class RoundingImpl {
   public:
-    RoundingImpl() = default;  // default constructor: leaves object in undefined state
+    RoundingImpl() = default;  // defaults to pass-through rounder
 
     RoundingImpl(const Precision& precision, UNumberFormatRoundingMode roundingMode,
                  const CurrencyUnit& currency, UErrorCode& status);
@@ -186,7 +186,7 @@ class RoundingImpl {
   private:
     Precision fPrecision;
     UNumberFormatRoundingMode fRoundingMode;
-    bool fPassThrough;
+    bool fPassThrough = true;  // default value
 };
 
 

--- a/icu4c/source/i18n/number_types.h
+++ b/icu4c/source/i18n/number_types.h
@@ -92,9 +92,10 @@ enum CompactType {
 };
 
 enum Signum {
-    SIGNUM_NEG = -1,
-    SIGNUM_ZERO = 0,
-    SIGNUM_POS = 1
+    SIGNUM_NEG = 0,
+    SIGNUM_NEG_ZERO = 1,
+    SIGNUM_POS_ZERO = 2,
+    SIGNUM_POS = 3
 };
 
 

--- a/icu4c/source/i18n/number_types.h
+++ b/icu4c/source/i18n/number_types.h
@@ -95,7 +95,8 @@ enum Signum {
     SIGNUM_NEG = 0,
     SIGNUM_NEG_ZERO = 1,
     SIGNUM_POS_ZERO = 2,
-    SIGNUM_POS = 3
+    SIGNUM_POS = 3,
+    SIGNUM_COUNT = 4,
 };
 
 

--- a/icu4c/source/i18n/unicode/numberformatter.h
+++ b/icu4c/source/i18n/unicode/numberformatter.h
@@ -155,6 +155,8 @@ class DecNum;
 class NumberRangeFormatterImpl;
 struct RangeMacroProps;
 struct UFormattedNumberImpl;
+class MutablePatternModifier;
+class ImmutablePatternModifier;
 
 /**
  * Used for NumberRangeFormatter and implemented in numrange_fluent.cpp.
@@ -980,8 +982,12 @@ class U_I18N_API IntegerWidth : public UMemory {
     friend struct impl::MacroProps;
     friend struct impl::MicroProps;
 
-    // To allow NumberFormatterImpl to access isBogus() and perform other operations:
+    // To allow NumberFormatterImpl to access isBogus():
     friend class impl::NumberFormatterImpl;
+
+    // To allow the use of this class when formatting:
+    friend class impl::MutablePatternModifier;
+    friend class impl::ImmutablePatternModifier;
 
     // So that NumberPropertyMapper can create instances
     friend class impl::NumberPropertyMapper;

--- a/icu4c/source/i18n/unicode/unumberformatter.h
+++ b/icu4c/source/i18n/unicode/unumberformatter.h
@@ -336,7 +336,7 @@ typedef enum UNumberSignDisplay {
 
     /**
      * Show the minus sign on negative numbers and the plus sign on positive numbers. Do not show a
-     * sign on zero or NaN, unless the sign bit is set (-0.0 gets a sign).
+     * sign on zero, numbers that round to zero, or NaN.
      *
      * @stable ICU 61
      */
@@ -344,9 +344,8 @@ typedef enum UNumberSignDisplay {
 
     /**
      * Use the locale-dependent accounting format on negative numbers, and show the plus sign on
-     * positive numbers. Do not show a sign on zero or NaN, unless the sign bit is set (-0.0 gets a
-     * sign). For more information on the accounting format, see the ACCOUNTING sign display
-     * strategy.
+     * positive numbers. Do not show a sign on zero, numbers that round to zero, or NaN. For more
+     * information on the accounting format, see the ACCOUNTING sign display strategy.
      *
      * @stable ICU 61
      */

--- a/icu4c/source/test/intltest/numbertest.h
+++ b/icu4c/source/test/intltest/numbertest.h
@@ -68,6 +68,7 @@ class NumberFormatterApiTest : public IntlTestWithFieldPosition {
     // TODO: Add this method if currency symbols override support is added.
     //void symbolsOverride();
     void sign();
+    void signNearZero();
     void signCoverage();
     void decimal();
     void scale();

--- a/icu4c/source/test/intltest/numbertest_api.cpp
+++ b/icu4c/source/test/intltest/numbertest_api.cpp
@@ -2114,7 +2114,7 @@ void NumberFormatterApiTest::signCoverage() {
         { UNUM_SIGN_AUTO, {        u"-∞", u"-1", u"-0",  u"0",  u"1",  u"∞",  u"NaN", u"-NaN" } },
         { UNUM_SIGN_ALWAYS, {      u"-∞", u"-1", u"-0", u"+0", u"+1", u"+∞", u"+NaN", u"-NaN" } },
         { UNUM_SIGN_NEVER, {        u"∞",  u"1",  u"0",  u"0",  u"1",  u"∞",  u"NaN",  u"NaN" } },
-        { UNUM_SIGN_EXCEPT_ZERO, { u"-∞", u"-1", u"-0",  u"0", u"+1", u"+∞",  u"NaN", u"-NaN" } },
+        { UNUM_SIGN_EXCEPT_ZERO, { u"-∞", u"-1",  u"0",  u"0", u"+1", u"+∞",  u"NaN",  u"NaN" } },
     };
     double negNaN = std::copysign(uprv_getNaN(), -0.0);
     const double inputs[] = {

--- a/icu4c/source/test/intltest/numbertest_patternmodifier.cpp
+++ b/icu4c/source/test/intltest/numbertest_patternmodifier.cpp
@@ -41,7 +41,10 @@ void PatternModifierTest::testBasic() {
     mod.setPatternAttributes(UNUM_SIGN_ALWAYS, false);
     assertEquals("Pattern a0b", u"+a", getPrefix(mod, status));
     assertEquals("Pattern a0b", u"b", getSuffix(mod, status));
-    mod.setNumberProperties(SIGNUM_ZERO, StandardPlural::Form::COUNT);
+    mod.setNumberProperties(SIGNUM_NEG_ZERO, StandardPlural::Form::COUNT);
+    assertEquals("Pattern a0b", u"-a", getPrefix(mod, status));
+    assertEquals("Pattern a0b", u"b", getSuffix(mod, status));
+    mod.setNumberProperties(SIGNUM_POS_ZERO, StandardPlural::Form::COUNT);
     assertEquals("Pattern a0b", u"+a", getPrefix(mod, status));
     assertEquals("Pattern a0b", u"b", getSuffix(mod, status));
     mod.setPatternAttributes(UNUM_SIGN_EXCEPT_ZERO, false);
@@ -66,7 +69,10 @@ void PatternModifierTest::testBasic() {
     mod.setPatternAttributes(UNUM_SIGN_ALWAYS, false);
     assertEquals("Pattern a0b;c-0d", u"c+", getPrefix(mod, status));
     assertEquals("Pattern a0b;c-0d", u"d", getSuffix(mod, status));
-    mod.setNumberProperties(SIGNUM_ZERO, StandardPlural::Form::COUNT);
+    mod.setNumberProperties(SIGNUM_NEG_ZERO, StandardPlural::Form::COUNT);
+    assertEquals("Pattern a0b;c-0d", u"c-", getPrefix(mod, status));
+    assertEquals("Pattern a0b;c-0d", u"d", getSuffix(mod, status));
+    mod.setNumberProperties(SIGNUM_POS_ZERO, StandardPlural::Form::COUNT);
     assertEquals("Pattern a0b;c-0d", u"c+", getPrefix(mod, status));
     assertEquals("Pattern a0b;c-0d", u"d", getSuffix(mod, status));
     mod.setPatternAttributes(UNUM_SIGN_EXCEPT_ZERO, false);
@@ -76,9 +82,8 @@ void PatternModifierTest::testBasic() {
     assertEquals("Pattern a0b;c-0d", u"c-", getPrefix(mod, status));
     assertEquals("Pattern a0b;c-0d", u"d", getSuffix(mod, status));
     mod.setPatternAttributes(UNUM_SIGN_NEVER, false);
-    // TODO: What should this behavior be?
-    assertEquals("Pattern a0b;c-0d", u"c-", getPrefix(mod, status));
-    assertEquals("Pattern a0b;c-0d", u"d", getSuffix(mod, status));
+    assertEquals("Pattern a0b;c-0d", u"a", getPrefix(mod, status));
+    assertEquals("Pattern a0b;c-0d", u"b", getSuffix(mod, status));
     assertSuccess("Spot 5", status);
 }
 

--- a/icu4c/source/test/testdata/numberpermutationtest.txt
+++ b/icu4c/source/test/testdata/numberpermutationtest.txt
@@ -2273,15 +2273,15 @@ compact-short precision-integer sign-accounting-except-zero
   es-MX
     0
     +92 k
-    -0
+    0
   zh-TW
     0
     +9萬
-    -0
+    0
   bn-BD
     ০
     +৯২ হা
-    -০
+    ০
 
 compact-short .000 sign-accounting-except-zero
   es-MX
@@ -4849,15 +4849,15 @@ percent precision-integer sign-accounting-except-zero
   es-MX
     0 %
     +91,827 %
-    -0 %
+    0 %
   zh-TW
     0%
     +91,827%
-    -0%
+    0%
   bn-BD
     ০%
     +৯১,৮২৭%
-    -০%
+    ০%
 
 percent .000 sign-accounting-except-zero
   es-MX
@@ -4905,15 +4905,15 @@ currency/EUR precision-integer sign-accounting-except-zero
   es-MX
     EUR 0
     +EUR 91,827
-    -EUR 0
+    EUR 0
   zh-TW
     €0
     +€91,827
-    (€0)
+    €0
   bn-BD
     ০€
     +৯১,৮২৭€
-    (০ €)
+    ০€
 
 currency/EUR .000 sign-accounting-except-zero
   es-MX
@@ -4961,15 +4961,15 @@ measure-unit/length-furlong precision-integer sign-accounting-except-zero
   es-MX
     0 fur
     +91,827 fur
-    -0 fur
+    0 fur
   zh-TW
     0 化朗
     +91,827 化朗
-    -0 化朗
+    0 化朗
   bn-BD
     ০ ফার্লং
     +৯১,৮২৭ ফার্লং
-    -০ ফার্লং
+    ০ ফার্লং
 
 measure-unit/length-furlong .000 sign-accounting-except-zero
   es-MX
@@ -6627,15 +6627,15 @@ unit-width-narrow precision-integer sign-accounting-except-zero
   es-MX
     0
     +91,827
-    -0
+    0
   zh-TW
     0
     +91,827
-    -0
+    0
   bn-BD
     ০
     +৯১,৮২৭
-    -০
+    ০
 
 unit-width-narrow .000 sign-accounting-except-zero
   es-MX
@@ -6683,15 +6683,15 @@ unit-width-full-name precision-integer sign-accounting-except-zero
   es-MX
     0
     +91,827
-    -0
+    0
   zh-TW
     0
     +91,827
-    -0
+    0
   bn-BD
     ০
     +৯১,৮২৭
-    -০
+    ০
 
 unit-width-full-name .000 sign-accounting-except-zero
   es-MX
@@ -7943,15 +7943,15 @@ precision-integer integer-width/##00 sign-accounting-except-zero
   es-MX
     00
     +1827
-    -00
+    00
   zh-TW
     00
     +1,827
-    -00
+    00
   bn-BD
     ০০
     +১,৮২৭
-    -০০
+    ০০
 
 .000 integer-width/##00 sign-accounting-except-zero
   es-MX
@@ -8167,15 +8167,15 @@ precision-integer scale/0.5 sign-accounting-except-zero
   es-MX
     0
     +45,914
-    -0
+    0
   zh-TW
     0
     +45,914
-    -0
+    0
   bn-BD
     ০
     +৪৫,৯১৪
-    -০
+    ০
 
 .000 scale/0.5 sign-accounting-except-zero
   es-MX
@@ -8335,15 +8335,15 @@ precision-integer group-on-aligned sign-accounting-except-zero
   es-MX
     0
     +91,827
-    -0
+    0
   zh-TW
     0
     +91,827
-    -0
+    0
   bn-BD
     ০
     +৯১,৮২৭
-    -০
+    ০
 
 .000 group-on-aligned sign-accounting-except-zero
   es-MX
@@ -8447,15 +8447,15 @@ precision-integer latin sign-accounting-except-zero
   es-MX
     0
     +91,827
-    -0
+    0
   zh-TW
     0
     +91,827
-    -0
+    0
   bn-BD
     0
     +91,827
-    -0
+    0
 
 .000 latin sign-accounting-except-zero
   es-MX
@@ -8559,15 +8559,15 @@ precision-integer sign-accounting-except-zero decimal-always
   es-MX
     0.
     +91,827.
-    -0.
+    0.
   zh-TW
     0.
     +91,827.
-    -0.
+    0.
   bn-BD
     ০.
     +৯১,৮২৭.
-    -০.
+    ০.
 
 .000 sign-accounting-except-zero decimal-always
   es-MX

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/AdoptingModifierStore.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/AdoptingModifierStore.java
@@ -86,6 +86,6 @@ public class AdoptingModifierStore implements ModifierStore {
     private static int getModIndex(Signum signum, StandardPlural plural) {
         assert signum != null;
         assert plural != null;
-        return plural.ordinal() * 4 + signum.ordinal();
+        return plural.ordinal() * Signum.COUNT + signum.ordinal();
     }
 }

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/AdoptingModifierStore.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/AdoptingModifierStore.java
@@ -3,6 +3,7 @@
 package com.ibm.icu.impl.number;
 
 import com.ibm.icu.impl.StandardPlural;
+import com.ibm.icu.impl.number.Modifier.Signum;
 
 /**
  * This implementation of ModifierStore adopts references to Modifiers.
@@ -11,7 +12,8 @@ import com.ibm.icu.impl.StandardPlural;
  */
 public class AdoptingModifierStore implements ModifierStore {
     private final Modifier positive;
-    private final Modifier zero;
+    private final Modifier posZero;
+    private final Modifier negZero;
     private final Modifier negative;
     final Modifier[] mods;
     boolean frozen;
@@ -22,9 +24,10 @@ public class AdoptingModifierStore implements ModifierStore {
      * <p>
      * If this constructor is used, a plural form CANNOT be passed to {@link #getModifier}.
      */
-    public AdoptingModifierStore(Modifier positive, Modifier zero, Modifier negative) {
+    public AdoptingModifierStore(Modifier positive, Modifier posZero, Modifier negZero, Modifier negative) {
         this.positive = positive;
-        this.zero = zero;
+        this.posZero = posZero;
+        this.negZero = negZero;
         this.negative = negative;
         this.mods = null;
         this.frozen = true;
@@ -39,13 +42,14 @@ public class AdoptingModifierStore implements ModifierStore {
      */
     public AdoptingModifierStore() {
         this.positive = null;
-        this.zero = null;
+        this.posZero = null;
+        this.negZero = null;
         this.negative = null;
-        this.mods = new Modifier[3 * StandardPlural.COUNT];
+        this.mods = new Modifier[4 * StandardPlural.COUNT];
         this.frozen = false;
     }
 
-    public void setModifier(int signum, StandardPlural plural, Modifier mod) {
+    public void setModifier(Signum signum, StandardPlural plural, Modifier mod) {
         assert !frozen;
         mods[getModIndex(signum, plural)] = mod;
     }
@@ -54,21 +58,34 @@ public class AdoptingModifierStore implements ModifierStore {
         frozen = true;
     }
 
-    public Modifier getModifierWithoutPlural(int signum) {
+    public Modifier getModifierWithoutPlural(Signum signum) {
         assert frozen;
         assert mods == null;
-        return signum == 0 ? zero : signum < 0 ? negative : positive;
+        assert signum != null;
+        switch (signum) {
+            case POS:
+                return positive;
+            case POS_ZERO:
+                return posZero;
+            case NEG_ZERO:
+                return negZero;
+            case NEG:
+                return negative;
+            default:
+                throw new AssertionError("Unreachable");
+        }
     }
 
-    public Modifier getModifier(int signum, StandardPlural plural) {
+    @Override
+    public Modifier getModifier(Signum signum, StandardPlural plural) {
         assert frozen;
         assert positive == null;
         return mods[getModIndex(signum, plural)];
     }
 
-    private static int getModIndex(int signum, StandardPlural plural) {
-        assert signum >= -1 && signum <= 1;
+    private static int getModIndex(Signum signum, StandardPlural plural) {
+        assert signum != null;
         assert plural != null;
-        return plural.ordinal() * 3 + (signum + 1);
+        return plural.ordinal() * 4 + signum.ordinal();
     }
 }

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/DecimalQuantity.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/DecimalQuantity.java
@@ -7,6 +7,7 @@ import java.math.MathContext;
 import java.text.FieldPosition;
 
 import com.ibm.icu.impl.StandardPlural;
+import com.ibm.icu.impl.number.Modifier.Signum;
 import com.ibm.icu.text.PluralRules;
 import com.ibm.icu.text.UFieldPosition;
 
@@ -130,8 +131,8 @@ public interface DecimalQuantity extends PluralRules.IFixedDecimal {
     /** @return Whether the value represented by this {@link DecimalQuantity} is less than zero. */
     public boolean isNegative();
 
-    /** @return -1 if the value is negative; 1 if positive; or 0 if zero. */
-    public int signum();
+    /** @return The appropriate value from the Signum enum. */
+    public Signum signum();
 
     /** @return Whether the value represented by this {@link DecimalQuantity} is infinite. */
     @Override

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/DecimalQuantity_AbstractBCD.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/DecimalQuantity_AbstractBCD.java
@@ -9,6 +9,7 @@ import java.text.FieldPosition;
 
 import com.ibm.icu.impl.StandardPlural;
 import com.ibm.icu.impl.Utility;
+import com.ibm.icu.impl.number.Modifier.Signum;
 import com.ibm.icu.text.PluralRules;
 import com.ibm.icu.text.PluralRules.Operand;
 import com.ibm.icu.text.UFieldPosition;
@@ -303,8 +304,18 @@ public abstract class DecimalQuantity_AbstractBCD implements DecimalQuantity {
     }
 
     @Override
-    public int signum() {
-        return isNegative() ? -1 : (isZeroish() && !isInfinite()) ? 0 : 1;
+    public Signum signum() {
+        boolean isZero = (isZeroish() && !isInfinite());
+        boolean isNeg = isNegative();
+        if (isZero && isNeg) {
+            return Signum.NEG_ZERO;
+        } else if (isZero) {
+            return Signum.POS_ZERO;
+        } else if (isNeg) {
+            return Signum.NEG;
+        } else {
+            return Signum.POS;
+        }
     }
 
     @Override

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/LongNameHandler.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/LongNameHandler.java
@@ -12,6 +12,7 @@ import com.ibm.icu.impl.ICUResourceBundle;
 import com.ibm.icu.impl.SimpleFormatterImpl;
 import com.ibm.icu.impl.StandardPlural;
 import com.ibm.icu.impl.UResource;
+import com.ibm.icu.impl.number.Modifier.Signum;
 import com.ibm.icu.number.NumberFormatter.UnitWidth;
 import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.text.PluralRules;
@@ -262,7 +263,7 @@ public class LongNameHandler implements MicroPropsGenerator, ModifierStore {
             String compiled = SimpleFormatterImpl.compileToStringMinMaxArguments(simpleFormat, sb, 0, 1);
             Modifier.Parameters parameters = new Modifier.Parameters();
             parameters.obj = this;
-            parameters.signum = 0;
+            parameters.signum = null;// Signum ignored
             parameters.plural = plural;
             modifiers.put(plural, new SimpleModifier(compiled, field, false, parameters));
         }
@@ -281,7 +282,7 @@ public class LongNameHandler implements MicroPropsGenerator, ModifierStore {
                     .compileToStringMinMaxArguments(compoundFormat, sb, 0, 1);
             Modifier.Parameters parameters = new Modifier.Parameters();
             parameters.obj = this;
-            parameters.signum = 0;
+            parameters.signum = null; // Signum ignored
             parameters.plural = plural;
             modifiers.put(plural, new SimpleModifier(compoundCompiled, field, false, parameters));
         }
@@ -296,7 +297,8 @@ public class LongNameHandler implements MicroPropsGenerator, ModifierStore {
     }
 
     @Override
-    public Modifier getModifier(int signum, StandardPlural plural) {
+    public Modifier getModifier(Signum signum, StandardPlural plural) {
+        // Signum ignored
         return modifiers.get(plural);
     }
 }

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/Modifier.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/Modifier.java
@@ -17,6 +17,13 @@ import com.ibm.icu.impl.StandardPlural;
  */
 public interface Modifier {
 
+    static enum Signum {
+        NEG,
+        NEG_ZERO,
+        POS_ZERO,
+        POS
+    };
+
     /**
      * Apply this Modifier to the string builder.
      *
@@ -65,7 +72,7 @@ public interface Modifier {
      */
     public static class Parameters {
         public ModifierStore obj;
-        public int signum;
+        public Signum signum;
         public StandardPlural plural;
     }
 

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/Modifier.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/Modifier.java
@@ -21,7 +21,9 @@ public interface Modifier {
         NEG,
         NEG_ZERO,
         POS_ZERO,
-        POS
+        POS;
+
+        static final int COUNT = Signum.values().length;
     };
 
     /**

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/ModifierStore.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/ModifierStore.java
@@ -3,6 +3,7 @@
 package com.ibm.icu.impl.number;
 
 import com.ibm.icu.impl.StandardPlural;
+import com.ibm.icu.impl.number.Modifier.Signum;
 
 /**
  * This is *not* a modifier; rather, it is an object that can return modifiers
@@ -14,5 +15,5 @@ public interface ModifierStore {
     /**
      * Returns a Modifier with the given parameters (best-effort).
      */
-    Modifier getModifier(int signum, StandardPlural plural);
+    Modifier getModifier(Signum signum, StandardPlural plural);
 }

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/MutablePatternModifier.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/MutablePatternModifier.java
@@ -155,19 +155,6 @@ public class MutablePatternModifier implements Modifier, SymbolProvider, MicroPr
      * @return An immutable that supports both positive and negative numbers.
      */
     public ImmutablePatternModifier createImmutable() {
-        return createImmutableAndChain(null);
-    }
-
-    /**
-     * Creates a new quantity-dependent Modifier that behaves the same as the current instance, but which
-     * is immutable and can be saved for future use. The number properties in the current instance are
-     * mutated; all other properties are left untouched.
-     *
-     * @param parent
-     *            The QuantityChain to which to chain this immutable.
-     * @return An immutable that supports both positive and negative numbers.
-     */
-    public ImmutablePatternModifier createImmutableAndChain(MicroPropsGenerator parent) {
         FormattedStringBuilder a = new FormattedStringBuilder();
         FormattedStringBuilder b = new FormattedStringBuilder();
         if (needsPlurals()) {
@@ -184,7 +171,7 @@ public class MutablePatternModifier implements Modifier, SymbolProvider, MicroPr
                 pm.setModifier(Signum.NEG, plural, createConstantModifier(a, b));
             }
             pm.freeze();
-            return new ImmutablePatternModifier(pm, rules, parent);
+            return new ImmutablePatternModifier(pm, rules);
         } else {
             // Faster path when plural keyword is not needed.
             setNumberProperties(Signum.POS, null);
@@ -196,7 +183,7 @@ public class MutablePatternModifier implements Modifier, SymbolProvider, MicroPr
             setNumberProperties(Signum.NEG, null);
             Modifier negative = createConstantModifier(a, b);
             AdoptingModifierStore pm = new AdoptingModifierStore(positive, posZero, negZero, negative);
-            return new ImmutablePatternModifier(pm, null, parent);
+            return new ImmutablePatternModifier(pm, null);
         }
     }
 
@@ -226,20 +213,27 @@ public class MutablePatternModifier implements Modifier, SymbolProvider, MicroPr
     public static class ImmutablePatternModifier implements MicroPropsGenerator {
         final AdoptingModifierStore pm;
         final PluralRules rules;
-        final MicroPropsGenerator parent;
+        /* final */ MicroPropsGenerator parent;
 
         ImmutablePatternModifier(
                 AdoptingModifierStore pm,
-                PluralRules rules,
-                MicroPropsGenerator parent) {
+                PluralRules rules) {
             this.pm = pm;
             this.rules = rules;
+            this.parent = null;
+        }
+
+        public ImmutablePatternModifier addToChain(MicroPropsGenerator parent) {
             this.parent = parent;
+            return this;
         }
 
         @Override
         public MicroProps processQuantity(DecimalQuantity quantity) {
             MicroProps micros = parent.processQuantity(quantity);
+            if (micros.modMiddle != null) {
+                return micros;
+            }
             applyToMicros(micros, quantity);
             return micros;
         }
@@ -274,6 +268,9 @@ public class MutablePatternModifier implements Modifier, SymbolProvider, MicroPr
     @Override
     public MicroProps processQuantity(DecimalQuantity fq) {
         MicroProps micros = parent.processQuantity(fq);
+        if (micros.modMiddle != null) {
+            return micros;
+        }
         if (needsPlurals()) {
             StandardPlural pluralForm = RoundingUtils.getPluralSafe(micros.rounder, rules, fq);
             setNumberProperties(fq.signum(), pluralForm);

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/MutablePatternModifier.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/MutablePatternModifier.java
@@ -231,6 +231,9 @@ public class MutablePatternModifier implements Modifier, SymbolProvider, MicroPr
         @Override
         public MicroProps processQuantity(DecimalQuantity quantity) {
             MicroProps micros = parent.processQuantity(quantity);
+            if (micros.rounder != null) {
+                micros.rounder.apply(quantity);
+            }
             if (micros.modMiddle != null) {
                 return micros;
             }
@@ -268,6 +271,9 @@ public class MutablePatternModifier implements Modifier, SymbolProvider, MicroPr
     @Override
     public MicroProps processQuantity(DecimalQuantity fq) {
         MicroProps micros = parent.processQuantity(fq);
+        if (micros.rounder != null) {
+            micros.rounder.apply(fq);
+        }
         if (micros.modMiddle != null) {
             return micros;
         }

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/PatternStringUtils.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/PatternStringUtils.java
@@ -5,6 +5,7 @@ package com.ibm.icu.impl.number;
 import java.math.BigDecimal;
 
 import com.ibm.icu.impl.StandardPlural;
+import com.ibm.icu.impl.number.Modifier.Signum;
 import com.ibm.icu.impl.number.Padder.PadPosition;
 import com.ibm.icu.number.NumberFormatter.SignDisplay;
 import com.ibm.icu.text.DecimalFormatSymbols;
@@ -13,6 +14,18 @@ import com.ibm.icu.text.DecimalFormatSymbols;
  * Assorted utilities relating to decimal formatting pattern strings.
  */
 public class PatternStringUtils {
+
+    // Note: the order of fields in this enum matters for parsing.
+    public static enum PatternSignType {
+        // Render using normal positive subpattern rules
+        POS,
+        // Render using rules to force the display of a plus sign
+        POS_SIGN,
+        // Render using negative subpattern rules
+        NEG;
+
+        public static final PatternSignType[] VALUES = PatternSignType.values();
+    };
 
     /**
      * Determine whether a given roundingIncrement should be ignored for formatting
@@ -23,7 +36,7 @@ public class PatternStringUtils {
      * it should not be ignored if maxFrac is 2 or more (but a roundingIncrement of
      * 0.005 is treated like 0.001 for significance).
      *
-     * This test is needed for both NumberPropertyMapper.oldToNew and 
+     * This test is needed for both NumberPropertyMapper.oldToNew and
      * PatternStringUtils.propertiesToPatternString, but NumberPropertyMapper
      * is package-private so we have it here.
      *
@@ -416,25 +429,19 @@ public class PatternStringUtils {
     public static void patternInfoToStringBuilder(
             AffixPatternProvider patternInfo,
             boolean isPrefix,
-            int signum,
-            SignDisplay signDisplay,
+            PatternSignType patternSignType,
             StandardPlural plural,
             boolean perMilleReplacesPercent,
             StringBuilder output) {
 
-        // Should the output render '+' where '-' would normally appear in the pattern?
-        boolean plusReplacesMinusSign = signum != -1
-                && (signDisplay == SignDisplay.ALWAYS
-                        || signDisplay == SignDisplay.ACCOUNTING_ALWAYS
-                        || (signum == 1
-                                && (signDisplay == SignDisplay.EXCEPT_ZERO
-                                        || signDisplay == SignDisplay.ACCOUNTING_EXCEPT_ZERO)))
-                && patternInfo.positiveHasPlusSign() == false;
+        boolean plusReplacesMinusSign = (patternSignType == PatternSignType.POS_SIGN)
+                && !patternInfo.positiveHasPlusSign();
 
-        // Should we use the affix from the negative subpattern? (If not, we will use the positive
-        // subpattern.)
+        // Should we use the affix from the negative subpattern?
+        // (If not, we will use the positive subpattern.)
         boolean useNegativeAffixPattern = patternInfo.hasNegativeSubpattern()
-                && (signum == -1 || (patternInfo.negativeHasMinusSign() && plusReplacesMinusSign));
+                && (patternSignType == PatternSignType.NEG
+                    || (patternInfo.negativeHasMinusSign() && plusReplacesMinusSign));
 
         // Resolve the flags for the affix pattern.
         int flags = 0;
@@ -453,8 +460,8 @@ public class PatternStringUtils {
         boolean prependSign;
         if (!isPrefix || useNegativeAffixPattern) {
             prependSign = false;
-        } else if (signum == -1) {
-            prependSign = signDisplay != SignDisplay.NEVER;
+        } else if (patternSignType == PatternSignType.NEG) {
+            prependSign = true;
         } else {
             prependSign = plusReplacesMinusSign;
         }
@@ -481,6 +488,55 @@ public class PatternStringUtils {
             }
             output.append(candidate);
         }
+    }
+
+    public static PatternSignType resolveSignDisplay(SignDisplay signDisplay, Signum signum) {
+        switch (signDisplay) {
+            case AUTO:
+            case ACCOUNTING:
+                switch (signum) {
+                    case NEG:
+                    case NEG_ZERO:
+                        return PatternSignType.NEG;
+                    case POS_ZERO:
+                    case POS:
+                        return PatternSignType.POS;
+                }
+                break;
+
+            case ALWAYS:
+            case ACCOUNTING_ALWAYS:
+                switch (signum) {
+                    case NEG:
+                    case NEG_ZERO:
+                        return PatternSignType.NEG;
+                    case POS_ZERO:
+                    case POS:
+                        return PatternSignType.POS_SIGN;
+                }
+                break;
+
+            case EXCEPT_ZERO:
+            case ACCOUNTING_EXCEPT_ZERO:
+                switch (signum) {
+                    case NEG:
+                        return PatternSignType.NEG;
+                    case NEG_ZERO:
+                    case POS_ZERO:
+                        return PatternSignType.POS;
+                    case POS:
+                        return PatternSignType.POS_SIGN;
+                }
+                break;
+
+            case NEVER:
+                return PatternSignType.POS;
+
+            default:
+                break;
+        }
+
+        throw new AssertionError("Unreachable");
     }
 
 }

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/RoundingUtils.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/RoundingUtils.java
@@ -228,6 +228,9 @@ public class RoundingUtils {
      */
     public static StandardPlural getPluralSafe(
             Precision rounder, PluralRules rules, DecimalQuantity dq) {
+        if (rounder == null) {
+            return dq.getStandardPlural(rules);
+        }
         // TODO(ICU-20500): Avoid the copy?
         DecimalQuantity copy = dq.createCopy();
         rounder.apply(copy);

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/parse/AffixMatcher.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/parse/AffixMatcher.java
@@ -12,7 +12,7 @@ import com.ibm.icu.impl.StringSegment;
 import com.ibm.icu.impl.number.AffixPatternProvider;
 import com.ibm.icu.impl.number.AffixUtils;
 import com.ibm.icu.impl.number.PatternStringUtils;
-import com.ibm.icu.number.NumberFormatter.SignDisplay;
+import com.ibm.icu.impl.number.PatternStringUtils.PatternSignType;
 
 /**
  * @author sffc
@@ -90,20 +90,27 @@ public class AffixMatcher implements NumberParseMatcher {
         StringBuilder sb = new StringBuilder();
         ArrayList<AffixMatcher> matchers = new ArrayList<>(6);
         boolean includeUnpaired = 0 != (parseFlags & ParsingUtils.PARSE_FLAG_INCLUDE_UNPAIRED_AFFIXES);
-        SignDisplay signDisplay = (0 != (parseFlags & ParsingUtils.PARSE_FLAG_PLUS_SIGN_ALLOWED))
-                ? SignDisplay.ALWAYS
-                : SignDisplay.AUTO;
 
         AffixPatternMatcher posPrefix = null;
         AffixPatternMatcher posSuffix = null;
 
         // Pre-process the affix strings to resolve LDML rules like sign display.
-        for (int signum = 1; signum >= -1; signum--) {
+        for (PatternSignType type : PatternSignType.VALUES) {
+
+            // Skip affixes in some cases
+            if (type == PatternSignType.POS
+                    && 0 != (parseFlags & ParsingUtils.PARSE_FLAG_PLUS_SIGN_ALLOWED)) {
+                continue;
+            }
+            if (type == PatternSignType.POS_SIGN
+                    && 0 == (parseFlags & ParsingUtils.PARSE_FLAG_PLUS_SIGN_ALLOWED)) {
+                continue;
+            }
+
             // Generate Prefix
             PatternStringUtils.patternInfoToStringBuilder(patternInfo,
                     true,
-                    signum,
-                    signDisplay,
+                    type,
                     StandardPlural.OTHER,
                     false,
                     sb);
@@ -113,15 +120,14 @@ public class AffixMatcher implements NumberParseMatcher {
             // Generate Suffix
             PatternStringUtils.patternInfoToStringBuilder(patternInfo,
                     false,
-                    signum,
-                    signDisplay,
+                    type,
                     StandardPlural.OTHER,
                     false,
                     sb);
             AffixPatternMatcher suffix = AffixPatternMatcher
                     .fromAffixPattern(sb.toString(), factory, parseFlags);
 
-            if (signum == 1) {
+            if (type == PatternSignType.POS) {
                 posPrefix = prefix;
                 posSuffix = suffix;
             } else if (Objects.equals(prefix, posPrefix) && Objects.equals(suffix, posSuffix)) {
@@ -130,17 +136,17 @@ public class AffixMatcher implements NumberParseMatcher {
             }
 
             // Flags for setting in the ParsedNumber; the token matchers may add more.
-            int flags = (signum == -1) ? ParsedNumber.FLAG_NEGATIVE : 0;
+            int flags = (type == PatternSignType.NEG) ? ParsedNumber.FLAG_NEGATIVE : 0;
 
             // Note: it is indeed possible for posPrefix and posSuffix to both be null.
             // We still need to add that matcher for strict mode to work.
             matchers.add(getInstance(prefix, suffix, flags));
             if (includeUnpaired && prefix != null && suffix != null) {
                 // The following if statements are designed to prevent adding two identical matchers.
-                if (signum == 1 || !Objects.equals(prefix, posPrefix)) {
+                if (type == PatternSignType.POS || !Objects.equals(prefix, posPrefix)) {
                     matchers.add(getInstance(prefix, null, flags));
                 }
-                if (signum == 1 || !Objects.equals(suffix, posSuffix)) {
+                if (type == PatternSignType.POS || !Objects.equals(suffix, posSuffix)) {
                     matchers.add(getInstance(null, suffix, flags));
                 }
             }

--- a/icu4j/main/classes/core/src/com/ibm/icu/number/CompactNotation.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/number/CompactNotation.java
@@ -66,9 +66,10 @@ public class CompactNotation extends Notation {
             CompactType compactType,
             PluralRules rules,
             MutablePatternModifier buildReference,
+            boolean safe,
             MicroPropsGenerator parent) {
         // TODO: Add a data cache? It would be keyed by locale, nsName, compact type, and compact style.
-        return new CompactHandler(this, locale, nsName, compactType, rules, buildReference, parent);
+        return new CompactHandler(this, locale, nsName, compactType, rules, buildReference, safe, parent);
     }
 
     private static class CompactHandler implements MicroPropsGenerator {
@@ -76,6 +77,7 @@ public class CompactNotation extends Notation {
         final PluralRules rules;
         final MicroPropsGenerator parent;
         final Map<String, ImmutablePatternModifier> precomputedMods;
+        final MutablePatternModifier unsafePatternModifier;
         final CompactData data;
 
         private CompactHandler(
@@ -85,6 +87,7 @@ public class CompactNotation extends Notation {
                 CompactType compactType,
                 PluralRules rules,
                 MutablePatternModifier buildReference,
+                boolean safe,
                 MicroPropsGenerator parent) {
             this.rules = rules;
             this.parent = parent;
@@ -94,13 +97,15 @@ public class CompactNotation extends Notation {
             } else {
                 data.populate(notation.compactCustomData);
             }
-            if (buildReference != null) {
+            if (safe) {
                 // Safe code path
                 precomputedMods = new HashMap<>();
                 precomputeAllModifiers(buildReference);
+                unsafePatternModifier = null;
             } else {
                 // Unsafe code path
                 precomputedMods = null;
+                unsafePatternModifier = buildReference;
             }
         }
 
@@ -145,13 +150,14 @@ public class CompactNotation extends Notation {
             } else {
                 // Unsafe code path.
                 // Overwrite the PatternInfo in the existing modMiddle.
-                assert micros.modMiddle instanceof MutablePatternModifier;
                 ParsedPatternInfo patternInfo = PatternStringParser.parseToPatternInfo(patternString);
-                ((MutablePatternModifier) micros.modMiddle).setPatternInfo(patternInfo, NumberFormat.Field.COMPACT);
+                unsafePatternModifier.setPatternInfo(patternInfo, NumberFormat.Field.COMPACT);
+                unsafePatternModifier.setNumberProperties(quantity.signum(), null);
+                micros.modMiddle = unsafePatternModifier;
             }
 
             // We already performed rounding. Do not perform it again.
-            micros.rounder = Precision.constructPassThrough();
+            micros.rounder = null;
 
             return micros;
         }

--- a/icu4j/main/classes/core/src/com/ibm/icu/number/NumberFormatter.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/number/NumberFormatter.java
@@ -327,7 +327,7 @@ public final class NumberFormatter {
 
         /**
          * Show the minus sign on negative numbers and the plus sign on positive numbers. Do not show a
-         * sign on zero or NaN, unless the sign bit is set (-0.0 gets a sign).
+         * sign on zero, numbers that round to zero, or NaN.
          *
          * @stable ICU 61
          * @see NumberFormatter
@@ -336,9 +336,8 @@ public final class NumberFormatter {
 
         /**
          * Use the locale-dependent accounting format on negative numbers, and show the plus sign on
-         * positive numbers. Do not show a sign on zero or NaN, unless the sign bit is set (-0.0 gets a
-         * sign). For more information on the accounting format, see the ACCOUNTING sign display
-         * strategy.
+         * positive numbers. Do not show a sign on zero, numbers that round to zero, or NaN. For more
+         * information on the accounting format, see the ACCOUNTING sign display strategy.
          *
          * @stable ICU 61
          * @see NumberFormatter

--- a/icu4j/main/classes/core/src/com/ibm/icu/number/NumberFormatterImpl.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/number/NumberFormatterImpl.java
@@ -17,6 +17,7 @@ import com.ibm.icu.impl.number.MicroProps;
 import com.ibm.icu.impl.number.MicroPropsGenerator;
 import com.ibm.icu.impl.number.MultiplierFormatHandler;
 import com.ibm.icu.impl.number.MutablePatternModifier;
+import com.ibm.icu.impl.number.MutablePatternModifier.ImmutablePatternModifier;
 import com.ibm.icu.impl.number.Padder;
 import com.ibm.icu.impl.number.PatternStringParser;
 import com.ibm.icu.impl.number.PatternStringParser.ParsedPatternInfo;
@@ -97,7 +98,9 @@ class NumberFormatterImpl {
      */
     public MicroProps preProcess(DecimalQuantity inValue) {
         MicroProps micros = microPropsGenerator.processQuantity(inValue);
-        micros.rounder.apply(inValue);
+        if (micros.rounder != null) {
+            micros.rounder.apply(inValue);
+        }
         if (micros.integerWidth.maxInt == -1) {
             inValue.setMinInteger(micros.integerWidth.minInt);
         } else {
@@ -111,7 +114,9 @@ class NumberFormatterImpl {
         MicroProps micros = new MicroProps(false);
         MicroPropsGenerator microPropsGenerator = macrosToMicroGenerator(macros, micros, false);
         micros = microPropsGenerator.processQuantity(inValue);
-        micros.rounder.apply(inValue);
+        if (micros.rounder != null) {
+            micros.rounder.apply(inValue);
+        }
         if (micros.integerWidth.maxInt == -1) {
             inValue.setMinInteger(micros.integerWidth.minInt);
         } else {
@@ -341,10 +346,9 @@ class NumberFormatterImpl {
         } else {
             patternMod.setSymbols(micros.symbols, currency, unitWidth, null);
         }
+        ImmutablePatternModifier immPatternMod = null;
         if (safe) {
-            chain = patternMod.createImmutableAndChain(chain);
-        } else {
-            chain = patternMod.addToChain(chain);
+            immPatternMod = patternMod.createImmutable();
         }
 
         // Outer modifier (CLDR units and currency long names)
@@ -367,8 +371,6 @@ class NumberFormatterImpl {
         }
 
         // Compact notation
-        // NOTE: Compact notation can (but might not) override the middle modifier and rounding.
-        // It therefore needs to go at the end of the chain.
         if (macros.notation instanceof CompactNotation) {
             if (rules == null) {
                 // Lazily create PluralRules
@@ -381,8 +383,16 @@ class NumberFormatterImpl {
                     micros.nsName,
                     compactType,
                     rules,
-                    safe ? patternMod : null,
+                    patternMod,
+                    safe,
                     chain);
+        }
+
+        // Always add the pattern modifier as the last element of the chain.
+        if (safe) {
+            chain = immPatternMod.addToChain(chain);
+        } else {
+            chain = patternMod.addToChain(chain);
         }
 
         return chain;

--- a/icu4j/main/classes/core/src/com/ibm/icu/number/NumberFormatterImpl.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/number/NumberFormatterImpl.java
@@ -98,9 +98,6 @@ class NumberFormatterImpl {
      */
     public MicroProps preProcess(DecimalQuantity inValue) {
         MicroProps micros = microPropsGenerator.processQuantity(inValue);
-        if (micros.rounder != null) {
-            micros.rounder.apply(inValue);
-        }
         if (micros.integerWidth.maxInt == -1) {
             inValue.setMinInteger(micros.integerWidth.minInt);
         } else {
@@ -114,9 +111,6 @@ class NumberFormatterImpl {
         MicroProps micros = new MicroProps(false);
         MicroPropsGenerator microPropsGenerator = macrosToMicroGenerator(macros, micros, false);
         micros = microPropsGenerator.processQuantity(inValue);
-        if (micros.rounder != null) {
-            micros.rounder.apply(inValue);
-        }
         if (micros.integerWidth.maxInt == -1) {
             inValue.setMinInteger(micros.integerWidth.minInt);
         } else {

--- a/icu4j/main/classes/core/src/com/ibm/icu/number/Precision.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/number/Precision.java
@@ -384,8 +384,6 @@ public abstract class Precision implements Cloneable {
     static final CurrencyRounderImpl MONETARY_STANDARD = new CurrencyRounderImpl(CurrencyUsage.STANDARD);
     static final CurrencyRounderImpl MONETARY_CASH = new CurrencyRounderImpl(CurrencyUsage.CASH);
 
-    static final PassThroughRounderImpl PASS_THROUGH = new PassThroughRounderImpl();
-
     static Precision constructInfinite() {
         return NONE;
     }
@@ -472,10 +470,6 @@ public abstract class Precision implements Cloneable {
             returnValue = constructFraction(minMaxFrac, minMaxFrac);
         }
         return returnValue.withMode(base.mathContext);
-    }
-
-    static Precision constructPassThrough() {
-        return PASS_THROUGH;
     }
 
     /**
@@ -710,17 +704,6 @@ public abstract class Precision implements Cloneable {
         public void apply(DecimalQuantity value) {
             // Call .withCurrency() before .apply()!
             throw new AssertionError();
-        }
-    }
-
-    static class PassThroughRounderImpl extends Precision {
-
-        public PassThroughRounderImpl() {
-        }
-
-        @Override
-        public void apply(DecimalQuantity value) {
-            // TODO: Assert that value has already been rounded
         }
     }
 

--- a/icu4j/main/classes/core/src/com/ibm/icu/number/ScientificNotation.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/number/ScientificNotation.java
@@ -196,7 +196,7 @@ public class ScientificNotation extends Notation implements Cloneable {
             }
 
             // We already performed rounding. Do not perform it again.
-            micros.rounder = Precision.constructPassThrough();
+            micros.rounder = null;
 
             return micros;
         }

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/data/numberpermutationtest.txt
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/data/numberpermutationtest.txt
@@ -1,4 +1,4 @@
-# © 2017 and later: Unicode, Inc. and others.
+# © 2019 and later: Unicode, Inc. and others.
 # License & terms of use: http://www.unicode.org/copyright.html
 
 compact-short percent unit-width-narrow
@@ -2273,15 +2273,15 @@ compact-short precision-integer sign-accounting-except-zero
   es-MX
     0
     +92 k
-    -0
+    0
   zh-TW
     0
     +9萬
-    -0
+    0
   bn-BD
     ০
     +৯২ হা
-    -০
+    ০
 
 compact-short .000 sign-accounting-except-zero
   es-MX
@@ -4849,15 +4849,15 @@ percent precision-integer sign-accounting-except-zero
   es-MX
     0 %
     +91,827 %
-    -0 %
+    0 %
   zh-TW
     0%
     +91,827%
-    -0%
+    0%
   bn-BD
     ০%
     +৯১,৮২৭%
-    -০%
+    ০%
 
 percent .000 sign-accounting-except-zero
   es-MX
@@ -4905,15 +4905,15 @@ currency/EUR precision-integer sign-accounting-except-zero
   es-MX
     EUR 0
     +EUR 91,827
-    -EUR 0
+    EUR 0
   zh-TW
     €0
     +€91,827
-    (€0)
+    €0
   bn-BD
     ০€
     +৯১,৮২৭€
-    (০ €)
+    ০€
 
 currency/EUR .000 sign-accounting-except-zero
   es-MX
@@ -4961,15 +4961,15 @@ measure-unit/length-furlong precision-integer sign-accounting-except-zero
   es-MX
     0 fur
     +91,827 fur
-    -0 fur
+    0 fur
   zh-TW
     0 化朗
     +91,827 化朗
-    -0 化朗
+    0 化朗
   bn-BD
     ০ ফার্লং
     +৯১,৮২৭ ফার্লং
-    -০ ফার্লং
+    ০ ফার্লং
 
 measure-unit/length-furlong .000 sign-accounting-except-zero
   es-MX
@@ -6627,15 +6627,15 @@ unit-width-narrow precision-integer sign-accounting-except-zero
   es-MX
     0
     +91,827
-    -0
+    0
   zh-TW
     0
     +91,827
-    -0
+    0
   bn-BD
     ০
     +৯১,৮২৭
-    -০
+    ০
 
 unit-width-narrow .000 sign-accounting-except-zero
   es-MX
@@ -6683,15 +6683,15 @@ unit-width-full-name precision-integer sign-accounting-except-zero
   es-MX
     0
     +91,827
-    -0
+    0
   zh-TW
     0
     +91,827
-    -0
+    0
   bn-BD
     ০
     +৯১,৮২৭
-    -০
+    ০
 
 unit-width-full-name .000 sign-accounting-except-zero
   es-MX
@@ -7943,15 +7943,15 @@ precision-integer integer-width/##00 sign-accounting-except-zero
   es-MX
     00
     +1827
-    -00
+    00
   zh-TW
     00
     +1,827
-    -00
+    00
   bn-BD
     ০০
     +১,৮২৭
-    -০০
+    ০০
 
 .000 integer-width/##00 sign-accounting-except-zero
   es-MX
@@ -8167,15 +8167,15 @@ precision-integer scale/0.5 sign-accounting-except-zero
   es-MX
     0
     +45,914
-    -0
+    0
   zh-TW
     0
     +45,914
-    -0
+    0
   bn-BD
     ০
     +৪৫,৯১৪
-    -০
+    ০
 
 .000 scale/0.5 sign-accounting-except-zero
   es-MX
@@ -8335,15 +8335,15 @@ precision-integer group-on-aligned sign-accounting-except-zero
   es-MX
     0
     +91,827
-    -0
+    0
   zh-TW
     0
     +91,827
-    -0
+    0
   bn-BD
     ০
     +৯১,৮২৭
-    -০
+    ০
 
 .000 group-on-aligned sign-accounting-except-zero
   es-MX
@@ -8447,15 +8447,15 @@ precision-integer latin sign-accounting-except-zero
   es-MX
     0
     +91,827
-    -0
+    0
   zh-TW
     0
     +91,827
-    -0
+    0
   bn-BD
     0
     +91,827
-    -0
+    0
 
 .000 latin sign-accounting-except-zero
   es-MX
@@ -8559,15 +8559,15 @@ precision-integer sign-accounting-except-zero decimal-always
   es-MX
     0.
     +91,827.
-    -0.
+    0.
   zh-TW
     0.
     +91,827.
-    -0.
+    0.
   bn-BD
     ০.
     +৯১,৮২৭.
-    -০.
+    ০.
 
 .000 sign-accounting-except-zero decimal-always
   es-MX

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/impl/number/DecimalQuantity_SimpleStorage.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/impl/number/DecimalQuantity_SimpleStorage.java
@@ -9,6 +9,7 @@ import java.text.FieldPosition;
 
 import com.ibm.icu.impl.StandardPlural;
 import com.ibm.icu.impl.number.DecimalQuantity;
+import com.ibm.icu.impl.number.Modifier.Signum;
 import com.ibm.icu.text.PluralRules;
 import com.ibm.icu.text.PluralRules.Operand;
 import com.ibm.icu.text.UFieldPosition;
@@ -517,8 +518,18 @@ public class DecimalQuantity_SimpleStorage implements DecimalQuantity {
   }
 
   @Override
-  public int signum() {
-      return isNegative() ? -1 : isZeroish() ? 0 : 1;
+  public Signum signum() {
+      boolean isZero = (isZeroish() && !isInfinite());
+      boolean isNeg = isNegative();
+      if (isZero && isNeg) {
+          return Signum.NEG_ZERO;
+      } else if (isZero) {
+          return Signum.POS_ZERO;
+      } else if (isNeg) {
+          return Signum.NEG;
+      } else {
+          return Signum.POS;
+      }
   }
 
   private void setNegative(boolean isNegative) {

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/MutablePatternModifierTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/MutablePatternModifierTest.java
@@ -12,6 +12,7 @@ import com.ibm.icu.impl.FormattedStringBuilder;
 import com.ibm.icu.impl.number.DecimalQuantity;
 import com.ibm.icu.impl.number.DecimalQuantity_DualStorageBCD;
 import com.ibm.icu.impl.number.MicroProps;
+import com.ibm.icu.impl.number.Modifier.Signum;
 import com.ibm.icu.impl.number.MutablePatternModifier;
 import com.ibm.icu.impl.number.PatternStringParser;
 import com.ibm.icu.number.NumberFormatter.SignDisplay;
@@ -32,19 +33,22 @@ public class MutablePatternModifierTest {
                 UnitWidth.SHORT,
                 null);
 
-        mod.setNumberProperties(1, null);
+        mod.setNumberProperties(Signum.POS, null);
         assertEquals("a", getPrefix(mod));
         assertEquals("b", getSuffix(mod));
         mod.setPatternAttributes(SignDisplay.ALWAYS, false);
         assertEquals("+a", getPrefix(mod));
         assertEquals("b", getSuffix(mod));
-        mod.setNumberProperties(0, null);
+        mod.setNumberProperties(Signum.POS_ZERO, null);
         assertEquals("+a", getPrefix(mod));
+        assertEquals("b", getSuffix(mod));
+        mod.setNumberProperties(Signum.NEG_ZERO, null);
+        assertEquals("-a", getPrefix(mod));
         assertEquals("b", getSuffix(mod));
         mod.setPatternAttributes(SignDisplay.EXCEPT_ZERO, false);
         assertEquals("a", getPrefix(mod));
         assertEquals("b", getSuffix(mod));
-        mod.setNumberProperties(-1, null);
+        mod.setNumberProperties(Signum.NEG, null);
         assertEquals("-a", getPrefix(mod));
         assertEquals("b", getSuffix(mod));
         mod.setPatternAttributes(SignDisplay.NEVER, false);
@@ -53,24 +57,27 @@ public class MutablePatternModifierTest {
 
         mod.setPatternInfo(PatternStringParser.parseToPatternInfo("a0b;c-0d"), null);
         mod.setPatternAttributes(SignDisplay.AUTO, false);
-        mod.setNumberProperties(1, null);
+        mod.setNumberProperties(Signum.POS, null);
         assertEquals("a", getPrefix(mod));
         assertEquals("b", getSuffix(mod));
         mod.setPatternAttributes(SignDisplay.ALWAYS, false);
         assertEquals("c+", getPrefix(mod));
         assertEquals("d", getSuffix(mod));
-        mod.setNumberProperties(0, null);
+        mod.setNumberProperties(Signum.POS_ZERO, null);
         assertEquals("c+", getPrefix(mod));
+        assertEquals("d", getSuffix(mod));
+        mod.setNumberProperties(Signum.NEG_ZERO, null);
+        assertEquals("c-", getPrefix(mod));
         assertEquals("d", getSuffix(mod));
         mod.setPatternAttributes(SignDisplay.EXCEPT_ZERO, false);
         assertEquals("a", getPrefix(mod));
         assertEquals("b", getSuffix(mod));
-        mod.setNumberProperties(-1, null);
+        mod.setNumberProperties(Signum.NEG, null);
         assertEquals("c-", getPrefix(mod));
         assertEquals("d", getSuffix(mod));
         mod.setPatternAttributes(SignDisplay.NEVER, false);
-        assertEquals("c-", getPrefix(mod)); // TODO: What should this behavior be?
-        assertEquals("d", getSuffix(mod));
+        assertEquals("a", getPrefix(mod));
+        assertEquals("b", getSuffix(mod));
     }
 
     @Test
@@ -112,7 +119,7 @@ public class MutablePatternModifierTest {
                 Currency.getInstance("USD"),
                 UnitWidth.SHORT,
                 null);
-        mod.setNumberProperties(1, null);
+        mod.setNumberProperties(Signum.POS_ZERO, null);
 
         // Unsafe Code Path
         FormattedStringBuilder nsb = new FormattedStringBuilder();

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
@@ -2036,7 +2036,7 @@ public class NumberFormatterApiTest {
             { {SignDisplay.AUTO}, { "-∞", "-1", "-0", "0", "1", "∞", "NaN", "-NaN" } },
             { {SignDisplay.ALWAYS}, { "-∞", "-1", "-0", "+0", "+1", "+∞", "+NaN", "-NaN" } },
             { {SignDisplay.NEVER}, { "∞", "1", "0", "0", "1", "∞", "NaN", "NaN" } },
-            { {SignDisplay.EXCEPT_ZERO}, { "-∞", "-1", "-0", "0", "+1", "+∞", "NaN", "-NaN" } },
+            { {SignDisplay.EXCEPT_ZERO}, { "-∞", "-1", "0", "0", "+1", "+∞", "NaN", "NaN" } },
         };
         double negNaN = Math.copySign(Double.NaN, -0.0);
         double inputs[] = new double[] {

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
@@ -1625,6 +1625,57 @@ public class NumberFormatterApiTest {
                 "00.008765",
                 "00");
 
+        assertFormatDescending(
+                "Integer Width Compact",
+                "compact-short integer-width/000",
+                NumberFormatter.with()
+                    .notation(Notation.compactShort())
+                    .integerWidth(IntegerWidth.zeroFillTo(3).truncateAt(3)),
+                ULocale.ENGLISH,
+                "088K",
+                "008.8K",
+                "876",
+                "088",
+                "008.8",
+                "000.88",
+                "000.088",
+                "000.0088",
+                "000");
+
+        assertFormatDescending(
+                "Integer Width Scientific",
+                "scientific integer-width/000",
+                NumberFormatter.with()
+                    .notation(Notation.scientific())
+                    .integerWidth(IntegerWidth.zeroFillTo(3).truncateAt(3)),
+                ULocale.ENGLISH,
+                "008.765E4",
+                "008.765E3",
+                "008.765E2",
+                "008.765E1",
+                "008.765E0",
+                "008.765E-1",
+                "008.765E-2",
+                "008.765E-3",
+                "000E0");
+
+        assertFormatDescending(
+                "Integer Width Engineering",
+                "engineering integer-width/000",
+                NumberFormatter.with()
+                    .notation(Notation.engineering())
+                    .integerWidth(IntegerWidth.zeroFillTo(3).truncateAt(3)),
+                ULocale.ENGLISH,
+                "087.65E3",
+                "008.765E3",
+                "876.5E0",
+                "087.65E0",
+                "008.765E0",
+                "876.5E-3",
+                "087.65E-3",
+                "008.765E-3",
+                "000E0");
+
         assertFormatSingle(
                 "Integer Width Remove All A",
                 "integer-width/00",
@@ -2027,6 +2078,45 @@ public class NumberFormatterApiTest {
                 ULocale.CANADA,
                 -444444,
                 "-444,444.00 US dollars");
+    }
+
+    @Test
+    public void signNearZero() {
+        // https://unicode-org.atlassian.net/browse/ICU-20709
+        Object[][] cases = {
+            { SignDisplay.AUTO,  1.1, "1" },
+            { SignDisplay.AUTO,  0.9, "1" },
+            { SignDisplay.AUTO,  0.1, "0" },
+            { SignDisplay.AUTO, -0.1, "-0" }, // interesting case
+            { SignDisplay.AUTO, -0.9, "-1" },
+            { SignDisplay.AUTO, -1.1, "-1" },
+            { SignDisplay.ALWAYS,  1.1, "+1" },
+            { SignDisplay.ALWAYS,  0.9, "+1" },
+            { SignDisplay.ALWAYS,  0.1, "+0" },
+            { SignDisplay.ALWAYS, -0.1, "-0" },
+            { SignDisplay.ALWAYS, -0.9, "-1" },
+            { SignDisplay.ALWAYS, -1.1, "-1" },
+            { SignDisplay.EXCEPT_ZERO,  1.1, "+1" },
+            { SignDisplay.EXCEPT_ZERO,  0.9, "+1" },
+            { SignDisplay.EXCEPT_ZERO,  0.1, "0" }, // interesting case
+            { SignDisplay.EXCEPT_ZERO, -0.1, "0" }, // interesting case
+            { SignDisplay.EXCEPT_ZERO, -0.9, "-1" },
+            { SignDisplay.EXCEPT_ZERO, -1.1, "-1" },
+        };
+        for (Object[] cas : cases) {
+            SignDisplay sign = (SignDisplay) cas[0];
+            double input = (Double) cas[1];
+            String expected = (String) cas[2];
+            String actual = NumberFormatter.with()
+                .sign(sign)
+                .precision(Precision.integer())
+                .locale(Locale.US)
+                .format(input)
+                .toString();
+            assertEquals(
+                input + " @ SignDisplay " + sign,
+                expected, actual);
+        }
     }
 
     @Test

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberPermutationTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberPermutationTest.java
@@ -96,7 +96,7 @@ public class NumberPermutationTest extends TestFmwk {
 
         // Build up the golden data string as we evaluate all permutations
         ArrayList<String> resultLines = new ArrayList<>();
-        resultLines.add("# © 2017 and later: Unicode, Inc. and others.");
+        resultLines.add("# © 2019 and later: Unicode, Inc. and others.");
         resultLines.add("# License & terms of use: http://www.unicode.org/copyright.html");
         resultLines.add("");
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

**Tips for reviewing this PR:** I was very careful to split this PR into 3 disjoint commits which all pass tests on their own.  I suggest looking at each commit individually.

**Background:** As discussed in the ticket, we have had more in-depth discussion about what would be the best semantics for SignDisplay.EXCEPT_ZERO. I would like to make these semantics the default behavior in ICU. The changes involve numbers very close to zero.

This PR does not belong on the maintenance branch.  It is going on master for ICU 67.

@jefgen: assigning to you, but feel free to send it over to Markus or someone else.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20709
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [x] Documentation is changed or added

