### PR TITLE
ICU-20839 Add header test for utypes.h when using U_SHOW_CPLUSPLUS_API

### DIFF
--- a/icu4c/source/test/hdrtst/Makefile.in
+++ b/icu4c/source/test/hdrtst/Makefile.in
@@ -16,9 +16,12 @@
 ##  unicode/ucnv.h -	0
 ##
 ##    .. etc.  Anything other than zero is an error. (except for the deprecation tests, where '1' is the correct value)
-##              
+##
 ##  If a header fails the C compile test it is likely because the header is a
-##  C++ header and isn't properly guarded by the U_SHOW_CPLUSPLUS_API macro.
+##  C++ header and it isn't properly guarded by the U_SHOW_CPLUSPLUS_API macro.
+##
+##  If a header fails the cppguardtest test it is likely because the header doesn't
+##  include the utypes.h header first *before* using the macro U_SHOW_CPLUSPLUS_API.
 ##
 ##  If a header fails because it is deprecated, add it to the 'dfiles.txt'
 ##
@@ -37,7 +40,7 @@ all:
 	@echo Please read this Makefile for more information.
 	@echo run \'$(MAKE) check\' to run the test "(use -k if you don't want to stop on errs)"
 
-check: dtest ctest cpptest drafttest deprtest internaltest obsoletetest
+check: dtest ctest cpptest drafttest deprtest internaltest obsoletetest cppguardtest
 
 headertest:
 	@FAIL=0;stub=ht_stub_$(NAME.headers).$(SUFFIX.headers); for file in "$(prefix)/include/unicode"/*.h ; do \
@@ -108,6 +111,24 @@ dtest:
 	echo "$@: $$NONE - exit status $$FAIL" ; \
 	exit $$FAIL
 
+cppguardtest:
+	@FAIL=0;stub=ht_stub_cppguardtest.cpp; for file in "$(prefix)/include/unicode"/*.h ; do \
+		incfile=`basename $$file` ; \
+		if grep -q "U_SHOW_CPLUSPLUS_API" $$file ; then \
+			echo "$@ unicode/$$incfile" ; \
+			echo "#include <unicode/$$incfile>" > $$stub ; \
+			echo 'void junk(){}' >> $$stub ; \
+			echo '#if !defined(U_SHOW_CPLUSPLUS_API)' >> $$stub ; \
+			echo "#error The header '$$incfile' refers to the macro U_SHOW_CPLUSPLUS_API (defined in utypes.h) but either does not include utypes.h or does so incorrectly." >> $$stub ; \
+			echo '#endif' >> $$stub ; \
+			$(COMPILE.cc) $(cppflags) $$stub || FAIL=1 ; \
+			rm -f $$stub; \
+		else \
+			echo "$@ skipping unicode/$$incfile" ; \
+		fi ; \
+	done ; \
+	exit $$FAIL
+
 clean:
 	-@rm -f ht_*
 
@@ -118,4 +139,4 @@ Makefile: $(srcdir)/Makefile.in  $(top_builddir)/config.status
 	cd $(top_builddir) \
 	&& CONFIG_FILES=$(subdir)/$@ CONFIG_HEADERS= $(SHELL) ./config.status
 
-.PHONY:	doclean check all headertest cpptest dtest ctest clean distclean
+.PHONY:	doclean check all headertest cpptest dtest cppguardtest ctest clean distclean


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-20839

This adds another test/check to the `hdrtst` checker, which is intended to catch any usage of the macro `U_SHOW_CPLUSPLUS_API` without properly including the header file `utypes.h` first -- which causes/caused issues like ICU-20836.

The header file `utypes.h` is what defines the macro `U_SHOW_CPLUSPLUS_API`. So if a public header file uses the macro *before* it is defined it will evaluate as 0, causing the code to be removed by the preprocessor.

The test works by creating a temporary cpp file that includes each public header file that refers to `U_SHOW_CPLUSPLUS_API`, and then checks that the macro is actually defined *after* including the public header file.
If the macro is used before `utypes.h` is included, then the definition of `U_SHOW_CPLUSPLUS_API` will be omitted, which causes the test to fail.

Note: The test uses a simple `grep` to check if a public header refers to the macro rather than simply checking every single header file. If we were to check every header file then we'd also need a list of headers to *exclude*, since `utypes.h` itself includes other header files, leading to a circular problem. (See the comments on ICU-20836 for more).

Note 2: that this PR currently fails, as the fix for ICU-20836 hasn't yet been merged to the `master` branch. (PR #872)
However, this failure confirms that the test is actually working properly, as it detects the issue in the `plurrule.h` header file.

Output from the Travis CI build bot:
```
cppguardtest unicode/plurfmt.h
cppguardtest unicode/plurrule.h
ht_stub_cppguardtest.cpp:4:2: error: #error The header 'plurrule.h' refers to the macro U_SHOW_CPLUSPLUS_API (defined in utypes.h) but either does not include utypes.h or does so incorrectly.
 #error The header 'plurrule.h' refers to the macro U_SHOW_CPLUSPLUS_API (define
  ^
cppguardtest skipping unicode/ptypes.h
cppguardtest skipping unicode/putil.h
cppguardtest unicode/rbbi.h
cppguardtest unicode/rbnf.h
```

Once the PR #872 for merging `maint/maint-65` into `master` is completed, I will rebase this PR which will "fix" the test failure.