### PR TITLE
ICU-13734 Adding tests for DecimalFormat strict mode handling of flexible whitespace

### DIFF
--- a/icu4c/source/test/intltest/numfmtst.cpp
+++ b/icu4c/source/test/intltest/numfmtst.cpp
@@ -242,6 +242,7 @@ void NumberFormatTest::runIndexedTest( int32_t index, UBool exec, const char* &n
   TESTCASE_AUTO(Test13731_DefaultCurrency);
   TESTCASE_AUTO(Test20499_CurrencyVisibleDigitsPlural);
   TESTCASE_AUTO(Test13735_GroupingSizeGetter);
+  TESTCASE_AUTO(Test13734_StrictFlexibleWhitespace);
   TESTCASE_AUTO_END;
 }
 
@@ -9723,6 +9724,28 @@ void NumberFormatTest::Test13735_GroupingSizeGetter() {
         assertEquals("pat #,##0 then disabled: ", 3, df.getGroupingSize());
         df.setGroupingUsed(true);
         assertEquals("pat #,##0 then enabled: ", 3, df.getGroupingSize());
+    }
+}
+
+void NumberFormatTest::Test13734_StrictFlexibleWhitespace() {
+    IcuTestErrorCode status(*this, "Test13734_StrictFlexibleWhitespace");
+    {
+        DecimalFormat df("+0", {"en", status}, status);
+        df.setLenient(FALSE);
+        Formattable result;
+        ParsePosition ppos;
+        df.parse("+  33", result, ppos);
+        assertEquals("ppos : ", 0, ppos.getIndex());
+        assertEquals("result : ", "0", result.getDecimalNumber(status).data());
+    }
+    {
+        DecimalFormat df("+ 0", {"en", status}, status);
+        df.setLenient(FALSE);
+        Formattable result;
+        ParsePosition ppos;
+        df.parse("+  33", result, ppos);
+        assertEquals("ppos : ", 0, ppos.getIndex());
+        assertEquals("result : ", "0", result.getDecimalNumber(status).data());
     }
 }
 

--- a/icu4c/source/test/intltest/numfmtst.h
+++ b/icu4c/source/test/intltest/numfmtst.h
@@ -298,6 +298,7 @@ class NumberFormatTest: public CalendarTimeZoneTest {
     void Test13731_DefaultCurrency();
     void Test20499_CurrencyVisibleDigitsPlural();
     void Test13735_GroupingSizeGetter();
+    void Test13734_StrictFlexibleWhitespace();
 
  private:
     UBool testFormattableAsUFormattable(const char *file, int line, Formattable &f);

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/NumberFormatTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/NumberFormatTest.java
@@ -6690,4 +6690,25 @@ public class NumberFormatTest extends TestFmwk {
             assertEquals("pat #,##0 then enabled: ", 3, df.getGroupingSize());
         }
     }
+
+    @Test
+    public void test13734_StrictFlexibleWhitespace() {
+        DecimalFormatSymbols EN = DecimalFormatSymbols.getInstance(ULocale.ENGLISH);
+        {
+          DecimalFormat df = new DecimalFormat("+0", EN);
+          df.setParseStrict(true);
+          ParsePosition ppos = new ParsePosition(0);
+          Number result = df.parse("+  33", ppos);
+          assertEquals("ppos: ", 0, ppos.getIndex());
+          assertEquals("result: ", null, result);
+        }
+        {
+          DecimalFormat df = new DecimalFormat("+ 0", EN);
+          df.setParseStrict(true);
+          ParsePosition ppos = new ParsePosition(0);
+          Number result = df.parse("+  33", ppos);
+          assertEquals("ppos: ", 0, ppos.getIndex());
+          assertEquals("result: ", null, result);
+        }
+    }
 }


### PR DESCRIPTION
##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-13734
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [X] Tests included
- [ ] Documentation is changed or added

