### PR TITLE
ICU-20859 ICU4C: Python data build uses wrong value for tool_cfg

### DIFF
--- a/icu4c/source/data/makedata.mak
+++ b/icu4c/source/data/makedata.mak
@@ -270,7 +270,7 @@ $(COREDATA_TS):
 		--mode windows-exec \
 		--src_dir "$(ICUSRCDATA)" \
 		--tool_dir "$(ICUTOOLS)" \
-		--tool_cfg "$(CFG)" \
+		--tool_cfg "$(CFGTOOLS)" \
 		--out_dir "$(ICUBLD_PKG)" \
 		--tmp_dir "$(ICUTMP)" \
 		--filter_file "$(ICU_DATA_FILTER_FILE)" \


### PR DESCRIPTION
The `tool_cfg` setting that is passed to the Python data build script should use `CFGTOOLS` instead of `CFG`.
The rest of the `Makedata.mak` makefile uses `CFGTOOLS`, so this is inconsistent.

However, this also causes build failures on ARM64 builds when the data file hasn't previously been built (for either x86 or x64). -- (Thanks to Marc Sweetgall for reporting/finding this!).

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20859
- [x] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

