### PR TITLE
ICU-20858 Fix Windows data build failure with long paths

### DIFF
--- a/icu4c/source/python/icutools/databuilder/renderers/common_exec.py
+++ b/icu4c/source/python/icutools/databuilder/renderers/common_exec.py
@@ -120,12 +120,15 @@ def run_shell_command(command_line, platform, verbose):
     # If the command line length on Windows exceeds the absolute maximum that CMD supports (8191), then
     # we temporarily switch over to use PowerShell for the command, and then switch back to CMD.
     # We don't want to use PowerShell for everything though, as it tends to be slower.
-    if (platform == "windows") and (len(command_line) > 8190):
-        if verbose:
-            print("Command length exceeds the max length for CMD on Windows, using PowerShell instead.")
+    if (platform == "windows"):
         previous_comspec = os.environ["COMSPEC"]
-        os.environ["COMSPEC"] = 'powershell'
-        changed_windows_comspec = True
+        # Add 7 to the length for the argument /c with quotes.
+        # For example:  C:\WINDOWS\system32\cmd.exe /c "<command_line>"
+        if ((len(previous_comspec) + len(command_line) + 7) > 8190):
+            if verbose:
+                print("Command length exceeds the max length for CMD on Windows, using PowerShell instead.")
+            os.environ["COMSPEC"] = 'powershell'
+            changed_windows_comspec = True
     if verbose:
         print("Running: %s" % command_line)
         returncode = subprocess.call(


### PR DESCRIPTION
There is an edge case that was missed in the change for ICU-20858.
The length of the path to the current `COMSPEC` should be included in the length of the total command line.
Otherwise it is still possible for the command line length to exceed the 8,191 length limit, leading to build failures.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20858
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

