### PR TITLE
ICU-20875 Include <cstddef> for max_align_t

### DIFF
--- a/icu4c/source/common/uarrsort.cpp
+++ b/icu4c/source/common/uarrsort.cpp
@@ -18,6 +18,8 @@
 *   Internal function for sorting arrays.
 */
 
+#include <cstddef>
+
 #include "unicode/utypes.h"
 #include "cmemory.h"
 #include "uarrsort.h"
@@ -35,7 +37,7 @@ enum {
 };
 
 static constexpr int32_t sizeInMaxAlignTs(int32_t sizeInBytes) {
-    return (sizeInBytes + sizeof(max_align_t) - 1) / sizeof(max_align_t);
+    return (sizeInBytes + sizeof(std::max_align_t) - 1) / sizeof(std::max_align_t);
 }
 
 /* UComparator convenience implementations ---------------------------------- */
@@ -139,7 +141,7 @@ static void
 insertionSort(char *array, int32_t length, int32_t itemSize,
               UComparator *cmp, const void *context, UErrorCode *pErrorCode) {
 
-    icu::MaybeStackArray<max_align_t, sizeInMaxAlignTs(STACK_ITEM_SIZE)> v;
+    icu::MaybeStackArray<std::max_align_t, sizeInMaxAlignTs(STACK_ITEM_SIZE)> v;
     if (sizeInMaxAlignTs(itemSize) > v.getCapacity() &&
             v.resize(sizeInMaxAlignTs(itemSize)) == nullptr) {
         *pErrorCode = U_MEMORY_ALLOCATION_ERROR;
@@ -233,7 +235,7 @@ static void
 quickSort(char *array, int32_t length, int32_t itemSize,
             UComparator *cmp, const void *context, UErrorCode *pErrorCode) {
     /* allocate two intermediate item variables (x and w) */
-    icu::MaybeStackArray<max_align_t, sizeInMaxAlignTs(STACK_ITEM_SIZE) * 2> xw;
+    icu::MaybeStackArray<std::max_align_t, sizeInMaxAlignTs(STACK_ITEM_SIZE) * 2> xw;
     if(sizeInMaxAlignTs(itemSize)*2 > xw.getCapacity() &&
             xw.resize(sizeInMaxAlignTs(itemSize) * 2) == nullptr) {
         *pErrorCode=U_MEMORY_ALLOCATION_ERROR;

--- a/icu4c/source/common/utext.cpp
+++ b/icu4c/source/common/utext.cpp
@@ -16,6 +16,8 @@
 *   created by: Markus W. Scherer
 */
 
+#include <cstddef>
+
 #include "unicode/utypes.h"
 #include "unicode/ustring.h"
 #include "unicode/unistr.h"
@@ -566,8 +568,8 @@ enum {
 //    when a provider asks for a UText to be allocated with extra storage.
 
 struct ExtendedUText {
-    UText          ut;
-    max_align_t    extension;
+    UText               ut;
+    std::max_align_t    extension;
 };
 
 static const UText emptyText = UTEXT_INITIALIZER;
@@ -582,7 +584,7 @@ utext_setup(UText *ut, int32_t extraSpace, UErrorCode *status) {
         // We need to heap-allocate storage for the new UText
         int32_t spaceRequired = sizeof(UText);
         if (extraSpace > 0) {
-            spaceRequired = sizeof(ExtendedUText) + extraSpace - sizeof(max_align_t);
+            spaceRequired = sizeof(ExtendedUText) + extraSpace - sizeof(std::max_align_t);
         }
         ut = (UText *)uprv_malloc(spaceRequired);
         if (ut == NULL) {

--- a/icu4c/source/tools/toolutil/toolutil.cpp
+++ b/icu4c/source/tools/toolutil/toolutil.cpp
@@ -60,6 +60,8 @@
 
 #include <errno.h>
 
+#include <cstddef>
+
 #include "unicode/errorcode.h"
 #include "unicode/putil.h"
 #include "cmemory.h"
@@ -243,7 +245,7 @@ struct UToolMemory {
     char name[64];
     int32_t capacity, maxCapacity, size, idx;
     void *array;
-    alignas(max_align_t) char staticArray[1];
+    alignas(std::max_align_t) char staticArray[1];
 };
 
 U_CAPI UToolMemory * U_EXPORT2


### PR DESCRIPTION
The definition of `max_align_t` is not guaranteed to be available unless
the appropriate header is included. Since use of `<stddef.h>` from C++ is
deprecated, that's `<cstddef>`, and `max_align_t` is thus defined under the
std namespace rather than in the global namespace.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20875
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added
