### PR TITLE
ICU-20863 Regex Named Capture map, add a missing nullptr check.

### DIFF
--- a/icu4c/source/i18n/repattrn.cpp
+++ b/icu4c/source/i18n/repattrn.cpp
@@ -850,7 +850,7 @@ void RegexPattern::dumpPattern() const {
     }
 
     printf("Named Capture Groups:\n");
-    if (uhash_count(fNamedCaptureMap) == 0) {
+    if (!fNamedCaptureMap || uhash_count(fNamedCaptureMap) == 0) {
         printf("   None\n");
     } else {
         int32_t pos = UHASH_FIRST;


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-20863

Follow-up on PR #890 