### PR TITLE
ICU-20693 Fix erroneous addition of cldrVersion

### DIFF
--- a/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/LdmlConverter.java
+++ b/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/LdmlConverter.java
@@ -419,7 +419,7 @@ public final class LdmlConverter {
                 break;
 
             case CURRENCY_DATA:
-                processSupplemental("supplementalData", CURRENCY_DATA_PATHS, "curr", true);
+                processSupplemental("supplementalData", CURRENCY_DATA_PATHS, "curr", false);
                 break;
 
             case METADATA:


### PR DESCRIPTION
ICU-20693 The cldrVersion value is added as a bit of a hack in the supplementalData.txt file (because that data doesn't come from CLDR XML directly). However it should only go into the "main" misc/supplementalData.txt, not the curr/supplementalData.txt file.
This fix just sets the flag to add it to false for the curr/ version.

This can be seen via the diffs for the new tools:

    diff -r -I '^[ /]\*' /icu-65-1/icu4c/source/data/curr/supplementalData.txt /tmp/icu65/curr/supplementalData.txt
    ...
    5207a5244
    >     cldrVersion{"36"}

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20693
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
