### PR TITLE
ICU-20693 Fix alt values to support per-locale mappings and remove source paths.

### DIFF
--- a/tools/cldr/cldr-to-icu/build-icu-data.xml
+++ b/tools/cldr/cldr-to-icu/build-icu-data.xml
@@ -305,8 +305,9 @@
 
                  This feature is typically used to select alternate translations (e.g. short forms)
                  for certain paths. -->
-            <!-- <altPath target="//path/to/value[@attr='foo']" source="//path/to/value[@attr='bar']"/> -->
-
+            <!-- <altPath target="//path/to/value[@attr='foo']"
+                          source="//path/to/value[@attr='bar']"
+                          locales="xx,yy_ZZ"/> -->
         </convert>
     </target>
 </project>

--- a/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/AlternateLocaleData.java
+++ b/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/AlternateLocaleData.java
@@ -4,8 +4,10 @@ package org.unicode.icu.tool.cldrtoicu;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static org.unicode.cldr.api.CldrDataType.LDML;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -17,6 +19,9 @@ import org.unicode.cldr.api.CldrPath;
 import org.unicode.cldr.api.CldrValue;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Table;
 
 /**
  * A factory for data suppliers which can filter CLDR values by substituting values from one path
@@ -46,32 +51,46 @@ public final class AlternateLocaleData {
      * values are obtained. For each map entry, the target and source paths must be in the same
      * namespace (i.e. have the same path element names).
      */
-    public static CldrDataSupplier transform(CldrDataSupplier src, Map<CldrPath, CldrPath> altPaths) {
-        return new CldrDataFilter(src, altPaths);
+    public static CldrDataSupplier transform(
+        CldrDataSupplier src,
+        Map<CldrPath, CldrPath> globalAltPaths,
+        Table<String, CldrPath, CldrPath> localeAltPaths) {
+        return new CldrDataFilter(src, globalAltPaths, localeAltPaths);
     }
 
     private static final class CldrDataFilter extends CldrDataSupplier {
         private final CldrDataSupplier src;
         // Mapping from target (destination) to source path. This is necessary since two targets
         // could come from the same source).
-        private final ImmutableMap<CldrPath, CldrPath> altPaths;
+        private final ImmutableMap<CldrPath, CldrPath> globalAltPaths;
+        private final ImmutableTable<String, CldrPath, CldrPath> localeAltPaths;
 
         CldrDataFilter(
-            CldrDataSupplier src, Map<CldrPath, CldrPath> altPaths) {
+        CldrDataSupplier src,
+        Map<CldrPath, CldrPath> globalAltPaths,
+        Table<String, CldrPath, CldrPath> localeAltPaths) {
             this.src = checkNotNull(src);
-            this.altPaths = ImmutableMap.copyOf(altPaths);
-            altPaths.forEach((t, s) -> checkArgument(hasSameNamespace(checkLdml(t), checkLdml(s)),
+            this.globalAltPaths = ImmutableMap.copyOf(globalAltPaths);
+            this.localeAltPaths = ImmutableTable.copyOf(localeAltPaths);
+            this.globalAltPaths
+                .forEach((t, s) -> checkArgument(hasSameNamespace(checkLdml(t), checkLdml(s)),
                 "alternate paths must have the same namespace: target=%s, source=%s", t, s));
+            this.localeAltPaths.cellSet()
+                .forEach(c -> checkArgument(
+                    hasSameNamespace(checkLdml(c.getColumnKey()), checkLdml(c.getValue())),
+                "alternate paths must have the same namespace: locale=%s, target=%s, source=%s",
+                    c.getRowKey(), c.getColumnKey(), c.getValue()));
         }
 
         @Override
         public CldrDataSupplier withDraftStatusAtLeast(CldrDraftStatus draftStatus) {
-            return new CldrDataFilter(src.withDraftStatusAtLeast(draftStatus), altPaths);
+            return new CldrDataFilter(
+                src.withDraftStatusAtLeast(draftStatus), globalAltPaths, localeAltPaths);
         }
 
         @Override
         public CldrData getDataForLocale(String localeId, CldrResolution resolution) {
-            return new AltData(src.getDataForLocale(localeId, resolution));
+            return new AltData(src.getDataForLocale(localeId, resolution), localeId);
         }
 
         @Override
@@ -85,8 +104,28 @@ public final class AlternateLocaleData {
         }
 
         private final class AltData extends FilteredData {
-            AltData(CldrData srcData) {
+            // Calculated per locale/data instance to make lokup as fast as possible.
+            private final ImmutableMap<CldrPath, CldrPath> altPaths;
+            // Any source paths which are not also target paths are removed. This is legacy
+            // behaviour inherited from the original build tools, the reason for which is not
+            // known. If it becomes desirable to retain the source values in their original
+            // locations, this can just be removed.
+            private final ImmutableSet<CldrPath> toRemove;
+
+            AltData(CldrData srcData, String localeId) {
                 super(srcData);
+                ImmutableMap<CldrPath, CldrPath> altPaths  = globalAltPaths;
+                if (!localeAltPaths.row(localeId).isEmpty()) {
+                    Map<CldrPath, CldrPath> combinedPaths = new HashMap<>();
+                    // Locale specific path mappings overwrite global ones.
+                    combinedPaths.putAll(globalAltPaths);
+                    combinedPaths.putAll(localeAltPaths.row(localeId));
+                    altPaths = ImmutableMap.copyOf(combinedPaths);
+                }
+                this.altPaths = altPaths;
+                this.toRemove = altPaths.values().stream()
+                    .filter(p -> !this.altPaths.containsKey(p))
+                    .collect(toImmutableSet());
             }
 
             @Override
@@ -98,7 +137,7 @@ public final class AlternateLocaleData {
                         return altValue.replacePath(value.getPath());
                     }
                 }
-                return value;
+                return toRemove.contains(value.getPath()) ? null : value;
             }
         }
     }


### PR DESCRIPTION
This should now match the desired behaviour used by Google to remap alt-values for paths.
You can now specify a list of locale IDs for an <altPath> element and any source paths are removed from the filtered data.

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20693
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted

