### PR TITLE
ICU-20844 reduce restriction on minInt=minFrac=0

### DIFF
--- a/icu4c/source/i18n/decimfmt.cpp
+++ b/icu4c/source/i18n/decimfmt.cpp
@@ -1834,7 +1834,8 @@ void DecimalFormat::doFastFormatInt32(int32_t input, bool isNegative, UnicodeStr
     char16_t localBuffer[localCapacity];
     char16_t* ptr = localBuffer + localCapacity;
     int8_t group = 0;
-    for (int8_t i = 0; i < fields->fastData.maxInt && (input != 0 || i < fields->fastData.minInt); i++) {
+    int8_t minInt = (fields->fastData.minInt < 1)? 1: fields->fastData.minInt;
+    for (int8_t i = 0; i < fields->fastData.maxInt && (input != 0 || i < minInt); i++) {
         if (group++ == 3 && fields->fastData.cpGroupingSeparator != 0) {
             *(--ptr) = fields->fastData.cpGroupingSeparator;
             group = 1;

--- a/icu4c/source/i18n/number_formatimpl.cpp
+++ b/icu4c/source/i18n/number_formatimpl.cpp
@@ -509,6 +509,12 @@ int32_t NumberFormatterImpl::writeNumber(const MicroProps& micros, DecimalQuanti
 
         // Add the fraction digits
         length += writeFractionDigits(micros, quantity, string, length + index, status);
+
+        if (length == 0) {
+            // Force output of the digit for value 0
+            length += utils::insertDigitFromSymbols(
+                    string, index, 0, *micros.symbols, UNUM_INTEGER_FIELD, status);
+        }
     }
 
     return length;

--- a/icu4c/source/i18n/number_mapper.cpp
+++ b/icu4c/source/i18n/number_mapper.cpp
@@ -125,10 +125,8 @@ MacroProps NumberPropertyMapper::oldToNew(const DecimalFormatProperties& propert
     }
     // Validate min/max int/frac.
     // For backwards compatibility, minimum overrides maximum if the two conflict.
-    // The following logic ensures that there is always a minimum of at least one digit.
     if (minInt == 0 && maxFrac != 0) {
-        // Force a digit after the decimal point.
-        minFrac = minFrac <= 0 ? 1 : minFrac;
+        minFrac = (minFrac < 0 || (minFrac == 0 && maxInt == 0)) ? 1 : minFrac;
         maxFrac = maxFrac < 0 ? -1 : maxFrac < minFrac ? minFrac : maxFrac;
         minInt = 0;
         maxInt = maxInt < 0 ? -1 : maxInt > kMaxIntFracSig ? -1 : maxInt;

--- a/icu4c/source/test/intltest/numbertest_api.cpp
+++ b/icu4c/source/test/intltest/numbertest_api.cpp
@@ -1648,7 +1648,7 @@ void NumberFormatterApiTest::integerWidth() {
             u".8765",
             u".08765",
             u".008765",
-            u""); // TODO: Avoid the empty string here?
+            u"0");  // see ICU-20844
 
     assertFormatDescending(
             u"Integer Width Zero Fill 3",


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20844
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

- In NumberPropertyMapper::oldToNew, remove restriction against minInt=minFrac=0 (only if maxInt != 0)
- Ensure DecimalFormat::doFastFormatInt32 always produces at least 1 digit

This does not break any existing tests but does fix the problem demonstrated by the newly added test for this.

This PR is just for C. If the approach seems OK, I will create a separate PR for Java.