### PR TITLE
ICU-20904 Don't use char16_t with C++98/03

### DIFF
--- a/icu4c/source/common/unicode/umachine.h
+++ b/icu4c/source/common/unicode/umachine.h
@@ -372,7 +372,7 @@ typedef int8_t UBool;
     typedef char16_t UChar;
 #elif defined(UCHAR_TYPE)
     typedef UCHAR_TYPE UChar;
-#elif defined(__cplusplus)
+#elif (U_CPLUSPLUS_VERSION >= 11)
     typedef char16_t UChar;
 #else
     typedef uint16_t UChar;


### PR DESCRIPTION
When C code includes the ICU headers, the `UChar` type is defined to be
`uint16_t`. But when C++ code includes the headers, `UChar` is `char16_t`
even when `U_SHOW_CPLUSPLUS_API` has been set to 0. Apart from arguably
being an inconsistency in the API, this means that C++98 or C++03 code
can't use the C API even though C99 code can.

So, change unicode/umachine.h to check not just whether `__cplusplus` is
defined but the value of `U_CPLUSPLUS_VERSION` when deciding how to
typedef UChar.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20904
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

