### PR TITLE
ICU-20907 Disable optimization for MSVC on ARM64 on versions below 16.4

### DIFF
--- a/icu4c/source/common/normalizer2impl.cpp
+++ b/icu4c/source/common/normalizer2impl.cpp
@@ -2088,6 +2088,13 @@ uint8_t Normalizer2Impl::getPreviousTrailCC(const uint8_t *start, const uint8_t 
 // minDecompNoCP etc. and smallFCD[] are intended to help with any loss of performance,
 // at least for ASCII & CJK.
 
+// Ticket 20907 - The optimizer in MSVC/Visual Studio versions below 16.4 has trouble with this
+// function on Windows ARM64. As a work-around, we disable optimizations for this function.
+// This work-around could/should be removed once the following versions of Visual Studio are no
+// longer supported: All versions of VS2017, and versions of VS2019 below 16.4.
+#if (defined(_MSC_VER) && (defined(_M_ARM64)) && (_MSC_VER < 1924))
+#pragma optimize( "", off )
+#endif
 // Gets the FCD value from the regular normalization data.
 uint16_t Normalizer2Impl::getFCD16FromNormData(UChar32 c) const {
     uint16_t norm16=getNorm16(c);
@@ -2121,6 +2128,9 @@ uint16_t Normalizer2Impl::getFCD16FromNormData(UChar32 c) const {
     }
     return norm16;
 }
+#if (defined(_MSC_VER) && (defined(_M_ARM64)) && (_MSC_VER < 1924))
+#pragma optimize( "", on )
+#endif
 
 // Dual functionality:
 // buffer!=NULL: normalize

--- a/icu4c/source/common/ubidiwrt.cpp
+++ b/icu4c/source/common/ubidiwrt.cpp
@@ -346,6 +346,13 @@ ubidi_writeReverse(const UChar *src, int32_t srcLength,
     return u_terminateUChars(dest, destSize, destLength, pErrorCode);
 }
 
+// Ticket 20907 - The optimizer in MSVC/Visual Studio versions below 16.4 has trouble with this
+// function on Windows ARM64. As a work-around, we disable optimizations for this function.
+// This work-around could/should be removed once the following versions of Visual Studio are no
+// longer supported: All versions of VS2017, and versions of VS2019 below 16.4.
+#if (defined(_MSC_VER) && (defined(_M_ARM64)) && (_MSC_VER < 1924))
+#pragma optimize( "", off )
+#endif
 U_CAPI int32_t U_EXPORT2
 ubidi_writeReordered(UBiDi *pBiDi,
                      UChar *dest, int32_t destSize,
@@ -638,3 +645,6 @@ ubidi_writeReordered(UBiDi *pBiDi,
 
     return u_terminateUChars(saveDest, destCapacity, destCapacity-destSize, pErrorCode);
 }
+#if (defined(_MSC_VER) && (defined(_M_ARM64)) && (_MSC_VER < 1924))
+#pragma optimize( "", on )
+#endif


### PR DESCRIPTION
The Visual Studio/MSVC optimizer has trouble with these functions when building for Windows ARM64 on versions below 16.4.
(Thanks to @marswe for help with this issue!)

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20907
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

