### PR TITLE
ICU-20877 i18n: Don't use C++11 math

### DIFF
--- a/icu4c/source/i18n/decimfmt.cpp
+++ b/icu4c/source/i18n/decimfmt.cpp
@@ -1801,7 +1801,7 @@ bool DecimalFormat::fastFormatDouble(double input, UnicodeString& output) const 
         return false;
     }
     if (std::isnan(input)
-            || std::trunc(input) != input
+            || uprv_trunc(input) != input
             || input <= INT32_MIN
             || input > INT32_MAX) {
         return false;

--- a/icu4c/source/i18n/number_decimalquantity.cpp
+++ b/icu4c/source/i18n/number_decimalquantity.cpp
@@ -456,7 +456,7 @@ void DecimalQuantity::_setToDoubleFast(double n) {
         for (; i <= -22; i += 22) n /= 1e22;
         n /= DOUBLE_MULTIPLIERS[-i];
     }
-    auto result = static_cast<int64_t>(std::round(n));
+    auto result = static_cast<int64_t>(uprv_round(n));
     if (result != 0) {
         _setToLong(result);
         scale -= fracLength;


### PR DESCRIPTION
It's not available with some libc implementations. Specifically,
BIONIC and uClibc-ng. uprv_ variants are available.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20877
- [x] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

