### PR TITLE
ICU-20917 LocaleMatcher: prefer a more-default locale

### DIFF
--- a/icu4c/source/common/locdistance.h
+++ b/icu4c/source/common/locdistance.h
@@ -82,7 +82,7 @@ private:
         return (indexAndDistance & DISTANCE_MASK) >> DISTANCE_SHIFT;
     }
 
-    LocaleDistance(const LocaleDistanceData &data);
+    LocaleDistance(const LocaleDistanceData &data, const XLikelySubtags &likely);
     LocaleDistance(const LocaleDistance &other) = delete;
     LocaleDistance &operator=(const LocaleDistance &other) = delete;
 
@@ -109,6 +109,8 @@ private:
     int32_t getDefaultRegionDistance() const {
         return defaultRegionDistance;
     }
+
+    const XLikelySubtags &likelySubtags;
 
     // The trie maps each dlang+slang+dscript+sscript+dregion+sregion
     // (encoded in ASCII with bit 7 set on the last character of each subtag) to a distance.

--- a/icu4c/source/common/loclikelysubtags.h
+++ b/icu4c/source/common/loclikelysubtags.h
@@ -85,6 +85,18 @@ public:
     // VisibleForTesting
     LSR makeMaximizedLsrFrom(const Locale &locale, UErrorCode &errorCode) const;
 
+    /**
+     * Tests whether lsr is "more likely" than other.
+     * For example, fr-Latn-FR is more likely than fr-Latn-CH because
+     * FR is the default region for fr-Latn.
+     *
+     * The likelyInfo caches lookup information between calls.
+     * The return value is an updated likelyInfo value,
+     * with bit 0 set if lsr is "more likely".
+     * The initial value of likelyInfo must be negative.
+     */
+    int32_t compareLikely(const LSR &lsr, const LSR &other, int32_t likelyInfo) const;
+
     // TODO(ICU-20777): Switch Locale/uloc_ likely-subtags API from the old code
     // in loclikely.cpp to this new code, including activating this
     // minimizeSubtags() function. The LocaleMatcher does not minimize.
@@ -110,6 +122,8 @@ private:
      * Raw access to addLikelySubtags. Input must be in canonical format, eg "en", not "eng" or "EN".
      */
     LSR maximize(const char *language, const char *script, const char *region) const;
+
+    int32_t getLikelyIndex(const char *language, const char *script) const;
 
     static int32_t trieNext(BytesTrie &iter, const char *s, int32_t i);
 

--- a/icu4c/source/test/testdata/localeMatcherTest.txt
+++ b/icu4c/source/test/testdata/localeMatcherTest.txt
@@ -733,7 +733,7 @@ ja >> fr
 @favor=script
 en-GB >> en-GB
 en-US >> en
-fr >> en-GB
+fr >> en
 ja >> fr
 
 ** test: testEmptyWithDefault
@@ -761,8 +761,8 @@ en-GB >> en-GB
 en-US >> en
 fr-FR >> fr
 ja-JP >> fr
+zu >> en
 # For a language that doesn't match anything, return the default.
-zu >> en-GB
 zxx >> fr
 
 @favor=script
@@ -770,7 +770,7 @@ en-GB >> en-GB
 en-US >> en
 fr-FR >> fr
 ja-JP >> fr
-zu >> en-GB
+zu >> en
 zxx >> en
 
 ** test: TestExactMatch
@@ -1322,7 +1322,7 @@ en >> en-US
 @favor=script
 und >> und
 ja >> und
-fr-CA >> en-GB
+fr-CA >> en-US
 en-AU >> en-GB
 en-BZ >> en-GB
 en-CA >> en-GB
@@ -1359,8 +1359,8 @@ fr >> und
 @supported=en-GB, en-US, en, en-AU
 und >> und
 ja >> und
-fr-CA >> en-GB
-fr >> en-GB
+fr-CA >> en-US
+fr >> en-US
 @supported=en-AU, ja, ca
 fr >> en-AU
 @supported=pl, ja, ca
@@ -1901,7 +1901,7 @@ fr-FR >> fr # Parent match is chosen.
 fr-FR >> fr-CA # Sibling match is chosen.
 @supported=fr-CA, fr-FR
 fr >> fr-FR # Inferred region match is chosen.
-fr-SN >> fr-CA
+fr-SN >> fr-FR
 @supported=en, fr-FR
 fr >> fr-FR # Child match is chosen.
 @supported=de, en, it
@@ -1931,7 +1931,7 @@ fr-FR >> fr
 fr-FR >> fr-CA
 @supported=fr-CA, fr-FR
 fr >> fr-FR
-fr-SN >> fr-CA
+fr-SN >> fr-FR
 @supported=en, fr-FR
 fr >> fr-FR
 @supported=de, en, it
@@ -1951,3 +1951,10 @@ ru >> uk
 zh-CN >> zh-TW
 @supported=ja
 ru >> und
+
+** test: favor a more-default locale among equally imperfect matches
+@supported=fr-CA, fr-CH, fr-FR, fr-GB
+fr-SN >> fr-FR
+@supported=sr-Latn, sr-Cyrl, sr-Grek
+@threshold=60
+sr-Thai >> sr-Cyrl

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/data/localeMatcherTest.txt
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/data/localeMatcherTest.txt
@@ -733,7 +733,7 @@ ja >> fr
 @favor=script
 en-GB >> en-GB
 en-US >> en
-fr >> en-GB
+fr >> en
 ja >> fr
 
 ** test: testEmptyWithDefault
@@ -761,8 +761,8 @@ en-GB >> en-GB
 en-US >> en
 fr-FR >> fr
 ja-JP >> fr
+zu >> en
 # For a language that doesn't match anything, return the default.
-zu >> en-GB
 zxx >> fr
 
 @favor=script
@@ -770,7 +770,7 @@ en-GB >> en-GB
 en-US >> en
 fr-FR >> fr
 ja-JP >> fr
-zu >> en-GB
+zu >> en
 zxx >> en
 
 ** test: TestExactMatch
@@ -1322,7 +1322,7 @@ en >> en-US
 @favor=script
 und >> und
 ja >> und
-fr-CA >> en-GB
+fr-CA >> en-US
 en-AU >> en-GB
 en-BZ >> en-GB
 en-CA >> en-GB
@@ -1359,8 +1359,8 @@ fr >> und
 @supported=en-GB, en-US, en, en-AU
 und >> und
 ja >> und
-fr-CA >> en-GB
-fr >> en-GB
+fr-CA >> en-US
+fr >> en-US
 @supported=en-AU, ja, ca
 fr >> en-AU
 @supported=pl, ja, ca
@@ -1901,7 +1901,7 @@ fr-FR >> fr # Parent match is chosen.
 fr-FR >> fr-CA # Sibling match is chosen.
 @supported=fr-CA, fr-FR
 fr >> fr-FR # Inferred region match is chosen.
-fr-SN >> fr-CA
+fr-SN >> fr-FR
 @supported=en, fr-FR
 fr >> fr-FR # Child match is chosen.
 @supported=de, en, it
@@ -1931,7 +1931,7 @@ fr-FR >> fr
 fr-FR >> fr-CA
 @supported=fr-CA, fr-FR
 fr >> fr-FR
-fr-SN >> fr-CA
+fr-SN >> fr-FR
 @supported=en, fr-FR
 fr >> fr-FR
 @supported=de, en, it
@@ -1951,3 +1951,10 @@ ru >> uk
 zh-CN >> zh-TW
 @supported=ja
 ru >> und
+
+** test: favor a more-default locale among equally imperfect matches
+@supported=fr-CA, fr-CH, fr-FR, fr-GB
+fr-SN >> fr-FR
+@supported=sr-Latn, sr-Cyrl, sr-Grek
+@threshold=60
+sr-Thai >> sr-Cyrl


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-20917

Compares two supported locales that match equally well but not perfectly. Favors the one which has more-default subtags.

I had thought about another approach: Doing a more complicated addLikelySubtags lookup, keeping information in the LSR about how close it is to the default, and scoring on that. However, that seemed tricky, would slow down all addLikelySubtags processing -- and we only want to distinguish between two supported locales, so we need not tweak the match distance between desired and supported.