### PR TITLE
ICU-20928 Fix incorrect javadoc reference in DecimalFormatProperties

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/DecimalFormatProperties.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/DecimalFormatProperties.java
@@ -65,7 +65,7 @@ public class DecimalFormatProperties implements Cloneable, Serializable {
         /**
          * Internal parse mode for increased compatibility with java.text.DecimalFormat.
          * Used by Android libcore. To enable this feature, java.text.DecimalFormat holds an instance of
-         * ICU4J's DecimalFormat and enable it by calling setParseStrictMode(ParseMode.COMPATIBILITY).
+         * ICU4J's DecimalFormat and enable it by calling setParseStrictMode(ParseMode.JAVA_COMPATIBILITY).
          */
         JAVA_COMPATIBILITY,
     }


### PR DESCRIPTION
ParseMode.COMPATIBILITY was eventually renamed to
ParseMode.JAVA_COMPATIBILITY but it's javadoc was not updated.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20928
- [x] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [x] Documentation is changed or added

