### PR TITLE
ICU-20929 Fix unused constants in double-conversion-strtod.cpp

### DIFF
--- a/icu4c/source/i18n/double-conversion-strtod.cpp
+++ b/icu4c/source/i18n/double-conversion-strtod.cpp
@@ -49,10 +49,6 @@ U_NAMESPACE_BEGIN
 
 namespace double_conversion {
 
-// 2^53 = 9007199254740992.
-// Any integer with at most 15 decimal digits will hence fit into a double
-// (which has a 53bit significand) without loss of precision.
-static const int kMaxExactDoubleIntegerDecimalDigits = 15;
 // 2^64 = 18446744073709551616 > 10^19
 static const int kMaxUint64DecimalDigits = 19;
 
@@ -68,6 +64,12 @@ static const int kMinDecimalPower = -324;
 // 2^64 = 18446744073709551616
 static const uint64_t kMaxUint64 = DOUBLE_CONVERSION_UINT64_2PART_C(0xFFFFFFFF, FFFFFFFF);
 
+#if defined(DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS)
+
+// 2^53 = 9007199254740992.
+// Any integer with at most 15 decimal digits will hence fit into a double
+// (which has a 53bit significand) without loss of precision.
+static const int kMaxExactDoubleIntegerDecimalDigits = 15;
 
 static const double exact_powers_of_ten[] = {
   1.0,  // 10^0
@@ -96,6 +98,8 @@ static const double exact_powers_of_ten[] = {
   10000000000000000000000.0
 };
 static const int kExactPowersOfTenSize = DOUBLE_CONVERSION_ARRAY_SIZE(exact_powers_of_ten);
+
+#endif // #if defined(DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS)
 
 // Maximum number of significant digits in the decimal representation.
 // In fact the value is 772 (see conversions.cc), but to give us some margin


### PR DESCRIPTION
Wrap conditionally-used constant declarations so they are also defined only when they will be used to prevent compile error with `-Wall`enabled:

```
external/icu/icu4c/source/i18n/double-conversion-strtod.cpp:55:18: error: unused variable 'kMaxExactDoubleIntegerDecimalDigits' [-Werror,-Wunused-const-variable]
static const int kMaxExactDoubleIntegerDecimalDigits = 15;

external/icu/icu4c/source/i18n/double-conversion-strtod.cpp:72:21: error: variable 'exact_powers_of_ten' is not needed and will not be emitted [-Werror,-Wunneeded-internal-declaration]
static const double exact_powers_of_ten[] = {

external/icu/icu4c/source/i18n/double-conversion-strtod.cpp:98:18: error: unused variable 'kExactPowersOfTenSize' [-Werror,-Wunused-const-variable]
static const int kExactPowersOfTenSize = DOUBLE_CONVERSION_ARRAY_SIZE(exact_powers_of_ten);
```

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20929
- [x] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

