### PR TITLE
ICU-20931 Fixes uloc_acceptLanguage fallback

### DIFF
--- a/icu4c/source/common/uloc.cpp
+++ b/icu4c/source/common/uloc.cpp
@@ -2371,7 +2371,7 @@ uloc_acceptLanguage(char *result, int32_t resultAvailable,
         }
     }
 
-    for(maxLen--;maxLen>0;maxLen--) {
+    for(;maxLen>0;maxLen--) {
         for(i=0;i<acceptListCount;i++) {
             if(fallbackList[i] && ((int32_t)uprv_strlen(fallbackList[i])==maxLen)) {
 #if defined(ULOC_DEBUG)

--- a/icu4c/source/test/cintltst/cloctst.h
+++ b/icu4c/source/test/cintltst/cloctst.h
@@ -114,8 +114,8 @@ static void TestCollation(void);
 static void TestULocale(void);
 static void TestUResourceBundle(void);
 static void TestDisplayName(void);
-
 static void TestAcceptLanguage(void);
+static void TestAcceptLanguageLimited(void);
 
 static void TestOrientation(void);
 


### PR DESCRIPTION
uloc_acceptLanguage fallback computation will never attempt
to find a fallback if the list of available locales only contains
2-letter locales.

For example, for available locales {"fr", "es", "de"} and accept list
of {"es_MX", "nl", "ar_EG"}, no match would be found. But the call
should find "es".

This change fixes fallback computation and adds a regression test.

`TestAcceptLanguage` did not catch this bug because it always used all available locales, many
of which have IDs longer than 2 bytes.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20931
- [X] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [X] Tests included
- [ ] Documentation is changed or added

