### PR TITLE
ICU-20934 Fix TZ test error

### DIFF
--- a/icu4c/source/test/intltest/tztest.cpp
+++ b/icu4c/source/test/intltest/tztest.cpp
@@ -860,7 +860,9 @@ void TimeZoneTest::TestShortZoneIDs()
         {"PRT", -240, FALSE}, // ICU Link - America/Puerto_Rico
         {"CNT", -210, TRUE},  // ICU Link - America/St_Johns
         {"AGT", -180, FALSE}, // ICU Link - America/Argentina/Buenos_Aires
-        {"BET", -180, TRUE},  // ICU Link - America/Sao_Paulo
+        // Per https://mm.icann.org/pipermail/tz-announce/2019-July/000056.html
+        //      Brazil has canceled DST and will stay on standard time indefinitely.
+        {"BET", -180, FALSE},  // ICU Link - America/Sao_Paulo
         {"GMT", 0, FALSE},    // Olson etcetera Link - Etc/GMT
         {"UTC", 0, FALSE},    // Olson etcetera 0
         {"ECT", 60, TRUE},    // ICU Link - Europe/Paris
@@ -2251,8 +2253,11 @@ static struct   {
        
       {"America/Sao_Paulo",  "en", FALSE, TimeZone::SHORT, "GMT-3"/*"BRT"*/},
       {"America/Sao_Paulo",  "en", FALSE, TimeZone::LONG,  "Brasilia Standard Time"},
-      {"America/Sao_Paulo",  "en", TRUE,  TimeZone::SHORT, "GMT-2"/*"BRST"*/},
-      {"America/Sao_Paulo",  "en", TRUE,  TimeZone::LONG,  "Brasilia Summer Time"},
+
+      // Per https://mm.icann.org/pipermail/tz-announce/2019-July/000056.html
+      //      Brazil has canceled DST and will stay on standard time indefinitely.
+      // {"America/Sao_Paulo",  "en", TRUE,  TimeZone::SHORT, "GMT-2"/*"BRST"*/},
+      // {"America/Sao_Paulo",  "en", TRUE,  TimeZone::LONG,  "Brasilia Summer Time"},
        
       // No Summer Time, but had it before 1983.
       {"Pacific/Honolulu",   "en", FALSE, TimeZone::SHORT, "HST"},

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/timezone/TimeZoneTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/timezone/TimeZoneTest.java
@@ -151,7 +151,9 @@ public class TimeZoneTest extends TestFmwk
             new ZoneDescriptor("PRT", -240, false), // ICU Link - America/Puerto_Rico
             new ZoneDescriptor("CNT", -210, true),  // ICU Link - America/St_Johns
             new ZoneDescriptor("AGT", -180, false), // ICU Link - America/Argentina/Buenos_Aires
-            new ZoneDescriptor("BET", -180, true),  // ICU Link - America/Sao_Paulo
+            // Per https://mm.icann.org/pipermail/tz-announce/2019-July/000056.html
+            // Brazil has canceled DST and will stay on standard time indefinitely.
+            new ZoneDescriptor("BET", -180, false),  // ICU Link - America/Sao_Paulo
             new ZoneDescriptor("GMT", 0, false),    // Olson etcetera Link - Etc/GMT
             new ZoneDescriptor("UTC", 0, false),    // Olson etcetera 0
             new ZoneDescriptor("ECT", 60, true),    // ICU Link - Europe/Paris
@@ -1783,8 +1785,10 @@ public class TimeZoneTest extends TestFmwk
 
             {"America/Sao_Paulo",   "en",   Boolean.FALSE,  TZSHORT,    "GMT-3"/*"BRT"*/},
             {"America/Sao_Paulo",   "en",   Boolean.FALSE,  TZLONG,     "Brasilia Standard Time"},
-            {"America/Sao_Paulo",   "en",   Boolean.TRUE,   TZSHORT,    "GMT-2"/*"BRST"*/},
-            {"America/Sao_Paulo",   "en",   Boolean.TRUE,   TZLONG,     "Brasilia Summer Time"},
+            // Per https://mm.icann.org/pipermail/tz-announce/2019-July/000056.html
+            // Brazil has canceled DST and will stay on standard time indefinitely.
+            // {"America/Sao_Paulo",   "en",   Boolean.TRUE,   TZSHORT,    "GMT-2"/*"BRST"*/},
+            // {"America/Sao_Paulo",   "en",   Boolean.TRUE,   TZLONG,     "Brasilia Summer Time"},
 
             // No Summer Time, but had it before 1983.
             {"Pacific/Honolulu",    "en",   Boolean.FALSE,  TZSHORT,    "HST"},


### PR DESCRIPTION
Somehow these tests are now fail on trunks.
Per https://mm.icann.org/pipermail/tz-announce/2019-July/000056.html
     Brazil has canceled DST and will stay on standard time indefinitely.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20934
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [X] Tests included
- [X] Documentation is changed or added

