### PR TITLE
Update ufile.cpp

### DIFF
--- a/icu4c/source/io/ufile.cpp
+++ b/icu4c/source/io/ufile.cpp
@@ -151,9 +151,7 @@ u_fopen_u(const UChar   *filename,
     UFILE     *result;
 #if !U_PLATFORM_USES_ONLY_WIN32_API
     char buffer[256];
-
     u_austrcpy(buffer, filename);
-
     result = u_fopen(buffer, perm, locale, codepage);
 #else
     /* When Windows API is available, use Windows API _wfopen instead. */

--- a/icu4c/source/io/ufile.cpp
+++ b/icu4c/source/io/ufile.cpp
@@ -149,11 +149,11 @@ u_fopen_u(const UChar   *filename,
         const char    *codepage)
 {
     UFILE     *result;
+#if !U_PLATFORM_USES_ONLY_WIN32_API
     char buffer[256];
 
     u_austrcpy(buffer, filename);
 
-#if !U_PLATFORM_USES_ONLY_WIN32_API
     result = u_fopen(buffer, perm, locale, codepage);
 #else
     /* When Windows API is available, use Windows API _wfopen instead. */

--- a/icu4c/source/io/ufile.cpp
+++ b/icu4c/source/io/ufile.cpp
@@ -153,10 +153,14 @@ u_fopen_u(const UChar   *filename,
 
     u_austrcpy(buffer, filename);
 
+#if !U_PLATFORM_USES_ONLY_WIN32_API
     result = u_fopen(buffer, perm, locale, codepage);
-#if U_PLATFORM_USES_ONLY_WIN32_API
-    /* Try Windows API _wfopen if the above fails. */
-    if (!result) {
+#else
+    /* When Windows API is available, use Windows API _wfopen instead. */
+    /* Don't expect u_fopen to fail, because */
+    /* it might cause a mojibaked file name without a fail */
+    /* when perm contains "w" or "a". */
+    {
         // TODO: test this code path, including wperm.
         wchar_t wperm[40] = {};
         size_t  retVal;


### PR DESCRIPTION
When Windows API is available, use Windows API _wfopen instead.
Don't expect u_fopen to fail, because it might cause a mojibaked file name without a fail when perm contains "w" or "a".

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

