### PR TITLE
ICU-10858 Fix missing fTimeZoneFormat assignment in SimpleDateFormat::operator=

### DIFF
--- a/icu4c/source/i18n/smpdtfmt.cpp
+++ b/icu4c/source/i18n/smpdtfmt.cpp
@@ -583,11 +583,14 @@ SimpleDateFormat& SimpleDateFormat::operator=(const SimpleDateFormat& other)
     fHasMinute = other.fHasMinute;
     fHasSecond = other.fHasSecond;
 
-    // TimeZoneFormat in ICU4C only depends on a locale for now
-    if (fLocale != other.fLocale) {
-        delete fTimeZoneFormat;
-        fTimeZoneFormat = NULL; // forces lazy instantiation with the other locale
-        fLocale = other.fLocale;
+    fLocale = other.fLocale;
+
+    // TimeZoneFormat can now be set independently via setter.
+    // If it is NULL, it will be lazily initialized from locale
+    delete fTimeZoneFormat;
+    fTimeZoneFormat = NULL;
+    if (other.fTimeZoneFormat) {
+        fTimeZoneFormat = new TimeZoneFormat(*other.fTimeZoneFormat);
     }
 
 #if !UCONFIG_NO_BREAK_ITERATION

--- a/icu4c/source/test/intltest/dtfmrgts.h
+++ b/icu4c/source/test/intltest/dtfmrgts.h
@@ -59,6 +59,7 @@ public:
     void TestT10334(void);
     void TestT10619(void);
     void TestT10855(void);
+    void TestT10858(void);
     void TestT10906(void);
     void TestT13380(void);
  };


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-10858
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [x] Documentation is changed or added

Notes to reviewer:
This PR fixes the SimpleDateFormat::operator= issue described in ICU-10858 with corresponding regression unit test. This does _not_ address SimpleDateFormat's equality operator nor the number bear formats overrides described in the ticket.

Please kindly advise on the following:
* since this only covers part of ICU-10858, what is the recommended tracking practice? Is it still appropriate to attach this PR to ICU-10858, or a new ticket is required?

* unit test is added to "icu4c/source/test/intltest/dtfmrgts.cpp". Is this the recommended location to validate this behavior?

Thanks,
Campion
