### PR TITLE
ICU-20942 ICU-20934 Update Apache Ivy to 2.5.0, cherry-pick Brazil DST change into ICU 66

### DIFF
--- a/icu4c/source/test/intltest/tztest.cpp
+++ b/icu4c/source/test/intltest/tztest.cpp
@@ -860,7 +860,9 @@ void TimeZoneTest::TestShortZoneIDs()
         {"PRT", -240, FALSE}, // ICU Link - America/Puerto_Rico
         {"CNT", -210, TRUE},  // ICU Link - America/St_Johns
         {"AGT", -180, FALSE}, // ICU Link - America/Argentina/Buenos_Aires
-        {"BET", -180, TRUE},  // ICU Link - America/Sao_Paulo
+        // Per https://mm.icann.org/pipermail/tz-announce/2019-July/000056.html
+        //      Brazil has canceled DST and will stay on standard time indefinitely.
+        {"BET", -180, FALSE},  // ICU Link - America/Sao_Paulo
         {"GMT", 0, FALSE},    // Olson etcetera Link - Etc/GMT
         {"UTC", 0, FALSE},    // Olson etcetera 0
         {"ECT", 60, TRUE},    // ICU Link - Europe/Paris
@@ -2251,8 +2253,11 @@ static struct   {
        
       {"America/Sao_Paulo",  "en", FALSE, TimeZone::SHORT, "GMT-3"/*"BRT"*/},
       {"America/Sao_Paulo",  "en", FALSE, TimeZone::LONG,  "Brasilia Standard Time"},
-      {"America/Sao_Paulo",  "en", TRUE,  TimeZone::SHORT, "GMT-2"/*"BRST"*/},
-      {"America/Sao_Paulo",  "en", TRUE,  TimeZone::LONG,  "Brasilia Summer Time"},
+
+      // Per https://mm.icann.org/pipermail/tz-announce/2019-July/000056.html
+      //      Brazil has canceled DST and will stay on standard time indefinitely.
+      // {"America/Sao_Paulo",  "en", TRUE,  TimeZone::SHORT, "GMT-2"/*"BRST"*/},
+      // {"America/Sao_Paulo",  "en", TRUE,  TimeZone::LONG,  "Brasilia Summer Time"},
        
       // No Summer Time, but had it before 1983.
       {"Pacific/Honolulu",   "en", FALSE, TimeZone::SHORT, "HST"},

--- a/icu4j/build.xml
+++ b/icu4j/build.xml
@@ -197,7 +197,7 @@
     </target>
 
     <!-- Ivy Targets -->
-    <property name="ivy.install.version" value="2.1.0-rc2" />
+    <property name="ivy.install.version" value="2.5.0" />
     <condition property="ivy.home" value="${env.IVY_HOME}">
         <isset property="env.IVY_HOME" />
     </condition>

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/timezone/TimeZoneTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/timezone/TimeZoneTest.java
@@ -151,7 +151,9 @@ public class TimeZoneTest extends TestFmwk
             new ZoneDescriptor("PRT", -240, false), // ICU Link - America/Puerto_Rico
             new ZoneDescriptor("CNT", -210, true),  // ICU Link - America/St_Johns
             new ZoneDescriptor("AGT", -180, false), // ICU Link - America/Argentina/Buenos_Aires
-            new ZoneDescriptor("BET", -180, true),  // ICU Link - America/Sao_Paulo
+            // Per https://mm.icann.org/pipermail/tz-announce/2019-July/000056.html
+            // Brazil has canceled DST and will stay on standard time indefinitely.
+            new ZoneDescriptor("BET", -180, false),  // ICU Link - America/Sao_Paulo
             new ZoneDescriptor("GMT", 0, false),    // Olson etcetera Link - Etc/GMT
             new ZoneDescriptor("UTC", 0, false),    // Olson etcetera 0
             new ZoneDescriptor("ECT", 60, true),    // ICU Link - Europe/Paris
@@ -1783,8 +1785,10 @@ public class TimeZoneTest extends TestFmwk
 
             {"America/Sao_Paulo",   "en",   Boolean.FALSE,  TZSHORT,    "GMT-3"/*"BRT"*/},
             {"America/Sao_Paulo",   "en",   Boolean.FALSE,  TZLONG,     "Brasilia Standard Time"},
-            {"America/Sao_Paulo",   "en",   Boolean.TRUE,   TZSHORT,    "GMT-2"/*"BRST"*/},
-            {"America/Sao_Paulo",   "en",   Boolean.TRUE,   TZLONG,     "Brasilia Summer Time"},
+            // Per https://mm.icann.org/pipermail/tz-announce/2019-July/000056.html
+            // Brazil has canceled DST and will stay on standard time indefinitely.
+            // {"America/Sao_Paulo",   "en",   Boolean.TRUE,   TZSHORT,    "GMT-2"/*"BRST"*/},
+            // {"America/Sao_Paulo",   "en",   Boolean.TRUE,   TZLONG,     "Brasilia Summer Time"},
 
             // No Summer Time, but had it before 1983.
             {"Pacific/Honolulu",    "en",   Boolean.FALSE,  TZSHORT,    "HST"},


### PR DESCRIPTION
Note: This PR is into the `maint/maint-66` branch.

This PR contains two commits:
- Fix the failing ICU4J build by bumping Apache Ivy to 2.5.0
- Cherry-picking #959 (Brazil TZ change) into ICU 66.

For the first commit:
It looks like Apache Ivy is trying to use HTTP to download `junit` -- but the Maven repo seems to only supports HTTPS. This change bumps the old version of Apache Ivy from 2.1.0-rc2 (released on Jul 23, 2009) to 2.5.0 (the most recent stable version, released Oct 20, 2019).
I'll create another PR to cherry-pick this single commit into `master` once this is merged.

For the second commit:
This is cherry-picked from 11ad8d69fb4c70e529c592d37df5a30c925b6af4 (PR #959).

### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20942
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

ALLOW_MANY_COMMITS=true
DISABLE_JIRA_ISSUE_MATCH=true