### PR TITLE
ICU-20938 Add --skip-dll-export option to genccode to prevent exporti…

### DIFF
--- a/icu4c/source/tools/genccode/genccode.c
+++ b/icu4c/source/tools/genccode/genccode.c
@@ -69,6 +69,7 @@ enum {
 #ifdef CAN_GENERATE_OBJECTS
   kOptObject,
   kOptMatchArch,
+  kOptSkipDllExport,
 #endif
   kOptFilename,
   kOptAssembly
@@ -82,8 +83,9 @@ static UOption options[]={
      UOPTION_DEF("name", 'n', UOPT_REQUIRES_ARG),
      UOPTION_DEF("entrypoint", 'e', UOPT_REQUIRES_ARG),
 #ifdef CAN_GENERATE_OBJECTS
-/*5*/UOPTION_DEF("object", 'o', UOPT_NO_ARG),
+/*6*/UOPTION_DEF("object", 'o', UOPT_NO_ARG),
      UOPTION_DEF("match-arch", 'm', UOPT_REQUIRES_ARG),
+     UOPTION_DEF("skip-dll-export", '\0', UOPT_NO_ARG),
 #endif
      UOPTION_DEF("filename", 'f', UOPT_REQUIRES_ARG),
      UOPTION_DEF("assembly", 'a', UOPT_REQUIRES_ARG)
@@ -127,7 +129,8 @@ main(int argc, char* argv[]) {
         fprintf(stderr,
             "\t-o or --object      write a .obj file instead of .c\n"
             "\t-m or --match-arch file.o  match the architecture (CPU, 32/64 bits) of the specified .o\n"
-            "\t                    ELF format defaults to i386. Windows defaults to the native platform.\n");
+            "\t                    ELF format defaults to i386. Windows defaults to the native platform.\n"
+            "\t--skip-dll-export   Don't export the ICU data entry point symbol (for use when statically linking)\n");
 #endif
         fprintf(stderr,
             "\t-f or --filename    Specify an alternate base filename. (default: symbolname_typ)\n"
@@ -193,7 +196,8 @@ main(int argc, char* argv[]) {
                                 options[kOptMatchArch].doesOccur ? options[kOptMatchArch].value : NULL,
                                 options[kOptFilename].doesOccur ? options[kOptFilename].value : NULL,
                                 NULL,
-                                0);
+                                0,
+                                !options[kOptSkipDllExport].doesOccur);
                 break;
 #endif
             default:

--- a/icu4c/source/tools/pkgdata/pkgdata.cpp
+++ b/icu4c/source/tools/pkgdata/pkgdata.cpp
@@ -775,7 +775,8 @@ static int32_t pkg_executeOptions(UPKGOptions *o) {
                         (optMatchArch[0] == 0 ? NULL : optMatchArch),
                         NULL,
                         gencFilePath,
-                        sizeof(gencFilePath));
+                        sizeof(gencFilePath),
+                        TRUE);
                     pkg_destroyOptMatchArch(optMatchArch);
 #if U_PLATFORM_IS_LINUX_BASED
                     result = pkg_generateLibraryFile(targetDir, mode, gencFilePath);

--- a/icu4c/source/tools/toolutil/pkg_genc.cpp
+++ b/icu4c/source/tools/toolutil/pkg_genc.cpp
@@ -878,7 +878,8 @@ writeObjectCode(
         const char *optMatchArch,
         const char *optFilename,
         char *outFilePath,
-        size_t outFilePathCapacity) {
+        size_t outFilePathCapacity,
+        UBool optWinDllExport) {
     /* common variables */
     char buffer[4096], entry[96]={ 0 };
     FileStream *in, *out;
@@ -887,6 +888,8 @@ writeObjectCode(
 
     uint16_t cpu, bits;
     UBool makeBigEndian;
+
+    (void)optWinDllExport; /* unused except Windows */
 
     /* platform-specific variables and initialization code */
 #ifdef U_ELF
@@ -1254,12 +1257,17 @@ writeObjectCode(
     uprv_memset(&symbolNames, 0, sizeof(symbolNames));
 
     /* write the linker export directive */
-    uprv_strcpy(objHeader.linkerOptions, "-export:");
-    length=8;
-    uprv_strcpy(objHeader.linkerOptions+length, entry);
-    length+=entryLength;
-    uprv_strcpy(objHeader.linkerOptions+length, ",data ");
-    length+=6;
+    if (optWinDllExport) {
+        uprv_strcpy(objHeader.linkerOptions, "-export:");
+        length=8;
+        uprv_strcpy(objHeader.linkerOptions+length, entry);
+        length+=entryLength;
+        uprv_strcpy(objHeader.linkerOptions+length, ",data ");
+        length+=6;
+    }
+    else {
+        length=0;
+    }
 
     /* set the file header */
     objHeader.fileHeader.Machine=cpu;

--- a/icu4c/source/tools/toolutil/pkg_genc.h
+++ b/icu4c/source/tools/toolutil/pkg_genc.h
@@ -100,6 +100,7 @@ writeObjectCode(
     const char *optMatchArch,
     const char *optFilename,
     char *outFilePath,
-    size_t outFilePathCapacity);
+    size_t outFilePathCapacity,
+    UBool optWinDllExport);
 
 #endif


### PR DESCRIPTION
…ng statically linked ICU data from executables.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20938
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

