### PR TITLE
ICU-20953 Tell GitHub to use JSONC to fix syntax highlighting for comments

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -84,3 +84,7 @@ configure text !eol
 
 # Enable syntax highlighting on GitHub.com
 .cpyskip.txt linguist-language=Ignore-List
+
+# Use JSONC for syntax highlighting on GitHub.com
+*.json linguist-language=jsonc
+


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20953
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

### Description:
This change informs GitHub to use the "JSONC" format for JSON files when syntax highlighting, in order to better handle comments in JSON files.
(Note: There should be no "real" impact here other than fixing the syntax highlighting.)

#### Before:
![image](https://user-images.githubusercontent.com/29107334/73388535-45f62980-4287-11ea-8ef4-6fb1fd2de223.png)

#### After:
![image](https://user-images.githubusercontent.com/29107334/73388571-56a69f80-4287-11ea-8ccf-edeb73d84eb4.png)
