### PR TITLE
ICU-20954 Fix currency spacing in suffix.

### DIFF
--- a/icu4c/source/i18n/number_modifiers.cpp
+++ b/icu4c/source/i18n/number_modifiers.cpp
@@ -358,7 +358,7 @@ CurrencySpacingEnabledModifier::CurrencySpacingEnabledModifier(const FormattedSt
         fAfterPrefixInsert.setToBogus();
     }
     if (suffix.length() > 0 && suffix.fieldAt(0) == Field(UFIELD_CATEGORY_NUMBER, UNUM_CURRENCY_FIELD)) {
-        int suffixCp = suffix.getLastCodePoint();
+        int suffixCp = suffix.getFirstCodePoint();
         UnicodeSet suffixUnicodeSet = getUnicodeSet(symbols, IN_CURRENCY, SUFFIX, status);
         if (suffixUnicodeSet.contains(suffixCp)) {
             fBeforeSuffixUnicodeSet = getUnicodeSet(symbols, IN_NUMBER, SUFFIX, status);

--- a/icu4c/source/test/intltest/numbertest.h
+++ b/icu4c/source/test/intltest/numbertest.h
@@ -95,6 +95,7 @@ class NumberFormatterApiTest : public IntlTestWithFieldPosition {
     CurrencyUnit ESP;
     CurrencyUnit PTE;
     CurrencyUnit RON;
+    CurrencyUnit CNY;
 
     MeasureUnit METER;
     MeasureUnit DAY;

--- a/icu4c/source/test/intltest/numbertest_api.cpp
+++ b/icu4c/source/test/intltest/numbertest_api.cpp
@@ -33,6 +33,7 @@ NumberFormatterApiTest::NumberFormatterApiTest(UErrorCode& status)
           ESP(u"ESP", status),
           PTE(u"PTE", status),
           RON(u"RON", status),
+          CNY(u"CNY", status),
           FRENCH_SYMBOLS(Locale::getFrench(), status),
           SWISS_SYMBOLS(Locale("de-CH"), status),
           MYANMAR_SYMBOLS(Locale("my"), status) {
@@ -893,6 +894,15 @@ void NumberFormatterApiTest::unitCurrency() {
             Locale("ro-RO"),
             24,
             u"24,00 lei românești");
+
+    assertFormatSingle(
+            u"Currency spacing in suffix (ICU-20954)",
+            u"currency/CNY",
+            u"currency/CNY",
+            NumberFormatter::with().unit(CNY),
+            Locale("lu"),
+            123.12,
+            u"123,12 CN¥");
 }
 
 void NumberFormatterApiTest::unitPercent() {

--- a/icu4c/source/test/testdata/numberpermutationtest.txt
+++ b/icu4c/source/test/testdata/numberpermutationtest.txt
@@ -951,7 +951,7 @@ compact-short currency/EUR sign-accounting-except-zero
   bn-BD
     ০€
     +৯২ হা€
-    (০.২২ €)
+    (০.২২€)
 
 compact-short measure-unit/length-furlong sign-accounting-except-zero
   es-MX
@@ -993,7 +993,7 @@ scientific/+ee/sign-always currency/EUR sign-accounting-except-zero
   bn-BD
     ০.০০E+০০€
     +৯.১৮E+০৪€
-    (২.২২E-০১ €)
+    (২.২২E-০১€)
 
 scientific/+ee/sign-always measure-unit/length-furlong sign-accounting-except-zero
   es-MX
@@ -3877,7 +3877,7 @@ currency/EUR unit-width-narrow sign-accounting-except-zero
   bn-BD
     ০.০০€
     +৯১,৮২৭.৩৬€
-    (০.২২ €)
+    (০.২২€)
 
 currency/EUR unit-width-full-name sign-accounting-except-zero
   es-MX
@@ -4927,7 +4927,7 @@ currency/EUR .000 sign-accounting-except-zero
   bn-BD
     ০.০০০€
     +৯১,৮২৭.৩৬৪€
-    (০.২২২ €)
+    (০.২২২€)
 
 currency/EUR .##/@@@+ sign-accounting-except-zero
   es-MX
@@ -4941,7 +4941,7 @@ currency/EUR .##/@@@+ sign-accounting-except-zero
   bn-BD
     ০€
     +৯১,৮২৭.৩৬€
-    (০.২২২ €)
+    (০.২২২€)
 
 currency/EUR @@ sign-accounting-except-zero
   es-MX
@@ -4955,7 +4955,7 @@ currency/EUR @@ sign-accounting-except-zero
   bn-BD
     ০.০€
     +৯২,০০০€
-    (০.২২ €)
+    (০.২২€)
 
 measure-unit/length-furlong precision-integer sign-accounting-except-zero
   es-MX
@@ -5375,7 +5375,7 @@ currency/EUR rounding-mode-floor sign-accounting-except-zero
   bn-BD
     ০.০০€
     +৯১,৮২৭.৩৬€
-    (০.২৩ €)
+    (০.২৩€)
 
 measure-unit/length-furlong rounding-mode-floor sign-accounting-except-zero
   es-MX
@@ -5585,7 +5585,7 @@ currency/EUR integer-width/##00 sign-accounting-except-zero
   bn-BD
     ০০.০০€
     +১,৮২৭.৩৬€
-    (০০.২২ €)
+    (০০.২২€)
 
 measure-unit/length-furlong integer-width/##00 sign-accounting-except-zero
   es-MX
@@ -5753,7 +5753,7 @@ currency/EUR scale/0.5 sign-accounting-except-zero
   bn-BD
     ০.০০€
     +৪৫,৯১৩.৬৮€
-    (০.১১ €)
+    (০.১১€)
 
 measure-unit/length-furlong scale/0.5 sign-accounting-except-zero
   es-MX
@@ -5879,7 +5879,7 @@ currency/EUR group-on-aligned sign-accounting-except-zero
   bn-BD
     ০.০০€
     +৯১,৮২৭.৩৬€
-    (০.২২ €)
+    (০.২২€)
 
 measure-unit/length-furlong group-on-aligned sign-accounting-except-zero
   es-MX
@@ -5963,7 +5963,7 @@ currency/EUR latin sign-accounting-except-zero
   bn-BD
     0.00€
     +91,827.36€
-    (0.22 €)
+    (0.22€)
 
 measure-unit/length-furlong latin sign-accounting-except-zero
   es-MX
@@ -6047,7 +6047,7 @@ currency/EUR sign-accounting-except-zero decimal-always
   bn-BD
     ০.০০€
     +৯১,৮২৭.৩৬€
-    (০.২২ €)
+    (০.২২€)
 
 measure-unit/length-furlong sign-accounting-except-zero decimal-always
   es-MX

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/CurrencySpacingEnabledModifier.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/CurrencySpacingEnabledModifier.java
@@ -54,7 +54,7 @@ public class CurrencySpacingEnabledModifier extends ConstantMultiFieldModifier {
             afterPrefixInsert = null;
         }
         if (suffix.length() > 0 && suffix.fieldAt(0) == NumberFormat.Field.CURRENCY) {
-            int suffixCp = suffix.getLastCodePoint();
+            int suffixCp = suffix.getFirstCodePoint();
             UnicodeSet suffixUnicodeSet = getUnicodeSet(symbols, IN_CURRENCY, SUFFIX);
             if (suffixUnicodeSet.contains(suffixCp)) {
                 beforeSuffixUnicodeSet = getUnicodeSet(symbols, IN_NUMBER, SUFFIX);

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/data/numberpermutationtest.txt
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/data/numberpermutationtest.txt
@@ -951,7 +951,7 @@ compact-short currency/EUR sign-accounting-except-zero
   bn-BD
     ০€
     +৯২ হা€
-    (০.২২ €)
+    (০.২২€)
 
 compact-short measure-unit/length-furlong sign-accounting-except-zero
   es-MX
@@ -993,7 +993,7 @@ scientific/+ee/sign-always currency/EUR sign-accounting-except-zero
   bn-BD
     ০.০০E+০০€
     +৯.১৮E+০৪€
-    (২.২২E-০১ €)
+    (২.২২E-০১€)
 
 scientific/+ee/sign-always measure-unit/length-furlong sign-accounting-except-zero
   es-MX
@@ -3877,7 +3877,7 @@ currency/EUR unit-width-narrow sign-accounting-except-zero
   bn-BD
     ০.০০€
     +৯১,৮২৭.৩৬€
-    (০.২২ €)
+    (০.২২€)
 
 currency/EUR unit-width-full-name sign-accounting-except-zero
   es-MX
@@ -4927,7 +4927,7 @@ currency/EUR .000 sign-accounting-except-zero
   bn-BD
     ০.০০০€
     +৯১,৮২৭.৩৬৪€
-    (০.২২২ €)
+    (০.২২২€)
 
 currency/EUR .##/@@@+ sign-accounting-except-zero
   es-MX
@@ -4941,7 +4941,7 @@ currency/EUR .##/@@@+ sign-accounting-except-zero
   bn-BD
     ০€
     +৯১,৮২৭.৩৬€
-    (০.২২২ €)
+    (০.২২২€)
 
 currency/EUR @@ sign-accounting-except-zero
   es-MX
@@ -4955,7 +4955,7 @@ currency/EUR @@ sign-accounting-except-zero
   bn-BD
     ০.০€
     +৯২,০০০€
-    (০.২২ €)
+    (০.২২€)
 
 measure-unit/length-furlong precision-integer sign-accounting-except-zero
   es-MX
@@ -5375,7 +5375,7 @@ currency/EUR rounding-mode-floor sign-accounting-except-zero
   bn-BD
     ০.০০€
     +৯১,৮২৭.৩৬€
-    (০.২৩ €)
+    (০.২৩€)
 
 measure-unit/length-furlong rounding-mode-floor sign-accounting-except-zero
   es-MX
@@ -5585,7 +5585,7 @@ currency/EUR integer-width/##00 sign-accounting-except-zero
   bn-BD
     ০০.০০€
     +১,৮২৭.৩৬€
-    (০০.২২ €)
+    (০০.২২€)
 
 measure-unit/length-furlong integer-width/##00 sign-accounting-except-zero
   es-MX
@@ -5753,7 +5753,7 @@ currency/EUR scale/0.5 sign-accounting-except-zero
   bn-BD
     ০.০০€
     +৪৫,৯১৩.৬৮€
-    (০.১১ €)
+    (০.১১€)
 
 measure-unit/length-furlong scale/0.5 sign-accounting-except-zero
   es-MX
@@ -5879,7 +5879,7 @@ currency/EUR group-on-aligned sign-accounting-except-zero
   bn-BD
     ০.০০€
     +৯১,৮২৭.৩৬€
-    (০.২২ €)
+    (০.২২€)
 
 measure-unit/length-furlong group-on-aligned sign-accounting-except-zero
   es-MX
@@ -5963,7 +5963,7 @@ currency/EUR latin sign-accounting-except-zero
   bn-BD
     0.00€
     +91,827.36€
-    (0.22 €)
+    (0.22€)
 
 measure-unit/length-furlong latin sign-accounting-except-zero
   es-MX
@@ -6047,7 +6047,7 @@ currency/EUR sign-accounting-except-zero decimal-always
   bn-BD
     ০.০০€
     +৯১,৮২৭.৩৬€
-    (০.২২ €)
+    (০.২২€)
 
 measure-unit/length-furlong sign-accounting-except-zero decimal-always
   es-MX

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
@@ -66,6 +66,7 @@ public class NumberFormatterApiTest {
     private static final Currency ESP = Currency.getInstance("ESP");
     private static final Currency PTE = Currency.getInstance("PTE");
     private static final Currency RON = Currency.getInstance("RON");
+    private static final Currency CNY = Currency.getInstance("CNY");
 
     @Test
     public void notationSimple() {
@@ -864,6 +865,15 @@ public class NumberFormatterApiTest {
                 ULocale.forLanguageTag("ro-RO"),
                 24,
                 "24,00 lei românești");
+
+        assertFormatSingle(
+                "Currency spacing in suffix (ICU-20954)",
+                "currency/CNY",
+                "currency/CNY",
+                NumberFormatter.with().unit(CNY),
+                ULocale.forLanguageTag("lu"),
+                123.12,
+                "123,12 CN¥");
     }
 
     @Test


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20954
- [x] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

