### PR TITLE
ICU-20973 Fix rewritten operator!= failure due non-bool return type

### DIFF
--- a/icu4c/source/common/uchriter.cpp
+++ b/icu4c/source/common/uchriter.cpp
@@ -84,6 +84,11 @@ UCharCharacterIterator::operator==(const ForwardCharacterIterator& that) const {
         && end == realThat.end;
 }
 
+UBool
+UCharCharacterIterator::operator!=(const ForwardCharacterIterator& that) const {
+    return !operator==(that);
+}
+
 int32_t
 UCharCharacterIterator::hashCode() const {
     return ustr_hashUCharsN(text, textLength) ^ pos ^ begin ^ end;

--- a/icu4c/source/common/unicode/chariter.h
+++ b/icu4c/source/common/unicode/chariter.h
@@ -126,7 +126,7 @@ public:
      * same text-storage object
      * @stable ICU 2.0
      */
-    inline UBool operator!=(const ForwardCharacterIterator& that) const;
+    virtual UBool operator!=(const ForwardCharacterIterator& that) const = 0;
     
     /**
      * Generates a hash code for this iterator.  
@@ -691,11 +691,6 @@ protected:
      */
     int32_t  end;
 };
-
-inline UBool
-ForwardCharacterIterator::operator!=(const ForwardCharacterIterator& that) const {
-    return !operator==(that);
-}
 
 inline int32_t
 CharacterIterator::setToStart() {

--- a/icu4c/source/common/unicode/uchriter.h
+++ b/icu4c/source/common/unicode/uchriter.h
@@ -122,6 +122,16 @@ public:
   virtual UBool          operator==(const ForwardCharacterIterator& that) const;
 
   /**
+   * Returns true if the iterators iterate over the same range of the
+   * same string and are pointing at the same character.
+   * @param that The ForwardCharacterIterator used to be compared for equality
+   * @return true if the iterators iterate over the same range of the
+   * same string and are pointing at the same character.
+   * @stable ICU 2.0
+   */
+  virtual UBool          operator!=(const ForwardCharacterIterator& that) const;
+
+  /**
    * Generates a hash code for this iterator.
    * @return the hash code.
    * @stable ICU 2.0

--- a/icu4c/source/common/unifiedcache.h
+++ b/icu4c/source/common/unifiedcache.h
@@ -123,8 +123,12 @@ class CacheKey : public CacheKeyBase {
    /**
     * Two objects are equal if they are of the same type.
     */
-   virtual UBool operator == (const CacheKeyBase &other) const {
+   virtual UBool operator== (const CacheKeyBase &other) const {
        return typeid(*this) == typeid(other);
+   }
+
+   virtual UBool operator!= (const CacheKeyBase &other) const {
+       return !operator==(other);
    }
 };
 
@@ -144,12 +148,12 @@ class LocaleCacheKey : public CacheKey<T> {
    virtual int32_t hashCode() const {
        return (int32_t)(37u * (uint32_t)CacheKey<T>::hashCode() + (uint32_t)fLoc.hashCode());
    }
-   virtual UBool operator == (const CacheKeyBase &other) const {
+   virtual UBool operator==(const CacheKeyBase &other) const {
        // reflexive
        if (this == &other) {
            return TRUE;
        }
-       if (!CacheKey<T>::operator == (other)) {
+       if (!CacheKey<T>::operator== (other)) {
            return FALSE;
        }
        // We know this and other are of same class because operator== on
@@ -157,6 +161,9 @@ class LocaleCacheKey : public CacheKey<T> {
        const LocaleCacheKey<T> *fOther =
                static_cast<const LocaleCacheKey<T> *>(&other);
        return fLoc == fOther->fLoc;
+   }
+   virtual UBool operator!=(const CacheKeyBase &other) const {
+       return !operator==(other);
    }
    virtual CacheKeyBase *clone() const {
        return new LocaleCacheKey<T>(*this);

--- a/icu4c/source/i18n/basictz.cpp
+++ b/icu4c/source/i18n/basictz.cpp
@@ -408,7 +408,7 @@ BasicTimeZone::getTimeZoneRulesAfter(UDate start, InitialTimeZoneRule*& initial,
                 if (!avail) {
                     break;
                 }
-                if (*(tzt0.getTo()) == *tar) {
+                if (*tar == *tzt0.getTo()) {
                     break;
                 }
                 t = tzt0.getTime();

--- a/icu4c/source/i18n/choicfmt.cpp
+++ b/icu4c/source/i18n/choicfmt.cpp
@@ -141,6 +141,12 @@ ChoiceFormat::operator==(const Format& that) const
     return msgPattern == thatAlias.msgPattern;
 }
 
+UBool
+ChoiceFormat::operator!=(const Format& that) const
+{
+    return !operator==(that);
+}
+
 // -------------------------------------
 // copy constructor
 

--- a/icu4c/source/i18n/coll.cpp
+++ b/icu4c/source/i18n/coll.cpp
@@ -644,7 +644,7 @@ UBool Collator::operator==(const Collator& other) const
 
 UBool Collator::operator!=(const Collator& other) const
 {
-    return (UBool)!(*this == other);
+    return !operator==(other);
 }
 
 int32_t U_EXPORT2 Collator::getBound(const uint8_t       *source,

--- a/icu4c/source/i18n/datefmt.cpp
+++ b/icu4c/source/i18n/datefmt.cpp
@@ -191,6 +191,11 @@ DateFormat::operator==(const Format& other) const
          (fCapitalizationContext == fmt->fCapitalizationContext) );
 }
 
+UBool
+DateFormat::operator!=(const Format& other) const
+{
+    return !operator==(other);
+}
 //----------------------------------------------------------------------
 
 UnicodeString&

--- a/icu4c/source/i18n/decimfmt.cpp
+++ b/icu4c/source/i18n/decimfmt.cpp
@@ -510,6 +510,10 @@ UBool DecimalFormat::operator==(const Format& other) const {
     return fields->properties == otherDF->fields->properties && *fields->symbols == *otherDF->fields->symbols;
 }
 
+UBool DecimalFormat::operator!=(const Format& other) const {
+    return !operator==(other);
+}
+
 UnicodeString& DecimalFormat::format(double number, UnicodeString& appendTo, FieldPosition& pos) const {
     if (fields == nullptr) {
         appendTo.setToBogus();

--- a/icu4c/source/i18n/dtitvfmt.cpp
+++ b/icu4c/source/i18n/dtitvfmt.cpp
@@ -220,6 +220,11 @@ DateIntervalFormat::clone() const {
     return new DateIntervalFormat(*this);
 }
 
+UBool
+DateIntervalFormat::operator!=(const Format& other) const {
+    return !operator==(other);
+}
+
 
 UBool
 DateIntervalFormat::operator==(const Format& other) const {

--- a/icu4c/source/i18n/measfmt.cpp
+++ b/icu4c/source/i18n/measfmt.cpp
@@ -460,6 +460,10 @@ UBool MeasureFormat::operator==(const Format &other) const {
             **numberFormat == **rhs.numberFormat);
 }
 
+UBool MeasureFormat::operator!=(const Format &other) const {
+    return !operator==(other);
+}
+
 MeasureFormat *MeasureFormat::clone() const {
     return new MeasureFormat(*this);
 }

--- a/icu4c/source/i18n/msgfmt.cpp
+++ b/icu4c/source/i18n/msgfmt.cpp
@@ -433,6 +433,12 @@ MessageFormat::operator==(const Format& rhs) const
     return TRUE;
 }
 
+UBool
+MessageFormat::operator!=(const Format& rhs) const
+{
+    return !operator==(rhs);
+}
+
 // -------------------------------------
 // Creates a copy of this MessageFormat, the caller owns the copy.
 

--- a/icu4c/source/i18n/numfmt.cpp
+++ b/icu4c/source/i18n/numfmt.cpp
@@ -345,6 +345,12 @@ NumberFormat::operator==(const Format& that) const
               fCapitalizationContext == other->fCapitalizationContext)));
 }
 
+UBool
+NumberFormat::operator!=(const Format& that) const
+{
+    return !operator==(that);
+}
+
 // -------------------------------------
 // Default implementation sets unsupported error; subclasses should
 // override.

--- a/icu4c/source/i18n/rulebasedcollator.cpp
+++ b/icu4c/source/i18n/rulebasedcollator.cpp
@@ -271,6 +271,11 @@ RuleBasedCollator::operator==(const Collator& other) const {
     return TRUE;
 }
 
+UBool
+RuleBasedCollator::operator!=(const Collator& other) const {
+    return !operator==(other);
+}
+
 int32_t
 RuleBasedCollator::hashCode() const {
     int32_t h = settings->hashCode();

--- a/icu4c/source/i18n/simpletz.cpp
+++ b/icu4c/source/i18n/simpletz.cpp
@@ -240,6 +240,13 @@ SimpleTimeZone::operator==(const TimeZone& that) const
             hasSameRules(that)));
 }
 
+UBool
+SimpleTimeZone::operator!=(const TimeZone& that) const
+{
+    return !operator==(that);
+}
+
+
 // -------------------------------------
 
 // Called by TimeZone::createDefault() inside a Mutex - be careful.

--- a/icu4c/source/i18n/smpdtfmt.cpp
+++ b/icu4c/source/i18n/smpdtfmt.cpp
@@ -646,6 +646,11 @@ SimpleDateFormat::operator==(const Format& other) const
     return FALSE;
 }
 
+UBool
+SimpleDateFormat::operator!=(const Format& other) const
+{
+    return !operator==(other);
+}
 //----------------------------------------------------------------------
 
 void SimpleDateFormat::construct(EStyle timeStyle,

--- a/icu4c/source/i18n/stsearch.cpp
+++ b/icu4c/source/i18n/stsearch.cpp
@@ -218,6 +218,11 @@ UBool StringSearch::operator==(const SearchIterator &that) const
     return FALSE;
 }
 
+UBool StringSearch::operator!=(const SearchIterator &that) const {
+    //return (operator==(that) == TRUE ? FALSE : TRUE);
+    return !operator==(that);
+}
+
 // public get and set methods ----------------------------------------
 
 void StringSearch::setOffset(int32_t position, UErrorCode &status)

--- a/icu4c/source/i18n/unicode/choicfmt.h
+++ b/icu4c/source/i18n/unicode/choicfmt.h
@@ -264,6 +264,16 @@ public:
     virtual UBool operator==(const Format& other) const;
 
     /**
+     * Returns false if the given Format objects are semantically equal.
+     * Objects of different subclasses are considered unequal.
+     *
+     * @param other    ChoiceFormat object to be compared
+     * @return         false if other is the same as this.
+     * @deprecated ICU 49 Use MessageFormat instead, with plural and select arguments.
+     */
+    virtual UBool operator!=(const Format& other) const;
+
+    /**
      * Sets the pattern.
      * @param pattern   The pattern to be applied.
      * @param status    Output param set to success/failure code on

--- a/icu4c/source/i18n/unicode/datefmt.h
+++ b/icu4c/source/i18n/unicode/datefmt.h
@@ -237,6 +237,11 @@ public:
      */
     virtual UBool operator==(const Format&) const;
 
+    /**
+     * Equality operator.  Returns true if the two formats have the same behavior.
+     * @stable ICU 2.0
+     */
+    virtual UBool operator!=(const Format&) const;
 
     using Format::format;
 

--- a/icu4c/source/i18n/unicode/decimfmt.h
+++ b/icu4c/source/i18n/unicode/decimfmt.h
@@ -911,6 +911,15 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      */
     UBool operator==(const Format& other) const U_OVERRIDE;
 
+    /**
+     * Return true if the given Format objects are semantically equal.
+     * Objects of different subclasses are considered unequal.
+     *
+     * @param other    the object to be compared with.
+     * @return         true if the given Format objects are semantically equal.
+     * @stable ICU 2.0
+     */
+    UBool operator!=(const Format& other) const;
 
     using NumberFormat::format;
 

--- a/icu4c/source/i18n/unicode/dtitvfmt.h
+++ b/icu4c/source/i18n/unicode/dtitvfmt.h
@@ -452,7 +452,7 @@ public:
      * @return      true if the given Format objects are not semantically equal.
      * @stable ICU 4.0
      */
-    UBool operator!=(const Format& other) const;
+    virtual UBool operator!=(const Format& other) const;
 
 
     using Format::format;
@@ -1143,11 +1143,6 @@ private:
     UnicodeString* fTimePattern;
     UnicodeString* fDateTimeFormat;
 };
-
-inline UBool
-DateIntervalFormat::operator!=(const Format& other) const  {
-    return !operator==(other);
-}
 
 U_NAMESPACE_END
 

--- a/icu4c/source/i18n/unicode/format.h
+++ b/icu4c/source/i18n/unicode/format.h
@@ -120,7 +120,7 @@ public:
      * @return         Return true if the given Format objects are not semantically.
      * @stable ICU 2.0
      */
-    UBool operator!=(const Format& other) const { return !operator==(other); }
+    virtual UBool operator!=(const Format& other) const { return !operator==(other); }
 
     /**
      * Clone this object polymorphically.  The caller is responsible

--- a/icu4c/source/i18n/unicode/measfmt.h
+++ b/icu4c/source/i18n/unicode/measfmt.h
@@ -150,6 +150,12 @@ class U_I18N_API MeasureFormat : public Format {
     virtual UBool operator==(const Format &other) const;
 
     /**
+     * Return true if given Format objects are semantically equal.
+     * @stable ICU 66
+     */
+    virtual UBool operator!=(const Format &other) const;
+
+    /**
      * Clones this object polymorphically.
      * @stable ICU 53
      */

--- a/icu4c/source/i18n/unicode/msgfmt.h
+++ b/icu4c/source/i18n/unicode/msgfmt.h
@@ -432,6 +432,15 @@ public:
     virtual UBool operator==(const Format& other) const;
 
     /**
+     * Returns true if the given Format objects are not semantically equal.
+     * Objects of different subclasses are considered unequal.
+     * @param other  the object to be compared with.
+     * @return       false if the given Format objects are semantically equal.
+     * @stable ICU 2.0
+     */
+    virtual UBool operator!=(const Format& other) const;
+
+    /**
      * Sets the locale to be used for creating argument Format objects.
      * @param theLocale    the new locale value to be set.
      * @stable ICU 2.0

--- a/icu4c/source/i18n/unicode/numfmt.h
+++ b/icu4c/source/i18n/unicode/numfmt.h
@@ -278,6 +278,13 @@ public:
      */
     virtual UBool operator==(const Format& other) const;
 
+    /**
+     * Return true if the given Format objects are semantically equal.
+     * Objects of different subclasses are considered unequal.
+     * @return    true if the given Format objects are semantically equal.
+     * @stable ICU 2.0
+     */
+    virtual UBool operator!=(const Format& other) const;
 
     using Format::format;
 

--- a/icu4c/source/i18n/unicode/simpletz.h
+++ b/icu4c/source/i18n/unicode/simpletz.h
@@ -112,6 +112,7 @@ public:
      * @stable ICU 2.0
      */
     virtual UBool operator==(const TimeZone& that) const;
+    virtual UBool operator!=(const TimeZone& that) const;
 
     /**
      * Constructs a SimpleTimeZone with the given raw GMT offset and time zone ID,

--- a/icu4c/source/i18n/unicode/smpdtfmt.h
+++ b/icu4c/source/i18n/unicode/smpdtfmt.h
@@ -877,6 +877,7 @@ public:
      * @stable ICU 2.0
      */
     virtual UBool operator==(const Format& other) const;
+    virtual UBool operator!=(const Format& other) const;
 
 
     using DateFormat::format;

--- a/icu4c/source/i18n/unicode/stsearch.h
+++ b/icu4c/source/i18n/unicode/stsearch.h
@@ -298,6 +298,7 @@ public:
      * @stable ICU 2.0
      */
     virtual UBool operator==(const SearchIterator &that) const;
+    virtual UBool operator!=(const SearchIterator &that) const;
 
     // public get and set methods ----------------------------------------
 

--- a/icu4c/source/i18n/unicode/tblcoll.h
+++ b/icu4c/source/i18n/unicode/tblcoll.h
@@ -226,6 +226,14 @@ public:
     virtual UBool operator==(const Collator& other) const;
 
     /**
+     * Returns true if argument is the same as this object.
+     * @param other Collator object to be compared.
+     * @return true if arguments is the same as this object.
+     * @stable ICU 2.0
+     */
+    virtual UBool operator!=(const Collator& other) const;
+
+    /**
      * Makes a copy of this object.
      * @return a copy of this object, owned by the caller
      * @stable ICU 2.0

--- a/icu4c/source/i18n/unicode/timezone.h
+++ b/icu4c/source/i18n/unicode/timezone.h
@@ -456,7 +456,10 @@ public:
      *              otherwise.
      * @stable ICU 2.0
      */
-    UBool operator!=(const TimeZone& that) const {return !operator==(that);}
+    virtual UBool operator!=(const TimeZone& that) const
+    {
+        return !operator==(that);
+    }
 
     /**
      * Returns the TimeZone's adjusted GMT offset (i.e., the number of milliseconds to add

--- a/icu4c/source/i18n/unicode/tmutfmt.h
+++ b/icu4c/source/i18n/unicode/tmutfmt.h
@@ -135,15 +135,6 @@ public:
     TimeUnitFormat& operator=(const TimeUnitFormat& other);
 
     /**
-     * Return true if the given Format objects are not semantically equal.
-     * Objects of different subclasses are considered unequal.
-     * @param other the object to be compared with.
-     * @return      true if the given Format objects are not semantically equal.
-     * @deprecated ICU 53
-     */
-    UBool operator!=(const Format& other) const;
-
-    /**
      * Set the locale used for formatting or parsing.
      * @param locale  the locale to be set
      * @param status  output param set to success/failure code on exit
@@ -236,10 +227,6 @@ private:
     friend struct TimeUnitFormatReadSink;
 };
 
-inline UBool
-TimeUnitFormat::operator!=(const Format& other) const  {
-    return !operator==(other);
-}
 
 U_NAMESPACE_END
 

--- a/icu4c/source/test/intltest/alphaindextst.cpp
+++ b/icu4c/source/test/intltest/alphaindextst.cpp
@@ -159,7 +159,7 @@ void AlphabeticIndexTest::APITest() {
     LocalPointer<Collator> germanCol(Collator::createInstance(Locale::getGerman(), status));
     TEST_CHECK_STATUS;
     const RuleBasedCollator &indexCol = index->getCollator();
-    TEST_ASSERT(*germanCol == indexCol);
+    TEST_ASSERT(indexCol == *germanCol);
 
     UnicodeString ELLIPSIS;  ELLIPSIS.append((UChar32)0x2026);
     UnicodeString s = index->getUnderflowLabel();

--- a/icu4c/source/test/intltest/apicoll.cpp
+++ b/icu4c/source/test/intltest/apicoll.cpp
@@ -921,9 +921,9 @@ CollationAPITest::TestDuplicate(/* char* par */)
         logln("Collation tailoring failed.");
         return;
     }
-    doAssert((*col1 != *col3), "Cloned object is equal to some dummy");
+    doAssert((*col3 != *col1), "Cloned object is equal to some dummy");
     *col3 = *((RuleBasedCollator*)col1);
-    doAssert((*col1 == *col3), "Copied object is not equal to the orginal");
+    doAssert((*col3 == *col1), "Copied object is not equal to the orginal");
 
     UCollationResult res;
     UnicodeString first((UChar)0x0061);
@@ -2046,7 +2046,7 @@ public:
                              uint8_t*result, int32_t resultLength) const;
     virtual UnicodeSet *getTailoredSet(UErrorCode &status) const;
     virtual UBool operator==(const Collator& other) const;
-    // Collator::operator!= calls !Collator::operator== which works for all subclasses.
+    virtual UBool operator!=(const Collator& other) const;
     virtual void setLocales(const Locale& requestedLocale, const Locale& validLocale, const Locale& actualLocale);
     TestCollator() : Collator() {}
     TestCollator(UCollationStrength collationStrength, 
@@ -2064,6 +2064,11 @@ inline UBool TestCollator::operator==(const Collator& other) const {
     //    const TestCollator &o = (const TestCollator&)other;
     //    (compare this vs. o's subclass fields)
 }
+
+inline UBool TestCollator::operator!=(const Collator& other) const {
+    return !operator==(other);
+}
+
 
 TestCollator* TestCollator::clone() const
 {

--- a/icu4c/source/test/intltest/citrtest.cpp
+++ b/icu4c/source/test/intltest/citrtest.cpp
@@ -57,6 +57,10 @@ public:
         return TRUE;
     }
 
+    virtual UBool operator!=(const ForwardCharacterIterator& /*that*/) const{
+        return FALSE;
+    }
+
     virtual SCharacterIterator* clone(void) const {
         return NULL;
     }
@@ -1086,6 +1090,11 @@ public:
         return
             this==&that ||
             (typeid(*this)==typeid(that) && pos==((SubCharIter &)that).pos);
+    }
+
+    // dummy implementations of other pure virtual base class functions
+    virtual UBool operator!=(const ForwardCharacterIterator &that) const {
+        return !operator==(that);
     }
 
     virtual int32_t hashCode() const {

--- a/icu4c/source/test/intltest/dcfmapts.cpp
+++ b/icu4c/source/test/intltest/dcfmapts.cpp
@@ -202,7 +202,7 @@ void IntlTestDecimalFormatAPI::testAPI(/*char *par*/)
     }
 
     Format *clone = def.clone();
-    if( ! (*clone == def) ) {
+    if( ! (def == *clone) ) {
         errln((UnicodeString)"ERROR: Clone() failed");
     }
     delete clone;

--- a/icu4c/source/test/intltest/sdtfmtts.cpp
+++ b/icu4c/source/test/intltest/sdtfmtts.cpp
@@ -131,7 +131,7 @@ void IntlTestSimpleDateFormatAPI::testAPI(/*char *par*/)
     }
 
     Format *clone = def.clone();
-    if( ! (*clone == def) ) {
+    if( ! (def == *clone) ) {
         errln("ERROR: Clone() (or ==) failed");
     }
     delete clone;

--- a/icu4c/source/test/intltest/tztest.cpp
+++ b/icu4c/source/test/intltest/tztest.cpp
@@ -95,15 +95,15 @@ TimeZoneTest::TestGenericAPI()
     if (zone->useDaylightTime()) errln("FAIL: useDaylightTime should return FALSE");
 
     TimeZone* zoneclone = zone->clone();
-    if (!(*zoneclone == *zone)) errln("FAIL: clone or operator== failed");
+    if (!(*zone == *zoneclone)) errln("FAIL: clone or operator== failed");
     zoneclone->setID("abc");
-    if (!(*zoneclone != *zone)) errln("FAIL: clone or operator!= failed");
+    if (!(*zone != *zoneclone)) errln("FAIL: clone or operator!= failed");
     delete zoneclone;
 
     zoneclone = zone->clone();
-    if (!(*zoneclone == *zone)) errln("FAIL: clone or operator== failed");
+    if (!(*zone == *zoneclone)) errln("FAIL: clone or operator== failed");
     zoneclone->setRawOffset(45678);
-    if (!(*zoneclone != *zone)) errln("FAIL: clone or operator!= failed");
+    if (!(*zone != *zoneclone)) errln("FAIL: clone or operator!= failed");
 
     SimpleTimeZone copy(*zone);
     if (!(copy == *zone)) errln("FAIL: copy constructor or operator== failed");
@@ -115,8 +115,8 @@ TimeZoneTest::TestGenericAPI()
 
     TimeZone::adoptDefault(zone);
     TimeZone* defaultzone = TimeZone::createDefault();
-    if (defaultzone == zone ||
-        !(*defaultzone == *zone))
+    if (zone == defaultzone ||
+        !(*zone == *defaultzone))
         errln("FAIL: createDefault failed");
     TimeZone::adoptDefault(saveDefault);
     delete defaultzone;


### PR DESCRIPTION
[ICU-20973]

Note that the change in icu4c/source/i18n/basictz.cpp is a work around waiting the reply on the ticket raised to gcc: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=93699