### PR TITLE
ICU-20626 Adding valgrind to the CI tests for ICU4C.

### DIFF
--- a/.ci-builds/.azure-valgrind.yml
+++ b/.ci-builds/.azure-valgrind.yml
@@ -1,0 +1,75 @@
+# Azure Pipelines configuration for Valgrind for ICU4C.
+# 
+# Note: The valgrind test configuration is in a separate file
+# so that it can be run independently from the regular builds.
+#
+# The Ubuntu images don't have valgrind installed by default, so we need
+# install it first.
+#
+# Only run valgrind on the master and maint branches, and
+# batch up any pending changes so that we will only have at most
+# one build running at a given time (since it takes time).
+trigger:
+  batch: true
+  branches:
+    include:
+    - master
+    - maint/maint-*
+  paths:
+    include:
+    - '*'
+    exclude:
+    - docs/*
+    - icu4j/*
+    - tools/*
+    - vendor/*
+    - .appveyor.xml
+    - .cpyskip.txt
+    - .travis.yml
+    - KEYS
+    - README.md
+
+pr: none
+
+jobs:
+#-------------------------------------------------------------------------
+- job: ICU4C_Clang_Valgrind_Ubuntu_1604
+  displayName: 'C: Linux Clang Valgrind (Ubuntu 16.04)'
+  timeoutInMinutes: 60
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  steps:
+    - checkout: self
+      lfs: true
+      fetchDepth: 1
+    - script: |
+        set -ex
+        sudo apt -y update
+        sudo apt install -y valgrind
+      displayName: 'Install valgrind'
+      timeoutInMinutes: 5
+    - script: |
+        cd icu4c/source && ./runConfigureICU --enable-debug Linux --disable-renaming --disable-layout --disable-layoutex && make -j2 tests
+      displayName: 'Build'
+      timeoutInMinutes: 10
+      env:
+        CC: clang
+        CXX: clang++
+    - script: |
+        cd icu4c/source/test/intltest && LD_LIBRARY_PATH=../../lib:../../stubdata:../../tools/ctestfw:$LD_LIBRARY_PATH valgrind --tool=memcheck --error-exitcode=1 --leak-check=full --show-reachable=yes ./intltest
+      displayName: 'Valgrind intltest'
+      timeoutInMinutes: 45
+    - script: |
+        cd icu4c/source/test/cintltst && LD_LIBRARY_PATH=../../lib:../../stubdata:../../tools/ctestfw:$LD_LIBRARY_PATH valgrind --tool=memcheck --error-exitcode=1 --leak-check=full --show-reachable=yes ./cintltst
+      displayName: 'Valgrind cintltst'
+      timeoutInMinutes: 15
+    - script: |
+        cd icu4c/source/test/iotest && LD_LIBRARY_PATH=../../lib:../../stubdata:../../tools/ctestfw:$LD_LIBRARY_PATH valgrind --tool=memcheck --error-exitcode=1 --leak-check=full --show-reachable=yes ./iotest
+      displayName: 'Valgrind iotest'
+      timeoutInMinutes: 5
+    - script: |
+        cd icu4c/source/tools/icuinfo && LD_LIBRARY_PATH=../../lib:../../stubdata:../../tools/ctestfw:$LD_LIBRARY_PATH valgrind --tool=memcheck --error-exitcode=1 --leak-check=full --show-reachable=yes ./icuinfo
+      displayName: 'Valgrind icuinfo'
+      timeoutInMinutes: 5
+
+#-------------------------------------------------------------------------


### PR DESCRIPTION
This adds a separate CI pipeline on Azure for running [valgrind](https://en.wikipedia.org/wiki/Valgrind) continuously on ICU4C in an automated fashion.

The base Ubuntu images don't have valgrind installed by default though, so we need to install valgrind first via `apt`.

For running valgrind, this set the option `--error-exitcode=1` so that *any* errors found by valgrind will fail the CI build.

This also sets the option `--leak-check=full` so that valgrind will report any leaked memory as well.
(Though this does slow down the execution time a bit).


**Note:** ICU4C currently does *not* run cleanly under valgrind, so this new automated CI run will fail under these issues are addressed. I've filed a separate ticket for this here [ICU-21001](https://unicode-org.atlassian.net/browse/ICU-21001).


##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20626
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

