### PR TITLE
ICU-21001 Fixing problems found by running valgrind.

### DIFF
--- a/icu4c/source/common/ucurr.cpp
+++ b/icu4c/source/common/ucurr.cpp
@@ -866,7 +866,7 @@ getCurrencyNameCount(const char* loc, int32_t* total_currency_name_count, int32_
     *total_currency_name_count = 0;
     *total_currency_symbol_count = 0;
     const UChar* s = NULL;
-    char locale[ULOC_FULLNAME_CAPACITY];
+    char locale[ULOC_FULLNAME_CAPACITY] = "";
     uprv_strcpy(locale, loc);
     const icu::Hashtable *currencySymbolsEquiv = getCurrSymbolsEquiv();
     for (;;) {
@@ -941,7 +941,7 @@ collectCurrencyNames(const char* locale,
     // Look up the Currencies resource for the given locale.
     UErrorCode ec2 = U_ZERO_ERROR;
 
-    char loc[ULOC_FULLNAME_CAPACITY];
+    char loc[ULOC_FULLNAME_CAPACITY] = "";
     uloc_getName(locale, loc, sizeof(loc), &ec2);
     if (U_FAILURE(ec2) || ec2 == U_STRING_NOT_TERMINATED_WARNING) {
         ec = U_ILLEGAL_ARGUMENT_ERROR;

--- a/icu4c/source/common/unames.cpp
+++ b/icu4c/source/common/unames.cpp
@@ -1519,7 +1519,8 @@ U_CAPI UChar32 U_EXPORT2
 u_charFromName(UCharNameChoice nameChoice,
                const char *name,
                UErrorCode *pErrorCode) {
-    char upper[120], lower[120];
+    char upper[120] = {0};
+    char lower[120] = {0};
     FindName findName;
     AlgorithmicRange *algRange;
     uint32_t *p;

--- a/icu4c/source/common/uresbund.cpp
+++ b/icu4c/source/common/uresbund.cpp
@@ -2611,8 +2611,8 @@ ures_getFunctionalEquivalent(char *result, int32_t resultCapacity,
     char defVal[1024] = ""; /* default value for given locale */
     char defLoc[1024] = ""; /* default value for given locale */
     char base[1024] = ""; /* base locale */
-    char found[1024];
-    char parent[1024];
+    char found[1024] = "";
+    char parent[1024] = "";
     char full[1024] = "";
     UResourceBundle bund1, bund2;
     UResourceBundle *res = NULL;

--- a/icu4c/source/common/uscript.cpp
+++ b/icu4c/source/common/uscript.cpp
@@ -58,8 +58,8 @@ static int32_t
 getCodesFromLocale(const char *locale,
                    UScriptCode *scripts, int32_t capacity, UErrorCode *err) {
     UErrorCode internalErrorCode = U_ZERO_ERROR;
-    char lang[8];
-    char script[8];
+    char lang[8] = {0};
+    char script[8] = {0};
     int32_t scriptLength;
     if(U_FAILURE(*err)) { return 0; }
     // Multi-script languages, equivalent to the LocaleScript data

--- a/icu4c/source/i18n/calendar.cpp
+++ b/icu4c/source/i18n/calendar.cpp
@@ -958,7 +958,7 @@ Calendar::makeInstance(const Locale& aLocale, UErrorCode& success) {
 #endif
         c->setWeekData(aLocale, c->getType(), success);  // set the correct locale (this was an indirected calendar)
 
-        char keyword[ULOC_FULLNAME_CAPACITY];
+        char keyword[ULOC_FULLNAME_CAPACITY] = "";
         UErrorCode tmpStatus = U_ZERO_ERROR;
         l.getKeywordValue("calendar", keyword, ULOC_FULLNAME_CAPACITY, tmpStatus);
         if (U_SUCCESS(tmpStatus) && uprv_strcmp(keyword, "iso8601") == 0) {

--- a/icu4c/source/i18n/dtptngen.cpp
+++ b/icu4c/source/i18n/dtptngen.cpp
@@ -324,6 +324,7 @@ DateTimePatternGenerator::createEmptyInstance(UErrorCode& status) {
 DateTimePatternGenerator::DateTimePatternGenerator(UErrorCode &status) :
     skipMatcher(nullptr),
     fAvailableFormatKeyHash(nullptr),
+    fDefaultHourFormatChar(0),
     internalErrorCode(U_ZERO_ERROR)
 {
     fp = new FormatParser();
@@ -338,6 +339,7 @@ DateTimePatternGenerator::DateTimePatternGenerator(UErrorCode &status) :
 DateTimePatternGenerator::DateTimePatternGenerator(const Locale& locale, UErrorCode &status) :
     skipMatcher(nullptr),
     fAvailableFormatKeyHash(nullptr),
+    fDefaultHourFormatChar(0),
     internalErrorCode(U_ZERO_ERROR)
 {
     fp = new FormatParser();
@@ -356,6 +358,7 @@ DateTimePatternGenerator::DateTimePatternGenerator(const DateTimePatternGenerato
     UObject(),
     skipMatcher(nullptr),
     fAvailableFormatKeyHash(nullptr),
+    fDefaultHourFormatChar(0),
     internalErrorCode(U_ZERO_ERROR)
 {
     fp = new FormatParser();
@@ -1639,7 +1642,7 @@ DateTimePatternGenerator::adjustFieldTypes(const UnicodeString& pattern,
                             && (typeValue!= UDATPG_YEAR_FIELD || reqFieldChar==CAP_Y))
                             ? reqFieldChar
                             : field.charAt(0);
-                    if (typeValue == UDATPG_HOUR_FIELD) {
+                    if (typeValue == UDATPG_HOUR_FIELD && fDefaultHourFormatChar != 0) {
                         // The adjustment here is required to match spec (https://www.unicode.org/reports/tr35/tr35-dates.html#dfst-hour).
                         // It is necessary to match the hour-cycle preferred by the Locale.
                         // Given that, we need to do the following adjustments:

--- a/icu4c/source/i18n/gender.cpp
+++ b/icu4c/source/i18n/gender.cpp
@@ -160,7 +160,7 @@ const GenderInfo* GenderInfo::loadInstance(const Locale& locale, UErrorCode& sta
   if (s == NULL) {
     return &gObjs[NEUTRAL];
   }
-  char type_str[256];
+  char type_str[256] = "";
   u_UCharsToChars(s, type_str, resLen + 1);
   if (uprv_strcmp(type_str, gNeutralStr) == 0) {
     return &gObjs[NEUTRAL];

--- a/icu4c/source/i18n/name2uni.cpp
+++ b/icu4c/source/i18n/name2uni.cpp
@@ -190,6 +190,7 @@ void NameUnicodeTransliterator::handleTransliterate(Replaceable& text, UTransPos
                 }
 
                 if (uprv_isInvariantUString(name.getBuffer(), len)) {
+                    cbuf[0] = 0;
                     name.extract(0, len, cbuf, maxLen, US_INV);
 
                     UErrorCode status = U_ZERO_ERROR;

--- a/icu4c/source/i18n/numsys.cpp
+++ b/icu4c/source/i18n/numsys.cpp
@@ -118,7 +118,7 @@ NumberingSystem::createInstance(const Locale & inLocale, UErrorCode& status) {
 
     UBool nsResolved = TRUE;
     UBool usingFallback = FALSE;
-    char buffer[ULOC_KEYWORDS_CAPACITY];
+    char buffer[ULOC_KEYWORDS_CAPACITY] = "";
     int32_t count = inLocale.getKeywordValue("numbers", buffer, sizeof(buffer), status);
     if (U_FAILURE(status) || status == U_STRING_NOT_TERMINATED_WARNING) {
         // the "numbers" keyword exceeds ULOC_KEYWORDS_CAPACITY; ignore and use default.

--- a/icu4c/source/test/intltest/dadrcal.cpp
+++ b/icu4c/source/test/intltest/dadrcal.cpp
@@ -448,7 +448,7 @@ void DataDrivenCalendarTest::processTest(TestData *testData) {
     //Calendar *cal= NULL;
     //const UChar *arguments= NULL;
     //int32_t argLen = 0;
-    char testType[256];
+    char testType[256] = "";
     const DataMap *settings= NULL;
     //const UChar *type= NULL;
     UErrorCode status = U_ZERO_ERROR;

--- a/icu4c/source/test/intltest/dadrfmt.cpp
+++ b/icu4c/source/test/intltest/dadrfmt.cpp
@@ -330,7 +330,7 @@ void DataDrivenFormatTest::processTest(TestData *testData) {
     //Format *cal= NULL;
     //const UChar *arguments= NULL;
     //int32_t argLen = 0;
-    char testType[256];
+    char testType[256] = "";
     const DataMap *settings= NULL;
     //const UChar *type= NULL;
     UErrorCode status = U_ZERO_ERROR;

--- a/icu4c/source/test/intltest/tztest.cpp
+++ b/icu4c/source/test/intltest/tztest.cpp
@@ -537,7 +537,7 @@ TimeZoneTest::TestGetAvailableIDsNew()
     const UnicodeString *id1, *id2;
     UnicodeString canonicalID;
     UBool isSystemID;
-    char region[4];
+    char region[4] = {0};
     int32_t zoneCount;
 
     any = canonical = canonicalLoc = any_US = canonical_US = canonicalLoc_US = any_W5 = any_CA_W5 = any_US_E14 = NULL;

--- a/icu4c/source/tools/icuinfo/icuinfo.cpp
+++ b/icu4c/source/tools/icuinfo/icuinfo.cpp
@@ -58,6 +58,12 @@ static void do_init() {
     }
 }
 
+static void do_cleanup() {
+  if (icuInitted) {
+    u_cleanup();
+    icuInitted = FALSE;
+  }
+}
 
 void cmd_millis()
 {
@@ -294,6 +300,8 @@ main(int argc, char* argv[]) {
     if(!didSomething) {
       cmd_version(FALSE, errorCode);  /* at least print the version # */
     }
+
+    do_cleanup();
 
     return U_FAILURE(errorCode);
 }


### PR DESCRIPTION
This makes fixes to the ICU4C source code in order to cleanly run all the icu4c tests (intltest, cintltst,
iotest, and even icuinfo) under valgrind with `--leak-check=full` enabled.

Note: This is needed for PR #1009.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21001
- [x] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

