### PR TITLE
ICU-20626 Remove "pr:none" from Valgrind CI config to enable comment triggers

### DIFF
--- a/.ci-builds/.azure-valgrind.yml
+++ b/.ci-builds/.azure-valgrind.yml
@@ -29,8 +29,6 @@ trigger:
     - KEYS
     - README.md
 
-pr: none
-
 jobs:
 #-------------------------------------------------------------------------
 - job: ICU4C_Clang_Valgrind_Ubuntu_1604


### PR DESCRIPTION
It seems that having "pr:none" completely disables running on PRs, even
when explicitly triggered by a comment.

(See here for more info: https://github.com/MicrosoftDocs/vsts-docs/issues/4206#issuecomment-493451760).

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20626
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

