### PR TITLE
ICU-21019 x86: Add .note.gnu.property section for Intel CET

### DIFF
--- a/icu4c/source/tools/toolutil/pkg_genc.cpp
+++ b/icu4c/source/tools/toolutil/pkg_genc.cpp
@@ -131,6 +131,9 @@ static const struct AssemblyType {
     {"gcc",
         ".globl %s\n"
         "\t.section .note.GNU-stack,\"\",%%progbits\n"
+        "#ifdef __CET__\n"
+        "# include <cet.h>\n"
+        "#endif\n"
         "\t.section .rodata\n"
         "\t.balign 16\n"
         "#ifdef U_HIDE_DATA_SYMBOL\n"


### PR DESCRIPTION
Intel Control-flow Enforcement Technology (CET):

https://software.intel.com/en-us/articles/intel-sdm

contains shadow stack (SHSTK) and indirect branch tracking (IBT).  When
CET is enabled, ELF object files must be marked with .note.gnu.property
section.  GCC provides <cet.h> which can be included in assembly codes
to generate CET maker when compiling with -fcf-protection.

This fixes:

https://unicode-org.atlassian.net/browse/ICU-21019