### PR TITLE
ICU-20879 fix typo in tests, calender → calendar

### DIFF
--- a/icu4c/source/test/intltest/calregts.cpp
+++ b/icu4c/source/test/intltest/calregts.cpp
@@ -2913,7 +2913,7 @@ void CalendarRegressionTest::TestT8596(void) {
     gc->setFirstDayOfWeek(UCAL_MONDAY);
     gc->setMinimalDaysInFirstWeek(4);
 
-    // Force the calender to resolve the fields once.
+    // Force the calendar to resolve the fields once.
     // The maximum week number in 2011 is 52.
     gc->set(UCAL_YEAR, 2011);
     gc->get(UCAL_YEAR, status);

--- a/icu4c/source/test/intltest/caltest.cpp
+++ b/icu4c/source/test/intltest/caltest.cpp
@@ -2327,7 +2327,7 @@ void CalendarTest::TestTimeStamp() {
     Calendar *cal;
 
     // Create a new Gregorian Calendar.
-    cal = Calendar::createInstance("en_US@calender=gregorian", status);
+    cal = Calendar::createInstance("en_US@calendar=gregorian", status);
     if (U_FAILURE(status)) {
         dataerrln("Error creating Gregorian calendar.");
         return;

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/calendar/CalendarRegressionTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/calendar/CalendarRegressionTest.java
@@ -2287,7 +2287,7 @@ public class CalendarRegressionTest extends com.ibm.icu.dev.test.TestFmwk {
         gc.setFirstDayOfWeek(Calendar.MONDAY);
         gc.setMinimalDaysInFirstWeek(4);
 
-        // Force the calender to resolve the fields once.
+        // Force the calendar to resolve the fields once.
         // The maximum week number in 2011 is 52.
         gc.set(Calendar.YEAR, 2011);
         gc.get(Calendar.YEAR);


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20879
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

Fix typo in ICU tests, calender → calendar (one instance in actual code, two in comments)
