### PR TITLE
ICU-20605 travis: make dist.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,8 @@ matrix:
         - CFLAGS="-Wimplicit-fallthrough"
         - CXXFLAGS="-Wimplicit-fallthrough"
       compiler: clang
+      before_install:
+        - sudo apt-get -y install doxygen  # for make dist
       before_script:
         - cd icu4c/source
         - ./runConfigureICU Linux
@@ -87,6 +89,7 @@ matrix:
         - make -j2 check
         - ( cd test/depstest && python3 depstest.py ../../../source/ )
         - ( cd .. && source/test/hdrtst/testtagsguards.sh )
+        - make dist # not sure if this is -j safe everywhere.
 
     - name: "c: osx clang"
       language: cpp


### PR DESCRIPTION
[ICU-20605]

- run 'make dist' after the linux clang build
~- upgrade ubuntu xenial (16 LTS) to bionic (18 LTS) [(schedule)](https://wiki.ubuntu.com/Releases)~

HT: https://github.com/unicode-org/icu/pull/1048#discussion_r392544485


[ICU-20605]: https://unicode-org.atlassian.net/browse/ICU-20605