### PR TITLE
ICU-21024 RBBI Table Builder / Coverity CID 1460598 "Dodgy Code" issue

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/text/RBBITableBuilder.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/RBBITableBuilder.java
@@ -814,12 +814,12 @@ class RBBITableBuilder {
                fRB.fRuleStatusVals.add(Integer.valueOf(1));    // Num of statuses in group
                fRB.fRuleStatusVals.add(Integer.valueOf(0));    //   and our single status of zero
 
-               SortedSet<Integer> s0 = new TreeSet<>();
-               Integer izero = Integer.valueOf(0);
-               fRB.fStatusSets.put(s0, izero);
-               SortedSet<Integer> s1 = new TreeSet<>();
-               s1.add(izero);
-               fRB.fStatusSets.put(s0, izero);
+               SortedSet<Integer> s0 = new TreeSet<>();        // mapping for rules with no explicit tagging
+               fRB.fStatusSets.put(s0, Integer.valueOf(0));    //   (key is an empty set).
+
+               SortedSet<Integer> s1 = new TreeSet<>();        // mapping for rules with explicit tagging of {0}
+               s1.add(Integer.valueOf(0));
+               fRB.fStatusSets.put(s1, Integer.valueOf(0));
            }
 
            //    For each state, check whether the state's status tag values are


### PR DESCRIPTION
Fix the issue identified by Coverity.
The problem was in code handling the mapping from the table build time
representation of a set of status values for an RBBI rule to the corresponding
status data as saved in a binary RBBI rule file.

The problem was benign, the rbbi data built by the incorrect code would
would still operate correctly, although it might not byte-for-byte match
that built by ICU4C. (The problem was in Java only.)

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21024
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

