### PR TITLE
ICU-21022 Use logKnownIssue to avoid TestDateFormatRoundTrip exhaustive fail

### DIFF
--- a/icu4c/source/test/intltest/dtfmtrtts.cpp
+++ b/icu4c/source/test/intltest/dtfmtrtts.cpp
@@ -470,7 +470,14 @@ void DateFormatRoundTripTest::test(DateFormat *fmt, const Locale &origLocale, UB
               } else if(!strcmp(type,"hebrew")) {
                   maxSmatch = 3;
                   maxDmatch = 3;
-                }
+              } else if (timeOnly && uprv_strcmp(origLocale.getName(),"ar_JO@calendar=islamic-civil")==0 &&
+                      logKnownIssue("21022", "ar_JO@calendar=islamic-civil timeOnly roundtrip converges too slowly")) {
+                  // For some reason, for time-only tests, ar_JO@calendar=islamic-civil is no
+                  // longer converging to a match as fast as expected above. Investigate with
+                  // ICU-21022, but meanwhile allow more cycles for convergence.
+                  maxSmatch = 2;
+                  maxDmatch = 3;
+              }
             }
 
             // Use @v to see verbose results on successful cases
@@ -478,7 +485,9 @@ void DateFormatRoundTripTest::test(DateFormat *fmt, const Locale &origLocale, UB
             if (optionv || fail) {
                 if (fail) {
                     errln(UnicodeString("\nFAIL: Pattern: ") + pat +
-                          " in Locale: " + origLocale.getName());
+                          " in Locale: " + origLocale.getName() +
+                          "\nget dmatch: " + dmatch + " (expected max " + maxDmatch +
+                          "), smatch: " + smatch + " (expected max " + maxSmatch + ")");
                 } else {
                     errln(UnicodeString("\nOk: Pattern: ") + pat +
                           " in Locale: " + origLocale.getName());


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21022
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

In exhaustive mode, TestDateFormatRoundTrip has a failure in which the successive parse/format cycles for ar_JO@calendar=islamic-civil in time-format-only mode fail to converge as rapidly as expected. For now just add a logKnownIssue that allows more cycles for convergence in this case.