### PR TITLE
ICU-21032 Backport of ICU-20958 to 61.x

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,79 @@
+# AppVeyor configuration for CI Builds of ICU4C.
+
+image: Visual Studio 2017
+platform: x64
+
+# Don't clone the entire repo.
+clone_depth: 1
+
+# Cache things between builds to speed things up and save bandwidth.
+cache:
+  - c:\icu-ci-cache
+
+# Notes:
+#  - The VS2017 build is disabled (commented out) below, as we build both VS2015 and VS2017
+#    on Azure Pipelines instead, since that is much faster.
+#
+#  - For the Cygwin build, the CYG_MIRROR URL below is from the "Cygwin Time Machine" archive,
+#    and that URL maps to the 64-bit version of Cygwin 2.11.2-1 (with timestamp 1550062412).
+#    This was the last release of Cygwin 2.11 before version 3.0.0 was released.
+#    See: http://www.crouchingtigerhiddenfruitbat.org/Cygwin/timemachine.html
+#
+#    Note: The archived Cygwin repo does not keep or retain any file signature files, so we
+#    must use the "-X" or "--no-verify" option below in the setup command.
+
+environment:
+  global:
+    ICU_CI_CACHE: c:\icu-ci-cache
+    CYG_URL: https://cygwin.com/setup-x86_64.exe
+    CYG_MIRROR: http://ctm.crouchingtigerhiddenfruitbat.org/pub/cygwin/circa/64bit/2019/02/13/045332
+    CYG_PACKAGES: automake,gcc-core,gcc-g++,make,pkg-config,perl,python3
+    CYG_ROOT: c:\cygwin-root
+    CYG_CACHE: '%ICU_CI_CACHE%\cygwin64'
+    CYG_CACHED_SETUP: '%CYG_CACHE%\setup.exe'
+
+  matrix:
+    - BUILDSYSTEM: cygwin64-gcc
+      CC: gcc
+      CXX: g++
+      APPVEYOR_SAVE_CACHE_ON_ERROR: true
+#    - BUILDSYSTEM: VS2017
+#      configuration: Release
+#      APPVEYOR_CACHE_SKIP_RESTORE: true
+#      APPVEYOR_CACHE_SKIP_SAVE: true
+
+for:
+  -
+    matrix:
+      only:
+        - BUILDSYSTEM: cygwin64-gcc
+
+    install:
+      - ps: >-
+          if ( !(Test-Path "${env:CYG_CACHED_SETUP}" -NewerThan (Get-Date).AddDays(-7)) )
+          {
+            Write-Host "Cached Cygwin setup does not exist or is older than 7 days, downloading from external site."
+            New-Item -Force -Type Directory $env:CYG_CACHE
+            Invoke-WebRequest $env:CYG_URL -OutFile $env:CYG_CACHED_SETUP
+          }
+      - cmd: >-
+          %CYG_CACHED_SETUP% --no-verify --quiet-mode --no-shortcuts --no-startmenu --no-desktop --upgrade-also --only-site --site "%CYG_MIRROR%" --root "%CYG_ROOT%"  --local-package-dir "%CYG_CACHE%" --packages "%CYG_PACKAGES%"
+
+    # Check that we have a working Cygwin environment before building.
+    before_build:
+      - "%CYG_ROOT%\\bin\\sh -lc 'echo Hello'"
+      - "%CYG_ROOT%\\bin\\sh -lc 'uname -a'"
+
+    build_script:
+      - '%CYG_ROOT%\\bin\\bash -lc "cd $(cygpath ${APPVEYOR_BUILD_FOLDER}) && cd icu4c/source && ./runConfigureICU Cygwin && make check"'
+
+#  -
+#    matrix:
+#      only:
+#        - BUILDSYSTEM: VS2017
+#
+#    build:
+#      project: icu4c/source/allinone/allinone.sln
+#
+#    test_script:
+#      - icu4c/source/allinone/icucheck.bat x64 Release

--- a/.ci-builds/.azure-exhaustive-tests.yml
+++ b/.ci-builds/.azure-exhaustive-tests.yml
@@ -1,0 +1,62 @@
+# Azure Pipelines configuration for Exhaustive Tests for ICU.
+# 
+# Note: The exhaustive test configuration is in a separate file
+# so that it can be run independently from the regular builds.
+#
+# Only run the exhaustive tests on the master and maint branches, and
+# also batch up any pending changes so that we will only have at most
+# one build running at a given time (since they take a long time).
+trigger:
+  batch: true
+  branches:
+    include:
+    - master
+    - maint/maint-*
+
+jobs:
+#-------------------------------------------------------------------------
+# Note: The exhaustive tests for J take longer than the C tests. They 
+# take roughly 85 min to complete on the Azure VMs.
+- job: ICU4J_OpenJDK_Ubuntu_1604
+  displayName: 'J: Linux OpenJDK (Ubuntu 16.04)'
+  timeoutInMinutes: 100
+  pool:
+    vmImage: 'Ubuntu 16.04'
+    demands: ant
+  steps:
+    - checkout: self
+      lfs: true
+      fetchDepth: 1
+    - script: |
+        echo "Building ICU4J" && cd icu4j && ant init && ant exhaustiveCheck
+      displayName: 'Build and Exhaustive Tests'
+      env:
+        BUILD: ICU4J
+    - script: |
+        [ -d icu4j/out/junit-results ] && cd icu4j && cat `find out/junit-results -name "*.txt" -exec grep -l FAILED {} \;`
+      condition: failed() # only run if the build fails.
+      displayName: 'List failures (if any)'
+      timeoutInMinutes: 2
+#-------------------------------------------------------------------------
+# Note: The exhaustive tests take roughly 65 mins to complete on the
+# Azure VMs.
+- job: ICU4C_Clang_Exhaustive_Ubuntu_1604
+  displayName: 'C: Linux Clang Exhaustive Tests (Ubuntu 16.04)'
+  timeoutInMinutes: 80
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  steps:
+    - checkout: self
+      lfs: true
+      fetchDepth: 1
+    - script: |
+        cd icu4c/source && ./runConfigureICU Linux && make -j2
+      displayName: 'Build'
+    - script: |
+        cd icu4c/source && make check-exhaustive
+      displayName: 'Exhaustive Tests'
+      env:
+        CC: clang
+        CXX: clang++
+#-------------------------------------------------------------------------
+

--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -1,0 +1,289 @@
+# Azure Pipelines (VSTS) configuration for CI builds for ICU.
+
+jobs:
+#-------------------------------------------------------------------------
+- job: ICU4J_OpenJDK_Ubuntu_1604
+  displayName: 'J: Linux OpenJDK (Ubuntu 16.04)'
+  timeoutInMinutes: 20
+  pool:
+    vmImage: 'Ubuntu 16.04'
+    demands: ant
+  steps:
+    - checkout: self
+      lfs: true
+      fetchDepth: 1
+    - script: |
+        echo "Building ICU4J" && cd icu4j && ant init && ant check 
+      displayName: 'Build and Test'
+      env:
+        BUILD: ICU4J
+    - script: |
+        [ -d icu4j/out/junit-results ] && cd icu4j && cat `find out/junit-results -name "*.txt" -exec grep -l FAILED {} \;`
+      condition: failed() # only run if the build fails.
+      displayName: 'List failures (if any)'
+#-------------------------------------------------------------------------
+- job: ICU4C_Clang_Ubuntu_1604
+  displayName: 'C: Linux Clang (Ubuntu 16.04)'
+  timeoutInMinutes: 30
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  steps:
+    - checkout: self
+      lfs: true
+      fetchDepth: 1
+    - script: |
+        cd icu4c/source && ./runConfigureICU Linux && make -j2 check
+      displayName: 'Build and Test'
+      env:
+        CC: clang
+        CXX: clang++
+#-------------------------------------------------------------------------
+- job: ICU4C_Clang_Ubuntu_1604_WarningsAsWarnings
+  displayName: 'C: Linux Clang WarningsAsWarnings (Ubuntu 16.04)'
+  timeoutInMinutes: 30
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  steps:
+    - checkout: self
+      lfs: true
+      fetchDepth: 1
+    - script: |
+        export CPPFLAGS="-Wall -Wextra -Wextra-semi -Wundef -Wnon-virtual-dtor" && cd icu4c/source && ./runConfigureICU Linux && make -j2 tests
+      displayName: 'Build only (WarningsAsWarnings)'
+      env:
+        CC: clang
+        CXX: clang++
+#-------------------------------------------------------------------------
+- job: ICU4C_Clang_Ubuntu_DataFilter_1604
+  displayName: 'C: Linux Clang DataFilter (Ubuntu 16.04)'
+  timeoutInMinutes: 30
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  steps:
+    - checkout: self
+      lfs: true
+      fetchDepth: 1
+    - script: |
+        cd icu4c/source && \
+        ICU_DATA_FILTER_FILE=../../.ci-builds/data-filter.json ./runConfigureICU Linux && \
+        make -j2 tests && \
+        \[ ! -d data/out/build/icudt66l/translit \] && \
+        (cd test/intltest && LD_LIBRARY_PATH=../../lib:../../tools/ctestfw ./intltest translit/TransliteratorTest/TestBasicTransliteratorEvenWithoutData)
+      displayName: 'Build with Data Filter'
+      env:
+        CC: clang
+        CXX: clang++
+#-------------------------------------------------------------------------
+- job: ICU4C_MSVC_x64_Release_Distrelease
+  displayName: 'C: MSVC 64-bit Release (VS 2017) + Distrelease'
+  timeoutInMinutes: 30
+  pool:
+    vmImage: 'vs2017-win2016'
+    demands: 
+      - msbuild
+      - visualstudio
+      - Cmd
+  steps:
+    - checkout: self
+      lfs: true
+      fetchDepth: 1
+    - task: VSBuild@1
+      displayName: 'Build Solution'
+      inputs:
+        solution: icu4c/source/allinone/allinone.sln
+        platform: x64
+        configuration: Release
+    - task: BatchScript@1
+      displayName: 'Run Tests (icucheck.bat)'
+      inputs:
+        filename: icu4c/source/allinone/icucheck.bat
+        arguments: 'x64 Release'
+    - task: PowerShell@2
+      displayName: 'PowerShell: Distrelease script (x64)'
+      inputs:
+        targetType: filePath
+        filePath: 'icu4c/packaging/distrelease.ps1'
+        arguments: '-arch x64'
+        workingDirectory: icu4c
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish x64 Artifacts: icu-windows.zip'
+      inputs:
+        PathtoPublish: 'icu4c/source/dist/icu-windows.zip'
+        ArtifactName: '$(Build.BuildNumber)_ICU4C_MSVC_x64_Release'
+#-------------------------------------------------------------------------
+- job: ICU4C_MSVC_x86_Release_Distrelease
+  displayName: 'C: MSVC 32-bit Release (VS 2017) + Distrelease'
+  timeoutInMinutes: 30
+  pool:
+    vmImage: 'vs2017-win2016'
+    demands: 
+      - msbuild
+      - visualstudio
+      - Cmd
+  steps:
+    - checkout: self
+      lfs: true
+      fetchDepth: 1
+    - task: VSBuild@1
+      displayName: 'Build Solution'
+      inputs:
+        solution: icu4c/source/allinone/allinone.sln
+        platform: Win32
+        configuration: Release
+    - task: PowerShell@2
+      displayName: 'PowerShell: Distrelease script (x86)'
+      inputs:
+        targetType: filePath
+        filePath: 'icu4c/packaging/distrelease.ps1'
+        arguments: '-arch x86'
+        workingDirectory: icu4c
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish x86 Artifacts: icu-windows.zip'
+      inputs:
+        PathtoPublish: 'icu4c/source/dist/icu-windows.zip'
+        ArtifactName: '$(Build.BuildNumber)_ICU4C_MSVC_x86_Release'
+#-------------------------------------------------------------------------
+- job: ICU4C_MSVC_x64_ARM32_ARM64_Release_Distrelease
+  displayName: 'C: MSVC x64 ARM32 ARM64 Release (VS 2017) + Distrelease ARM64'
+  timeoutInMinutes: 60
+  pool:
+    vmImage: 'vs2017-win2016'
+    demands: 
+      - msbuild
+      - visualstudio
+      - Cmd
+  steps:
+    - checkout: self
+      lfs: true
+      fetchDepth: 1
+    - task: VSBuild@1
+      displayName: 'Build Solution'
+      inputs:
+        solution: icu4c/source/allinone/allinone.sln
+        platform: x64
+        configuration: Release
+    - task: VSBuild@1
+      displayName: 'Build ARM32'
+      inputs:
+        solution: icu4c/source/allinone/allinone.sln
+        platform: ARM
+        configuration: Release
+    - task: VSBuild@1
+      displayName: 'Build ARM64'
+      inputs:
+        solution: icu4c/source/allinone/allinone.sln
+        platform: ARM64
+        configuration: Release
+    - task: PowerShell@2
+      displayName: 'PowerShell: Distrelease script (ARM64)'
+      inputs:
+        targetType: filePath
+        filePath: 'icu4c/packaging/distrelease.ps1'
+        arguments: '-arch ARM64'
+        workingDirectory: icu4c
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish ARM64 Artifacts: icu-windows.zip'
+      inputs:
+        PathtoPublish: 'icu4c/source/dist/icu-windows.zip'
+        ArtifactName: '$(Build.BuildNumber)_ICU4C_MSVC_ARM64_Release'
+#-------------------------------------------------------------------------
+- job: ICU4C_MSVC_x64_Release_DataFilter
+  displayName: 'C: MSVC 64-bit Release DataFilter (VS 2017)'
+  timeoutInMinutes: 30
+  pool:
+    vmImage: 'vs2017-win2016'
+    demands: 
+      - msbuild
+      - visualstudio
+      - Cmd
+  steps:
+    - checkout: self
+      lfs: true
+      fetchDepth: 1
+    - powershell: |
+        $filterPath = $Env:BUILD_SOURCESDIRECTORY + "\.ci-builds\data-filter.json"
+        $vstsCommandString = "vso[task.setvariable variable=ICU_DATA_FILTER_FILE]" + $filterPath
+        Write-Host "##$vstsCommandString"
+    - task: VSBuild@1
+      displayName: 'Build Solution with Data Filter'
+      inputs:
+        solution: icu4c/source/allinone/allinone.sln
+        platform: x64
+        configuration: Release
+        msbuildArgs: '/p:SkipUWP=true'
+#-------------------------------------------------------------------------
+- job: ICU4C_MSVC_x86_Debug
+  displayName: 'C: MSVC 32-bit Debug (VS 2017)'
+  timeoutInMinutes: 60
+  pool:
+    vmImage: 'vs2017-win2016'
+    demands: 
+      - msbuild
+      - visualstudio
+      - Cmd
+  steps:
+    - checkout: self
+      lfs: true
+      fetchDepth: 1
+    - task: VSBuild@1
+      displayName: 'Build Solution'
+      inputs:
+        solution: icu4c/source/allinone/allinone.sln
+        platform: Win32
+        configuration: Debug
+    - task: BatchScript@1
+      displayName: 'Run Tests (icucheck.bat)'
+      inputs:
+        filename: icu4c/source/allinone/icucheck.bat
+        arguments: 'x86 Debug'
+#-------------------------------------------------------------------------
+- job: ICU4C_MSYS2_GCC_x86_64_Release
+  displayName: 'C: MSYS2 GCC x86_64 Release'
+  timeoutInMinutes: 45
+  pool:
+    vmImage: 'vs2017-win2016'
+    demands:
+      - Cmd
+  steps:
+    - checkout: self
+      lfs: true
+      fetchDepth: 1
+    - script: |
+       choco install -y msys2
+       rem refreshenv
+      displayName: 'Install MSYS2'
+    - script: |
+       c:\tools\msys64\usr\bin\bash.exe -lc "echo 'Hello World' && uname -a"
+       c:\tools\msys64\usr\bin\bash.exe -lc "pacman --noconfirm -S mingw-w64-x86_64-toolchain"
+       c:\tools\msys64\usr\bin\bash.exe -lc "pacman --noconfirm -S make"
+       exit
+      displayName: 'Install mingw-w64-x86_64-toolchain'
+    - script: |
+       set MSYSTEM=MINGW64
+       c:\tools\msys64\usr\bin\bash.exe -lc "cd $BUILD_SOURCESDIRECTORY && cd icu4c/source && ./runConfigureICU MinGW --prefix='/tmp/build-icu' && make -j2 check"
+      displayName: 'Build and Test'
+    - script: |
+       set MSYSTEM=MINGW64
+       c:\tools\msys64\usr\bin\bash.exe -lc "cd $BUILD_SOURCESDIRECTORY && cd icu4c/source && make install && cd /tmp/build-icu && echo 'Recursive ls' && ls -lR"
+      displayName: 'make install'
+    - script: |
+       set MSYSTEM=MINGW64
+       c:\tools\msys64\usr\bin\bash.exe -lc "echo 'Run icuinfo from MSYS shell' && cd /tmp/build-icu/bin && ./icuinfo.exe"
+       echo 'Run icuinfo from CMD shell' && cd /d C:\tools\msys64\tmp\build-icu\bin && set PATH=C:\tools\msys64\mingw64\bin;%PATH% && icuinfo.exe"
+      displayName: 'run icuinfo'
+#-------------------------------------------------------------------------
+- job: ICU4C_Clang_MacOSX_WarningsAsWarnings
+  displayName: 'C: macOSX Clang WarningsAsWarnings (Mojave 10.14)'
+  timeoutInMinutes: 30
+  pool:
+    vmImage: 'macOS-10.14'
+  steps:
+    - checkout: self
+      lfs: true
+      fetchDepth: 1
+    - script: |
+        export CPPFLAGS="-Wall -Wextra -Wextra-semi -Wundef -Wnon-virtual-dtor" && cd icu4c/source && ./runConfigureICU MacOSX && make -j2 tests
+      displayName: 'Build only (WarningsAsErrors)'
+      env:
+        CC: clang
+        CXX: clang++

--- a/.ci-builds/.azure-valgrind.yml
+++ b/.ci-builds/.azure-valgrind.yml
@@ -1,0 +1,73 @@
+# Azure Pipelines configuration for Valgrind for ICU4C.
+# 
+# Note: The valgrind test configuration is in a separate file
+# so that it can be run independently from the regular builds.
+#
+# The Ubuntu images don't have valgrind installed by default, so we need
+# install it first.
+#
+# Only run valgrind on the master and maint branches, and
+# batch up any pending changes so that we will only have at most
+# one build running at a given time (since it takes time).
+trigger:
+  batch: true
+  branches:
+    include:
+    - master
+    - maint/maint-*
+  paths:
+    include:
+    - '*'
+    exclude:
+    - docs/*
+    - icu4j/*
+    - tools/*
+    - vendor/*
+    - .appveyor.xml
+    - .cpyskip.txt
+    - .travis.yml
+    - KEYS
+    - README.md
+
+jobs:
+#-------------------------------------------------------------------------
+- job: ICU4C_Clang_Valgrind_Ubuntu_1604
+  displayName: 'C: Linux Clang Valgrind (Ubuntu 16.04)'
+  timeoutInMinutes: 60
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  steps:
+    - checkout: self
+      lfs: true
+      fetchDepth: 1
+    - script: |
+        set -ex
+        sudo apt -y update
+        sudo apt install -y valgrind
+      displayName: 'Install valgrind'
+      timeoutInMinutes: 5
+    - script: |
+        cd icu4c/source && ./runConfigureICU --enable-debug Linux --disable-renaming --disable-layout --disable-layoutex && make -j2 tests
+      displayName: 'Build'
+      timeoutInMinutes: 10
+      env:
+        CC: clang
+        CXX: clang++
+    - script: |
+        cd icu4c/source/test/intltest && LD_LIBRARY_PATH=../../lib:../../stubdata:../../tools/ctestfw:$LD_LIBRARY_PATH valgrind --tool=memcheck --error-exitcode=1 --leak-check=full --show-reachable=yes ./intltest
+      displayName: 'Valgrind intltest'
+      timeoutInMinutes: 45
+    - script: |
+        cd icu4c/source/test/cintltst && LD_LIBRARY_PATH=../../lib:../../stubdata:../../tools/ctestfw:$LD_LIBRARY_PATH valgrind --tool=memcheck --error-exitcode=1 --leak-check=full --show-reachable=yes ./cintltst
+      displayName: 'Valgrind cintltst'
+      timeoutInMinutes: 15
+    - script: |
+        cd icu4c/source/test/iotest && LD_LIBRARY_PATH=../../lib:../../stubdata:../../tools/ctestfw:$LD_LIBRARY_PATH valgrind --tool=memcheck --error-exitcode=1 --leak-check=full --show-reachable=yes ./iotest
+      displayName: 'Valgrind iotest'
+      timeoutInMinutes: 5
+    - script: |
+        cd icu4c/source/tools/icuinfo && LD_LIBRARY_PATH=../../lib:../../stubdata:../../tools/ctestfw:$LD_LIBRARY_PATH valgrind --tool=memcheck --error-exitcode=1 --leak-check=full --show-reachable=yes ./icuinfo
+      displayName: 'Valgrind icuinfo'
+      timeoutInMinutes: 5
+
+#-------------------------------------------------------------------------

--- a/.ci-builds/data-filter.json
+++ b/.ci-builds/data-filter.json
@@ -1,0 +1,38 @@
+{
+  "localeFilter": {
+    "filterType": "language",
+    "whitelist": [
+      "en",
+      "de",
+      "zh"
+    ]
+  },
+// Test mixed feature filter and resource filter
+// Exlude translit data so we can run test for ICU-20673
+  "featureFilters": {
+    "misc": {
+      "whitelist": ["supplementalData"]
+    },
+    "translit": "exclude"
+  },
+  "resourceFilters": [
+    {
+      "categories": ["misc"],
+      "files": {
+        "whitelist": ["supplementalData"]
+      },
+      "rules": ["+/*"]
+    }
+  ],
+// Test fileReplacements (relative path)
+  "fileReplacements": {
+    "directory": "$SRC",
+    "replacements": [
+      {
+        "src": "brkitr/rules/line.txt",
+        "dest": "brkitr/rules/line_normal.txt"
+      },
+      "misc/dayPeriods.txt"
+    ]
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,173 @@
+matrix:
+  include:
+
+    # ICU4C Docs Build
+    #    TODO: publish the latest built docs from master on GitHub pages.
+    #          See https://gist.github.com/vidavidorra/548ffbcdae99d752da02 for ideas.
+    - name:     "c: docs"
+      dist:     xenial
+      language: cpp
+      addons:
+         apt:
+           update: true
+           packages:
+             - doxygen
+      before_script:
+        - cd icu4c/source
+        - ./runConfigureICU Linux --disable-renaming
+      script:
+        # fail if 'warning:' appears in doxygen's output, but ignore warnings from file Doxyfile.
+        # The Doxygen version from Travis is down-rev, and doesn't recognize some options
+        # in the Doxyfile config file.
+        # Regex note: (?! ... ) is a negative lookahead. Succeed if the pattern is not present.
+        #- set +o pipefail && make doc 2>&1 | tee doxygen.log && ( ! grep -P 'warning:(?! .* file Doxyfile)' doxygen.log )
+        # in this branch, we have doc warnings.
+        make doc
+
+
+    - name: "j"
+      language: java
+      addons:
+        apt:
+          packages:
+            - ant
+            - ant-optional
+      env:      BUILD=ICU4J
+      before_script:
+        - cd icu4j
+        - ant init
+      script:
+        - ant check
+      after_failure:
+          -  cat `find out/junit-results -name "*.txt" -exec grep -l FAILED {} \;`
+
+    - name: "c: linux gcc 8 Wextra"
+      dist:     bionic
+      language: cpp
+      addons:
+         apt:
+           packages:
+             - g++-8
+      env: PREFIX=/tmp/icu-prefix CC=gcc-8 CXX=g++-8 CXXFLAGS="-Wextra"
+      before_script:
+        - mkdir build
+        - cd build
+        - ../icu4c/source/runConfigureICU Linux --disable-debug --enable-release --disable-layoutex --prefix="${PREFIX}" || (tail -100 config.log ; false)
+        - make -j2
+      script:
+        - make -j2 check
+        - make install
+        #- PATH="${PREFIX}/bin:$PATH" make -C test/hdrtst check
+
+    # gcc debug build.
+    # Includes dependency checker.
+    # Note - the dependency checker needs to be run on both a debug and an optimized build.
+    # This one (gcc) for debug, and linux clang (below) for optimized.
+    #
+    # Test both out-of-source and in-source builds. This one (gcc) for out-of-source,
+    # and linux clang (below) for in-source.
+    #
+    # Invokes test/hdrtst to check public headers compliance.
+
+    - name: "c: linux gcc"
+      dist:     xenial
+      language: cpp
+      compiler: gcc
+      env:      PREFIX=/tmp/icu-prefix
+      before_script:
+        - mkdir build
+        - cd build
+        - ../icu4c/source/runConfigureICU --enable-debug --disable-release Linux --prefix="${PREFIX}" --enable-tracing
+        - make -j2
+      script:
+        - make -j2 check
+        #- ( cd ../icu4c/source/test/depstest && ./depstest.py ../../../../build/ )
+        - make install
+        #- PATH="${PREFIX}/bin:$PATH" make -C test/hdrtst check
+
+    # clang release build with some options to enforce useful constraints.
+    # Includes dependency checker on an in-source, optimized build.
+    # Includes checking @draft etc. API tags vs. ifndef guards like
+    # U_HIDE_DRAFT_API and U_FORCE_HIDE_DRAFT_API.
+    # (FORCE guards make this tool pass but won't compile to working code.
+    # See the testtagsguards.sh script for details.)
+    - name: "c: linux clang"
+      dist:     xenial
+      language: cpp
+      env:
+        - CPPFLAGS="-DU_NO_DEFAULT_INCLUDE_UTF_HEADERS=1"
+        - CFLAGS="-Wimplicit-fallthrough"
+        - CXXFLAGS="-Wimplicit-fallthrough"
+      compiler: clang
+      before_install:
+        - sudo apt-get -y install doxygen  # for make dist
+      before_script:
+        - cd icu4c/source
+        - ./runConfigureICU Linux
+        - make -j2
+      script:
+        - make -j2 check
+        - ( cd test/depstest && python3 depstest.py ../../../source/ )
+        #- ( cd .. && source/test/hdrtst/testtagsguards.sh )
+        #- make dist # not sure if this is -j safe everywhere.
+
+    - name: "c: osx clang"
+      language: cpp
+      env:      BUILD=MACINTOSH
+      os:       osx
+      compiler: clang
+      # Use the macOS target to test Python 2 in data build script.
+      # TODO(ICU-20301): Change this back to the default Python version 3.
+      script:   cd icu4c/source && PYTHON=python2 ./runConfigureICU MacOSX && make -j2 check
+
+    # Clang Linux with address sanitizer.
+    # Note - the 'sudo: true' option forces Travis to use a Virtual machine on GCE instead of
+    #        a Container on EC2 or Packet. Asan builds of ICU fail otherwise.
+    - name: "c: linux asan"
+      language: cpp
+      env:
+        - CPPFLAGS="-fsanitize=address"
+        - LDFLAGS="-fsanitize=address"
+      os:       linux
+      dist:     xenial
+      sudo:     true
+      compiler: clang
+      before_script:
+        - cd icu4c/source
+        - ./runConfigureICU --enable-debug --disable-release Linux --disable-renaming --enable-tracing
+        - make -j2
+      script:
+        - make -j2 check
+
+
+    # Clang Linux with thread sanitizer.
+    #
+    - name: "c: linux tsan"
+      language: cpp
+      env:
+          - INTLTEST_OPTS="utility/MultithreadTest"
+          - CPPFLAGS="-fsanitize=thread"
+          - LDFLAGS=-fsanitize=thread
+      os:       linux
+      dist:     xenial
+      sudo:     true
+      compiler: clang
+      script:
+          - cd icu4c/source
+          - ./runConfigureICU --enable-debug --disable-release Linux --disable-renaming
+          - make -j2
+          - make -j2 -C test
+          - make -j2 -C test/intltest check
+
+    # copyright scan / future linter
+    # - name: "lint"
+    #   script:
+    #       - perl tools/scripts/cpysearch/cpyscan.pl
+
+    # - name: "j: icu4c release tools"
+    #   language: "java"
+    #   script:
+    #     - mvn -f tools/release/java/pom.xml package dependency:analyze
+    #   cache:
+    #     directories:
+    #     - $HOME/.m2

--- a/icu4c/source/common/putil.cpp
+++ b/icu4c/source/common/putil.cpp
@@ -533,6 +533,30 @@ uprv_fmin(double x, double y)
     return (x > y ? y : x);
 }
 
+#include <iostream>
+
+U_CAPI UBool U_EXPORT2
+uprv_add32_overflow(int32_t a, int32_t b, int32_t* res) {
+    // NOTE: Some compilers (GCC, Clang) have primitives available, like __builtin_add_overflow.
+    // This function could be optimized by calling one of those primitives.
+    auto a64 = static_cast<int64_t>(a);
+    auto b64 = static_cast<int64_t>(b);
+    int64_t res64 = a64 + b64;
+    *res = static_cast<int32_t>(res64);
+    return res64 != *res;
+}
+
+U_CAPI UBool U_EXPORT2
+uprv_mul32_overflow(int32_t a, int32_t b, int32_t* res) {
+    // NOTE: Some compilers (GCC, Clang) have primitives available, like __builtin_mul_overflow.
+    // This function could be optimized by calling one of those primitives.
+    auto a64 = static_cast<int64_t>(a);
+    auto b64 = static_cast<int64_t>(b);
+    int64_t res64 = a64 * b64;
+    *res = static_cast<int32_t>(res64);
+    return res64 != *res;
+}
+
 /**
  * Truncates the given double.
  * trunc(3.3) = 3.0, trunc (-3.3) = -3.0

--- a/icu4c/source/common/putil.cpp
+++ b/icu4c/source/common/putil.cpp
@@ -533,8 +533,6 @@ uprv_fmin(double x, double y)
     return (x > y ? y : x);
 }
 
-#include <iostream>
-
 U_CAPI UBool U_EXPORT2
 uprv_add32_overflow(int32_t a, int32_t b, int32_t* res) {
     // NOTE: Some compilers (GCC, Clang) have primitives available, like __builtin_add_overflow.

--- a/icu4c/source/common/putilimp.h
+++ b/icu4c/source/common/putilimp.h
@@ -391,6 +391,32 @@ U_INTERNAL double  U_EXPORT2 uprv_log(double d);
  */
 U_INTERNAL double  U_EXPORT2 uprv_round(double x);
 
+/**
+ * Adds the signed integers a and b, storing the result in res.
+ * Checks for signed integer overflow.
+ * Similar to the GCC/Clang extension __builtin_add_overflow
+ *
+ * @param a The first operand.
+ * @param b The second operand.
+ * @param res a + b
+ * @return true if overflow occurred; false if no overflow occurred.
+ * @internal
+ */
+U_INTERNAL UBool U_EXPORT2 uprv_add32_overflow(int32_t a, int32_t b, int32_t* res);
+
+/**
+ * Multiplies the signed integers a and b, storing the result in res.
+ * Checks for signed integer overflow.
+ * Similar to the GCC/Clang extension __builtin_mul_overflow
+ *
+ * @param a The first multiplicand.
+ * @param b The second multiplicand.
+ * @param res a * b
+ * @return true if overflow occurred; false if no overflow occurred.
+ * @internal
+ */
+U_INTERNAL UBool U_EXPORT2 uprv_mul32_overflow(int32_t a, int32_t b, int32_t* res);
+
 #if 0
 /**
  * Returns the number of digits after the decimal point in a double number x.

--- a/icu4c/source/common/unicode/unistr.h
+++ b/icu4c/source/common/unicode/unistr.h
@@ -243,6 +243,9 @@ class UnicodeStringAppendable;  // unicode/appendable.h
  * than other ICU APIs. In particular:
  * - If indexes are out of bounds for a UnicodeString object
  *   (<0 or >length()) then they are "pinned" to the nearest boundary.
+ * - If the buffer passed to an insert/append/replace operation is owned by the
+ *   target object, e.g., calling str.append(str), an extra copy may take place
+ *   to ensure safety.
  * - If primitive string pointer values (e.g., const char16_t * or char *)
  *   for input strings are NULL, then those input string parameters are treated
  *   as if they pointed to an empty string.

--- a/icu4c/source/common/unistr.cpp
+++ b/icu4c/source/common/unistr.cpp
@@ -1447,10 +1447,15 @@ UnicodeString::doReplace(int32_t start,
   }
 
   if(srcChars == 0) {
-    srcStart = srcLength = 0;
-  } else if(srcLength < 0) {
-    // get the srcLength if necessary
-    srcLength = u_strlen(srcChars + srcStart);
+    srcLength = 0;
+  } else {
+    // Perform all remaining operations relative to srcChars + srcStart.
+    // From this point forward, do not use srcStart.
+    srcChars += srcStart;
+    if (srcLength < 0) {
+      // get the srcLength if necessary
+      srcLength = u_strlen(srcChars);
+    }
   }
 
   // pin the indices to legal values
@@ -1465,17 +1470,28 @@ UnicodeString::doReplace(int32_t start,
   }
   newLength += srcLength;
 
+  // Check for insertion into ourself
+  const UChar *oldArray = getArrayStart();
+  if (isBufferWritable() &&
+      oldArray < srcChars + srcLength &&
+      srcChars < oldArray + oldLength) {
+    // Copy into a new UnicodeString and start over
+    UnicodeString copy(srcChars, srcLength);
+    if (copy.isBogus()) {
+      setToBogus();
+      return *this;
+    }
+    return doReplace(start, length, copy.getArrayStart(), 0, srcLength);
+  }
+
   // cloneArrayIfNeeded(doCopyArray=FALSE) may change fArray but will not copy the current contents;
   // therefore we need to keep the current fArray
   UChar oldStackBuffer[US_STACKBUF_SIZE];
-  UChar *oldArray;
   if((fUnion.fFields.fLengthAndFlags&kUsingStackBuffer) && (newLength > US_STACKBUF_SIZE)) {
     // copy the stack buffer contents because it will be overwritten with
     // fUnion.fFields values
-    u_memcpy(oldStackBuffer, fUnion.fStackFields.fBuffer, oldLength);
+    u_memcpy(oldStackBuffer, oldArray, oldLength);
     oldArray = oldStackBuffer;
-  } else {
-    oldArray = getArrayStart();
   }
 
   // clone our array and allocate a bigger array if needed
@@ -1503,7 +1519,7 @@ UnicodeString::doReplace(int32_t start,
   }
 
   // now fill in the hole with the new string
-  us_arrayCopy(srcChars, srcStart, newArray, start, srcLength);
+  us_arrayCopy(srcChars, 0, newArray, start, srcLength);
 
   setLength(newLength);
 
@@ -1536,9 +1552,13 @@ UnicodeString::doAppend(const UChar *srcChars, int32_t srcStart, int32_t srcLeng
     return *this;
   }
 
+  // Perform all remaining operations relative to srcChars + srcStart.
+  // From this point forward, do not use srcStart.
+  srcChars += srcStart;
+
   if(srcLength < 0) {
     // get the srcLength if necessary
-    if((srcLength = u_strlen(srcChars + srcStart)) == 0) {
+    if((srcLength = u_strlen(srcChars)) == 0) {
       return *this;
     }
   }
@@ -1556,8 +1576,8 @@ UnicodeString::doAppend(const UChar *srcChars, int32_t srcStart, int32_t srcLeng
     // or
     //   str.appendString(buffer, length)
     // or similar.
-    if(srcChars + srcStart != newArray + oldLength) {
-      us_arrayCopy(srcChars, srcStart, newArray, oldLength, srcLength);
+    if(srcChars != newArray + oldLength) {
+      us_arrayCopy(srcChars, 0, newArray, oldLength, srcLength);
     }
     setLength(newLength);
   }

--- a/icu4c/source/test/cintltst/putiltst.c
+++ b/icu4c/source/test/cintltst/putiltst.c
@@ -128,6 +128,20 @@ static void TestPUtilAPI(void){
         log_err("ERROR: uprv_isInfinite failed.\n");
     }
 
+    log_verbose("Testing the APIs uprv_add32_overflow and uprv_mul32_overflow\n");
+    int32_t overflow_result;
+    doAssert(FALSE, uprv_add32_overflow(INT32_MAX - 2, 1, &overflow_result), "should not overflow");
+    doAssert(INT32_MAX - 1, overflow_result, "should equal INT32_MAX - 1");
+    doAssert(FALSE, uprv_add32_overflow(INT32_MAX - 2, 2, &overflow_result), "should not overflow");
+    doAssert(INT32_MAX, overflow_result, "should equal exactly INT32_MAX");
+    doAssert(TRUE, uprv_add32_overflow(INT32_MAX - 2, 3, &overflow_result), "should overflow");
+    doAssert(FALSE, uprv_mul32_overflow(INT32_MAX / 5, 4, &overflow_result), "should not overflow");
+    doAssert(INT32_MAX / 5 * 4, overflow_result, "should equal INT32_MAX / 5 * 4");
+    doAssert(TRUE, uprv_mul32_overflow(INT32_MAX / 5, 6, &overflow_result), "should overflow");
+    // Test on negative numbers:
+    doAssert(FALSE, uprv_add32_overflow(-3, -2, &overflow_result), "should not overflow");
+    doAssert(-5, overflow_result, "should equal -5");
+
 #if 0
     log_verbose("Testing the API uprv_digitsAfterDecimal()....\n");
     doAssert(uprv_digitsAfterDecimal(value1), 3, "uprv_digitsAfterDecimal() failed.");

--- a/icu4c/source/test/intltest/ustrtest.cpp
+++ b/icu4c/source/test/intltest/ustrtest.cpp
@@ -64,6 +64,8 @@ void UnicodeStringTest::runIndexedTest( int32_t index, UBool exec, const char* &
     TESTCASE_AUTO(TestUInt16Pointers);
     TESTCASE_AUTO(TestWCharPointers);
     TESTCASE_AUTO(TestNullPointers);
+    TESTCASE_AUTO(TestUnicodeStringInsertAppendToSelf);
+    TESTCASE_AUTO(TestLargeAppend);
     TESTCASE_AUTO_END;
 }
 
@@ -2246,7 +2248,6 @@ UnicodeStringTest::TestNullPointers() {
     UnicodeString(u"def").extract(nullptr, 0, errorCode);
     assertEquals("buffer overflow extracting to nullptr", U_BUFFER_OVERFLOW_ERROR, errorCode);
 }
-
 void UnicodeStringTest::TestUnicodeStringInsertAppendToSelf() {
     IcuTestErrorCode status(*this, "TestUnicodeStringAppendToSelf");
 

--- a/icu4c/source/test/intltest/ustrtest.h
+++ b/icu4c/source/test/intltest/ustrtest.h
@@ -96,6 +96,8 @@ public:
     void TestUInt16Pointers();
     void TestWCharPointers();
     void TestNullPointers();
+    void TestUnicodeStringInsertAppendToSelf();
+    void TestLargeAppend();
 };
 
 #endif


### PR DESCRIPTION
[ICU-21032] Backport of [ICU-20958] aka #971 

Includes partial backports so that this can be merged:
- ICU-13634 Adding functions for integer overflow
- ICU-13634 Removing stray #include added in r41136.
- ICU-13707 Make UnicodeString safe when appended or inserted into itself. (#147)

Multiple commits to preserve history, so:

ALLOW_MANY_COMMITS=true

[ICU-21032]: https://unicode-org.atlassian.net/browse/ICU-21032
[ICU-20958]: https://unicode-org.atlassian.net/browse/ICU-20958