### PR TITLE
ICU-20435 Fix parallel builds with Cygwin to 3.x

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,8 +66,7 @@ for:
       - "%CYG_ROOT%\\bin\\sh -lc 'uname -a'"
 
     build_script:
-      - '%CYG_ROOT%\\bin\\bash -lc "cd $(cygpath ${APPVEYOR_BUILD_FOLDER}) && cd icu4c/source && ./runConfigureICU Cygwin && make"'
-      - '%CYG_ROOT%\\bin\\bash -lc "cd $(cygpath ${APPVEYOR_BUILD_FOLDER}) && cd icu4c/source && make -j2 check"'
+      - '%CYG_ROOT%\\bin\\bash -lc "cd $(cygpath ${APPVEYOR_BUILD_FOLDER}) && cd icu4c/source && ./runConfigureICU Cygwin && make -j2 check"'
 
 #  -
 #    matrix:

--- a/icu4c/source/config/mh-cygwin
+++ b/icu4c/source/config/mh-cygwin
@@ -105,7 +105,7 @@ ICULIBSUFFIX_VERSION = $(LIB_VERSION_MAJOR)
 #%$(SO_TARGET_VERSION_MAJOR).$(SO): %$(SO_TARGET_VERSION).$(SO)
 #	$(RM) $@ && cp ${<F} $@
 %.$(SO): %$(SO_TARGET_VERSION_MAJOR).$(SO)
-	$(RM) $(subst cyg,lib,$@).$(A) && ln -s $(subst cyg,lib,${<F}).$(A) $(subst cyg,lib,$@).$(A)
+	ln -fs $(subst cyg,lib,${<F}).$(A) $(subst cyg,lib,$@).$(A)
 
 ## Install libraries as executable
 INSTALL-L=$(INSTALL_PROGRAM)

--- a/icu4c/source/config/mh-cygwin64
+++ b/icu4c/source/config/mh-cygwin64
@@ -105,7 +105,7 @@ ICULIBSUFFIX_VERSION = $(LIB_VERSION_MAJOR)
 #%$(SO_TARGET_VERSION_MAJOR).$(SO): %$(SO_TARGET_VERSION).$(SO)
 #	$(RM) $@ && cp ${<F} $@
 %.$(SO): %$(SO_TARGET_VERSION_MAJOR).$(SO)
-	$(RM) $(subst cyg,lib,$@).$(A) && ln -s $(subst cyg,lib,${<F}).$(A) $(subst cyg,lib,$@).$(A)
+	ln -fs $(subst cyg,lib,${<F}).$(A) $(subst cyg,lib,$@).$(A)
 
 ## Install libraries as executable
 INSTALL-L=$(INSTALL_PROGRAM)


### PR DESCRIPTION
This is a follow-up to PR #1059.

Parallel builds on Cygwin 3.x were broken, this PR fixes them, and changes the AppVeyor CI config to use a parallel build (which saves for each run on PRs).

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20435
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

