### PR TITLE
ICU-21020 Fix a typo in the LocalizedNumberRangeFormatter's documentation

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/number/LocalizedNumberRangeFormatter.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/number/LocalizedNumberRangeFormatter.java
@@ -69,7 +69,7 @@ public class LocalizedNumberRangeFormatter extends NumberRangeFormatterSettings<
      * @param second
      *            The second number in the range, usually to the right in LTR locales.
      * @return A FormattedNumberRange object; call .toString() to get the string.
-     * @throw IllegalArgumentException if first or second is null
+     * @throws IllegalArgumentException if first or second is null
      * @stable ICU 63
      * @see NumberRangeFormatter
      */


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-21020