### PR TITLE
ICU-21026 fix GCC warnings of signed-int left shift

### DIFF
--- a/icu4c/source/tools/gensprep/store.c
+++ b/icu4c/source/tools/gensprep/store.c
@@ -412,7 +412,8 @@ storeMapping(uint32_t codepoint, uint32_t* mapping,int32_t length,
         int16_t delta = (int16_t)((int32_t)codepoint - (int16_t) mapping[0]);
         if(delta >= SPREP_DELTA_RANGE_NEGATIVE_LIMIT && delta <= SPREP_DELTA_RANGE_POSITIVE_LIMIT){
 
-            trieWord = delta << 2;
+            trieWord = delta;
+            trieWord <<= 2;
 
 
             /* make sure that the second bit is OFF */


### PR DESCRIPTION
##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21026
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

