### PR TITLE
ICU-21037 Reduce size of BreakIterator brk files

### DIFF
--- a/icu4c/source/common/rbbidata.h
+++ b/icu4c/source/common/rbbidata.h
@@ -58,7 +58,7 @@ ubrk_swap(const UDataSwapper *ds,
 U_NAMESPACE_BEGIN
 
 // The current RBBI data format version.
-static const uint8_t RBBI_DATA_FORMAT_VERSION[] = {5, 0, 0, 0};
+static const uint8_t RBBI_DATA_FORMAT_VERSION[] = {6, 0, 0, 0};
 
 /*  
  *   The following structs map exactly onto the raw data from ICU common data file. 
@@ -94,32 +94,40 @@ struct RBBIDataHeader {
 
 
 
-struct  RBBIStateTableRow {
-    int16_t          fAccepting;    /*  Non-zero if this row is for an accepting state.   */
-                                    /*  Value 0: not an accepting state.                  */
-                                    /*       -1: Unconditional Accepting state.           */
-                                    /*    positive:  Look-ahead match has completed.      */
-                                    /*           Actual boundary position happened earlier */
-                                    /*           Value here == fLookAhead in earlier      */
-                                    /*              state, at actual boundary pos.        */
-    int16_t          fLookAhead;    /*  Non-zero if this row is for a state that          */
-                                    /*    corresponds to a '/' in the rule source.        */
-                                    /*    Value is the same as the fAccepting             */
-                                    /*      value for the rule (which will appear         */
-                                    /*      in a different state.                         */
-    int16_t          fTagIdx;       /*  Non-zero if this row covers a {tagged} position   */
-                                    /*     from a rule.  Value is the index in the        */
-                                    /*     StatusTable of the set of matching             */
-                                    /*     tags (rule status values)                      */
-    int16_t          fReserved;
-    uint16_t         fNextState[1]; /*  Next State, indexed by char category.             */
-                                    /*    Variable-length array declared with length 1    */
-                                    /*    to disable bounds checkers.                     */
-                                    /*    Array Size is actually fData->fHeader->fCatCount*/
-                                    /*    CAUTION:  see RBBITableBuilder::getTableSize()  */
-                                    /*              before changing anything here.        */
+#define DECLARE_STATE_TABLE_ROW_STRUCT(name, T) \
+struct  name { \
+    T                fAccepting;    /*  Non-zero if this row is for an accepting state.   */ \
+                                    /*  Value 0: not an accepting state.                  */ \
+                                    /*       -1: Unconditional Accepting state.           */ \
+                                    /*    positive:  Look-ahead match has completed.      */ \
+                                    /*           Actual boundary position happened earlier */ \
+                                    /*           Value here == fLookAhead in earlier      */ \
+                                    /*              state, at actual boundary pos.        */ \
+    T                fLookAhead;    /*  Non-zero if this row is for a state that          */ \
+                                    /*    corresponds to a '/' in the rule source.        */ \
+                                    /*    Value is the same as the fAccepting             */ \
+                                    /*      value for the rule (which will appear         */ \
+                                    /*      in a different state.                         */ \
+    T                fTagIdx;       /*  Non-zero if this row covers a {tagged} position   */ \
+                                    /*     from a rule.  Value is the index in the        */ \
+                                    /*     StatusTable of the set of matching             */ \
+                                    /*     tags (rule status values)                      */ \
+    T                fReserved; \
+    T                fNextState[1]; /*  Next State, indexed by char category.             */ \
+                                    /*    Variable-length array declared with length 1    */ \
+                                    /*    to disable bounds checkers.                     */ \
+                                    /*    Array Size is actually fData->fHeader->fCatCount*/ \
+                                    /*    CAUTION:  see RBBITableBuilder::getTableSize()  */ \
+                                    /*              before changing anything here.        */ \
 };
 
+DECLARE_STATE_TABLE_ROW_STRUCT(RBBIStateTableRowS16, int16_t)
+DECLARE_STATE_TABLE_ROW_STRUCT(RBBIStateTableRowS8, int8_t)
+
+union RBBIStateTableRow {
+  RBBIStateTableRowS16 s16;
+  RBBIStateTableRowS8 s8;
+};
 
 struct RBBIStateTable {
     uint32_t         fNumStates;    /*  Number of states.                                 */
@@ -135,7 +143,8 @@ struct RBBIStateTable {
 
 typedef enum {
     RBBI_LOOKAHEAD_HARD_BREAK = 1,
-    RBBI_BOF_REQUIRED = 2
+    RBBI_BOF_REQUIRED = 2,
+    RBBI_8BITS_ROWS = 4
 } RBBIStateTableFlags;
 
 
@@ -170,7 +179,7 @@ public:
     const RBBIDataHeader     *fHeader;
     const RBBIStateTable     *fForwardTable;
     const RBBIStateTable     *fReverseTable;
-    const UChar              *fRuleSource;
+    const char               *fRuleSource;
     const int32_t            *fRuleStatusTable; 
 
     /* number of int32_t values in the rule status table.   Used to sanity check indexing */

--- a/icu4c/source/common/rbbirb.h
+++ b/icu4c/source/common/rbbirb.h
@@ -174,8 +174,8 @@ public:
     UVector                       *fRuleStatusVals;  // The values that can be returned
                                                      //   from getRuleStatus().
 
-    RBBIDataHeader                *flattenData();    // Create the flattened (runtime format)
-                                                     // data tables..
+    RBBIDataHeader                *flattenData(UBool use8Bits);    // Create the flattened (runtime format)
+                                                                   // data tables..
 private:
     RBBIRuleBuilder(const RBBIRuleBuilder &other); // forbid copying of this class
     RBBIRuleBuilder &operator=(const RBBIRuleBuilder &other); // forbid copying of this class

--- a/icu4c/source/common/rbbiscan.cpp
+++ b/icu4c/source/common/rbbiscan.cpp
@@ -829,16 +829,14 @@ static const UChar      chRParen    = 0x29;
 UnicodeString RBBIRuleScanner::stripRules(const UnicodeString &rules) {
     UnicodeString strippedRules;
     int32_t rulesLength = rules.length();
-    bool skippingSpaces = false;
 
     for (int32_t idx=0; idx<rulesLength; idx = rules.moveIndex32(idx, 1)) {
         UChar32 cp = rules.char32At(idx);
         bool whiteSpace = u_hasBinaryProperty(cp, UCHAR_PATTERN_WHITE_SPACE);
-        if (skippingSpaces && whiteSpace) {
+        if (whiteSpace) {
             continue;
         }
         strippedRules.append(cp);
-        skippingSpaces = whiteSpace;
     }
     return strippedRules;
 }

--- a/icu4c/source/common/rbbisetb.h
+++ b/icu4c/source/common/rbbisetb.h
@@ -83,7 +83,7 @@ public:
     ~RBBISetBuilder();
 
     void     buildRanges();
-    void     buildTrie();
+    void     buildTrie(UBool use8Bits);
     void     addValToSets(UVector *sets,      uint32_t val);
     void     addValToSet (RBBINode *usetNode, uint32_t val);
     int32_t  getNumCharCategories() const;   // CharCategories are the same as input symbol set to the
@@ -102,6 +102,7 @@ public:
     void     mergeCategories(IntPair categories);
 
     static constexpr int32_t DICT_BIT = 0x4000;
+    static constexpr int32_t DICT_BIT_FOR_8BITS_TRIE  = 0x0080;
 
 #ifdef RBBI_DEBUG
     void     printSets();
@@ -133,6 +134,7 @@ private:
     int32_t               fGroupCount;
 
     UBool                 fSawBOF;
+    UBool                 fUse8Bits;
 
     RBBISetBuilder(const RBBISetBuilder &other); // forbid copying of this class
     RBBISetBuilder &operator=(const RBBISetBuilder &other); // forbid copying of this class

--- a/icu4c/source/common/rbbitblb.h
+++ b/icu4c/source/common/rbbitblb.h
@@ -47,11 +47,11 @@ public:
     void     buildForwardTable();
 
     /** Return the runtime size in bytes of the built state table.  */
-    int32_t  getTableSize() const;
+    int32_t  getTableSize(UBool use8Bits) const;
 
     /** Fill in the runtime state table. Sufficient memory must exist at the specified location.
      */
-    void     exportTable(void *where);
+    void     exportTable(void *where, UBool use8Bits);
 
     /**
      *  Find duplicate (redundant) character classes. Begin looking with categories.first.
@@ -79,11 +79,11 @@ public:
     void     buildSafeReverseTable(UErrorCode &status);
 
     /** Return the runtime size in bytes of the built safe reverse state table. */
-    int32_t  getSafeTableSize() const;
+    int32_t  getSafeTableSize(UBool use8Bits) const;
 
     /** Fill in the runtime safe state table. Sufficient memory must exist at the specified location.
      */
-    void     exportSafeTable(void *where);
+    void     exportSafeTable(void *where, UBool use8Bits);
 
 
 private:

--- a/icu4c/source/common/ubidi_props_data.h
+++ b/icu4c/source/common/ubidi_props_data.h
@@ -906,6 +906,7 @@ static const UBiDiProps ubidi_props_singleton={
     ubidi_props_trieIndex,
     ubidi_props_trieIndex+3568,
     NULL,
+    NULL,
     3568,
     8968,
     0x1a0,

--- a/icu4c/source/common/ucase_props_data.h
+++ b/icu4c/source/common/ucase_props_data.h
@@ -935,6 +935,7 @@ static const UCaseProps ucase_props_singleton={
     ucase_props_trieIndex,
     ucase_props_trieIndex+3288,
     NULL,
+    NULL,
     3288,
     9068,
     0x188,

--- a/icu4c/source/common/uchar_props_data.h
+++ b/icu4c/source/common/uchar_props_data.h
@@ -1413,6 +1413,7 @@ static const UTrie2 propsTrie={
     propsTrie_index,
     propsTrie_index+4532,
     NULL,
+    NULL,
     4532,
     17744,
     0xa40,
@@ -3382,6 +3383,7 @@ static const uint16_t propsVectorsTrie_index[31228]={
 static const UTrie2 propsVectorsTrie={
     propsVectorsTrie_index,
     propsVectorsTrie_index+5024,
+    NULL,
     NULL,
     5024,
     26204,

--- a/icu4c/source/common/utrie_swap.cpp
+++ b/icu4c/source/common/utrie_swap.cpp
@@ -136,6 +136,9 @@ utrie2_swap(const UDataSwapper *ds,
 
     size=sizeof(UTrie2Header)+trie.indexLength*2;
     switch(valueBits) {
+    case UTRIE2_8_VALUE_BITS:
+        size+=dataLength;
+        break;
     case UTRIE2_16_VALUE_BITS:
         size+=dataLength*2;
         break;
@@ -163,6 +166,11 @@ utrie2_swap(const UDataSwapper *ds,
 
         /* swap the index and the data */
         switch(valueBits) {
+        case UTRIE2_8_VALUE_BITS:
+            ds->swapArray16(ds, inTrie+1, trie.indexLength*2, outTrie+1, pErrorCode);
+            uprv_memmove((uint8_t *)(outTrie+1)+trie.indexLength*2,
+                         (uint8_t *)(inTrie+1)+trie.indexLength*2, dataLength);
+            break;
         case UTRIE2_16_VALUE_BITS:
             ds->swapArray16(ds, inTrie+1, (trie.indexLength+dataLength)*2, outTrie+1, pErrorCode);
             break;

--- a/icu4c/source/test/intltest/rbbiapts.cpp
+++ b/icu4c/source/test/intltest/rbbiapts.cpp
@@ -1030,7 +1030,7 @@ void RBBIAPITest::RoundtripRule(const char *dataFile) {
     parseError.offset = 0;
     LocalUDataMemoryPointer data(udata_open(U_ICUDATA_BRKITR, "brk", dataFile, &status));
     uint32_t length;
-    const UChar *builtSource;
+    const char *builtSource;
     const uint8_t *rbbiRules;
     const uint8_t *builtRules;
 
@@ -1040,7 +1040,7 @@ void RBBIAPITest::RoundtripRule(const char *dataFile) {
     }
 
     builtRules = (const uint8_t *)udata_getMemory(data.getAlias());
-    builtSource = (const UChar *)(builtRules + ((RBBIDataHeader*)builtRules)->fRuleSource);
+    builtSource = (const char *)(builtRules + ((RBBIDataHeader*)builtRules)->fRuleSource);
     LocalPointer<RuleBasedBreakIterator> brkItr (new RuleBasedBreakIterator(builtSource, parseError, status));
     if (U_FAILURE(status)) {
         errln("%s:%d createRuleBasedBreakIterator: ICU Error \"%s\"  at line %d, column %d\n",

--- a/icu4c/source/test/intltest/rbbitst.cpp
+++ b/icu4c/source/test/intltest/rbbitst.cpp
@@ -4618,7 +4618,7 @@ void RBBITest::TestBug12677() {
     RuleBasedBreakIterator bi(rules, pe, status);
     assertSuccess(WHERE, status);
     UnicodeString rtRules = bi.getRules();
-    assertEquals(WHERE, UnicodeString(u"!!forward; $x = [ab#]; '#' '?'; "),  rtRules);
+    assertEquals(WHERE, UnicodeString(u"!!forward;$x=[ab#];'#''?';"),  rtRules);
 }
 
 
@@ -4632,6 +4632,7 @@ void RBBITest::TestTableRedundancies() {
 
     RBBIDataWrapper *dw = bi->fData;
     const RBBIStateTable *fwtbl = dw->fForwardTable;
+    UBool in8Bits = fwtbl->fFlags & RBBI_8BITS_ROWS;
     int32_t numCharClasses = dw->fHeader->fCatCount;
     // printf("Char Classes: %d     states: %d\n", numCharClasses, fwtbl->fNumStates);
 
@@ -4642,7 +4643,7 @@ void RBBITest::TestTableRedundancies() {
         UnicodeString s;
         for (int32_t r = 1; r < (int32_t)fwtbl->fNumStates; r++) {
             RBBIStateTableRow  *row = (RBBIStateTableRow *) (fwtbl->fTableData + (fwtbl->fRowLen * r));
-            s.append(row->fNextState[column]);
+            s.append(in8Bits ? row->s8.fNextState[column] : row->s16.fNextState[column]);
         }
         columns.push_back(s);
     }
@@ -4662,12 +4663,22 @@ void RBBITest::TestTableRedundancies() {
     for (int32_t r=0; r < (int32_t)fwtbl->fNumStates; r++) {
         UnicodeString s;
         RBBIStateTableRow  *row = (RBBIStateTableRow *) (fwtbl->fTableData + (fwtbl->fRowLen * r));
-        assertTrue(WHERE, row->fAccepting >= -1);
-        s.append(row->fAccepting + 1);   // values of -1 are expected.
-        s.append(row->fLookAhead);
-        s.append(row->fTagIdx);
-        for (int32_t column = 0; column < numCharClasses; column++) {
-            s.append(row->fNextState[column]);
+        if (in8Bits) {
+            assertTrue(WHERE, row->s8.fAccepting >= -1);
+            s.append(row->s8.fAccepting + 1);   // values of -1 are expected.
+            s.append(row->s8.fLookAhead);
+            s.append(row->s8.fTagIdx);
+            for (int32_t column = 0; column < numCharClasses; column++) {
+                s.append(row->s8.fNextState[column]);
+            }
+        } else {
+            assertTrue(WHERE, row->s16.fAccepting >= -1);
+            s.append(row->s16.fAccepting + 1);   // values of -1 are expected.
+            s.append(row->s16.fLookAhead);
+            s.append(row->s16.fTagIdx);
+            for (int32_t column = 0; column < numCharClasses; column++) {
+                s.append(row->s16.fNextState[column]);
+            }
         }
         rows.push_back(s);
     }
@@ -4740,12 +4751,14 @@ void RBBITest::TestReverse(std::unique_ptr<RuleBasedBreakIterator>bi) {
 
     RBBIDataWrapper *data = bi->fData;
     int32_t categoryCount = data->fHeader->fCatCount;
+    UBool use8Bits = categoryCount < 127;
+    uint32_t dict_bit = use8Bits ? 0x0080 : 0x4000;
     UTrie2  *trie = data->fTrie;
 
     std::vector<UnicodeString> strings(categoryCount, UnicodeString());
     for (int cp=0; cp<0x1fff0; ++cp) {
         int cat = utrie2_get32(trie, cp);
-        cat &= ~0x4000;    // And off the dictionary bit from the category.
+        cat &= ~dict_bit;    // And off the dictionary bit from the category.
         assertTrue(WHERE, cat < categoryCount && cat >= 0);
         if (cat < 0 || cat >= categoryCount) return;
         strings[cat].append(cp);

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/Trie2Writable.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/Trie2Writable.java
@@ -998,6 +998,16 @@ public class Trie2Writable extends Trie2 {
         return frozenTrie;
     }
 
+    /**
+     * Produce an optimized, read-only Trie2_8 from this writable Trie.
+     * 
+     */
+    public Trie2_8 toTrie2_8() {
+        Trie2_8 frozenTrie = new Trie2_8();
+        freeze(frozenTrie, ValueWidth.BITS_8);
+        return frozenTrie;
+    }
+
   
     /**
      * Maximum length of the runtime index array.
@@ -1053,8 +1063,10 @@ public class Trie2Writable extends Trie2 {
         int indexLength = allIndexesLength;
         if (valueBits==ValueWidth.BITS_16) {
             indexLength += dataLength;
-        } else {
+        } else if (valueBits==ValueWidth.BITS_32) {
             dest.data32 = new int[dataLength];
+        } else {
+            dest.data8 = new byte[dataLength];
         }
         dest.index = new char[indexLength];
         
@@ -1076,7 +1088,7 @@ public class Trie2Writable extends Trie2 {
         //    convenient to do here.)
         dest.header = new Trie2.UTrie2Header();
         dest.header.signature         = 0x54726932; /* "Tri2" */
-        dest.header.options           = valueBits==ValueWidth.BITS_16 ? 0 : 1;
+        dest.header.options           = valueBits==ValueWidth.BITS_16 ? 0 : valueBits==ValueWidth.BITS_32 ? 1 : 2;
         dest.header.indexLength       = dest.indexLength;
         dest.header.shiftedDataLength = dest.dataLength>>UTRIE2_INDEX_SHIFT;
         dest.header.index2NullOffset  = dest.index2NullOffset;
@@ -1145,6 +1157,12 @@ public class Trie2Writable extends Trie2 {
             /* write 32-bit data values */
             for (i=0; i<dataLength; i++) {
                 dest.data32[i] = this.data[i];
+            }
+            break;
+        case BITS_8:
+            /* write 8-bit data values */
+            for (i=0; i<dataLength; i++) {
+                dest.data8[i] = (byte)this.data[i];
             }
             break;
         }        

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/Trie2_8.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/Trie2_8.java
@@ -1,0 +1,254 @@
+// © 2020 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html#License
+/*
+ *******************************************************************************
+ * Copyright (C) 2009-2014, International Business Machines Corporation and
+ * others. All Rights Reserved.
+ *******************************************************************************
+ */
+
+package com.ibm.icu.impl;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * @author aheninger
+ *
+ * A read-only Trie2, holding 8 bit data values.
+ * 
+ * A Trie2 is a highly optimized data structure for mapping from Unicode
+ * code points (values ranging from 0 to 0x10ffff) to a 8, 16 or 32 bit value.
+ *
+ * See class Trie2 for descriptions of the API for accessing the contents of a trie.
+ * 
+ * The fundamental data access methods are declared final in this class, with
+ * the intent that applications might gain a little extra performance, when compared
+ * with calling the same methods via the abstract UTrie2 base class.
+ */
+
+public class Trie2_8 extends Trie2 {
+    
+    /**
+     * Internal constructor, not for general use.
+     */
+    Trie2_8() {
+    }
+    
+    
+    /**
+     * Create a Trie2 from its serialized form.  Inverse of utrie2_serialize().
+     * The serialized format is identical between ICU4C and ICU4J, so this function
+     * will work with serialized Trie2s from either.
+     *
+     * The serialized Trie2 in the bytes may be in either little or big endian byte order.
+     * This allows using serialized Tries from ICU4C without needing to consider the
+     * byte order of the system that created them.
+     *
+     * @param bytes a byte buffer to the serialized form of a UTrie2.
+     * @return An unserialized Trie_8, ready for use.
+     * @throws IllegalArgumentException if the stream does not contain a serialized Trie2.
+     * @throws IOException if a read error occurs in the buffer.
+     * @throws ClassCastException if the bytes contains a serialized Trie2_16 or Tier2_32
+     */
+    public static Trie2_8 createFromSerialized(ByteBuffer bytes) throws IOException {
+        return (Trie2_8) Trie2.createFromSerialized(bytes);
+    }
+
+    /**
+     * Get the value for a code point as stored in the Trie2.
+     *
+     * @param codePoint the code point
+     * @return the value
+     */
+    @Override
+    public final int get(int codePoint) {
+        int value;
+        int ix;
+        if (codePoint >= 0) {
+            if (codePoint < 0x0d800 || (codePoint > 0x0dbff && codePoint <= 0x0ffff)) {
+                // Ordinary BMP code point, excluding leading surrogates.
+                // BMP uses a single level lookup.  BMP index starts at offset 0 in the Trie2 index.
+                // 32 bit data is stored in the index array itself.
+                ix = index[codePoint >> UTRIE2_SHIFT_2];
+                ix = (ix << UTRIE2_INDEX_SHIFT) + (codePoint & UTRIE2_DATA_MASK);
+                value = 0x00ff & data8[ix];
+                return value;
+            } 
+            if (codePoint <= 0xffff) {
+                // Lead Surrogate Code Point.  A Separate index section is stored for
+                // lead surrogate code units and code points.
+                //   The main index has the code unit data.
+                //   For this function, we need the code point data.
+                // Note: this expression could be refactored for slightly improved efficiency, but
+                //       surrogate code points will be so rare in practice that it's not worth it.
+                ix = index[UTRIE2_LSCP_INDEX_2_OFFSET + ((codePoint - 0xd800) >> UTRIE2_SHIFT_2)];
+                ix = (ix << UTRIE2_INDEX_SHIFT) + (codePoint & UTRIE2_DATA_MASK);
+                value = 0x00ff & data8[ix];
+                return value;
+            }
+            if (codePoint < highStart) {
+                // Supplemental code point, use two-level lookup.
+                ix = (UTRIE2_INDEX_1_OFFSET - UTRIE2_OMITTED_BMP_INDEX_1_LENGTH) + (codePoint >> UTRIE2_SHIFT_1);
+                ix = index[ix];
+                ix += (codePoint >> UTRIE2_SHIFT_2) & UTRIE2_INDEX_2_MASK;
+                ix = index[ix];
+                ix = (ix << UTRIE2_INDEX_SHIFT) + (codePoint & UTRIE2_DATA_MASK);
+                value = 0x00ff & data8[ix];
+                return value;
+            }
+            if (codePoint <= 0x10ffff) {
+                value = 0x00ff & data8[highValueIndex];
+                return value;
+            }
+        }
+        
+        // Fall through.  The code point is outside of the legal range of 0..0x10ffff.
+        return errorValue;
+    }
+
+    
+    /**
+     * Get a Trie2 value for a UTF-16 code unit.
+     * 
+     * This function returns the same value as get() if the input 
+     * character is outside of the lead surrogate range
+     * 
+     * There are two values stored in a Trie2 for inputs in the lead
+     * surrogate range.  This function returns the alternate value,
+     * while Trie2.get() returns the main value.
+     * 
+     * @param codeUnit a 16 bit code unit or lead surrogate value.
+     * @return the value
+     */
+    @Override
+    public int getFromU16SingleLead(char codeUnit){
+        int value;
+        int ix;
+        
+        ix = index[codeUnit >> UTRIE2_SHIFT_2];
+        ix = (ix << UTRIE2_INDEX_SHIFT) + (codeUnit & UTRIE2_DATA_MASK);
+        value = data8[ix];
+        return value;
+
+    }
+    
+    /**
+     * Serialize a Trie2_8 onto an OutputStream.
+     * 
+     * A Trie2 can be serialized multiple times.
+     * The serialized data is compatible with ICU4C UTrie2 serialization.
+     * Trie2 serialization is unrelated to Java object serialization.
+     *  
+     * @param os the stream to which the serialized Trie2 data will be written.
+     * @return the number of bytes written.
+     * @throw IOException on an error writing to the OutputStream.
+     */
+    public int serialize(OutputStream os) throws IOException {
+        DataOutputStream dos = new DataOutputStream(os);
+        int  bytesWritten = 0;
+        
+        bytesWritten += serializeHeader(dos);        
+        dos.write(data8, 0, dataLength);
+        bytesWritten += dataLength;
+        return bytesWritten;
+    }
+
+    /**
+     * @return the number of bytes of the serialized trie
+     */
+    public int getSerializedLength() {
+        return 16+header.indexLength*2+dataLength;
+    }
+
+    /**
+     * Given a starting code point, find the last in a range of code points,
+     * all with the same value.
+     * 
+     * This function is part of the implementation of iterating over the
+     * Trie2's contents.
+     * @param startingCP The code point at which to begin looking.
+     * @return The last code point with the same value as the starting code point.
+     */
+    @Override
+    int rangeEnd(int startingCP, int limit, int value) {
+        int   cp = startingCP;
+        int   block = 0;
+        int   index2Block = 0;
+        
+        // Loop runs once for each of
+        //   - a partial data block
+        //   - a reference to the null (default) data block.
+        //   - a reference to the index2 null block
+        
+      outerLoop:
+        for (;;) {
+            if (cp >= limit) {
+                break;
+            }
+            if (cp < 0x0d800 || (cp > 0x0dbff && cp <= 0x0ffff)) {
+                // Ordinary BMP code point, excluding leading surrogates.
+                // BMP uses a single level lookup.  BMP index starts at offset 0 in the Trie2 index.
+                // 16 bit data is stored in the index array itself.
+                index2Block = 0;
+                block       = index[cp >> UTRIE2_SHIFT_2] << UTRIE2_INDEX_SHIFT;
+            } else if (cp < 0xffff) {
+                // Lead Surrogate Code Point, 0xd800 <= cp < 0xdc00
+                index2Block = UTRIE2_LSCP_INDEX_2_OFFSET;
+                block       = index[index2Block + ((cp - 0xd800) >> UTRIE2_SHIFT_2)] << UTRIE2_INDEX_SHIFT;
+            } else if (cp < highStart) {
+                // Supplemental code point, use two-level lookup.
+                int ix = (UTRIE2_INDEX_1_OFFSET - UTRIE2_OMITTED_BMP_INDEX_1_LENGTH) + (cp >> UTRIE2_SHIFT_1);
+                index2Block = index[ix];
+                block = index[index2Block + ((cp >> UTRIE2_SHIFT_2) & UTRIE2_INDEX_2_MASK)] << UTRIE2_INDEX_SHIFT;
+            } else  {
+                // Code point above highStart.
+                if (value == data8[highValueIndex]) {
+                    cp = limit;
+                }
+                break;
+            } 
+            
+            if (index2Block == index2NullOffset) {
+                if (value != initialValue) {
+                    break;
+                }
+                cp += UTRIE2_CP_PER_INDEX_1_ENTRY;
+            } else if (block == dataNullOffset) {
+                // The block at dataNullOffset has all values == initialValue.
+                // Because Trie2 iteration always proceeds in ascending order, we will always
+                //   encounter a null block at its beginning, and can skip over
+                //   a number of code points equal to the length of the block.
+                if (value != initialValue) {
+                    break;
+                }
+                cp += UTRIE2_DATA_BLOCK_LENGTH;
+            } else {
+                // Current position refers to an ordinary data block.
+                // Walk over the data entries, checking the values.
+                int startIx = block + (cp & UTRIE2_DATA_MASK);
+                int limitIx = block + UTRIE2_DATA_BLOCK_LENGTH;
+                for (int ix = startIx; ix<limitIx; ix++) {
+                    if (data8[ix] != value) {
+                        // We came to an entry with a different value.
+                        //   We are done.
+                        cp += (ix - startIx);
+                        break outerLoop;
+                    }
+                }
+                // The ordinary data block contained our value until its end.
+                //  Advance the current code point, and continue the outer loop.
+                cp += limitIx - startIx;
+            }
+        }
+        if (cp > limit) {
+            cp = limit;
+        }
+    
+        return cp - 1;
+    }
+
+}
+

--- a/icu4j/main/classes/core/src/com/ibm/icu/text/RBBIRuleScanner.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/RBBIRuleScanner.java
@@ -697,16 +697,14 @@ class RBBIRuleScanner {
     static String stripRules(String rules) {
         StringBuilder strippedRules = new StringBuilder();
         int rulesLength = rules.length();
-        boolean skippingSpaces = false;
 
         for (int idx = 0; idx < rulesLength; idx = rules.offsetByCodePoints(idx, 1)) {
             int cp = rules.codePointAt(idx);
             boolean whiteSpace = UCharacter.hasBinaryProperty(cp, UProperty.PATTERN_WHITE_SPACE);
-            if (skippingSpaces && whiteSpace) {
+            if (whiteSpace) {
                 continue;
             }
             strippedRules.appendCodePoint(cp);
-            skippingSpaces = whiteSpace;
         }
         return strippedRules.toString();
     }

--- a/icu4j/main/classes/core/src/com/ibm/icu/text/RuleBasedBreakIterator.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/RuleBasedBreakIterator.java
@@ -823,7 +823,8 @@ public class RuleBasedBreakIterator extends BreakIterator {
         CharacterIterator text = fText;
         Trie2 trie = fRData.fTrie;
 
-        short[] stateTable  = fRData.fFTable.fTable;
+        short[] stateTable16  = fRData.fFTable.fTable16;
+        byte[] stateTable8  = fRData.fFTable.fTable8;
         int initialPosition = fPosition;
         text.setIndex(initialPosition);
         int result          = initialPosition;
@@ -844,6 +845,9 @@ public class RuleBasedBreakIterator extends BreakIterator {
         short category      = 3;
         int flagsState      = fRData.fFTable.fFlags;
         int mode            = RBBI_RUN;
+        int dict_mask       = ((flagsState & RBBIDataWrapper.RBBI_8BITS_ROW) != 0) ?
+            RBBIDataWrapper.DICT_BIT_FOR_8BITS_TRIE :
+            RBBIDataWrapper.DICT_BIT;
         if ((flagsState & RBBIDataWrapper.RBBI_BOF_REQUIRED) != 0) {
             category = 2;
             mode     = RBBI_START;
@@ -885,10 +889,10 @@ public class RuleBasedBreakIterator extends BreakIterator {
                 //    Chars that need to be handled by a dictionary have a flag bit set
                 //    in their category values.
                 //
-                if ((category & 0x4000) != 0)  {
+                if ((category & dict_mask) != 0)  {
                     fDictionaryCharCount++;
                     //  And off the dictionary flag bit.
-                    category &= ~0x4000;
+                    category &= ~dict_mask;
                 }
 
                 if (TRACE) {
@@ -910,32 +914,61 @@ public class RuleBasedBreakIterator extends BreakIterator {
             }
 
             // look up a state transition in the state table
-            state = stateTable[row + RBBIDataWrapper.NEXTSTATES + category];
-            row   = fRData.getRowIndex(state);
+            if (stateTable8 != null) {
+                state = stateTable8[row + RBBIDataWrapper.NEXTSTATES + category];
+                row   = fRData.getRowIndex(state);
+                if (stateTable8[row + RBBIDataWrapper.ACCEPTING] == -1) {
+                    // Match found, common case
+                    result = text.getIndex();
+                    if (c >= UTF16.SUPPLEMENTARY_MIN_VALUE && c <= UTF16.CODEPOINT_MAX_VALUE) {
+                        // The iterator has been left in the middle of a surrogate pair.
+                        // We want the start of it.
+                        result--;
+                    }
 
-            if (stateTable[row + RBBIDataWrapper.ACCEPTING] == -1) {
-                // Match found, common case
-                result = text.getIndex();
-                if (c >= UTF16.SUPPLEMENTARY_MIN_VALUE && c <= UTF16.CODEPOINT_MAX_VALUE) {
-                    // The iterator has been left in the middle of a surrogate pair.
-                    // We want the start of it.
-                    result--;
+                    //  Remember the break status (tag) values.
+                    fRuleStatusIndex = stateTable8[row + RBBIDataWrapper.TAGIDX];
                 }
 
-                //  Remember the break status (tag) values.
-                fRuleStatusIndex = stateTable[row + RBBIDataWrapper.TAGIDX];
-            }
+                int completedRule = stateTable8[row + RBBIDataWrapper.ACCEPTING];
+                if (completedRule > 0) {
+                    // Lookahead match is completed
+                    int lookaheadResult = fLookAheadMatches.getPosition(completedRule);
+                    if (lookaheadResult >= 0) {
+                        fRuleStatusIndex = stateTable8[row + RBBIDataWrapper.TAGIDX];
+                        fPosition = lookaheadResult;
+                        return lookaheadResult;
+                    }
+                }
 
-            int completedRule = stateTable[row + RBBIDataWrapper.ACCEPTING];
-            if (completedRule > 0) {
-                // Lookahead match is completed
-                int lookaheadResult = fLookAheadMatches.getPosition(completedRule);
-                if (lookaheadResult >= 0) {
-                    fRuleStatusIndex = stateTable[row + RBBIDataWrapper.TAGIDX];
-                    fPosition = lookaheadResult;
-                    return lookaheadResult;
+            } else {
+                state = stateTable16[row + RBBIDataWrapper.NEXTSTATES + category];
+                row   = fRData.getRowIndex(state);
+                if (stateTable16[row + RBBIDataWrapper.ACCEPTING] == -1) {
+                    // Match found, common case
+                    result = text.getIndex();
+                    if (c >= UTF16.SUPPLEMENTARY_MIN_VALUE && c <= UTF16.CODEPOINT_MAX_VALUE) {
+                        // The iterator has been left in the middle of a surrogate pair.
+                        // We want the start of it.
+                        result--;
+                    }
+
+                    //  Remember the break status (tag) values.
+                    fRuleStatusIndex = stateTable16[row + RBBIDataWrapper.TAGIDX];
+                }
+
+                int completedRule = stateTable16[row + RBBIDataWrapper.ACCEPTING];
+                if (completedRule > 0) {
+                    // Lookahead match is completed
+                    int lookaheadResult = fLookAheadMatches.getPosition(completedRule);
+                    if (lookaheadResult >= 0) {
+                        fRuleStatusIndex = stateTable16[row + RBBIDataWrapper.TAGIDX];
+                        fPosition = lookaheadResult;
+                        return lookaheadResult;
+                    }
                 }
             }
+
 
             // If we are at the position of the '/' in a look-ahead (hard break) rule;
             // record the current position, to be returned later, if the full rule matches.
@@ -943,7 +976,9 @@ public class RuleBasedBreakIterator extends BreakIterator {
             //       This would enable hard-break rules with no following context.
             //       But there are line break test failures when trying this. Investigate.
             //       Issue ICU-20837
-            int rule =  stateTable[row + RBBIDataWrapper.LOOKAHEAD];
+            int rule =  (stateTable8 != null) ?
+                stateTable8[row + RBBIDataWrapper.LOOKAHEAD] :
+                stateTable16[row + RBBIDataWrapper.LOOKAHEAD];
             if (rule != 0) {
                 int  pos = text.getIndex();
                 if (c >= UTF16.SUPPLEMENTARY_MIN_VALUE && c <= UTF16.CODEPOINT_MAX_VALUE) {
@@ -1003,7 +1038,12 @@ public class RuleBasedBreakIterator extends BreakIterator {
         // caches for quicker access
         CharacterIterator text = fText;
         Trie2 trie = fRData.fTrie;
-        short[] stateTable  = fRData.fRTable.fTable;
+        short[] stateTable16  = fRData.fRTable.fTable16;
+        byte[] stateTable8  = fRData.fRTable.fTable8;
+        int flagsState      = fRData.fRTable.fFlags;
+        int dict_mask       = ((flagsState & RBBIDataWrapper.RBBI_8BITS_ROW) != 0) ?
+            RBBIDataWrapper.DICT_BIT_FOR_8BITS_TRIE :
+            RBBIDataWrapper.DICT_BIT;
 
         CISetIndex32(text, fromPosition);
         if (TRACE) {
@@ -1029,7 +1069,7 @@ public class RuleBasedBreakIterator extends BreakIterator {
             //
             //  And off the dictionary flag bit. For reverse iteration it is not used.
             category = (short) trie.get(c);
-            category &= ~0x4000;
+            category &= ~dict_mask;
             if (TRACE) {
                 System.out.print("            " +  RBBIDataWrapper.intToString(text.getIndex(), 5));
                 System.out.print(RBBIDataWrapper.intToHexString(c, 10));
@@ -1039,7 +1079,9 @@ public class RuleBasedBreakIterator extends BreakIterator {
             // State Transition - move machine to its next state
             //
             assert(category < fRData.fHeader.fCatCount);
-            state = stateTable[row + RBBIDataWrapper.NEXTSTATES + category];
+            state = (stateTable8 != null) ?
+                stateTable8[row + RBBIDataWrapper.NEXTSTATES + category] :
+                stateTable16[row + RBBIDataWrapper.NEXTSTATES + category];
             row   = fRData.getRowIndex(state);
 
             if (state == STOP_STATE) {
@@ -1209,6 +1251,8 @@ public class RuleBasedBreakIterator extends BreakIterator {
             int         category;
             int         current;
             int         foundBreakCount = 0;
+            int dict_mask = fRData.fHeader.fCatCount < 127 ?
+                RBBIDataWrapper.DICT_BIT_FOR_8BITS_TRIE : RBBIDataWrapper.DICT_BIT;
 
             // Loop through the text, looking for ranges of dictionary characters.
             // For each span, find the appropriate break engine, and ask it to find
@@ -1219,7 +1263,7 @@ public class RuleBasedBreakIterator extends BreakIterator {
             category = (short)fRData.fTrie.get(c);
 
             while(true) {
-                while((current = fText.getIndex()) < rangeEnd && (category & 0x4000) == 0) {
+                while((current = fText.getIndex()) < rangeEnd && (category & dict_mask) == 0) {
                     c = CharacterIteration.next32(fText);    // pre-increment
                     category = (short)fRData.fTrie.get(c);
                 }

--- a/icu4j/main/shared/data/icudata.jar
+++ b/icu4j/main/shared/data/icudata.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:71879fb1441641469ad42809317e9326cda811b2c48d04493b62aefe0ce26b0b
-size 13149611
+oid sha256:ddbddf87a2ac5c2737893dc8c174bb23e708f77ed086d292a37e6f5f45d3a5b3
+size 315

--- a/icu4j/main/shared/data/icudata.jar
+++ b/icu4j/main/shared/data/icudata.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ddbddf87a2ac5c2737893dc8c174bb23e708f77ed086d292a37e6f5f45d3a5b3
-size 315
+oid sha256:75ad8698271acaba546651677bd087404a45686446c1a10275ea4c3e14006f60
+size 13142936

--- a/icu4j/main/shared/data/icutzdata.jar
+++ b/icu4j/main/shared/data/icutzdata.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:20dc0361653f0fe3739e1cf43fc3e54f0695b651b80bd4039a981cacef068ef2
-size 298
+oid sha256:26ff8de63a46f97abc4d543f46de8295ec1317e412b30de8584353345244cd1b
+size 94304

--- a/icu4j/main/shared/data/icutzdata.jar
+++ b/icu4j/main/shared/data/icutzdata.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4360c9bc505145e73669436e8c188d0dc9f3a831333228df9e291ebf6060908c
-size 94304
+oid sha256:20dc0361653f0fe3739e1cf43fc3e54f0695b651b80bd4039a981cacef068ef2
+size 298

--- a/icu4j/main/shared/data/testdata.jar
+++ b/icu4j/main/shared/data/testdata.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:94af01f2a6e9f05c76a50247ffc64f8fd732c111cef83fd928920335eceb0dbc
-size 726452
+oid sha256:785d703f1545d0f194967ba8ba3cafd3993f052d725cda108dc7941efb92dfbc
+size 723481

--- a/icu4j/main/shared/data/testdata.jar
+++ b/icu4j/main/shared/data/testdata.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:785d703f1545d0f194967ba8ba3cafd3993f052d725cda108dc7941efb92dfbc
+oid sha256:c2dfb07c680c96d7c401da966b345e1817191fef062797e8ce789275ad2aff80
 size 723481

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/rbbi/RBBITest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/rbbi/RBBITest.java
@@ -562,7 +562,7 @@ public class RBBITest extends TestFmwk {
 
         RuleBasedBreakIterator bi  = new RuleBasedBreakIterator(rules);
         String rtRules = bi.toString();        // getRules() in C++
-        assertEquals("Break Iterator rule stripping test", "!!forward; $x = [ab#]; '#' '?'; ",  rtRules);
+        assertEquals("Break Iterator rule stripping test", "!!forward;$x=[ab#];'#''?';",  rtRules);
     }
 
     @Test
@@ -582,7 +582,9 @@ public class RBBITest extends TestFmwk {
             StringBuilder s = new StringBuilder();
             for (int r = 1; r < fwtbl.fNumStates; r++) {
                 int row = dw.getRowIndex(r);
-                short tableVal = fwtbl.fTable[row + RBBIDataWrapper.NEXTSTATES + column];
+                short tableVal = (fwtbl.fTable8 != null) ?
+                    fwtbl.fTable8[row + RBBIDataWrapper.NEXTSTATES + column] :
+                    fwtbl.fTable16[row + RBBIDataWrapper.NEXTSTATES + column];
                 s.append((char)tableVal);
             }
             columns.add(s.toString());
@@ -602,13 +604,24 @@ public class RBBITest extends TestFmwk {
         for (int r=0; r<fwtbl.fNumStates; r++) {
             StringBuilder s = new StringBuilder();
             int row = dw.getRowIndex(r);
-            assertTrue("Accepting < -1", fwtbl.fTable[row + RBBIDataWrapper.ACCEPTING] >= -1);
-            s.append(fwtbl.fTable[row + RBBIDataWrapper.ACCEPTING]);
-            s.append(fwtbl.fTable[row + RBBIDataWrapper.LOOKAHEAD]);
-            s.append(fwtbl.fTable[row + RBBIDataWrapper.TAGIDX]);
-            for (int column=0; column<numCharClasses; column++) {
-                short tableVal = fwtbl.fTable[row + RBBIDataWrapper.NEXTSTATES + column];
-                s.append((char)tableVal);
+            if (fwtbl.fTable8 != null) {
+                assertTrue("Accepting < -1", fwtbl.fTable8[row + RBBIDataWrapper.ACCEPTING] >= -1);
+                s.append(fwtbl.fTable8[row + RBBIDataWrapper.ACCEPTING]);
+                s.append(fwtbl.fTable8[row + RBBIDataWrapper.LOOKAHEAD]);
+                s.append(fwtbl.fTable8[row + RBBIDataWrapper.TAGIDX]);
+                for (int column=0; column<numCharClasses; column++) {
+                    short tableVal = fwtbl.fTable8[row + RBBIDataWrapper.NEXTSTATES + column];
+                    s.append((char)tableVal);
+                }
+            } else {
+                assertTrue("Accepting < -1", fwtbl.fTable16[row + RBBIDataWrapper.ACCEPTING] >= -1);
+                s.append(fwtbl.fTable16[row + RBBIDataWrapper.ACCEPTING]);
+                s.append(fwtbl.fTable16[row + RBBIDataWrapper.LOOKAHEAD]);
+                s.append(fwtbl.fTable16[row + RBBIDataWrapper.TAGIDX]);
+                for (int column=0; column<numCharClasses; column++) {
+                    short tableVal = fwtbl.fTable16[row + RBBIDataWrapper.NEXTSTATES + column];
+                    s.append((char)tableVal);
+                }
             }
             rows.add(s.toString());
         }


### PR DESCRIPTION
1. Change the rule string to UTF8 and no whitespaces
2. Bump up version number
3. Implement 8 bits state table
4. Use 0x0080 for dict but instead of 0x4000 if catCount < 127
5. Implement 8bits trie2 in C++ and Java.

This is target for 68.1 not 67.1
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21037
- [X] Updated PR title and link in previous line to include Issue number
- [] Issue accepted
- [X] Tests included
- [X] Documentation is changed or added

Size impact:

File | Before | After | Saving | Saving %
-- | -- | -- | -- | --
brkitr/char.brk | 25520 | 16128 | 9392 | 36.80%
brkitr/line.brk | 47048 | 26576 | 20472 | 43.51%
brkitr/line_cj.brk | 47120 | 26608 | 20512 | 43.53%
brkitr/line_loose.brk | 47408 | 26744 | 20664 | 43.59%
brkitr/line_loose_cj.brk | 49264 | 27608 | 21656 | 43.96%
brkitr/line_normal.brk | 46736 | 26416 | 20320 | 43.48%
brkitr/line_normal_cj.brk | 47552 | 26808 | 20744 | 43.62%
brkitr/sent.brk | 37640 | 22768 | 14872 | 39.51%
brkitr/sent_el.brk | 37672 | 22784 | 14888 | 39.52%
brkitr/title.brk | 20240 | 13520 | 6720 | 33.20%
brkitr/word.brk | 42176 | 25032 | 17144 | 40.65%
brkitr/word_POSIX.brk | 42208 | 25040 | 17168 | 40.67%
TOTAL | 490584 | 286032 | 204552 | 41.70%



Please do not review it yet. The change is not ready. Just try to create the PR so I can use the trybot

