### PR TITLE
ICU-21015 Fixing gcc compiler warnings

### DIFF
--- a/icu4c/source/i18n/dtptngen.cpp
+++ b/icu4c/source/i18n/dtptngen.cpp
@@ -2197,6 +2197,11 @@ DateTimeMatcher::DateTimeMatcher(const DateTimeMatcher& other) {
     copyFrom(other.skeleton);
 }
 
+DateTimeMatcher& DateTimeMatcher::operator=(const DateTimeMatcher& other) {
+    copyFrom(other.skeleton);
+    return *this;
+}
+
 
 void
 DateTimeMatcher::set(const UnicodeString& pattern, FormatParser* fp) {

--- a/icu4c/source/i18n/dtptngen_impl.h
+++ b/icu4c/source/i18n/dtptngen_impl.h
@@ -238,6 +238,7 @@ public:
     int32_t getDistance(const DateTimeMatcher& other, int32_t includeMask, DistanceInfo& distanceInfo) const;
     DateTimeMatcher();
     DateTimeMatcher(const DateTimeMatcher& other);
+    DateTimeMatcher& operator=(const DateTimeMatcher& other);
     virtual ~DateTimeMatcher();
     int32_t getFieldMask() const;
 };

--- a/icu4c/source/i18n/unicode/basictz.h
+++ b/icu4c/source/i18n/unicode/basictz.h
@@ -207,6 +207,12 @@ protected:
     BasicTimeZone(const BasicTimeZone& source);
 
     /**
+     * Copy assignment.
+     * @stable ICU 3.8
+     */
+    BasicTimeZone& operator=(const BasicTimeZone&) = default;
+
+    /**
      * Gets the set of TimeZoneRule instances applicable to the specified time and after.
      * @param start     The start date used for extracting time zone rules
      * @param initial   Receives the InitialTimeZone, always not NULL

--- a/icu4c/source/i18n/unicode/numsys.h
+++ b/icu4c/source/i18n/unicode/numsys.h
@@ -74,6 +74,12 @@ public:
     NumberingSystem(const NumberingSystem& other);
 
     /**
+     * Copy assignment.
+     * @stable ICU 4.2
+     */
+    NumberingSystem& operator=(const NumberingSystem& other) = default;
+
+    /**
      * Destructor.
      * @stable ICU 4.2
      */

--- a/icu4c/source/test/cintltst/ccapitst.c
+++ b/icu4c/source/test/cintltst/ccapitst.c
@@ -3035,7 +3035,7 @@ static void TestJ1968(void) {
 
     err = U_ZERO_ERROR;
     myConvName[UCNV_MAX_CONVERTER_NAME_LENGTH-1] = ',';
-    strncpy(myConvName + UCNV_MAX_CONVERTER_NAME_LENGTH, "locale=", 7);
+    memcpy(myConvName + UCNV_MAX_CONVERTER_NAME_LENGTH, "locale=", 7);
     cnv = ucnv_open(myConvName, &err);
     if (cnv || err != U_ILLEGAL_ARGUMENT_ERROR) {
         log_err("4) Didn't get U_ILLEGAL_ARGUMENT_ERROR as expected %s\n", u_errorName(err));

--- a/icu4c/source/test/intltest/convtest.cpp
+++ b/icu4c/source/test/intltest/convtest.cpp
@@ -1185,9 +1185,13 @@ ConversionTest::ToUnicodeCase(ConversionCase &cc, UConverterToUCallback callback
             cc.offsets=NULL;
         }
         else {
-            memset(resultOffsets, -1, UPRV_LENGTHOF(resultOffsets));
+            for (int32_t i = 0; i < UPRV_LENGTHOF(resultOffsets); i++) {
+                resultOffsets[i] = -1;
+            }
         }
-        memset(result, -1, UPRV_LENGTHOF(result));
+        for (int32_t i = 0; i < UPRV_LENGTHOF(result); i++) {
+            result[i] = -1;
+        }
         errorCode.reset();
         resultLength=stepToUnicode(cc, cnv.getAlias(),
                                 result, UPRV_LENGTHOF(result),
@@ -1615,8 +1619,12 @@ ConversionTest::FromUnicodeCase(ConversionCase &cc, UConverterFromUCallback call
     ok=TRUE;
     for(i=0; i<UPRV_LENGTHOF(steps) && ok; ++i) {
         step=steps[i].step;
-        memset(resultOffsets, -1, UPRV_LENGTHOF(resultOffsets));
-        memset(result, -1, UPRV_LENGTHOF(result));
+        for (int32_t i = 0; i < UPRV_LENGTHOF(resultOffsets); i++) {
+            resultOffsets[i] = -1;
+        }
+        for (int32_t i = 0; i < UPRV_LENGTHOF(result); i++) {
+            result[i] = -1;
+        }
         errorCode=U_ZERO_ERROR;
         resultLength=stepFromUnicode(cc, cnv,
                                 result, UPRV_LENGTHOF(result),

--- a/icu4c/source/test/intltest/rbbitst.cpp
+++ b/icu4c/source/test/intltest/rbbitst.cpp
@@ -4285,7 +4285,7 @@ void RBBITest::RunMonkey(BreakIterator *bi, RBBIMonkeyKind &mk, const char *name
                     u_charName(c, U_EXTENDED_CHAR_NAME, cName, sizeof(cName), &status);
 
                     char buffer[200];
-                    snprintf(buffer, 200,
+                    auto ret = snprintf(buffer, UPRV_LENGTHOF(buffer),
                              "%4s %3i :  %1s  %1s  %10s  %-*s  %-40s  %-40s",
                              currentLineFlag.c_str(),
                              ci,
@@ -4295,6 +4295,8 @@ void RBBITest::RunMonkey(BreakIterator *bi, RBBIMonkeyKind &mk, const char *name
                              classNameSize,
                              mk.classNameFromCodepoint(c).c_str(),
                              mk.getAppliedRule(ci).c_str(), cName);
+                    (void)ret;
+                    U_ASSERT(0 <= ret && ret < UPRV_LENGTHOF(buffer));
 
                     // Output the error
                     if (ci == i) {

--- a/icu4c/source/tools/pkgdata/pkgdata.cpp
+++ b/icu4c/source/tools/pkgdata/pkgdata.cpp
@@ -46,6 +46,7 @@
 #include "flagparser.h"
 #include "filetools.h"
 #include "charstr.h"
+#include "uassert.h"
 
 #if U_HAVE_POPEN
 # include <unistd.h>
@@ -1132,12 +1133,15 @@ static int32_t pkg_installLibrary(const char *installDir, const char *targetDir,
     int32_t result = 0;
     char cmd[SMALL_BUFFER_MAX_SIZE];
 
-    sprintf(cmd, "cd %s && %s %s %s%s%s",
+    auto ret = snprintf(cmd,
+            SMALL_BUFFER_MAX_SIZE,
+            "cd %s && %s %s %s%s%s",
             targetDir,
             pkgDataFlags[INSTALL_CMD],
             libFileNames[LIB_FILE_VERSION],
-            installDir, PKGDATA_FILE_SEP_STRING, libFileNames[LIB_FILE_VERSION]
-            );
+            installDir, PKGDATA_FILE_SEP_STRING, libFileNames[LIB_FILE_VERSION]);
+    (void)ret;
+    U_ASSERT(0 <= ret && ret < SMALL_BUFFER_MAX_SIZE);
 
     result = runCommand(cmd);
 
@@ -1255,10 +1259,14 @@ static int32_t pkg_installFileMode(const char *installDir, const char *srcDir, c
                     buffer[bufferLength-1] = 0;
                 }
 
-                sprintf(cmd, "%s %s%s%s %s%s%s",
+                auto ret = snprintf(cmd,
+                        SMALL_BUFFER_MAX_SIZE,
+                        "%s %s%s%s %s%s%s",
                         pkgDataFlags[INSTALL_CMD],
                         srcDir, PKGDATA_FILE_SEP_STRING, buffer,
                         installDir, PKGDATA_FILE_SEP_STRING, buffer);
+                (void)ret;
+                U_ASSERT(0 <= ret && ret < SMALL_BUFFER_MAX_SIZE);
 
                 result = runCommand(cmd);
                 if (result != 0) {
@@ -1690,12 +1698,20 @@ static int32_t pkg_createWithoutAssemblyCode(UPKGOptions *o, const char *targetD
                             break;
                         }
                     }
-                    sprintf(newName, "%s_%s",
+                    auto ret = snprintf(newName,
+                            SMALL_BUFFER_MAX_SIZE,
+                            "%s_%s",
                             DATA_PREFIX[n],
                             newNameTmp);
-                    sprintf(dataName, "%s_%s",
+                    (void)ret;
+                    U_ASSERT(0 <= ret && ret < SMALL_BUFFER_MAX_SIZE);
+                    ret = snprintf(dataName,
+                            SMALL_BUFFER_MAX_SIZE,
+                            "%s_%s",
                             o->shortName,
                             DATA_PREFIX[n]);
+                    (void)ret;
+                    U_ASSERT(0 <= ret && ret < SMALL_BUFFER_MAX_SIZE);
                 }
                 if (newName[0] != 0) {
                     break;


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21015
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

We accepted this ticket for ICU 67, and I didn't get the fix ready by the official code freeze, and then Markus said no, punt to 68.  But I would really rather see this in ICU 67.  There is one actual potential bug in library code, and there are also some changes in ICU public header files, which means that anyone using GCC and building against ICU may also encounter these errors, which is a standard we should avoid.