### PR TITLE
ICU-20979 Update ICU4C readme

### DIFF
--- a/icu4c/readme.html
+++ b/icu4c/readme.html
@@ -236,9 +236,6 @@
 
     <h2><a name="News" href="#News" id="News">What Is New In This Release?</a></h2>
 
-    <p>This release updates to Unicode 13 beta, CLDR 36.1, and includes some bug fixes.
-    This is a low-impact release with no other significant feature additions or implementation changes.</p>
-
     <p>See the <a href="http://site.icu-project.org/download/67">ICU 67 download page</a>
     for more information on this release, including any other changes, bug fixes, known issues,
     changes to supported platforms and build environments,


### PR DESCRIPTION
Removed stale reference to Unicode 13 and CLDR 36. Thanks Yoshito for catching this in the ICU4J readme update in PR #1086.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20979 
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [x] Documentation is changed or added

