### PR TITLE
ICU-20979 delete no-longer-relevant comment related to U_HIDE macros

### DIFF
--- a/icu4c/source/i18n/unicode/numberformatter.h
+++ b/icu4c/source/i18n/unicode/numberformatter.h
@@ -2426,7 +2426,6 @@ class U_I18N_API LocalizedNumberFormatter
 class U_I18N_API FormattedNumber : public UMemory, public FormattedValue {
   public:
 
-    // Default constructor cannot have #ifndef U_HIDE_DRAFT_API
     /**
      * Default constructor; makes an empty FormattedNumber.
      * @stable ICU 64


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20979
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

This was for the BRS task to
"Check non-stable API macros (U_HIDE_DRAFT_API and others)".

After the updates for API promotion, the only further thing that I found to change was to remove one no-longer-relevant comment related to U_HIDE macros.