### PR TITLE
ICU-21060 Fix the foo-per-a-b -> foo-b-per-a bug.

### DIFF
--- a/icu4c/source/test/intltest/measfmttest.cpp
+++ b/icu4c/source/test/intltest/measfmttest.cpp
@@ -3427,7 +3427,9 @@ void MeasureFormatTest::TestIdentifiers() {
         const char* id;
         const char* normalized;
     } cases[] = {
-        { true, "square-meter-per-square-meter", "square-meter-per-square-meter" },
+        {true, "square-meter-per-square-meter", "square-meter-per-square-meter"},
+        {true, "kilogram-meter-per-square-meter-square-second",
+         "kilogram-meter-per-square-meter-square-second"},
         // TODO(ICU-20920): Add more test cases once the proper ranking is available.
     };
     for (const auto& cas : cases) {


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21060
- [X] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [X] Tests included
- [ ] Documentation is changed or added

The core change in this PR is at line 425 in measunit_extra.cpp:

    case COMPOUND_PART_TIMES:
        if (fAfterPer) {
            result.dimensionality = -1;
        }
        break;

The sawPlus/sawAnd change is a cosmetic addition/improvement.