### PR TITLE
ICU-3655 No getAvailableLocales in RuleBasedNumberFormat

### DIFF
--- a/icu4c/source/i18n/rbnf.cpp
+++ b/icu4c/source/i18n/rbnf.cpp
@@ -1116,6 +1116,30 @@ RuleBasedNumberFormat::findRuleSet(const UnicodeString& name, UErrorCode& status
     return NULL;
 }
 
+const Locale* U_EXPORT2
+RuleBasedNumberFormat::getAvailableLocales(int32_t& count)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    UEnumeration* locs = ures_openAvailableLocales(U_ICUDATA_RBNF, &status);
+    count = 0;
+    if (U_SUCCESS(status)) {
+        status = U_ZERO_ERROR;
+        int32_t n = uenum_count(locs, &status);
+        if (U_FAILURE(status)) {
+            return NULL;
+        } else {
+            Locale* locales = new Locale[n];
+            for (int32_t i = 0; i < n; i++) {
+                const char* loc = uenum_next(locs, NULL, &status);
+                locales[i] = Locale::createCanonical(loc);
+            }
+            count = n;
+            return locales;
+        }
+    }
+    return NULL;
+}
+
 UnicodeString&
 RuleBasedNumberFormat::format(const DecimalQuantity &number,
                      UnicodeString& appendTo,

--- a/icu4c/source/i18n/unicode/rbnf.h
+++ b/icu4c/source/i18n/unicode/rbnf.h
@@ -780,6 +780,12 @@ public:
   virtual UnicodeString getRuleSetDisplayName(const UnicodeString& ruleSetName,
                           const Locale& locale = Locale::getDefault());
 
+    /**
+     * Get the set of Locales for which RuleBasedNumberFormat are installed.
+     * @param count    Output param to receive the size of the locales
+     * @draft ICU 68
+     */
+  static const Locale* U_EXPORT2 getAvailableLocales(int32_t& count);
 
   using NumberFormat::format;
 

--- a/icu4c/source/test/intltest/itrbnf.cpp
+++ b/icu4c/source/test/intltest/itrbnf.cpp
@@ -77,6 +77,7 @@ void IntlTestRBNF::runIndexedTest(int32_t index, UBool exec, const char* &name, 
         TESTCASE(25, TestCompactDecimalFormatStyle);
         TESTCASE(26, TestParseFailure);
         TESTCASE(27, TestMinMaxIntegerDigitsIgnored);
+        TESTCASE(28, TestAvailableLocales);
 #else
         TESTCASE(0, TestRBNFDisabled);
 #endif
@@ -2318,6 +2319,23 @@ void IntlTestRBNF::TestMinMaxIntegerDigitsIgnored() {
         assertEquals("Min integer digits are ignored", u"three", result);
         rbnf.format(1012, result.remove(), status);
         assertEquals("Max integer digits are ignored", u"one thousand twelve", result);
+    }
+}
+
+void IntlTestRBNF::TestAvailableLocales() {
+    int32_t i, locCount = 0;
+    const Locale* locList = RuleBasedNumberFormat::getAvailableLocales(locCount);
+
+    logln("Testing the no of available locales");
+    if(locCount == 0 || locList == NULL) {
+        errln("getAvailableLocales() returned an empty list!");
+    } else if (locCount < 0) {
+        errln("getAvailableLocales() returned a wrong value!= %d", locCount);
+    } else {
+        logln("Number of locales returned = %d", locCount);
+        for (i = 0; i < locCount; i++) {
+            logln(" %s", locList[i].getName());
+        }
     }
 }
 

--- a/icu4c/source/test/intltest/itrbnf.h
+++ b/icu4c/source/test/intltest/itrbnf.h
@@ -149,6 +149,7 @@ class IntlTestRBNF : public IntlTest {
     void TestCompactDecimalFormatStyle();
     void TestParseFailure();
     void TestMinMaxIntegerDigitsIgnored();
+    void TestAvailableLocales();
 
 protected:
   virtual void doTest(RuleBasedNumberFormat* formatter, const char* const testData[][2], UBool testParsing);

--- a/icu4j/main/classes/core/src/com/ibm/icu/text/RuleBasedNumberFormat.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/RuleBasedNumberFormat.java
@@ -1137,6 +1137,24 @@ public class RuleBasedNumberFormat extends NumberFormat {
     }
 
     /**
+     * Get the set of ULocales available for the RBNF bundle.
+     * @return the list of available locales
+     * @draft ICU 68
+     */
+    public static final ULocale[] getAvailableULocales() {
+        return ICUResourceBundle.getAvailableULocales(ICUData.ICU_RBNF_BASE_NAME, ICUResourceBundle.ICU_DATA_CLASS_LOADER);
+    }
+
+    /**
+     * Get the set of Locales available for the RBNF bundle.
+     * @return the list of available locales
+     * @draft ICU 68
+     */
+    public static final Locale[] getAvailableLocales() {
+        return ICUResourceBundle.getAvailableLocales(ICUData.ICU_RBNF_BASE_NAME, ICUResourceBundle.ICU_DATA_CLASS_LOADER);
+    }
+
+    /**
      * Formats the specified number according to the specified rule set.
      * @param number The number to format.
      * @param ruleSet The name of the rule set to format the number with.

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/RbnfTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/RbnfTest.java
@@ -1810,4 +1810,36 @@ public class RbnfTest extends TestFmwk {
         assertEquals("infinity", rbnf.format(Double.POSITIVE_INFINITY));
         assertEquals("not a number", rbnf.format(Double.NaN));
     }
+
+    private void doAvailableLocalesTesting(Object[] localeList) {
+
+        int locCount = localeList.length;
+
+        if (isVerbose()) {
+            logln("Testing the no of available locales");
+        }
+
+        if (locCount == 0) {
+            errln("getAvailableLocales() returned an empty list!\n");
+        } else if (locCount < 0) {
+            errln("getAvailableLocales() returned a wrong value! = " + locCount);
+        } else {
+            if (isVerbose()) {
+                logln("Number of locales returned = " + locCount);
+                for (int i = 0; i < locCount; i++) {
+                    logln(localeList[i].toString());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void TestGetAvailableLocales() {
+        doAvailableLocalesTesting(RuleBasedNumberFormat.getAvailableLocales());
+    }
+
+    @Test
+    public void TestGetAvailableULocales() {
+        doAvailableLocalesTesting(RuleBasedNumberFormat.getAvailableULocales());
+    }
 }


### PR DESCRIPTION
ICU-3655 No getAvailableLocales in RuleBasedNumberFormat

- Add static methods to return the proper list of locales
that implement RBNF rules.
