### PR TITLE
ICU-20926 Adding test to verify fallback rule of DateIntervalFormat

### DIFF
--- a/icu4c/source/test/intltest/dtifmtts.h
+++ b/icu4c/source/test/intltest/dtifmtts.h
@@ -70,6 +70,7 @@ public:
     void testCreateInstanceForAllLocales();
 
     void testTicket20707();
+    void testTicket20710();
 
 private:
     /**


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20926
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

Cc @sffc 

I added tests with some skeletons, however I was not able to find the skeleton that would result in the same pattern we get from `DateFormate::createTimeInstance (DateFormat::kFull, DateFormat::kFull, locale);`.  Considering the test as it is, it is passing. After I get green light for it, I'll add Java version of this test.
