### PR TITLE
ICU-21055 Remove test inputs causing logKnownIssues test run to hang

### DIFF
--- a/icu4c/source/test/intltest/restsnew.cpp
+++ b/icu4c/source/test/intltest/restsnew.cpp
@@ -1395,6 +1395,14 @@ void NewResourceBundleTest::TestFilter() {
     }
 }
 
+/*
+ * The following test for ICU-20706 has infinite loops on certain inputs for
+ * locales and calendars.  In order to unblock the build (ICU-21055), those
+ * specific values are temporarily removed.
+ * The issue of the infinite loops and its blocking dependencies were captured
+ * in ICU-21080.
+ */
+
 void NewResourceBundleTest::TestIntervalAliasFallbacks() {
     const char* locales[] = {
         // Thee will not cause infinity loop
@@ -1402,6 +1410,7 @@ void NewResourceBundleTest::TestIntervalAliasFallbacks() {
         "ja",
 
         // These will cause infinity loop
+#if 0
         "fr_CA",
         "en_150",
         "es_419",
@@ -1413,6 +1422,7 @@ void NewResourceBundleTest::TestIntervalAliasFallbacks() {
         "zh_Hant",
         "zh_Hant_TW",
         "zh_TW",
+#endif
     };
     const char* calendars[] = {
         // These won't cause infinity loop
@@ -1420,6 +1430,7 @@ void NewResourceBundleTest::TestIntervalAliasFallbacks() {
         "chinese",
 
         // These will cause infinity loop
+#if 0
         "islamic",
         "islamic-civil",
         "islamic-tbla",
@@ -1428,6 +1439,7 @@ void NewResourceBundleTest::TestIntervalAliasFallbacks() {
         "islamic-rgsa",
         "japanese",
         "roc",
+#endif
     };
 
     for (int lidx = 0; lidx < UPRV_LENGTHOF(locales); lidx++) {

--- a/icu4c/source/test/intltest/restsnew.h
+++ b/icu4c/source/test/intltest/restsnew.h
@@ -39,6 +39,7 @@ public:
     void TestGetByFallback(void);
 
     void TestFilter(void);
+
     void TestIntervalAliasFallbacks(void);
 
 #if U_ENABLE_TRACING


### PR DESCRIPTION
##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21055
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [X] Tests included
- [ ] Documentation is changed or added

I filed ICU-21080 to capture the outstanding work needed to restore the input values into the test case.