### PR TITLE
ICU-21085 Fix issue of __has_attribute on Windows

### DIFF
--- a/icu4c/source/i18n/double-conversion-utils.h
+++ b/icu4c/source/i18n/double-conversion-utils.h
@@ -74,9 +74,12 @@ inline void abort_noreturn() { abort(); }
 #endif
 #endif
 
-#if defined(__clang__) && __has_attribute(uninitialized)
+#if defined(__clang__) && defined(__has_attribute)
+#if __has_attribute(uninitialized)
 #define DOUBLE_CONVERSION_STACK_UNINITIALIZED __attribute__((uninitialized))
-#else
+#endif
+#endif
+#if !defined(DOUBLE_CONVERSION_STACK_UNINITIALIZED)
 #define DOUBLE_CONVERSION_STACK_UNINITIALIZED
 #endif
 


### PR DESCRIPTION
Fix "source\i18n\double-conversion-utils.h(77):
warning C4067: unexpected tokens following preprocessor directive - expected a newline"

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21085
- [X] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

