### PR TITLE
ICU-21089 Adding check for alt-path consistency.

### DIFF
--- a/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/LdmlConverter.java
+++ b/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/LdmlConverter.java
@@ -567,6 +567,7 @@ public final class LdmlConverter {
     }
 
     private void writeDependencyGraph(Path dir, DependencyGraph depGraph) {
+        createDirectory(dir);
         try (BufferedWriter w = Files.newBufferedWriter(dir.resolve("LOCALE_DEPS.json"), UTF_8);
             PrintWriter out = new PrintWriter(w)) {
             depGraph.writeJsonTo(out, fileHeader);


### PR DESCRIPTION
The will now report when an alt-path mapping exists but for which the target path is missing in that locale. This only triggers at the moment when an alt-path exists, it's not a consistency check over all of CLDR (this would be better as a new tool on the CLDR side using the new API).

One minor additional fix relating to directory creation (which prevented easy debugging).

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21089
- [x] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

