### PR TITLE
ICU-21089 Ignoring incomplete alt path mappings.

### DIFF
--- a/tools/cldr/cldr-to-icu/build-icu-data.xml
+++ b/tools/cldr/cldr-to-icu/build-icu-data.xml
@@ -315,7 +315,7 @@
 
             <!-- The following elements configure alternate values for some special case paths.
                  The target path will only be replaced if both it, and the source path, exist in
-                 the CLDR data (new paths will not be added if only the source path exists).
+                 the CLDR data (paths will not be modified if only the source path exists).
 
                  Since the paths must represent the same semantic type of data, they must be in the
                  same "namespace" (same element names) and must not contain value attributes. Thus

--- a/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/AlternateLocaleData.java
+++ b/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/AlternateLocaleData.java
@@ -104,7 +104,7 @@ public final class AlternateLocaleData {
         }
 
         private final class AltData extends FilteredData {
-            // Calculated per locale/data instance to make lokup as fast as possible.
+            // Calculated per locale/data instance to make lookup as fast as possible.
             private final ImmutableMap<CldrPath, CldrPath> altPaths;
             // Any source paths which are not also target paths are removed. This is legacy
             // behaviour inherited from the original build tools, the reason for which is not
@@ -123,8 +123,13 @@ public final class AlternateLocaleData {
                     altPaths = ImmutableMap.copyOf(combinedPaths);
                 }
                 this.altPaths = altPaths;
-                this.toRemove = altPaths.values().stream()
-                    .filter(p -> !this.altPaths.containsKey(p))
+                this.toRemove = altPaths.entrySet().stream()
+                    // Only remove source paths that are not also target paths...
+                    .filter(e -> !this.altPaths.containsKey(e.getValue()))
+                    // ... and if the target path it will be transformed to actually exists.
+                    .filter(e -> getSourceData().get(e.getKey()) != null)
+                    // The value in the mapping is the source path (it's target->source for lookup).
+                    .map(Map.Entry::getValue)
                     .collect(toImmutableSet());
             }
 

--- a/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/LdmlConverter.java
+++ b/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/LdmlConverter.java
@@ -567,6 +567,7 @@ public final class LdmlConverter {
     }
 
     private void writeDependencyGraph(Path dir, DependencyGraph depGraph) {
+        createDirectory(dir);
         try (BufferedWriter w = Files.newBufferedWriter(dir.resolve("LOCALE_DEPS.json"), UTF_8);
             PrintWriter out = new PrintWriter(w)) {
             depGraph.writeJsonTo(out, fileHeader);

--- a/tools/cldr/cldr-to-icu/src/test/java/org/unicode/icu/tool/cldrtoicu/AlternateLocaleDataTest.java
+++ b/tools/cldr/cldr-to-icu/src/test/java/org/unicode/icu/tool/cldrtoicu/AlternateLocaleDataTest.java
@@ -96,9 +96,10 @@ public class AlternateLocaleDataTest {
         CldrData unresolved = transformed.getDataForLocale("xx", UNRESOLVED);
         CldrData resolved = transformed.getDataForLocale("xx", RESOLVED);
 
-        // We still remove the source even if there was no target.
-        assertValuesUnordered(unresolved);
-        assertValuesUnordered(resolved);
+        // If there's no target the alt-path mapping is incomplete and we do nothing (this matches
+        // the old CLDR tool behaviour and reasonable but can hide inconsistencies in CLDR data).
+        assertValuesUnordered(unresolved, source);
+        assertValuesUnordered(resolved, source);
     }
 
     @Test


### PR DESCRIPTION
The converter will now keep alt-paths when an alt-path mapping exists but for which the target path is missing in a locale. This is consistent with the old behaviour and doesn't tie the <altPath> mapping with any implied semantics of CLDR data (which is not true of the alternate PR https://github.com/unicode-org/icu/pull/1129). The downside is that this PR will not give any warnings about the mapping being ignored.

One minor additional fix relating to directory creation (which prevented easy debugging).

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21089
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [x] Documentation is changed or added

