### PR TITLE
ICU-21109 Add support for locale-dependent minimum grouping digits to DecimalFormat

### DIFF
--- a/icu4c/source/i18n/number_grouping.cpp
+++ b/icu4c/source/i18n/number_grouping.cpp
@@ -64,6 +64,13 @@ Grouper Grouper::forProperties(const DecimalFormatProperties& properties) {
 }
 
 void Grouper::setLocaleData(const impl::ParsedPatternInfo &patternInfo, const Locale& locale) {
+    if (fMinGrouping == -2) {
+        fMinGrouping = getMinGroupingForLocale(locale);
+    } else if (fMinGrouping == -3) {
+        fMinGrouping = static_cast<int16_t>(uprv_max(2, getMinGroupingForLocale(locale)));
+    } else {
+        // leave fMinGrouping alone
+    }
     if (fGrouping1 != -2 && fGrouping2 != -4) {
         return;
     }
@@ -75,13 +82,6 @@ void Grouper::setLocaleData(const impl::ParsedPatternInfo &patternInfo, const Lo
     }
     if (grouping3 == -1) {
         grouping2 = grouping1;
-    }
-    if (fMinGrouping == -2) {
-        fMinGrouping = getMinGroupingForLocale(locale);
-    } else if (fMinGrouping == -3) {
-        fMinGrouping = static_cast<int16_t>(uprv_max(2, getMinGroupingForLocale(locale)));
-    } else {
-        // leave fMinGrouping alone
     }
     fGrouping1 = grouping1;
     fGrouping2 = grouping2;

--- a/icu4c/source/i18n/unicode/decimfmt.h
+++ b/icu4c/source/i18n/unicode/decimfmt.h
@@ -1674,8 +1674,12 @@ class U_I18N_API DecimalFormat : public NumberFormat {
     int32_t getMinimumGroupingDigits() const;
 
     /**
-     * Sets the minimum grouping digits. Setting to a value less than or
-     * equal to 1 turns off minimum grouping digits.
+     * Sets the minimum grouping digits. Set to -1 to disable this feature.
+     *
+     * The following special values are accepted:
+     *
+     * - -2 => use the locale default minimum grouping digits.
+     * - -3 => use the locale default, but always at least 2.
      *
      * For more control over grouping strategies, use NumberFormatter.
      *

--- a/icu4c/source/test/intltest/numfmtst.cpp
+++ b/icu4c/source/test/intltest/numfmtst.cpp
@@ -9077,6 +9077,36 @@ void NumberFormatTest::TestMinimumGroupingDigits() {
     df.format(12345, result.remove(), status);
     status.errIfFailureAndReset();
     assertEquals("Should have grouping", u"12,345", result);
+
+    // Test special values -2 and -3
+    struct TestCase {
+        const char* locale;
+        int32_t minGroup;
+        double input;
+        const char16_t* expected;
+    } cases[] = {
+        { "en-US", -2, 1000, u"1,000" },
+        { "en-US", -2, 10000, u"10,000" },
+        { "en-US", -3, 1000, u"1000" },
+        { "en-US", -3, 10000, u"10,000" },
+        { "es-MX", -2, 1000, u"1000" },
+        { "es-MX", -2, 10000, u"10,000" },
+        { "es-MX", -3, 1000, u"1000" },
+        { "es-MX", -3, 10000, u"10,000" },
+    };
+    for (const auto& cas : cases) {
+        UnicodeString message = UnicodeString(cas.locale)
+            + u" " + Int64ToUnicodeString(cas.minGroup)
+            + u" " + DoubleToUnicodeString(cas.input);
+        status.setScope(message);
+        DecimalFormat df(u"#,##0", {cas.locale, status}, status);
+        if (status.errIfFailureAndReset()) { continue; }
+        df.setMinimumGroupingDigits(cas.minGroup);
+        UnicodeString actual;
+        df.format(cas.input, actual, status);
+        if (status.errIfFailureAndReset()) { continue; }
+        assertEquals(message, cas.expected, actual);
+    }
 }
 
 void NumberFormatTest::Test11897_LocalizedPatternSeparator() {


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21109
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [x] Tests included
- [x] Documentation is changed or added

