### PR TITLE
ICU-21104 Add new build bot: Ubuntu 18.04 with C++14

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -6,7 +6,7 @@ jobs:
   displayName: 'J: Linux OpenJDK (Ubuntu 16.04)'
   timeoutInMinutes: 20
   pool:
-    vmImage: 'Ubuntu 16.04'
+    vmImage: 'ubuntu-16.04'
     demands: ant
   steps:
     - checkout: self
@@ -26,7 +26,7 @@ jobs:
   displayName: 'C: Linux Clang (Ubuntu 16.04)'
   timeoutInMinutes: 30
   pool:
-    vmImage: 'Ubuntu 16.04'
+    vmImage: 'ubuntu-16.04'
   steps:
     - checkout: self
       lfs: true
@@ -42,7 +42,7 @@ jobs:
   displayName: 'C: Linux Clang WarningsAsErrors (Ubuntu 16.04)'
   timeoutInMinutes: 30
   pool:
-    vmImage: 'Ubuntu 16.04'
+    vmImage: 'ubuntu-16.04'
   steps:
     - checkout: self
       lfs: true
@@ -58,7 +58,7 @@ jobs:
   displayName: 'C: Linux Clang DataFilter (Ubuntu 16.04)'
   timeoutInMinutes: 30
   pool:
-    vmImage: 'Ubuntu 16.04'
+    vmImage: 'ubuntu-16.04'
   steps:
     - checkout: self
       lfs: true
@@ -70,6 +70,22 @@ jobs:
         \[ ! -d data/out/build/icudt66l/translit \] && \
         (cd test/intltest && LD_LIBRARY_PATH=../../lib:../../tools/ctestfw ./intltest translit/TransliteratorTest/TestBasicTransliteratorEvenWithoutData)
       displayName: 'Build with Data Filter'
+      env:
+        CC: clang
+        CXX: clang++
+#-------------------------------------------------------------------------
+- job: ICU4C_Clang_Cpp14_Debug_Ubuntu_1804
+  displayName: 'C: Linux Clang C++14 Debug (Ubuntu 18.04)'
+  timeoutInMinutes: 30
+  pool:
+    vmImage: 'ubuntu-18.04'
+  steps:
+    - checkout: self
+      lfs: true
+      fetchDepth: 1
+    - script: |
+        export CXXFLAGS="-std=c++14 -Winvalid-constexpr" && cd icu4c/source && ./runConfigureICU --enable-debug --disable-release Linux --disable-layout --disable-layoutex && make -j2 check
+      displayName: 'Build and Test C++14'
       env:
         CC: clang
         CXX: clang++

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ matrix:
     #
     # Invokes test/hdrtst to check public headers compliance.
 
-    - name: "c: linux gcc"
+    - name: "c: linux gcc (debug)"
       dist:     xenial
       language: cpp
       compiler: gcc
@@ -118,10 +118,27 @@ matrix:
       # TODO(ICU-20301): Change this back to the default Python version 3.
       script:   cd icu4c/source && PYTHON=python2 ./runConfigureICU MacOSX && make -j2 check
 
+    # out of source gcc 8 build with c++14, runs icuinfo
+    - name: "c: linux gcc 8 c++14"
+      dist:     bionic
+      language: cpp
+      addons:
+         apt:
+           packages:
+             - g++-8
+      env: PREFIX=/tmp/icu-prefix CC=gcc-8 CXX=g++-8 CXXFLAGS="-std=c++14"
+      before_script:
+        - mkdir build && cd build
+        - ../icu4c/source/runConfigureICU Linux --disable-layout --disable-layoutex --prefix="${PREFIX}"
+        - make -j2
+      script:
+        - make -j2 check && make install
+        - cd "${PREFIX}/bin" && LD_LIBRARY_PATH=../lib ./icuinfo
+
     # Clang Linux with address sanitizer.
     # Note - the 'sudo: true' option forces Travis to use a Virtual machine on GCE instead of
     #        a Container on EC2 or Packet. Asan builds of ICU fail otherwise.
-    - name: "c: linux asan"
+    - name: "c: linux asan (debug)"
       language: cpp
       env:
         - CPPFLAGS="-fsanitize=address"
@@ -140,7 +157,7 @@ matrix:
 
     # Clang Linux with thread sanitizer.
     #
-    - name: "c: linux tsan"
+    - name: "c: linux tsan (debug)"
       language: cpp
       env:
           - INTLTEST_OPTS="utility/MultithreadTest"


### PR DESCRIPTION
Note: The Ubuntu 18.04 image doesn't have HarfBuzz, so we need to disable building the layout engine.

(Related PR: #1132).

Also updating/fixing the Ubuntu image name to use the preferred VM Image name.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21104
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

