### PR TITLE
ICU-20545 Detect file separator char from dir

### DIFF
--- a/icu4c/source/tools/toolutil/unewdata.cpp
+++ b/icu4c/source/tools/toolutil/unewdata.cpp
@@ -56,15 +56,25 @@ udata_create(const char *dir, const char *type, const char *name,
         *pErrorCode=U_MEMORY_ALLOCATION_ERROR;
         return NULL;
     }
-    
+
+    char dirSepChar = U_FILE_SEP_CHAR;
+#if (U_FILE_SEP_CHAR != U_FILE_ALT_SEP_CHAR)
+    // We may need to append a different directory separator when building for Cygwin or MSYS2.
+    if(dir && *dir) {
+      if(!uprv_strchr(dir, U_FILE_SEP_CHAR) && uprv_strchr(dir, U_FILE_ALT_SEP_CHAR)) {
+          dirSepChar = U_FILE_ALT_SEP_CHAR;
+      }
+    }
+#endif
+
     /* Check that the full path won't be too long */
     length = 0;					/* Start with nothing */
     if(dir != NULL  && *dir !=0)	/* Add directory length if one was given */
     {
     	length += static_cast<int32_t>(strlen(dir));
-	
+
     	/* Add 1 if dir doesn't end with path sep */
-        if (dir[strlen(dir) - 1]!= U_FILE_SEP_CHAR) {
+        if (dir[strlen(dir) - 1]!= dirSepChar) {
             length++;
         }
 	}
@@ -74,7 +84,7 @@ udata_create(const char *dir, const char *type, const char *name,
         length += static_cast<int32_t>(strlen(type));
     }
 
-        
+
      /* LDH buffer Length error check */
     if(length  > ((int32_t)sizeof(filename) - 1))
     {
@@ -82,13 +92,13 @@ udata_create(const char *dir, const char *type, const char *name,
    	    uprv_free(pData);
 	    return NULL;
     }
-   
+
     /* open the output file */
     if(dir!=NULL && *dir!=0) { /* if dir has a value, we prepend it to the filename */
         char *p=filename+strlen(dir);
         uprv_strcpy(filename, dir);
-        if (*(p-1)!=U_FILE_SEP_CHAR) {
-            *p++=U_FILE_SEP_CHAR;
+        if (*(p-1)!=dirSepChar) {
+            *p++=dirSepChar;
             *p=0;
         }
     } else { /* otherwise, we'll output to the current dir */


### PR DESCRIPTION
[ICU-20545]

If `udata_create` won't find `U_FILE_SEP_CHAR` at the end of a `dir` variable,
then it appends it. The problem starts if the `dir` variable uses
`U_FILE_ALT_SEP_CHAR` which is not equal to `U_FILE_SEP_CHAR`. Then the
resulting path could look like this
`../data\mappings/cns-11643-1992.ucm`
instead of this
`../data/mappings/cns-11643-1992.ucm`

This patch uses `U_FILE_SEP_CHAR` unless it detects that the `dir` variable
doesn't use it, and uses `U_FILE_ALT_SEP_CHAR` instead.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20545
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added



[ICU-20545]: https://unicode-org.atlassian.net/browse/ICU-20545