### PR TITLE
ICU-13339 Do not parse decimal point for integers

### DIFF
--- a/icu4c/source/test/iotest/iotest.cpp
+++ b/icu4c/source/test/iotest/iotest.cpp
@@ -360,6 +360,41 @@ static void U_CALLCONV DataDrivenPrintf(void)
 U_CDECL_END
 
 U_CDECL_BEGIN
+static void U_CALLCONV ScanfMultipleIntegers(void)
+{
+    UnicodeString input = UNICODE_STRING("[1.2.3]", 7);
+    UnicodeString fmt = UNICODE_STRING("[%d.%d.%d]", 10);
+    DataDrivenLogger logger;
+
+    const int32_t expectedFirst = 1;
+    const int32_t expectedSecond = 2;
+    const int32_t expectedThird = 3;
+    const int32_t expectedResult = 3;
+    int32_t first = 0;
+    int32_t second = 0;
+    int32_t third = 0;
+    int32_t result = u_sscanf_u(input.getBuffer(), fmt.getBuffer(), &first, &second, &third);
+
+    if(first != expectedFirst){
+        log_err("error in scanfmultipleintegers test 'first' Got: %d Exp: %d\n", 
+                first, expectedFirst);
+    }
+    if(second != expectedSecond){
+        log_err("error in scanfmultipleintegers test 'second' Got: %d Exp: %d\n",
+                second, expectedSecond);
+    }
+    if(third != expectedThird){
+        log_err("error in scanfmultipleintegers test 'third' Got: %d Exp: %d\n",
+                third, expectedThird);
+    }
+    if(result != expectedResult){
+        log_err("error in scanfmultipleintegers test 'result'  Got: %d Exp: %d\n",
+                result, expectedResult);
+    }
+}
+U_CDECL_END
+
+U_CDECL_BEGIN
 static void U_CALLCONV DataDrivenScanf(void)
 {
 #if !UCONFIG_NO_FORMATTING && !UCONFIG_NO_FILE_IO
@@ -698,6 +733,7 @@ static void addAllTests(TestNode** root) {
     addTest(root, &DataDrivenPrintfPrecision, "datadriv/DataDrivenPrintfPrecision");
     addTest(root, &DataDrivenScanf, "datadriv/DataDrivenScanf");
 #endif
+    addTest(root, &ScanfMultipleIntegers, "ScanfMultipleIntegers");
     addStreamTests(root);
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-13339
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [X] Tests included
- [X] Documentation is changed or added => fixed the code to match the existing documentation

I have made changes to `u_scanf_integer_handler()` in `uscanf_p.cpp`, to make sure that parsing an integer will not (try to) parse a decimal point. The usecase where I discovered the bug: 

`u_sscanf_u("[1.2.3]", "[%d.%d.%d]", &first, &second, &third);`

I am a longtime icu user, but not a very accomplished git user. I would be happy to get your feedback on procedural or programming mistakes I made. I would **really** like to have this issue fixed.

Full disclosure: The ticket was raised by a colleague and I.