### PR TITLE
ICU-21121 Enable tests for MacOSX build bot.

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -282,8 +282,8 @@ jobs:
       lfs: true
       fetchDepth: 1
     - script: |
-        export CPPFLAGS="-Werror -Wall -Wextra -Wextra-semi -Wundef -Wnon-virtual-dtor" && cd icu4c/source && ./runConfigureICU MacOSX && make -j2 tests
-      displayName: 'Build only (WarningsAsErrors)'
+        export CPPFLAGS="-Werror -Wall -Wextra -Wextra-semi -Wundef -Wnon-virtual-dtor" && cd icu4c/source && ./runConfigureICU MacOSX && make -j2 check
+      displayName: 'Build and Test (WarningsAsErrors)'
       env:
         CC: clang
         CXX: clang++


### PR DESCRIPTION
Enable running the ICU4C tests for Mac OSX on the Azure build bot.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21121
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

