### PR TITLE
ICU-21119 Log failed commands & enable verbose output from ICU data build on Windows/DEBUG

### DIFF
--- a/icu4c/source/data/makedata.mak
+++ b/icu4c/source/data/makedata.mak
@@ -248,6 +248,13 @@ ALL : GODATA "$(ICU_LIB_TARGET)" "$(TESTDATAOUT)\testdata.dat" $(ARM_CROSSBUILD_
 
 !ENDIF
 
+# Verbose output when building the data for Debug builds.
+!IF "$(DEBUG)" == "true"
+ICU_DATA_BUILD_VERBOSE=--verbose
+!ELSE
+ICU_DATA_BUILD_VERBOSE=
+!ENDIF
+
 # Three main targets: tools, core data, and test data.
 # Keep track of whether they are built via timestamp files.
 
@@ -277,6 +284,7 @@ $(COREDATA_TS):
 		--out_dir "$(ICUBLD_PKG)" \
 		--tmp_dir "$(ICUTMP)" \
 		--filter_file "$(ICU_DATA_FILTER_FILE)" \
+		$(ICU_DATA_BUILD_VERBOSE) \
 		$(ICU_DATA_BUILDTOOL_OPTS)
 	@echo "timestamp" > $(COREDATA_TS)
 

--- a/icu4c/source/data/makedata.vcxproj
+++ b/icu4c/source/data/makedata.vcxproj
@@ -22,11 +22,12 @@
     <OutDir>.\data\tmp\$(Platform)\</OutDir>
     <IntDir>.\data\build\</IntDir>
     <MakeCFG>$(Platform)\$(Configuration)</MakeCFG>
+    <DebugBuild Condition="'$(Configuration)'=='Debug'">true</DebugBuild>
     <!-- The ICU projects use "Win32" to mean "x86", so we need to special case it. -->
     <OutDir Condition="'$(Platform)'=='Win32'">.\data\tmp\x86\</OutDir>
     <MakeCFG Condition="'$(Platform)'=='Win32'">x86\$(Configuration)</MakeCFG>
     <!-- NMake -->
-    <NMakeBuildCommandLine>NMAKE /f makedata.mak ICUMAKE="$(ProjectDir)\" CFG=$(MakeCFG)</NMakeBuildCommandLine>
+    <NMakeBuildCommandLine>NMAKE /f makedata.mak ICUMAKE="$(ProjectDir)\" CFG=$(MakeCFG) DEBUG=$(DebugBuild)</NMakeBuildCommandLine>
     <NMakeReBuildCommandLine>NMAKE /f makedata.mak ICUMAKE="$(ProjectDir)\" CFG=$(MakeCFG) clean all</NMakeReBuildCommandLine>
     <NMakeCleanCommandLine>NMAKE /f makedata.mak ICUMAKE="$(ProjectDir)\" CFG=$(MakeCFG) clean</NMakeCleanCommandLine>
     <NMakeOutput/>

--- a/icu4c/source/python/icutools/databuilder/renderers/common_exec.py
+++ b/icu4c/source/python/icutools/databuilder/renderers/common_exec.py
@@ -1,6 +1,10 @@
 # Copyright (C) 2018 and later: Unicode, Inc. and others.
 # License & terms of use: http://www.unicode.org/copyright.html
 
+# Python 2/3 Compatibility (ICU-20299)
+# TODO(ICU-20301): Remove this.
+from __future__ import print_function
+
 from . import *
 from .. import *
 from .. import utils
@@ -146,4 +150,6 @@ def run_shell_command(command_line, platform, verbose):
             )
     if changed_windows_comspec:
         os.environ["COMSPEC"] = previous_comspec
+    if returncode != 0:
+        print("Command failed: %s" % command_line, file=sys.stderr)
     return returncode


### PR DESCRIPTION
If the ICU data build fails during the Python data build script on Windows, then you don't get very helpful error messages/logs. This isn't as much of an issue on non-Windows platforms, as the Python data build script is run as part of the configure script, and not during the build (make).

The change in this PR does two things:
- It logs the command line for any failed command executed during the data build (for any platform).
- It enables `--verbose` when building under DEBUG mode on Windows.

This should help to track down build failure issues that occur during the data build, like the one in PR #1141. 🙂

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21119
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

