### PR TITLE
ICU-21098 fix ticket URLs for logKnownIssue tickets.

### DIFF
--- a/icu4c/source/test/intltest/intltest.cpp
+++ b/icu4c/source/test/intltest/intltest.cpp
@@ -1016,7 +1016,7 @@ UBool IntlTest::logKnownIssue(const char *ticket, const UnicodeString &msg) {
   UBool firstForTicket = TRUE, firstForWhere = TRUE;
   knownList = udbg_knownIssue_openU(knownList, ticket, fullpath, msg2.getTerminatedBuffer(), &firstForTicket, &firstForWhere);
 
-  msg2 = UNICODE_STRING_SIMPLE("(Known issue #") +
+  msg2 = UNICODE_STRING_SIMPLE("(Known issue ") +
       UnicodeString(ticket, -1, US_INV) + UNICODE_STRING_SIMPLE(") ") + msg;
   if(firstForTicket || firstForWhere) {
     infoln(msg2);

--- a/icu4c/source/test/intltest/intltest.h
+++ b/icu4c/source/test/intltest/intltest.h
@@ -166,30 +166,27 @@ public:
     virtual void logln( void );
 
     /**
-     * Replaces isICUVersionAtLeast and isICUVersionBefore
-     * log that an issue is known.
+     * Logs that an issue is known. Can be called multiple times.
      * Usually used this way:
-     * <code>if( ... && logKnownIssue("12345", "some bug")) continue; </code>
-     * @param ticket ticket string, "12345" or "cldrbug:1234"
+     * <code>if( ... && logKnownIssue("ICU-12345", "some bug")) continue; </code>
+     * @param ticket ticket string, "ICU-12345" or "CLDR-1234"
      * @param message optional message string
      * @return true if test should be skipped
      */
     UBool logKnownIssue( const char *ticket, const UnicodeString &message );
     /**
-     * Replaces isICUVersionAtLeast and isICUVersionBefore
-     * log that an issue is known.
+     * Logs that an issue is known. Can be called multiple times.
      * Usually used this way:
-     * <code>if( ... && logKnownIssue("12345", "some bug")) continue; </code>
-     * @param ticket ticket string, "12345" or "cldrbug:1234"
+     * <code>if( ... && logKnownIssue("ICU-12345", "some bug")) continue; </code>
+     * @param ticket ticket string, "ICU-12345" or "CLDR-1234"
      * @return true if test should be skipped
      */
     UBool logKnownIssue( const char *ticket );
     /**
-     * Replaces isICUVersionAtLeast and isICUVersionBefore
-     * log that an issue is known.
+     * Log that an issue is known. Can be called multiple times.
      * Usually used this way:
-     * <code>if( ... && logKnownIssue("12345", "some bug")) continue; </code>
-     * @param ticket ticket string, "12345" or "cldrbug:1234"
+     * <code>if( ... && logKnownIssue("ICU-12345", "some bug")) continue; </code>
+     * @param ticket ticket string, "ICU-12345" or "CLDR-1234"
      * @param message optional message string
      * @return true if test should be skipped
      */

--- a/icu4c/source/tools/ctestfw/ctest.c
+++ b/icu4c/source/tools/ctestfw/ctest.c
@@ -709,9 +709,9 @@ static UBool vlog_knownIssue(const char *ticket, const char *pattern, va_list ap
                                      &firstForTicket, &firstForWhere);
 
     if(firstForTicket || firstForWhere) {
-      log_info("(Known issue #%s) %s\n", ticket, buf);
+      log_info("(Known issue %s) %s\n", ticket, buf);
     } else {
-      log_verbose("(Known issue #%s) %s\n", ticket, buf);
+      log_verbose("(Known issue %s) %s\n", ticket, buf);
     }
 
     return TRUE;

--- a/icu4c/source/tools/ctestfw/unicode/ctest.h
+++ b/icu4c/source/tools/ctestfw/unicode/ctest.h
@@ -228,7 +228,7 @@ log_data_err(const char *pattern, ...);
 
 /**
  * Log a known issue.
- * @param ticket ticket number such as "12345" for ICU tickets or "cldrbug:6636" for CLDR tickets.
+ * @param ticket ticket number such as "ICU-12345" for ICU tickets or "CLDR-6636" for CLDR tickets.
  * @param fmt ...  sprintf-style format, optional message. can be NULL.
  * @return TRUE if known issue test should be skipped, FALSE if it should be run
  */

--- a/icu4c/source/tools/toolutil/udbgutil.cpp
+++ b/icu4c/source/tools/toolutil/udbgutil.cpp
@@ -594,24 +594,11 @@ U_CAPI void udbg_writeIcuInfo(FILE *out) {
   fprintf(out, " </icuSystemParams>\n");
 }
 
-#define ICU_TRAC_URL "http://bugs.icu-project.org/trac/ticket/"
-#define CLDR_TRAC_URL "http://unicode.org/cldr/trac/ticket/"
-#define CLDR_TICKET_PREFIX "cldrbug:"
+#define UNICODE_BUG_URL "https://unicode-org.atlassian.net/browse/"
+#define OLD_CLDR_PREFIX "cldrbug:"
+#define CLDR_BUG_PREFIX "CLDR-"
+#define ICU_BUG_PREFIX "ICU-"
 
-U_CAPI char *udbg_knownIssueURLFrom(const char *ticket, char *buf) {
-  if( ticket==NULL ) {
-    return NULL;
-  }
-
-  if( !strncmp(ticket, CLDR_TICKET_PREFIX, strlen(CLDR_TICKET_PREFIX)) ) {
-    strcpy( buf, CLDR_TRAC_URL );
-    strcat( buf, ticket+strlen(CLDR_TICKET_PREFIX) );
-  } else {
-    strcpy( buf, ICU_TRAC_URL );
-    strcat( buf, ticket );
-  }
-  return buf;
-}
 
 
 #include <set>
@@ -641,8 +628,27 @@ KnownIssues::~KnownIssues()
 {
 }
 
-void KnownIssues::add(const char *ticket, const char *where, const UChar *msg, UBool *firstForTicket, UBool *firstForWhere)
+/**
+ * Map cldr:1234 to CLDR-1234
+ * Map 1234 to ICU-1234
+ */
+static std::string mapTicketId(const char *ticketStr) {
+  std::string ticket(ticketStr);
+  // TODO: Can remove this function once all logKnownIssue calls are switched over
+  // to the ICU-1234 and CLDR-1234 format.
+  if(ticket.rfind(OLD_CLDR_PREFIX) == 0) {
+    // map cldrbug:1234 to CLDR-1234
+    ticket.replace(0, uprv_strlen(OLD_CLDR_PREFIX), CLDR_BUG_PREFIX);
+  } else if(::isdigit(ticket[0])) {
+    // map 1234 to ICU-1234
+    ticket.insert(0, ICU_BUG_PREFIX);
+  }
+  return ticket;
+}
+
+void KnownIssues::add(const char *ticketStr, const char *where, const UChar *msg, UBool *firstForTicket, UBool *firstForWhere)
 {
+  const std::string ticket = mapTicketId(ticketStr);
   if(fTable.find(ticket) == fTable.end()) {
     if(firstForTicket!=NULL) *firstForTicket = TRUE;
     fTable[ticket] = std::map < std::string, std::set < std::string > >();
@@ -664,8 +670,9 @@ void KnownIssues::add(const char *ticket, const char *where, const UChar *msg, U
   fTable[ticket][where].insert(std::string(icu::CStr(ustr)()));
 }
 
-void KnownIssues::add(const char *ticket, const char *where, const char *msg, UBool *firstForTicket, UBool *firstForWhere)
+void KnownIssues::add(const char *ticketStr, const char *where, const char *msg, UBool *firstForTicket, UBool *firstForWhere)
 {
+  const std::string ticket = mapTicketId(ticketStr);
   if(fTable.find(ticket) == fTable.end()) {
     if(firstForTicket!=NULL) *firstForTicket = TRUE;
     fTable[ticket] = std::map < std::string, std::set < std::string > >();
@@ -697,8 +704,13 @@ UBool KnownIssues::print()
           std::map <  std::string,  std::set <  std::string > > >::iterator i = fTable.begin();
        i != fTable.end();
        i++ ) {
-    char URL[1024];
-    std::cout << '#' << (*i).first << " <" << udbg_knownIssueURLFrom( (*i).first.c_str(), URL ) << ">" << std::endl;
+    const std::string ticketid = (*i).first;
+    std::cout << "[" << ticketid << "] ";
+    if(ticketid.rfind(ICU_BUG_PREFIX) == 0 || ticketid.rfind(CLDR_BUG_PREFIX) == 0) {
+      // If it's a unicode.org bug.
+      std::cout << UNICODE_BUG_URL << ticketid;
+    } // Else: some other kind of bug. Allow this, but without a URL.
+    std::cout << std::endl;
 
     for( std::map< std::string, std::set < std::string > >::iterator ii = (*i).second.begin();
          ii != (*i).second.end();

--- a/icu4c/source/tools/toolutil/udbgutil.h
+++ b/icu4c/source/tools/toolutil/udbgutil.h
@@ -114,14 +114,6 @@ U_CAPI void udbg_writeIcuInfo(FILE *f);
 #define UDBG_KNOWNISSUE_LEN 255
 
 /**
- * Convert a "known issue" string into a URL
- * @param ticket ticket string such as "10245" or "cldrbug:5013"
- * @param buf output buffer - must be UDBG_KNOWNISSUE_LEN in size
- * @return pointer to output buffer, or NULL on err
- */
-U_CAPI char *udbg_knownIssueURLFrom(const char *ticket, char *buf);
-
-/**
  * Open (or reopen) a 'known issue' table.
  * @param ptr pointer to 'table'. Opaque.
  * @return new or existing ptr


### PR DESCRIPTION
ICU-21098
- Still allows "1234" or "cldrbug:1234" format ticket IDs
- However, docs recommend "ICU-1234" or "CLDR-1234" format
in the future.
- Other ticket IDs could be used, but won't be linkified.

New format:
```
--------------------------------------
KNOWN ISSUES
[CLDR-1911] https://unicode-org.atlassian.net/browse/CLDR-1911
  /TransliteratorRoundTripTest/TestDevanagariLatin/TestDevanagariLatin
  /TransliteratorRoundTripTest/TestGreek/TestGreek
  /TransliteratorRoundTripTest/TestGreekUNGEGN/TestGreekUNGEGN
  /TransliteratorRoundTripTest/TestHebrew/TestHebrew
  /TransliteratorRoundTripTest/TestInterIndic/TestInterIndic
  /TransliteratorRoundTripTest/Testel/Testel
[CLDR-6745] https://unicode-org.atlassian.net/browse/CLDR-6745
  /UCAConformanceTest/TestRulesNonIgnorable/TestRulesNonIgnorable
     "UCARules.txt has problems"
[ICU-11052] https://unicode-org.atlassian.net/browse/ICU-11052
  /TimeZoneFormatTest/TestTimeRoundTrip/TestTimeRoundTrip
     "Ambiguous zone name - Samoa Time"
[ICU-11891] https://unicode-org.atlassian.net/browse/ICU-11891
  /UnicodeSetTest/TestUCAUnsafeBackwards/TestUCAUnsafeBackwards
     "UnicodeSet fails to round trip on CollationRoot...unsafeBackwards set"
[ICU-13574] https://unicode-org.atlassian.net/browse/ICU-13574
  /NumberFormatTest/Test11035_FormatCurrencyAmount/Test11035_FormatCurrencyAmount
[ICU-20400] https://unicode-org.atlassian.net/browse/ICU-20400
  /NewResourceBundleTest/TestIntervalAliasFallbacks/TestIntervalAliasFallbacks
[ICU-20727] https://unicode-org.atlassian.net/browse/ICU-20727
  /LocaleMatcherTest/testDataDriven/testDataDriven
     "ignoring makeResolvedLocale() line 583"
     "ignoring makeResolvedLocale() line 600"
[ICU-21097] https://unicode-org.atlassian.net/browse/ICU-21097
  /RBBITest/TestUnicodeFiles/TestUnicodeFiles
 To run suppressed tests, use the -K option. 
OK: All tests passed without error.
--------------------------------------
```

[CLDR-1911]: https://unicode-org.atlassian.net/browse/CLDR-1911
[CLDR-6745]: https://unicode-org.atlassian.net/browse/CLDR-6745
[ICU-11052]: https://unicode-org.atlassian.net/browse/ICU-11052
[ICU-11891]: https://unicode-org.atlassian.net/browse/ICU-11891