### PR TITLE
ICU-21137 Adjust VSCode IDE settings and README.

### DIFF
--- a/.cpyskip.txt
+++ b/.cpyskip.txt
@@ -98,6 +98,10 @@ icu4j/main/tests/core/src/com/ibm/icu/dev/data/unicode/UnicodeData.txt
 icu4j/main/tests/core/src/com/ibm/icu/dev/test/duration/testdata/*
 icu4j/perf-tests/data/conversion/*
 #
+# docs
+#
+docs/ide4c/vscode/*.json
+#
 # tools
 #
 tools/trac/IcuCodeTools/*

--- a/docs/ide4c/vscode/README.md
+++ b/docs/ide4c/vscode/README.md
@@ -3,8 +3,20 @@
 
 # Configuring VS Code for ICU4C
 
-  - create `.vscode` folder in icu4c/source
-  - Copy `tasks.json` and `launch.json` files into `.vscode` folder
+  - Create a `.vscode` folder in icu4c/source
+  - Copy the `tasks.json`, `launch.json` and `c_cpp_properties.json` files into
+    the `.vscode` folder.
+  - To test only specific test targets, specify them under `args` in
+    `launch.json`.
+  - To adjust the parallelism when building, adjust the `args` in `tasks.json`.
+    - `-l20` tells VSCode to not launch jobs if the system load average is above
+      20 (note that the [system load
+      average](https://en.wikipedia.org/wiki/Load_(computing)) is *not* a CPU
+      usage percentage).
+    - `-j24` limits the number of jobs launched in parallel to 24. The system
+      load average takes a while to respond, reducing this number helps the
+      initial bad system performance when a new build is launched.
 
-NOTE
- Before you build `icu4c` from vs code. run [`./runConfigureICU` command first](http://userguide.icu-project.org/icufaq).
+NOTE:
+Run the [`./runConfigureICU` command](http://userguide.icu-project.org/icufaq)
+before building `icu4c` from VSCode.

--- a/docs/ide4c/vscode/c_cpp_properties.json
+++ b/docs/ide4c/vscode/c_cpp_properties.json
@@ -1,0 +1,21 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/tools/toolutil",
+                "${workspaceFolder}/tools/ctestfw",
+                "${workspaceFolder}/common",
+                "${workspaceFolder}/i18n"
+            ],
+            "defines": [
+                "U_DISABLE_RENAMING=1"
+            ],
+            "compilerPath": "/usr/bin/clang",
+            "cStandard": "c11",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "clang-x64"
+        }
+    ],
+    "version": 4
+}

--- a/docs/ide4c/vscode/launch.json
+++ b/docs/ide4c/vscode/launch.json
@@ -20,10 +20,12 @@
                 }
             ],
             "args": [ // Here you add which test cases you want to run, leaving it empty will run all the test cases.
-                "rbbi/RBBITest" // Just for example.
+                // Examples:
+                // "rbbi/RBBITest",
+                // "format/NumberFormatTest"
             ],
             "stopAtEntry": false, // If you want to add a break point in the beginning of the program (i.e. test cases).
-            "cwd": "${workspaceFolder}",
+            "cwd": "${workspaceFolder}/test/intltest",
             "externalConsole": false, //set to true to see output in an external terminal instead
             "MIMode": "gdb", // Use "lldb" for mac osx.
             "logging": {
@@ -51,7 +53,7 @@
                 }
             ],
             "args": [ // Here you add which test cases you want to run, leaving it empty will run all the test cases.
-                "/tsutil/cstrcase" // Just for example.
+                // "/tsutil/cstrcase" // Just for example.
             ],
             "stopAtEntry": false, // If you want to add a break point in the beginning of the program (i.e. test cases).
             "cwd": "${workspaceFolder}",
@@ -82,7 +84,7 @@
                 }
             ],
             "args": [ // Here you add which test cases you want to run, leaving it empty will run all the test cases.
-                "/datadriv" // Just for example.
+                // "/datadriv" // Just for example.
             ],
             "stopAtEntry": false, // If you want to add a break point in the beginning of the program (i.e. test cases).
             "cwd": "${workspaceFolder}",

--- a/docs/ide4c/vscode/tasks.json
+++ b/docs/ide4c/vscode/tasks.json
@@ -1,6 +1,5 @@
 // © 2020 and later: Unicode, Inc. and others.
 // License & terms of use: http://www.unicode.org/copyright.html#License
-
 {
     "version": "2.0.0",
     "tasks": [
@@ -20,8 +19,8 @@
             "args": [
                 "all",
                 "--debug", // Enable debug mode.
-                "-j", // Use more than one core in parallel
-                "-l90" // Use 90 percent of the CPU
+                "-j24", // Launch no more than 24 jobs in parallel
+                "-l20" // Stop launching jobs if system load average is too high
             ]
         },
         {
@@ -29,8 +28,8 @@
             "command": "make", // Could be any other shell command
             "args": [
                 "tests",
-                "-j", // Use more than one core in parallel
-                "-l90" // Use 90 percent of the CPU
+                "-j24", // Launch no more than 24 jobs in parallel
+                "-l20" // Stop launching jobs if system load average is too high
             ],
             "type": "shell"
         }


### PR DESCRIPTION
- Adds c_cpp_properties.json, primarily for the includePath settings.
- make's "-l" parameter is system load average, not CPU percentage.
  A load average of 90 makes my laptop unusable, changing to -l20.
- Load average takes a while to respond, specify -j24 to always limit
  parallel jobs to a maximum of 24.
- Set intltest's Current Working Directory correctly to enable finding
  resources.
- Make running all tests the unit-testing default.
- Document the adjustments that can be made in the README.
- Skip these json files when checking for copyright notices. Pure json
  does not permit comments, so c_cpp_properties.json cannot have
  comments.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21137
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [x] Documentation is changed or added

