### PR TITLE
ICU-21140 Make UTF-8 explicit for all file access.

### DIFF
--- a/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/IcuTextWriter.java
+++ b/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/IcuTextWriter.java
@@ -3,6 +3,7 @@
 package org.unicode.icu.tool.cldrtoicu;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
@@ -49,7 +50,7 @@ final class IcuTextWriter {
             Files.createDirectories(outDir);
             Path file = outDir.resolve(icuData.getName() + ".txt");
             OpenOption[] fileOptions = allowOverwrite ? OVERWRITE_FILES : ONLY_NEW_FILES;
-            try (Writer w = Files.newBufferedWriter(file, fileOptions);
+            try (Writer w = Files.newBufferedWriter(file, UTF_8, fileOptions);
                 PrintWriter out = new PrintWriter(w)) {
                 new IcuTextWriter(icuData).writeTo(out, header);
             }

--- a/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/ant/CleanOutputDirectoryTask.java
+++ b/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/ant/CleanOutputDirectoryTask.java
@@ -5,6 +5,7 @@ package org.unicode.icu.tool.cldrtoicu.ant;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.partitioningBy;
@@ -212,7 +213,7 @@ public final class CleanOutputDirectoryTask extends Task {
             // Directories, symbolic links, devices etc.
             return false;
         }
-        try (BufferedReader r = Files.newBufferedReader(path)) {
+        try (BufferedReader r = Files.newBufferedReader(path, UTF_8)) {
             // A byte-order-mark (BOM) is added to ICU data files, but not JSON deps files, so just
             // treat it as optional everywhere (it's not the important thing we check here).
             r.mark(1);
@@ -274,7 +275,7 @@ public final class CleanOutputDirectoryTask extends Task {
 
     private static ImmutableList<String> readLinesFromResource(String name) {
         try (InputStream in = CleanOutputDirectoryTask.class.getResourceAsStream(name)) {
-            return ImmutableList.copyOf(CharStreams.readLines(new InputStreamReader(in)));
+            return ImmutableList.copyOf(CharStreams.readLines(new InputStreamReader(in, UTF_8)));
         } catch (IOException e) {
             throw new RuntimeException("cannot read resource: " + name, e);
         }

--- a/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/mapper/TransformsMapper.java
+++ b/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/mapper/TransformsMapper.java
@@ -4,6 +4,7 @@ package org.unicode.icu.tool.cldrtoicu.mapper;
 
 import static com.google.common.base.CharMatcher.whitespace;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static org.unicode.cldr.api.AttributeKey.keyOf;
 import static org.unicode.cldr.api.CldrDataType.SUPPLEMENTAL;
@@ -91,7 +92,7 @@ public final class TransformsMapper {
             Path file = ruleFileOutputDir.resolve(p);
             try {
                 // Specify "CREATE_NEW" since we don't want to overwrite any existing files.
-                return new PrintWriter(Files.newBufferedWriter(file, CREATE_NEW));
+                return new PrintWriter(Files.newBufferedWriter(file, UTF_8, CREATE_NEW));
             } catch (IOException e) {
                 throw new RuntimeException("error opening file: " + file, e);
             }


### PR DESCRIPTION
I found one more case where UTF-8 had to be specified and I made it explicit in all the remaining file accesses I could find. While I'm glad UTF-8 is default in Files.newBufferedReader(), the fact that Java has for so many years assumed that "no charset" implies "system default" means the people reading the code are potentially going to be confused if it's omitted, so I just added it consistently everywhere.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21140
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

