### PR TITLE
ICU-21143 Applying non-zero offset to null pointer is undefined behaviour

### DIFF
--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -708,7 +708,7 @@ Locale& Locale::init(const char* localeID, UBool canonicalize)
                     const char* end = begin;
                     // We may have multiple variants, need to look at each of
                     // them.
-                    do {
+                    for (;;) {
                         status = U_ZERO_ERROR;
                         end = uprv_strchr(begin, '_');
                         int32_t len = (end == nullptr) ? int32_t(uprv_strlen(begin)) : int32_t(end - begin);
@@ -739,8 +739,9 @@ Locale& Locale::init(const char* localeID, UBool canonicalize)
                                              uprv_strchr(fullName, '@'), status).data(), false);
                             break;
                         }
+                        if (end == nullptr) break;
                         begin = end + 1;
-                    } while (end != nullptr);
+                    }
                 }  // End of handle language _ variant
                 // Handle cases of key pattern "language _ Script _ REGION"
                 // ex: Map "ks_Arab_IN" to "ks_IN"


### PR DESCRIPTION
The result of pointer end + 1 will not be used if end is nullptr so it doesn't really matter that the result of this operation is undefined, but it's therefore also unnecessary to perform the operation at all.

Changing this removes this unnecessary operation and by doing so gives the undefined behaviour sanitizer one thing less to worry about.