### PR TITLE
ICU-21150 Backport fix for broken Windows build with prebuilt data to 67

### DIFF
--- a/icu4c/source/data/makedata.mak
+++ b/icu4c/source/data/makedata.mak
@@ -378,7 +378,7 @@ icu4j-data-install :
 #
 # testdata - nmake will invoke pkgdata, which will create testdata.dat
 #
-"$(TESTDATAOUT)\testdata.dat": "$(TESTDATA)\*" $(TOOLS_TS) $(COREDATA_TS)
+"$(TESTDATAOUT)\testdata.dat": "$(TESTDATA)\*" $(TOOLS_TS)
 	@cd "$(TESTDATA)"
 	@echo building testdata...
 	nmake /nologo /f "$(TESTDATA)\testdata.mak" TESTDATA=. ICUTOOLS="$(ICUTOOLS)" ICUPBIN="$(ICUPBIN)" ICUP="$(ICUP)" CFG=$(CFGTOOLS) TESTDATAOUT="$(TESTDATAOUT)" TESTDATABLD="$(TESTDATABLD)" ICUSRCDATA="$(ICUSRCDATA)" DLL_OUTPUT="$(DLL_OUTPUT)"


### PR DESCRIPTION
This cherry-picks the fix for ICU-21102 from the `master` branch to the `maint/maint-67` branch.

This is cherry-picked from:
ICU-21102 Fix broken builds on Windows when using a pre-built data file (from the tgz).

PR #1139
(cherry picked from commit 82a5959b863ac647fce3bcc5804ed906fb3b4bc0)

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21150
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

