### PR TITLE
ICU-21169 Add SimpleUnitImpl::getSimpleUnitID() method

### DIFF
--- a/icu4c/source/common/unicode/bytestriebuilder.h
+++ b/icu4c/source/common/unicode/bytestriebuilder.h
@@ -101,9 +101,10 @@ public:
      * Multiple calls to buildStringPiece() return StringPieces referring to the
      * builder's same byte array, without rebuilding.
      * If buildStringPiece() is called after build(), the trie will be
-     * re-serialized into a new array.
-     * If build() is called after buildStringPiece(), the trie object will become
-     * the owner of the previously returned array.
+     * re-serialized into a new array (because build() passes on ownership).
+     * If build() is called after buildStringPiece(), the trie object returned
+     * by build() will become the owner of the underlying string for the
+     * previously returned StringPiece.
      * After clear() has been called, a new array will be used as well.
      * @param buildOption Build option, see UStringTrieBuildOption.
      * @param errorCode Standard ICU error code. Its input value must

--- a/icu4c/source/common/unicode/ucharstriebuilder.h
+++ b/icu4c/source/common/unicode/ucharstriebuilder.h
@@ -101,9 +101,10 @@ public:
      * Multiple calls to buildUnicodeString() set the UnicodeStrings to the
      * builder's same char16_t array, without rebuilding.
      * If buildUnicodeString() is called after build(), the trie will be
-     * re-serialized into a new array.
-     * If build() is called after buildUnicodeString(), the trie object will become
-     * the owner of the previously returned array.
+     * re-serialized into a new array (because build() passes on ownership).
+     * If build() is called after buildUnicodeString(), the trie object returned
+     * by build() will become the owner of the underlying data for the
+     * previously returned UnicodeString.
      * After clear() has been called, a new array will be used as well.
      * @param buildOption Build option, see UStringTrieBuildOption.
      * @param result A UnicodeString which will be set to the char16_t-serialized

--- a/icu4c/source/i18n/measunit_impl.h
+++ b/icu4c/source/i18n/measunit_impl.h
@@ -33,6 +33,16 @@ struct SingleUnitImpl : public UMemory {
     MeasureUnit build(UErrorCode& status) const;
 
     /**
+     * Returns the "simple unit ID", without SI or dimensionality prefix: this
+     * instance may represent a square-kilometer, but only "meter" will be
+     * returned.
+     *
+     * The returned pointer points at static memory and does not need to be
+     * cleaned up.
+     */
+    const char *getSimpleUnitID() const;
+
+    /**
      * Compare this SingleUnitImpl to another SingleUnitImpl for the sake of
      * sorting and coalescing.
      *

--- a/icu4c/source/test/depstest/dependencies.txt
+++ b/icu4c/source/test/depstest/dependencies.txt
@@ -1065,7 +1065,7 @@ group: sharedbreakiterator
 group: units_extra
     measunit_extra.o
   deps
-    units ucharstriebuilder ucharstrie uclean_i18n
+    units bytestriebuilder bytestrie uclean_i18n
 
 group: units
     measunit.o currunit.o nounit.o


### PR DESCRIPTION
Also swap a UCharsTrie for a BytesTrie, providing us with a set of char* values we can also return through getIdentifier().

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21169
- [X] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

