### PR TITLE
ICU-20869 Fix compiler warning in FixedDecimal::getFractionalDigits().

### DIFF
--- a/icu4c/source/i18n/plurrule.cpp
+++ b/icu4c/source/i18n/plurrule.cpp
@@ -1661,7 +1661,9 @@ int64_t FixedDecimal::getFractionalDigits(double n, int32_t v) {
       case 3: return (int64_t)(fract*1000.0 + 0.5);
       default:
           double scaled = floor(fract * pow(10.0, (double)v) + 0.5);
-          if (scaled > U_INT64_MAX) {
+          if (scaled >= static_cast<double>(U_INT64_MAX)) {
+              // Note: a double cannot accurately represent U_INT64_MAX. Casting it to double
+              //       will round up to the next representable value, which is U_INT64_MAX + 1.
               return U_INT64_MAX;
           } else {
               return (int64_t)scaled;


### PR DESCRIPTION
Fix a clang compiler warning and a potential undefined behavior arising
from casting an out-of-range double to an int. See the Jira ticket for a
more detailed description of the problem.

This PR is to fix the immediate problem. Longer term, the function
may be replaced entirely - see issue ICU-21147.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20869
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

