### PR TITLE
ICU-21142 Improving Maven handling of CLDR API Jar file for new tools.

### DIFF
--- a/tools/cldr/cldr-to-icu/build-icu-data.xml
+++ b/tools/cldr/cldr-to-icu/build-icu-data.xml
@@ -83,7 +83,7 @@
     <!-- Build a standalone JAR which is called by Ant (and which avoids needing to mess
          about making Ant know the Maven class-path). -->
     <target name="prepare-jar" depends="init-args">
-        <exec executable="mvn" searchpath="true">
+        <exec executable="mvn" searchpath="true" failonerror="true">
             <arg value="compile"/>
         </exec>
     </target>

--- a/tools/cldr/lib/README.txt
+++ b/tools/cldr/lib/README.txt
@@ -55,6 +55,7 @@ To update the local Maven repository (e.g. to install the CLDR jar) then from
 this directory (lib/) you should run:
 
 $ mvn install:install-file \
+  -Dproject.parent.relativePath="" \
   -DgroupId=org.unicode.cldr \
   -DartifactId=cldr-api \
   -Dversion=0.1-SNAPSHOT \
@@ -63,10 +64,11 @@ $ mvn install:install-file \
   -DlocalRepositoryPath=. \
   -Dfile=<CLDR_ROOT>/tools/java/cldr.jar
 
-And if you have updated one of these libraries then from the main project
-directory (i.e. the directory the Maven pom.xml file(s) are in) run:
+And if you have updated one of these libraries then from this directory run:
 
-$ mvn dependency:purge-local-repository -DsnapshotsOnly=true
+$ mvn dependency:purge-local-repository \
+  -Dproject.parent.relativePath="" \
+  -DmanualIncludes=org.unicode.cldr:cldr-api:jar
 
 After doing this, you should see something like the following list of files in
 this directory:
@@ -80,3 +82,20 @@ org/unicode/cldr/cldr-api/0.1-SNAPSHOT/cldr-api-0.1-SNAPSHOT.jar
 Finally, if you choose to update the version number of the snapshot, then also
 update all the the pom.xml files which reference it (but this is unlikely to be
 necessary).
+
+Troubleshooting
+---------------
+
+While the Maven system should keep the CLDR JAR up to date, there is a chance
+that you may have an out of date JAR installed elsewhere. If you have any
+issues with the JAR not being the expected version (e.g. after making changes)
+then run the above "purge" step again, from this directory.
+
+This should re-resolve the current JAR snapshot from the repository in this
+directory. Having purged the Maven cache, next time you build a project, you
+should see something like:
+
+[exec] Downloading from <xxx>: <url>/org/unicode/cldr/cldr-api/0.1-SNAPSHOT/maven-metadata.xml
+[exec] [INFO] Building jar: <path-to-icu-root>/tools/cldr/cldr-to-icu/target/cldr-to-icu-1.0-SNAPSHOT-jar-with-dependencies.jar
+
+This shows that it has had to re-fetch the JAR file.

--- a/tools/cldr/lib/install-cldr-jars.sh
+++ b/tools/cldr/lib/install-cldr-jars.sh
@@ -84,6 +84,7 @@ popd > /dev/null
 # The -B flag is "batch" mode and won't mess about with escape codes in the log file.
 echo "Installing CLDR JAR file..."
 run_with_logging mvn -B install:install-file \
+  -Dproject.parent.relativePath="" \
   -DgroupId=org.unicode.cldr \
   -DartifactId=cldr-api \
   -Dversion=0.1-SNAPSHOT \
@@ -93,7 +94,9 @@ run_with_logging mvn -B install:install-file \
   -Dfile="${CLDR_TOOLS_DIR}/cldr.jar"
 
 echo "Syncing local Maven repository..."
-run_with_logging mvn -B dependency:purge-local-repository -DsnapshotsOnly=true
+run_with_logging mvn -B dependency:purge-local-repository \
+  -Dproject.parent.relativePath="" \
+  -DmanualIncludes=org.unicode.cldr:cldr-api:jar 
 
 mv -f "${LOG_FILE}" "last_log.txt"
 echo "All done! (log file: last_log.txt)"

--- a/tools/cldr/lib/pom.xml
+++ b/tools/cldr/lib/pom.xml
@@ -26,7 +26,13 @@
          to identify the absolute path of a parent POM file). However since
          child POM files should have a <parent> declaration with the relative
          path in it, we can use that. Note however that this is a bit fragile
-         and relies on <relativePath> being a directory, not a POM file. -->
+         and relies on <relativePath> being a directory, not a POM file.
+         
+         In order to allow the local repository to work either when it is used
+         by a child POM file or when it's used directly (e.g. for installing
+         or purging the cache) when it is invoked from this directory, the
+           -Dproject.parent.relativePath=""
+         argument must be given. -->
     <repositories>
         <repository>
             <id>local-maven-repo</id>


### PR DESCRIPTION
Hugo recently had an issue involving stale cache entries and other teething troubles. This PR should fix them. It:
* Fixes an issue whereby purging of cached libraries might not work.
* Makes the ICU tool fail if the Maven build step fails.
* Updates docs to reflect new script location and talk about troubleshooting.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21142
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [x] Documentation is changed or added

