### PR TITLE
ICU-21144 LocaleMatcher setMaxDistance(), isMatch()

### DIFF
--- a/icu4c/source/common/locdistance.h
+++ b/icu4c/source/common/locdistance.h
@@ -39,6 +39,10 @@ public:
         return shiftedDistance / (1 << DISTANCE_SHIFT);
     }
 
+    static int32_t getDistanceFloor(int32_t indexAndDistance) {
+        return (indexAndDistance & DISTANCE_MASK) >> DISTANCE_SHIFT;
+    }
+
     static int32_t getIndex(int32_t indexAndDistance) {
         // assert indexAndDistance >= 0;
         return indexAndDistance >> INDEX_SHIFT;
@@ -78,10 +82,6 @@ private:
     static constexpr int32_t DISTANCE_MASK = 0x3ff;
     // tic constexpr int32_t MAX_INDEX = 0x1fffff;  // avoids sign bit
     static constexpr int32_t INDEX_NEG_1 = 0xfffffc00;
-
-    static int32_t getDistanceFloor(int32_t indexAndDistance) {
-        return (indexAndDistance & DISTANCE_MASK) >> DISTANCE_SHIFT;
-    }
 
     LocaleDistance(const LocaleDistanceData &data, const XLikelySubtags &likely);
     LocaleDistance(const LocaleDistance &other) = delete;

--- a/icu4c/source/common/unicode/localematcher.h
+++ b/icu4c/source/common/unicode/localematcher.h
@@ -480,6 +480,31 @@ public:
             return *this;
         }
 
+#ifndef U_HIDE_DRAFT_API
+        /**
+         * Sets the maximum distance for an acceptable match.
+         * The matcher will return a match for a pair of locales only if
+         * they match at least as well as the pair given here.
+         *
+         * For example, setMaxDistance(en-US, en-GB) limits matches to ones where the
+         * (desired, support) locales have a distance no greater than a region subtag difference.
+         * This is much stricter than the CLDR default.
+         *
+         * The details of locale matching are subject to changes in
+         * CLDR data and in the algorithm.
+         * Specifying a maximum distance in relative terms via a sample pair of locales
+         * insulates from changes that affect all distance metrics similarly,
+         * but some changes will necessarily affect relative distances between
+         * different pairs of locales.
+         *
+         * @param desired the desired locale for distance comparison.
+         * @param supported the supported locale for distance comparison.
+         * @return this Builder object
+         * @draft ICU 68
+         */
+        Builder &setMaxDistance(const Locale &desired, const Locale &supported);
+#endif  // U_HIDE_DRAFT_API
+
         /**
          * Sets the UErrorCode if an error occurred while setting parameters.
          * Preserves older error codes in the outErrorCode.
@@ -522,6 +547,8 @@ public:
         bool withDefault_ = true;
         ULocMatchFavorSubtag favor_ = ULOCMATCH_FAVOR_LANGUAGE;
         ULocMatchDirection direction_ = ULOCMATCH_DIRECTION_WITH_ONE_WAY;
+        Locale *maxDistanceDesired_ = nullptr;
+        Locale *maxDistanceSupported_ = nullptr;
     };
 
     // FYI No public LocaleMatcher constructors in C++; use the Builder.
@@ -618,6 +645,23 @@ public:
      * @draft ICU 65
      */
     Result getBestMatchResult(Locale::Iterator &desiredLocales, UErrorCode &errorCode) const;
+#endif  // U_HIDE_DRAFT_API
+
+#ifndef U_HIDE_DRAFT_API
+    /**
+     * Returns true if the pair of locales matches acceptably.
+     * This is influenced by Builder options such as setDirection(), setFavorSubtag(),
+     * and setMaxDistance().
+     *
+     * @param desired The desired locale.
+     * @param supported The supported locale.
+     * @param errorCode ICU error code. Its input value must pass the U_SUCCESS() test,
+     *                  or else the function returns immediately. Check for U_FAILURE()
+     *                  on output or use with function chaining. (See User Guide for details.)
+     * @return true if the pair of locales matches acceptably.
+     * @draft ICU 68
+     */
+    UBool isMatch(const Locale &desired, const Locale &supported, UErrorCode &errorCode) const;
 #endif  // U_HIDE_DRAFT_API
 
 #ifndef U_HIDE_INTERNAL_API

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/locale/LocaleDistance.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/locale/LocaleDistance.java
@@ -92,7 +92,7 @@ public class LocaleDistance {
         return shiftedDistance / (1 << DISTANCE_SHIFT);
     }
 
-    private static final int getDistanceFloor(int indexAndDistance) {
+    public static final int getDistanceFloor(int indexAndDistance) {
         return (indexAndDistance & DISTANCE_MASK) >> DISTANCE_SHIFT;
     }
 

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/LocaleMatcherTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/LocaleMatcherTest.java
@@ -678,6 +678,29 @@ public class LocaleMatcherTest extends TestFmwk {
     }
 
     @Test
+    public void testMaxDistanceAndIsMatch() {
+        LocaleMatcher.Builder builder = LocaleMatcher.builder();
+        LocaleMatcher standard = builder.build();
+        ULocale germanLux = new ULocale("de-LU");
+        ULocale germanPhoenician = new ULocale("de-Phnx-AT");
+        ULocale greek = new ULocale("el");
+        assertTrue("standard de-LU / de", standard.isMatch(germanLux, ULocale.GERMAN));
+        assertFalse("standard de-Phnx-AT / de", standard.isMatch(germanPhoenician, ULocale.GERMAN));
+
+        // Allow a script difference to still match.
+        LocaleMatcher loose = builder.setMaxDistance(germanPhoenician, ULocale.GERMAN).build();
+        assertTrue("loose de-LU / de", loose.isMatch(germanLux, ULocale.GERMAN));
+        assertTrue("loose de-Phnx-AT / de", loose.isMatch(germanPhoenician, ULocale.GERMAN));
+        assertFalse("loose el / de", loose.isMatch(greek, ULocale.GERMAN));
+
+        // Allow at most a regional difference.
+        LocaleMatcher regional = builder.setMaxDistance(new Locale("de", "AT"), Locale.GERMAN).build();
+        assertTrue("regional de-LU / de", regional.isMatch(new Locale("de", "LU"), Locale.GERMAN));
+        assertFalse("regional da / no", regional.isMatch(new Locale("da"), new Locale("no")));
+        assertFalse("regional zh-Hant / zh", regional.isMatch(Locale.CHINESE, Locale.TRADITIONAL_CHINESE));
+    }
+
+    @Test
     public void testCanonicalize() {
         LocaleMatcher matcher = LocaleMatcher.builder().build();
         assertEquals("bh --> bho", new ULocale("bho"), matcher.canonicalize(new ULocale("bh")));


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-21144
- LocaleMatcher.Builder.setMaxDistance(desired, supported)
- non-static LocaleMatcher.isMatch(desired, supported)