### PR TITLE
ICU-21177 Update README.md badges to point to new Azure Pipelines URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ The ICU project is under the stewardship of [The Unicode Consortium](https://www
 Build | Status
 ------|-------
 TravisCI | [![Build Status](https://travis-ci.org/unicode-org/icu.svg?branch=master)](https://travis-ci.org/unicode-org/icu)
-Azure Pipelines | [![Build Status](https://unicode-icu.visualstudio.com/ICU/_apis/build/status/CI?branchName=master)](https://unicode-icu.visualstudio.com/ICU/_build/latest?definitionId=21&branchName=master)
-Azure Pipelines (Exhaustive Tests) | [![Build Status](https://unicode-icu.visualstudio.com/ICU/_apis/build/status/CI-Exhaustive-Master?branchName=master)](https://unicode-icu.visualstudio.com/ICU/_build/latest?definitionId=24&branchName=master)
-Azure Pipelines (Valgrind ICU4C) | [![Build Status](https://unicode-icu.visualstudio.com/ICU/_apis/build/status/CI-Valgrind-Master?branchName=master)](https://unicode-icu.visualstudio.com/ICU/_build/latest?definitionId=30&branchName=master)
-AppVeyor | [![Build status](https://ci.appveyor.com/api/projects/status/6ev1ssb6efahsvs2?svg=true)](https://ci.appveyor.com/project/unicode-org/icu)
+Azure Pipelines | [![Build Status](https://dev.azure.com/ms/icu/_apis/build/status/unicode-org/CI?branchName=master)](https://dev.azure.com/ms/icu/_build/latest?definitionId=360&branchName=master)
+Azure Pipelines (Exhaustive Tests) | [![Build Status](https://dev.azure.com/ms/icu/_apis/build/status/unicode-org/CI-Exhaustive-Main?branchName=master)](https://dev.azure.com/ms/icu/_build/latest?definitionId=361&branchName=master)
+Azure Pipelines (Valgrind ICU4C) | [![Build Status](https://dev.azure.com/ms/icu/_apis/build/status/unicode-org/CI-Valgrind-Main?branchName=master)](https://dev.azure.com/ms/icu/_build/latest?definitionId=362&branchName=master)
+AppVeyor | [![Build status](https://ci.appveyor.com/api/projects/status/6ev1ssb6efahsvs2/branch/master?svg=true)](https://ci.appveyor.com/project/unicode-org/icu/branch/master)
 Fuzzing | [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/icu.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:icu)
 
 


### PR DESCRIPTION
This PR changes/updates the CI build status badges in the top-level README file to point to the new Azure DevOps Pipelines URL.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21177
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

