### PR TITLE
ICU-21176 spoof checker: remove whitelist/blacklist metaphors from AP…

### DIFF
--- a/icu4c/source/i18n/unicode/uspoof.h
+++ b/icu4c/source/i18n/unicode/uspoof.h
@@ -691,8 +691,10 @@ uspoof_clone(const USpoofChecker *sc, UErrorCode *status);
  * Specify the bitmask of checks that will be performed by {@link uspoof_check}. Calling this method
  * overwrites any checks that may have already been enabled. By default, all checks are enabled.
  *
- * To enable specific checks and disable all others, the "whitelisted" checks should be ORed together. For
- * example, to fail strings containing characters outside of the set specified by {@link uspoof_setAllowedChars} and
+ * To enable specific checks and disable all others,
+ * OR together only the bit constants for the desired checks.
+ * For example, to fail strings containing characters outside of
+ * the set specified by {@link uspoof_setAllowedChars} and
  * also strings that contain digits from mixed numbering systems:
  *
  * <pre>
@@ -701,8 +703,9 @@ uspoof_clone(const USpoofChecker *sc, UErrorCode *status);
  * }
  * </pre>
  *
- * To disable specific checks and enable all others, the "blacklisted" checks should be ANDed away from
- * ALL_CHECKS. For example, if you are not planning to use the {@link uspoof_areConfusable} functionality,
+ * To disable specific checks and enable all others,
+ * start with ALL_CHECKS and "AND away" the not-desired checks.
+ * For example, if you are not planning to use the {@link uspoof_areConfusable} functionality,
  * it is good practice to disable the CONFUSABLE check:
  *
  * <pre>

--- a/icu4j/main/classes/core/src/com/ibm/icu/text/SpoofChecker.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/SpoofChecker.java
@@ -618,8 +618,10 @@ public class SpoofChecker {
          * Specify the bitmask of checks that will be performed by {@link SpoofChecker#failsChecks}. Calling this method
          * overwrites any checks that may have already been enabled. By default, all checks are enabled.
          *
-         * To enable specific checks and disable all others, the "whitelisted" checks should be ORed together. For
-         * example, to fail strings containing characters outside of the set specified by {@link #setAllowedChars} and
+         * To enable specific checks and disable all others,
+         * OR together only the bit constants for the desired checks.
+         * For example, to fail strings containing characters outside of
+         * the set specified by {@link #setAllowedChars} and
          * also strings that contain digits from mixed numbering systems:
          *
          * <pre>
@@ -628,8 +630,9 @@ public class SpoofChecker {
          * }
          * </pre>
          *
-         * To disable specific checks and enable all others, the "blacklisted" checks should be ANDed away from
-         * ALL_CHECKS. For example, if you are not planning to use the {@link SpoofChecker#areConfusable} functionality,
+         * To disable specific checks and enable all others,
+         * start with ALL_CHECKS and "AND away" the not-desired checks.
+         * For example, if you are not planning to use the {@link SpoofChecker#areConfusable} functionality,
          * it is good practice to disable the CONFUSABLE check:
          *
          * <pre>


### PR DESCRIPTION
…I docs

They didn't add any value, and can be seen as culturally insensitive.

https://unicode-org.atlassian.net/browse/ICU-21176