### PR TITLE
ICU-21192 MeasureUnit Identifier spec compliance: s/p/pow/

### DIFF
--- a/icu4c/source/i18n/measunit_extra.cpp
+++ b/icu4c/source/i18n/measunit_extra.cpp
@@ -60,7 +60,7 @@ enum InitialCompoundPart {
     INITIAL_COMPOUND_PART_PER = kInitialCompoundPartOffset,
 };
 
-// Trie value offset for powers like "square-", "cubic-", "p2-" etc.
+// Trie value offset for powers like "square-", "cubic-", "pow2-" etc.
 constexpr int32_t kPowerPartOffset = 256;
 
 enum PowerPart {
@@ -249,20 +249,20 @@ void U_CALLCONV initUnitExtras(UErrorCode& status) {
     b.add("per-", INITIAL_COMPOUND_PART_PER, status);
     b.add("square-", POWER_PART_P2, status);
     b.add("cubic-", POWER_PART_P3, status);
-    b.add("p2-", POWER_PART_P2, status);
-    b.add("p3-", POWER_PART_P3, status);
-    b.add("p4-", POWER_PART_P4, status);
-    b.add("p5-", POWER_PART_P5, status);
-    b.add("p6-", POWER_PART_P6, status);
-    b.add("p7-", POWER_PART_P7, status);
-    b.add("p8-", POWER_PART_P8, status);
-    b.add("p9-", POWER_PART_P9, status);
-    b.add("p10-", POWER_PART_P10, status);
-    b.add("p11-", POWER_PART_P11, status);
-    b.add("p12-", POWER_PART_P12, status);
-    b.add("p13-", POWER_PART_P13, status);
-    b.add("p14-", POWER_PART_P14, status);
-    b.add("p15-", POWER_PART_P15, status);
+    b.add("pow2-", POWER_PART_P2, status);
+    b.add("pow3-", POWER_PART_P3, status);
+    b.add("pow4-", POWER_PART_P4, status);
+    b.add("pow5-", POWER_PART_P5, status);
+    b.add("pow6-", POWER_PART_P6, status);
+    b.add("pow7-", POWER_PART_P7, status);
+    b.add("pow8-", POWER_PART_P8, status);
+    b.add("pow9-", POWER_PART_P9, status);
+    b.add("pow10-", POWER_PART_P10, status);
+    b.add("pow11-", POWER_PART_P11, status);
+    b.add("pow12-", POWER_PART_P12, status);
+    b.add("pow13-", POWER_PART_P13, status);
+    b.add("pow14-", POWER_PART_P14, status);
+    b.add("pow15-", POWER_PART_P15, status);
     if (U_FAILURE(status)) { return; }
 
     // Add sanctioned simple units by offset
@@ -645,11 +645,11 @@ void serializeSingle(const SingleUnitImpl& singleUnit, bool first, CharString& o
     } else if (posPower == 3) {
         output.append("cubic-", status);
     } else if (posPower < 10) {
-        output.append('p', status);
+        output.append("pow", status);
         output.append(posPower + '0', status);
         output.append('-', status);
     } else if (posPower <= 15) {
-        output.append("p1", status);
+        output.append("pow1", status);
         output.append('0' + (posPower % 10), status);
         output.append('-', status);
     } else {

--- a/icu4c/source/test/intltest/measfmttest.cpp
+++ b/icu4c/source/test/intltest/measfmttest.cpp
@@ -3258,7 +3258,7 @@ void MeasureFormatTest::TestIdentifiers() {
         {"per-kilometer", "per-kilometer"},
 
         // Normalization of power and per
-        {"p2-foot-and-p2-mile", "square-foot-and-square-mile"},
+        {"pow2-foot-and-pow2-mile", "square-foot-and-square-mile"},
         {"gram-square-gram-per-dekagram", "cubic-gram-per-dekagram"},
         {"kilogram-per-meter-per-second", "kilogram-per-meter-second"},
 
@@ -3290,8 +3290,10 @@ void MeasureFormatTest::TestInvalidIdentifiers() {
         "+meter",
         "-kilometer",
         "+kilometer",
-        "-p2-meter",
-        "+p2-meter",
+        "-pow2-meter",
+        "+pow2-meter",
+        "p2-meter",
+        "p4-meter",
         "+",
         "-",
         "-mile",
@@ -3347,8 +3349,8 @@ void MeasureFormatTest::TestCompoundUnitOperations() {
 
     verifySingleUnit(squareMeter, UMEASURE_SI_PREFIX_ONE, 2, "square-meter");
     verifySingleUnit(overCubicCentimeter, UMEASURE_SI_PREFIX_CENTI, -3, "per-cubic-centimeter");
-    verifySingleUnit(quarticKilometer, UMEASURE_SI_PREFIX_KILO, 4, "p4-kilometer");
-    verifySingleUnit(overQuarticKilometer1, UMEASURE_SI_PREFIX_KILO, -4, "per-p4-kilometer");
+    verifySingleUnit(quarticKilometer, UMEASURE_SI_PREFIX_KILO, 4, "pow4-kilometer");
+    verifySingleUnit(overQuarticKilometer1, UMEASURE_SI_PREFIX_KILO, -4, "per-pow4-kilometer");
 
     assertTrue("power inequality", quarticKilometer != overQuarticKilometer1);
 
@@ -3361,9 +3363,9 @@ void MeasureFormatTest::TestCompoundUnitOperations() {
         .reciprocal(status)
         .withSIPrefix(UMEASURE_SI_PREFIX_KILO, status);
 
-    verifySingleUnit(overQuarticKilometer2, UMEASURE_SI_PREFIX_KILO, -4, "per-p4-kilometer");
-    verifySingleUnit(overQuarticKilometer3, UMEASURE_SI_PREFIX_KILO, -4, "per-p4-kilometer");
-    verifySingleUnit(overQuarticKilometer4, UMEASURE_SI_PREFIX_KILO, -4, "per-p4-kilometer");
+    verifySingleUnit(overQuarticKilometer2, UMEASURE_SI_PREFIX_KILO, -4, "per-pow4-kilometer");
+    verifySingleUnit(overQuarticKilometer3, UMEASURE_SI_PREFIX_KILO, -4, "per-pow4-kilometer");
+    verifySingleUnit(overQuarticKilometer4, UMEASURE_SI_PREFIX_KILO, -4, "per-pow4-kilometer");
 
     assertTrue("reciprocal equality", overQuarticKilometer1 == overQuarticKilometer2);
     assertTrue("reciprocal equality", overQuarticKilometer1 == overQuarticKilometer3);
@@ -3442,17 +3444,17 @@ void MeasureFormatTest::TestCompoundUnitOperations() {
     assertTrue("kilometer equality", kilometer == kilometer2);
 
     // Test out-of-range powers
-    MeasureUnit power15 = MeasureUnit::forIdentifier("p15-kilometer", status);
-    verifySingleUnit(power15, UMEASURE_SI_PREFIX_KILO, 15, "p15-kilometer");
+    MeasureUnit power15 = MeasureUnit::forIdentifier("pow15-kilometer", status);
+    verifySingleUnit(power15, UMEASURE_SI_PREFIX_KILO, 15, "pow15-kilometer");
     status.errIfFailureAndReset();
-    MeasureUnit power16a = MeasureUnit::forIdentifier("p16-kilometer", status);
+    MeasureUnit power16a = MeasureUnit::forIdentifier("pow16-kilometer", status);
     status.expectErrorAndReset(U_ILLEGAL_ARGUMENT_ERROR);
     MeasureUnit power16b = power15.product(kilometer, status);
     status.expectErrorAndReset(U_ILLEGAL_ARGUMENT_ERROR);
-    MeasureUnit powerN15 = MeasureUnit::forIdentifier("per-p15-kilometer", status);
-    verifySingleUnit(powerN15, UMEASURE_SI_PREFIX_KILO, -15, "per-p15-kilometer");
+    MeasureUnit powerN15 = MeasureUnit::forIdentifier("per-pow15-kilometer", status);
+    verifySingleUnit(powerN15, UMEASURE_SI_PREFIX_KILO, -15, "per-pow15-kilometer");
     status.errIfFailureAndReset();
-    MeasureUnit powerN16a = MeasureUnit::forIdentifier("per-p16-kilometer", status);
+    MeasureUnit powerN16a = MeasureUnit::forIdentifier("per-pow16-kilometer", status);
     status.expectErrorAndReset(U_ILLEGAL_ARGUMENT_ERROR);
     MeasureUnit powerN16b = powerN15.product(overQuarticKilometer1, status);
     status.expectErrorAndReset(U_ILLEGAL_ARGUMENT_ERROR);


### PR DESCRIPTION
This is a cherry-pick of the upstream-impacting commit from https://github.com/icu-units/icu/pull/18

Specification:
https://www.unicode.org/reports/tr35/tr35-general.html#Unit_Identifiers

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21192
- [X] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [X] Tests included
- [ ] Documentation is changed or added

