### PR TITLE
ICU-21158 Fix doc of UDISPCTX_NO_SUBSTITUTE

### DIFF
--- a/icu4c/source/common/unicode/udisplaycontext.h
+++ b/icu4c/source/common/unicode/udisplaycontext.h
@@ -156,7 +156,8 @@ enum UDisplayContext {
     UDISPCTX_SUBSTITUTE = (UDISPCTX_TYPE_SUBSTITUTE_HANDLING<<8) + 0,
     /**
      * A possible setting for SUBSTITUTE_HANDLING:
-     * Returns a null value when no data is available.
+     * Returns a null value with error code set to U_ILLEGAL_ARGUMENT_ERROR when no
+     * data is available.
      * @stable ICU 58
      */
     UDISPCTX_NO_SUBSTITUTE = (UDISPCTX_TYPE_SUBSTITUTE_HANDLING<<8) + 1

--- a/icu4c/source/test/cintltst/cloctst.c
+++ b/icu4c/source/test/cintltst/cloctst.c
@@ -47,6 +47,7 @@ static void TestLocDataErrorCodeChaining(void);
 static void TestLocDataWithRgTag(void);
 static void TestLanguageExemplarsFallbacks(void);
 static void TestDisplayNameBrackets(void);
+static void TestIllegalArgumentWhenNoDataWithNoSubstitute(void);
 
 static void TestUnicodeDefines(void);
 
@@ -263,6 +264,7 @@ void addLocaleTest(TestNode** root)
     TESTCASE(TestUnicodeDefines);
     TESTCASE(TestEnglishExemplarCharacters);
     TESTCASE(TestDisplayNameBrackets);
+    TESTCASE(TestIllegalArgumentWhenNoDataWithNoSubstitute);
     TESTCASE(TestIsRightToLeft);
     TESTCASE(TestToUnicodeLocaleKey);
     TESTCASE(TestToLegacyKey);
@@ -1192,6 +1194,70 @@ static void TestDisplayNameBrackets()
 #endif
     (void)ulen;   /* Suppress variable not used warning */
     }
+}
+
+/*------------------------------
+ * TestIllegalArgumentWhenNoDataWithNoSubstitute
+ */
+
+static void TestIllegalArgumentWhenNoDataWithNoSubstitute()
+{
+    UErrorCode status = U_ZERO_ERROR;
+    UChar getName[kDisplayNameBracketsMax];
+    UDisplayContext contexts[] = {
+        UDISPCTX_NO_SUBSTITUTE,
+    };
+    ULocaleDisplayNames* ldn = uldn_openForContext("en", contexts, 1, &status);
+
+    uldn_localeDisplayName(ldn, "efg", getName, kDisplayNameBracketsMax, &status);
+    if (status != U_ILLEGAL_ARGUMENT_ERROR) {
+        log_err("FAIL uldn_localeDisplayName should return U_ILLEGAL_ARGUMENT_ERROR "
+                "while no resource under UDISPCTX_NO_SUBSTITUTE");
+    }
+
+    status = U_ZERO_ERROR;
+    uldn_languageDisplayName(ldn, "zz", getName, kDisplayNameBracketsMax, &status);
+    if (status != U_ILLEGAL_ARGUMENT_ERROR) {
+        log_err("FAIL uldn_languageDisplayName should return U_ILLEGAL_ARGUMENT_ERROR "
+                "while no resource under UDISPCTX_NO_SUBSTITUTE");
+    }
+
+    status = U_ZERO_ERROR;
+    uldn_scriptDisplayName(ldn, "Aaaa", getName, kDisplayNameBracketsMax, &status);
+    if (status != U_ILLEGAL_ARGUMENT_ERROR) {
+        log_err("FAIL uldn_scriptDisplayName should return U_ILLEGAL_ARGUMENT_ERROR "
+                "while no resource under UDISPCTX_NO_SUBSTITUTE");
+    }
+
+    status = U_ZERO_ERROR;
+    uldn_regionDisplayName(ldn, "KK", getName, kDisplayNameBracketsMax, &status);
+    if (status != U_ILLEGAL_ARGUMENT_ERROR) {
+        log_err("FAIL uldn_regionDisplayName should return U_ILLEGAL_ARGUMENT_ERROR "
+                "while no resource under UDISPCTX_NO_SUBSTITUTE");
+    }
+
+    status = U_ZERO_ERROR;
+    uldn_variantDisplayName(ldn, "ZZ", getName, kDisplayNameBracketsMax, &status);
+    if (status != U_ILLEGAL_ARGUMENT_ERROR) {
+        log_err("FAIL uldn_variantDisplayName should return U_ILLEGAL_ARGUMENT_ERROR "
+                "while no resource under UDISPCTX_NO_SUBSTITUTE");
+    }
+
+    status = U_ZERO_ERROR;
+    uldn_keyDisplayName(ldn, "zz", getName, kDisplayNameBracketsMax, &status);
+    if (status != U_ILLEGAL_ARGUMENT_ERROR) {
+        log_err("FAIL uldn_keyDisplayName should return U_ILLEGAL_ARGUMENT_ERROR "
+                "while no resource under UDISPCTX_NO_SUBSTITUTE");
+    }
+
+    status = U_ZERO_ERROR;
+    uldn_keyValueDisplayName(ldn, "ca", "zz", getName, kDisplayNameBracketsMax, &status);
+    if (status != U_ILLEGAL_ARGUMENT_ERROR) {
+        log_err("FAIL uldn_keyValueDisplayName should return U_ILLEGAL_ARGUMENT_ERROR "
+                "while no resource under UDISPCTX_NO_SUBSTITUTE");
+    }
+
+    uldn_close(ldn);
 }
 
 /*------------------------------


### PR DESCRIPTION
Add document to mention U_ILLEGAL_ARGUMENT_ERROR would be set to error
code when there are no data for UDISPCTX_NO_SUBSTITUTE.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21158
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [x] Tests included
- [X] Documentation is changed or added

