### PR TITLE
ICU-20684 Fix Use-of-uninitialized-value in isMatchAtCPBoundary

### DIFF
--- a/icu4c/source/common/ustring.cpp
+++ b/icu4c/source/common/ustring.cpp
@@ -45,7 +45,7 @@ isMatchAtCPBoundary(const UChar *start, const UChar *match, const UChar *matchLi
         /* the leading edge of the match is in the middle of a surrogate pair */
         return FALSE;
     }
-    if(U16_IS_LEAD(*(matchLimit-1)) && match!=limit && U16_IS_TRAIL(*matchLimit)) {
+    if(U16_IS_LEAD(*(matchLimit-1)) && matchLimit!=limit && U16_IS_TRAIL(*matchLimit)) {
         /* the trailing edge of the match is in the middle of a surrogate pair */
         return FALSE;
     }

--- a/icu4c/source/test/cintltst/custrtst.c
+++ b/icu4c/source/test/cintltst/custrtst.c
@@ -962,6 +962,16 @@ TestSurrogateSearching() {
     ) {
         log_err("error: one of the u_str[str etc](\"aba\") incorrectly finds something\n");
     }
+    /* Regression test for ICU-20684 Use-of-uninitialized-value in isMatchAtCPBoundary
+     * Condition: search the same string while the first char is not an
+     * surrogate and the last char is the leading surragte.
+     */
+    {
+        static const UChar s[]={ 0x0020, 0xD9C1 };
+        if (u_strFindFirst(s, 2, s, 2) != s) {
+            log_err("error: ending with a partial supplementary code point should match\n");
+        }
+    }
 }
 
 static void TestStringCopy()


### PR DESCRIPTION
Downstream bug https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=15505
Fix Fuzzer-detected Use-of-uninitialized-value in isMatchAtCPBoundary

To test to show the bug in the new test case, configure and build with
CFLAGS="-fsanitize=memory" CXXFLAGS="-fsanitize=memory" ./runConfigureICU \
  --enable-debug --disable-release  Linux  --disable-layoutex

Test with
cintltst /tsutil/custrtst

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20684
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [X] Tests included
- [X] Documentation is changed or added

