### PR TITLE
ICU-21174 Increase safety of Measure and writeAffixes.

### DIFF
--- a/icu4c/source/i18n/measure.cpp
+++ b/icu4c/source/i18n/measure.cpp
@@ -23,7 +23,7 @@ U_NAMESPACE_BEGIN
 
 UOBJECT_DEFINE_RTTI_IMPLEMENTATION(Measure)
 
-Measure::Measure() {}
+Measure::Measure() : unit(nullptr) {}
 
 Measure::Measure(const Formattable& _number, MeasureUnit* adoptedUnit,
                  UErrorCode& ec) :
@@ -35,7 +35,7 @@ Measure::Measure(const Formattable& _number, MeasureUnit* adoptedUnit,
 }
 
 Measure::Measure(const Measure& other) :
-    UObject(other), unit(0) {
+    UObject(other), unit(nullptr) {
     *this = other;
 }
 
@@ -43,7 +43,11 @@ Measure& Measure::operator=(const Measure& other) {
     if (this != &other) {
         delete unit;
         number = other.number;
-        unit = other.unit->clone();
+        if (other.unit != nullptr) {
+            unit = other.unit->clone();
+        } else {
+            unit = nullptr;
+        }
     }
     return *this;
 }

--- a/icu4c/source/i18n/number_formatimpl.cpp
+++ b/icu4c/source/i18n/number_formatimpl.cpp
@@ -417,6 +417,7 @@ NumberFormatterImpl::resolvePluralRules(const PluralRules* rulesPtr, const Local
 
 int32_t NumberFormatterImpl::writeAffixes(const MicroProps& micros, FormattedStringBuilder& string,
                                           int32_t start, int32_t end, UErrorCode& status) {
+    U_ASSERT(micros.modOuter != nullptr);
     // Always apply the inner modifier (which is "strong").
     int32_t length = micros.modInner->apply(string, start, end, status);
     if (micros.padding.isValid()) {


### PR DESCRIPTION
Measure: initialize unit to nullptr, and don't dereference it if it is
nullptr.

NumberFormatterImpl::writeAffixes: U_ASSERT not-null, instead of
segfaulting for coding mistakes.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21174
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

