### PR TITLE
ICU-21212 Fix non ASCII charcters handling in the u_strFromPunycode

### DIFF
--- a/icu4c/source/common/punycode.cpp
+++ b/icu4c/source/common/punycode.cpp
@@ -455,7 +455,8 @@ u_strFromPunycode(const UChar *src, int32_t srcLength,
                 return 0;
             }
 
-            digit=basicToDigit[(uint8_t)src[in++]];
+            const UChar ch = src[in++];
+            digit=ch<256 ? basicToDigit[(uint8_t)ch] : -1;
             if(digit<0) {
                 *pErrorCode=U_INVALID_CHAR_FOUND;
                 return 0;

--- a/icu4c/source/test/intltest/uts46test.cpp
+++ b/icu4c/source/test/intltest/uts46test.cpp
@@ -300,6 +300,8 @@ static const TestCase testCases[]={
       "xn--a\\uFFFD.pt", UIDNA_ERROR_INVALID_ACE_LABEL },
     { "xn--a-\\u00C4.pt", "B",  // invalid Punycode
       "xn--a-\\u00E4.pt", UIDNA_ERROR_PUNYCODE },
+    { "xn--ple\\u0450", "B",  // invalid Punycode
+      "xn--ple\\u0450", UIDNA_ERROR_PUNYCODE },
     { "\\u65E5\\u672C\\u8A9E\\u3002\\uFF2A\\uFF30", "B",  // Japanese with fullwidth ".jp"
       "\\u65E5\\u672C\\u8A9E.jp", 0 },
     { "\\u2615", "B", "\\u2615", 0 },  // Unicode 4.0 HOT BEVERAGE


### PR DESCRIPTION
Emit error if there is a non ASCII character in punycode.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21212
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

