### PR TITLE
ICU-21216 Windows: Ensure directory exists before running rc

### DIFF
--- a/icu4c/source/data/Makefile.in
+++ b/icu4c/source/data/Makefile.in
@@ -241,6 +241,7 @@ ifeq ($(ENABLE_SO_VERSION_DATA),1)
 ifeq ($(PKGDATA_MODE),dll)
 SO_VERSION_DATA = $(OUTTMPDIR)/icudata.res
 $(SO_VERSION_DATA) : $(MISCSRCDIR)/icudata.rc
+	mkdir -p $(@D)
 ifeq ($(MSYS_RC_MODE),1)
 	rc.exe -i$(srcdir)/../common -i$(top_builddir)/common -fo$@ $(CPPFLAGS) $<
 else


### PR DESCRIPTION
When building in parallel it's possible that the rc command is invoked
before other rules get around to creating the output directory.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21216
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

