### PR TITLE
ICU-20808 Add test for the C locale to default to en_US_POSIX

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -37,6 +37,12 @@ jobs:
       env:
         CC: clang
         CXX: clang++
+    - script: |
+        cd icu4c/source/test/cintltst && LANG=C LD_LIBRARY_PATH=../../lib:../../tools/ctestfw ./cintltst /tsutil/cloctst/TestCDefaultLocale
+      displayName: 'Test C Default locale'
+    - script: |
+        cd icu4c/source/test/cintltst && LANG=C.UTF-8 LD_LIBRARY_PATH=../../lib:../../tools/ctestfw ./cintltst /tsutil/cloctst/TestCDefaultLocale
+      displayName: 'Test C.UTF-8 Default locale'
 #-------------------------------------------------------------------------
 - job: ICU4C_Clang_Ubuntu_1604_WarningsAsErrors
   displayName: 'C: Linux Clang WarningsAsErrors (Ubuntu 16.04)'

--- a/icu4c/source/test/cintltst/cloctst.c
+++ b/icu4c/source/test/cintltst/cloctst.c
@@ -261,6 +261,7 @@ void addLocaleTest(TestNode** root)
     TESTCASE(TestToLanguageTag);
     TESTCASE(TestBug20132);
     TESTCASE(TestBug20149);
+    TESTCASE(TestCDefaultLocale);
     TESTCASE(TestForLanguageTag);
     TESTCASE(TestLangAndRegionCanonicalize);
     TESTCASE(TestTrailingNull);
@@ -408,6 +409,10 @@ static void TestNullDefault() {
             log_err("Failure returned from uloc_setDefault - \"%s\"\n", u_errorName(status));
         }
         
+    }
+    uloc_setDefault(original, &status);
+    if (U_FAILURE(status)) {
+        log_err("Failed to change the default locale back to %s\n", original);
     }
     
 }
@@ -6812,5 +6817,19 @@ static void TestUsingDefaultWarning() {
         u_UCharsToChars(buff, errorOutputBuff, length+1);
         log_err("ERROR: in uloc_getDisplayKeywordValue %s %s return len:%d %s with status %d %s\n",
                 keyword_value, keyword, length, errorOutputBuff, status, myErrorName(status));
+      }
+}      
+// Test case for ICU-20575
+// This test checks if the environment variable LANG is set, 
+// and if so ensures that both C and C.UTF-8 cause ICU's default locale to be en_US_POSIX.
+static void TestCDefaultLocale(){
+    const char *defaultLocale = uloc_getDefault();
+    char *env_var = getenv("LANG");
+    if (env_var == NULL) {
+      log_verbose("Skipping TestCDefaultLocale test, as the LANG variable is not set.");
+      return;
+    }
+    if ((strcmp(env_var, "C") == 0 || strcmp(env_var, "C.UTF-8") == 0) && strcmp(defaultLocale, "en_US_POSIX") != 0) {
+      log_err("The default locale for LANG=%s should be en_US_POSIX, not %s\n", env_var, defaultLocale);
     }
 }

--- a/icu4c/source/test/cintltst/cloctst.h
+++ b/icu4c/source/test/cintltst/cloctst.h
@@ -136,6 +136,8 @@ static void TestToLegacyKey(void);
 static void TestToUnicodeLocaleType(void);
 static void TestToLegacyType(void);
 static void TestBug20149(void);
+static void TestCDefaultLocale(void);
+
 
 /**
  * U_USING_DEFAULT_WARNING


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

This PR adds a test to make sure that the `C` and `C.UTF-8` LANG setting will cause ICU to have `en_US_POSIX` as the default locale. It seems that in some previous versions this was changed and we now want to make sure that it remains the same or a test fails to let us know it changed so we can investigate further. 


- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20808
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [X] Tests included
- [ ] Documentation is changed or added

