### PR TITLE
ICU-21157 Fix incorrect null termination.

### DIFF
--- a/icu4c/source/common/locdispnames.cpp
+++ b/icu4c/source/common/locdispnames.cpp
@@ -733,7 +733,7 @@ uloc_getDisplayName(const char *locale,
                     int32_t padLen;
                     patPos+=subLen;
                     padLen=(subi==0 ? sub1Pos : patLen)-patPos;
-                    if(length+padLen < destCapacity) {
+                    if(length+padLen <= destCapacity) {
                         p=dest+length;
                         for(int32_t i=0;i<padLen;++i) {
                             *p++=pattern[patPos++];

--- a/icu4c/source/test/cintltst/cloctst.h
+++ b/icu4c/source/test/cintltst/cloctst.h
@@ -124,6 +124,11 @@ static void TestOrientation(void);
 static void TestLikelySubtags(void);
 
 /**
+ * test terminate correctly.
+ */
+static void Test21157CorrectTerminating(void);
+
+/**
  * language tag
  */
 static void TestForLanguageTag(void);


### PR DESCRIPTION
While the buffer is the exact length of the output string, the
function should not null terminate it but set status to
U_STRING_NOT_TERMINATED_WARNING.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21157
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [X] Tests included
- [X] Documentation is changed or added

