### PR TITLE
ICU-13727 limit length of input for Punycode encode/decode

### DIFF
--- a/icu4c/source/common/punycode.h
+++ b/icu4c/source/common/punycode.h
@@ -65,7 +65,7 @@ http://www.nicemice.net/amc/
  *
  * @see u_strFromPunycode
  */
-U_CFUNC int32_t
+U_CAPI int32_t
 u_strToPunycode(const UChar *src, int32_t srcLength,
                 UChar *dest, int32_t destCapacity,
                 const UBool *caseFlags,
@@ -100,7 +100,7 @@ u_strToPunycode(const UChar *src, int32_t srcLength,
  *
  * @see u_strToPunycode
  */
-U_CFUNC int32_t
+U_CAPI int32_t
 u_strFromPunycode(const UChar *src, int32_t srcLength,
                   UChar *dest, int32_t destCapacity,
                   UBool *caseFlags,


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-13727

See the bug ticket for a discussion of the length limits.

Using the new input-too-long error/exception.

The unit tests deliberately use much longer input strings. I do not want them to be tighter than necessary.