### PR TITLE
ICU-21237 Removing the obsolete license information for all ICU data files

### DIFF
--- a/tools/cldr/cldr-to-icu/src/main/resources/ldml2icu_header.txt
+++ b/tools/cldr/cldr-to-icu/src/main/resources/ldml2icu_header.txt
@@ -1,2 +1,1 @@
 © 2016 and later: Unicode, Inc. and others.
-License & terms of use: http://www.unicode.org/copyright.html#License


### PR DESCRIPTION
If this goes in, I think it means that the next data generation run someone does will need to handle deleting and overwriting files manually (since the cleanup code uses the header to determine if a file can safely be removed during data regeneration).

See the ticket for an alternative idea.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21237
- [x] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted

