### PR TITLE
ICU-21035 Replace backward compatibility ulocimp_getLanguage() overload.

### DIFF
--- a/icu4c/source/common/loclikely.cpp
+++ b/icu4c/source/common/loclikely.cpp
@@ -464,8 +464,18 @@ parseTagString(
         goto error;
     }
 
-    subtagLength = ulocimp_getLanguage(position, lang, *langLength, &position);
-    u_terminateChars(lang, *langLength, subtagLength, err);
+    {
+        icu::CharString result = ulocimp_getLanguage(position, &position, *err);
+        if (U_FAILURE(*err)) {
+            goto error;
+        }
+
+        subtagLength = result.length();
+        if (subtagLength <= *langLength) {
+            uprv_memcpy(lang, result.data(), subtagLength);
+        }
+        u_terminateChars(lang, *langLength, subtagLength, err);
+    }
 
     /*
      * Note that we explicit consider U_STRING_NOT_TERMINATED_WARNING

--- a/icu4c/source/common/ulocimp.h
+++ b/icu4c/source/common/ulocimp.h
@@ -13,6 +13,8 @@
 #include "unicode/bytestream.h"
 #include "unicode/uloc.h"
 
+#include "charstr.h"
+
 /**
  * Create an iterator over the specified keywords list
  * @param keywordList double-null terminated list. Will be copied.
@@ -47,10 +49,10 @@ uloc_getCurrentCountryID(const char* oldID);
 U_CFUNC const char* 
 uloc_getCurrentLanguageID(const char* oldID);
 
-U_CFUNC int32_t
+icu::CharString U_EXPORT2
 ulocimp_getLanguage(const char *localeID,
-                    char *language, int32_t languageCapacity,
-                    const char **pEnd);
+                    const char **pEnd,
+                    UErrorCode &status);
 
 U_CFUNC int32_t
 ulocimp_getScript(const char *localeID,


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-21035

By always calling the dynamic memory allocation implementation directly
instead, the fixed memory buffer boundary gets pushed one step further
towards the edges.