### PR TITLE
ICU-21249 Updating double-conversion for ICU 68

### DIFF
--- a/vendor/double-conversion/upstream/.gitignore
+++ b/vendor/double-conversion/upstream/.gitignore
@@ -27,3 +27,5 @@ _deps
 *.cmake
 *.kdev4
 DartConfiguration.tcl
+bazel-*
+

--- a/vendor/double-conversion/upstream/BUILD
+++ b/vendor/double-conversion/upstream/BUILD
@@ -1,5 +1,7 @@
 # Bazel(http://bazel.io) BUILD file
 
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
 licenses(["notice"])
 
 exports_files(["LICENSE"])
@@ -10,12 +12,11 @@ cc_library(
         "double-conversion/bignum.cc",
         "double-conversion/bignum-dtoa.cc",
         "double-conversion/cached-powers.cc",
-        "double-conversion/diy-fp.cc",
-        "double-conversion/double-conversion.cc",
+        "double-conversion/double-to-string.cc",
         "double-conversion/fast-dtoa.cc",
         "double-conversion/fixed-dtoa.cc",
+        "double-conversion/string-to-double.cc",
         "double-conversion/strtod.cc",
-        "double-conversion/utils.h",
     ],
     hdrs = [
         "double-conversion/bignum.h",
@@ -23,10 +24,13 @@ cc_library(
         "double-conversion/cached-powers.h",
         "double-conversion/diy-fp.h",
         "double-conversion/double-conversion.h",
+        "double-conversion/double-to-string.h",
         "double-conversion/fast-dtoa.h",
         "double-conversion/fixed-dtoa.h",
         "double-conversion/ieee.h",
+        "double-conversion/string-to-double.h",
         "double-conversion/strtod.h",
+        "double-conversion/utils.h",
     ],
     linkopts = [
         "-lm",

--- a/vendor/double-conversion/upstream/CMakeLists.txt
+++ b/vendor/double-conversion/upstream/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.0)
 project(double-conversion VERSION 3.1.5)
 
+if(BUILD_SHARED_LIBS AND MSVC)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 set(headers
     double-conversion/bignum.h
     double-conversion/cached-powers.h

--- a/vendor/double-conversion/upstream/test/cctest/CMakeLists.txt
+++ b/vendor/double-conversion/upstream/test/cctest/CMakeLists.txt
@@ -18,6 +18,9 @@ set(CCTEST_SRC
 
 add_executable(cctest ${CCTEST_SRC})
 target_link_libraries(cctest double-conversion)
+if(MSVC)
+    target_compile_options(cctest PRIVATE /bigobj)
+endif()
 
 add_test(NAME test_bignum
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
The diffs are clean.  The only changes are in build files; the library code is unchanged.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21249
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

