### PR TITLE
ICU-21251 release icu4j.jar/utilities.jar to GH Maven

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -1,0 +1,40 @@
+name: Publish icu4j.jar/utilities.jar to GH Maven
+on:
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          lfs: true
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: icu4j ant releaseCLDR
+        run: ant -noinput releaseCLDR -f icu4j/build.xml
+      - name: deploy it
+        run: |
+          MYVERSION=$(sed -n -e 's%^\s*maven.pom.ver[ =]*%%p' < icu4j/build.properties)-$(echo ${GITHUB_REF} | cut -d/ -f3- | tr ./ _-)
+          echo Github Ref ${GITHUB_REF} @ ${GITHUB_SHA}, version ${MYVERSION}
+          mvn deploy:deploy-file -DgroupId=com.ibm.icu \
+            -DartifactId=icu4j-for-cldr \
+            -Dversion=${MYVERSION} \
+            -Dpackaging=jar \
+            -Dfile=icu4j/release_cldr/icu4j.jar \
+            -Dsources=icu4j/release_cldr/icu4j-src.jar \
+            -DrepositoryId=github \
+            -Durl=https://maven.pkg.github.com/${GITHUB_REPOSITORY}
+          mvn deploy:deploy-file -DgroupId=com.ibm.icu \
+            -DartifactId=utilities-for-cldr \
+            -Dversion=${MYVERSION} \
+            -Dpackaging=jar \
+            -Dfile=icu4j/release_cldr/utilities.jar \
+            -Dsources=icu4j/release_cldr/utilities-src.jar \
+            -DrepositoryId=github \
+            -Durl=https://maven.pkg.github.com/${GITHUB_REPOSITORY}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+# Note: can use 0.0.0-${GITHUB_SHA} as the version for hash-based.
+# i.e. build on every commit

--- a/icu4j/.gitignore
+++ b/icu4j/.gitignore
@@ -1,0 +1,1 @@
+/release_cldr

--- a/icu4j/main/classes/core/src/com/ibm/icu/text/DecimalFormat.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/DecimalFormat.java
@@ -2015,10 +2015,10 @@ public class DecimalFormat extends NumberFormat {
   }
 
   /**
-   * {@icu} Constant for {@link #setMinimumGroupingDigits()} to specify display
+   * {@icu} Constant for {@link #setMinimumGroupingDigits(int)} to specify display
    * grouping using the default strategy for all locales.
    *
-   * @see #setMinimumGroupingDigits
+   * @see #setMinimumGroupingDigits(int)
    * @see #MINIMUM_GROUPING_DIGITS_MIN2
    * @category Separators
    * @provisional This API might change or be removed in a future release.
@@ -2027,11 +2027,11 @@ public class DecimalFormat extends NumberFormat {
   public static final int MINIMUM_GROUPING_DIGITS_AUTO = -2;
 
   /**
-   * {@icu} Constant for {@link #setMinimumGroupingDigits()} to specify display
+   * {@icu} Constant for {@link #setMinimumGroupingDigits(int)} to specify display
    * grouping using locale defaults, except do not show grouping on values smaller than
    * 10000 (such that there is a minimum of two digits before the first separator).
    *
-   * @see #setMinimumGroupingDigits
+   * @see #setMinimumGroupingDigits(int)
    * @see #MINIMUM_GROUPING_DIGITS_AUTO
    * @category Separators
    * @provisional This API might change or be removed in a future release.


### PR DESCRIPTION
ICU-21251

- on a release (created from Github), publish to
<https://github.com/unicode-org/icu/packages>
- also fix a doc bug in DecimalFormat
- this is intended for CLDR use to support CLDR-11585 maven

No effect on current build systems, no effect on commit or PRs.