### PR TITLE
ICU-21253 remove std from max_align_t

### DIFF
--- a/icu4c/source/common/uarrsort.cpp
+++ b/icu4c/source/common/uarrsort.cpp
@@ -37,7 +37,7 @@ enum {
 };
 
 static constexpr int32_t sizeInMaxAlignTs(int32_t sizeInBytes) {
-    return (sizeInBytes + sizeof(std::max_align_t) - 1) / sizeof(std::max_align_t);
+    return (sizeInBytes + sizeof(max_align_t) - 1) / sizeof(max_align_t);
 }
 
 /* UComparator convenience implementations ---------------------------------- */
@@ -141,7 +141,7 @@ static void
 insertionSort(char *array, int32_t length, int32_t itemSize,
               UComparator *cmp, const void *context, UErrorCode *pErrorCode) {
 
-    icu::MaybeStackArray<std::max_align_t, sizeInMaxAlignTs(STACK_ITEM_SIZE)> v;
+    icu::MaybeStackArray<max_align_t, sizeInMaxAlignTs(STACK_ITEM_SIZE)> v;
     if (sizeInMaxAlignTs(itemSize) > v.getCapacity() &&
             v.resize(sizeInMaxAlignTs(itemSize)) == nullptr) {
         *pErrorCode = U_MEMORY_ALLOCATION_ERROR;
@@ -235,7 +235,7 @@ static void
 quickSort(char *array, int32_t length, int32_t itemSize,
             UComparator *cmp, const void *context, UErrorCode *pErrorCode) {
     /* allocate two intermediate item variables (x and w) */
-    icu::MaybeStackArray<std::max_align_t, sizeInMaxAlignTs(STACK_ITEM_SIZE) * 2> xw;
+    icu::MaybeStackArray<max_align_t, sizeInMaxAlignTs(STACK_ITEM_SIZE) * 2> xw;
     if(sizeInMaxAlignTs(itemSize)*2 > xw.getCapacity() &&
             xw.resize(sizeInMaxAlignTs(itemSize) * 2) == nullptr) {
         *pErrorCode=U_MEMORY_ALLOCATION_ERROR;

--- a/icu4c/source/common/utext.cpp
+++ b/icu4c/source/common/utext.cpp
@@ -569,7 +569,7 @@ enum {
 
 struct ExtendedUText {
     UText               ut;
-    std::max_align_t    extension;
+    max_align_t    extension;
 };
 
 static const UText emptyText = UTEXT_INITIALIZER;
@@ -584,7 +584,7 @@ utext_setup(UText *ut, int32_t extraSpace, UErrorCode *status) {
         // We need to heap-allocate storage for the new UText
         int32_t spaceRequired = sizeof(UText);
         if (extraSpace > 0) {
-            spaceRequired = sizeof(ExtendedUText) + extraSpace - sizeof(std::max_align_t);
+            spaceRequired = sizeof(ExtendedUText) + extraSpace - sizeof(max_align_t);
         }
         ut = (UText *)uprv_malloc(spaceRequired);
         if (ut == NULL) {

--- a/icu4c/source/tools/toolutil/toolutil.cpp
+++ b/icu4c/source/tools/toolutil/toolutil.cpp
@@ -245,7 +245,7 @@ struct UToolMemory {
     char name[64];
     int32_t capacity, maxCapacity, size, idx;
     void *array;
-    alignas(std::max_align_t) char staticArray[1];
+    alignas(max_align_t) char staticArray[1];
 };
 
 U_CAPI UToolMemory * U_EXPORT2


### PR DESCRIPTION
Causes compilation failure under CentOS 7 whose GCC (4.8.2) has a
cstddef header that does not place max_align_t under the std namespace.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

https://unicode-org.atlassian.net/browse/ICU-21253

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21253
- [x] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

