### PR TITLE
ICU-21267 stop defining & using FALSE & TRUE macros in public headers

### DIFF
--- a/docs/userguide/dev/codingguidelines.md
+++ b/docs/userguide/dev/codingguidelines.md
@@ -439,11 +439,29 @@ includes other header files. The most common types are `uint8_t`, `uint16_t`,
 `uint32_t`, `int8_t`, `int16_t`, `int32_t`, `char16_t`,
 `UChar` (same as `char16_t`), `UChar32` (signed, 32-bit), and `UErrorCode`.
 
-The language built-in type bool and constants true and false may be used
+The language built-in type `bool` and constants `true` and `false` may be used
 internally, for local variables and parameters of internal functions. The ICU
 type `UBool` must be used in public APIs and in the definition of any persistent
-data structures. `UBool` is guaranteed to be one byte in size and signed; bool is
+data structures. `UBool` is guaranteed to be one byte in size and signed; `bool` is
 not.
+
+Traditionally, ICU4C has defined its own `FALSE`=0 / `TRUE`=1 macros for use with `UBool`.
+Starting with ICU 68 (2020q4), we no longer define these in public header files
+(unless `U_DEFINE_FALSE_AND_TRUE`=1),
+in order to avoid name collisions with code outside ICU defining enum constants and similar
+with these names.
+
+Instead, the versions of the C and C++ standards we require now do define type `bool`
+and values `false` & `true`, and we and our users can use these values.
+
+As of ICU 68, we are not changing ICU4C API from `UBool` to `bool`.
+Doing so in C API, or in structs that cross the library boundary,
+would break binary compatibility.
+Doing so only in other places in C++ could be confusingly inconsistent.
+We may revisit this.
+
+Note that the details of type `bool` (e.g., `sizeof`) depend on the compiler and
+may differ between C and C++.
 
 #### File Names (.h, .c, .cpp, data files if possible, etc.)
 

--- a/icu4c/source/common/cmemory.h
+++ b/icu4c/source/common/cmemory.h
@@ -292,7 +292,7 @@ public:
     /**
      * Default constructor initializes with internal T[stackCapacity] buffer.
      */
-    MaybeStackArray() : ptr(stackArray), capacity(stackCapacity), needToRelease(FALSE) {}
+    MaybeStackArray() : ptr(stackArray), capacity(stackCapacity), needToRelease(false) {}
     /**
      * Automatically allocates the heap array if the argument is larger than the stack capacity.
      * Intended for use when an approximate capacity is known at compile time but the true
@@ -362,7 +362,7 @@ public:
             releaseArray();
             ptr=otherArray;
             capacity=otherCapacity;
-            needToRelease=FALSE;
+            needToRelease=false;
         }
     }
     /**
@@ -400,7 +400,7 @@ private:
     void resetToStackArray() {
         ptr=stackArray;
         capacity=stackCapacity;
-        needToRelease=FALSE;
+        needToRelease=false;
     }
     /* No comparison operators with other MaybeStackArray's. */
     bool operator==(const MaybeStackArray & /*other*/) = delete;
@@ -458,7 +458,7 @@ inline T *MaybeStackArray<T, stackCapacity>::resize(int32_t newCapacity, int32_t
             releaseArray();
             ptr=p;
             capacity=newCapacity;
-            needToRelease=TRUE;
+            needToRelease=true;
         }
         return p;
     } else {
@@ -514,7 +514,7 @@ public:
     /**
      * Default constructor initializes with internal H+T[stackCapacity] buffer.
      */
-    MaybeStackHeaderAndArray() : ptr(&stackHeader), capacity(stackCapacity), needToRelease(FALSE) {}
+    MaybeStackHeaderAndArray() : ptr(&stackHeader), capacity(stackCapacity), needToRelease(false) {}
     /**
      * Destructor deletes the memory (if owned).
      */
@@ -563,7 +563,7 @@ public:
             releaseMemory();
             ptr=otherMemory;
             capacity=otherCapacity;
-            needToRelease=FALSE;
+            needToRelease=false;
         }
     }
     /**
@@ -602,8 +602,8 @@ private:
         }
     }
     /* No comparison operators with other MaybeStackHeaderAndArray's. */
-    bool operator==(const MaybeStackHeaderAndArray & /*other*/) {return FALSE;}
-    bool operator!=(const MaybeStackHeaderAndArray & /*other*/) {return TRUE;}
+    bool operator==(const MaybeStackHeaderAndArray & /*other*/) {return false;}
+    bool operator!=(const MaybeStackHeaderAndArray & /*other*/) {return true;}
     /* No ownership transfer: No copy constructor, no assignment operator. */
     MaybeStackHeaderAndArray(const MaybeStackHeaderAndArray & /*other*/) {}
     void operator=(const MaybeStackHeaderAndArray & /*other*/) {}
@@ -632,7 +632,7 @@ inline H *MaybeStackHeaderAndArray<H, T, stackCapacity>::resize(int32_t newCapac
             releaseMemory();
             ptr=p;
             capacity=newCapacity;
-            needToRelease=TRUE;
+            needToRelease=true;
         }
         return p;
     } else {
@@ -664,7 +664,7 @@ inline H *MaybeStackHeaderAndArray<H, T, stackCapacity>::orphanOrClone(int32_t l
     resultCapacity=length;
     ptr=&stackHeader;
     capacity=stackCapacity;
-    needToRelease=FALSE;
+    needToRelease=false;
     return p;
 }
 

--- a/icu4c/source/common/normalizer2impl.h
+++ b/icu4c/source/common/normalizer2impl.h
@@ -171,7 +171,7 @@ public:
                  UErrorCode &errorCode);
     UBool appendBMP(UChar c, uint8_t cc, UErrorCode &errorCode) {
         if(remainingCapacity==0 && !resize(1, errorCode)) {
-            return FALSE;
+            return false;
         }
         if(lastCC<=cc || cc==0) {
             *limit++=c;
@@ -183,7 +183,7 @@ public:
             insert(c, cc);
         }
         --remainingCapacity;
-        return TRUE;
+        return true;
     }
     UBool appendZeroCC(UChar32 c, UErrorCode &errorCode);
     UBool appendZeroCC(const UChar *s, const UChar *sLimit, UErrorCode &errorCode);

--- a/icu4c/source/common/resource.h
+++ b/icu4c/source/common/resource.h
@@ -60,7 +60,7 @@ public:
     /**
      * @param i Array item index.
      * @param value Output-only, receives the value of the i'th item.
-     * @return TRUE if i is non-negative and less than getSize().
+     * @return true if i is non-negative and less than getSize().
      */
     UBool getValue(int32_t i, ResourceValue &value) const;
 
@@ -97,14 +97,14 @@ public:
      * @param i Table item index.
      * @param key Output-only, receives the key of the i'th item.
      * @param value Output-only, receives the value of the i'th item.
-     * @return TRUE if i is non-negative and less than getSize().
+     * @return true if i is non-negative and less than getSize().
      */
     UBool getKeyAndValue(int32_t i, const char *&key, ResourceValue &value) const;
 
     /**
      * @param key Key string to find in the table.
      * @param value Output-only, receives the value of the item with that key.
-     * @return TRUE if the table contains the key.
+     * @return true if the table contains the key.
      */
     UBool findValue(const char *key, ResourceValue &value) const;
 
@@ -141,7 +141,7 @@ public:
     inline UnicodeString getUnicodeString(UErrorCode &errorCode) const {
         int32_t len = 0;
         const UChar *r = getString(len, errorCode);
-        return UnicodeString(TRUE, r, len);
+        return UnicodeString(true, r, len);
     }
 
     /**
@@ -152,7 +152,7 @@ public:
     inline UnicodeString getAliasUnicodeString(UErrorCode &errorCode) const {
         int32_t len = 0;
         const UChar *r = getAliasString(len, errorCode);
-        return UnicodeString(TRUE, r, len);
+        return UnicodeString(true, r, len);
     }
 
     /**
@@ -199,7 +199,7 @@ public:
      * CLDR no-fallback data values of (three empty-set symbols)=={2205, 2205, 2205}
      * when enumerating tables with fallback from the specific resource bundle to root.
      *
-     * @return TRUE if this is a no-inheritance marker string
+     * @return true if this is a no-inheritance marker string
      */
     virtual UBool isNoInheritanceMarker() const = 0;
 

--- a/icu4c/source/common/unicode/appendable.h
+++ b/icu4c/source/common/unicode/appendable.h
@@ -45,7 +45,7 @@ class UnicodeString;
  *
  * The methods do not take UErrorCode parameters.
  * If an error occurs (e.g., out-of-memory),
- * in addition to returning FALSE from failing operations,
+ * in addition to returning false from failing operations,
  * the implementation must prevent unexpected behavior (e.g., crashes)
  * from further calls and should make the error condition available separately
  * (e.g., store a UErrorCode, make/keep a UnicodeString bogus).
@@ -62,7 +62,7 @@ public:
     /**
      * Appends a 16-bit code unit.
      * @param c code unit
-     * @return TRUE if the operation succeeded
+     * @return true if the operation succeeded
      * @stable ICU 4.8
      */
     virtual UBool appendCodeUnit(char16_t c) = 0;
@@ -71,7 +71,7 @@ public:
      * Appends a code point.
      * The default implementation calls appendCodeUnit(char16_t) once or twice.
      * @param c code point 0..0x10ffff
-     * @return TRUE if the operation succeeded
+     * @return true if the operation succeeded
      * @stable ICU 4.8
      */
     virtual UBool appendCodePoint(UChar32 c);
@@ -81,7 +81,7 @@ public:
      * The default implementation calls appendCodeUnit(char16_t) for each code unit.
      * @param s string, must not be NULL if length!=0
      * @param length string length, or -1 if NUL-terminated
-     * @return TRUE if the operation succeeded
+     * @return true if the operation succeeded
      * @stable ICU 4.8
      */
     virtual UBool appendString(const char16_t *s, int32_t length);
@@ -90,9 +90,9 @@ public:
      * Tells the object that the caller is going to append roughly
      * appendCapacity char16_ts. A subclass might use this to pre-allocate
      * a larger buffer if necessary.
-     * The default implementation does nothing. (It always returns TRUE.)
+     * The default implementation does nothing. (It always returns true.)
      * @param appendCapacity estimated number of char16_ts that will be appended
-     * @return TRUE if the operation succeeded
+     * @return true if the operation succeeded
      * @stable ICU 4.8
      */
     virtual UBool reserveAppendCapacity(int32_t appendCapacity);
@@ -171,7 +171,7 @@ public:
     /**
      * Appends a 16-bit code unit to the string.
      * @param c code unit
-     * @return TRUE if the operation succeeded
+     * @return true if the operation succeeded
      * @stable ICU 4.8
      */
     virtual UBool appendCodeUnit(char16_t c);
@@ -179,7 +179,7 @@ public:
     /**
      * Appends a code point to the string.
      * @param c code point 0..0x10ffff
-     * @return TRUE if the operation succeeded
+     * @return true if the operation succeeded
      * @stable ICU 4.8
      */
     virtual UBool appendCodePoint(UChar32 c);
@@ -188,7 +188,7 @@ public:
      * Appends a string to the UnicodeString.
      * @param s string, must not be NULL if length!=0
      * @param length string length, or -1 if NUL-terminated
-     * @return TRUE if the operation succeeded
+     * @return true if the operation succeeded
      * @stable ICU 4.8
      */
     virtual UBool appendString(const char16_t *s, int32_t length);
@@ -197,7 +197,7 @@ public:
      * Tells the UnicodeString that the caller is going to append roughly
      * appendCapacity char16_ts.
      * @param appendCapacity estimated number of char16_ts that will be appended
-     * @return TRUE if the operation succeeded
+     * @return true if the operation succeeded
      * @stable ICU 4.8
      */
     virtual UBool reserveAppendCapacity(int32_t appendCapacity);

--- a/icu4c/source/common/unicode/brkiter.h
+++ b/icu4c/source/common/unicode/brkiter.h
@@ -564,7 +564,7 @@ public:
      * BreakIterator::createXXXInstance to avoid undefined behavior.
      * @param key the registry key returned by a previous call to registerInstance
      * @param status the in/out status code, no special meanings are assigned
-     * @return TRUE if the iterator for the key was successfully unregistered
+     * @return true if the iterator for the key was successfully unregistered
      * @stable ICU 2.4
      */
     static UBool U_EXPORT2 unregister(URegistryKey key, UErrorCode& status);
@@ -655,7 +655,7 @@ private:
 
 inline UBool BreakIterator::isBufferClone()
 {
-    return FALSE;
+    return false;
 }
 
 #endif /* U_HIDE_DEPRECATED_API */

--- a/icu4c/source/common/unicode/bytestream.h
+++ b/icu4c/source/common/unicode/bytestream.h
@@ -197,7 +197,7 @@ public:
    * Returns the sink to its original state, without modifying the buffer.
    * Useful for reusing both the buffer and the sink for multiple streams.
    * Resets the state to NumberOfBytesWritten()=NumberOfBytesAppended()=0
-   * and Overflowed()=FALSE.
+   * and Overflowed()=false.
    * @return *this
    * @stable ICU 4.6
    */
@@ -236,7 +236,7 @@ public:
   /**
    * Returns true if any bytes were discarded, i.e., if there was an
    * attempt to write more than 'capacity' bytes.
-   * @return TRUE if more than 'capacity' bytes were Append()ed
+   * @return true if more than 'capacity' bytes were Append()ed
    * @stable ICU 4.2
    */
   UBool Overflowed() const { return overflowed_; }

--- a/icu4c/source/common/unicode/bytestrie.h
+++ b/icu4c/source/common/unicode/bytestrie.h
@@ -253,16 +253,16 @@ public:
     /**
      * Determines whether all byte sequences reachable from the current state
      * map to the same value.
-     * @param uniqueValue Receives the unique value, if this function returns TRUE.
+     * @param uniqueValue Receives the unique value, if this function returns true.
      *                    (output-only)
-     * @return TRUE if all byte sequences reachable from the current state
+     * @return true if all byte sequences reachable from the current state
      *         map to the same value.
      * @stable ICU 4.8
      */
     inline UBool hasUniqueValue(int32_t &uniqueValue) const {
         const uint8_t *pos=pos_;
         // Skip the rest of a pending linear-match node.
-        return pos!=NULL && findUniqueValue(pos+remainingMatchLength_+1, FALSE, uniqueValue);
+        return pos!=NULL && findUniqueValue(pos+remainingMatchLength_+1, false, uniqueValue);
     }
 
     /**
@@ -321,7 +321,7 @@ public:
         Iterator &reset();
 
         /**
-         * @return TRUE if there are more elements.
+         * @return true if there are more elements.
          * @stable ICU 4.8
          */
         UBool hasNext() const;
@@ -337,7 +337,7 @@ public:
          *                  pass the U_SUCCESS() test, or else the function returns
          *                  immediately. Check for U_FAILURE() on output or use with
          *                  function chaining. (See User Guide for details.)
-         * @return TRUE if there is another element.
+         * @return true if there is another element.
          * @stable ICU 4.8
          */
         UBool next(UErrorCode &errorCode);

--- a/icu4c/source/common/unicode/bytestriebuilder.h
+++ b/icu4c/source/common/unicode/bytestriebuilder.h
@@ -140,7 +140,7 @@ private:
     virtual int32_t skipElementsBySomeUnits(int32_t i, int32_t byteIndex, int32_t count) const;
     virtual int32_t indexOfElementWithNextUnit(int32_t i, int32_t byteIndex, char16_t byte) const;
 
-    virtual UBool matchNodesCanHaveValues() const { return FALSE; }
+    virtual UBool matchNodesCanHaveValues() const { return false; }
 
     virtual int32_t getMaxBranchLinearSubNodeLength() const { return BytesTrie::kMaxBranchLinearSubNodeLength; }
     virtual int32_t getMinLinearMatch() const { return BytesTrie::kMinLinearMatch; }

--- a/icu4c/source/common/unicode/caniter.h
+++ b/icu4c/source/common/unicode/caniter.h
@@ -25,11 +25,11 @@
  */
  
 /** Should permutation skip characters with combining class zero
- *  Should be either TRUE or FALSE. This is a compile time option
+ *  Should be either true or false. This is a compile time option
  *  @stable ICU 2.4
  */
 #ifndef CANITER_SKIP_ZEROES
-#define CANITER_SKIP_ZEROES TRUE
+#define CANITER_SKIP_ZEROES true
 #endif
 
 U_NAMESPACE_BEGIN

--- a/icu4c/source/common/unicode/chariter.h
+++ b/icu4c/source/common/unicode/chariter.h
@@ -65,7 +65,7 @@ U_NAMESPACE_BEGIN
  * check for the end of the iteration. When there are no more
  * characters in the text object:
  * <ul>
- * <li>The hasNext() function returns FALSE.</li>
+ * <li>The hasNext() function returns false.</li>
  * <li>nextPostInc() and next32PostInc() return DONE
  *     when one attempts to read beyond the end of the text object.</li>
  * </ul>
@@ -165,11 +165,11 @@ public:
     virtual UChar32       next32PostInc(void) = 0;
     
     /**
-     * Returns FALSE if there are no more code units or code points
+     * Returns false if there are no more code units or code points
      * at or after the current position in the iteration range.
      * This is used with nextPostInc() or next32PostInc() in forward
      * iteration.
-     * @returns FALSE if there are no more code units or code points
+     * @returns false if there are no more code units or code points
      * at or after the current position in the iteration range.
      * @stable ICU 2.0
      */
@@ -535,12 +535,12 @@ public:
     virtual UChar32       previous32(void) = 0;
 
     /**
-     * Returns FALSE if there are no more code units or code points
+     * Returns false if there are no more code units or code points
      * before the current position in the iteration range.
      * This is used with previous() or previous32() in backward
      * iteration.
-     * @return FALSE if there are no more code units or code points
-     * before the current position in the iteration range, return TRUE otherwise.
+     * @return false if there are no more code units or code points
+     * before the current position in the iteration range, return true otherwise.
      * @stable ICU 2.0
      */
     virtual UBool        hasPrevious() = 0;

--- a/icu4c/source/common/unicode/dtintrv.h
+++ b/icu4c/source/common/unicode/dtintrv.h
@@ -106,14 +106,14 @@ public:
 
     /**
      * Equality operator.
-     * @return TRUE if the two DateIntervals are the same
+     * @return true if the two DateIntervals are the same
      * @stable ICU 4.0
      */
     virtual UBool operator==(const DateInterval& other) const;
 
     /**
      * Non-equality operator
-     * @return TRUE if the two DateIntervals are not the same
+     * @return true if the two DateIntervals are not the same
      * @stable ICU 4.0
      */
     inline UBool operator!=(const DateInterval& other) const;

--- a/icu4c/source/common/unicode/edits.h
+++ b/icu4c/source/common/unicode/edits.h
@@ -159,7 +159,7 @@ public:
      * @param outErrorCode Set to an error code if it does not contain one already
      *                  and an error occurred while recording edits.
      *                  Otherwise unchanged.
-     * @return TRUE if U_FAILURE(outErrorCode)
+     * @return true if U_FAILURE(outErrorCode)
      * @stable ICU 59
      */
     UBool copyErrorTo(UErrorCode &outErrorCode) const;
@@ -171,7 +171,7 @@ public:
      */
     int32_t lengthDelta() const { return delta; }
     /**
-     * @return TRUE if there are any change edits
+     * @return true if there are any change edits
      * @stable ICU 59
      */
     UBool hasChanges() const { return numChanges != 0; }
@@ -207,8 +207,8 @@ public:
          */
         Iterator() :
                 array(nullptr), index(0), length(0),
-                remaining(0), onlyChanges_(FALSE), coarse(FALSE),
-                dir(0), changed(FALSE), oldLength_(0), newLength_(0),
+                remaining(0), onlyChanges_(false), coarse(false),
+                dir(0), changed(false), oldLength_(0), newLength_(0),
                 srcIndex(0), replIndex(0), destIndex(0) {}
         /**
          * Copy constructor.
@@ -226,7 +226,7 @@ public:
          * @param errorCode ICU error code. Its input value must pass the U_SUCCESS() test,
          *                  or else the function returns immediately. Check for U_FAILURE()
          *                  on output or use with function chaining. (See User Guide for details.)
-         * @return TRUE if there is another edit
+         * @return true if there is another edit
          * @stable ICU 59
          */
         UBool next(UErrorCode &errorCode) { return next(onlyChanges_, errorCode); }
@@ -247,11 +247,11 @@ public:
          * @param errorCode ICU error code. Its input value must pass the U_SUCCESS() test,
          *                  or else the function returns immediately. Check for U_FAILURE()
          *                  on output or use with function chaining. (See User Guide for details.)
-         * @return TRUE if the edit for the source index was found
+         * @return true if the edit for the source index was found
          * @stable ICU 59
          */
         UBool findSourceIndex(int32_t i, UErrorCode &errorCode) {
-            return findIndex(i, TRUE, errorCode) == 0;
+            return findIndex(i, true, errorCode) == 0;
         }
 
         /**
@@ -270,11 +270,11 @@ public:
          * @param errorCode ICU error code. Its input value must pass the U_SUCCESS() test,
          *                  or else the function returns immediately. Check for U_FAILURE()
          *                  on output or use with function chaining. (See User Guide for details.)
-         * @return TRUE if the edit for the destination index was found
+         * @return true if the edit for the destination index was found
          * @stable ICU 60
          */
         UBool findDestinationIndex(int32_t i, UErrorCode &errorCode) {
-            return findIndex(i, FALSE, errorCode) == 0;
+            return findIndex(i, false, errorCode) == 0;
         }
 
         /**
@@ -328,8 +328,8 @@ public:
         /**
          * Returns whether the edit currently represented by the iterator is a change edit.
          *
-         * @return TRUE if this edit replaces oldLength() units with newLength() different ones.
-         *         FALSE if oldLength units remain unchanged.
+         * @return true if this edit replaces oldLength() units with newLength() different ones.
+         *         false if oldLength units remain unchanged.
          * @stable ICU 59
          */
         UBool hasChange() const { return changed; }
@@ -347,8 +347,8 @@ public:
          * {@link #destinationIndex}, or in the replacement string, which starts at
          * {@link #replacementIndex}.
          *
-         * @return the number of units in the modified string, if hasChange() is TRUE.
-         *         Same as oldLength if hasChange() is FALSE.
+         * @return the number of units in the modified string, if hasChange() is true.
+         *         Same as oldLength if hasChange() is false.
          * @stable ICU 59
          */
         int32_t newLength() const { return newLength_; }
@@ -436,7 +436,7 @@ public:
      * @stable ICU 59
      */
     Iterator getCoarseChangesIterator() const {
-        return Iterator(array, length, TRUE, TRUE);
+        return Iterator(array, length, true, true);
     }
 
     /**
@@ -448,7 +448,7 @@ public:
      * @stable ICU 59
      */
     Iterator getCoarseIterator() const {
-        return Iterator(array, length, FALSE, TRUE);
+        return Iterator(array, length, false, true);
     }
 
     /**
@@ -460,7 +460,7 @@ public:
      * @stable ICU 59
      */
     Iterator getFineChangesIterator() const {
-        return Iterator(array, length, TRUE, FALSE);
+        return Iterator(array, length, true, false);
     }
 
     /**
@@ -471,7 +471,7 @@ public:
      * @stable ICU 59
      */
     Iterator getFineIterator() const {
-        return Iterator(array, length, FALSE, FALSE);
+        return Iterator(array, length, false, false);
     }
 
     /**

--- a/icu4c/source/common/unicode/filteredbrk.h
+++ b/icu4c/source/common/unicode/filteredbrk.h
@@ -85,8 +85,8 @@ class U_COMMON_API FilteredBreakIteratorBuilder : public UObject {
    * by the iterator.
    * @param string the string to suppress, such as "Mr."
    * @param status error code
-   * @return returns TRUE if the string was not present and now added,
-   * FALSE if the call was a no-op because the string was already being suppressed.
+   * @return returns true if the string was not present and now added,
+   * false if the call was a no-op because the string was already being suppressed.
    * @stable ICU 56
    */
   virtual UBool suppressBreakAfter(const UnicodeString& string, UErrorCode& status) = 0;
@@ -98,8 +98,8 @@ class U_COMMON_API FilteredBreakIteratorBuilder : public UObject {
    * locale data which may be suppressing certain strings.
    * @param string the exception to remove
    * @param status error code
-   * @return returns TRUE if the string was present and now removed,
-   * FALSE if the call was a no-op because the string was not being suppressed.
+   * @return returns true if the string was present and now removed,
+   * false if the call was a no-op because the string was not being suppressed.
    * @stable ICU 56
    */
   virtual UBool unsuppressBreakAfter(const UnicodeString& string, UErrorCode& status) = 0;

--- a/icu4c/source/common/unicode/idna.h
+++ b/icu4c/source/common/unicode/idna.h
@@ -95,7 +95,7 @@ public:
 
     /**
      * Converts a single domain name label into its ASCII form for DNS lookup.
-     * If any processing step fails, then info.hasErrors() will be TRUE and
+     * If any processing step fails, then info.hasErrors() will be true and
      * the result might not be an ASCII string.
      * The label might be modified according to the types of errors.
      * Labels with severe errors will be left in (or turned into) their Unicode form.
@@ -119,7 +119,7 @@ public:
 
     /**
      * Converts a single domain name label into its Unicode form for human-readable display.
-     * If any processing step fails, then info.hasErrors() will be TRUE.
+     * If any processing step fails, then info.hasErrors() will be true.
      * The label might be modified according to the types of errors.
      *
      * The UErrorCode indicates an error only in exceptional cases,
@@ -141,7 +141,7 @@ public:
 
     /**
      * Converts a whole domain name into its ASCII form for DNS lookup.
-     * If any processing step fails, then info.hasErrors() will be TRUE and
+     * If any processing step fails, then info.hasErrors() will be true and
      * the result might not be an ASCII string.
      * The domain name might be modified according to the types of errors.
      * Labels with severe errors will be left in (or turned into) their Unicode form.
@@ -165,7 +165,7 @@ public:
 
     /**
      * Converts a whole domain name into its Unicode form for human-readable display.
-     * If any processing step fails, then info.hasErrors() will be TRUE.
+     * If any processing step fails, then info.hasErrors() will be true.
      * The domain name might be modified according to the types of errors.
      *
      * The UErrorCode indicates an error only in exceptional cases,
@@ -273,10 +273,10 @@ public:
      * Constructor for stack allocation.
      * @stable ICU 4.6
      */
-    IDNAInfo() : errors(0), labelErrors(0), isTransDiff(FALSE), isBiDi(FALSE), isOkBiDi(TRUE) {}
+    IDNAInfo() : errors(0), labelErrors(0), isTransDiff(false), isBiDi(false), isOkBiDi(true) {}
     /**
      * Were there IDNA processing errors?
-     * @return TRUE if there were processing errors
+     * @return true if there were processing errors
      * @stable ICU 4.6
      */
     UBool hasErrors() const { return errors!=0; }
@@ -288,7 +288,7 @@ public:
      */
     uint32_t getErrors() const { return errors; }
     /**
-     * Returns TRUE if transitional and nontransitional processing produce different results.
+     * Returns true if transitional and nontransitional processing produce different results.
      * This is the case when the input label or domain name contains
      * one or more deviation characters outside a Punycode label (see UTS #46).
      * <ul>
@@ -297,7 +297,7 @@ public:
      * <li>With transitional processing, such characters are
      * mapped (sharp s/sigma) or removed (joiner/nonjoiner).
      * </ul>
-     * @return TRUE if transitional and nontransitional processing produce different results
+     * @return true if transitional and nontransitional processing produce different results
      * @stable ICU 4.6
      */
     UBool isTransitionalDifferent() const { return isTransDiff; }
@@ -310,9 +310,9 @@ private:
 
     void reset() {
         errors=labelErrors=0;
-        isTransDiff=FALSE;
-        isBiDi=FALSE;
-        isOkBiDi=TRUE;
+        isTransDiff=false;
+        isBiDi=false;
+        isOkBiDi=true;
     }
 
     uint32_t errors, labelErrors;

--- a/icu4c/source/common/unicode/localebuilder.h
+++ b/icu4c/source/common/unicode/localebuilder.h
@@ -286,7 +286,7 @@ public:
      * @param outErrorCode Set to an error code that occurred while setting subtags.
      *                  Unchanged if there is no such error or if outErrorCode
      *                  already contained an error.
-     * @return TRUE if U_FAILURE(outErrorCode)
+     * @return true if U_FAILURE(outErrorCode)
      * @draft ICU 65
      */
     UBool copyErrorTo(UErrorCode &outErrorCode) const;

--- a/icu4c/source/common/unicode/localematcher.h
+++ b/icu4c/source/common/unicode/localematcher.h
@@ -512,7 +512,7 @@ public:
          * @param outErrorCode Set to an error code if it does not contain one already
          *                  and an error occurred while setting parameters.
          *                  Otherwise unchanged.
-         * @return TRUE if U_FAILURE(outErrorCode)
+         * @return true if U_FAILURE(outErrorCode)
          * @draft ICU 65
          */
         UBool copyErrorTo(UErrorCode &outErrorCode) const;

--- a/icu4c/source/common/unicode/localpointer.h
+++ b/icu4c/source/common/unicode/localpointer.h
@@ -88,13 +88,13 @@ public:
     ~LocalPointerBase() { /* delete ptr; */ }
     /**
      * NULL check.
-     * @return TRUE if ==NULL
+     * @return true if ==NULL
      * @stable ICU 4.4
      */
     UBool isNull() const { return ptr==NULL; }
     /**
      * NULL check.
-     * @return TRUE if !=NULL
+     * @return true if !=NULL
      * @stable ICU 4.4
      */
     UBool isValid() const { return ptr!=NULL; }

--- a/icu4c/source/common/unicode/locid.h
+++ b/icu4c/source/common/unicode/locid.h
@@ -253,7 +253,7 @@ public:
     /**
      * Construct a locale from language, country, variant.
      * If an error occurs, then the constructed object will be "bogus"
-     * (isBogus() will return TRUE).
+     * (isBogus() will return true).
      *
      * @param language Lowercase two-letter or three-letter ISO-639 code.
      *  This parameter can instead be an ICU style C locale (e.g. "en_US"),
@@ -799,14 +799,14 @@ public:
     /**
      * Returns whether this locale's script is written right-to-left.
      * If there is no script subtag, then the likely script is used, see uloc_addLikelySubtags().
-     * If no likely script is known, then FALSE is returned.
+     * If no likely script is known, then false is returned.
      *
      * A script is right-to-left according to the CLDR script metadata
      * which corresponds to whether the script's letters have Bidi_Class=R or AL.
      *
-     * Returns TRUE for "ar" and "en-Hebr", FALSE for "zh" and "fa-Cyrl".
+     * Returns true for "ar" and "en-Hebr", false for "zh" and "fa-Cyrl".
      *
-     * @return TRUE if the locale's script is written right-to-left
+     * @return true if the locale's script is written right-to-left
      * @stable ICU 54
      */
     UBool isRightToLeft() const;
@@ -960,7 +960,7 @@ public:
 
     /**
      * Gets the bogus state. Locale object can be bogus if it doesn't exist
-     * @return FALSE if it is a real locale, TRUE if it is a bogus locale
+     * @return false if it is a real locale, true if it is a bogus locale
      * @stable ICU 2.1
      */
     inline UBool isBogus(void) const;
@@ -1020,7 +1020,7 @@ public:
         virtual ~Iterator();
 
         /**
-         * @return TRUE if next() can be called again.
+         * @return true if next() can be called again.
          * @draft ICU 65
          */
         virtual UBool hasNext() const = 0;
@@ -1051,7 +1051,7 @@ public:
         RangeIterator(Iter begin, Iter end) : it_(begin), end_(end) {}
 
         /**
-         * @return TRUE if next() can be called again.
+         * @return true if next() can be called again.
          * @draft ICU 65
          */
         UBool hasNext() const override { return it_ != end_; }
@@ -1089,7 +1089,7 @@ public:
                 it_(begin), end_(end), converter_(converter) {}
 
         /**
-         * @return TRUE if next() can be called again.
+         * @return true if next() can be called again.
          * @draft ICU 65
          */
         UBool hasNext() const override { return it_ != end_; }

--- a/icu4c/source/common/unicode/messagepattern.h
+++ b/icu4c/source/common/unicode/messagepattern.h
@@ -265,7 +265,7 @@ typedef enum UMessagePatternArgType UMessagePatternArgType;
 
 /**
  * \def UMSGPAT_ARG_TYPE_HAS_PLURAL_STYLE
- * Returns TRUE if the argument type has a plural style part sequence and semantics,
+ * Returns true if the argument type has a plural style part sequence and semantics,
  * for example UMSGPAT_ARG_TYPE_PLURAL and UMSGPAT_ARG_TYPE_SELECTORDINAL.
  * @stable ICU 50
  */
@@ -523,14 +523,14 @@ public:
 
     /**
      * @param other another object to compare with.
-     * @return TRUE if this object is equivalent to the other one.
+     * @return true if this object is equivalent to the other one.
      * @stable ICU 4.8
      */
     UBool operator==(const MessagePattern &other) const;
 
     /**
      * @param other another object to compare with.
-     * @return FALSE if this object is equivalent to the other one.
+     * @return false if this object is equivalent to the other one.
      * @stable ICU 4.8
      */
     inline UBool operator!=(const MessagePattern &other) const {
@@ -564,7 +564,7 @@ public:
 
     /**
      * Does the parsed pattern have named arguments like {first_name}?
-     * @return TRUE if the parsed pattern has at least one named argument.
+     * @return true if the parsed pattern has at least one named argument.
      * @stable ICU 4.8
      */
     UBool hasNamedArguments() const {
@@ -573,7 +573,7 @@ public:
 
     /**
      * Does the parsed pattern have numbered arguments like {2}?
-     * @return TRUE if the parsed pattern has at least one numbered argument.
+     * @return true if the parsed pattern has at least one numbered argument.
      * @stable ICU 4.8
      */
     UBool hasNumberedArguments() const {
@@ -664,7 +664,7 @@ public:
      * Compares the part's substring with the input string s.
      * @param part a part of this MessagePattern.
      * @param s a string.
-     * @return TRUE if getSubstring(part).equals(s).
+     * @return true if getSubstring(part).equals(s).
      * @stable ICU 4.8
      */
     UBool partSubstringMatches(const Part &part, const UnicodeString &s) const {
@@ -785,7 +785,7 @@ public:
          * Indicates whether the Part type has a numeric value.
          * If so, then that numeric value can be retrieved via MessagePattern.getNumericValue().
          * @param type The Part type to be tested.
-         * @return TRUE if the Part type has a numeric value.
+         * @return true if the Part type has a numeric value.
          * @stable ICU 4.8
          */
         static UBool hasNumericValue(UMessagePatternPartType type) {
@@ -794,14 +794,14 @@ public:
 
         /**
          * @param other another object to compare with.
-         * @return TRUE if this object is equivalent to the other one.
+         * @return true if this object is equivalent to the other one.
          * @stable ICU 4.8
          */
         UBool operator==(const Part &other) const;
 
         /**
          * @param other another object to compare with.
-         * @return FALSE if this object is equivalent to the other one.
+         * @return false if this object is equivalent to the other one.
          * @stable ICU 4.8
          */
         inline UBool operator!=(const Part &other) const {
@@ -869,7 +869,7 @@ private:
      * Parses a number from the specified message substring.
      * @param start start index into the message string
      * @param limit limit index into the message string, must be start<limit
-     * @param allowInfinity TRUE if U+221E is allowed (for ChoiceFormat)
+     * @param allowInfinity true if U+221E is allowed (for ChoiceFormat)
      * @param parseError
      * @param errorCode
      */
@@ -900,13 +900,13 @@ private:
     UBool isOrdinal(int32_t index);
 
     /**
-     * @return TRUE if we are inside a MessageFormat (sub-)pattern,
+     * @return true if we are inside a MessageFormat (sub-)pattern,
      *         as opposed to inside a top-level choice/plural/select pattern.
      */
     UBool inMessageFormatPattern(int32_t nestingLevel);
 
     /**
-     * @return TRUE if we are in a MessageFormat sub-pattern
+     * @return true if we are in a MessageFormat sub-pattern
      *         of a top-level ChoiceFormat pattern.
      */
     UBool inTopLevelChoiceMessage(int32_t nestingLevel, UMessagePatternArgType parentType);

--- a/icu4c/source/common/unicode/normalizer2.h
+++ b/icu4c/source/common/unicode/normalizer2.h
@@ -290,13 +290,13 @@ public:
      * Gets the decomposition mapping of c.
      * Roughly equivalent to normalizing the String form of c
      * on a UNORM2_DECOMPOSE Normalizer2 instance, but much faster, and except that this function
-     * returns FALSE and does not write a string
+     * returns false and does not write a string
      * if c does not have a decomposition mapping in this instance's data.
      * This function is independent of the mode of the Normalizer2.
      * @param c code point
      * @param decomposition String object which will be set to c's
      *                      decomposition mapping, if there is one.
-     * @return TRUE if c has a decomposition, otherwise FALSE
+     * @return true if c has a decomposition, otherwise false
      * @stable ICU 4.6
      */
     virtual UBool
@@ -319,11 +319,11 @@ public:
      * in this case, the result contains either one or two code points (=1..4 char16_ts).
      *
      * This function is independent of the mode of the Normalizer2.
-     * The default implementation returns FALSE.
+     * The default implementation returns false.
      * @param c code point
      * @param decomposition String object which will be set to c's
      *                      raw decomposition mapping, if there is one.
-     * @return TRUE if c has a decomposition, otherwise FALSE
+     * @return true if c has a decomposition, otherwise false
      * @stable ICU 49
      */
     virtual UBool
@@ -369,7 +369,7 @@ public:
      *                  pass the U_SUCCESS() test, or else the function returns
      *                  immediately. Check for U_FAILURE() on output or use with
      *                  function chaining. (See User Guide for details.)
-     * @return TRUE if s is normalized
+     * @return true if s is normalized
      * @stable ICU 4.4
      */
     virtual UBool
@@ -392,7 +392,7 @@ public:
      *                  pass the U_SUCCESS() test, or else the function returns
      *                  immediately. Check for U_FAILURE() on output or use with
      *                  function chaining. (See User Guide for details.)
-     * @return TRUE if s is normalized
+     * @return true if s is normalized
      * @stable ICU 60
      */
     virtual UBool
@@ -452,7 +452,7 @@ public:
      * character independently.
      * This is used for iterative normalization. See the class documentation for details.
      * @param c character to test
-     * @return TRUE if c has a normalization boundary before it
+     * @return true if c has a normalization boundary before it
      * @stable ICU 4.4
      */
     virtual UBool hasBoundaryBefore(UChar32 c) const = 0;
@@ -468,7 +468,7 @@ public:
      * This is used for iterative normalization. See the class documentation for details.
      * Note that this operation may be significantly slower than hasBoundaryBefore().
      * @param c character to test
-     * @return TRUE if c has a normalization boundary after it
+     * @return true if c has a normalization boundary after it
      * @stable ICU 4.4
      */
     virtual UBool hasBoundaryAfter(UChar32 c) const = 0;
@@ -483,7 +483,7 @@ public:
      * This is used for iterative normalization. See the class documentation for details.
      * Note that this operation may be significantly slower than hasBoundaryBefore().
      * @param c character to test
-     * @return TRUE if c is normalization-inert
+     * @return true if c is normalization-inert
      * @stable ICU 4.4
      */
     virtual UBool isInert(UChar32 c) const = 0;
@@ -612,7 +612,7 @@ public:
      * @param c code point
      * @param decomposition String object which will be set to c's
      *                      decomposition mapping, if there is one.
-     * @return TRUE if c has a decomposition, otherwise FALSE
+     * @return true if c has a decomposition, otherwise false
      * @stable ICU 4.6
      */
     virtual UBool
@@ -626,7 +626,7 @@ public:
      * @param c code point
      * @param decomposition String object which will be set to c's
      *                      raw decomposition mapping, if there is one.
-     * @return TRUE if c has a decomposition, otherwise FALSE
+     * @return true if c has a decomposition, otherwise false
      * @stable ICU 49
      */
     virtual UBool
@@ -664,7 +664,7 @@ public:
      *                  pass the U_SUCCESS() test, or else the function returns
      *                  immediately. Check for U_FAILURE() on output or use with
      *                  function chaining. (See User Guide for details.)
-     * @return TRUE if s is normalized
+     * @return true if s is normalized
      * @stable ICU 4.4
      */
     virtual UBool
@@ -687,7 +687,7 @@ public:
      *                  pass the U_SUCCESS() test, or else the function returns
      *                  immediately. Check for U_FAILURE() on output or use with
      *                  function chaining. (See User Guide for details.)
-     * @return TRUE if s is normalized
+     * @return true if s is normalized
      * @stable ICU 60
      */
     virtual UBool
@@ -724,7 +724,7 @@ public:
      * regardless of context.
      * For details see the Normalizer2 base class documentation.
      * @param c character to test
-     * @return TRUE if c has a normalization boundary before it
+     * @return true if c has a normalization boundary before it
      * @stable ICU 4.4
      */
     virtual UBool hasBoundaryBefore(UChar32 c) const U_OVERRIDE;
@@ -734,7 +734,7 @@ public:
      * regardless of context.
      * For details see the Normalizer2 base class documentation.
      * @param c character to test
-     * @return TRUE if c has a normalization boundary after it
+     * @return true if c has a normalization boundary after it
      * @stable ICU 4.4
      */
     virtual UBool hasBoundaryAfter(UChar32 c) const U_OVERRIDE;
@@ -743,7 +743,7 @@ public:
      * Tests if the character is normalization-inert.
      * For details see the Normalizer2 base class documentation.
      * @param c character to test
-     * @return TRUE if c is normalization-inert
+     * @return true if c is normalization-inert
      * @stable ICU 4.4
      */
     virtual UBool isInert(UChar32 c) const U_OVERRIDE;

--- a/icu4c/source/common/unicode/normlzr.h
+++ b/icu4c/source/common/unicode/normlzr.h
@@ -234,7 +234,7 @@ public:
    *
    * @param source    the string to be composed.
    * @param compat    Perform compatibility decomposition before composition.
-   *                  If this argument is <code>FALSE</code>, only canonical
+   *                  If this argument is <code>false</code>, only canonical
    *                  decomposition will be performed.
    * @param options   the optional features to be enabled (0 for no options)
    * @param result    The composed string (on output).
@@ -256,7 +256,7 @@ public:
    *
    * @param source    the string to be decomposed.
    * @param compat    Perform compatibility decomposition.
-   *                  If this argument is <code>FALSE</code>, only canonical
+   *                  If this argument is <code>false</code>, only canonical
    *                  decomposition will be performed.
    * @param options   the optional features to be enabled (0 for no options)
    * @param result    The decomposed string (on output).
@@ -315,7 +315,7 @@ public:
    * never a "maybe".
    * For NFD, NFKD, and FCD, both functions work exactly the same.
    * For NFC and NFKC where quickCheck may return "maybe", this function will
-   * perform further tests to arrive at a TRUE/FALSE result.
+   * perform further tests to arrive at a true/false result.
    *
    * @param src        String that is to be tested if it is in a normalization format.
    * @param mode       Which normalization form to test for.
@@ -577,7 +577,7 @@ public:
   int32_t            endIndex(void) const;
 
   /**
-   * Returns TRUE when both iterators refer to the same character in the same
+   * Returns true when both iterators refer to the same character in the same
    * input text.
    *
    * @param that a Normalizer object to compare this one to
@@ -587,7 +587,7 @@ public:
   UBool        operator==(const Normalizer& that) const;
 
   /**
-   * Returns FALSE when both iterators refer to the same character in the same
+   * Returns false when both iterators refer to the same character in the same
    * input text.
    *
    * @param that a Normalizer object to compare this one to
@@ -655,8 +655,8 @@ public:
    * It is possible to specify multiple options that are all turned on or off.
    *
    * @param   option  the option(s) whose value is/are to be set.
-   * @param   value   the new setting for the option.  Use <code>TRUE</code> to
-   *                  turn the option(s) on and <code>FALSE</code> to turn it/them off.
+   * @param   value   the new setting for the option.  Use <code>true</code> to
+   *                  turn the option(s) on and <code>false</code> to turn it/them off.
    *
    * @see #getOption
    * @deprecated ICU 56 Use Normalizer2 instead.
@@ -666,11 +666,11 @@ public:
 
   /**
    * Determine whether an option is turned on or off.
-   * If multiple options are specified, then the result is TRUE if any
+   * If multiple options are specified, then the result is true if any
    * of them are set.
    * <p>
    * @param option the option(s) that are to be checked
-   * @return TRUE if any of the option(s) are set
+   * @return true if any of the option(s) are set
    * @see #setOption
    * @deprecated ICU 56 Use Normalizer2 instead.
    */

--- a/icu4c/source/common/unicode/parsepos.h
+++ b/icu4c/source/common/unicode/parsepos.h
@@ -97,14 +97,14 @@ public:
 
     /**
      * Equality operator.
-     * @return TRUE if the two parse positions are equal, FALSE otherwise.
+     * @return true if the two parse positions are equal, false otherwise.
      * @stable ICU 2.0
      */
     inline UBool              operator==(const ParsePosition& that) const;
 
     /**
      * Equality operator.
-     * @return TRUE if the two parse positions are not equal, FALSE otherwise.
+     * @return true if the two parse positions are not equal, false otherwise.
      * @stable ICU 2.0
      */
     inline UBool              operator!=(const ParsePosition& that) const;
@@ -196,9 +196,9 @@ inline UBool
 ParsePosition::operator==(const ParsePosition& copy) const
 {
   if(index != copy.index || errorIndex != copy.errorIndex)
-  return FALSE;
+  return false;
   else
-  return TRUE;
+  return true;
 }
 
 inline UBool

--- a/icu4c/source/common/unicode/rbbi.h
+++ b/icu4c/source/common/unicode/rbbi.h
@@ -253,20 +253,20 @@ public:
     RuleBasedBreakIterator& operator=(const RuleBasedBreakIterator& that);
 
     /**
-     * Equality operator.  Returns TRUE if both BreakIterators are of the
+     * Equality operator.  Returns true if both BreakIterators are of the
      * same class, have the same behavior, and iterate over the same text.
      * @param that The BreakIterator to be compared for equality
-     * @return TRUE if both BreakIterators are of the
+     * @return true if both BreakIterators are of the
      * same class, have the same behavior, and iterate over the same text.
      *  @stable ICU 2.0
      */
     virtual UBool operator==(const BreakIterator& that) const;
 
     /**
-     * Not-equal operator.  If operator== returns TRUE, this returns FALSE,
+     * Not-equal operator.  If operator== returns true, this returns false,
      * and vice versa.
      * @param that The BreakIterator to be compared for inequality
-     * @return TRUE if both BreakIterators are not same.
+     * @return true if both BreakIterators are not same.
      *  @stable ICU 2.0
      */
     inline UBool operator!=(const BreakIterator& that) const;

--- a/icu4c/source/common/unicode/resbund.h
+++ b/icu4c/source/common/unicode/resbund.h
@@ -286,7 +286,7 @@ public:
     /**
      * Checks whether the resource has another element to iterate over.
      *
-     * @return TRUE if there are more elements, FALSE if there is no more elements
+     * @return true if there are more elements, false if there is no more elements
      * @stable ICU 2.0
      */
     UBool

--- a/icu4c/source/common/unicode/simpleformatter.h
+++ b/icu4c/source/common/unicode/simpleformatter.h
@@ -125,7 +125,7 @@ public:
      * @param errorCode ICU error code in/out parameter.
      *                  Must fulfill U_SUCCESS before the function call.
      *                  Set to U_ILLEGAL_ARGUMENT_ERROR for bad argument syntax.
-     * @return TRUE if U_SUCCESS(errorCode).
+     * @return true if U_SUCCESS(errorCode).
      * @stable ICU 57
      */
     UBool applyPattern(const UnicodeString &pattern, UErrorCode &errorCode) {
@@ -144,7 +144,7 @@ public:
      *                  Must fulfill U_SUCCESS before the function call.
      *                  Set to U_ILLEGAL_ARGUMENT_ERROR for bad argument syntax and
      *                  too few or too many arguments.
-     * @return TRUE if U_SUCCESS(errorCode).
+     * @return true if U_SUCCESS(errorCode).
      * @stable ICU 57
      */
     UBool applyPatternMinMaxArguments(const UnicodeString &pattern,

--- a/icu4c/source/common/unicode/strenum.h
+++ b/icu4c/source/common/unicode/strenum.h
@@ -196,7 +196,7 @@ public:
      * Compares this enumeration to other to check if both are equal
      *
      * @param that The other string enumeration to compare this object to
-     * @return TRUE if the enumerations are equal. FALSE if not.
+     * @return true if the enumerations are equal. false if not.
      * @stable ICU 3.6 
      */
     virtual UBool operator==(const StringEnumeration& that)const;
@@ -204,7 +204,7 @@ public:
      * Compares this enumeration to other to check if both are not equal
      *
      * @param that The other string enumeration to compare this object to
-     * @return TRUE if the enumerations are equal. FALSE if not.
+     * @return true if the enumerations are equal. false if not.
      * @stable ICU 3.6 
      */
     virtual UBool operator!=(const StringEnumeration& that)const;

--- a/icu4c/source/common/unicode/stringpiece.h
+++ b/icu4c/source/common/unicode/stringpiece.h
@@ -209,7 +209,7 @@ class U_COMMON_API StringPiece : public UMemory {
   int32_t length() const { return length_; }
   /**
    * Returns whether the string is empty.
-   * @return TRUE if the string is empty
+   * @return true if the string is empty
    * @stable ICU 4.2
    */
   UBool empty() const { return length_ == 0; }
@@ -331,7 +331,7 @@ class U_COMMON_API StringPiece : public UMemory {
  * Global operator == for StringPiece
  * @param x The first StringPiece to compare.
  * @param y The second StringPiece to compare.
- * @return TRUE if the string data is equal
+ * @return true if the string data is equal
  * @stable ICU 4.8
  */
 U_EXPORT UBool U_EXPORT2 
@@ -341,7 +341,7 @@ operator==(const StringPiece& x, const StringPiece& y);
  * Global operator != for StringPiece
  * @param x The first StringPiece to compare.
  * @param y The second StringPiece to compare.
- * @return TRUE if the string data is not equal
+ * @return true if the string data is not equal
  * @stable ICU 4.8
  */
 inline UBool operator!=(const StringPiece& x, const StringPiece& y) {

--- a/icu4c/source/common/unicode/stringtriebuilder.h
+++ b/icu4c/source/common/unicode/stringtriebuilder.h
@@ -279,10 +279,10 @@ protected:
      */
     class ValueNode : public Node {
     public:
-        ValueNode(int32_t initialHash) : Node(initialHash), hasValue(FALSE), value(0) {}
+        ValueNode(int32_t initialHash) : Node(initialHash), hasValue(false), value(0) {}
         virtual UBool operator==(const Node &other) const;
         void setValue(int32_t v) {
-            hasValue=TRUE;
+            hasValue=true;
             value=v;
             hash=hash*37u+v;
         }

--- a/icu4c/source/common/unicode/ubidi.h
+++ b/icu4c/source/common/unicode/ubidi.h
@@ -597,7 +597,7 @@ U_NAMESPACE_END
  * this "inverse Bidi" and that the current implementation provides only an
  * approximation of "inverse Bidi".</p>
  *
- * <p>With <code>isInverse</code> set to <code>TRUE</code>,
+ * <p>With <code>isInverse</code> set to <code>true</code>,
  * this function changes the behavior of some of the subsequent functions
  * in a way that they can be used for the inverse Bidi algorithm.
  * Specifically, runs of text with numeric characters will be treated in a
@@ -610,12 +610,12 @@ U_NAMESPACE_END
  * the runs of the logically ordered output.</p>
  *
  * <p>Calling this function with argument <code>isInverse</code> set to
- * <code>TRUE</code> is equivalent to calling
+ * <code>true</code> is equivalent to calling
  * <code>ubidi_setReorderingMode</code> with argument
  * <code>reorderingMode</code>
  * set to <code>#UBIDI_REORDER_INVERSE_NUMBERS_AS_L</code>.<br>
  * Calling this function with argument <code>isInverse</code> set to
- * <code>FALSE</code> is equivalent to calling
+ * <code>false</code> is equivalent to calling
  * <code>ubidi_setReorderingMode</code> with argument
  * <code>reorderingMode</code>
  * set to <code>#UBIDI_REORDER_DEFAULT</code>.
@@ -635,12 +635,12 @@ ubidi_setInverse(UBiDi *pBiDi, UBool isInverse);
 /**
  * Is this Bidi object set to perform the inverse Bidi algorithm?
  * <p>Note: calling this function after setting the reordering mode with
- * <code>ubidi_setReorderingMode</code> will return <code>TRUE</code> if the
+ * <code>ubidi_setReorderingMode</code> will return <code>true</code> if the
  * reordering mode was set to <code>#UBIDI_REORDER_INVERSE_NUMBERS_AS_L</code>,
- * <code>FALSE</code> for all other values.</p>
+ * <code>false</code> for all other values.</p>
  *
  * @param pBiDi is a <code>UBiDi</code> object.
- * @return TRUE if the Bidi object is set to perform the inverse Bidi algorithm
+ * @return true if the Bidi object is set to perform the inverse Bidi algorithm
  * by handling numbers as L.
  *
  * @see ubidi_setInverse
@@ -679,7 +679,7 @@ ubidi_orderParagraphsLTR(UBiDi *pBiDi, UBool orderParagraphsLTR);
  * successive paragraphs progress from left to right?
  *
  * @param pBiDi is a <code>UBiDi</code> object.
- * @return TRUE if the Bidi object is set to allocate level 0 to block
+ * @return true if the Bidi object is set to allocate level 0 to block
  *         separators.
  *
  * @see ubidi_orderParagraphsLTR
@@ -717,7 +717,7 @@ typedef enum UBiDiReorderingMode {
       * @stable ICU 3.6 */
     UBIDI_REORDER_RUNS_ONLY,
     /** Visual to Logical algorithm which handles numbers like L
-      * (same algorithm as selected by <code>ubidi_setInverse(TRUE)</code>.
+      * (same algorithm as selected by <code>ubidi_setInverse(true)</code>.
       * @see ubidi_setInverse
       * @stable ICU 3.6 */
     UBIDI_REORDER_INVERSE_NUMBERS_AS_L,
@@ -836,7 +836,7 @@ typedef enum UBiDiReorderingMode {
  * reordered sequence (the option <code>#UBIDI_INSERT_LRM_FOR_NUMERIC</code> can
  * be used with function <code>ubidi_writeReordered</code> to this end. This
  * mode is equivalent to calling <code>ubidi_setInverse()</code> with
- * argument <code>isInverse</code> set to <code>TRUE</code>.</li>
+ * argument <code>isInverse</code> set to <code>true</code>.</li>
  *
  * <li>When the reordering mode is set to
  * <code>#UBIDI_REORDER_INVERSE_LIKE_DIRECT</code>, the "direct" Logical to Visual
@@ -938,7 +938,7 @@ typedef enum UBiDiReorderingOption {
      *
      * <p>If this option is set in conjunction with reordering mode
      * <code>#UBIDI_REORDER_INVERSE_NUMBERS_AS_L</code> or with calling
-     * <code>ubidi_setInverse(TRUE)</code>, it implies
+     * <code>ubidi_setInverse(true)</code>, it implies
      * option <code>#UBIDI_INSERT_LRM_FOR_NUMERIC</code>
      * in calls to function <code>ubidi_writeReordered()</code>.</p>
      *
@@ -1019,7 +1019,7 @@ typedef enum UBiDiReorderingOption {
      *
      * <p>When the <code>UBIDI_OPTION_STREAMING</code> option is used,
      * it is recommended to call <code>ubidi_orderParagraphsLTR()</code> with
-     * argument <code>orderParagraphsLTR</code> set to <code>TRUE</code> before
+     * argument <code>orderParagraphsLTR</code> set to <code>true</code> before
      * calling <code>ubidi_setPara</code> so that later paragraphs may be
      * concatenated to previous paragraphs on the right.</p>
      *

--- a/icu4c/source/common/unicode/ubiditransform.h
+++ b/icu4c/source/common/unicode/ubiditransform.h
@@ -150,10 +150,10 @@ typedef struct UBiDiTransform UBiDiTransform;
  * calling <code>ubidi_setPara</code> with
  * <code>paraLevel == UBIDI_DEFAULT_RTL</code>,</li>
  * <li><Visual LTR, Logical LTR>: this is equivalent to
- * calling <code>ubidi_setInverse(UBiDi*, TRUE)</code> and then
+ * calling <code>ubidi_setInverse(UBiDi*, true)</code> and then
  * <code>ubidi_setPara</code> with <code>paraLevel == UBIDI_LTR</code>,</li>
  * <li><Visual LTR, Logical RTL>: this is equivalent to
- * calling <code>ubidi_setInverse(UBiDi*, TRUE)</code> and then
+ * calling <code>ubidi_setInverse(UBiDi*, true)</code> and then
  * <code>ubidi_setPara</code> with <code>paraLevel == UBIDI_RTL</code>.</li>
  * </ul>
  * All combinations that involve the Visual RTL scheme are unsupported by

--- a/icu4c/source/common/unicode/uchar.h
+++ b/icu4c/source/common/unicode/uchar.h
@@ -80,7 +80,7 @@ U_CDECL_BEGIN
  * and the ICU User Guide chapter on Properties (http://icu-project.org/userguide/properties.html).
  *
  * Many properties are accessible via generic functions that take a UProperty selector.
- * - u_hasBinaryProperty() returns a binary value (TRUE/FALSE) per property and code point.
+ * - u_hasBinaryProperty() returns a binary value (true/false) per property and code point.
  * - u_getIntPropertyValue() returns an integer value per property and code point.
  *   For each supported enumerated or catalog property, there is
  *   an enum type for all of the property's values, and
@@ -2586,8 +2586,8 @@ typedef enum UVerticalOrientation {
  * @param c Code point to test.
  * @param which UProperty selector constant, identifies which binary property to check.
  *        Must be UCHAR_BINARY_START<=which<UCHAR_BINARY_LIMIT.
- * @return TRUE or FALSE according to the binary Unicode property value for c.
- *         Also FALSE if 'which' is out of bounds or if the Unicode version
+ * @return true or false according to the binary Unicode property value for c.
+ *         Also false if 'which' is out of bounds or if the Unicode version
  *         does not have data for the property at all, or not for this code point.
  *
  * @see UProperty
@@ -2708,7 +2708,7 @@ u_isUWhiteSpace(UChar32 c);
  *         for enumerated properties, corresponds to the numeric value of the enumerated
  *         constant of the respective property value enumeration type
  *         (cast to enum type if necessary).
- *         Returns 0 or 1 (for FALSE/TRUE) for binary Unicode properties.
+ *         Returns 0 or 1 (for false/true) for binary Unicode properties.
  *         Returns a bit-mask for mask properties.
  *         Returns 0 if 'which' is out of bounds or if the Unicode version
  *         does not have data for the property at all, or not for this code point.
@@ -2754,7 +2754,7 @@ u_getIntPropertyMinValue(UProperty which);
  *
  * - UCHAR_BIDI_CLASS:    0/18 (U_LEFT_TO_RIGHT/U_BOUNDARY_NEUTRAL)
  * - UCHAR_SCRIPT:        0/45 (USCRIPT_COMMON/USCRIPT_TAGBANWA)
- * - UCHAR_IDEOGRAPHIC:   0/1  (FALSE/TRUE)
+ * - UCHAR_IDEOGRAPHIC:   0/1  (false/true)
  *
  * For undefined UProperty constant values, min/max values will be 0/-1.
  *
@@ -2842,7 +2842,7 @@ u_getNumericValue(UChar32 c);
  * documentation at the top of this header file.
  *
  * @param c the code point to be tested
- * @return TRUE if the code point is an Ll lowercase letter
+ * @return true if the code point is an Ll lowercase letter
  *
  * @see UCHAR_LOWERCASE
  * @see u_isupper
@@ -2868,7 +2868,7 @@ u_islower(UChar32 c);
  * documentation at the top of this header file.
  *
  * @param c the code point to be tested
- * @return TRUE if the code point is an Lu uppercase letter
+ * @return true if the code point is an Lu uppercase letter
  *
  * @see UCHAR_UPPERCASE
  * @see u_islower
@@ -2886,7 +2886,7 @@ u_isupper(UChar32 c);
  * Same as java.lang.Character.isTitleCase().
  *
  * @param c the code point to be tested
- * @return TRUE if the code point is an Lt titlecase letter
+ * @return true if the code point is an Lt titlecase letter
  *
  * @see u_isupper
  * @see u_islower
@@ -2910,7 +2910,7 @@ u_istitle(UChar32 c);
  * documentation at the top of this header file.
  *
  * @param c the code point to be tested
- * @return TRUE if the code point is a digit character according to Character.isDigit()
+ * @return true if the code point is a digit character according to Character.isDigit()
  *
  * @stable ICU 2.0
  */
@@ -2929,7 +2929,7 @@ u_isdigit(UChar32 c);
  * documentation at the top of this header file.
  *
  * @param c the code point to be tested
- * @return TRUE if the code point is a letter character
+ * @return true if the code point is a letter character
  *
  * @see u_isdigit
  * @see u_isalnum
@@ -2952,7 +2952,7 @@ u_isalpha(UChar32 c);
  * documentation at the top of this header file.
  *
  * @param c the code point to be tested
- * @return TRUE if the code point is an alphanumeric character according to Character.isLetterOrDigit()
+ * @return true if the code point is an alphanumeric character according to Character.isLetterOrDigit()
  *
  * @stable ICU 2.0
  */
@@ -2975,7 +2975,7 @@ u_isalnum(UChar32 c);
  * documentation at the top of this header file.
  *
  * @param c the code point to be tested
- * @return TRUE if the code point is a hexadecimal digit
+ * @return true if the code point is a hexadecimal digit
  *
  * @stable ICU 2.6
  */
@@ -2991,7 +2991,7 @@ u_isxdigit(UChar32 c);
  * documentation at the top of this header file.
  *
  * @param c the code point to be tested
- * @return TRUE if the code point is a punctuation character
+ * @return true if the code point is a punctuation character
  *
  * @stable ICU 2.6
  */
@@ -3001,7 +3001,7 @@ u_ispunct(UChar32 c);
 /**
  * Determines whether the specified code point is a "graphic" character
  * (printable, excluding spaces).
- * TRUE for all characters except those with general categories
+ * true for all characters except those with general categories
  * "Cc" (control codes), "Cf" (format controls), "Cs" (surrogates),
  * "Cn" (unassigned), and "Z" (separators).
  *
@@ -3010,7 +3010,7 @@ u_ispunct(UChar32 c);
  * documentation at the top of this header file.
  *
  * @param c the code point to be tested
- * @return TRUE if the code point is a "graphic" character
+ * @return true if the code point is a "graphic" character
  *
  * @stable ICU 2.6
  */
@@ -3022,13 +3022,13 @@ u_isgraph(UChar32 c);
  * a character that visibly separates words on a line.
  * The following are equivalent definitions:
  *
- * TRUE for Unicode White_Space characters except for "vertical space controls"
+ * true for Unicode White_Space characters except for "vertical space controls"
  * where "vertical space controls" are the following characters:
  * U+000A (LF) U+000B (VT) U+000C (FF) U+000D (CR) U+0085 (NEL) U+2028 (LS) U+2029 (PS)
  *
  * same as
  *
- * TRUE for U+0009 (TAB) and characters with general category "Zs" (space separators).
+ * true for U+0009 (TAB) and characters with general category "Zs" (space separators).
  *
  * Note: There are several ICU whitespace functions; please see the uchar.h
  * file documentation for a detailed comparison.
@@ -3038,7 +3038,7 @@ u_isgraph(UChar32 c);
  * documentation at the top of this header file.
  *
  * @param c the code point to be tested
- * @return TRUE if the code point is a "blank"
+ * @return true if the code point is a "blank"
  *
  * @stable ICU 2.6
  */
@@ -3057,7 +3057,7 @@ u_isblank(UChar32 c);
  * Same as java.lang.Character.isDefined().
  *
  * @param c the code point to be tested
- * @return TRUE if the code point is assigned a character
+ * @return true if the code point is assigned a character
  *
  * @see u_isdigit
  * @see u_isalpha
@@ -3102,7 +3102,7 @@ u_isspace(UChar32 c);
  * file documentation for a detailed comparison.
  *
  * @param c the code point to be tested
- * @return TRUE if the code point is a space character according to Character.isSpaceChar()
+ * @return true if the code point is a space character according to Character.isSpaceChar()
  *
  * @see u_isspace
  * @see u_isWhitespace
@@ -3142,7 +3142,7 @@ u_isJavaSpaceChar(UChar32 c);
  * file documentation for a detailed comparison.
  *
  * @param c the code point to be tested
- * @return TRUE if the code point is a whitespace character according to Java/ICU
+ * @return true if the code point is a whitespace character according to Java/ICU
  *
  * @see u_isspace
  * @see u_isJavaSpaceChar
@@ -3167,7 +3167,7 @@ u_isWhitespace(UChar32 c);
  * documentation at the top of this header file.
  *
  * @param c the code point to be tested
- * @return TRUE if the code point is a control character
+ * @return true if the code point is a control character
  *
  * @see UCHAR_DEFAULT_IGNORABLE_CODE_POINT
  * @see u_isprint
@@ -3183,7 +3183,7 @@ u_iscntrl(UChar32 c);
  * Same as java.lang.Character.isISOControl().
  *
  * @param c the code point to be tested
- * @return TRUE if the code point is an ISO control code
+ * @return true if the code point is an ISO control code
  *
  * @see u_iscntrl
  * @stable ICU 2.6
@@ -3200,7 +3200,7 @@ u_isISOControl(UChar32 c);
  * documentation at the top of this header file.
  *
  * @param c the code point to be tested
- * @return TRUE if the code point is a printable character
+ * @return true if the code point is a printable character
  *
  * @see UCHAR_DEFAULT_IGNORABLE_CODE_POINT
  * @see u_iscntrl
@@ -3220,7 +3220,7 @@ u_isprint(UChar32 c);
  * Letter (L), Number (N), Punctuation (P), Symbol (S), or Space Separator (Zs).
  *
  * @param c the code point to be tested
- * @return TRUE if the code point is a base character according to this function
+ * @return true if the code point is a base character according to this function
  *
  * @see u_isalpha
  * @see u_isdigit
@@ -3258,7 +3258,7 @@ u_charDirection(UChar32 c);
  * Same as UCHAR_BIDI_MIRRORED
  *
  * @param c the code point to be tested
- * @return TRUE if the character has the Bidi_Mirrored property
+ * @return true if the character has the Bidi_Mirrored property
  *
  * @see UCHAR_BIDI_MIRRORED
  * @stable ICU 2.0
@@ -3341,13 +3341,13 @@ u_charType(UChar32 c);
  * of code points c (where start<=c<limit)
  * with the same Unicode general category ("character type").
  *
- * The callback function can stop the enumeration by returning FALSE.
+ * The callback function can stop the enumeration by returning false.
  *
  * @param context an opaque pointer, as passed into utrie_enum()
  * @param start the first code point in a contiguous range with value
  * @param limit one past the last code point in a contiguous range with value
  * @param type the general category for all code points in [start..limit[
- * @return FALSE to stop the enumeration
+ * @return false to stop the enumeration
  *
  * @stable ICU 2.1
  * @see UCharCategory
@@ -3521,14 +3521,14 @@ u_charFromName(UCharNameChoice nameChoice,
  * Type of a callback function for u_enumCharNames() that gets called
  * for each Unicode character with the code point value and
  * the character name.
- * If such a function returns FALSE, then the enumeration is stopped.
+ * If such a function returns false, then the enumeration is stopped.
  *
  * @param context The context pointer that was passed to u_enumCharNames().
  * @param code The Unicode code point for the character with this name.
  * @param nameChoice Selector for which kind of names is enumerated.
  * @param name The character's name, zero-terminated.
  * @param length The length of the name.
- * @return TRUE if the enumeration should continue, FALSE to stop it.
+ * @return true if the enumeration should continue, false to stop it.
  *
  * @see UCharNameChoice
  * @see u_enumCharNames
@@ -3722,7 +3722,7 @@ u_getPropertyValueEnum(UProperty property,
  * Same as UCHAR_ID_START
  *
  * @param c the code point to be tested
- * @return TRUE if the code point may start an identifier
+ * @return true if the code point may start an identifier
  *
  * @see UCHAR_ID_START
  * @see u_isalpha
@@ -3746,7 +3746,7 @@ u_isIDStart(UChar32 c);
  * u_isIDIgnorable(c).
  *
  * @param c the code point to be tested
- * @return TRUE if the code point may occur in an identifier according to Java
+ * @return true if the code point may occur in an identifier according to Java
  *
  * @see UCHAR_ID_CONTINUE
  * @see u_isIDStart
@@ -3769,7 +3769,7 @@ u_isIDPart(UChar32 c);
  * Note that Unicode just recommends to ignore Cf (format controls).
  *
  * @param c the code point to be tested
- * @return TRUE if the code point is ignorable in identifiers according to Java
+ * @return true if the code point is ignorable in identifiers according to Java
  *
  * @see UCHAR_DEFAULT_IGNORABLE_CODE_POINT
  * @see u_isIDStart
@@ -3788,7 +3788,7 @@ u_isIDIgnorable(UChar32 c);
  * Same as java.lang.Character.isJavaIdentifierStart().
  *
  * @param c the code point to be tested
- * @return TRUE if the code point may start a Java identifier
+ * @return true if the code point may start a Java identifier
  *
  * @see     u_isJavaIDPart
  * @see     u_isalpha
@@ -3807,7 +3807,7 @@ u_isJavaIDStart(UChar32 c);
  * Same as java.lang.Character.isJavaIdentifierPart().
  *
  * @param c the code point to be tested
- * @return TRUE if the code point may occur in a Java identifier
+ * @return true if the code point may occur in a Java identifier
  *
  * @see     u_isIDIgnorable
  * @see     u_isJavaIDStart

--- a/icu4c/source/common/unicode/ucharstrie.h
+++ b/icu4c/source/common/unicode/ucharstrie.h
@@ -268,16 +268,16 @@ public:
     /**
      * Determines whether all strings reachable from the current state
      * map to the same value.
-     * @param uniqueValue Receives the unique value, if this function returns TRUE.
+     * @param uniqueValue Receives the unique value, if this function returns true.
      *                    (output-only)
-     * @return TRUE if all strings reachable from the current state
+     * @return true if all strings reachable from the current state
      *         map to the same value.
      * @stable ICU 4.8
      */
     inline UBool hasUniqueValue(int32_t &uniqueValue) const {
         const char16_t *pos=pos_;
         // Skip the rest of a pending linear-match node.
-        return pos!=NULL && findUniqueValue(pos+remainingMatchLength_+1, FALSE, uniqueValue);
+        return pos!=NULL && findUniqueValue(pos+remainingMatchLength_+1, false, uniqueValue);
     }
 
     /**
@@ -335,7 +335,7 @@ public:
         Iterator &reset();
 
         /**
-         * @return TRUE if there are more elements.
+         * @return true if there are more elements.
          * @stable ICU 4.8
          */
         UBool hasNext() const;
@@ -351,7 +351,7 @@ public:
          *                  pass the U_SUCCESS() test, or else the function returns
          *                  immediately. Check for U_FAILURE() on output or use with
          *                  function chaining. (See User Guide for details.)
-         * @return TRUE if there is another element.
+         * @return true if there is another element.
          * @stable ICU 4.8
          */
         UBool next(UErrorCode &errorCode);
@@ -371,7 +371,7 @@ public:
         UBool truncateAndStop() {
             pos_=NULL;
             value_=-1;  // no real value for str
-            return TRUE;
+            return true;
         }
 
         const char16_t *branchNext(const char16_t *pos, int32_t length, UErrorCode &errorCode);

--- a/icu4c/source/common/unicode/ucharstriebuilder.h
+++ b/icu4c/source/common/unicode/ucharstriebuilder.h
@@ -148,7 +148,7 @@ private:
     virtual int32_t skipElementsBySomeUnits(int32_t i, int32_t unitIndex, int32_t count) const;
     virtual int32_t indexOfElementWithNextUnit(int32_t i, int32_t unitIndex, char16_t unit) const;
 
-    virtual UBool matchNodesCanHaveValues() const { return TRUE; }
+    virtual UBool matchNodesCanHaveValues() const { return true; }
 
     virtual int32_t getMaxBranchLinearSubNodeLength() const { return UCharsTrie::kMaxBranchLinearSubNodeLength; }
     virtual int32_t getMinLinearMatch() const { return UCharsTrie::kMinLinearMatch; }

--- a/icu4c/source/common/unicode/uchriter.h
+++ b/icu4c/source/common/unicode/uchriter.h
@@ -274,11 +274,11 @@ public:
   virtual UChar32       next32PostInc(void);
 
   /**
-   * Returns FALSE if there are no more code units or code points
+   * Returns false if there are no more code units or code points
    * at or after the current position in the iteration range.
    * This is used with nextPostInc() or next32PostInc() in forward
    * iteration.
-   * @return FALSE if there are no more code units or code points
+   * @return false if there are no more code units or code points
    * at or after the current position in the iteration range.
    * @stable ICU 2.0
    */
@@ -303,11 +303,11 @@ public:
   virtual UChar32       previous32(void);
 
   /**
-   * Returns FALSE if there are no more code units or code points
+   * Returns false if there are no more code units or code points
    * before the current position in the iteration range.
    * This is used with previous() or previous32() in backward
    * iteration.
-   * @return FALSE if there are no more code units or code points
+   * @return false if there are no more code units or code points
    * before the current position in the iteration range.
    * @stable ICU 2.0
    */

--- a/icu4c/source/common/unicode/ucnv.h
+++ b/icu4c/source/common/unicode/ucnv.h
@@ -918,7 +918,7 @@ ucnv_getType(const UConverter * converter);
  * Gets the "starter" (lead) bytes for converters of type MBCS.
  * Will fill in an <TT>U_ILLEGAL_ARGUMENT_ERROR</TT> if converter passed in
  * is not MBCS. Fills in an array of type UBool, with the value of the byte
- * as offset to the array. For example, if (starters[0x20] == TRUE) at return,
+ * as offset to the array. For example, if (starters[0x20] == true) at return,
  * it means that the byte 0x20 is a starter byte in this converter.
  * Context pointers are always owned by the caller.
  *
@@ -1103,7 +1103,7 @@ ucnv_setFromUCallBack (UConverter * converter,
  *  consumed. At that point, the caller should reset the source and
  *  sourceLimit pointers to point to the next chunk.
  *
- * At the end of the stream (flush==TRUE), the input is completely consumed
+ * At the end of the stream (flush==true), the input is completely consumed
  * when *source==sourceLimit and no error code is set.
  * The converter object is then automatically reset by this function.
  * (This means that a converter need not be reset explicitly between data
@@ -1128,9 +1128,9 @@ ucnv_setFromUCallBack (UConverter * converter,
  * e.g: <TT>offsets[3]</TT> is equal to 6, it means that the <TT>target[3]</TT> was a result of transcoding <TT>source[6]</TT>
  * For output data carried across calls, and other data without a specific source character
  * (such as from escape sequences or callbacks)  -1 will be placed for offsets.
- * @param flush set to <TT>TRUE</TT> if the current source buffer is the last available
- * chunk of the source, <TT>FALSE</TT> otherwise. Note that if a failing status is returned,
- * this function may have to be called multiple times with flush set to <TT>TRUE</TT> until
+ * @param flush set to <TT>true</TT> if the current source buffer is the last available
+ * chunk of the source, <TT>false</TT> otherwise. Note that if a failing status is returned,
+ * this function may have to be called multiple times with flush set to <TT>true</TT> until
  * the source buffer is consumed.
  * @param err the error status.  <TT>U_ILLEGAL_ARGUMENT_ERROR</TT> will be set if the
  * converter is <TT>NULL</TT>.
@@ -1172,7 +1172,7 @@ ucnv_fromUnicode (UConverter * converter,
  *  consumed. At that point, the caller should reset the source and
  *  sourceLimit pointers to point to the next chunk.
  *
- * At the end of the stream (flush==TRUE), the input is completely consumed
+ * At the end of the stream (flush==true), the input is completely consumed
  * when *source==sourceLimit and no error code is set
  * The converter object is then automatically reset by this function.
  * (This means that a converter need not be reset explicitly between data
@@ -1196,9 +1196,9 @@ ucnv_fromUnicode (UConverter * converter,
  * e.g: <TT>offsets[3]</TT> is equal to 6, it means that the <TT>target[3]</TT> was a result of transcoding <TT>source[6]</TT>
  * For output data carried across calls, and other data without a specific source character
  * (such as from escape sequences or callbacks)  -1 will be placed for offsets.
- * @param flush set to <TT>TRUE</TT> if the current source buffer is the last available
- * chunk of the source, <TT>FALSE</TT> otherwise. Note that if a failing status is returned,
- * this function may have to be called multiple times with flush set to <TT>TRUE</TT> until
+ * @param flush set to <TT>true</TT> if the current source buffer is the last available
+ * chunk of the source, <TT>false</TT> otherwise. Note that if a failing status is returned,
+ * this function may have to be called multiple times with flush set to <TT>true</TT> until
  * the source buffer is consumed.
  * @param err the error status.  <TT>U_ILLEGAL_ARGUMENT_ERROR</TT> will be set if the
  * converter is <TT>NULL</TT>.
@@ -1298,7 +1298,7 @@ ucnv_toUChars(UConverter *cnv,
  * - Convenient.
  *
  * Limitations compared to ucnv_toUnicode():
- * - Always assumes flush=TRUE.
+ * - Always assumes flush=true.
  *   This makes ucnv_getNextUChar() unsuitable for "streaming" conversion,
  *   that is, for where the input is supplied in multiple buffers,
  *   because ucnv_getNextUChar() will assume the end of the input at the end
@@ -1309,7 +1309,7 @@ ucnv_toUChars(UConverter *cnv,
  * ucnv_getNextUChar() uses the current state of the converter
  * (unlike ucnv_toUChars() which always resets first).
  * However, if ucnv_getNextUChar() is called after ucnv_toUnicode()
- * stopped in the middle of a character sequence (with flush=FALSE),
+ * stopped in the middle of a character sequence (with flush=false),
  * then ucnv_getNextUChar() will always use the slower ucnv_toUnicode()
  * internally until the next character boundary.
  * (This is new in ICU 2.6. In earlier releases, ucnv_getNextUChar() had to
@@ -1388,7 +1388,7 @@ ucnv_getNextUChar(UConverter * converter,
  *
  * ucnv_convertEx() also provides further convenience:
  * - an option to reset the converters at the beginning
- *   (if reset==TRUE, see parameters;
+ *   (if reset==true, see parameters;
  *    also sets *pivotTarget=*pivotSource=pivotStart)
  * - allow NUL-terminated input
  *   (only a single NUL byte, will not work for charsets with multi-byte NULs)
@@ -1445,7 +1445,7 @@ ucnv_getNextUChar(UConverter * converter,
  *                    &target, u8+capacity,
  *                    &s, s+length,
  *                    NULL, NULL, NULL, NULL,
- *                    TRUE, TRUE,
+ *                    true, true,
  *                    pErrorCode);
  *
  *     myReleaseCachedUTF8Converter(utf8Cnv);
@@ -1477,7 +1477,7 @@ ucnv_getNextUChar(UConverter * converter,
  *                      It must be pivotStart<=*pivotSource<=*pivotTarget<=pivotLimit
  *                      and pivotStart<pivotLimit (unless pivotStart==NULL).
  * @param pivotLimit    Pointer to the first unit after the pivot buffer.
- * @param reset         If TRUE, then ucnv_resetToUnicode(sourceCnv) and
+ * @param reset         If true, then ucnv_resetToUnicode(sourceCnv) and
  *                      ucnv_resetFromUnicode(targetCnv) are called, and the
  *                      pivot pointers are reset (*pivotTarget=*pivotSource=pivotStart).
  * @param flush         If true, indicates the end of the input.
@@ -1921,8 +1921,8 @@ ucnv_fixFileSeparator(const UConverter *cnv, UChar *source, int32_t sourceLen);
  * Determines if the converter contains ambiguous mappings of the same
  * character or not.
  * @param cnv the converter to be tested
- * @return TRUE if the converter contains ambiguous mapping of the same
- * character, FALSE otherwise.
+ * @return true if the converter contains ambiguous mapping of the same
+ * character, false otherwise.
  * @stable ICU 2.0
  */
 U_STABLE UBool U_EXPORT2
@@ -1938,8 +1938,8 @@ ucnv_isAmbiguous(const UConverter *cnv);
  * http://www.icu-project.org/userguide/conversion-data.html#ucmformat
  *
  * @param cnv The converter to set the fallback mapping usage on.
- * @param usesFallback TRUE if the user wants the converter to take advantage of the fallback
- * mapping, FALSE otherwise.
+ * @param usesFallback true if the user wants the converter to take advantage of the fallback
+ * mapping, false otherwise.
  * @stable ICU 2.0
  * @see ucnv_usesFallback
  */
@@ -1951,7 +1951,7 @@ ucnv_setFallback(UConverter *cnv, UBool usesFallback);
  * This flag has restrictions, see ucnv_setFallback().
  *
  * @param cnv The converter to be tested
- * @return TRUE if the converter uses fallback, FALSE otherwise.
+ * @return true if the converter uses fallback, false otherwise.
  * @stable ICU 2.0
  * @see ucnv_setFallback
  */
@@ -2030,10 +2030,10 @@ ucnv_toUCountPending(const UConverter* cnv, UErrorCode* status);
  * but a UTF-32 converter encodes each code point with 4 bytes.
  * Note: This method is not intended to be used to determine whether the charset has a
  * fixed ratio of bytes to Unicode codes <i>units</i> for any particular Unicode encoding form.
- * FALSE is returned with the UErrorCode if error occurs or cnv is NULL.
+ * false is returned with the UErrorCode if error occurs or cnv is NULL.
  * @param cnv       The converter to be tested
  * @param status    ICU error code in/out paramter
- * @return TRUE if the converter is fixed-width
+ * @return true if the converter is fixed-width
  * @stable ICU 4.8
  */
 U_STABLE UBool U_EXPORT2

--- a/icu4c/source/common/unicode/ucnv_err.h
+++ b/icu4c/source/common/unicode/ucnv_err.h
@@ -193,7 +193,7 @@ typedef enum {
  */
 typedef struct {
     uint16_t size;              /**< The size of this struct. @stable ICU 2.0 */
-    UBool flush;                /**< The internal state of converter will be reset and data flushed if set to TRUE. @stable ICU 2.0    */
+    UBool flush;                /**< The internal state of converter will be reset and data flushed if set to true. @stable ICU 2.0    */
     UConverter *converter;      /**< Pointer to the converter that is opened and to which this struct is passed as an argument. @stable ICU 2.0  */
     const UChar *source;        /**< Pointer to the source source buffer. @stable ICU 2.0    */
     const UChar *sourceLimit;   /**< Pointer to the limit (end + 1) of source buffer. @stable ICU 2.0    */
@@ -209,7 +209,7 @@ typedef struct {
  */
 typedef struct {
     uint16_t size;              /**< The size of this struct   @stable ICU 2.0 */
-    UBool flush;                /**< The internal state of converter will be reset and data flushed if set to TRUE. @stable ICU 2.0   */
+    UBool flush;                /**< The internal state of converter will be reset and data flushed if set to true. @stable ICU 2.0   */
     UConverter *converter;      /**< Pointer to the converter that is opened and to which this struct is passed as an argument. @stable ICU 2.0 */
     const char *source;         /**< Pointer to the source source buffer. @stable ICU 2.0    */
     const char *sourceLimit;    /**< Pointer to the limit (end + 1) of source buffer. @stable ICU 2.0    */

--- a/icu4c/source/common/unicode/ucurr.h
+++ b/icu4c/source/common/unicode/ucurr.h
@@ -167,7 +167,7 @@ ucurr_register(const UChar* isoCode,
  * restored.
  * @param key the registry key returned by a previous call to ucurr_register
  * @param status the in/out status code, no special meanings are assigned
- * @return TRUE if the currency for this key was successfully unregistered
+ * @return true if the currency for this key was successfully unregistered
  * @stable ICU 2.6
  */
 U_STABLE UBool U_EXPORT2
@@ -181,7 +181,7 @@ ucurr_unregister(UCurrRegistryKey key, UErrorCode* status);
  * @param currency null-terminated 3-letter ISO 4217 code
  * @param locale locale in which to display currency
  * @param nameStyle selector for which kind of name to return
- * @param isChoiceFormat always set to FALSE, or can be NULL;
+ * @param isChoiceFormat always set to false, or can be NULL;
  *     display names are static strings;
  *     since ICU 4.4, ChoiceFormat patterns are no longer supported
  * @param len fill-in parameter to receive length of result
@@ -205,7 +205,7 @@ ucurr_getName(const UChar* currency,
  * currency object in the en_US locale is "US dollar" or "US dollars".
  * @param currency null-terminated 3-letter ISO 4217 code
  * @param locale locale in which to display currency
- * @param isChoiceFormat always set to FALSE, or can be NULL;
+ * @param isChoiceFormat always set to false, or can be NULL;
  *     display names are static strings;
  *     since ICU 4.4, ChoiceFormat patterns are no longer supported
  * @param pluralCount plural count
@@ -373,7 +373,7 @@ ucurr_openISOCurrencies(uint32_t currType, UErrorCode *pErrorCode);
   * @param errorCode 
   *            ICU error code 
    * 
-  * @return TRUE if the given ISO 4217 3-letter code is supported on the specified date range. 
+  * @return true if the given ISO 4217 3-letter code is supported on the specified date range. 
   * 
   * @stable ICU 4.8 
   */ 

--- a/icu4c/source/common/unicode/udata.h
+++ b/icu4c/source/common/unicode/udata.h
@@ -169,8 +169,8 @@ typedef struct UDataMemory UDataMemory;
  * @param pInfo A pointer to the <code>UDataInfo</code> structure
  *              of data that has been loaded and will be returned
  *              by <code>udata_openChoice()</code> if this function
- *              returns <code>TRUE</code>.
- * @return TRUE if the current data memory is acceptable
+ *              returns <code>true</code>.
+ * @return true if the current data memory is acceptable
  * @stable ICU 2.0
  */
 typedef UBool U_CALLCONV
@@ -242,7 +242,7 @@ udata_open(const char *path, const char *type, const char *name,
  *             This may be <code>NULL</code> or empty.
  * @param name A string that specifies the name of the data.
  * @param isAcceptable This function is called to verify that loaded data
- *                     is useful for the client code. If it returns FALSE
+ *                     is useful for the client code. If it returns false
  *                     for all data items, then <code>udata_openChoice()</code>
  *                     will return with an error.
  * @param context Arbitrary parameter to be passed into isAcceptable.

--- a/icu4c/source/common/unicode/uidna.h
+++ b/icu4c/source/common/unicode/uidna.h
@@ -23,6 +23,7 @@
 
 #if !UCONFIG_NO_IDNA
 
+#include <stdbool.h>
 #include "unicode/parseerr.h"
 
 #if U_SHOW_CPLUSPLUS_API
@@ -185,7 +186,7 @@ typedef struct UIDNAInfo {
     /** sizeof(UIDNAInfo) @stable ICU 4.6 */
     int16_t size;
     /**
-     * Set to TRUE if transitional and nontransitional processing produce different results.
+     * Set to true if transitional and nontransitional processing produce different results.
      * For details see C++ IDNAInfo::isTransitionalDifferent().
      * @stable ICU 4.6
      */
@@ -207,7 +208,7 @@ typedef struct UIDNAInfo {
  */
 #define UIDNA_INFO_INITIALIZER { \
     (int16_t)sizeof(UIDNAInfo), \
-    FALSE, FALSE, \
+    false, false, \
     0, 0, 0 }
 
 /**

--- a/icu4c/source/common/unicode/uloc.h
+++ b/icu4c/source/common/unicode/uloc.h
@@ -1010,15 +1010,15 @@ uloc_setKeywordValue(const char* keywordName,
 /**
  * Returns whether the locale's script is written right-to-left.
  * If there is no script subtag, then the likely script is used, see uloc_addLikelySubtags().
- * If no likely script is known, then FALSE is returned.
+ * If no likely script is known, then false is returned.
  *
  * A script is right-to-left according to the CLDR script metadata
  * which corresponds to whether the script's letters have Bidi_Class=R or AL.
  *
- * Returns TRUE for "ar" and "en-Hebr", FALSE for "zh" and "fa-Cyrl".
+ * Returns true for "ar" and "en-Hebr", false for "zh" and "fa-Cyrl".
  *
  * @param locale input locale ID
- * @return TRUE if the locale's script is written right-to-left
+ * @return true if the locale's script is written right-to-left
  * @stable ICU 54
  */
 U_STABLE UBool U_EXPORT2
@@ -1270,10 +1270,10 @@ uloc_forLanguageTag(const char* langtag,
 /**
  * Returns a well-formed language tag for this locale ID. 
  * <p> 
- * <b>Note</b>: When <code>strict</code> is FALSE, any locale
+ * <b>Note</b>: When <code>strict</code> is false, any locale
  * fields which do not satisfy the BCP47 syntax requirement will
  * be omitted from the result.  When <code>strict</code> is
- * TRUE, this function sets U_ILLEGAL_ARGUMENT_ERROR to the
+ * true, this function sets U_ILLEGAL_ARGUMENT_ERROR to the
  * <code>err</code> if any locale fields do not satisfy the
  * BCP47 syntax requirement.
  * @param localeID  the input locale ID

--- a/icu4c/source/common/unicode/umachine.h
+++ b/icu4c/source/common/unicode/umachine.h
@@ -49,6 +49,7 @@
  * ANSI C headers:
  * stddef.h defines wchar_t
  */
+#include <stdbool.h>
 #include <stddef.h>
 
 /*==========================================================================*/
@@ -170,11 +171,11 @@
 
 /**
  * \def UPRV_BLOCK_MACRO_END
- * Defined as "while (FALSE)" by default.
+ * Defined as "while (false)" by default.
  * @internal
  */
 #ifndef UPRV_BLOCK_MACRO_END
-#define UPRV_BLOCK_MACRO_END while (FALSE)
+#define UPRV_BLOCK_MACRO_END while (false)
 #endif
 
 /*==========================================================================*/
@@ -257,18 +258,59 @@
 /* Boolean data type                                                        */
 /*==========================================================================*/
 
-/** The ICU boolean type @stable ICU 2.0 */
+/**
+ * The ICU boolean type, a signed-byte integer.
+ * ICU-specific for historical reasons: The C and C++ standards used to not define type bool.
+ * Also provides a fixed type definition, as opposed to
+ * type bool whose details (e.g., sizeof) may vary by compiler and between C and C++.
+ *
+ * @stable ICU 2.0
+ */
 typedef int8_t UBool;
 
+/**
+ * \def U_DEFINE_FALSE_AND_TRUE
+ * Normally turns off defining macros FALSE=0 & TRUE=1 in public ICU headers.
+ * These obsolete macros sometimes break compilation of other code that
+ * defines enum constants or similar with these names.
+ * C++ has long defined bool/false/true.
+ * C99 also added definitions for these, although as macros; see stdbool.h.
+ *
+ * You may transitionally define U_DEFINE_FALSE_AND_TRUE=1 if you need time to migrate code.
+ *
+ * @internal ICU 68
+ */
+#ifdef U_DEFINE_FALSE_AND_TRUE
+    // Use the predefined value.
+#elif defined(U_COMBINED_IMPLEMENTATION) || \
+        defined(U_COMMON_IMPLEMENTATION) || defined(U_I18N_IMPLEMENTATION) || \
+        defined(U_IO_IMPLEMENTATION) || defined(U_LAYOUTEX_IMPLEMENTATION) || \
+        defined(U_TOOLUTIL_IMPLEMENTATION)
+    // Inside ICU: Keep FALSE & TRUE available.
+#   define U_DEFINE_FALSE_AND_TRUE 1
+#else
+    // Outside ICU: Avoid collision with non-macro definitions of FALSE & TRUE.
+#   define U_DEFINE_FALSE_AND_TRUE 0
+#endif
+
+#if U_DEFINE_FALSE_AND_TRUE || defined(U_IN_DOXYGEN)
 #ifndef TRUE
-/** The TRUE value of a UBool @stable ICU 2.0 */
+/**
+ * The TRUE value of a UBool.
+ *
+ * @deprecated ICU 68 Use standard "true" instead.
+ */
 #   define TRUE  1
 #endif
 #ifndef FALSE
-/** The FALSE value of a UBool @stable ICU 2.0 */
+/**
+ * The FALSE value of a UBool.
+ *
+ * @deprecated ICU 68 Use standard "false" instead.
+ */
 #   define FALSE 0
 #endif
-
+#endif  // U_DEFINE_FALSE_AND_TRUE
 
 /*==========================================================================*/
 /* Unicode data types                                                       */

--- a/icu4c/source/common/unicode/unimatch.h
+++ b/icu4c/source/common/unicode/unimatch.h
@@ -115,11 +115,11 @@ public:
      * considered for matching will be text.charAt(limit-1) in the
      * forward direction or text.charAt(limit+1) in the backward
      * direction.
-     * @param incremental if TRUE, then assume further characters may
+     * @param incremental if true, then assume further characters may
      * be inserted at limit and check for partial matching.  Otherwise
      * assume the text as given is complete.
      * @return a match degree value indicating a full match, a partial
-     * match, or a mismatch.  If incremental is FALSE then
+     * match, or a mismatch.  If incremental is false then
      * U_PARTIAL_MATCH should never be returned.
      * @stable ICU 2.4
      */
@@ -134,17 +134,17 @@ public:
      * will produce another matcher that is equal to this one.
      * @param result the string to receive the pattern.  Previous
      * contents will be deleted.
-     * @param escapeUnprintable if TRUE then convert unprintable
+     * @param escapeUnprintable if true then convert unprintable
      * character to their hex escape representations, \\uxxxx or
      * \\Uxxxxxxxx.  Unprintable characters are those other than
      * U+000A, U+0020..U+007E.
      * @stable ICU 2.4
      */
     virtual UnicodeString& toPattern(UnicodeString& result,
-                                     UBool escapeUnprintable = FALSE) const = 0;
+                                     UBool escapeUnprintable = false) const = 0;
 
     /**
-     * Returns TRUE if this matcher will match a character c, where c
+     * Returns true if this matcher will match a character c, where c
      * & 0xFF == v, at offset, in the forward direction (with limit >
      * offset).  This is used by <tt>RuleBasedTransliterator</tt> for
      * indexing.

--- a/icu4c/source/common/unicode/uniset.h
+++ b/icu4c/source/common/unicode/uniset.h
@@ -325,7 +325,7 @@ public:
      * A bogus set has no value. It is different from an empty set.
      * It can be used to indicate that no set value is available.
      *
-     * @return TRUE if the set is bogus/invalid, FALSE otherwise
+     * @return true if the set is bogus/invalid, false otherwise
      * @see setToBogus()
      * @stable ICU 4.0
      */
@@ -333,7 +333,7 @@ public:
 
     /**
      * Make this UnicodeSet object invalid.
-     * The string will test TRUE with isBogus().
+     * The string will test true with isBogus().
      *
      * A bogus set has no value. It is different from an empty set.
      * It can be used to indicate that no set value is available.
@@ -563,7 +563,7 @@ public:
     /**
      * Determines whether the set has been frozen (made immutable) or not.
      * See the ICU4J Freezable interface for details.
-     * @return TRUE/FALSE for whether the set has been frozen
+     * @return true/false for whether the set has been frozen
      * @see freeze
      * @see cloneAsThawed
      * @stable ICU 3.8
@@ -700,14 +700,14 @@ public:
      * A frozen set will not be modified.
      * @param result the string to receive the rules.  Previous
      * contents will be deleted.
-     * @param escapeUnprintable if TRUE then convert unprintable
+     * @param escapeUnprintable if true then convert unprintable
      * character to their hex escape representations, \\uxxxx or
      * \\Uxxxxxxxx.  Unprintable characters are those other than
      * U+000A, U+0020..U+007E.
      * @stable ICU 2.0
      */
     virtual UnicodeString& toPattern(UnicodeString& result,
-                             UBool escapeUnprintable = FALSE) const;
+                                     UBool escapeUnprintable = false) const;
 
     /**
      * Modifies this set to contain those code points which have the given value
@@ -1636,7 +1636,7 @@ private:
     static const UnicodeSet* getInclusions(int32_t src, UErrorCode &status);
 
     /**
-     * A filter that returns TRUE if the given code point should be
+     * A filter that returns true if the given code point should be
      * included in the UnicodeSet being constructed.
      */
     typedef UBool (*Filter)(UChar32 codePoint, void* context);

--- a/icu4c/source/common/unicode/unistr.h
+++ b/icu4c/source/common/unicode/unistr.h
@@ -113,9 +113,9 @@ class UnicodeStringAppendable;  // unicode/appendable.h
  * @stable ICU 2.0
  */
 #if !U_CHAR16_IS_TYPEDEF
-# define UNICODE_STRING(cs, _length) icu::UnicodeString(TRUE, u ## cs, _length)
+# define UNICODE_STRING(cs, _length) icu::UnicodeString(true, u ## cs, _length)
 #else
-# define UNICODE_STRING(cs, _length) icu::UnicodeString(TRUE, (const char16_t*)u ## cs, _length)
+# define UNICODE_STRING(cs, _length) icu::UnicodeString(true, (const char16_t*)u ## cs, _length)
 #endif
 
 /**
@@ -320,8 +320,8 @@ public:
   /**
    * Equality operator. Performs only bitwise comparison.
    * @param text The UnicodeString to compare to this one.
-   * @return TRUE if `text` contains the same characters as this one,
-   * FALSE otherwise.
+   * @return true if `text` contains the same characters as this one,
+   * false otherwise.
    * @stable ICU 2.0
    */
   inline UBool operator== (const UnicodeString& text) const;
@@ -329,8 +329,8 @@ public:
   /**
    * Inequality operator. Performs only bitwise comparison.
    * @param text The UnicodeString to compare to this one.
-   * @return FALSE if `text` contains the same characters as this one,
-   * TRUE otherwise.
+   * @return false if `text` contains the same characters as this one,
+   * true otherwise.
    * @stable ICU 2.0
    */
   inline UBool operator!= (const UnicodeString& text) const;
@@ -338,8 +338,8 @@ public:
   /**
    * Greater than operator. Performs only bitwise comparison.
    * @param text The UnicodeString to compare to this one.
-   * @return TRUE if the characters in this are bitwise
-   * greater than the characters in `text`, FALSE otherwise
+   * @return true if the characters in this are bitwise
+   * greater than the characters in `text`, false otherwise
    * @stable ICU 2.0
    */
   inline UBool operator> (const UnicodeString& text) const;
@@ -347,8 +347,8 @@ public:
   /**
    * Less than operator. Performs only bitwise comparison.
    * @param text The UnicodeString to compare to this one.
-   * @return TRUE if the characters in this are bitwise
-   * less than the characters in `text`, FALSE otherwise
+   * @return true if the characters in this are bitwise
+   * less than the characters in `text`, false otherwise
    * @stable ICU 2.0
    */
   inline UBool operator< (const UnicodeString& text) const;
@@ -356,8 +356,8 @@ public:
   /**
    * Greater than or equal operator. Performs only bitwise comparison.
    * @param text The UnicodeString to compare to this one.
-   * @return TRUE if the characters in this are bitwise
-   * greater than or equal to the characters in `text`, FALSE otherwise
+   * @return true if the characters in this are bitwise
+   * greater than or equal to the characters in `text`, false otherwise
    * @stable ICU 2.0
    */
   inline UBool operator>= (const UnicodeString& text) const;
@@ -365,8 +365,8 @@ public:
   /**
    * Less than or equal operator. Performs only bitwise comparison.
    * @param text The UnicodeString to compare to this one.
-   * @return TRUE if the characters in this are bitwise
-   * less than or equal to the characters in `text`, FALSE otherwise
+   * @return true if the characters in this are bitwise
+   * less than or equal to the characters in `text`, false otherwise
    * @stable ICU 2.0
    */
   inline UBool operator<= (const UnicodeString& text) const;
@@ -855,8 +855,8 @@ public:
   /**
    * Determine if this starts with the characters in `text`
    * @param text The text to match.
-   * @return TRUE if this starts with the characters in `text`,
-   * FALSE otherwise
+   * @return true if this starts with the characters in `text`,
+   * false otherwise
    * @stable ICU 2.0
    */
   inline UBool startsWith(const UnicodeString& text) const;
@@ -867,8 +867,8 @@ public:
    * @param srcText The text to match.
    * @param srcStart the offset into `srcText` to start matching
    * @param srcLength the number of characters in `srcText` to match
-   * @return TRUE if this starts with the characters in `text`,
-   * FALSE otherwise
+   * @return true if this starts with the characters in `text`,
+   * false otherwise
    * @stable ICU 2.0
    */
   inline UBool startsWith(const UnicodeString& srcText,
@@ -879,8 +879,8 @@ public:
    * Determine if this starts with the characters in `srcChars`
    * @param srcChars The characters to match.
    * @param srcLength the number of characters in `srcChars`
-   * @return TRUE if this starts with the characters in `srcChars`,
-   * FALSE otherwise
+   * @return true if this starts with the characters in `srcChars`,
+   * false otherwise
    * @stable ICU 2.0
    */
   inline UBool startsWith(ConstChar16Ptr srcChars,
@@ -892,7 +892,7 @@ public:
    * @param srcChars The characters to match.
    * @param srcStart the offset into `srcText` to start matching
    * @param srcLength the number of characters in `srcChars` to match
-   * @return TRUE if this ends with the characters in `srcChars`, FALSE otherwise
+   * @return true if this ends with the characters in `srcChars`, false otherwise
    * @stable ICU 2.0
    */
   inline UBool startsWith(const char16_t *srcChars,
@@ -902,8 +902,8 @@ public:
   /**
    * Determine if this ends with the characters in `text`
    * @param text The text to match.
-   * @return TRUE if this ends with the characters in `text`,
-   * FALSE otherwise
+   * @return true if this ends with the characters in `text`,
+   * false otherwise
    * @stable ICU 2.0
    */
   inline UBool endsWith(const UnicodeString& text) const;
@@ -914,8 +914,8 @@ public:
    * @param srcText The text to match.
    * @param srcStart the offset into `srcText` to start matching
    * @param srcLength the number of characters in `srcText` to match
-   * @return TRUE if this ends with the characters in `text`,
-   * FALSE otherwise
+   * @return true if this ends with the characters in `text`,
+   * false otherwise
    * @stable ICU 2.0
    */
   inline UBool endsWith(const UnicodeString& srcText,
@@ -926,8 +926,8 @@ public:
    * Determine if this ends with the characters in `srcChars`
    * @param srcChars The characters to match.
    * @param srcLength the number of characters in `srcChars`
-   * @return TRUE if this ends with the characters in `srcChars`,
-   * FALSE otherwise
+   * @return true if this ends with the characters in `srcChars`,
+   * false otherwise
    * @stable ICU 2.0
    */
   inline UBool endsWith(ConstChar16Ptr srcChars,
@@ -939,8 +939,8 @@ public:
    * @param srcChars The characters to match.
    * @param srcStart the offset into `srcText` to start matching
    * @param srcLength the number of characters in `srcChars` to match
-   * @return TRUE if this ends with the characters in `srcChars`,
-   * FALSE otherwise
+   * @return true if this ends with the characters in `srcChars`,
+   * false otherwise
    * @stable ICU 2.0
    */
   inline UBool endsWith(const char16_t *srcChars,
@@ -1804,7 +1804,7 @@ public:
 
   /**
    * Determine if this string is empty.
-   * @return TRUE if this string contains 0 characters, FALSE otherwise.
+   * @return true if this string contains 0 characters, false otherwise.
    * @stable ICU 2.0
    */
   inline UBool isEmpty(void) const;
@@ -1832,12 +1832,12 @@ public:
   /**
    * Determine if this object contains a valid string.
    * A bogus string has no value. It is different from an empty string,
-   * although in both cases isEmpty() returns TRUE and length() returns 0.
+   * although in both cases isEmpty() returns true and length() returns 0.
    * setToBogus() and isBogus() can be used to indicate that no string value is available.
    * For a bogus string, getBuffer() and getTerminatedBuffer() return NULL, and
    * length() returns 0.
    *
-   * @return TRUE if the string is bogus/invalid, FALSE otherwise
+   * @return true if the string is bogus/invalid, false otherwise
    * @see setToBogus()
    * @stable ICU 2.0
    */
@@ -2067,7 +2067,7 @@ public:
 
   /**
    * Make this UnicodeString object invalid.
-   * The string will test TRUE with isBogus().
+   * The string will test true with isBogus().
    *
    * A bogus string has no value. It is different from an empty string.
    * It can be used to indicate that no string value is available.
@@ -2459,7 +2459,7 @@ public:
 
   /**
    * Replaceable API
-   * @return TRUE if it has MetaData
+   * @return true if it has MetaData
    * @stable ICU 2.4
    */
   virtual UBool hasMetaData() const;
@@ -2590,7 +2590,7 @@ public:
    * @param targetLength the desired length of the string
    * @param padChar the character to use for padding. Defaults to
    * space (U+0020)
-   * @return TRUE if the text was padded, FALSE otherwise.
+   * @return true if the text was padded, false otherwise.
    * @stable ICU 2.0
    */
   UBool padLeading(int32_t targetLength,
@@ -2604,7 +2604,7 @@ public:
    * @param targetLength the desired length of the string
    * @param padChar the character to use for padding. Defaults to
    * space (U+0020)
-   * @return TRUE if the text was padded, FALSE otherwise.
+   * @return true if the text was padded, false otherwise.
    * @stable ICU 2.0
    */
   UBool padTrailing(int32_t targetLength,
@@ -2613,7 +2613,7 @@ public:
   /**
    * Truncate this UnicodeString to the `targetLength`.
    * @param targetLength the desired length of this UnicodeString.
-   * @return TRUE if the text was truncated, FALSE otherwise
+   * @return true if the text was truncated, false otherwise
    * @stable ICU 2.0
    */
   inline UBool truncate(int32_t targetLength);
@@ -3615,7 +3615,7 @@ private:
   void unBogus();
 
   // implements assigment operator, copy constructor, and fastCopyFrom()
-  UnicodeString &copyFrom(const UnicodeString &src, UBool fastCopy=FALSE);
+  UnicodeString &copyFrom(const UnicodeString &src, UBool fastCopy=false);
 
   // Copies just the fields without memory management.
   void copyFieldsFrom(UnicodeString &src, UBool setSrcToBogus) U_NOEXCEPT;
@@ -3668,13 +3668,13 @@ private:
    * the buffer is refCounted (shared), and refCount>1, or
    * the buffer is too small.
    *
-   * Return FALSE if memory could not be allocated.
+   * Return false if memory could not be allocated.
    */
   UBool cloneArrayIfNeeded(int32_t newCapacity = -1,
                             int32_t growCapacity = -1,
-                            UBool doCopyArray = TRUE,
+                            UBool doCopyArray = true,
                             int32_t **pBufferToDelete = 0,
-                            UBool forceClone = FALSE);
+                            UBool forceClone = false);
 
   /**
    * Common function for UnicodeString case mappings.
@@ -4732,12 +4732,12 @@ UnicodeString::truncate(int32_t targetLength)
   if(isBogus() && targetLength == 0) {
     // truncate(0) of a bogus string makes the string empty and non-bogus
     unBogus();
-    return FALSE;
+    return false;
   } else if((uint32_t)targetLength < (uint32_t)length()) {
     setLength(targetLength);
-    return TRUE;
+    return true;
   } else {
-    return FALSE;
+    return false;
   }
 }
 

--- a/icu4c/source/common/unicode/unorm.h
+++ b/icu4c/source/common/unicode/unorm.h
@@ -274,7 +274,7 @@ unorm_quickCheckWithOptions(const UChar *src, int32_t srcLength,
  * never a "maybe".
  * For NFD, NFKD, and FCD, both functions work exactly the same.
  * For NFC and NFKC where quickCheck may return "maybe", this function will
- * perform further tests to arrive at a TRUE/FALSE result.
+ * perform further tests to arrive at a true/false result.
  *
  * @param src        String that is to be tested if it is in a normalization format.
  * @param srcLength  Length of source to test, or -1 if NUL-terminated.
@@ -358,10 +358,10 @@ unorm_isNormalizedWithOptions(const UChar *src, int32_t srcLength,
  * It is useful for operations like a normalizing transliterator, where one would
  * not want to replace a piece of text if it is not modified.
  *
- * If doNormalize==TRUE and pNeededToNormalize!=NULL then *pNeeded... is set TRUE
+ * If doNormalize==true and pNeededToNormalize!=NULL then *pNeeded... is set true
  * if the normalization was necessary.
  *
- * If doNormalize==FALSE then *pNeededToNormalize will be set to FALSE.
+ * If doNormalize==false then *pNeededToNormalize will be set to false.
  *
  * If the buffer overflows, then *pNeededToNormalize will be undefined;
  * essentially, whenever U_FAILURE is true (like in buffer overflows), this result
@@ -373,11 +373,11 @@ unorm_isNormalizedWithOptions(const UChar *src, int32_t srcLength,
  * @param mode The normalization mode.
  * @param options The normalization options, ORed together (0 for no options).
  * @param doNormalize Indicates if the source text up to the next boundary
- *                    is to be normalized (TRUE) or just copied (FALSE).
+ *                    is to be normalized (true) or just copied (false).
  * @param pNeededToNormalize Output flag indicating if the normalization resulted in
  *                           different text from the input.
  *                           Not defined if an error occurs including buffer overflow.
- *                           Always FALSE if !doNormalize.
+ *                           Always false if !doNormalize.
  * @param pErrorCode ICU error code in/out parameter.
  *                   Must fulfill U_SUCCESS before the function call.
  * @return Length of output (number of UChars) when successful or buffer overflow.
@@ -406,11 +406,11 @@ unorm_next(UCharIterator *src,
  * @param mode The normalization mode.
  * @param options The normalization options, ORed together (0 for no options).
  * @param doNormalize Indicates if the source text up to the next boundary
- *                    is to be normalized (TRUE) or just copied (FALSE).
+ *                    is to be normalized (true) or just copied (false).
  * @param pNeededToNormalize Output flag indicating if the normalization resulted in
  *                           different text from the input.
  *                           Not defined if an error occurs including buffer overflow.
- *                           Always FALSE if !doNormalize.
+ *                           Always false if !doNormalize.
  * @param pErrorCode ICU error code in/out parameter.
  *                   Must fulfill U_SUCCESS before the function call.
  * @return Length of output (number of UChars) when successful or buffer overflow.

--- a/icu4c/source/common/unicode/unorm2.h
+++ b/icu4c/source/common/unicode/unorm2.h
@@ -436,7 +436,7 @@ unorm2_getCombiningClass(const UNormalizer2 *norm2, UChar32 c);
  *                   pass the U_SUCCESS() test, or else the function returns
  *                   immediately. Check for U_FAILURE() on output or use with
  *                   function chaining. (See User Guide for details.)
- * @return TRUE if s is normalized
+ * @return true if s is normalized
  * @stable ICU 4.4
  */
 U_STABLE UBool U_EXPORT2
@@ -501,7 +501,7 @@ unorm2_spanQuickCheckYes(const UNormalizer2 *norm2,
  * For details see the Normalizer2 base class documentation.
  * @param norm2 UNormalizer2 instance
  * @param c character to test
- * @return TRUE if c has a normalization boundary before it
+ * @return true if c has a normalization boundary before it
  * @stable ICU 4.4
  */
 U_STABLE UBool U_EXPORT2
@@ -513,7 +513,7 @@ unorm2_hasBoundaryBefore(const UNormalizer2 *norm2, UChar32 c);
  * For details see the Normalizer2 base class documentation.
  * @param norm2 UNormalizer2 instance
  * @param c character to test
- * @return TRUE if c has a normalization boundary after it
+ * @return true if c has a normalization boundary after it
  * @stable ICU 4.4
  */
 U_STABLE UBool U_EXPORT2
@@ -524,7 +524,7 @@ unorm2_hasBoundaryAfter(const UNormalizer2 *norm2, UChar32 c);
  * For details see the Normalizer2 base class documentation.
  * @param norm2 UNormalizer2 instance
  * @param c character to test
- * @return TRUE if c is normalization-inert
+ * @return true if c is normalization-inert
  * @stable ICU 4.4
  */
 U_STABLE UBool U_EXPORT2

--- a/icu4c/source/common/unicode/ures.h
+++ b/icu4c/source/common/unicode/ures.h
@@ -386,10 +386,10 @@ ures_getString(const UResourceBundle* resourceBundle,
  * it may need to be copied, or transformed from UTF-16 using u_strToUTF8()
  * or equivalent.
  *
- * If forceCopy==TRUE, then the string is always written to the dest buffer
+ * If forceCopy==true, then the string is always written to the dest buffer
  * and dest is returned.
  *
- * If forceCopy==FALSE, then the string is returned as a pointer if possible,
+ * If forceCopy==false, then the string is returned as a pointer if possible,
  * without needing a dest buffer (it can be NULL). If the string needs to be
  * copied or transformed, then it may be placed into dest at an arbitrary offset.
  *
@@ -407,10 +407,10 @@ ures_getString(const UResourceBundle* resourceBundle,
  *               terminating NUL, even in case of U_BUFFER_OVERFLOW_ERROR.
  *               Can be NULL, meaning capacity=0 and the string length is not
  *               returned to the caller.
- * @param forceCopy If TRUE, then the output string will always be written to
+ * @param forceCopy If true, then the output string will always be written to
  *                  dest, with U_BUFFER_OVERFLOW_ERROR and
  *                  U_STRING_NOT_TERMINATED_WARNING set if appropriate.
- *                  If FALSE, then the dest buffer may or may not contain a
+ *                  If false, then the dest buffer may or may not contain a
  *                  copy of the string. dest may or may not be modified.
  *                  If a copy needs to be written, then the UErrorCode parameter
  *                  indicates overflow etc. as usual.
@@ -569,7 +569,7 @@ ures_resetIterator(UResourceBundle *resourceBundle);
  * Checks whether the given resource has another element to iterate over.
  *
  * @param resourceBundle a resource
- * @return TRUE if there are more elements, FALSE if there is no more elements
+ * @return true if there are more elements, false if there is no more elements
  * @stable ICU 2.0
  */
 U_STABLE UBool U_EXPORT2
@@ -651,10 +651,10 @@ ures_getStringByIndex(const UResourceBundle *resourceBundle,
  * it may need to be copied, or transformed from UTF-16 using u_strToUTF8()
  * or equivalent.
  *
- * If forceCopy==TRUE, then the string is always written to the dest buffer
+ * If forceCopy==true, then the string is always written to the dest buffer
  * and dest is returned.
  *
- * If forceCopy==FALSE, then the string is returned as a pointer if possible,
+ * If forceCopy==false, then the string is returned as a pointer if possible,
  * without needing a dest buffer (it can be NULL). If the string needs to be
  * copied or transformed, then it may be placed into dest at an arbitrary offset.
  *
@@ -673,10 +673,10 @@ ures_getStringByIndex(const UResourceBundle *resourceBundle,
  *               terminating NUL, even in case of U_BUFFER_OVERFLOW_ERROR.
  *               Can be NULL, meaning capacity=0 and the string length is not
  *               returned to the caller.
- * @param forceCopy If TRUE, then the output string will always be written to
+ * @param forceCopy If true, then the output string will always be written to
  *                  dest, with U_BUFFER_OVERFLOW_ERROR and
  *                  U_STRING_NOT_TERMINATED_WARNING set if appropriate.
- *                  If FALSE, then the dest buffer may or may not contain a
+ *                  If false, then the dest buffer may or may not contain a
  *                  copy of the string. dest may or may not be modified.
  *                  If a copy needs to be written, then the UErrorCode parameter
  *                  indicates overflow etc. as usual.
@@ -744,10 +744,10 @@ ures_getStringByKey(const UResourceBundle *resB,
  * it may need to be copied, or transformed from UTF-16 using u_strToUTF8()
  * or equivalent.
  *
- * If forceCopy==TRUE, then the string is always written to the dest buffer
+ * If forceCopy==true, then the string is always written to the dest buffer
  * and dest is returned.
  *
- * If forceCopy==FALSE, then the string is returned as a pointer if possible,
+ * If forceCopy==false, then the string is returned as a pointer if possible,
  * without needing a dest buffer (it can be NULL). If the string needs to be
  * copied or transformed, then it may be placed into dest at an arbitrary offset.
  *
@@ -766,10 +766,10 @@ ures_getStringByKey(const UResourceBundle *resB,
  *               terminating NUL, even in case of U_BUFFER_OVERFLOW_ERROR.
  *               Can be NULL, meaning capacity=0 and the string length is not
  *               returned to the caller.
- * @param forceCopy If TRUE, then the output string will always be written to
+ * @param forceCopy If true, then the output string will always be written to
  *                  dest, with U_BUFFER_OVERFLOW_ERROR and
  *                  U_STRING_NOT_TERMINATED_WARNING set if appropriate.
- *                  If FALSE, then the dest buffer may or may not contain a
+ *                  If false, then the dest buffer may or may not contain a
  *                  copy of the string. dest may or may not be modified.
  *                  If a copy needs to be written, then the UErrorCode parameter
  *                  indicates overflow etc. as usual.
@@ -814,7 +814,7 @@ ures_getUnicodeString(const UResourceBundle *resB, UErrorCode* status) {
     int32_t len = 0;
     const UChar *r = ures_getString(resB, &len, status);
     if(U_SUCCESS(*status)) {
-        result.setTo(TRUE, r, len);
+        result.setTo(true, r, len);
     } else {
         result.setToBogus();
     }
@@ -839,7 +839,7 @@ ures_getNextUnicodeString(UResourceBundle *resB, const char ** key, UErrorCode* 
     int32_t len = 0;
     const UChar* r = ures_getNextString(resB, &len, key, status);
     if(U_SUCCESS(*status)) {
-        result.setTo(TRUE, r, len);
+        result.setTo(true, r, len);
     } else {
         result.setToBogus();
     }
@@ -861,7 +861,7 @@ ures_getUnicodeStringByIndex(const UResourceBundle *resB, int32_t indexS, UError
     int32_t len = 0;
     const UChar* r = ures_getStringByIndex(resB, indexS, &len, status);
     if(U_SUCCESS(*status)) {
-        result.setTo(TRUE, r, len);
+        result.setTo(true, r, len);
     } else {
         result.setToBogus();
     }
@@ -884,7 +884,7 @@ ures_getUnicodeStringByKey(const UResourceBundle *resB, const char* key, UErrorC
     int32_t len = 0;
     const UChar* r = ures_getStringByKey(resB, key, &len, status);
     if(U_SUCCESS(*status)) {
-        result.setTo(TRUE, r, len);
+        result.setTo(true, r, len);
     } else {
         result.setToBogus();
     }

--- a/icu4c/source/common/unicode/uscript.h
+++ b/icu4c/source/common/unicode/uscript.h
@@ -562,7 +562,7 @@ uscript_getScript(UChar32 codepoint, UErrorCode *err);
  * For more information, see UAX #24: http://www.unicode.org/reports/tr24/.
  * @param c code point
  * @param sc script code
- * @return TRUE if sc is in Script_Extensions(c)
+ * @return true if sc is in Script_Extensions(c)
  * @stable ICU 49
  */
 U_STABLE UBool U_EXPORT2
@@ -672,34 +672,34 @@ U_STABLE UScriptUsage U_EXPORT2
 uscript_getUsage(UScriptCode script);
 
 /**
- * Returns TRUE if the script is written right-to-left.
+ * Returns true if the script is written right-to-left.
  * For example, Arab and Hebr.
  *
  * @param script script code
- * @return TRUE if the script is right-to-left
+ * @return true if the script is right-to-left
  * @stable ICU 51
  */
 U_STABLE UBool U_EXPORT2
 uscript_isRightToLeft(UScriptCode script);
 
 /**
- * Returns TRUE if the script allows line breaks between letters (excluding hyphenation).
+ * Returns true if the script allows line breaks between letters (excluding hyphenation).
  * Such a script typically requires dictionary-based line breaking.
  * For example, Hani and Thai.
  *
  * @param script script code
- * @return TRUE if the script allows line breaks between letters
+ * @return true if the script allows line breaks between letters
  * @stable ICU 51
  */
 U_STABLE UBool U_EXPORT2
 uscript_breaksBetweenLetters(UScriptCode script);
 
 /**
- * Returns TRUE if in modern (or most recent) usage of the script case distinctions are customary.
+ * Returns true if in modern (or most recent) usage of the script case distinctions are customary.
  * For example, Latn and Cyrl.
  *
  * @param script script code
- * @return TRUE if the script is cased
+ * @return true if the script is cased
  * @stable ICU 51
  */
 U_STABLE UBool U_EXPORT2

--- a/icu4c/source/common/unicode/uset.h
+++ b/icu4c/source/common/unicode/uset.h
@@ -161,7 +161,7 @@ typedef enum USetSpanCondition {
      * Continues a span() while there is no set element at the current position.
      * Increments by one code point at a time.
      * Stops before the first set element (character or string).
-     * (For code points only, this is like while contains(current)==FALSE).
+     * (For code points only, this is like while contains(current)==false).
      *
      * When span() returns, the substring between where it started and the position
      * it returned consists only of characters that are not in the set,
@@ -172,7 +172,7 @@ typedef enum USetSpanCondition {
     USET_SPAN_NOT_CONTAINED = 0,
     /**
      * Spans the longest substring that is a concatenation of set elements (characters or strings).
-     * (For characters only, this is like while contains(current)==TRUE).
+     * (For characters only, this is like while contains(current)==true).
      *
      * When span() returns, the substring between where it started and the position
      * it returned consists only of set elements (characters or strings) that are in the set.
@@ -188,7 +188,7 @@ typedef enum USetSpanCondition {
     /**
      * Continues a span() while there is a set element at the current position.
      * Increments by the longest matching element at each position.
-     * (For characters only, this is like while contains(current)==TRUE).
+     * (For characters only, this is like while contains(current)==true).
      *
      * When span() returns, the substring between where it started and the position
      * it returned consists only of set elements (characters or strings) that are in the set.
@@ -352,7 +352,7 @@ uset_clone(const USet *set);
  * Determines whether the set has been frozen (made immutable) or not.
  * See the ICU4J Freezable interface for details.
  * @param set the set
- * @return TRUE/FALSE for whether the set has been frozen
+ * @return true/false for whether the set has been frozen
  * @see uset_freeze
  * @see uset_cloneAsThawed
  * @stable ICU 3.8
@@ -517,7 +517,7 @@ uset_resemblesPattern(const UChar *pattern, int32_t patternLength,
  * @param set the set
  * @param result the string to receive the rules, may be NULL
  * @param resultCapacity the capacity of result, may be 0 if result is NULL
- * @param escapeUnprintable if TRUE then convert unprintable
+ * @param escapeUnprintable if true then convert unprintable
  * character to their hex escape representations, \\uxxxx or
  * \\Uxxxxxxxx.  Unprintable characters are those other than
  * U+000A, U+0020..U+007E.
@@ -533,7 +533,7 @@ uset_toPattern(const USet* set,
 
 /**
  * Adds the given character to the given USet.  After this call,
- * uset_contains(set, c) will return TRUE.
+ * uset_contains(set, c) will return true.
  * A frozen set will not be modified.
  * @param set the object to which to add the character
  * @param c the character to add
@@ -559,7 +559,7 @@ uset_addAll(USet* set, const USet *additionalSet);
 
 /**
  * Adds the given range of characters to the given USet.  After this call,
- * uset_contains(set, start, end) will return TRUE.
+ * uset_contains(set, start, end) will return true.
  * A frozen set will not be modified.
  * @param set the object to which to add the character
  * @param start the first character of the range to add, inclusive
@@ -571,7 +571,7 @@ uset_addRange(USet* set, UChar32 start, UChar32 end);
 
 /**
  * Adds the given string to the given USet.  After this call,
- * uset_containsString(set, str, strLen) will return TRUE.
+ * uset_containsString(set, str, strLen) will return true.
  * A frozen set will not be modified.
  * @param set the object to which to add the character
  * @param str the string to add
@@ -595,7 +595,7 @@ uset_addAllCodePoints(USet* set, const UChar *str, int32_t strLen);
 
 /**
  * Removes the given character from the given USet.  After this call,
- * uset_contains(set, c) will return FALSE.
+ * uset_contains(set, c) will return false.
  * A frozen set will not be modified.
  * @param set the object from which to remove the character
  * @param c the character to remove
@@ -606,7 +606,7 @@ uset_remove(USet* set, UChar32 c);
 
 /**
  * Removes the given range of characters from the given USet.  After this call,
- * uset_contains(set, start, end) will return FALSE.
+ * uset_contains(set, start, end) will return false.
  * A frozen set will not be modified.
  * @param set the object to which to add the character
  * @param start the first character of the range to remove, inclusive
@@ -618,7 +618,7 @@ uset_removeRange(USet* set, UChar32 start, UChar32 end);
 
 /**
  * Removes the given string to the given USet.  After this call,
- * uset_containsString(set, str, strLen) will return FALSE.
+ * uset_containsString(set, str, strLen) will return false.
  * A frozen set will not be modified.
  * @param set the object to which to add the character
  * @param str the string to remove
@@ -759,7 +759,7 @@ U_STABLE void U_EXPORT2
 uset_removeAllStrings(USet* set);
 
 /**
- * Returns TRUE if the given USet contains no characters and no
+ * Returns true if the given USet contains no characters and no
  * strings.
  * @param set the set
  * @return true if set is empty
@@ -769,7 +769,7 @@ U_STABLE UBool U_EXPORT2
 uset_isEmpty(const USet* set);
 
 /**
- * Returns TRUE if the given USet contains the given character.
+ * Returns true if the given USet contains the given character.
  * This function works faster with a frozen set.
  * @param set the set
  * @param c The codepoint to check for within the set
@@ -780,19 +780,19 @@ U_STABLE UBool U_EXPORT2
 uset_contains(const USet* set, UChar32 c);
 
 /**
- * Returns TRUE if the given USet contains all characters c
+ * Returns true if the given USet contains all characters c
  * where start <= c && c <= end.
  * @param set the set
  * @param start the first character of the range to test, inclusive
  * @param end the last character of the range to test, inclusive
- * @return TRUE if set contains the range
+ * @return true if set contains the range
  * @stable ICU 2.2
  */
 U_STABLE UBool U_EXPORT2
 uset_containsRange(const USet* set, UChar32 start, UChar32 end);
 
 /**
- * Returns TRUE if the given USet contains the given string.
+ * Returns true if the given USet contains the given string.
  * @param set the set
  * @param str the string
  * @param strLen the length of the string or -1 if null terminated.
@@ -1095,7 +1095,7 @@ U_STABLE void U_EXPORT2
 uset_setSerializedToOne(USerializedSet* fillSet, UChar32 c);
 
 /**
- * Returns TRUE if the given USerializedSet contains the given
+ * Returns true if the given USerializedSet contains the given
  * character.
  * @param set the serialized set
  * @param c The codepoint to check for within the set

--- a/icu4c/source/common/unicode/usetiter.h
+++ b/icu4c/source/common/unicode/usetiter.h
@@ -176,7 +176,7 @@ class U_COMMON_API UnicodeSetIterator : public UObject {
      * If there are no more elements in the set, return false.
      *
      * <p>
-     * If <tt>isString() == TRUE</tt>, the value is a
+     * If <tt>isString() == true</tt>, the value is a
      * string, otherwise the value is a
      * single code point.  Elements of either type can be retrieved
      * with the function <tt>getString()</tt>, while elements of
@@ -197,7 +197,7 @@ class U_COMMON_API UnicodeSetIterator : public UObject {
     /**
      * Returns the next element in the set, either a code point range
      * or a string.  If there are no more elements in the set, return
-     * false.  If <tt>isString() == TRUE</tt>, the value is a
+     * false.  If <tt>isString() == true</tt>, the value is a
      * string and can be accessed with <tt>getString()</tt>.  Otherwise the value is a
      * range of one or more code points from <tt>getCodepoint()</tt> to
      * <tt>getCodepointeEnd()</tt> inclusive.
@@ -205,7 +205,7 @@ class U_COMMON_API UnicodeSetIterator : public UObject {
      * <p>The order of iteration is all code points ranges in sorted
      * order, followed by all strings sorted order.  Ranges are
      * disjoint and non-contiguous.  The value returned from <tt>getString()</tt>
-     * is undefined unless <tt>isString() == TRUE</tt>.  Do not mix calls to
+     * is undefined unless <tt>isString() == true</tt>.  Do not mix calls to
      * <tt>next()</tt> and <tt>nextRange()</tt> without calling
      * <tt>reset()</tt> between them.  The results of doing so are
      * undefined.

--- a/icu4c/source/common/unicode/ustring.h
+++ b/icu4c/source/common/unicode/ustring.h
@@ -462,8 +462,8 @@ u_strcmpCodePointOrder(const UChar *s1, const UChar *s2);
  * @param s2 Second source string.
  * @param length2 Length of second source string, or -1 if NUL-terminated.
  *
- * @param codePointOrder Choose between code unit order (FALSE)
- *                       and code point order (TRUE).
+ * @param codePointOrder Choose between code unit order (false)
+ *                       and code point order (true).
  *
  * @return <0 or 0 or >0 as usual for string comparisons
  *
@@ -485,8 +485,8 @@ u_strCompare(const UChar *s1, int32_t length1,
  *
  * @param iter1 First source string iterator.
  * @param iter2 Second source string iterator.
- * @param codePointOrder Choose between code unit order (FALSE)
- *                       and code point order (TRUE).
+ * @param codePointOrder Choose between code unit order (false)
+ *                       and code point order (true).
  *
  * @return <0 or 0 or >0 as usual for string comparisons
  *
@@ -903,13 +903,13 @@ u_memrchr32(const UChar *s, UChar32 c, int32_t count);
  *
  *     U_STRING_DECL(ustringVar1, "Quick-Fox 2", 11);
  *     U_STRING_DECL(ustringVar2, "jumps 5%", 8);
- *     static UBool didInit=FALSE;
+ *     static UBool didInit=false;
  *
  *     int32_t function() {
  *         if(!didInit) {
  *             U_STRING_INIT(ustringVar1, "Quick-Fox 2", 11);
  *             U_STRING_INIT(ustringVar2, "jumps 5%", 8);
- *             didInit=TRUE;
+ *             didInit=true;
  *         }
  *         return u_strcmp(ustringVar1, ustringVar2);
  *     }

--- a/icu4c/source/common/unicode/utext.h
+++ b/icu4c/source/common/unicode/utext.h
@@ -323,7 +323,7 @@ utext_openCharacterIterator(UText *ut, icu::CharacterIterator *ci, UErrorCode *s
   *  shallow clones provide some protection against errors of this type by
   *  disabling text modification via the cloned UText.
   *
-  *  A shallow clone made with the readOnly parameter == FALSE will preserve the 
+  *  A shallow clone made with the readOnly parameter == false will preserve the 
   *  utext_isWritable() state of the source object.  Note, however, that
   *  write operations must be avoided while more than one UText exists that refer
   *  to the same underlying text.
@@ -339,8 +339,8 @@ utext_openCharacterIterator(UText *ut, icu::CharacterIterator *ci, UErrorCode *s
   *                If non-NULL, must refer to an already existing UText, which will then
   *                be reset to become the clone.
   *  @param src    The UText to be cloned.
-  *  @param deep   TRUE to request a deep clone, FALSE for a shallow clone.
-  *  @param readOnly TRUE to request that the cloned UText have read only access to the 
+  *  @param deep   true to request a deep clone, false for a shallow clone.
+  *  @param readOnly true to request that the cloned UText have read only access to the 
   *                underlying text.  
 
   *  @param status Errors are returned here.  For deep clones, U_UNSUPPORTED_ERROR
@@ -357,11 +357,11 @@ utext_clone(UText *dest, const UText *src, UBool deep, UBool readOnly, UErrorCod
   *  Compare two UText objects for equality.
   *  UTexts are equal if they are iterating over the same text, and
   *    have the same iteration position within the text.
-  *    If either or both of the parameters are NULL, the comparison is FALSE.
+  *    If either or both of the parameters are NULL, the comparison is false.
   *
   *  @param a   The first of the two UTexts to compare.
   *  @param b   The other UText to be compared.
-  *  @return    TRUE if the two UTexts are equal.
+  *  @return    true if the two UTexts are equal.
   *  @stable ICU 3.6
   */
 U_STABLE UBool U_EXPORT2
@@ -389,7 +389,7 @@ U_STABLE int64_t U_EXPORT2
 utext_nativeLength(UText *ut);
 
 /**
- *  Return TRUE if calculating the length of the text could be expensive.
+ *  Return true if calculating the length of the text could be expensive.
  *  Finding the length of NUL terminated strings is considered to be expensive.
  *
  *  Note that the value of this function may change
@@ -398,7 +398,7 @@ utext_nativeLength(UText *ut);
  *  be expensive to report it.
  *
  * @param ut the text to be accessed.
- * @return TRUE if determining the length of the text could be time consuming.
+ * @return true if determining the length of the text could be time consuming.
  * @stable ICU 3.4
  */
 U_STABLE UBool U_EXPORT2
@@ -584,7 +584,7 @@ utext_setNativeIndex(UText *ut, int64_t nativeIndex);
  *
  * @param ut the text to be accessed.
  * @param delta the signed number of code points to move the iteration position.
- * @return TRUE if the position could be moved the requested number of positions while
+ * @return true if the position could be moved the requested number of positions while
  *              staying within the range [0 - text length].
  * @stable ICU 3.4
  */
@@ -768,16 +768,16 @@ utext_extract(UText *ut,
 
 
 /**
- *  Return TRUE if the text can be written (modified) with utext_replace() or
+ *  Return true if the text can be written (modified) with utext_replace() or
  *  utext_copy().  For the text to be writable, the text provider must
  *  be of a type that supports writing and the UText must not be frozen.
  *
- *  Attempting to modify text when utext_isWriteable() is FALSE will fail -
+ *  Attempting to modify text when utext_isWriteable() is false will fail -
  *  the text will not be modified, and an error will be returned from the function
  *  that attempted the modification.
  *
  * @param  ut   the UText to be tested.
- * @return TRUE if the text is modifiable.
+ * @return true if the text is modifiable.
  *
  * @see    utext_freeze()
  * @see    utext_replace()
@@ -794,7 +794,7 @@ utext_isWritable(const UText *ut);
   * @see Replaceable::hasMetaData()
   *
   * @param ut The UText to be tested
-  * @return TRUE if the underlying text includes meta data.
+  * @return true if the underlying text includes meta data.
   * @stable ICU 3.4
   */
 U_STABLE UBool U_EXPORT2
@@ -808,7 +808,7 @@ utext_hasMetaData(const UText *ut);
  *  newly inserted replacement text.
  *
  * This function is only available on UText types that support writing,
- * that is, ones where utext_isWritable() returns TRUE.
+ * that is, ones where utext_isWritable() returns true.
  *
  * When using this function, there should be only a single UText opened onto the
  * underlying native text string.  Behavior after a replace operation
@@ -850,7 +850,7 @@ utext_replace(UText *ut,
  * at the destination position.
  *
  * This function is only available on UText types that support writing,
- * that is, ones where utext_isWritable() returns TRUE.
+ * that is, ones where utext_isWritable() returns true.
  *
  * When using this function, there should be only a single UText opened onto the
  * underlying native text string.  Behavior after a copy operation
@@ -863,7 +863,7 @@ utext_replace(UText *ut,
  *                     to be copied.
  * @param destIndex    The native destination index to which the source substring is
  *                     copied or moved.
- * @param move         If TRUE, then the substring is moved, not copied/duplicated.
+ * @param move         If true, then the substring is moved, not copied/duplicated.
  * @param status       receives any error status.  Possible errors include U_NO_WRITE_PERMISSION
  *                       
  * @stable ICU 3.4
@@ -972,7 +972,7 @@ enum {
   *  @param dest   A UText struct to be filled in with the result of the clone operation,
   *                or NULL if the clone function should heap-allocate a new UText struct.
   *  @param src    The UText to be cloned.
-  *  @param deep   TRUE to request a deep clone, FALSE for a shallow clone.
+  *  @param deep   true to request a deep clone, false for a shallow clone.
   *  @param status Errors are returned here.  For deep clones, U_UNSUPPORTED_ERROR
   *                should be returned if the text provider is unable to clone the
   *                original text.
@@ -1008,9 +1008,9 @@ UTextNativeLength(UText *ut);
  *
  * @param ut          the UText being accessed.
  * @param nativeIndex Requested index of the text to be accessed.
- * @param forward     If TRUE, then the returned chunk must contain text
+ * @param forward     If true, then the returned chunk must contain text
  *                    starting from the index, so that start<=index<limit.
- *                    If FALSE, then the returned chunk must contain text
+ *                    If false, then the returned chunk must contain text
  *                    before the index, so that start<index<=limit.
  * @return            True if the requested index could be accessed.  The chunk
  *                    will contain the requested text.
@@ -1114,7 +1114,7 @@ UTextReplace(UText *ut,
  * @param nativeStart  The index of the start of the region to be copied or moved
  * @param nativeLimit  The index of the character following the region to be replaced.
  * @param nativeDest   The destination index to which the source substring is copied or moved.
- * @param move         If TRUE, then the substring is moved, not copied/duplicated.
+ * @param move         If true, then the substring is moved, not copied/duplicated.
  * @param status       receives any error status.  Possible errors include U_NO_WRITE_PERMISSION
  *
  * @stable ICU 3.4

--- a/icu4c/source/common/unicode/utf.h
+++ b/icu4c/source/common/unicode/utf.h
@@ -124,7 +124,7 @@
 /**
  * Is this code point a Unicode noncharacter?
  * @param c 32-bit code point
- * @return TRUE or FALSE
+ * @return true or false
  * @stable ICU 2.4
  */
 #define U_IS_UNICODE_NONCHAR(c) \
@@ -145,7 +145,7 @@
  * and that boundary is tested first for performance.
  *
  * @param c 32-bit code point
- * @return TRUE or FALSE
+ * @return true or false
  * @stable ICU 2.4
  */
 #define U_IS_UNICODE_CHAR(c) \
@@ -155,7 +155,7 @@
 /**
  * Is this code point a BMP code point (U+0000..U+ffff)?
  * @param c 32-bit code point
- * @return TRUE or FALSE
+ * @return true or false
  * @stable ICU 2.8
  */
 #define U_IS_BMP(c) ((uint32_t)(c)<=0xffff)
@@ -163,7 +163,7 @@
 /**
  * Is this code point a supplementary code point (U+10000..U+10ffff)?
  * @param c 32-bit code point
- * @return TRUE or FALSE
+ * @return true or false
  * @stable ICU 2.8
  */
 #define U_IS_SUPPLEMENTARY(c) ((uint32_t)((c)-0x10000)<=0xfffff)
@@ -171,7 +171,7 @@
 /**
  * Is this code point a lead surrogate (U+d800..U+dbff)?
  * @param c 32-bit code point
- * @return TRUE or FALSE
+ * @return true or false
  * @stable ICU 2.4
  */
 #define U_IS_LEAD(c) (((c)&0xfffffc00)==0xd800)
@@ -179,7 +179,7 @@
 /**
  * Is this code point a trail surrogate (U+dc00..U+dfff)?
  * @param c 32-bit code point
- * @return TRUE or FALSE
+ * @return true or false
  * @stable ICU 2.4
  */
 #define U_IS_TRAIL(c) (((c)&0xfffffc00)==0xdc00)
@@ -187,7 +187,7 @@
 /**
  * Is this code point a surrogate (U+d800..U+dfff)?
  * @param c 32-bit code point
- * @return TRUE or FALSE
+ * @return true or false
  * @stable ICU 2.4
  */
 #define U_IS_SURROGATE(c) (((c)&0xfffff800)==0xd800)
@@ -196,7 +196,7 @@
  * Assuming c is a surrogate code point (U_IS_SURROGATE(c)),
  * is it a lead surrogate?
  * @param c 32-bit code point
- * @return TRUE or FALSE
+ * @return true or false
  * @stable ICU 2.4
  */
 #define U_IS_SURROGATE_LEAD(c) (((c)&0x400)==0)
@@ -205,7 +205,7 @@
  * Assuming c is a surrogate code point (U_IS_SURROGATE(c)),
  * is it a trail surrogate?
  * @param c 32-bit code point
- * @return TRUE or FALSE
+ * @return true or false
  * @stable ICU 4.2
  */
 #define U_IS_SURROGATE_TRAIL(c) (((c)&0x400)!=0)

--- a/icu4c/source/common/unicode/utf16.h
+++ b/icu4c/source/common/unicode/utf16.h
@@ -34,6 +34,7 @@
 #ifndef __UTF16_H__
 #define __UTF16_H__
 
+#include <stdbool.h>
 #include "unicode/umachine.h"
 #ifndef __UTF_H__
 #   include "unicode/utf.h"
@@ -44,7 +45,7 @@
 /**
  * Does this code unit alone encode a code point (BMP, not a surrogate)?
  * @param c 16-bit code unit
- * @return TRUE or FALSE
+ * @return true or false
  * @stable ICU 2.4
  */
 #define U16_IS_SINGLE(c) !U_IS_SURROGATE(c)
@@ -52,7 +53,7 @@
 /**
  * Is this code unit a lead surrogate (U+d800..U+dbff)?
  * @param c 16-bit code unit
- * @return TRUE or FALSE
+ * @return true or false
  * @stable ICU 2.4
  */
 #define U16_IS_LEAD(c) (((c)&0xfffffc00)==0xd800)
@@ -60,7 +61,7 @@
 /**
  * Is this code unit a trail surrogate (U+dc00..U+dfff)?
  * @param c 16-bit code unit
- * @return TRUE or FALSE
+ * @return true or false
  * @stable ICU 2.4
  */
 #define U16_IS_TRAIL(c) (((c)&0xfffffc00)==0xdc00)
@@ -68,7 +69,7 @@
 /**
  * Is this code unit a surrogate (U+d800..U+dfff)?
  * @param c 16-bit code unit
- * @return TRUE or FALSE
+ * @return true or false
  * @stable ICU 2.4
  */
 #define U16_IS_SURROGATE(c) U_IS_SURROGATE(c)
@@ -77,7 +78,7 @@
  * Assuming c is a surrogate code point (U16_IS_SURROGATE(c)),
  * is it a lead surrogate?
  * @param c 16-bit code unit
- * @return TRUE or FALSE
+ * @return true or false
  * @stable ICU 2.4
  */
 #define U16_IS_SURROGATE_LEAD(c) (((c)&0x400)==0)
@@ -86,7 +87,7 @@
  * Assuming c is a surrogate code point (U16_IS_SURROGATE(c)),
  * is it a trail surrogate?
  * @param c 16-bit code unit
- * @return TRUE or FALSE
+ * @return true or false
  * @stable ICU 4.2
  */
 #define U16_IS_SURROGATE_TRAIL(c) (((c)&0x400)!=0)
@@ -379,13 +380,13 @@
  * "Safe" macro, checks for a valid code point.
  * If a surrogate pair is written, checks for sufficient space in the string.
  * If the code point is not valid or a trail surrogate does not fit,
- * then isError is set to TRUE.
+ * then isError is set to true.
  *
  * @param s const UChar * string buffer
  * @param i string offset, must be i<capacity
  * @param capacity size of the string buffer
  * @param c code point to append
- * @param isError output UBool set to TRUE if an error occurs, otherwise not modified
+ * @param isError output UBool set to true if an error occurs, otherwise not modified
  * @see U16_APPEND_UNSAFE
  * @stable ICU 2.4
  */
@@ -396,7 +397,7 @@
         (s)[(i)++]=(uint16_t)(((c)>>10)+0xd7c0); \
         (s)[(i)++]=(uint16_t)(((c)&0x3ff)|0xdc00); \
     } else /* c>0x10ffff or not enough space */ { \
-        (isError)=TRUE; \
+        (isError)=true; \
     } \
 } UPRV_BLOCK_MACRO_END
 

--- a/icu4c/source/common/unicode/utf8.h
+++ b/icu4c/source/common/unicode/utf8.h
@@ -34,6 +34,7 @@
 #ifndef __UTF8_H__
 #define __UTF8_H__
 
+#include <stdbool.h>
 #include "unicode/umachine.h"
 #ifndef __UTF_H__
 #   include "unicode/utf.h"
@@ -166,7 +167,7 @@ utf8_back1SafeBody(const uint8_t *s, int32_t start, int32_t i);
 /**
  * Does this code unit (byte) encode a code point by itself (US-ASCII 0..0x7f)?
  * @param c 8-bit code unit (byte)
- * @return TRUE or FALSE
+ * @return true or false
  * @stable ICU 2.4
  */
 #define U8_IS_SINGLE(c) (((c)&0x80)==0)
@@ -174,7 +175,7 @@ utf8_back1SafeBody(const uint8_t *s, int32_t start, int32_t i);
 /**
  * Is this code unit (byte) a UTF-8 lead byte? (0xC2..0xF4)
  * @param c 8-bit code unit (byte)
- * @return TRUE or FALSE
+ * @return true or false
  * @stable ICU 2.4
  */
 #define U8_IS_LEAD(c) ((uint8_t)((c)-0xc2)<=0x32)
@@ -183,7 +184,7 @@ utf8_back1SafeBody(const uint8_t *s, int32_t start, int32_t i);
 /**
  * Is this code unit (byte) a UTF-8 trail byte? (0x80..0xBF)
  * @param c 8-bit code unit (byte)
- * @return TRUE or FALSE
+ * @return true or false
  * @stable ICU 2.4
  */
 #define U8_IS_TRAIL(c) ((int8_t)(c)<-0x40)
@@ -445,13 +446,13 @@ utf8_back1SafeBody(const uint8_t *s, int32_t start, int32_t i);
  * "Safe" macro, checks for a valid code point.
  * If a non-ASCII code point is written, checks for sufficient space in the string.
  * If the code point is not valid or trail bytes do not fit,
- * then isError is set to TRUE.
+ * then isError is set to true.
  *
  * @param s const uint8_t * string buffer
  * @param i int32_t string offset, must be i<capacity
  * @param capacity int32_t size of the string buffer
  * @param c UChar32 code point to append
- * @param isError output UBool set to TRUE if an error occurs, otherwise not modified
+ * @param isError output UBool set to true if an error occurs, otherwise not modified
  * @see U8_APPEND_UNSAFE
  * @stable ICU 2.4
  */
@@ -472,7 +473,7 @@ utf8_back1SafeBody(const uint8_t *s, int32_t start, int32_t i);
         (s)[(i)++]=(uint8_t)(((__uc>>6)&0x3f)|0x80); \
         (s)[(i)++]=(uint8_t)((__uc&0x3f)|0x80); \
     } else { \
-        (isError)=TRUE; \
+        (isError)=true; \
     } \
 } UPRV_BLOCK_MACRO_END
 

--- a/icu4c/source/common/unicode/utf_old.h
+++ b/icu4c/source/common/unicode/utf_old.h
@@ -109,7 +109,7 @@
  * Where such a distinction is useful, there are two versions of the macros, "unsafe" and "safe"
  * ones with ..._UNSAFE and ..._SAFE suffixes. The unsafe macros are fast but may cause
  * program failures if the strings are not well-formed. The safe macros have an additional, boolean
- * parameter "strict". If strict is FALSE, then only illegal sequences are detected.
+ * parameter "strict". If strict is false, then only illegal sequences are detected.
  * Otherwise, irregular sequences and non-characters are detected as well (like single surrogates).
  * Safe macros return special error code points for illegal/irregular sequences:
  * Typically, U+ffff, or values that would result in a code unit sequence of the same length
@@ -181,7 +181,7 @@ typedef int32_t UTextOffset;
 
 /**
  * The default choice for general Unicode string macros is to use the ..._SAFE macro implementations
- * with strict=FALSE.
+ * with strict=false.
  *
  * @deprecated ICU 2.4. Obsolete, see utf_old.h.
  */

--- a/icu4c/source/extra/uconv/uconv.cpp
+++ b/icu4c/source/extra/uconv/uconv.cpp
@@ -323,7 +323,7 @@ static int printConverters(const char *pname, const char *lookfor,
                         if (U_SUCCESS(err)) {
                             /* List the standard tags */
                             const char *standardName;
-                            UBool isFirst = TRUE;
+                            UBool isFirst = true;
                             UErrorCode enumError = U_ZERO_ERROR;
                             while ((standardName = uenum_next(nameEnum, NULL, &enumError))) {
                                 /* See if this alias is supported by this standard. */
@@ -335,7 +335,7 @@ static int printConverters(const char *pname, const char *lookfor,
                                     /* Print a * after the default standard name */
                                     printf(" %s%s", stds[s], (isFirst ? "*" : ""));
                                 }
-                                isFirst = FALSE;
+                                isFirst = false;
                             }
                         }
                     }
@@ -518,7 +518,7 @@ cnvSigType(UConverter *cnv) {
         ucnv_fromUnicode(cnv,
             &out, buffer + sizeof(buffer),
             &in, a + 1,
-            NULL, TRUE, &err);
+            NULL, true, &err);
         ucnv_resetFromUnicode(cnv);
 
         if (NULL != ucnv_detectUnicodeSignature(buffer, (int32_t)(out - buffer), NULL, &err) &&
@@ -589,12 +589,12 @@ ConvertFile::convertFile(const char *pname,
                          FILE * outfile, int verbose)
 {
     FILE *infile;
-    UBool ret = TRUE;
+    UBool ret = true;
     UConverter *convfrom = 0;
     UConverter *convto = 0;
     UErrorCode err = U_ZERO_ERROR;
     UBool flush;
-    UBool closeFile = FALSE;
+    UBool closeFile = false;
     const char *cbufp, *prevbufp;
     char *bufp;
 
@@ -615,7 +615,7 @@ ConvertFile::convertFile(const char *pname,
     // use conversion offsets for error messages
     // unless a transliterator is used -
     // a text transformation will reorder characters in unpredictable ways
-    UBool useOffsets = TRUE;
+    UBool useOffsets = true;
 
     // Open the correct input file or connect to stdin for reading input
 
@@ -628,9 +628,9 @@ ConvertFile::convertFile(const char *pname,
             str2.append((UChar32) 0);
             initMsg(pname);
             u_wmsg(stderr, "cantOpenInputF", str1.getBuffer(), str2.getBuffer());
-            return FALSE;
+            return false;
         }
-        closeFile = TRUE;
+        closeFile = true;
     } else {
         infilestr = "-";
         infile = stdin;
@@ -638,7 +638,7 @@ ConvertFile::convertFile(const char *pname,
         if (setmode(fileno(stdin), O_BINARY) == -1) {
             initMsg(pname);
             u_wmsg(stderr, "cantSetInBinMode");
-            return FALSE;
+            return false;
         }
 #endif
     }
@@ -686,7 +686,7 @@ ConvertFile::convertFile(const char *pname,
             goto error_exit;
         }
 
-        useOffsets = FALSE;
+        useOffsets = false;
     }
 #endif
 
@@ -733,7 +733,7 @@ ConvertFile::convertFile(const char *pname,
     rd = 0;
 
     do {
-        willexit = FALSE;
+        willexit = false;
 
         // input file offset at the beginning of the next buffer
         infoffset += static_cast<uint32_t>(rd);
@@ -823,7 +823,7 @@ ConvertFile::convertFile(const char *pname,
                         str.getTerminatedBuffer(),
                         u_wmsg_errorName(err));
 
-                willexit = TRUE;
+                willexit = true;
                 err = U_ZERO_ERROR; /* reset the error for the rest of the conversion. */
             }
 
@@ -1013,7 +1013,7 @@ ConvertFile::convertFile(const char *pname,
                            u_wmsg_errorName(err));
                     u_wmsg(stderr, "errorUnicode", str.getTerminatedBuffer());
 
-                    willexit = TRUE;
+                    willexit = true;
                     err = U_ZERO_ERROR; /* reset the error for the rest of the conversion. */
                 }
 
@@ -1027,7 +1027,7 @@ ConvertFile::convertFile(const char *pname,
                     UnicodeString str(strerror(errno));
                     initMsg(pname);
                     u_wmsg(stderr, "cantWrite", str.getTerminatedBuffer());
-                    willexit = TRUE;
+                    willexit = true;
                 }
 
                 if (willexit) {
@@ -1042,7 +1042,7 @@ ConvertFile::convertFile(const char *pname,
     goto normal_exit;
 
 error_exit:
-    ret = FALSE;
+    ret = false;
 
 normal_exit:
     // Cleanup.
@@ -1107,7 +1107,7 @@ main(int argc, char **argv)
     const char *tocpage = 0;
     const char *translit = 0;
     const char *outfilestr = 0;
-    UBool fallback = FALSE;
+    UBool fallback = false;
 
     UConverterFromUCallback fromucallback = UCNV_FROM_U_CALLBACK_STOP;
     const void *fromuctxt = 0;
@@ -1119,10 +1119,10 @@ main(int argc, char **argv)
 
     const char *pname;
 
-    UBool printConvs = FALSE, printCanon = FALSE, printTranslits = FALSE;
+    UBool printConvs = false, printCanon = false, printTranslits = false;
     const char *printName = 0;
 
-    UBool verbose = FALSE;
+    UBool verbose = false;
     UErrorCode status = U_ZERO_ERROR;
 
     ConvertFile cf;
@@ -1173,9 +1173,9 @@ main(int argc, char **argv)
             else
                 usage(pname, 1);
         } else if (!strcmp("--fallback", *iter)) {
-            fallback = TRUE;
+            fallback = true;
         } else if (!strcmp("--no-fallback", *iter)) {
-            fallback = FALSE;
+            fallback = false;
         } else if (strcmp("-b", *iter) == 0 || !strcmp("--block-size", *iter)) {
             iter++;
             if (iter != end) {
@@ -1194,7 +1194,7 @@ main(int argc, char **argv)
             if (printTranslits) {
                 usage(pname, 1);
             }
-            printConvs = TRUE;
+            printConvs = true;
         } else if (strcmp("--default-code", *iter) == 0) {
             if (printTranslits) {
                 usage(pname, 1);
@@ -1218,13 +1218,13 @@ main(int argc, char **argv)
             } else
                 usage(pname, 1);
         } else if (strcmp("--canon", *iter) == 0) {
-            printCanon = TRUE;
+            printCanon = true;
         } else if (strcmp("-L", *iter) == 0
             || !strcmp("--list-transliterators", *iter)) {
             if (printConvs) {
                 usage(pname, 1);
             }
-            printTranslits = TRUE;
+            printTranslits = true;
         } else if (strcmp("-h", *iter) == 0 || !strcmp("-?", *iter)
             || !strcmp("--help", *iter)) {
             usage(pname, 0);
@@ -1283,9 +1283,9 @@ main(int argc, char **argv)
                 usage(pname, 1);
             }
         } else if (!strcmp("-s", *iter) || !strcmp("--silent", *iter)) {
-            verbose = FALSE;
+            verbose = false;
         } else if (!strcmp("-v", *iter) || !strcmp("--verbose", *iter)) {
-            verbose = TRUE;
+            verbose = true;
         } else if (!strcmp("-V", *iter) || !strcmp("--version", *iter)) {
             printf("%s v2.1  ICU " U_ICU_VERSION "\n", pname);
             return 0;

--- a/icu4c/source/extra/uconv/uwmsg.c
+++ b/icu4c/source/extra/uconv/uwmsg.c
@@ -24,6 +24,7 @@
 #include "cmemory.h"
 #include "cstring.h"
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -68,7 +69,7 @@ uprint(const UChar *s,
         /* perform the conversion */
         ucnv_fromUnicode(converter, &myTarget,  myTarget + arraySize,
             &mySource, mySourceEnd, NULL,
-            TRUE, status);
+            true, status);
 
         /* Write the converted data to the FILE* */
         fwrite(buf, sizeof(char), myTarget - buf, f);

--- a/icu4c/source/i18n/collationfcd.h
+++ b/icu4c/source/i18n/collationfcd.h
@@ -84,7 +84,7 @@ public:
         // Handles all of Unicode 0..10FFFF.
         // c can be negative, e.g., U_SENTINEL.
         // U+0300 is the first character with lccc!=0.
-        if(c < 0x300) { return FALSE; }
+        if(c < 0x300) { return false; }
         if(c > 0xffff) { c = U16_LEAD(c); }
         int32_t i;
         return

--- a/icu4c/source/i18n/collationiterator.h
+++ b/icu4c/source/i18n/collationiterator.h
@@ -76,9 +76,9 @@ private:
             // (Rather than buffer.getCapacity().)
             if(length < INITIAL_CAPACITY || ensureAppendCapacity(1, errorCode)) {
                 ++length;
-                return TRUE;
+                return true;
             } else {
-                return FALSE;
+                return false;
             }
         }
 

--- a/icu4c/source/i18n/fphdlimp.h
+++ b/icu4c/source/i18n/fphdlimp.h
@@ -41,8 +41,8 @@ class U_I18N_API FieldPositionHandler: public UMemory {
 
 class FieldPositionOnlyHandler : public FieldPositionHandler {
   FieldPosition& pos;
-  UBool acceptFirstOnly = FALSE;
-  UBool seenFirst = FALSE;
+  UBool acceptFirstOnly = false;
+  UBool seenFirst = false;
 
  public:
   FieldPositionOnlyHandler(FieldPosition& pos);

--- a/icu4c/source/i18n/numparse_types.h
+++ b/icu4c/source/i18n/numparse_types.h
@@ -72,7 +72,7 @@ class CompactUnicodeString {
     }
 
     inline UnicodeString toAliasedUnicodeString() const {
-        return UnicodeString(TRUE, fBuffer.getAlias(), -1);
+        return UnicodeString(true, fBuffer.getAlias(), -1);
     }
 
     bool operator==(const CompactUnicodeString& other) const {

--- a/icu4c/source/i18n/plurrule_impl.h
+++ b/icu4c/source/i18n/plurrule_impl.h
@@ -320,8 +320,8 @@ public:
     int32_t opNum = -1;             // for mod expressions, the right operand of the mod.
     int32_t value = -1;             // valid for 'is' rules only.
     UVector32 *rangeList = nullptr; // for 'in', 'within' rules. Null otherwise.
-    UBool negated = FALSE;          // TRUE for negated rules.
-    UBool integerOnly = FALSE;      // TRUE for 'within' rules.
+    UBool negated = false;          // true for negated rules.
+    UBool integerOnly = false;      // true for 'within' rules.
     tokenType digitsType = none;    // n | i | v | f constraint.
     AndConstraint *next = nullptr;
     // Internal error status, used for errors that occur during the copy constructor.
@@ -357,8 +357,8 @@ public:
     OrConstraint   *ruleHeader = nullptr;
     UnicodeString   fDecimalSamples;  // Samples strings from rule source
     UnicodeString   fIntegerSamples;  //   without @decimal or @integer, otherwise unprocessed.
-    UBool           fDecimalSamplesUnbounded = FALSE;
-    UBool           fIntegerSamplesUnbounded = FALSE;
+    UBool           fDecimalSamplesUnbounded = false;
+    UBool           fIntegerSamplesUnbounded = false;
     // Internal error status, used for errors that occur during the copy constructor.
     UErrorCode      fInternalStatus = U_ZERO_ERROR;
 

--- a/icu4c/source/i18n/unicode/alphaindex.h
+++ b/icu4c/source/i18n/unicode/alphaindex.h
@@ -549,14 +549,14 @@ public:
 
 
     /**
-     *   Advance the iteration over the Buckets of this index.  Return FALSE if
+     *   Advance the iteration over the Buckets of this index.  Return false if
      *   there are no more Buckets.
      *
      *   @param status  Error code, will be set with the reason if the operation fails.
      *   U_ENUM_OUT_OF_SYNC_ERROR will be reported if the index is modified while
      *   an enumeration of its contents are in process.
      *
-     *   @return TRUE if success, FALSE if at end of iteration
+     *   @return true if success, false if at end of iteration
      *   @stable ICU 4.8
      */
     virtual UBool nextBucket(UErrorCode &status);
@@ -609,7 +609,7 @@ public:
      *   @param status  Error code, will be set with the reason if the operation fails.
      *   U_ENUM_OUT_OF_SYNC_ERROR will be reported if the index is modified while
      *   an enumeration of its contents are in process.
-     *   @return TRUE if successful, FALSE when the iteration advances past the last item.
+     *   @return true if successful, false when the iteration advances past the last item.
      *   @stable ICU 4.8
      */
     virtual UBool nextRecord(UErrorCode &status);

--- a/icu4c/source/i18n/unicode/basictz.h
+++ b/icu4c/source/i18n/unicode/basictz.h
@@ -56,7 +56,7 @@ public:
      * @param base      The base time.
      * @param inclusive Whether the base time is inclusive or not.
      * @param result    Receives the first transition after the base time.
-     * @return  TRUE if the transition is found.
+     * @return  true if the transition is found.
      * @stable ICU 3.8
      */
     virtual UBool getNextTransition(UDate base, UBool inclusive, TimeZoneTransition& result) const = 0;
@@ -66,7 +66,7 @@ public:
      * @param base      The base time.
      * @param inclusive Whether the base time is inclusive or not.
      * @param result    Receives the most recent transition before the base time.
-     * @return  TRUE if the transition is found.
+     * @return  true if the transition is found.
      * @stable ICU 3.8
      */
     virtual UBool getPreviousTransition(UDate base, UBool inclusive, TimeZoneTransition& result) const = 0;

--- a/icu4c/source/i18n/unicode/calendar.h
+++ b/icu4c/source/i18n/unicode/calendar.h
@@ -464,10 +464,10 @@ public:
     UBool operator!=(const Calendar& that) const {return !operator==(that);}
 
     /**
-     * Returns TRUE if the given Calendar object is equivalent to this
+     * Returns true if the given Calendar object is equivalent to this
      * one.  An equivalent Calendar will behave exactly as this one
      * does, but it may be set to a different time.  By contrast, for
-     * the operator==() method to return TRUE, the other Calendar must
+     * the operator==() method to return true, the other Calendar must
      * be set to the same time.
      *
      * @param other the Calendar to be compared with this Calendar
@@ -1359,7 +1359,7 @@ public:
      *     localeID.append(calType);
      *     char langTag[100];
      *     UErrorCode errorCode = U_ZERO_ERROR;
-     *     int32_t length = uloc_toLanguageTag(localeID.c_str(), langTag, (int32_t)sizeof(langTag), TRUE, &errorCode);
+     *     int32_t length = uloc_toLanguageTag(localeID.c_str(), langTag, (int32_t)sizeof(langTag), true, &errorCode);
      *     if (U_FAILURE(errorCode)) {
      *         // deal with errors & overflow
      *     }
@@ -1410,21 +1410,21 @@ public:
     virtual int32_t getWeekendTransition(UCalendarDaysOfWeek dayOfWeek, UErrorCode &status) const;
 
     /**
-     * Returns TRUE if the given UDate is in the weekend in
+     * Returns true if the given UDate is in the weekend in
      * this calendar system.
      * @param date The UDate in question.
      * @param status The error code for the operation.
-     * @return TRUE if the given UDate is in the weekend in
-     * this calendar system, FALSE otherwise.
+     * @return true if the given UDate is in the weekend in
+     * this calendar system, false otherwise.
      * @stable ICU 4.4
      */
     virtual UBool isWeekend(UDate date, UErrorCode &status) const;
 
     /**
-     * Returns TRUE if this Calendar's current date-time is in the weekend in
+     * Returns true if this Calendar's current date-time is in the weekend in
      * this calendar system.
-     * @return TRUE if this Calendar's current date-time is in the weekend in
-     * this calendar system, FALSE otherwise.
+     * @return true if this Calendar's current date-time is in the weekend in
+     * this calendar system, false otherwise.
      * @stable ICU 4.4
      */
     virtual UBool isWeekend(void) const;
@@ -2372,7 +2372,7 @@ private:
      *
      * @param key the registry key returned by a previous call to registerFactory
      * @param status the in/out status code, no special meanings are assigned
-     * @return TRUE if the factory for the key was successfully unregistered
+     * @return true if the factory for the key was successfully unregistered
      * @internal
      */
     static UBool unregister(URegistryKey key, UErrorCode& status);
@@ -2398,7 +2398,7 @@ private:
 #endif /* !UCONFIG_NO_SERVICE */
 
     /**
-     * @return TRUE if this calendar has a default century (i.e. 03 -> 2003)
+     * @return true if this calendar has a default century (i.e. 03 -> 2003)
      * @internal
      */
     virtual UBool haveDefaultCentury() const = 0;
@@ -2458,7 +2458,7 @@ private:
      * @param base The base time, inclusive
      * @param transitionTime Receives the result time
      * @param status The error status
-     * @return TRUE if a transition is found.
+     * @return true if a transition is found.
      */
     UBool getImmediatePreviousZoneTransition(UDate base, UDate *transitionTime, UErrorCode& status) const;
 
@@ -2531,7 +2531,7 @@ Calendar::internalSet(UCalendarDateFields field, int32_t value)
 {
     fFields[field] = value;
     fStamp[field] = kInternallySet;
-    fIsSet[field]     = TRUE; // Remove later
+    fIsSet[field]     = true; // Remove later
 }
 
 

--- a/icu4c/source/i18n/unicode/choicfmt.h
+++ b/icu4c/source/i18n/unicode/choicfmt.h
@@ -106,7 +106,7 @@ class MessageFormat;
  * arrays of numbers, closure flags and strings,
  * they are interpreted just like
  * the sequence of <code>(number separator string)</code> in an equivalent pattern string.
- * <code>closure[i]==TRUE</code> corresponds to a <code>less_than</code> separator sign.
+ * <code>closure[i]==true</code> corresponds to a <code>less_than</code> separator sign.
  * The equivalent pattern string will be constructed automatically.</p>
  *
  * <p>During formatting, a number is mapped to the first range
@@ -126,7 +126,7 @@ class MessageFormat;
  * <p>Here is an example of two arrays that map the number
  * <code>1..7</code> to the English day of the week abbreviations
  * <code>Sun..Sat</code>. No closures array is given; this is the same as
- * specifying all closures to be <code>FALSE</code>.</p>
+ * specifying all closures to be <code>false</code>.</p>
  *
  * <pre>    {1,2,3,4,5,6,7},
  *     {&quot;Sun&quot;,&quot;Mon&quot;,&quot;Tue&quot;,&quot;Wed&quot;,&quot;Thur&quot;,&quot;Fri&quot;,&quot;Sat&quot;}</pre>
@@ -138,7 +138,7 @@ class MessageFormat;
  * like the turned bracket in European notation: [-Inf, 1) == [-Inf, 1[  )</p>
  *
  * <pre>    {0, 1, 1},
- *     {FALSE, FALSE, TRUE},
+ *     {false, false, true},
  *     {&quot;no files&quot;, &quot;one file&quot;, &quot;many files&quot;}</pre>
  *
  * <p>Here is an example that shows formatting and parsing: </p>
@@ -189,7 +189,7 @@ public:
 
     /**
      * Constructs a new ChoiceFormat with the given limits and message strings.
-     * All closure flags default to <code>FALSE</code>,
+     * All closure flags default to <code>false</code>,
      * equivalent to <code>less_than_or_equal</code> separators.
      *
      * Copies the limits and formats instead of adopting them.
@@ -210,9 +210,9 @@ public:
      *
      * @param limits Array of limit values
      * @param closures Array of booleans specifying whether each
-     * element of 'limits' is open or closed.  If FALSE, then the
+     * element of 'limits' is open or closed.  If false, then the
      * corresponding limit number is a member of its range.
-     * If TRUE, then the limit number belongs to the previous range it.
+     * If true, then the limit number belongs to the previous range it.
      * @param formats Array of formats
      * @param count Size of 'limits', 'closures', and 'formats' arrays
      * @deprecated ICU 49 Use MessageFormat instead, with plural and select arguments.
@@ -568,13 +568,13 @@ private:
      * The intervals may be closed, half open, or open.  This affects
      * formatting but does not affect parsing.  Interval i is affected
      * by fClosures[i] and fClosures[i+1].  If fClosures[i]
-     * is FALSE, then the value fChoiceLimits[i] is in interval i.
+     * is false, then the value fChoiceLimits[i] is in interval i.
      * That is, intervals i and i are:
      *
      *  i-1:                 ... x < fChoiceLimits[i]
      *    i: fChoiceLimits[i] <= x ...
      *
-     * If fClosures[i] is TRUE, then the value fChoiceLimits[i] is
+     * If fClosures[i] is true, then the value fChoiceLimits[i] is
      * in interval i-1.  That is, intervals i-1 and i are:
      *
      *  i-1:                ... x <= fChoiceLimits[i]

--- a/icu4c/source/i18n/unicode/coleitr.h
+++ b/icu4c/source/i18n/unicode/coleitr.h
@@ -253,7 +253,7 @@ public:
     /**
     * Checks if a comparison order is ignorable.
     * @param order the collation order.
-    * @return TRUE if a character is ignorable, FALSE otherwise.
+    * @return true if a character is ignorable, false otherwise.
     * @stable ICU 2.0
     */
     static inline UBool isIgnorable(int32_t order);

--- a/icu4c/source/i18n/unicode/coll.h
+++ b/icu4c/source/i18n/unicode/coll.h
@@ -236,21 +236,21 @@ public:
     // Collator public methods --------------------------------------------
 
     /**
-     * Returns TRUE if "other" is the same as "this".
+     * Returns true if "other" is the same as "this".
      *
-     * The base class implementation returns TRUE if "other" has the same type/class as "this":
+     * The base class implementation returns true if "other" has the same type/class as "this":
      * `typeid(*this) == typeid(other)`.
      *
      * Subclass implementations should do something like the following:
      *
-     *     if (this == &other) { return TRUE; }
-     *     if (!Collator::operator==(other)) { return FALSE; }  // not the same class
+     *     if (this == &other) { return true; }
+     *     if (!Collator::operator==(other)) { return false; }  // not the same class
      *
      *     const MyCollator &o = (const MyCollator&)other;
      *     (compare this vs. o's subclass fields)
      *
      * @param other Collator object to be compared
-     * @return TRUE if other is the same as this.
+     * @return true if other is the same as this.
      * @stable ICU 2.0
      */
     virtual UBool operator==(const Collator& other) const;
@@ -259,7 +259,7 @@ public:
      * Returns true if "other" is not the same as "this".
      * Calls ! operator==(const Collator&) const which works for all subclasses.
      * @param other Collator object to be compared
-     * @return TRUE if other is not the same as this.
+     * @return true if other is not the same as this.
      * @stable ICU 2.0
      */
     virtual UBool operator!=(const Collator& other) const;
@@ -841,7 +841,7 @@ public:
      * Collator::createInstance to avoid undefined behavior.
      * @param key the registry key returned by a previous call to registerInstance
      * @param status the in/out status code, no special meanings are assigned
-     * @return TRUE if the collator for the key was successfully unregistered
+     * @return true if the collator for the key was successfully unregistered
      * @stable ICU 2.6
      */
     static UBool U_EXPORT2 unregister(URegistryKey key, UErrorCode& status);

--- a/icu4c/source/i18n/unicode/curramt.h
+++ b/icu4c/source/i18n/unicode/curramt.h
@@ -41,7 +41,7 @@ class U_I18N_API CurrencyAmount: public Measure {
     /**
      * Construct an object with the given numeric amount and the given
      * ISO currency code.
-     * @param amount a numeric object; amount.isNumeric() must be TRUE
+     * @param amount a numeric object; amount.isNumeric() must be true
      * @param isoCode the 3-letter ISO 4217 currency code; must not be
      * NULL and must have length 3
      * @param ec input-output error code. If the amount or the isoCode

--- a/icu4c/source/i18n/unicode/dcfmtsym.h
+++ b/icu4c/source/i18n/unicode/dcfmtsym.h
@@ -378,7 +378,7 @@ private:
      *                             back to the locale.
      */
     void initialize(const Locale& locale, UErrorCode& success,
-        UBool useLastResortData = FALSE, const NumberingSystem* ns = nullptr);
+                    UBool useLastResortData = false, const NumberingSystem* ns = nullptr);
 
     /**
      * Initialize the symbols with default values.
@@ -543,12 +543,12 @@ inline const UnicodeString& DecimalFormatSymbols::getConstDigitSymbol(int32_t di
 // -------------------------------------
 
 inline void
-DecimalFormatSymbols::setSymbol(ENumberFormatSymbol symbol, const UnicodeString &value, const UBool propogateDigits = TRUE) {
+DecimalFormatSymbols::setSymbol(ENumberFormatSymbol symbol, const UnicodeString &value, const UBool propagateDigits = true) {
     if (symbol == kCurrencySymbol) {
-        fIsCustomCurrencySymbol = TRUE;
+        fIsCustomCurrencySymbol = true;
     }
     else if (symbol == kIntlCurrencySymbol) {
-        fIsCustomIntlCurrencySymbol = TRUE;
+        fIsCustomIntlCurrencySymbol = true;
     }
     if(symbol<kFormatSymbolCount) {
         fSymbols[symbol]=value;
@@ -559,7 +559,7 @@ DecimalFormatSymbols::setSymbol(ENumberFormatSymbol symbol, const UnicodeString 
     // Also record updates to fCodePointZero. Be conservative if in doubt.
     if (symbol == kZeroDigitSymbol) {
         UChar32 sym = value.char32At(0);
-        if ( propogateDigits && u_charDigitValue(sym) == 0 && value.countChar32() == 1 ) {
+        if ( propagateDigits && u_charDigitValue(sym) == 0 && value.countChar32() == 1 ) {
             fCodePointZero = sym;
             for ( int8_t i = 1 ; i<= 9 ; i++ ) {
                 sym++;

--- a/icu4c/source/i18n/unicode/decimfmt.h
+++ b/icu4c/source/i18n/unicode/decimfmt.h
@@ -564,11 +564,11 @@ class NumberParserImpl;
  *
  * <li>In order to enable significant digits formatting, use a pattern
  * containing the <code>'@'</code> pattern character.  Alternatively,
- * call setSignificantDigitsUsed(TRUE).
+ * call setSignificantDigitsUsed(true).
  *
  * <li>In order to disable significant digits formatting, use a
  * pattern that does not contain the <code>'@'</code> pattern
- * character. Alternatively, call setSignificantDigitsUsed(FALSE).
+ * character. Alternatively, call setSignificantDigitsUsed(false).
  *
  * <li>The number of significant digits has no effect on parsing.
  *
@@ -817,8 +817,8 @@ class U_I18N_API DecimalFormat : public NumberFormat {
     /**
      * Sets whether lenient parsing should be enabled (it is off by default).
      *
-     * @param enable \c TRUE if lenient parsing should be used,
-     *               \c FALSE otherwise.
+     * @param enable \c true if lenient parsing should be used,
+     *               \c false otherwise.
      * @stable ICU 4.8
      */
     void setLenient(UBool enable) U_OVERRIDE;
@@ -1507,7 +1507,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
 
     /**
      * Return whether or not scientific notation is used.
-     * @return TRUE if this object formats and parses scientific notation
+     * @return true if this object formats and parses scientific notation
      * @see #setScientificNotation
      * @see #getMinimumExponentDigits
      * @see #setMinimumExponentDigits
@@ -1523,7 +1523,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * maximum number of integer digits is set to more than 8, the effective
      * maximum will be 1.  This allows this call to generate a 'default' scientific
      * number format without additional changes.
-     * @param useScientific TRUE if this object formats and parses scientific
+     * @param useScientific true if this object formats and parses scientific
      * notation
      * @see #isScientificNotation
      * @see #getMinimumExponentDigits
@@ -1562,7 +1562,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
 
     /**
      * Return whether the exponent sign is always shown.
-     * @return TRUE if the exponent is always prefixed with either the
+     * @return true if the exponent is always prefixed with either the
      * localized minus sign or the localized plus sign, false if only negative
      * exponents are prefixed with the localized minus sign.
      * @see #setScientificNotation
@@ -1577,7 +1577,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
     /**
      * Set whether the exponent sign is always shown.  This has no effect
      * unless scientific notation is in use.
-     * @param expSignAlways TRUE if the exponent is always prefixed with either
+     * @param expSignAlways true if the exponent is always prefixed with either
      * the localized minus sign or the localized plus sign, false if only
      * negative exponents are prefixed with the localized minus sign.
      * @see #setScientificNotation
@@ -1696,7 +1696,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * Allows you to get the behavior of the decimal separator with integers.
      * (The decimal separator will always appear with decimals.)
      *
-     * @return    TRUE if the decimal separator always appear with decimals.
+     * @return    true if the decimal separator always appear with decimals.
      * Example: Decimal ON: 12345 -> 12345.; OFF: 12345 -> 12345
      * @stable ICU 2.0
      */
@@ -1706,7 +1706,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * Allows you to set the behavior of the decimal separator with integers.
      * (The decimal separator will always appear with decimals.)
      *
-     * @param newValue    set TRUE if the decimal separator will always appear with decimals.
+     * @param newValue    set true if the decimal separator will always appear with decimals.
      * Example: Decimal ON: 12345 -> 12345.; OFF: 12345 -> 12345
      * @stable ICU 2.0
      */
@@ -1715,7 +1715,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
     /**
      * Allows you to get the parse behavior of the pattern decimal mark.
      *
-     * @return    TRUE if input must contain a match to decimal mark in pattern
+     * @return    true if input must contain a match to decimal mark in pattern
      * @stable ICU 54
      */
     UBool isDecimalPatternMatchRequired(void) const;
@@ -1723,10 +1723,10 @@ class U_I18N_API DecimalFormat : public NumberFormat {
     /**
      * Allows you to set the parse behavior of the pattern decimal mark.
      *
-     * if TRUE, the input must have a decimal mark if one was specified in the pattern. When
-     * FALSE the decimal mark may be omitted from the input.
+     * if true, the input must have a decimal mark if one was specified in the pattern. When
+     * false the decimal mark may be omitted from the input.
      *
-     * @param newValue    set TRUE if input must contain a match to decimal mark in pattern
+     * @param newValue    set true if input must contain a match to decimal mark in pattern
      * @stable ICU 54
      */
     virtual void setDecimalPatternMatchRequired(UBool newValue);
@@ -1969,7 +1969,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * to one.  If the maximum significant digits count is less than
      * <code>min</code>, then it is set to <code>min</code>.
      * This function also enables the use of significant digits
-     * by this formatter - areSignificantDigitsUsed() will return TRUE.
+     * by this formatter - areSignificantDigitsUsed() will return true.
      * @see #areSignificantDigitsUsed
      * @param min the fewest significant digits to be shown
      * @stable ICU 3.0
@@ -1982,7 +1982,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * to one.  If the minimum significant digits count is greater
      * than <code>max</code>, then it is set to <code>max</code>.
      * This function also enables the use of significant digits
-     * by this formatter - areSignificantDigitsUsed() will return TRUE.
+     * by this formatter - areSignificantDigitsUsed() will return true.
      * @see #areSignificantDigitsUsed
      * @param max the most significant digits to be shown
      * @stable ICU 3.0

--- a/icu4c/source/i18n/unicode/dtfmtsym.h
+++ b/icu4c/source/i18n/unicode/dtfmtsym.h
@@ -919,7 +919,8 @@ private:
      *                             failure code upon return.
      * @param useLastResortData    determine if use last resort data
      */
-    void initializeData(const Locale& locale, const char *type, UErrorCode& status, UBool useLastResortData = FALSE);
+    void initializeData(const Locale& locale, const char *type,
+                        UErrorCode& status, UBool useLastResortData = false);
 
     /**
      * Copy or alias an array in another object, as appropriate.
@@ -983,12 +984,12 @@ private:
     static UDateFormatField U_EXPORT2 getPatternCharIndex(char16_t c);
 
     /**
-     * Returns TRUE if f (with its pattern character repeated count times) is a numeric field.
+     * Returns true if f (with its pattern character repeated count times) is a numeric field.
      */
     static UBool U_EXPORT2 isNumericField(UDateFormatField f, int32_t count);
 
     /**
-     * Returns TRUE if c (repeated count times) is the pattern character for a numeric field.
+     * Returns true if c (repeated count times) is the pattern character for a numeric field.
      */
     static UBool U_EXPORT2 isNumericPatternChar(char16_t c, int32_t count);
 public:

--- a/icu4c/source/i18n/unicode/dtitvfmt.h
+++ b/icu4c/source/i18n/unicode/dtitvfmt.h
@@ -796,7 +796,7 @@ private:
      *                          to be formatted into date interval string
      * @param toCalendar        calendar set to the to date in date interval
      *                          to be formatted into date interval string
-     * @param fromToOnSameDay   TRUE iff from and to dates are on the same day
+     * @param fromToOnSameDay   true iff from and to dates are on the same day
      *                          (any difference is in ampm/hours or below)
      * @param appendTo          Output parameter to receive result.
      *                          Result is appended to existing contents.
@@ -919,8 +919,8 @@ private:
      * @param dateSkeleton   normalized date skeleton
      * @param timeSkeleton   normalized time skeleton
      * @return               whether the resource is found for the skeleton.
-     *                       TRUE if interval pattern found for the skeleton,
-     *                       FALSE otherwise.
+     *                       true if interval pattern found for the skeleton,
+     *                       false otherwise.
      */
     UBool setSeparateDateTimePtn(const UnicodeString& dateSkeleton,
                                  const UnicodeString& timeSkeleton);
@@ -948,8 +948,8 @@ private:
      * @param extendedBestSkeleton  extended best match skeleton
      * @return                      whether the interval pattern is found
      *                              through extending skeleton or not.
-     *                              TRUE if interval pattern is found by
-     *                              extending skeleton, FALSE otherwise.
+     *                              true if interval pattern is found by
+     *                              extending skeleton, false otherwise.
      */
     UBool setIntervalPattern(UCalendarDateFields field,
                              const UnicodeString* skeleton,

--- a/icu4c/source/i18n/unicode/dtitvinf.h
+++ b/icu4c/source/i18n/unicode/dtitvinf.h
@@ -307,8 +307,8 @@ public:
 
     /** Get default order -- whether the first date in pattern is later date
                              or not.
-     * return default date ordering in interval pattern. TRUE if the first date
-     *        in pattern is later date, FALSE otherwise.
+     * return default date ordering in interval pattern. true if the first date
+     *        in pattern is later date, false otherwise.
      * @stable ICU 4.0
      */
     UBool getDefaultOrder() const;

--- a/icu4c/source/i18n/unicode/fieldpos.h
+++ b/icu4c/source/i18n/unicode/fieldpos.h
@@ -161,7 +161,7 @@ public:
     /** 
      * Equality operator.
      * @param that    the object to be compared with.
-     * @return        TRUE if the two field positions are equal, FALSE otherwise.
+     * @return        true if the two field positions are equal, false otherwise.
      * @stable ICU 2.0
      */
     UBool              operator==(const FieldPosition& that) const;
@@ -169,7 +169,7 @@ public:
     /** 
      * Equality operator.
      * @param that    the object to be compared with.
-     * @return        TRUE if the two field positions are not equal, FALSE otherwise.
+     * @return        true if the two field positions are not equal, false otherwise.
      * @stable ICU 2.0
      */
     UBool              operator!=(const FieldPosition& that) const;

--- a/icu4c/source/i18n/unicode/fmtable.h
+++ b/icu4c/source/i18n/unicode/fmtable.h
@@ -179,7 +179,7 @@ public:
     /**
      * Equality comparison.
      * @param other    the object to be compared with.
-     * @return        TRUE if other are equal to this, FALSE otherwise.
+     * @return        true if other are equal to this, false otherwise.
      * @stable ICU 2.0
      */
     UBool          operator==(const Formattable &other) const;
@@ -187,7 +187,7 @@ public:
     /**
      * Equality operator.
      * @param other    the object to be compared with.
-     * @return        TRUE if other are unequal to this, FALSE otherwise.
+     * @return        true if other are unequal to this, false otherwise.
      * @stable ICU 2.0
      */
     UBool          operator!=(const Formattable& other) const
@@ -277,9 +277,9 @@ public:
     Type            getType(void) const;
 
     /**
-     * Returns TRUE if the data type of this Formattable object
+     * Returns true if the data type of this Formattable object
      * is kDouble, kLong, or kInt64
-     * @return TRUE if this is a pure numeric object
+     * @return true if this is a pure numeric object
      * @stable ICU 3.0
      */
     UBool           isNumeric() const;

--- a/icu4c/source/i18n/unicode/formattedvalue.h
+++ b/icu4c/source/i18n/unicode/formattedvalue.h
@@ -116,7 +116,7 @@ class U_I18N_API ConstrainedFieldPosition : public UMemory {
      * Gets the field category for the current position.
      *
      * The return value is well-defined only after
-     * FormattedValue#nextPosition returns TRUE.
+     * FormattedValue#nextPosition returns true.
      *
      * @return The field category saved in the instance.
      * @stable ICU 64
@@ -129,7 +129,7 @@ class U_I18N_API ConstrainedFieldPosition : public UMemory {
      * Gets the field for the current position.
      *
      * The return value is well-defined only after
-     * FormattedValue#nextPosition returns TRUE.
+     * FormattedValue#nextPosition returns true.
      *
      * @return The field saved in the instance.
      * @stable ICU 64
@@ -141,7 +141,7 @@ class U_I18N_API ConstrainedFieldPosition : public UMemory {
     /**
      * Gets the INCLUSIVE start index for the current position.
      *
-     * The return value is well-defined only after FormattedValue#nextPosition returns TRUE.
+     * The return value is well-defined only after FormattedValue#nextPosition returns true.
      *
      * @return The start index saved in the instance.
      * @stable ICU 64
@@ -153,7 +153,7 @@ class U_I18N_API ConstrainedFieldPosition : public UMemory {
     /**
      * Gets the EXCLUSIVE end index stored for the current position.
      *
-     * The return value is well-defined only after FormattedValue#nextPosition returns TRUE.
+     * The return value is well-defined only after FormattedValue#nextPosition returns true.
      *
      * @return The end index saved in the instance.
      * @stable ICU 64
@@ -301,8 +301,8 @@ class U_I18N_API FormattedValue /* not : public UObject because this is an inter
      *         see ConstrainedFieldPosition#constrainCategory
      *         and ConstrainedFieldPosition#constrainField.
      * @param status Set if an error occurs.
-     * @return TRUE if a new occurrence of the field was found;
-     *         FALSE otherwise or if an error was set.
+     * @return true if a new occurrence of the field was found;
+     *         false otherwise or if an error was set.
      *
      * @stable ICU 64
      */

--- a/icu4c/source/i18n/unicode/fpositer.h
+++ b/icu4c/source/i18n/unicode/fpositer.h
@@ -96,7 +96,7 @@ public:
 
     /**
      * If the current position is valid, updates the FieldPosition values, advances the iterator,
-     * and returns TRUE, otherwise returns FALSE.
+     * and returns true, otherwise returns false.
      * @stable ICU 4.4
      */
     UBool next(FieldPosition& fp);

--- a/icu4c/source/i18n/unicode/gregocal.h
+++ b/icu4c/source/i18n/unicode/gregocal.h
@@ -344,7 +344,7 @@ public:
     UBool isLeapYear(int32_t year) const;
 
     /**
-     * Returns TRUE if the given Calendar object is equivalent to this
+     * Returns true if the given Calendar object is equivalent to this
      * one.  Calendar override.
      *
      * @param other the Calendar to be compared with this Calendar   
@@ -756,7 +756,7 @@ public:
  public: // internal implementation
 
     /**
-     * @return TRUE if this calendar has the notion of a default century
+     * @return true if this calendar has the notion of a default century
      * @internal 
      */
     virtual UBool haveDefaultCentury() const;

--- a/icu4c/source/i18n/unicode/measfmt.h
+++ b/icu4c/source/i18n/unicode/measfmt.h
@@ -309,7 +309,7 @@ class U_I18N_API MeasureFormat : public Format {
     /**
      * ICU use only.
      * Allows subclass to change locale. Note that this method also changes
-     * the NumberFormat object. Returns TRUE if locale changed; FALSE if no
+     * the NumberFormat object. Returns true if locale changed; false if no
      * change was made.
      * @internal.
      */

--- a/icu4c/source/i18n/unicode/measure.h
+++ b/icu4c/source/i18n/unicode/measure.h
@@ -48,7 +48,7 @@ class U_I18N_API Measure: public UObject {
      * Construct an object with the given numeric amount and the given
      * unit.  After this call, the caller must not delete the given
      * unit object.
-     * @param number a numeric object; amount.isNumeric() must be TRUE
+     * @param number a numeric object; amount.isNumeric() must be true
      * @param adoptedUnit the unit object, which must not be NULL
      * @param ec input-output error code. If the amount or the unit
      * is invalid, then this will be set to a failing value.

--- a/icu4c/source/i18n/unicode/msgfmt.h
+++ b/icu4c/source/i18n/unicode/msgfmt.h
@@ -920,7 +920,7 @@ private:
     int32_t            argTypeCapacity;
 
     /**
-     * TRUE if there are different argTypes for the same argument.
+     * true if there are different argTypes for the same argument.
      * This only matters when the MessageFormat is used in the plain C (umsg_xxx) API
      * where the pattern argTypes determine how the va_arg list is read.
      */

--- a/icu4c/source/i18n/unicode/numberformatter.h
+++ b/icu4c/source/i18n/unicode/numberformatter.h
@@ -372,9 +372,9 @@ class U_I18N_API Notation : public UMemory {
     UBool copyErrorTo(UErrorCode &status) const {
         if (fType == NTN_ERROR) {
             status = fUnion.errorCode;
-            return TRUE;
+            return true;
         }
-        return FALSE;
+        return false;
     }
 
     // To allow MacroProps to initialize empty instances:
@@ -726,9 +726,9 @@ class U_I18N_API Precision : public UMemory {
     UBool copyErrorTo(UErrorCode &status) const {
         if (fType == RND_ERROR) {
             status = fUnion.errorCode;
-            return TRUE;
+            return true;
         }
-        return FALSE;
+        return false;
     }
 
     // On the parent type so that this method can be called internally on Precision instances.
@@ -970,9 +970,9 @@ class U_I18N_API IntegerWidth : public UMemory {
     UBool copyErrorTo(UErrorCode &status) const {
         if (fHasError) {
             status = fUnion.errorCode;
-            return TRUE;
+            return true;
         }
-        return FALSE;
+        return false;
     }
 
     void apply(impl::DecimalQuantity &quantity, UErrorCode &status) const;
@@ -1098,9 +1098,9 @@ class U_I18N_API Scale : public UMemory {
     UBool copyErrorTo(UErrorCode &status) const {
         if (fError != U_ZERO_ERROR) {
             status = fError;
-            return TRUE;
+            return true;
         }
-        return FALSE;
+        return false;
     }
 
     void applyTo(impl::DecimalQuantity& quantity) const;
@@ -1193,12 +1193,12 @@ class U_I18N_API SymbolsWrapper : public UMemory {
     UBool copyErrorTo(UErrorCode &status) const {
         if (fType == SYMPTR_DFS && fPtr.dfs == nullptr) {
             status = U_MEMORY_ALLOCATION_ERROR;
-            return TRUE;
+            return true;
         } else if (fType == SYMPTR_NS && fPtr.ns == nullptr) {
             status = U_MEMORY_ALLOCATION_ERROR;
-            return TRUE;
+            return true;
         }
-        return FALSE;
+        return false;
     }
 
   private:
@@ -1342,9 +1342,9 @@ class U_I18N_API Padder : public UMemory {
     UBool copyErrorTo(UErrorCode &status) const {
         if (fWidth == -3) {
             status = fUnion.errorCode;
-            return TRUE;
+            return true;
         }
-        return FALSE;
+        return false;
     }
 
     bool isValid() const {
@@ -2121,13 +2121,13 @@ class U_I18N_API NumberFormatterSettings {
     /**
      * Sets the UErrorCode if an error occurred in the fluent chain.
      * Preserves older error codes in the outErrorCode.
-     * @return TRUE if U_FAILURE(outErrorCode)
+     * @return true if U_FAILURE(outErrorCode)
      * @stable ICU 60
      */
     UBool copyErrorTo(UErrorCode &outErrorCode) const {
         if (U_FAILURE(outErrorCode)) {
             // Do not overwrite the older error code
-            return TRUE;
+            return true;
         }
         fMacros.copyErrorTo(outErrorCode);
         return U_FAILURE(outErrorCode);

--- a/icu4c/source/i18n/unicode/numberrangeformatter.h
+++ b/icu4c/source/i18n/unicode/numberrangeformatter.h
@@ -354,13 +354,13 @@ class U_I18N_API NumberRangeFormatterSettings {
     /**
      * Sets the UErrorCode if an error occurred in the fluent chain.
      * Preserves older error codes in the outErrorCode.
-     * @return TRUE if U_FAILURE(outErrorCode)
+     * @return true if U_FAILURE(outErrorCode)
      * @stable ICU 63
      */
     UBool copyErrorTo(UErrorCode &outErrorCode) const {
         if (U_FAILURE(outErrorCode)) {
             // Do not overwrite the older error code
-            return TRUE;
+            return true;
         }
         fMacros.copyErrorTo(outErrorCode);
         return U_FAILURE(outErrorCode);

--- a/icu4c/source/i18n/unicode/numfmt.h
+++ b/icu4c/source/i18n/unicode/numfmt.h
@@ -704,8 +704,8 @@ public:
     /**
      * Sets whether lenient parsing should be enabled (it is off by default).
      *
-     * @param enable \c TRUE if lenient parsing should be used,
-     *               \c FALSE otherwise.
+     * @param enable \c true if lenient parsing should be used,
+     *               \c false otherwise.
      * @stable ICU 4.8
      */
     virtual void setLenient(UBool enable);
@@ -713,8 +713,8 @@ public:
     /**
      * Returns whether lenient parsing is enabled (it is off by default).
      *
-     * @return \c TRUE if lenient parsing is enabled,
-     *         \c FALSE otherwise.
+     * @return \c true if lenient parsing is enabled,
+     *         \c false otherwise.
      * @see #setLenient
      * @stable ICU 4.8
      */
@@ -870,7 +870,7 @@ public:
      * NumberFormat::createInstance to avoid undefined behavior.
      * @param key the registry key returned by a previous call to registerFactory
      * @param status the in/out status code, no special meanings are assigned
-     * @return TRUE if the factory for the key was successfully unregistered
+     * @return true if the factory for the key was successfully unregistered
      * @stable ICU 2.6
      */
     static UBool U_EXPORT2 unregister(URegistryKey key, UErrorCode& status);
@@ -1112,7 +1112,7 @@ protected:
 #ifndef U_HIDE_INTERNAL_API
     /**
      * Creates the specified number format style of the desired locale.
-     * If mustBeDecimalFormat is TRUE, then the returned pointer is
+     * If mustBeDecimalFormat is true, then the returned pointer is
      * either a DecimalFormat or it is NULL.
      * @internal
      */
@@ -1151,7 +1151,7 @@ private:
 
   private:
     UBool      fParseIntegerOnly;
-    UBool      fLenient; // TRUE => lenient parse is enabled
+    UBool      fLenient; // true => lenient parse is enabled
 
     // ISO currency code
     char16_t      fCurrency[4];
@@ -1228,7 +1228,7 @@ public:
     /**
      * @stable ICU 2.6
      */
-    SimpleNumberFormatFactory(const Locale& locale, UBool visible = TRUE);
+    SimpleNumberFormatFactory(const Locale& locale, UBool visible = true);
 
     /**
      * @stable ICU 3.0

--- a/icu4c/source/i18n/unicode/numsys.h
+++ b/icu4c/source/i18n/unicode/numsys.h
@@ -102,7 +102,7 @@ public:
     /**
      * Create a numbering system using the specified radix, type, and description. 
      * @param radix         The radix (base) for this numbering system.
-     * @param isAlgorithmic TRUE if the numbering system is algorithmic rather than numeric.
+     * @param isAlgorithmic true if the numbering system is algorithmic rather than numeric.
      * @param description   The string representing the set of digits used in a numeric system, or the name of the RBNF
      *                      ruleset to be used in an algorithmic system.
      * @param status ICU status
@@ -171,10 +171,10 @@ public:
 
 
     /**
-     * Returns TRUE if the given numbering system is algorithmic
+     * Returns true if the given numbering system is algorithmic
      *
-     * @return         TRUE if the numbering system is algorithmic.
-     *                 Otherwise, return FALSE.
+     * @return         true if the numbering system is algorithmic.
+     *                 Otherwise, return false.
      * @stable ICU 4.2
      */
     UBool isAlgorithmic() const;

--- a/icu4c/source/i18n/unicode/plurrule.h
+++ b/icu4c/source/i18n/unicode/plurrule.h
@@ -447,12 +447,12 @@ public:
                        UErrorCode& status);
 
     /**
-     * Returns TRUE if the given keyword is defined in this
+     * Returns true if the given keyword is defined in this
      * <code>PluralRules</code> object.
      *
      * @param keyword  the input keyword.
-     * @return         TRUE if the input keyword is defined.
-     *                 Otherwise, return FALSE.
+     * @return         true if the input keyword is defined.
+     *                 Otherwise, return false.
      * @stable ICU 4.0
      */
     UBool isKeyword(const UnicodeString& keyword) const;

--- a/icu4c/source/i18n/unicode/rbtz.h
+++ b/icu4c/source/i18n/unicode/rbtz.h
@@ -258,7 +258,7 @@ public:
      * @param base      The base time.
      * @param inclusive Whether the base time is inclusive or not.
      * @param result    Receives the first transition after the base time.
-     * @return  TRUE if the transition is found.
+     * @return  true if the transition is found.
      * @stable ICU 3.8
      */
     virtual UBool getNextTransition(UDate base, UBool inclusive, TimeZoneTransition& result) const;
@@ -268,7 +268,7 @@ public:
      * @param base      The base time.
      * @param inclusive Whether the base time is inclusive or not.
      * @param result    Receives the most recent transition before the base time.
-     * @return  TRUE if the transition is found.
+     * @return  true if the transition is found.
      * @stable ICU 3.8
      */
     virtual UBool getPreviousTransition(UDate base, UBool inclusive, TimeZoneTransition& result) const;

--- a/icu4c/source/i18n/unicode/regex.h
+++ b/icu4c/source/i18n/unicode/regex.h
@@ -116,7 +116,7 @@ public:
      * were constructed from identical source patterns using the same #URegexpFlag
      * settings.
      * @param that a RegexPattern object to compare with "this".
-     * @return TRUE if the objects are equivalent.
+     * @return true if the objects are equivalent.
      * @stable ICU 2.4
      */
     UBool           operator==(const RegexPattern& that) const;
@@ -126,7 +126,7 @@ public:
      * were constructed from identical source patterns using the same #URegexpFlag
      * settings.
      * @param that a RegexPattern object to compare with "this".
-     * @return TRUE if the objects are different.
+     * @return true if the objects are different.
      * @stable ICU 2.4
      */
     inline UBool    operator!=(const RegexPattern& that) const {return ! operator ==(that);}
@@ -764,7 +764,7 @@ public:
    /**
     *   Attempts to match the entire input region against the pattern.
     *    @param   status     A reference to a UErrorCode to receive any errors.
-    *    @return TRUE if there is a match
+    *    @return true if there is a match
     *    @stable ICU 2.4
     */
     virtual UBool matches(UErrorCode &status);
@@ -777,7 +777,7 @@ public:
     *   A successful match must extend to the end of the input.
     *    @param   startIndex The input string (native) index at which to begin matching.
     *    @param   status     A reference to a UErrorCode to receive any errors.
-    *    @return TRUE if there is a match
+    *    @return true if there is a match
     *    @stable ICU 2.8
     */
     virtual UBool matches(int64_t startIndex, UErrorCode &status);
@@ -793,7 +793,7 @@ public:
     *   end(), and group() functions.
     *
     *    @param   status     A reference to a UErrorCode to receive any errors.
-    *    @return  TRUE if there is a match at the start of the input string.
+    *    @return  true if there is a match at the start of the input string.
     *    @stable ICU 2.4
     */
     virtual UBool lookingAt(UErrorCode &status);
@@ -809,7 +809,7 @@ public:
     *
     *    @param   startIndex The input string (native) index at which to begin matching.
     *    @param   status     A reference to a UErrorCode to receive any errors.
-    *    @return  TRUE if there is a match.
+    *    @return  true if there is a match.
     *    @stable ICU 2.8
     */
     virtual UBool lookingAt(int64_t startIndex, UErrorCode &status);
@@ -824,7 +824,7 @@ public:
     *  Note that if the input string is changed by the application,
     *     use find(startPos, status) instead of find(), because the saved starting
     *     position may not be valid with the altered input string.
-    *  @return  TRUE if a match is found.
+    *  @return  true if a match is found.
     *  @stable ICU 2.4
     */
     virtual UBool find();
@@ -841,7 +841,7 @@ public:
     *  use find(startPos, status) instead of find(), because the saved starting
     *  position may not be valid with the altered input string.
     *  @param   status  A reference to a UErrorCode to receive any errors.
-    *  @return  TRUE if a match is found.
+    *  @return  true if a match is found.
     * @stable ICU 55
     */
     virtual UBool find(UErrorCode &status);
@@ -852,7 +852,7 @@ public:
     *
     *   @param   start     The (native) index in the input string to begin the search.
     *   @param   status    A reference to a UErrorCode to receive any errors.
-    *   @return  TRUE if a match is found.
+    *   @return  true if a match is found.
     *   @stable ICU 2.4
     */
     virtual UBool find(int64_t start, UErrorCode &status);
@@ -1271,7 +1271,7 @@ public:
       * See useTransparentBounds for a description of transparent and opaque bounds.
       * By default, a matcher uses opaque region boundaries.
       *
-      * @return TRUE if this matcher is using opaque bounds, false if it is not.
+      * @return true if this matcher is using opaque bounds, false if it is not.
       * @stable ICU 4.0
       */
       virtual UBool hasTransparentBounds() const;
@@ -1290,7 +1290,7 @@ public:
       *
       * By default, a matcher uses opaque bounds.
       *
-      * @param   b TRUE for transparent bounds; FALSE for opaque bounds
+      * @param   b true for transparent bounds; false for opaque bounds
       * @return  This Matcher;
       * @stable ICU 4.0
       **/
@@ -1301,7 +1301,7 @@ public:
       * Return true if this matcher is using anchoring bounds.
       * By default, matchers use anchoring region bounds.
       *
-      * @return TRUE if this matcher is using anchoring bounds.
+      * @return true if this matcher is using anchoring bounds.
       * @stable ICU 4.0
       */    
       virtual UBool hasAnchoringBounds() const;
@@ -1315,7 +1315,7 @@ public:
       *
       * Anchoring Bounds are the default for regions.
       *
-      * @param b TRUE if to enable anchoring bounds; FALSE to disable them.
+      * @param b true if to enable anchoring bounds; false to disable them.
       * @return  This Matcher
       * @stable ICU 4.0
       */
@@ -1323,26 +1323,26 @@ public:
 
 
     /**
-      * Return TRUE if the most recent matching operation attempted to access
+      * Return true if the most recent matching operation attempted to access
       *  additional input beyond the available input text.
       *  In this case, additional input text could change the results of the match.
       *
       *  hitEnd() is defined for both successful and unsuccessful matches.
-      *  In either case hitEnd() will return TRUE if if the end of the text was
+      *  In either case hitEnd() will return true if if the end of the text was
       *  reached at any point during the matching process.
       *
-      *  @return  TRUE if the most recent match hit the end of input
+      *  @return  true if the most recent match hit the end of input
       *  @stable ICU 4.0
       */
       virtual UBool hitEnd() const;
 
     /**
-      * Return TRUE the most recent match succeeded and additional input could cause
+      * Return true the most recent match succeeded and additional input could cause
       * it to fail. If this method returns false and a match was found, then more input
       * might change the match but the match won't be lost. If a match was not found,
       * then requireEnd has no meaning.
       *
-      * @return TRUE if more input could cause the most recent match to no longer match.
+      * @return true if more input could cause the most recent match to no longer match.
       * @stable ICU 4.0
       */
       virtual UBool requireEnd() const;
@@ -1781,7 +1781,7 @@ private:
     inline REStackFrame *StateSave(REStackFrame *fp, int64_t savePatIdx, UErrorCode &status);
     void                 IncrementTime(UErrorCode &status);
 
-    // Call user find callback function, if set. Return TRUE if operation should be interrupted.
+    // Call user find callback function, if set. Return true if operation should be interrupted.
     inline UBool         findProgressInterrupt(int64_t matchIndex, UErrorCode &status);
     
     int64_t              appendGroup(int32_t groupNum, UText *dest, UErrorCode &status) const;

--- a/icu4c/source/i18n/unicode/search.h
+++ b/icu4c/source/i18n/unicode/search.h
@@ -267,9 +267,9 @@ public:
     /**
      * Equality operator. 
      * @param that SearchIterator instance to be compared.
-     * @return TRUE if both BreakIterators are of the same class, have the 
+     * @return true if both BreakIterators are of the same class, have the 
      *         same behavior, terates over the same text and have the same
-     *         attributes. FALSE otherwise.
+     *         attributes. false otherwise.
      * @stable ICU 2.0
      */
     virtual UBool operator==(const SearchIterator &that) const;
@@ -277,7 +277,7 @@ public:
     /**
      * Not-equal operator. 
      * @param that SearchIterator instance to be compared.
-     * @return FALSE if operator== returns TRUE, and vice versa.
+     * @return false if operator== returns true, and vice versa.
      * @stable ICU 2.0
      */
     UBool operator!=(const SearchIterator &that) const;

--- a/icu4c/source/i18n/unicode/simpletz.h
+++ b/icu4c/source/i18n/unicode/simpletz.h
@@ -714,7 +714,7 @@ public:
      * @param base      The base time.
      * @param inclusive Whether the base time is inclusive or not.
      * @param result    Receives the first transition after the base time.
-     * @return  TRUE if the transition is found.
+     * @return  true if the transition is found.
      * @stable ICU 3.8
      */
     virtual UBool getNextTransition(UDate base, UBool inclusive, TimeZoneTransition& result) const;
@@ -724,7 +724,7 @@ public:
      * @param base      The base time.
      * @param inclusive Whether the base time is inclusive or not.
      * @param result    Receives the most recent transition before the base time.
-     * @return  TRUE if the transition is found.
+     * @return  true if the transition is found.
      * @stable ICU 3.8
      */
     virtual UBool getPreviousTransition(UDate base, UBool inclusive, TimeZoneTransition& result) const;

--- a/icu4c/source/i18n/unicode/smpdtfmt.h
+++ b/icu4c/source/i18n/unicode/smpdtfmt.h
@@ -1183,11 +1183,11 @@ public:
     /**
      * This is for ICU internal use only. Please do not use.
      * Check whether the 'field' is smaller than all the fields covered in
-     * pattern, return TRUE if it is. The sequence of calendar field,
+     * pattern, return true if it is. The sequence of calendar field,
      * from large to small is: ERA, YEAR, MONTH, DATE, AM_PM, HOUR, MINUTE,...
      * @param field    the calendar field need to check against
-     * @return         TRUE if the 'field' is smaller than all the fields
-     *                 covered in pattern. FALSE otherwise.
+     * @return         true if the 'field' is smaller than all the fields
+     *                 covered in pattern. false otherwise.
      * @internal ICU 4.0
      */
     UBool isFieldUnitIgnored(UCalendarDateFields field) const;
@@ -1196,12 +1196,12 @@ public:
     /**
      * This is for ICU internal use only. Please do not use.
      * Check whether the 'field' is smaller than all the fields covered in
-     * pattern, return TRUE if it is. The sequence of calendar field,
+     * pattern, return true if it is. The sequence of calendar field,
      * from large to small is: ERA, YEAR, MONTH, DATE, AM_PM, HOUR, MINUTE,...
      * @param pattern  the pattern to check against
      * @param field    the calendar field need to check against
-     * @return         TRUE if the 'field' is smaller than all the fields
-     *                 covered in pattern. FALSE otherwise.
+     * @return         true if the 'field' is smaller than all the fields
+     *                 covered in pattern. false otherwise.
      * @internal ICU 4.0
      */
     static UBool isFieldUnitIgnored(const UnicodeString& pattern,
@@ -1305,12 +1305,12 @@ private:
     static UBool isNumeric(char16_t formatChar, int32_t count);
 
     /**
-     * Returns TRUE if the patternOffset is at the start of a numeric field.
+     * Returns true if the patternOffset is at the start of a numeric field.
      */
     static UBool isAtNumericField(const UnicodeString &pattern, int32_t patternOffset);
 
     /**
-     * Returns TRUE if the patternOffset is right after a non-numeric field.
+     * Returns true if the patternOffset is right after a non-numeric field.
      */
     static UBool isAfterNonNumericField(const UnicodeString &pattern, int32_t patternOffset);
 
@@ -1390,11 +1390,11 @@ private:
      * @param text the text being parsed
      * @param textOffset the starting offset into the text. On output
      *                   will be set to the offset of the character after the match
-     * @param whitespaceLenient <code>TRUE</code> if whitespace parse is lenient, <code>FALSE</code> otherwise.
-     * @param partialMatchLenient <code>TRUE</code> if partial match parse is lenient, <code>FALSE</code> otherwise.
-     * @param oldLeniency <code>TRUE</code> if old leniency control is lenient, <code>FALSE</code> otherwise.
+     * @param whitespaceLenient <code>true</code> if whitespace parse is lenient, <code>false</code> otherwise.
+     * @param partialMatchLenient <code>true</code> if partial match parse is lenient, <code>false</code> otherwise.
+     * @param oldLeniency <code>true</code> if old leniency control is lenient, <code>false</code> otherwise.
      *
-     * @return <code>TRUE</code> if the literal text could be matched, <code>FALSE</code> otherwise.
+     * @return <code>true</code> if the literal text could be matched, <code>false</code> otherwise.
      */
     static UBool matchLiterals(const UnicodeString &pattern, int32_t &patternOffset,
                                const UnicodeString &text, int32_t &textOffset,

--- a/icu4c/source/i18n/unicode/sortkey.h
+++ b/icu4c/source/i18n/unicode/sortkey.h
@@ -150,7 +150,7 @@ public:
     /**
     * Compare if two collation keys are not the same.
     * @param source the collation key to compare to.
-    * @return Returns TRUE if two collation keys are different, FALSE otherwise.
+    * @return Returns true if two collation keys are different, false otherwise.
     * @stable ICU 2.0
     */
     UBool                   operator!=(const CollationKey& source) const;
@@ -159,7 +159,7 @@ public:
     /**
     * Test to see if the key is in an invalid state. The key will be in an
     * invalid state if it couldn't allocate memory for some operation.
-    * @return Returns TRUE if the key is in an invalid, FALSE otherwise.
+    * @return Returns true if the key is in an invalid, false otherwise.
     * @stable ICU 2.0
     */
     UBool                   isBogus(void) const;

--- a/icu4c/source/i18n/unicode/stsearch.h
+++ b/icu4c/source/i18n/unicode/stsearch.h
@@ -292,7 +292,7 @@ public:
     /**
      * Equality operator. 
      * @param that instance to be compared.
-     * @return TRUE if both instances have the same attributes, 
+     * @return true if both instances have the same attributes, 
      *         breakiterators, collators and iterate over the same text 
      *         while looking for the same pattern.
      * @stable ICU 2.0

--- a/icu4c/source/i18n/unicode/tblcoll.h
+++ b/icu4c/source/i18n/unicode/tblcoll.h
@@ -752,7 +752,7 @@ public:
      * Implements ucol_getContractionsAndExpansions().
      * Gets this collator's sets of contraction strings and/or
      * characters and strings that map to multiple collation elements (expansions).
-     * If addPrefixes is TRUE, then contractions that are expressed as
+     * If addPrefixes is true, then contractions that are expressed as
      * prefix/pre-context rules are included.
      * @param contractions if not NULL, the set to hold the contractions
      * @param expansions if not NULL, the set to hold the expansions
@@ -857,7 +857,7 @@ private:
      * Tests whether a character is "unsafe" for use as a collation starting point.
      *
      * @param c code point or code unit
-     * @return TRUE if c is unsafe
+     * @return true if c is unsafe
      * @see CollationElementIterator#setOffset(int)
      */
     UBool isUnsafe(UChar32 c) const;

--- a/icu4c/source/i18n/unicode/timezone.h
+++ b/icu4c/source/i18n/unicode/timezone.h
@@ -707,8 +707,8 @@ public:
      * there are time zones that used daylight savings time in the
      * past, but no longer used currently. For example, Asia/Tokyo has
      * never used daylight savings time since 1951. Most clients would
-     * expect that this method to return <code>FALSE</code> for such case.
-     * The default implementation of this method returns <code>TRUE</code>
+     * expect that this method to return <code>false</code> for such case.
+     * The default implementation of this method returns <code>true</code>
      * when the time zone uses daylight savings time in the current
      * (Gregorian) calendar year.
      * <p>In Java 7, <code>observesDaylightTime()</code> was added in
@@ -925,7 +925,7 @@ private:
      * @param hour Receives parsed hour field
      * @param minute Receives parsed minute field
      * @param second Receives parsed second field
-     * @return Returns TRUE when the given custom id is valid.
+     * @return Returns true when the given custom id is valid.
      */
     static UBool parseCustomID(const UnicodeString& id, int32_t& sign, int32_t& hour,
         int32_t& minute, int32_t& second);
@@ -948,7 +948,7 @@ private:
      * @param hour offset hours
      * @param min offset minutes
      * @param sec offset seconds
-     * @param negative sign of the offset, TRUE for negative offset.
+     * @param negative sign of the offset, true for negative offset.
      * @param id Receves the format result (normalized custom ID)
      * @return The reference to id
      */

--- a/icu4c/source/i18n/unicode/tmutamt.h
+++ b/icu4c/source/i18n/unicode/tmutamt.h
@@ -39,7 +39,7 @@ public:
     /**
      * Construct TimeUnitAmount object with the given number and the
      * given time unit. 
-     * @param number        a numeric object; number.isNumeric() must be TRUE
+     * @param number        a numeric object; number.isNumeric() must be true
      * @param timeUnitField the time unit field of a time unit
      * @param status        the input-output error code. 
      *                      If the number is not numeric or the timeUnitField

--- a/icu4c/source/i18n/unicode/translit.h
+++ b/icu4c/source/i18n/unicode/translit.h
@@ -882,7 +882,7 @@ public:
      * another transliterator.
      * @param text the text to be transliterated
      * @param index the position indices
-     * @param incremental if TRUE, then assume more characters may be inserted
+     * @param incremental if true, then assume more characters may be inserted
      * at index.limit, and postpone processing to accomodate future incoming
      * characters
      * @stable ICU 2.4
@@ -897,14 +897,14 @@ private:
      * Top-level transliteration method, handling filtering, incremental and
      * non-incremental transliteration, and rollback.  All transliteration
      * public API methods eventually call this method with a rollback argument
-     * of TRUE.  Other entities may call this method but rollback should be
-     * FALSE.
+     * of true.  Other entities may call this method but rollback should be
+     * false.
      *
      * <p>If this transliterator has a filter, break up the input text into runs
      * of unfiltered characters.  Pass each run to
      * subclass.handleTransliterate().
      *
-     * <p>In incremental mode, if rollback is TRUE, perform a special
+     * <p>In incremental mode, if rollback is true, perform a special
      * incremental procedure in which several passes are made over the input
      * text, adding one character at a time, and committing successful
      * transliterations as they occur.  Unsuccessful transliterations are rolled
@@ -912,12 +912,12 @@ private:
      *
      * @param text the text to be transliterated
      * @param index the position indices
-     * @param incremental if TRUE, then assume more characters may be inserted
+     * @param incremental if true, then assume more characters may be inserted
      * at index.limit, and postpone processing to accomodate future incoming
      * characters
-     * @param rollback if TRUE and if incremental is TRUE, then perform special
+     * @param rollback if true and if incremental is true, then perform special
      * incremental processing, as described above, and undo partial
-     * transliterations where necessary.  If incremental is FALSE then this
+     * transliterations where necessary.  If incremental is false then this
      * parameter is ignored.
      */
     virtual void filteredTransliterate(Replaceable& text,
@@ -1119,7 +1119,7 @@ public:
      * to recreate this transliterator.
      * @param result the string to receive the rules.  Previous
      * contents will be deleted.
-     * @param escapeUnprintable if TRUE then convert unprintable
+     * @param escapeUnprintable if true then convert unprintable
      * character to their hex escape representations, \\uxxxx or
      * \\Uxxxxxxxx.  Unprintable characters are those other than
      * U+000A, U+0020..U+007E.

--- a/icu4c/source/i18n/unicode/tzfmt.h
+++ b/icu4c/source/i18n/unicode/tzfmt.h
@@ -295,7 +295,7 @@ public:
      * Return true if the given Format objects are semantically equal.
      * Objects of different subclasses are considered unequal.
      * @param other The object to be compared with.
-     * @return Return TRUE if the given Format objects are semantically equal.
+     * @return Return true if the given Format objects are semantically equal.
      *                Objects of different subclasses are considered unequal.
      * @stable ICU 50
      */
@@ -814,7 +814,7 @@ private:
      * @param str the string
      * @param codeArray receives the result
      * @param capacity the capacity of codeArray
-     * @return TRUE when the specified code array is fully filled with code points
+     * @return true when the specified code array is fully filled with code points
      *         (no under/overflow).
      */
     static UBool toCodePoints(const UnicodeString& str, UChar32* codeArray, int32_t capacity);
@@ -849,8 +849,8 @@ private:
      * @param text the text contains ISO 8601 style time zone string (e.g. "-08:00", "Z")
      *      at the position.
      * @param pos the position, non-negative error index will be set on failure.
-     * @param extendedOnly TRUE if parsing the text as ISO 8601 extended offset format (e.g. "-08:00"),
-     *      or FALSE to evaluate the text as basic format.
+     * @param extendedOnly true if parsing the text as ISO 8601 extended offset format (e.g. "-08:00"),
+     *      or false to evaluate the text as basic format.
      * @param hasDigitOffset receiving if the parsed zone string contains offset digits.
      * @return the offset from GMT(UTC) in milliseconds for the given ISO 8601 style
      *      time zone string.

--- a/icu4c/source/i18n/unicode/tznames.h
+++ b/icu4c/source/i18n/unicode/tznames.h
@@ -139,7 +139,7 @@ public:
     /**
      * Return true if the given TimeZoneNames objects are semantically equal.
      * @param other the object to be compared with.
-     * @return Return TRUE if the given Format objects are semantically equal.
+     * @return Return true if the given Format objects are semantically equal.
      * @stable ICU 50
      */
     virtual UBool operator==(const TimeZoneNames& other) const = 0;
@@ -148,7 +148,7 @@ public:
      * Return true if the given TimeZoneNames objects are not semantically
      * equal.
      * @param other the object to be compared with.
-     * @return Return TRUE if the given Format objects are not semantically equal.
+     * @return Return true if the given Format objects are not semantically equal.
      * @stable ICU 50
      */
     UBool operator!=(const TimeZoneNames& other) const { return !operator==(other); }
@@ -373,7 +373,7 @@ public:
          * Gets the zone ID of a match at the specified index.
          * @param idx The index
          * @param tzID Receives the zone ID.
-         * @return TRUE if the zone ID was set to tzID.
+         * @return true if the zone ID was set to tzID.
          * @internal
          */
         UBool getTimeZoneIDAt(int32_t idx, UnicodeString& tzID) const;
@@ -382,7 +382,7 @@ public:
          * Gets the metazone ID of a match at the specified index.
          * @param idx The index
          * @param mzID Receives the metazone ID
-         * @return TRUE if the meta zone ID was set to mzID.
+         * @return true if the meta zone ID was set to mzID.
          * @internal
          */
         UBool getMetaZoneIDAt(int32_t idx, UnicodeString& mzID) const;

--- a/icu4c/source/i18n/unicode/ucal.h
+++ b/icu4c/source/i18n/unicode/ucal.h
@@ -871,7 +871,7 @@ ucal_getTimeZoneDisplayName(const UCalendar*          cal,
  * Daylight savings time is not used in all parts of the world.
  * @param cal The UCalendar to query.
  * @param status A pointer to an UErrorCode to receive any errors
- * @return TRUE if cal is currently in daylight savings time, FALSE otherwise
+ * @return true if cal is currently in daylight savings time, false otherwise
  * @stable ICU 2.0
  */
 U_STABLE UBool U_EXPORT2 
@@ -1125,12 +1125,12 @@ ucal_setDateTime(UCalendar*   cal,
                  UErrorCode*  status);
 
 /**
- * Returns TRUE if two UCalendars are equivalent.  Equivalent
+ * Returns true if two UCalendars are equivalent.  Equivalent
  * UCalendars will behave identically, but they may be set to
  * different times.
  * @param cal1 The first of the UCalendars to compare.
  * @param cal2 The second of the UCalendars to compare.
- * @return TRUE if cal1 and cal2 are equivalent, FALSE otherwise.
+ * @return true if cal1 and cal2 are equivalent, false otherwise.
  * @stable ICU 2.0
  */
 U_STABLE UBool U_EXPORT2 
@@ -1240,7 +1240,7 @@ ucal_set(UCalendar*           cal,
  * UCAL_WEEK_OF_YEAR, UCAL_WEEK_OF_MONTH, UCAL_DATE, UCAL_DAY_OF_YEAR, UCAL_DAY_OF_WEEK,
  * UCAL_DAY_OF_WEEK_IN_MONTH, UCAL_AM_PM, UCAL_HOUR, UCAL_HOUR_OF_DAY, UCAL_MINUTE, UCAL_SECOND,
  * UCAL_MILLISECOND, UCAL_ZONE_OFFSET, UCAL_DST_OFFSET.
- * @return TRUE if field is set, FALSE otherwise.
+ * @return true if field is set, false otherwise.
  * @see ucal_get
  * @see ucal_set
  * @see ucal_clearField
@@ -1467,13 +1467,13 @@ U_STABLE int32_t U_EXPORT2
 ucal_getWeekendTransition(const UCalendar *cal, UCalendarDaysOfWeek dayOfWeek, UErrorCode *status);
 
 /**
- * Returns TRUE if the given UDate is in the weekend in
+ * Returns true if the given UDate is in the weekend in
  * this calendar system.
  * @param cal The UCalendar to query.
  * @param date The UDate in question.
  * @param status The error code for the operation.
- * @return TRUE if the given UDate is in the weekend in
- * this calendar system, FALSE otherwise.
+ * @return true if the given UDate is in the weekend in
+ * this calendar system, false otherwise.
  * @stable ICU 4.4
  */
 U_STABLE UBool U_EXPORT2
@@ -1547,13 +1547,13 @@ typedef enum UTimeZoneTransitionType UTimeZoneTransitionType; /**< @stable ICU 5
 * the calendar's current date, in the time zone to which the calendar
 * is currently set. If there is no known time zone transition of the
 * requested type relative to the calendar's date, the function returns
-* FALSE.
+* false.
 * @param cal The UCalendar to query.
 * @param type The type of transition desired.
 * @param transition A pointer to a UDate to be set to the transition time.
-*         If the function returns FALSE, the value set is unspecified.
+*         If the function returns false, the value set is unspecified.
 * @param status A pointer to a UErrorCode to receive any errors.
-* @return TRUE if a valid transition time is set in *transition, FALSE
+* @return true if a valid transition time is set in *transition, false
 *         otherwise.
 * @stable ICU 50
 */

--- a/icu4c/source/i18n/unicode/ucol.h
+++ b/icu4c/source/i18n/unicode/ucol.h
@@ -452,12 +452,12 @@ ucol_openRules( const UChar        *rules,
  *                   state for a locale.
  * @param parseError if not NULL, structure that will get filled with error's pre
  *                   and post context in case of error.
- * @param forceDefaults if FALSE, the settings that are the same as the collator 
+ * @param forceDefaults if false, the settings that are the same as the collator 
  *                   default settings will not be applied (for example, setting
  *                   French secondary on a French collator would not be executed). 
- *                   If TRUE, all the settings will be applied regardless of the 
+ *                   If true, all the settings will be applied regardless of the 
  *                   collator default value. If the definition
- *                   strings are to be cached, should be set to FALSE.
+ *                   strings are to be cached, should be set to false.
  * @param status     Error code. Apart from regular error conditions connected to 
  *                   instantiating collators (like out of memory or similar), this
  *                   API will return an error if an invalid attribute or attribute/value
@@ -603,7 +603,7 @@ ucol_strcollUTF8(
  * @param sourceLength The length of source, or -1 if null-terminated.
  * @param target The target string.
  * @param targetLength The length of target, or -1 if null-terminated.
- * @return TRUE if source is greater than target, FALSE otherwise.
+ * @return true if source is greater than target, false otherwise.
  * @see ucol_strcoll
  * @see ucol_greaterOrEqual
  * @see ucol_equal
@@ -622,7 +622,7 @@ ucol_greater(const UCollator *coll,
  * @param sourceLength The length of source, or -1 if null-terminated.
  * @param target The target string.
  * @param targetLength The length of target, or -1 if null-terminated.
- * @return TRUE if source is greater than or equal to target, FALSE otherwise.
+ * @return true if source is greater than or equal to target, false otherwise.
  * @see ucol_strcoll
  * @see ucol_greater
  * @see ucol_equal
@@ -641,7 +641,7 @@ ucol_greaterOrEqual(const UCollator *coll,
  * @param sourceLength The length of source, or -1 if null-terminated.
  * @param target The target string.
  * @param targetLength The length of target, or -1 if null-terminated.
- * @return TRUE if source is equal to target, FALSE otherwise
+ * @return true if source is equal to target, false otherwise
  * @see ucol_strcoll
  * @see ucol_greater
  * @see ucol_greaterOrEqual
@@ -1439,12 +1439,12 @@ ucol_getUnsafeSet( const UCollator *coll,
  *                   state for a locale.
  * @param parseError if not NULL, structure that will get filled with error's pre
  *                   and post context in case of error.
- * @param forceDefaults if FALSE, the settings that are the same as the collator 
+ * @param forceDefaults if false, the settings that are the same as the collator 
  *                   default settings will not be applied (for example, setting
  *                   French secondary on a French collator would not be executed). 
- *                   If TRUE, all the settings will be applied regardless of the 
+ *                   If true, all the settings will be applied regardless of the 
  *                   collator default value. If the definition
- *                   strings are to be cached, should be set to FALSE.
+ *                   strings are to be cached, should be set to false.
  * @param status     Error code. Apart from regular error conditions connected to 
  *                   instantiating collators (like out of memory or similar), this
  *                   API will return an error if an invalid attribute or attribute/value

--- a/icu4c/source/i18n/unicode/ucsdet.h
+++ b/icu4c/source/i18n/unicode/ucsdet.h
@@ -360,7 +360,7 @@ ucsdet_getAllDetectableCharsets(const UCharsetDetector *ucsd,  UErrorCode *statu
   *  heuristics.
   *
   *  @param ucsd  The charset detector to check.
-  *  @return TRUE if filtering is enabled.
+  *  @return true if filtering is enabled.
   *  @stable ICU 3.6
   */
 
@@ -406,7 +406,7 @@ ucsdet_getDetectableCharsets(const UCharsetDetector *ucsd,  UErrorCode *status);
   *
   * @param ucsd a Charset detector.
   * @param encoding encoding the name of charset encoding.
-  * @param enabled <code>TRUE</code> to enable, or <code>FALSE</code> to disable the
+  * @param enabled <code>true</code> to enable, or <code>false</code> to disable the
   *   charset encoding.
   * @param status receives the return status. When the name of charset encoding
   *   is not supported, U_ILLEGAL_ARGUMENT_ERROR is set.

--- a/icu4c/source/i18n/unicode/udat.h
+++ b/icu4c/source/i18n/unicode/udat.h
@@ -1235,7 +1235,7 @@ udat_parseCalendar(const    UDateFormat*    format,
 * With lenient parsing, the parser may use heuristics to interpret inputs that do not
 * precisely match the pattern. With strict parsing, inputs must match the pattern.
 * @param fmt The formatter to query
-* @return TRUE if fmt is set to perform lenient parsing, FALSE otherwise.
+* @return true if fmt is set to perform lenient parsing, false otherwise.
 * @see udat_setLenient
 * @stable ICU 2.0
 */
@@ -1247,7 +1247,7 @@ udat_isLenient(const UDateFormat* fmt);
 * With lenient parsing, the parser may use heuristics to interpret inputs that do not
 * precisely match the pattern. With strict parsing, inputs must match the pattern.
 * @param fmt The formatter to set
-* @param isLenient TRUE if fmt should perform lenient parsing, FALSE otherwise.
+* @param isLenient true if fmt should perform lenient parsing, false otherwise.
 * @see dat_isLenient
 * @stable ICU 2.0
 */
@@ -1407,7 +1407,7 @@ udat_set2DigitYearStart(    UDateFormat     *fmt,
 * Extract the pattern from a UDateFormat.
 * The pattern will follow the pattern syntax rules.
 * @param fmt The formatter to query.
-* @param localized TRUE if the pattern should be localized, FALSE otherwise.
+* @param localized true if the pattern should be localized, false otherwise.
 * @param result A pointer to a buffer to receive the pattern.
 * @param resultLength The maximum size of result.
 * @param status A pointer to an UErrorCode to receive any errors
@@ -1426,7 +1426,7 @@ udat_toPattern(    const   UDateFormat     *fmt,
 * Set the pattern used by an UDateFormat.
 * The pattern should follow the pattern syntax rules.
 * @param format The formatter to set.
-* @param localized TRUE if the pattern is localized, FALSE otherwise.
+* @param localized true if the pattern is localized, false otherwise.
 * @param pattern The new pattern
 * @param patternLength The length of pattern, or -1 if null-terminated.
 * @see udat_toPattern

--- a/icu4c/source/i18n/unicode/uformattedvalue.h
+++ b/icu4c/source/i18n/unicode/uformattedvalue.h
@@ -220,7 +220,7 @@ ucfpos_constrainField(
  *
  * If a category or field constraint was set, this function returns the constrained
  * category. Otherwise, the return value is well-defined only after
- * ufmtval_nextPosition returns TRUE.
+ * ufmtval_nextPosition returns true.
  *
  * @param ucfpos The instance of UConstrainedFieldPosition.
  * @param ec Set if an error occurs.
@@ -238,7 +238,7 @@ ucfpos_getCategory(
  *
  * If a field constraint was set, this function returns the constrained
  * field. Otherwise, the return value is well-defined only after
- * ufmtval_nextPosition returns TRUE.
+ * ufmtval_nextPosition returns true.
  *
  * @param ucfpos The instance of UConstrainedFieldPosition.
  * @param ec Set if an error occurs.
@@ -254,7 +254,7 @@ ucfpos_getField(
 /**
  * Gets the INCLUSIVE start and EXCLUSIVE end index stored for the current position.
  *
- * The output values are well-defined only after ufmtval_nextPosition returns TRUE.
+ * The output values are well-defined only after ufmtval_nextPosition returns true.
  *
  * @param ucfpos The instance of UConstrainedFieldPosition.
  * @param pStart Set to the start index saved in the instance. Ignored if nullptr.
@@ -401,7 +401,7 @@ ufmtval_getString(
  *         see ucfpos_constrainCategory
  *         and ucfpos_constrainField.
  * @param ec Set if an error occurs.
- * @return TRUE if another position was found; FALSE otherwise.
+ * @return true if another position was found; false otherwise.
  * @stable ICU 64
  */
 U_STABLE UBool U_EXPORT2

--- a/icu4c/source/i18n/unicode/unirepl.h
+++ b/icu4c/source/i18n/unicode/unirepl.h
@@ -77,7 +77,7 @@ class U_I18N_API UnicodeReplacer /* not : public UObject because this is an inte
      * replacer that is equal to this one.
      * @param result the string to receive the pattern.  Previous
      * contents will be deleted.
-     * @param escapeUnprintable if TRUE then convert unprintable
+     * @param escapeUnprintable if true then convert unprintable
      * character to their hex escape representations, \\uxxxx or
      * \\Uxxxxxxxx.  Unprintable characters are defined by
      * Utility.isUnprintable().

--- a/icu4c/source/i18n/unicode/unum.h
+++ b/icu4c/source/i18n/unicode/unum.h
@@ -925,7 +925,7 @@ unum_parseToUFormattable(const UNumberFormat* fmt,
  * on a DecimalFormat, other formats return U_UNSUPPORTED_ERROR
  * in the status.
  * @param format The formatter to set.
- * @param localized TRUE if the pattern is localized, FALSE otherwise.
+ * @param localized true if the pattern is localized, false otherwise.
  * @param pattern The new pattern
  * @param patternLength The length of pattern, or -1 if null-terminated.
  * @param parseError A pointer to UParseError to receive information
@@ -1300,8 +1300,8 @@ unum_setTextAttribute(    UNumberFormat*                    fmt,
  * Extract the pattern from a UNumberFormat.  The pattern will follow
  * the DecimalFormat pattern syntax.
  * @param fmt The formatter to query.
- * @param isPatternLocalized TRUE if the pattern should be localized,
- * FALSE otherwise.  This is ignored if the formatter is a rule-based
+ * @param isPatternLocalized true if the pattern should be localized,
+ * false otherwise.  This is ignored if the formatter is a rule-based
  * formatter.
  * @param result A pointer to a buffer to receive the pattern.
  * @param resultLength The maximum size of result.

--- a/icu4c/source/i18n/unicode/unumberformatter.h
+++ b/icu4c/source/i18n/unicode/unumberformatter.h
@@ -625,7 +625,7 @@ unumf_resultToString(const UFormattedNumber* uresult, UChar* buffer, int32_t buf
  *            "beginIndex" field is set to the beginning of the first occurrence of the field after the
  *            input "endIndex", and "endIndex" is set to the end of that occurrence of the field
  *            (exclusive index). If a field position is not found, the FieldPosition is not changed and
- *            the method returns FALSE.
+ *            the method returns false.
  * @param ec Set if an error occurs.
  * @stable ICU 62
  */

--- a/icu4c/source/i18n/unicode/unumsys.h
+++ b/icu4c/source/i18n/unicode/unumsys.h
@@ -133,7 +133,7 @@ unumsys_getName(const UNumberingSystem *unumsys);
  * Returns whether the given UNumberingSystem object is for an algorithmic (not purely
  * positional) system.
  * @param unumsys   The UNumberingSystem whose algorithmic status is desired.
- * @return          TRUE if the specified UNumberingSystem object is for an algorithmic
+ * @return          true if the specified UNumberingSystem object is for an algorithmic
  *                  system.
  * @stable ICU 52
  */

--- a/icu4c/source/i18n/unicode/uregex.h
+++ b/icu4c/source/i18n/unicode/uregex.h
@@ -444,7 +444,7 @@ uregex_refreshUText(URegularExpression *regexp,
   *    @param  startIndex  The input string (native) index at which to begin matching, or -1
   *                        to match the input Region.
   *    @param  status      Receives errors detected by this function.
-  *    @return             TRUE if there is a match
+  *    @return             true if there is a match
   *    @stable ICU 3.0
   */
 U_STABLE UBool U_EXPORT2 
@@ -470,7 +470,7 @@ uregex_matches(URegularExpression *regexp,
   *    @param  startIndex  The input string (native) index at which to begin matching, or -1
   *                        to match the input Region.
   *    @param  status      Receives errors detected by this function.
-  *    @return             TRUE if there is a match
+  *    @return             true if there is a match
   *   @stable ICU 4.6
   */
 U_STABLE UBool U_EXPORT2 
@@ -498,7 +498,7 @@ uregex_matches64(URegularExpression *regexp,
   *    @param   startIndex  The input string (native) index at which to begin matching, or
   *                         -1 to match the Input Region
   *    @param   status      A reference to a UErrorCode to receive any errors.
-  *    @return  TRUE if there is a match.
+  *    @return  true if there is a match.
   *    @stable ICU 3.0
   */
 U_STABLE UBool U_EXPORT2 
@@ -527,7 +527,7 @@ uregex_lookingAt(URegularExpression *regexp,
   *    @param   startIndex  The input string (native) index at which to begin matching, or
   *                         -1 to match the Input Region
   *    @param   status      A reference to a UErrorCode to receive any errors.
-  *    @return  TRUE if there is a match.
+  *    @return  true if there is a match.
   *    @stable ICU 4.6
   */
 U_STABLE UBool U_EXPORT2 
@@ -551,7 +551,7 @@ uregex_lookingAt64(URegularExpression *regexp,
   *   @param   startIndex  The position (native) in the input string to begin the search, or
   *                        -1 to search within the Input Region.
   *   @param   status      A reference to a UErrorCode to receive any errors.
-  *   @return              TRUE if a match is found.
+  *   @return              true if a match is found.
   *   @stable ICU 3.0
   */
 U_STABLE UBool U_EXPORT2 
@@ -576,7 +576,7 @@ uregex_find(URegularExpression *regexp,
   *   @param   startIndex  The position (native) in the input string to begin the search, or
   *                        -1 to search within the Input Region.
   *   @param   status      A reference to a UErrorCode to receive any errors.
-  *   @return              TRUE if a match is found.
+  *   @return              true if a match is found.
   *   @stable ICU 4.6
   */
 U_STABLE UBool U_EXPORT2 
@@ -593,7 +593,7 @@ uregex_find64(URegularExpression *regexp,
   *
   *  @param   regexp      The compiled regular expression.
   *  @param   status      A reference to a UErrorCode to receive any errors.
-  *  @return              TRUE if a match is found.
+  *  @return              true if a match is found.
   *  @see uregex_reset
   *  @stable ICU 3.0
   */
@@ -960,7 +960,7 @@ uregex_regionEnd64(const  URegularExpression   *regexp,
   *
   * @param regexp The compiled regular expression.
   * @param status A pointer to a UErrorCode to receive any errors.
-  * @return TRUE if this matcher is using opaque bounds, false if it is not.
+  * @return true if this matcher is using opaque bounds, false if it is not.
   * @stable ICU 4.0
   */
 U_STABLE UBool U_EXPORT2
@@ -970,8 +970,8 @@ uregex_hasTransparentBounds(const  URegularExpression   *regexp,
 
 /**
   * Sets the transparency of region bounds for this URegularExpression.
-  * Invoking this function with an argument of TRUE will set matches to use transparent bounds.
-  * If the boolean argument is FALSE, then opaque bounds will be used.
+  * Invoking this function with an argument of true will set matches to use transparent bounds.
+  * If the boolean argument is false, then opaque bounds will be used.
   *
   * Using transparent bounds, the boundaries of the matching region are transparent
   * to lookahead, lookbehind, and boundary matching constructs. Those constructs can
@@ -983,7 +983,7 @@ uregex_hasTransparentBounds(const  URegularExpression   *regexp,
   * By default, opaque bounds are used.
   *
   * @param   regexp The compiled regular expression.
-  * @param   b      TRUE for transparent bounds; FALSE for opaque bounds
+  * @param   b      true for transparent bounds; false for opaque bounds
   * @param   status A pointer to a UErrorCode to receive any errors.
   * @stable ICU 4.0
   **/
@@ -999,7 +999,7 @@ uregex_useTransparentBounds(URegularExpression   *regexp,
   *
   * @param  regexp The compiled regular expression.
   * @param  status A pointer to a UErrorCode to receive any errors.
-  * @return TRUE if this matcher is using anchoring bounds.
+  * @return true if this matcher is using anchoring bounds.
   * @stable ICU 4.0
   */
 U_STABLE UBool U_EXPORT2
@@ -1016,7 +1016,7 @@ uregex_hasAnchoringBounds(const  URegularExpression   *regexp,
   * Anchoring Bounds are the default for regions.
   *
   * @param regexp The compiled regular expression.
-  * @param b      TRUE if to enable anchoring bounds; FALSE to disable them.
+  * @param b      true if to enable anchoring bounds; false to disable them.
   * @param status A pointer to a UErrorCode to receive any errors.
   * @stable ICU 4.0
   */
@@ -1026,13 +1026,13 @@ uregex_useAnchoringBounds(URegularExpression   *regexp,
                           UErrorCode           *status);
 
 /**
-  * Return TRUE if the most recent matching operation touched the
+  * Return true if the most recent matching operation touched the
   *  end of the text being processed.  In this case, additional input text could
   *  change the results of that match.
   *
   *  @param regexp The compiled regular expression.
   *  @param status A pointer to a UErrorCode to receive any errors.
-  *  @return  TRUE if the most recent match hit the end of input
+  *  @return  true if the most recent match hit the end of input
   *  @stable ICU 4.0
   */
 U_STABLE UBool U_EXPORT2
@@ -1040,14 +1040,14 @@ uregex_hitEnd(const  URegularExpression   *regexp,
                      UErrorCode           *status);
 
 /**
-  * Return TRUE the most recent match succeeded and additional input could cause
+  * Return true the most recent match succeeded and additional input could cause
   * it to fail. If this function returns false and a match was found, then more input
   * might change the match but the match won't be lost. If a match was not found,
   * then requireEnd has no meaning.
   *
   * @param regexp The compiled regular expression.
   * @param status A pointer to a UErrorCode to receive any errors.
-  * @return TRUE  if more input could cause the most recent match to no longer match.
+  * @return true  if more input could cause the most recent match to no longer match.
   * @stable ICU 4.0
   */
 U_STABLE UBool U_EXPORT2   
@@ -1483,7 +1483,7 @@ uregex_getStackLimit(const URegularExpression      *regexp,
 /**
  * Function pointer for a regular expression matching callback function.
  * When set, a callback function will be called periodically during matching
- * operations.  If the call back function returns FALSE, the matching
+ * operations.  If the call back function returns false, the matching
  * operation will be terminated early.
  *
  * Note:  the callback function must not call other functions on this
@@ -1494,8 +1494,8 @@ uregex_getStackLimit(const URegularExpression      *regexp,
  *                 uregex_setMatchCallback() is called.
  * @param steps    the accumulated processing time, in match steps, 
  *                 for this matching operation.
- * @return         TRUE to continue the matching operation.
- *                 FALSE to terminate the matching operation.
+ * @return         true to continue the matching operation.
+ *                 false to terminate the matching operation.
  * @stable ICU 4.0
  */
 U_CDECL_BEGIN
@@ -1557,7 +1557,7 @@ uregex_getMatchCallback(const URegularExpression    *regexp,
  * to be attempted, giving the application the opportunity to terminate a long-running
  * find operation.
  * 
- * If the call back function returns FALSE, the find operation will be terminated early.
+ * If the call back function returns false, the find operation will be terminated early.
  *
  * Note:  the callback function must not call other functions on this
  *        URegularExpression
@@ -1568,8 +1568,8 @@ uregex_getMatchCallback(const URegularExpression    *regexp,
  * @param matchIndex  the next index at which a match attempt will be attempted for this
  *                 find operation.  If this callback interrupts the search, this is the
  *                 index at which a find/findNext operation may be re-initiated.
- * @return         TRUE to continue the matching operation.
- *                 FALSE to terminate the matching operation.
+ * @return         true to continue the matching operation.
+ *                 false to terminate the matching operation.
  * @stable ICU 4.6
  */
 U_CDECL_BEGIN

--- a/icu4c/source/i18n/unicode/usearch.h
+++ b/icu4c/source/i18n/unicode/usearch.h
@@ -817,7 +817,7 @@ U_STABLE void U_EXPORT2 usearch_reset(UStringSearch *strsrch);
   *                    A value of -1 will be returned if no match was found.
   *          
   *  @param status     Report any errors.  Note that no match found is not an error.
-  *  @return           TRUE if a match was found, FALSE otherwise.
+  *  @return           true if a match was found, false otherwise.
   *
   *  @internal
   */
@@ -877,7 +877,7 @@ U_INTERNAL UBool U_EXPORT2 usearch_search(UStringSearch *strsrch,
   *                    A value of -1 will be returned if no match was found.
   *          
   *  @param status     Report any errors.  Note that no match found is not an error.
-  *  @return           TRUE if a match was found, FALSE otherwise.
+  *  @return           true if a match was found, false otherwise.
   *
   *  @internal
   */

--- a/icu4c/source/i18n/unicode/uspoof.h
+++ b/icu4c/source/i18n/unicode/uspoof.h
@@ -154,10 +154,10 @@
  *     UChar* skel = (UChar*) malloc(++len * sizeof(UChar));
  *     status = U_ZERO_ERROR;
  *     uspoof_getSkeleton(sc, 0, str, -1, skel, len, &status);
- *     UBool result = FALSE;
+ *     UBool result = false;
  *     for (size_t i=0; i<DICTIONARY_LENGTH; i++) {
  *         result = u_strcmp(skel, skeletons[i]) == 0;
- *         if (result == TRUE) { break; }
+ *         if (result == true) { break; }
  *     }
  *     // Has confusable in dictionary: 1 (status: U_ZERO_ERROR)
  *     printf("Has confusable in dictionary: %d (status: %s)\n", result, u_errorName(status));

--- a/icu4c/source/i18n/unicode/utrans.h
+++ b/icu4c/source/i18n/unicode/utrans.h
@@ -518,7 +518,7 @@ utrans_transIncrementalUChars(const UTransliterator* trans,
  * transliterator.
  *
  * @param trans     The transliterator
- * @param escapeUnprintable if TRUE then convert unprintable characters to their
+ * @param escapeUnprintable if true then convert unprintable characters to their
  *                  hex escape representations, \\uxxxx or \\Uxxxxxxxx.
  *                  Unprintable characters are those other than
  *                  U+000A, U+0020..U+007E.
@@ -540,9 +540,9 @@ utrans_toRules(     const UTransliterator* trans,
  * Returns the set of all characters that may be modified in the input text by
  * this UTransliterator, optionally ignoring the transliterator's current filter.
  * @param trans     The transliterator.
- * @param ignoreFilter If FALSE, the returned set incorporates the
+ * @param ignoreFilter If false, the returned set incorporates the
  *                  UTransliterator's current filter; if the filter is changed,
- *                  the return value of this function will change. If TRUE, the
+ *                  the return value of this function will change. If true, the
  *                  returned set ignores the effect of the UTransliterator's
  *                  current filter.
  * @param fillIn    Pointer to a USet object to receive the modifiable characters

--- a/icu4c/source/i18n/unicode/vtzone.h
+++ b/icu4c/source/i18n/unicode/vtzone.h
@@ -119,7 +119,7 @@ public:
      * created from VTIMEZONE data, the initial value is set by the TZURL property value
      * in the data.  Otherwise, the initial value is not set.
      * @param url Receives the RFC2445 TZURL property value.
-     * @return TRUE if TZURL attribute is available and value is set.
+     * @return true if TZURL attribute is available and value is set.
      * @stable ICU 3.8
      */
     UBool getTZURL(UnicodeString& url) const;
@@ -136,7 +136,7 @@ public:
      * was created from VTIMEZONE data, the initial value is set by the LAST-MODIFIED property
      * value in the data.  Otherwise, the initial value is not set.
      * @param lastModified Receives the last modified date.
-     * @return TRUE if lastModified attribute is available and value is set.
+     * @return true if lastModified attribute is available and value is set.
      * @stable ICU 3.8
      */
     UBool getLastModified(UDate& lastModified) const;
@@ -322,7 +322,7 @@ public:
      * @param base      The base time.
      * @param inclusive Whether the base time is inclusive or not.
      * @param result    Receives the first transition after the base time.
-     * @return  TRUE if the transition is found.
+     * @return  true if the transition is found.
      * @stable ICU 3.8
      */
     virtual UBool getNextTransition(UDate base, UBool inclusive, TimeZoneTransition& result) const;
@@ -332,7 +332,7 @@ public:
      * @param base      The base time.
      * @param inclusive Whether the base time is inclusive or not.
      * @param result    Receives the most recent transition before the base time.
-     * @return  TRUE if the transition is found.
+     * @return  true if the transition is found.
      * @stable ICU 3.8
      */
     virtual UBool getPreviousTransition(UDate base, UBool inclusive, TimeZoneTransition& result) const;

--- a/icu4c/source/io/unicode/ustdio.h
+++ b/icu4c/source/io/unicode/ustdio.h
@@ -363,7 +363,7 @@ U_NAMESPACE_END
 /**
  * Tests if the UFILE is at the end of the file stream.
  * @param f The UFILE from which to read.
- * @return Returns TRUE after the first read operation that attempts to
+ * @return Returns true after the first read operation that attempts to
  * read past the end of the file. It returns FALSE if the current position is
  * not end of file.
  * @stable ICU 3.0

--- a/icu4c/source/layoutex/layout/ParagraphLayout.h
+++ b/icu4c/source/layoutex/layout/ParagraphLayout.h
@@ -382,7 +382,7 @@ public:
      *
      * @param paragraphLevel is the directionality of the paragraph, as in the UBiDi object.
      *
-     * @param vertical is <code>TRUE</code> if the paragraph should be set vertically.
+     * @param vertical is <code>true</code> if the paragraph should be set vertically.
      *
      * @param status will be set to any error code encountered during construction.
      *
@@ -424,7 +424,7 @@ public:
      *
      * @param fontRuns is a pointer to a <code>FontRuns</code> object representing the font runs.
      *
-     * @return <code>TRUE</code> if the paragraph contains complex text.
+     * @return <code>true</code> if the paragraph contains complex text.
      *
      * @stable ICU 3.2
      */
@@ -438,7 +438,7 @@ public:
      *
      * @param count is the number of characters in the paragraph.
      *
-     * @return <code>TRUE</code> if any of the text requires complex processing.
+     * @return <code>true</code> if any of the text requires complex processing.
      *
      * @stable ICU 3.2
      */

--- a/icu4c/source/layoutex/layout/RunArrays.h
+++ b/icu4c/source/layoutex/layout/RunArrays.h
@@ -222,19 +222,19 @@ private:
 };
 
 inline RunArray::RunArray()
-    : UObject(), fClientArrays(FALSE), fLimits(NULL), fCount(0), fCapacity(0)
+    : UObject(), fClientArrays(false), fLimits(NULL), fCount(0), fCapacity(0)
 {
     // nothing else to do...
 }
 
 inline RunArray::RunArray(const RunArray & /*other*/)
-    : UObject(), fClientArrays(FALSE), fLimits(NULL), fCount(0), fCapacity(0)
+    : UObject(), fClientArrays(false), fLimits(NULL), fCount(0), fCapacity(0)
 {
     // nothing else to do...
 }
 
 inline RunArray::RunArray(const le_int32 *limits, le_int32 count)
-    : UObject(), fClientArrays(TRUE), fLimits(limits), fCount(count), fCapacity(count)
+    : UObject(), fClientArrays(true), fLimits(limits), fCount(count), fCapacity(count)
 {
     // nothing else to do...
 }

--- a/icu4c/source/layoutex/layout/playout.h
+++ b/icu4c/source/layoutex/layout/playout.h
@@ -82,7 +82,7 @@ typedef void pl_visualRun;
  *
  * @param paragraphLevel is the directionality of the paragraph, as in the UBiDi object.
  *
- * @param vertical is <code>TRUE</code> if the paragraph should be set vertically.
+ * @param vertical is <code>true</code> if the paragraph should be set vertically.
  *
  * @param status will be set to any error code encountered during construction.
  *
@@ -126,7 +126,7 @@ pl_close(pl_paragraph *paragraph);
  *
  * @param count is the number of characters in the paragraph.
  *
- * @return <code>TRUE</code> if any of the text requires complex processing.
+ * @return <code>true</code> if any of the text requires complex processing.
  *
  * @internal
  */

--- a/icu4c/source/samples/cal/uprint.c
+++ b/icu4c/source/samples/cal/uprint.c
@@ -18,6 +18,7 @@
 */
 
 #include "uprint.h"
+#include <stdbool.h>
 #include "unicode/ucnv.h"
 #include "unicode/ustring.h"
 
@@ -61,7 +62,7 @@ uprint(const UChar *s,
     /* perform the conversion */
     ucnv_fromUnicode(converter, &myTarget, myTarget + arraySize,
              &mySource, mySourceEnd, NULL,
-             TRUE, status);
+             true, status);
 
     /* Write the converted data to the FILE* */
     fwrite(buf, sizeof(char), myTarget - buf, f);

--- a/icu4c/source/samples/date/date.c
+++ b/icu4c/source/samples/date/date.c
@@ -19,6 +19,7 @@
 *******************************************************************************
 */
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -276,7 +277,7 @@ date(UDate when,
   fmt = udat_open(style, style, locale, tz, -1,NULL,0, status);
   if ( format != NULL ) {
     charsToUCharsDefault(uFormat,sizeof(uFormat)/sizeof(uFormat[0]),format,-1,status);
-    udat_applyPattern(fmt,FALSE,uFormat,-1);
+    udat_applyPattern(fmt,false,uFormat,-1);
   }
   len = udat_format(fmt, when, 0, len, 0, status);
   if(*status == U_BUFFER_OVERFLOW_ERROR) {
@@ -331,7 +332,7 @@ static UDate getWhen(const char *millis, const char *seconds, const char *format
     fmt = udat_open(style, style, locale, tz, -1,NULL,0, status);
     if ( format != NULL ) {
       charsToUCharsDefault(uFormat,sizeof(uFormat)/sizeof(uFormat[0]), format,-1,status);
-      udat_applyPattern(fmt,FALSE,uFormat,-1);
+      udat_applyPattern(fmt,false,uFormat,-1);
     }
     
     charsToUCharsDefault(uParse,sizeof(uParse)/sizeof(uParse[0]), parse,-1,status);

--- a/icu4c/source/samples/date/uprint.c
+++ b/icu4c/source/samples/date/uprint.c
@@ -19,6 +19,7 @@
 
 #include "uprint.h"
 
+#include <stdbool.h>
 #include "unicode/ucnv.h"
 #include "unicode/ustring.h"
 
@@ -62,7 +63,7 @@ uprint(const UChar *s,
 	/* perform the conversion */
 	ucnv_fromUnicode(converter, &myTarget,	myTarget + arraySize,
 			 &mySource, mySourceEnd, NULL,
-			 TRUE, status);
+			 true, status);
 
 	/* Write the converted data to the FILE* */
 	fwrite(buf, sizeof(char), myTarget - buf, f);

--- a/icu4c/source/test/intltest/colldata.cpp
+++ b/icu4c/source/test/intltest/colldata.cpp
@@ -22,6 +22,7 @@
 
 #include "unicode/regex.h"        // TODO: make conditional on regexp being built.
 
+#include "unicode/testlog.h"
 #include "unicode/uniset.h"
 #include "unicode/uset.h"
 #include "unicode/usetiter.h"

--- a/icu4c/source/test/intltest/numberformattesttuple.cpp
+++ b/icu4c/source/test/intltest/numberformattesttuple.cpp
@@ -11,6 +11,7 @@
 
 #if !UCONFIG_NO_FORMATTING
 
+#include "unicode/testlog.h"
 #include "ustrfmt.h"
 #include "charstr.h"
 #include "cstring.h"

--- a/icu4c/source/tools/ctestfw/unicode/testtype.h
+++ b/icu4c/source/tools/ctestfw/unicode/testtype.h
@@ -39,3 +39,9 @@
     #define T_CTEST_EXPORT_API T_CTEST_IMPORT
 #endif
 
+#ifndef TRUE
+#   define TRUE  1
+#endif
+#ifndef FALSE
+#   define FALSE 0
+#endif

--- a/icu4c/source/tools/genbrk/genbrk.cpp
+++ b/icu4c/source/tools/genbrk/genbrk.cpp
@@ -282,7 +282,7 @@ int  main(int argc, char **argv) {
     //
     //  Put the source rules into a UnicodeString
     //
-    UnicodeString ruleSourceS(FALSE, ruleSourceU, destCap);
+    UnicodeString ruleSourceS(false, ruleSourceU, destCap);
 
     //
     //  Create the break iterator from the rules

--- a/icu4c/source/tools/gencfu/gencfu.cpp
+++ b/icu4c/source/tools/gencfu/gencfu.cpp
@@ -179,9 +179,9 @@ int  main(int argc, char **argv) {
         copyright = U_COPYRIGHT_STRING;
     }
 
-    UBool quiet = FALSE;
+    UBool quiet = false;
     if (options[9].doesOccur) {
-      quiet = TRUE;
+      quiet = true;
     }
 
 #if UCONFIG_NO_REGULAR_EXPRESSIONS || UCONFIG_NO_NORMALIZATION || UCONFIG_NO_FILE_IO

--- a/icu4c/source/tools/gencnval/gencnval.c
+++ b/icu4c/source/tools/gencnval/gencnval.c
@@ -32,6 +32,7 @@
 #include "cstring.h"
 #include "uinvchar.h"
 #include "filestrm.h"
+#include "toolutil.h"
 #include "unicode/uclean.h"
 #include "unewdata.h"
 #include "uoptions.h"

--- a/icu4c/source/tools/genrb/errmsg.c
+++ b/icu4c/source/tools/genrb/errmsg.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include "cstring.h"
 #include "errmsg.h"
+#include "toolutil.h"
 
 U_CFUNC void error(uint32_t linenumber, const char *msg, ...)
 {

--- a/icu4c/source/tools/genrb/read.c
+++ b/icu4c/source/tools/genrb/read.c
@@ -20,6 +20,7 @@
 
 #include "read.h"
 #include "errmsg.h"
+#include "toolutil.h"
 #include "unicode/ustring.h"
 #include "unicode/utf16.h"
 

--- a/icu4c/source/tools/genrb/reslist.cpp
+++ b/icu4c/source/tools/genrb/reslist.cpp
@@ -39,6 +39,7 @@
 #include "unicode/putil.h"
 #include "errmsg.h"
 #include "filterrb.h"
+#include "toolutil.h"
 
 #include "uarrsort.h"
 #include "uelement.h"

--- a/icu4c/source/tools/genrb/reslist.h
+++ b/icu4c/source/tools/genrb/reslist.h
@@ -355,7 +355,7 @@ public:
               fNumCopies(0), fNumUnitsSaved(0), fNumCharsForLength(numCharsForLength) {
         // v3 pool string encoded as string-v2 with low offset
         fRes = URES_MAKE_RESOURCE(URES_STRING_V2, poolStringIndex);
-        fWritten = TRUE;
+        fWritten = true;
     }
     virtual ~StringResource();
 

--- a/icu4c/source/tools/genrb/rle.c
+++ b/icu4c/source/tools/genrb/rle.c
@@ -16,6 +16,7 @@
 *   01/11/02    Ram        Creation.
 *******************************************************************************
 */
+#include <stdbool.h>
 #include "rle.h"
 /**
  * The ESCAPE character is used during run-length encoding.  It signals
@@ -297,7 +298,7 @@ int32_t
 rleStringToByteArray(uint16_t* src, int32_t srcLen, uint8_t* target, int32_t tgtLen, UErrorCode* status) {
 
     int32_t length = 0;
-    UBool nextChar = TRUE;
+    UBool nextChar = true;
     uint16_t c = 0;
     int32_t node = 0;
     int32_t runLength = 0;
@@ -334,11 +335,11 @@ rleStringToByteArray(uint16_t* src, int32_t srcLen, uint8_t* target, int32_t tgt
         if (nextChar) {
             c = src[i++];
             b = (uint8_t) (c >> 8);
-            nextChar = FALSE;
+            nextChar = false;
         }
         else {
             b = (uint8_t) (c & 0xFF);
-            nextChar = TRUE;
+            nextChar = true;
         }
 
        /* This part of the loop is a tiny state machine which handles

--- a/icu4c/source/tools/gensprep/gensprep.c
+++ b/icu4c/source/tools/gensprep/gensprep.c
@@ -28,6 +28,7 @@
 
 #include "cmemory.h"
 #include "cstring.h"
+#include "toolutil.h"
 #include "unewdata.h"
 #include "uoptions.h"
 #include "uparse.h"

--- a/icu4c/source/tools/gensprep/store.c
+++ b/icu4c/source/tools/gensprep/store.c
@@ -23,6 +23,7 @@
 #include "cmemory.h"
 #include "cstring.h"
 #include "filestrm.h"
+#include "toolutil.h"
 #include "unicode/udata.h"
 #include "unicode/utf16.h"
 #include "utrie.h"

--- a/icu4c/source/tools/makeconv/genmbcs.cpp
+++ b/icu4c/source/tools/makeconv/genmbcs.cpp
@@ -26,6 +26,7 @@
 #include "ucm.h"
 #include "makeconv.h"
 #include "genmbcs.h"
+#include "toolutil.h"
 
 /*
  * TODO: Split this file into toUnicode, SBCSFromUnicode and MBCSFromUnicode files.

--- a/icu4c/source/tools/makeconv/ucnvstat.c
+++ b/icu4c/source/tools/makeconv/ucnvstat.c
@@ -15,6 +15,7 @@
 
 #include "unicode/utypes.h"
 #include "unicode/ucnv.h"
+#include "toolutil.h"
 #include "ucnv_bld.h"
 
 

--- a/icu4c/source/tools/pkgdata/pkgtypes.c
+++ b/icu4c/source/tools/pkgdata/pkgtypes.c
@@ -17,6 +17,7 @@
 *  common types for pkgdata
 */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "unicode/utypes.h"
@@ -294,9 +295,9 @@ UBool  pkg_listContains(CharList *l, const char *str)
 {
   for(;l;l=l->next){
     if(!uprv_strcmp(l->str, str)) {
-      return TRUE;
+      return true;
     }
   }
 
-  return FALSE;
+  return false;
 }

--- a/icu4c/source/tools/toolutil/toolutil.h
+++ b/icu4c/source/tools/toolutil/toolutil.h
@@ -23,6 +23,12 @@
 
 #include "unicode/utypes.h"
 
+#ifndef TRUE
+#   define TRUE  1
+#endif
+#ifndef FALSE
+#   define FALSE 0
+#endif
 
 #ifdef __cplusplus
 


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-21267

In public header files, and in a few internal ones included by tests and tools:
- Stop defining macros FALSE & TRUE unless U_DEFINE_FALSE_AND_TRUE=1.
- Deprecate FALSE & TRUE.
- Replace FALSE & TRUE with false & true.