### PR TITLE
ICU-20568 Fix NumberFormatterSettings::usage documentation

### DIFF
--- a/icu4c/source/i18n/unicode/numberformatter.h
+++ b/icu4c/source/i18n/unicode/numberformatter.h
@@ -2102,8 +2102,8 @@ class U_I18N_API NumberFormatterSettings {
 
 #ifndef U_HIDE_DRAFT_API
     /**
-     * Specifies the usage for which numbers will be formatted ("person",
-     * "road", "person", etc.)
+     * Specifies the usage for which numbers will be formatted ("person-height",
+     * "road", "rainfall", etc.)
      *
      * When a `usage` is specified, the output unit will change depending on the
      * `Locale` and the unit quantity. For example, formatting length
@@ -2777,4 +2777,3 @@ U_NAMESPACE_END
 #endif /* U_SHOW_CPLUSPLUS_API */
 
 #endif // __NUMBERFORMATTER_H__
-


### PR DESCRIPTION
- Original icu-design review took place in February ([ICU 67 API proposal status](https://docs.google.com/document/d/e/2PACX-1vQwfVlRqSzD3VHPNt5UGKad9lZSK1rj9M9h8VHi06cxu1wp3GwAWZvjDG1wLZXVHJQlO1-AJnXJM14e/pub) - ”[approved:2020-02-19] ICU proposal: Support Locale-aware Measurement Unit Formatting” - design at http://bit.ly/icu-measurement-formatting).
- Commit 45f79b6 was already reviewed in March at https://github.com/sffc/icu/pull/23. Please give extra attention to the following commit (459c33b).

This PR is intended to precede #1284 in order to make review easier.
- We could merge the PRs separately, or,
- we could rebase 1284 onto the result of this review in order to stack them and merge them at the same time.
  - (If we go this latter route, moving this PR into a new branch on unicode-org would make it easier to see the delta from 1289 to 1284, by temporarily pointing 1284 at this branch instead of master.)

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20568
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [ ] Tests included
- [X] Documentation is changed or added

