### PR TITLE
ICU-13845 Map to UTC-offset timezone when DST is off on Windows

### DIFF
--- a/icu4c/source/common/wintz.cpp
+++ b/icu4c/source/common/wintz.cpp
@@ -77,10 +77,6 @@ uprv_detectWindowsTimeZone()
     CharString winTZ;
     UErrorCode status = U_ZERO_ERROR;
     winTZ.appendInvariantChars(UnicodeString(TRUE, dynamicTZI.TimeZoneKeyName, -1), status);
-    // appendInvariantChars does not set status to indicate OOM.
-    if (winTZ.isEmpty()) {
-      return nullptr;
-    }
 
     // Map Windows Timezone name (non-localized) to ICU timezone ID (~ Olson timezone id).
     LocalUResourceBundlePointer winTZBundle(ures_openDirect(nullptr, "windowsZones", &status));
@@ -106,14 +102,7 @@ uprv_detectWindowsTimeZone()
     }
 
     CharString icuTZStr;
-    icuTZStr.appendInvariantChars(icuTZ16, tzLen, status);
-    // As of Sep 2020, all timezone IDs are < 40 (the internal stack buffer size of CharString).
-    // To be future-proof, add a check. This check wouldn't be necessary if
-    // appendInvariantChars() sets status to indicate OOM.
-    if (icuTZStr.isEmpty()) {
-      return nullptr;
-    }
-    return icuTZStr.cloneData(status);
+    return icuTZStr.appendInvariantChars(icuTZ16, tzLen, status).cloneData(status);
 }
 
 U_NAMESPACE_END


### PR DESCRIPTION
1. Try to detect when DST is turned off manually on Windows. (not tested)
   Find the non-DST offset and map a Windows timezone to a GMT+<offset>
   zone.

2. Refactor uprv_detectWindowsTimeZone

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-13845
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added
