### PR TITLE
ICU-21262 add br collation for cldr-to-icu build

### DIFF
--- a/tools/cldr/cldr-to-icu/build-icu-data.xml
+++ b/tools/cldr/cldr-to-icu/build-icu-data.xml
@@ -278,7 +278,7 @@
                     root,
 
                     // A-B
-                    af, am, ars, ar, as, az, be, bg, bn, bo, bs_Cyrl, bs,
+                    af, am, ars, ar, as, az, be, bg, bn, bo, br, bs_Cyrl, bs,
 
                     // C-F
                     ca, ceb, chr, cs, cy, da, de_AT, de, dsb, dz, ee, el, en,


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21262
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

This just adds the br collation to the cldr-to-icu integration build. It will not have any effect until the next cldr-to-icu integration. I checked and this is the only item in CLDR coll/rbnf/brkiter data that was missing from the build-icu-data.xml file.