### PR TITLE
ICU-21264 Re-enable optimizations for various functions for MSVC with VS2019 and above

### DIFF
--- a/icu4c/source/common/uloc_tag.cpp
+++ b/icu4c/source/common/uloc_tag.cpp
@@ -1988,11 +1988,12 @@ _appendPrivateuseToLanguageTag(const char* localeID, icu::ByteSink& sink, UBool 
 #define PRIV 0x0080
 
 /**
- * Ticket #12705 - Visual Studio 2015 Update 3 contains a new code optimizer which has problems optimizing
- * this function. (See https://blogs.msdn.microsoft.com/vcblog/2016/05/04/new-code-optimizer/ )
- * As a workaround, we will turn off optimization just for this function on VS2015 Update 3 and above.
+ * Ticket #12705 - The optimizer in Visual Studio 2015 Update 3 has problems optimizing this function.
+ * As a work-around, optimization is disabled for this function on VS2015 and VS2017.
+ * This work-around should be removed once the following versions of Visual Studio are no
+ * longer supported: All versions of VS2015/VS2017, and versions of VS2019 below 16.4.
  */
-#if (defined(_MSC_VER) && (_MSC_VER >= 1900) && defined(_MSC_FULL_VER) && (_MSC_FULL_VER >= 190024210))
+#if defined(_MSC_VER) && (_MSC_VER >= 1900) && (_MSC_VER < 1924)
 #pragma optimize( "", off )
 #endif
 
@@ -2405,10 +2406,8 @@ ultag_parse(const char* tag, int32_t tagLen, int32_t* parsedLen, UErrorCode* sta
     return t.orphan();
 }
 
-/**
-* Ticket #12705 - Turn optimization back on.
-*/
-#if (defined(_MSC_VER) && (_MSC_VER >= 1900) && defined(_MSC_FULL_VER) && (_MSC_FULL_VER >= 190024210))
+// Ticket #12705 - Turn optimization back on.
+#if defined(_MSC_VER) && (_MSC_VER >= 1900) && (_MSC_VER < 1924)
 #pragma optimize( "", on )
 #endif
 

--- a/icu4c/source/test/cintltst/utf8tst.c
+++ b/icu4c/source/test/cintltst/utf8tst.c
@@ -758,10 +758,12 @@ static void TestFwdBack() {
 }
 
 /**
-* Ticket #13636 - Visual Studio 2017 has problems optimizing this function.
-* As a workaround, we will turn off optimization just for this function on VS2017 and above.
-*/
-#if defined(_MSC_VER) && (_MSC_VER > 1900)
+ * Ticket #13636 - The optimizer in Visual Studio 2017 has problems optimizing this function.
+ * As a work-around, optimization is disabled for this function on VS2017.
+ * This work-around should be removed once the following versions of Visual Studio are no
+ * longer supported: All versions of VS2017, and versions of VS2019 below 16.4.
+ */
+#if defined(_MSC_VER) && (_MSC_VER > 1900) && (_MSC_VER < 1924)
 #pragma optimize( "", off )
 #endif
 
@@ -850,10 +852,8 @@ static void TestFwdBackUnsafe() {
     }
 }
 
-/**
-* Ticket #13636 - Turn optimization back on.
-*/
-#if defined(_MSC_VER) && (_MSC_VER > 1900)
+// Ticket #13636 - Turn optimization back on.
+#if defined(_MSC_VER) && (_MSC_VER > 1900) && (_MSC_VER < 1924)
 #pragma optimize( "", on )
 #endif
 


### PR DESCRIPTION
A number of functions had the optimizer turned off due to optimizer bugs that were present in VS2015 and VS2017.

Since we can now build with VS 2019 (see PR #1288), we can enable optimization for these functions for MSVC when building with VS2019 or higher.

Note: Unfortunately, it seems that the MSVC compiler (using the latest VS2019) is *still* having issues with the following function:
`void ExtraData::writeExtraData(UChar32 c, Norm &norm)`
https://github.com/unicode-org/icu/blob/master/icu4c/source/tools/gennorm2/extradata.cpp#L189
So we’ll need to keep this one turned off for now.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21264
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added
