### PR TITLE
ICU-21043 Fix calendar problems

### DIFF
--- a/icu4c/source/i18n/hebrwcal.cpp
+++ b/icu4c/source/i18n/hebrwcal.cpp
@@ -393,7 +393,8 @@ int32_t HebrewCalendar::startOfYear(int32_t year, UErrorCode &status)
     int32_t day = CalendarCache::get(&gCache, year, status);
 
     if (day == 0) {
-        int32_t months = (235 * year - 234) / 19;           // # of months before year
+        // # of months before year
+        int32_t months = (int32_t)ClockMath::floorDivide((235 * (int64_t)year - 234), (int64_t)19);
 
         int64_t frac = (int64_t)months * MONTH_FRACT + BAHARAD;  // Fractional part of day #
         day  = months * 29 + (int32_t)(frac / DAY_PARTS);        // Whole # part of calculation
@@ -566,8 +567,8 @@ void HebrewCalendar::validateField(UCalendarDateFields field, UErrorCode &status
 */
 void HebrewCalendar::handleComputeFields(int32_t julianDay, UErrorCode &status) {
     int32_t d = julianDay - 347997;
-    double m = ((d * (double)DAY_PARTS)/ (double) MONTH_PARTS);         // Months (approx)
-    int32_t year = (int32_t)( ((19. * m + 234.) / 235.) + 1.);     // Years (approx)
+    double m = ClockMath::floorDivide((d * (double)DAY_PARTS), (double) MONTH_PARTS);  // Months (approx)
+    int32_t year = (int32_t)(ClockMath::floorDivide((19. * m + 234.), 235.) + 1.);     // Years (approx)
     int32_t ys  = startOfYear(year, status);                   // 1st day of year
     int32_t dayOfYear = (d - ys);
 

--- a/icu4c/source/i18n/indiancal.cpp
+++ b/icu4c/source/i18n/indiancal.cpp
@@ -83,7 +83,6 @@ static const int32_t LIMITS[UCAL_FIELD_COUNT][4] = {
     {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // IS_LEAP_MONTH
 };
 
-static const double JULIAN_EPOCH = 1721425.5;
 static const int32_t INDIAN_ERA_START  = 78;
 static const int32_t INDIAN_YEAR_START = 80;
 
@@ -96,7 +95,7 @@ int32_t IndianCalendar::handleGetLimit(UCalendarDateFields field, ELimitType lim
  */
 static UBool isGregorianLeap(int32_t year)
 {
-    return ((year % 4) == 0) && (!(((year % 100) == 0) && ((year % 400) != 0))); 
+    return Grego::isLeapYear(year);
 }
   
 //----------------------------------------------------------------------
@@ -137,56 +136,22 @@ int32_t IndianCalendar::handleGetYearLength(int32_t eyear) const {
  * Returns the Julian Day corresponding to gregorian date
  *
  * @param year The Gregorian year
- * @param month The month in Gregorian Year
+ * @param month The month in Gregorian Year, 0 based.
  * @param date The date in Gregorian day in month
  */
 static double gregorianToJD(int32_t year, int32_t month, int32_t date) {
-   double julianDay = (JULIAN_EPOCH - 1) +
-      (365 * (year - 1)) +
-      uprv_floor((year - 1) / 4) +
-      (-uprv_floor((year - 1) / 100)) +
-      uprv_floor((year - 1) / 400) +
-      uprv_floor((((367 * month) - 362) / 12) +
-            ((month <= 2) ? 0 :
-             (isGregorianLeap(year) ? -1 : -2)
-            ) +
-            date);
-
-   return julianDay;
+   return Grego::fieldsToDay(year, month, date) + kEpochStartAsJulianDay - 0.5;
 }
 
 /*
  * Returns the Gregorian Date corresponding to a given Julian Day
+ * Month is 0 based.
  * @param jd The Julian Day
  */
 static int32_t* jdToGregorian(double jd, int32_t gregorianDate[3]) {
-   double wjd, depoch, quadricent, dqc, cent, dcent, quad, dquad, yindex, yearday, leapadj;
-   int32_t year, month, day;
-   wjd = uprv_floor(jd - 0.5) + 0.5;
-   depoch = wjd - JULIAN_EPOCH;
-   quadricent = uprv_floor(depoch / 146097);
-   dqc = (int32_t)uprv_floor(depoch) % 146097;
-   cent = uprv_floor(dqc / 36524);
-   dcent = (int32_t)uprv_floor(dqc) % 36524;
-   quad = uprv_floor(dcent / 1461);
-   dquad = (int32_t)uprv_floor(dcent) % 1461;
-   yindex = uprv_floor(dquad / 365);
-   year = (int32_t)((quadricent * 400) + (cent * 100) + (quad * 4) + yindex);
-   if (!((cent == 4) || (yindex == 4))) {
-      year++;
-   }
-   yearday = wjd - gregorianToJD(year, 1, 1);
-   leapadj = ((wjd < gregorianToJD(year, 3, 1)) ? 0
-         :
-         (isGregorianLeap(year) ? 1 : 2)
-         );
-   month = (int32_t)uprv_floor((((yearday + leapadj) * 12) + 373) / 367);
-   day = (int32_t)(wjd - gregorianToJD(year, month, 1)) + 1;
-
-   gregorianDate[0] = year;
-   gregorianDate[1] = month;
-   gregorianDate[2] = day;
-
+   int32_t gdow;
+   Grego::dayToFields(jd - kEpochStartAsJulianDay,
+                      gregorianDate[0], gregorianDate[1], gregorianDate[2], gdow);
    return gregorianDate;
 }
 
@@ -203,11 +168,11 @@ static double IndianToJD(int32_t year, int32_t month, int32_t date) {
 
    if(isGregorianLeap(gyear)) {
       leapMonth = 31;
-      start = gregorianToJD(gyear, 3, 21);
+      start = gregorianToJD(gyear, 2 /* The third month in 0 based month */, 21);
    } 
    else {
       leapMonth = 30;
-      start = gregorianToJD(gyear, 3, 22);
+      start = gregorianToJD(gyear, 2 /* The third month in 0 based month */, 22);
    }
 
    if (month == 1) {
@@ -297,7 +262,7 @@ void IndianCalendar::handleComputeFields(int32_t julianDay, UErrorCode&  /* stat
 
     gregorianYear = jdToGregorian(julianDay, gd)[0];          // Gregorian date for Julian day
     IndianYear = gregorianYear - INDIAN_ERA_START;            // Year in Saka era
-    jdAtStartOfGregYear = gregorianToJD(gregorianYear, 1, 1); // JD at start of Gregorian year
+    jdAtStartOfGregYear = gregorianToJD(gregorianYear, 0, 1); // JD at start of Gregorian year
     yday = (int32_t)(julianDay - jdAtStartOfGregYear);        // Day number in Gregorian year (starting from 0)
 
     if (yday < INDIAN_YEAR_START) {

--- a/icu4c/source/i18n/islamcal.cpp
+++ b/icu4c/source/i18n/islamcal.cpp
@@ -368,7 +368,7 @@ int32_t IslamicCalendar::yearStart(int32_t year) const{
     if (cType == CIVIL || cType == TBLA ||
         (cType == UMALQURA && (year < UMALQURA_YEAR_START || year > UMALQURA_YEAR_END))) 
     {
-        return (year-1)*354 + ClockMath::floorDivide((3+11*year),30);
+        return (year-1)*354 + ClockMath::floorDivide((3+11*(int64_t)year),(int64_t)30);
     } else if(cType==ASTRONOMICAL){
         return trueMonthStart(12*(year-1));
     } else {
@@ -391,7 +391,7 @@ int32_t IslamicCalendar::monthStart(int32_t year, int32_t month) const {
     if (cType == CIVIL || cType == TBLA) {
         // This does not handle months out of the range 0..11
         return (int32_t)uprv_ceil(29.5*month)
-            + (year-1)*354 + (int32_t)ClockMath::floorDivide((3+11*year),30);
+            + (year-1)*354 + (int32_t)ClockMath::floorDivide((3+11*(int64_t)year),(int64_t)30);
     } else if(cType==ASTRONOMICAL){
         return trueMonthStart(12*(year-1) + month);
     } else {
@@ -447,7 +447,8 @@ int32_t IslamicCalendar::trueMonthStart(int32_t month) const
                 }
             } while (age < 0);
         }
-        start = (int32_t)ClockMath::floorDivide((origin - HIJRA_MILLIS), (double)kOneDay) + 1;
+        start = (int32_t)(ClockMath::floorDivide(
+            (int64_t)((int64_t)origin - HIJRA_MILLIS), (int64_t)kOneDay) + 1);
         CalendarCache::put(&gMonthCache, month, start, status);
     }
 trueMonthStartEnd :
@@ -639,13 +640,14 @@ void IslamicCalendar::handleComputeFields(int32_t julianDay, UErrorCode &status)
             months--;
         }
 
-        year = months / 12 + 1;
-        month = months % 12;
+        year = months >=  0 ? ((months / 12) + 1) : ((months + 1 ) / 12);
+        month = ((months % 12) + 12 ) % 12;
     } else if(cType == UMALQURA) {
         int32_t umalquraStartdays = yearStart(UMALQURA_YEAR_START) ;
         if( days < umalquraStartdays){
                 //Use Civil calculation
-                year  = (int)ClockMath::floorDivide( (double)(30 * days + 10646) , 10631.0 );
+                year  = (int32_t)ClockMath::floorDivide(
+                    (30 * (int64_t)days + 10646) , (int64_t)10631.0 );
                 month = (int32_t)uprv_ceil((days - 29 - yearStart(year)) / 29.5 );
                 month = month<11?month:11;
                 startDate = monthStart(year, month);

--- a/icu4c/source/test/intltest/incaltst.h
+++ b/icu4c/source/test/intltest/incaltst.h
@@ -28,6 +28,10 @@ public:
 
     void TestBuddhist(void);
     void TestBuddhistFormat(void);
+    void TestBug21043Indian(void);
+    void TestBug21044Hebrew(void);
+    void TestBug21045Islamic(void);
+    void TestBug21046IslamicUmalqura(void);
 
     void TestTaiwan(void);
 
@@ -39,10 +43,31 @@ public:
     void TestPersian(void);
     void TestPersianFormat(void);
 
+    void TestConsistencyGregorian(void);
+    void TestConsistencyCoptic(void);
+    void TestConsistencyEthiopic(void);
+    void TestConsistencyROC(void);
+    void TestConsistencyChinese(void);
+    void TestConsistencyDangi(void);
+    void TestConsistencyBuddhist(void);
+    void TestConsistencyEthiopicAmeteAlem(void);
+    void TestConsistencyHebrew(void);
+    void TestConsistencyIndian(void);
+    void TestConsistencyIslamic(void);
+    void TestConsistencyIslamicCivil(void);
+    void TestConsistencyIslamicRGSA(void);
+    void TestConsistencyIslamicTBLA(void);
+    void TestConsistencyIslamicUmalqura(void);
+    void TestConsistencyPersian(void);
+    void TestConsistencyJapanese(void);
+
  protected:
     // Test a Gregorian-Like calendar
     void quasiGregorianTest(Calendar& cal, const Locale& gregoLocale, const int32_t *data);
     void simpleTest(const Locale& loc, const UnicodeString& expect, UDate expectDate, UErrorCode& status);
+    void checkConsistency(const char* locale);
+
+    int32_t daysToCheckInConsistency;
  
 public: // package
     // internal routine for checking date

--- a/icu4c/source/test/testdata/calendar.txt
+++ b/icu4c/source/test/testdata/calendar.txt
@@ -438,7 +438,7 @@ calendar:table(nofallback) {
                     "MILLIS=-180799750799999",
                     "add",
                     "YEAR=100000", // year + 100000
-                    "MILLIS=2974930006022001",
+                    "MILLIS=2974932601622001",
                },
             }
         }	          


### PR DESCRIPTION
This PR fixes
ICU-21043 Erroneous date display in indian calendar of all dates prior to 0001-01-01.
ICU-21044 Hebrew Calendar calculation is incorrect when the year < 1
ICU-21045 Erroneous date display in islamic and islamic-rgsa calendars of all dates prior to 0622-07-18.
ICU-21046 Erroneous date display in islamic-umalqura calendar of all dates prior to  -195366-07-23.

The problem in the indiancal.cpp is
* ICU-21043 the gregorian/julain convesion is wrong. Swith to use
i18n/gregoimp.h fix the problem.

The problem in the hebrwcal.cpp is
* ICU-21044 the use of bulit in / is wrong when the year or month could be < 1.
Fix it by switching to use ClockMath::floorDivide in i18n/gregoimp.h .

The problem in the islamcal.cpp:
* ICU-21045: The math of % negative number for year and month is wrong.
* ICU-21046: Not use int64_t methods and caused int32_t overflow while the year is a
huge negative number. Cast to int64_t to force using the int64_t version
for the math fix the problem.

Also add tests to exhaust test 8000 years for all calendar. In quick
mode, only test 2.5 years.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21043
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [X] Tests included
- [X] Documentation is changed or added

