### PR TITLE
ICU-21271 Fix valgrind failure in dtptngen.cpp

### DIFF
--- a/icu4c/source/i18n/dtptngen.cpp
+++ b/icu4c/source/i18n/dtptngen.cpp
@@ -893,7 +893,7 @@ DateTimePatternGenerator::getCalendarTypeToUse(const Locale& locale, CharString&
             err = localStatus;
             return;
         }
-        if (calendarTypeLen < ULOC_KEYWORDS_CAPACITY) {
+        if (calendarTypeLen > 0 && calendarTypeLen < ULOC_KEYWORDS_CAPACITY) {
             destination.clear().append(calendarType, -1, err);
             if (U_FAILURE(err)) { return; }
         }


### PR DESCRIPTION
We need to check that `calendarTypeLen > 0`, otherwise it will try to append random memory.

### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21271
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

