### PR TITLE
ICU-21174 Drop MaybeStackVector::appendAll()

### DIFF
--- a/icu4c/source/common/cmemory.h
+++ b/icu4c/source/common/cmemory.h
@@ -826,19 +826,6 @@ public:
     T* operator[](ptrdiff_t i) {
         return this->fPool[i];
     }
-
-    /**
-     * Append copies of all the items from another MaybeStackVector to this one.
-     */
-    void appendAll(const MaybeStackVector& other, UErrorCode& status) {
-        for (int32_t i = 0; i < other.fCount; i++) {
-            T* item = emplaceBack(*other[i]);
-            if (!item) {
-                status = U_MEMORY_ALLOCATION_ERROR;
-                return;
-            }
-        }
-    }
 };
 
 

--- a/icu4c/source/i18n/measunit.cpp
+++ b/icu4c/source/i18n/measunit.cpp
@@ -2280,6 +2280,20 @@ int32_t MeasureUnit::getOffset() const {
     return gOffsets[fTypeId] + fSubTypeId;
 }
 
+MeasureUnitImpl MeasureUnitImpl::copy(UErrorCode &status) const {
+    MeasureUnitImpl result;
+    result.complexity = complexity;
+    result.identifier.append(identifier, status);
+    for (int32_t i = 0; i < units.length(); i++) {
+        SingleUnitImpl *item = result.units.emplaceBack(*units[i]);
+        if (!item) {
+            status = U_MEMORY_ALLOCATION_ERROR;
+            return result;
+        }
+    }
+    return result;
+}
+
 U_NAMESPACE_END
 
 #endif /* !UNCONFIG_NO_FORMATTING */

--- a/icu4c/source/i18n/measunit_impl.h
+++ b/icu4c/source/i18n/measunit_impl.h
@@ -22,7 +22,7 @@ static const char kDefaultCurrency8[] = "XXX";
 /**
  * A struct representing a single unit (optional SI prefix and dimensionality).
  */
-struct SingleUnitImpl : public UMemory {
+struct U_I18N_API SingleUnitImpl : public UMemory {
     /**
      * Gets a single unit from the MeasureUnit. If there are multiple single units, sets an error
      * code and returns the base dimensionless unit. Parses if necessary.
@@ -120,12 +120,20 @@ struct SingleUnitImpl : public UMemory {
     int32_t dimensionality = 1;
 };
 
+// Export explicit template instantiations of MaybeStackArray, MemoryPool and
+// MaybeStackVector. This is required when building DLLs for Windows. (See
+// datefmt.h, collationiterator.h, erarules.h and others for similar examples.)
+#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
+template class U_I18N_API MaybeStackArray<SingleUnitImpl*, 8>;
+template class U_I18N_API MemoryPool<SingleUnitImpl, 8>;
+template class U_I18N_API MaybeStackVector<SingleUnitImpl, 8>;
+#endif
 
 /**
  * Internal representation of measurement units. Capable of representing all complexities of units,
  * including mixed and compound units.
  */
-struct MeasureUnitImpl : public UMemory {
+struct U_I18N_API MeasureUnitImpl : public UMemory {
     /** Extract the MeasureUnitImpl from a MeasureUnit. */
     static inline const MeasureUnitImpl* get(const MeasureUnit& measureUnit) {
         return measureUnit.fImpl;
@@ -179,13 +187,7 @@ struct MeasureUnitImpl : public UMemory {
     /**
      * Create a copy of this MeasureUnitImpl. Don't use copy constructor to make this explicit.
      */
-    inline MeasureUnitImpl copy(UErrorCode& status) const {
-        MeasureUnitImpl result;
-        result.complexity = complexity;
-        result.units.appendAll(units, status);
-        result.identifier.append(identifier, status);
-        return result;
-    }
+    MeasureUnitImpl copy(UErrorCode& status) const;
 
     /** Mutates this MeasureUnitImpl to take the reciprocal. */
     void takeReciprocal(UErrorCode& status);
@@ -215,7 +217,6 @@ struct MeasureUnitImpl : public UMemory {
      */
     CharString identifier;
 };
-
 
 U_NAMESPACE_END
 


### PR DESCRIPTION
Rationale: appendAll() requires T to have a copy constructor. For Units work, we're using MaybeStackVector to store things that cannot be copy-constructed. While Clang succeeds, we have MSVC failures when we export the required symbols.

This was cherry-picked out of the big ICU4C Units-upstreaming PR: https://github.com/unicode-org/icu/pull/1284/commits/2f4561c7a76794b90c800768b407977a2336df5a / https://github.com/unicode-org/icu/pull/1284.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21174
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

