### PR TITLE
ICU-21106 avoid buffer overflow in u_fopen_u

### DIFF
--- a/icu4c/source/io/unicode/ustdio.h
+++ b/icu4c/source/io/unicode/ustdio.h
@@ -231,7 +231,7 @@ typedef enum {
  * That is, data written to a UFILE will be formatted using the conventions
  * specified by that UFILE's Locale; this data will be in the character set
  * specified by that UFILE's codepage.
- * @param filename The name of the file to open.
+ * @param filename The name of the file to open. Must be 0-terminated.
  * @param perm The read/write permission for the UFILE; one of "r", "w", "rw"
  * @param locale The locale whose conventions will be used to format 
  * and parse output. If this parameter is NULL, the default locale will 
@@ -254,7 +254,7 @@ u_fopen(const char    *filename,
  * That is, data written to a UFILE will be formatted using the conventions
  * specified by that UFILE's Locale; this data will be in the character set
  * specified by that UFILE's codepage.
- * @param filename The name of the file to open.
+ * @param filename The name of the file to open. Must be 0-terminated.
  * @param perm The read/write permission for the UFILE; one of "r", "w", "rw"
  * @param locale The locale whose conventions will be used to format
  * and parse output. If this parameter is NULL, the default locale will

--- a/icu4c/source/test/iotest/iotest.cpp
+++ b/icu4c/source/test/iotest/iotest.cpp
@@ -889,15 +889,20 @@ int main(int argc, char* argv[])
     nerrors = runTestRequest(root, argc, argv);
 
 #if 1
+    static const char* filenamesToRemove[] = { STANDARD_TEST_FILE, MEDIUMNAME_TEST_FILE, LONGNAME_TEST_FILE, nullptr };
+    const char** filenamesToRemovePtr = filenamesToRemove;
+    const char* filenameToRemove;
+    while ((filenameToRemove = *filenamesToRemovePtr++) != nullptr)
     {
-        FILE* fileToRemove = fopen(STANDARD_TEST_FILE, "r");
+
+        FILE* fileToRemove = fopen(filenameToRemove, "r");
         /* This should delete any temporary files. */
         if (fileToRemove) {
             fclose(fileToRemove);
-            log_verbose("Deleting: %s\n", STANDARD_TEST_FILE);
-            if (remove(STANDARD_TEST_FILE) != 0) {
+            log_verbose("Deleting: %s\n", filenameToRemove);
+            if (remove(filenameToRemove) != 0) {
                 /* Maybe someone didn't close the file correctly. */
-                fprintf(stderr, "FAIL: Could not delete %s\n", STANDARD_TEST_FILE);
+                fprintf(stderr, "FAIL: Could not delete %s\n", filenameToRemove);
                 nerrors += 1;
             }
         }

--- a/icu4c/source/test/iotest/iotest.h
+++ b/icu4c/source/test/iotest/iotest.h
@@ -36,6 +36,8 @@ U_CDECL_BEGIN
 extern const UChar NEW_LINE[];
 extern const char C_NEW_LINE[];
 extern const char *STANDARD_TEST_FILE;
+extern const char *MEDIUMNAME_TEST_FILE;
+extern const char *LONGNAME_TEST_FILE;
 U_CDECL_END
 
 #define STANDARD_TEST_NUM_RANGE 1000


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21106
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

This avoids possible buffer overflow in u_fopen_u for long filenames due to use of u_austrcpy with fixed-size buffer. Instead, this uses UnicodeString.extract for conversion to platform codepage, with buffer allocation if result would overflow fixed buffer.

It adds a test opening a file with a very long name. I noticed that existing u_file open tests generally *created* files for writing instead of opening existing files for reading. @grhoten, @jefgen, @markusicu: Do we (still) have platform compatibility issues that might cause problems adding a file with a long name (in the first version of this the filename itself is 254 characters, but the path passed to u_fopen_u is >256) with a specified content encoding (UTF-8)?