### PR TITLE
ICU-21108 Fix CI job names after VS2019 update, and add CI build using the VS2015 toolset

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -243,7 +243,7 @@ jobs:
 #-------------------------------------------------------------------------
 # VS 2017 Builds
 #-------------------------------------------------------------------------
-- job: ICU4C_MSVC_x64_Release
+- job: ICU4C_MSVC_x64_Release_VS2017
   displayName: 'C: MSVC 64-bit Release (VS 2017)'
   timeoutInMinutes: 30
   pool:
@@ -268,7 +268,7 @@ jobs:
         filename: icu4c/source/allinone/icucheck.bat
         arguments: 'x64 Release'
 #-------------------------------------------------------------------------
-- job: ICU4C_MSVC_x86_Debug
+- job: ICU4C_MSVC_x86_Debug_VS2017
   displayName: 'C: MSVC 32-bit Debug (VS 2017)'
   timeoutInMinutes: 60
   pool:
@@ -292,6 +292,34 @@ jobs:
       inputs:
         filename: icu4c/source/allinone/icucheck.bat
         arguments: 'x86 Debug'
+#-------------------------------------------------------------------------
+# VS2019 using the VS2015 toolset
+#-------------------------------------------------------------------------
+- job: ICU4C_MSVC_x64_Release_VS2015
+  displayName: 'C: MSVC 64-bit Release (VS 2015)'
+  timeoutInMinutes: 30
+  pool:
+    vmImage: 'windows-2019'
+    demands: 
+      - msbuild
+      - visualstudio
+      - Cmd
+  steps:
+    - checkout: self
+      lfs: true
+      fetchDepth: 10
+    - task: VSBuild@1
+      displayName: 'Build Solution'
+      inputs:
+        solution: icu4c/source/allinone/allinone.sln
+        platform: x64
+        configuration: Release
+        msbuildArgs: /p:SkipUWP=true /p:DefaultPlatformToolset=v140 /p:AutodetectWin10SDK=true
+    - task: BatchScript@1
+      displayName: 'Run Tests (icucheck.bat)'
+      inputs:
+        filename: icu4c/source/allinone/icucheck.bat
+        arguments: 'x64 Release'
 #-------------------------------------------------------------------------
 - job: ICU4C_MSYS2_GCC_x86_64_Release
   displayName: 'C: MSYS2 GCC x86_64 Release'

--- a/icu4c/source/allinone/Build.Windows.PlatformToolset.props
+++ b/icu4c/source/allinone/Build.Windows.PlatformToolset.props
@@ -37,7 +37,7 @@
   <PropertyGroup Condition="'$(WindowsTargetPlatformVersion)'=='' and '$(PlatformToolset)'=='v142'">
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(WindowsTargetPlatformVersion)'=='' and '$(PlatformToolset)'=='v141'">
+  <PropertyGroup Condition="'$(WindowsTargetPlatformVersion)'=='' and ('$(PlatformToolset)'=='v141' or '$(AutodetectWin10SDK)'=='true')">
     <!-- Detect the SDK version. -->
     <WindowsSdkInstallFolder_10 Condition="'$(WindowsSdkInstallFolder_10)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@InstallationFolder)</WindowsSdkInstallFolder_10>
     <WindowsSdkInstallFolder_10 Condition="'$(WindowsSdkInstallFolder_10)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0@InstallationFolder)</WindowsSdkInstallFolder_10>


### PR DESCRIPTION
This also adds a new `AutodetectWin10SDK` parameter, so that we can build with the VS2019 installation (which doesn't have the Win8.1 SDK) but still use the VS2015 compiler/toolset.
(Note: The Win10 SDK is still backwards compatible with Win7).

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21108
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

