### PR TITLE
ICU-21272 Add Windows ARM64 Debug build to CI build configuration

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -216,9 +216,9 @@ jobs:
         PathtoPublish: 'icu4c/source/dist/icu-windows.zip'
         ArtifactName: '$(Build.BuildNumber)_ICU4C_MSVC_ARM64_Release'
 #-------------------------------------------------------------------------
-- job: ICU4C_MSVC_x64_Debug
-  displayName: 'C: MSVC 64-bit Debug (VS 2019)'
-  timeoutInMinutes: 30
+- job: ICU4C_MSVC_x64_ARM64_Debug
+  displayName: 'C: MSVC x64 ARM64 Debug (VS 2019)'
+  timeoutInMinutes: 45
   pool:
     vmImage: 'windows-2019'
     demands: 
@@ -236,10 +236,16 @@ jobs:
         platform: x64
         configuration: Debug
     - task: BatchScript@1
-      displayName: 'Run Tests (icucheck.bat)'
+      displayName: 'Run x64 Debug Tests (icucheck.bat)'
       inputs:
         filename: icu4c/source/allinone/icucheck.bat
         arguments: 'x64 Debug'
+    - task: VSBuild@1
+      displayName: 'Build ARM64 Debug'
+      inputs:
+        solution: icu4c/source/allinone/allinone.sln
+        platform: ARM64
+        configuration: Debug
 #-------------------------------------------------------------------------
 # VS 2017 Builds
 #-------------------------------------------------------------------------

--- a/icu4c/source/data/makedata.mak
+++ b/icu4c/source/data/makedata.mak
@@ -161,9 +161,11 @@ ARM_CROSSBUILD_TS=$(ICUTMP)\$(ARM_CROSS_BUILD).timestamp
 #
 #  TOOLS CFG PATH
 #      Generally the tools want to run on the same architecture as is being built.
-#      Thus ARM and ARM64 need to use another build of the other tools, so make sure to get an usable cfg path.
+#      Thus ARM and ARM64 need to use another build of the other tools, so make sure to get an usable CFG path.
 #      Since tools, particularly pkggen, have architecture built-in, we made x64 on
-#      Windows be machine-independent and use those tools.
+#      Windows be machine-independent and use those tools for both ARM and ARM64.
+#      Note: If we're building ARM/ARM64 Debug, then we'll use the x64 Debug tools.
+#      If we're building ARM/ARM64 Release, then we'll use the x64 Release tools.
 #
 !IF "$(ARM_CROSS_BUILD)" == ""
 CFGTOOLS=$(CFG)


### PR DESCRIPTION
This is part 2 of the fix for [ICU-21272](https://unicode-org.atlassian.net/browse/ICU-21272):
- The fix for `makedata.mk` was done in PR #1316.
- This PR changes/modifies the CI builds to add another build for ARM64 Debug to the CI pipeline to prevent any regressions.

Description:
The ARM/ARM64 builds for ICU4C for Windows require building x64 *first*, as they use the x64 tools in order to cross-build ARM/ARM64. In the `makedata.mk` file, there was an accidental hard-coded reference to always use the `x64\Release` version of the tools. However, this should use `x64\Debug` if you're building ARM/ARM64 for `Debug`, and `x64\Release` for `Release`.

Thanks to @shaobero for finding and reporting this issue. :)

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21272
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added
