### PR TITLE
ICU-21196 Clarify API docs for input strings in ucoleiter.h and usearch.h

### DIFF
--- a/icu4c/source/i18n/unicode/ucoleitr.h
+++ b/icu4c/source/i18n/unicode/ucoleitr.h
@@ -23,7 +23,7 @@
 #if !UCONFIG_NO_COLLATION
 
 /**  
- * This indicates an error has occured during processing or if no more CEs is 
+ * This indicates an error has occurred during processing or if no more CEs is 
  * to be returned.
  * @stable ICU 2.0
  */
@@ -66,14 +66,14 @@ typedef struct UCollationElements UCollationElements;
  * .      UCollationElements *c;
  * .      UCollatorOld *coll;
  * .      UErrorCode success = U_ZERO_ERROR;
- * .      s=(UChar*)malloc(sizeof(UChar) * (strlen("This is a test")+1) );
- * .      u_uastrcpy(s, "This is a test");
+ * .      str=(UChar*)malloc(sizeof(UChar) * (strlen("This is a test")+1) );
+ * .      u_uastrcpy(str, "This is a test");
  * .      coll = ucol_open(NULL, &success);
  * .      c = ucol_openElements(coll, str, u_strlen(str), &status);
  * .      order = ucol_next(c, &success);
  * .      ucol_reset(c);
  * .      order = ucol_prev(c, &success);
- * .      free(s);
+ * .      free(str);
  * .      ucol_close(coll);
  * .      ucol_closeElements(c);
  * .  }
@@ -102,6 +102,10 @@ typedef struct UCollationElements UCollationElements;
 /**
  * Open the collation elements for a string.
  *
+ * The UCollationElements retains a pointer to the supplied text.
+ * The caller must not modify or delete the text while the UCollationElements
+ * object is used to iterate over this text.
+ *
  * @param coll The collator containing the desired collation rules.
  * @param text The text to iterate over.
  * @param textLength The number of characters in text, or -1 if null-terminated
@@ -114,7 +118,6 @@ ucol_openElements(const UCollator  *coll,
                   const UChar      *text,
                         int32_t    textLength,
                         UErrorCode *status);
-
 
 /**
  * get a hash code for a key... Not very useful!
@@ -153,7 +156,7 @@ ucol_reset(UCollationElements *elems);
  * @param elems The UCollationElements containing the text.
  * @param status A pointer to a UErrorCode to receive any errors.
  * @return The next collation elements ordering, otherwise returns UCOL_NULLORDER 
- *         if an error has occured or if the end of string has been reached
+ *         if an error has occurred or if the end of string has been reached
  * @stable ICU 2.0
  */
 U_CAPI int32_t U_EXPORT2 
@@ -168,7 +171,7 @@ ucol_next(UCollationElements *elems, UErrorCode *status);
  *               a U_BUFFER_OVERFLOW_ERROR is returned if the internal stack
  *               buffer has been exhausted.
  * @return The previous collation elements ordering, otherwise returns 
- *         UCOL_NULLORDER if an error has occured or if the start of string has 
+ *         UCOL_NULLORDER if an error has occurred or if the start of string has 
  *         been reached.
  * @stable ICU 2.0
  */
@@ -194,6 +197,11 @@ ucol_getMaxExpansion(const UCollationElements *elems, int32_t order);
  * Property settings for collation will remain the same.
  * In order to reset the iterator to the current collation property settings,
  * the API reset() has to be called.
+ *
+ * The UCollationElements retains a pointer to the supplied text.
+ * The caller must not modify or delete the text while the UCollationElements
+ * object is used to iterate over this text.
+ *
  * @param elems The UCollationElements to set.
  * @param text The source text containing the collation elements.
  * @param textLength The length of text, or -1 if null-terminated.
@@ -202,7 +210,7 @@ ucol_getMaxExpansion(const UCollationElements *elems, int32_t order);
  * @stable ICU 2.0
  */
 U_CAPI void U_EXPORT2 
-ucol_setText(      UCollationElements *elems, 
+ucol_setText(      UCollationElements *elems,
              const UChar              *text,
                    int32_t            textLength,
                    UErrorCode         *status);
@@ -233,7 +241,7 @@ ucol_getOffset(const UCollationElements *elems);
  */
 U_CAPI void U_EXPORT2 
 ucol_setOffset(UCollationElements *elems,
-               int32_t        offset,
+               int32_t             offset,
                UErrorCode         *status);
 
 /**

--- a/icu4c/source/i18n/unicode/usearch.h
+++ b/icu4c/source/i18n/unicode/usearch.h
@@ -28,8 +28,8 @@
  * \brief C API: StringSearch
  *
  * C APIs for an engine that provides language-sensitive text searching based 
- * on the comparison rules defined in a <tt>UCollator</tt> data struct,
- * see <tt>ucol.h</tt>. This ensures that language eccentricity can be 
+ * on the comparison rules defined in a <code>UCollator</code> data struct,
+ * see <code>ucol.h</code>. This ensures that language eccentricity can be 
  * handled, e.g. for the German collator, characters &szlig; and SS will be matched 
  * if case is chosen to be ignored. 
  * See the <a href="http://source.icu-project.org/repos/icu/icuhtml/trunk/design/collation/ICU_collation_design.htm">
@@ -57,18 +57,18 @@
  * Option 2. will be the default.
  * <p>
  * This search has APIs similar to that of other text iteration mechanisms 
- * such as the break iterators in <tt>ubrk.h</tt>. Using these 
+ * such as the break iterators in <code>ubrk.h</code>. Using these 
  * APIs, it is easy to scan through text looking for all occurrences of 
  * a given pattern. This search iterator allows changing of direction by 
- * calling a <tt>reset</tt> followed by a <tt>next</tt> or <tt>previous</tt>. 
- * Though a direction change can occur without calling <tt>reset</tt> first,  
+ * calling a <code>reset</code> followed by a <code>next</code> or <code>previous</code>. 
+ * Though a direction change can occur without calling <code>reset</code> first,  
  * this operation comes with some speed penalty.
  * Generally, match results in the forward direction will match the result 
  * matches in the backwards direction in the reverse order
  * <p>
- * <tt>usearch.h</tt> provides APIs to specify the starting position 
- * within the text string to be searched, e.g. <tt>usearch_setOffset</tt>,
- * <tt>usearch_preceding</tt> and <tt>usearch_following</tt>. Since the 
+ * <code>usearch.h</code> provides APIs to specify the starting position 
+ * within the text string to be searched, e.g. <code>usearch_setOffset</code>,
+ * <code>usearch_preceding</code> and <code>usearch_following</code>. Since the 
  * starting position will be set as it is specified, please take note that 
  * there are some dangerous positions which the search may render incorrect 
  * results:
@@ -104,7 +104,7 @@
  * Though collator attributes will be taken into consideration while 
  * performing matches, there are no APIs here for setting and getting the 
  * attributes. These attributes can be set by getting the collator
- * from <tt>usearch_getCollator</tt> and using the APIs in <tt>ucol.h</tt>.
+ * from <code>usearch_getCollator</code> and using the APIs in <code>ucol.h</code>.
  * Lastly to update String Search to the new collator attributes, 
  * usearch_reset() has to be called.
  * <p> 
@@ -280,9 +280,13 @@ typedef enum {
 /* open and close ------------------------------------------------------ */
 
 /**
-* Creating a search iterator data struct using the argument locale language
+* Creates a String Search iterator data struct using the argument locale language
 * rule set. A collator will be created in the process, which will be owned by
-* this search and will be deleted in <tt>usearch_close</tt>.
+* this String Search and will be deleted in <code>usearch_close</code>.
+*
+* The UStringSearch retains a pointer to both the pattern and text strings.
+* The caller must not modify or delete them while using the UStringSearch.
+*
 * @param pattern for matching
 * @param patternlength length of the pattern, -1 for null-termination
 * @param text text string
@@ -291,9 +295,9 @@ typedef enum {
 * @param breakiter A BreakIterator that will be used to restrict the points
 *                  at which matches are detected. If a match is found, but 
 *                  the match's start or end index is not a boundary as 
-*                  determined by the <tt>BreakIterator</tt>, the match will 
+*                  determined by the <code>BreakIterator</code>, the match will 
 *                  be rejected and another will be searched for. 
-*                  If this parameter is <tt>NULL</tt>, no break detection is 
+*                  If this parameter is <code>NULL</code>, no break detection is 
 *                  attempted.
 * @param status for errors if it occurs. If pattern or text is NULL, or if
 *               patternlength or textlength is 0 then an 
@@ -301,53 +305,58 @@ typedef enum {
 * @return search iterator data structure, or NULL if there is an error.
 * @stable ICU 2.4
 */
-U_CAPI UStringSearch * U_EXPORT2 usearch_open(const UChar          *pattern, 
-                                              int32_t         patternlength, 
-                                        const UChar          *text, 
+U_CAPI UStringSearch * U_EXPORT2 usearch_open(const UChar    *pattern,
+                                              int32_t         patternlength,
+                                        const UChar          *text,
                                               int32_t         textlength,
                                         const char           *locale,
                                               UBreakIterator *breakiter,
                                               UErrorCode     *status);
 
 /**
-* Creating a search iterator data struct using the argument collator language
-* rule set. Note, user retains the ownership of this collator, thus the 
+* Creates a String Search iterator data struct using the argument collator language
+* rule set. Note, user retains the ownership of this collator, thus the
 * responsibility of deletion lies with the user.
-* NOTE: string search cannot be instantiated from a collator that has 
-* collate digits as numbers (CODAN) turned on.
+
+* NOTE: String Search cannot be instantiated from a collator that has
+* collate digits as numbers (CODAN) turned on (UCOL_NUMERIC_COLLATION).
+*
+* The UStringSearch retains a pointer to both the pattern and text strings.
+* The caller must not modify or delete them while using the UStringSearch.
+*
 * @param pattern for matching
 * @param patternlength length of the pattern, -1 for null-termination
 * @param text text string
 * @param textlength length of the text string, -1 for null-termination
 * @param collator used for the language rules
 * @param breakiter A BreakIterator that will be used to restrict the points
-*                  at which matches are detected. If a match is found, but 
-*                  the match's start or end index is not a boundary as 
-*                  determined by the <tt>BreakIterator</tt>, the match will 
-*                  be rejected and another will be searched for. 
-*                  If this parameter is <tt>NULL</tt>, no break detection is 
+*                  at which matches are detected. If a match is found, but
+*                  the match's start or end index is not a boundary as
+*                  determined by the <code>BreakIterator</code>, the match will
+*                  be rejected and another will be searched for.
+*                  If this parameter is <code>NULL</code>, no break detection is
 *                  attempted.
-* @param status for errors if it occurs. If collator, pattern or text is NULL, 
-*               or if patternlength or textlength is 0 then an 
+* @param status for errors if it occurs. If collator, pattern or text is NULL,
+*               or if patternlength or textlength is 0 then an
 *               U_ILLEGAL_ARGUMENT_ERROR is returned.
 * @return search iterator data structure, or NULL if there is an error.
 * @stable ICU 2.4
 */
 U_CAPI UStringSearch * U_EXPORT2 usearch_openFromCollator(
-                                         const UChar *pattern, 
+                                         const UChar          *pattern,
                                                int32_t         patternlength,
-                                         const UChar          *text, 
+                                         const UChar          *text,
                                                int32_t         textlength,
                                          const UCollator      *collator,
                                                UBreakIterator *breakiter,
                                                UErrorCode     *status);
 
 /**
-* Destroying and cleaning up the search iterator data struct.
-* If a collator is created in <tt>usearch_open</tt>, it will be destroyed here.
-* @param searchiter data struct to clean up
-* @stable ICU 2.4
-*/
+ * Destroys and cleans up the String Search iterator data struct.
+ * If a collator was created in <code>usearch_open</code>, then it will be destroyed here.
+ * @param searchiter The UStringSearch to clean up
+ * @stable ICU 2.4
+ */
 U_CAPI void U_EXPORT2 usearch_close(UStringSearch *searchiter);
 
 #if U_SHOW_CPLUSPLUS_API
@@ -386,14 +395,14 @@ U_NAMESPACE_END
 * @param status error status if any.
 * @stable ICU 2.4
 */
-U_CAPI void U_EXPORT2 usearch_setOffset(UStringSearch *strsrch, 
-                                        int32_t    position,
+U_CAPI void U_EXPORT2 usearch_setOffset(UStringSearch *strsrch,
+                                        int32_t        position,
                                         UErrorCode    *status);
 
 /**
 * Return the current index in the string text being searched.
 * If the iteration has gone past the end of the text (or past the beginning 
-* for a backwards search), <tt>USEARCH_DONE</tt> is returned.
+* for a backwards search), <code>USEARCH_DONE</code> is returned.
 * @param strsrch search iterator data struct
 * @see #USEARCH_DONE
 * @stable ICU 2.4
@@ -403,7 +412,7 @@ U_CAPI int32_t U_EXPORT2 usearch_getOffset(const UStringSearch *strsrch);
 /**
 * Sets the text searching attributes located in the enum USearchAttribute
 * with values from the enum USearchAttributeValue.
-* <tt>USEARCH_DEFAULT</tt> can be used for all attributes for resetting.
+* <code>USEARCH_DEFAULT</code> can be used for all attributes for resetting.
 * @param strsrch search iterator data struct
 * @param attribute text attribute to be set
 * @param value text attribute value
@@ -411,7 +420,7 @@ U_CAPI int32_t U_EXPORT2 usearch_getOffset(const UStringSearch *strsrch);
 * @see #usearch_getAttribute
 * @stable ICU 2.4
 */
-U_CAPI void U_EXPORT2 usearch_setAttribute(UStringSearch         *strsrch, 
+U_CAPI void U_EXPORT2 usearch_setAttribute(UStringSearch         *strsrch,
                                            USearchAttribute       attribute,
                                            USearchAttributeValue  value,
                                            UErrorCode            *status);
@@ -431,12 +440,12 @@ U_CAPI USearchAttributeValue U_EXPORT2 usearch_getAttribute(
 /**
 * Returns the index to the match in the text string that was searched.
 * This call returns a valid result only after a successful call to 
-* <tt>usearch_first</tt>, <tt>usearch_next</tt>, <tt>usearch_previous</tt>, 
-* or <tt>usearch_last</tt>.
+* <code>usearch_first</code>, <code>usearch_next</code>, <code>usearch_previous</code>, 
+* or <code>usearch_last</code>.
 * Just after construction, or after a searching method returns 
-* <tt>USEARCH_DONE</tt>, this method will return <tt>USEARCH_DONE</tt>.
+* <code>USEARCH_DONE</code>, this method will return <code>USEARCH_DONE</code>.
 * <p>
-* Use <tt>usearch_getMatchedLength</tt> to get the matched string length.
+* Use <code>usearch_getMatchedLength</code> to get the matched string length.
 * @param strsrch search iterator data struct
 * @return index to a substring within the text string that is being 
 *         searched.
@@ -453,10 +462,10 @@ U_CAPI int32_t U_EXPORT2 usearch_getMatchedStart(
 /**
 * Returns the length of text in the string which matches the search pattern. 
 * This call returns a valid result only after a successful call to 
-* <tt>usearch_first</tt>, <tt>usearch_next</tt>, <tt>usearch_previous</tt>, 
-* or <tt>usearch_last</tt>.
+* <code>usearch_first</code>, <code>usearch_next</code>, <code>usearch_previous</code>, 
+* or <code>usearch_last</code>.
 * Just after construction, or after a searching method returns 
-* <tt>USEARCH_DONE</tt>, this method will return 0.
+* <code>USEARCH_DONE</code>, this method will return 0.
 * @param strsrch search iterator data struct
 * @return The length of the match in the string text, or 0 if there is no 
 *         match currently.
@@ -472,17 +481,17 @@ U_CAPI int32_t U_EXPORT2 usearch_getMatchedLength(
 
 /**
 * Returns the text that was matched by the most recent call to 
-* <tt>usearch_first</tt>, <tt>usearch_next</tt>, <tt>usearch_previous</tt>, 
-* or <tt>usearch_last</tt>.
+* <code>usearch_first</code>, <code>usearch_next</code>, <code>usearch_previous</code>, 
+* or <code>usearch_last</code>.
 * If the iterator is not pointing at a valid match (e.g. just after 
-* construction or after <tt>USEARCH_DONE</tt> has been returned, returns
+* construction or after <code>USEARCH_DONE</code> has been returned, returns
 * an empty string. If result is not large enough to store the matched text,
 * result will be filled with the partial text and an U_BUFFER_OVERFLOW_ERROR 
 * will be returned in status. result will be null-terminated whenever 
 * possible. If the buffer fits the matched text exactly, a null-termination 
 * is not possible, then a U_STRING_NOT_TERMINATED_ERROR set in status.
 * Pre-flighting can be either done with length = 0 or the API 
-* <tt>usearch_getMatchedLength</tt>.
+* <code>usearch_getMatchedLength</code>.
 * @param strsrch search iterator data struct
 * @param result UChar buffer to store the matched string
 * @param resultCapacity length of the result buffer
@@ -509,9 +518,9 @@ U_CAPI int32_t U_EXPORT2 usearch_getMatchedText(const UStringSearch *strsrch,
 * @param breakiter A BreakIterator that will be used to restrict the points
 *                  at which matches are detected. If a match is found, but 
 *                  the match's start or end index is not a boundary as 
-*                  determined by the <tt>BreakIterator</tt>, the match will 
+*                  determined by the <code>BreakIterator</code>, the match will 
 *                  be rejected and another will be searched for. 
-*                  If this parameter is <tt>NULL</tt>, no break detection is 
+*                  If this parameter is <code>NULL</code>, no break detection is 
 *                  attempted.
 * @param status for errors if it occurs
 * @see #usearch_getBreakIterator
@@ -524,8 +533,8 @@ U_CAPI void U_EXPORT2 usearch_setBreakIterator(UStringSearch  *strsrch,
 /**
 * Returns the BreakIterator that is used to restrict the points at which 
 * matches are detected. This will be the same object that was passed to the 
-* constructor or to <tt>usearch_setBreakIterator</tt>. Note that 
-* <tt>NULL</tt> 
+* constructor or to <code>usearch_setBreakIterator</code>. Note that 
+* <code>NULL</code> 
 * is a legal value; it means that break detection should not be attempted.
 * @param strsrch search iterator data struct
 * @return break iterator used
@@ -536,11 +545,15 @@ U_CAPI const UBreakIterator * U_EXPORT2 usearch_getBreakIterator(
                                               const UStringSearch *strsrch);
     
 #endif
-    
+
 /**
 * Set the string text to be searched. Text iteration will hence begin at the 
 * start of the text string. This method is useful if you want to re-use an 
 * iterator to search for the same pattern within a different body of text.
+*
+* The UStringSearch retains a pointer to the text string. The caller must not
+* modify or delete the string while using the UStringSearch.
+*
 * @param strsrch search iterator data struct
 * @param text new string to look for match
 * @param textlength length of the new string, -1 for null-termination
@@ -569,9 +582,9 @@ U_CAPI const UChar * U_EXPORT2 usearch_getText(const UStringSearch *strsrch,
 /**
 * Gets the collator used for the language rules. 
 * <p>
-* Deleting the returned <tt>UCollator</tt> before calling 
-* <tt>usearch_close</tt> would cause the string search to fail.
-* <tt>usearch_close</tt> will delete the collator if this search owns it.
+* Deleting the returned <code>UCollator</code> before calling 
+* <code>usearch_close</code> would cause the string search to fail.
+* <code>usearch_close</code> will delete the collator if this search owns it.
 * @param strsrch search iterator data struct
 * @return collator
 * @stable ICU 2.4
@@ -597,6 +610,10 @@ U_CAPI void U_EXPORT2 usearch_setCollator(      UStringSearch *strsrch,
 * Sets the pattern used for matching.
 * Internal data like the Boyer Moore table will be recalculated, but the 
 * iterator's position is unchanged.
+*
+* The UStringSearch retains a pointer to the pattern string. The caller must not
+* modify or delete the string while using the UStringSearch.
+*
 * @param strsrch search iterator data struct
 * @param pattern string
 * @param patternlength pattern length, -1 for null-terminated string
@@ -628,13 +645,13 @@ U_CAPI const UChar * U_EXPORT2 usearch_getPattern(
 * Returns the first index at which the string text matches the search 
 * pattern.  
 * The iterator is adjusted so that its current index (as returned by 
-* <tt>usearch_getOffset</tt>) is the match position if one was found.
-* If a match is not found, <tt>USEARCH_DONE</tt> will be returned and
-* the iterator will be adjusted to the index <tt>USEARCH_DONE</tt>.
+* <code>usearch_getOffset</code>) is the match position if one was found.
+* If a match is not found, <code>USEARCH_DONE</code> will be returned and
+* the iterator will be adjusted to the index <code>USEARCH_DONE</code>.
 * @param strsrch search iterator data struct
 * @param status for errors if it occurs
 * @return The character index of the first match, or 
-* <tt>USEARCH_DONE</tt> if there are no matches.
+* <code>USEARCH_DONE</code> if there are no matches.
 * @see #usearch_getOffset
 * @see #USEARCH_DONE
 * @stable ICU 2.4
@@ -643,13 +660,13 @@ U_CAPI int32_t U_EXPORT2 usearch_first(UStringSearch *strsrch,
                                            UErrorCode    *status);
 
 /**
-* Returns the first index equal or greater than <tt>position</tt> at which
+* Returns the first index equal or greater than <code>position</code> at which
 * the string text
 * matches the search pattern. The iterator is adjusted so that its current 
-* index (as returned by <tt>usearch_getOffset</tt>) is the match position if 
+* index (as returned by <code>usearch_getOffset</code>) is the match position if 
 * one was found.
-* If a match is not found, <tt>USEARCH_DONE</tt> will be returned and
-* the iterator will be adjusted to the index <tt>USEARCH_DONE</tt>
+* If a match is not found, <code>USEARCH_DONE</code> will be returned and
+* the iterator will be adjusted to the index <code>USEARCH_DONE</code>
 * <p>
 * Search positions that may render incorrect results are highlighted in the
 * header comments. If position is less than or greater than the text range 
@@ -657,8 +674,8 @@ U_CAPI int32_t U_EXPORT2 usearch_first(UStringSearch *strsrch,
 * @param strsrch search iterator data struct
 * @param position to start the search at
 * @param status for errors if it occurs
-* @return The character index of the first match following <tt>pos</tt>,
-*         or <tt>USEARCH_DONE</tt> if there are no matches.
+* @return The character index of the first match following <code>pos</code>,
+*         or <code>USEARCH_DONE</code> if there are no matches.
 * @see #usearch_getOffset
 * @see #USEARCH_DONE
 * @stable ICU 2.4
@@ -670,13 +687,13 @@ U_CAPI int32_t U_EXPORT2 usearch_following(UStringSearch *strsrch,
 /**
 * Returns the last index in the target text at which it matches the search 
 * pattern. The iterator is adjusted so that its current 
-* index (as returned by <tt>usearch_getOffset</tt>) is the match position if 
+* index (as returned by <code>usearch_getOffset</code>) is the match position if 
 * one was found.
-* If a match is not found, <tt>USEARCH_DONE</tt> will be returned and
-* the iterator will be adjusted to the index <tt>USEARCH_DONE</tt>.
+* If a match is not found, <code>USEARCH_DONE</code> will be returned and
+* the iterator will be adjusted to the index <code>USEARCH_DONE</code>.
 * @param strsrch search iterator data struct
 * @param status for errors if it occurs
-* @return The index of the first match, or <tt>USEARCH_DONE</tt> if there 
+* @return The index of the first match, or <code>USEARCH_DONE</code> if there 
 *         are no matches.
 * @see #usearch_getOffset
 * @see #USEARCH_DONE
@@ -686,26 +703,26 @@ U_CAPI int32_t U_EXPORT2 usearch_last(UStringSearch *strsrch,
                                           UErrorCode    *status);
 
 /**
-* Returns the first index less than <tt>position</tt> at which the string text 
+* Returns the first index less than <code>position</code> at which the string text 
 * matches the search pattern. The iterator is adjusted so that its current 
-* index (as returned by <tt>usearch_getOffset</tt>) is the match position if 
+* index (as returned by <code>usearch_getOffset</code>) is the match position if 
 * one was found.
-* If a match is not found, <tt>USEARCH_DONE</tt> will be returned and
-* the iterator will be adjusted to the index <tt>USEARCH_DONE</tt>
+* If a match is not found, <code>USEARCH_DONE</code> will be returned and
+* the iterator will be adjusted to the index <code>USEARCH_DONE</code>
 * <p>
 * Search positions that may render incorrect results are highlighted in the
 * header comments. If position is less than or greater than the text range 
 * for searching, an U_INDEX_OUTOFBOUNDS_ERROR will be returned.
 * <p>
-* When <tt>USEARCH_OVERLAP</tt> option is off, the last index of the
-* result match is always less than <tt>position</tt>.
-* When <tt>USERARCH_OVERLAP</tt> is on, the result match may span across
-* <tt>position</tt>.
+* When <code>USEARCH_OVERLAP</code> option is off, the last index of the
+* result match is always less than <code>position</code>.
+* When <code>USERARCH_OVERLAP</code> is on, the result match may span across
+* <code>position</code>.
 * @param strsrch search iterator data struct
 * @param position index position the search is to begin at
 * @param status for errors if it occurs
-* @return The character index of the first match preceding <tt>pos</tt>,
-*         or <tt>USEARCH_DONE</tt> if there are no matches.
+* @return The character index of the first match preceding <code>pos</code>,
+*         or <code>USEARCH_DONE</code> if there are no matches.
 * @see #usearch_getOffset
 * @see #USEARCH_DONE
 * @stable ICU 2.4
@@ -718,14 +735,14 @@ U_CAPI int32_t U_EXPORT2 usearch_preceding(UStringSearch *strsrch,
 * Returns the index of the next point at which the string text matches the
 * search pattern, starting from the current position.
 * The iterator is adjusted so that its current 
-* index (as returned by <tt>usearch_getOffset</tt>) is the match position if 
+* index (as returned by <code>usearch_getOffset</code>) is the match position if 
 * one was found.
-* If a match is not found, <tt>USEARCH_DONE</tt> will be returned and
-* the iterator will be adjusted to the index <tt>USEARCH_DONE</tt>
+* If a match is not found, <code>USEARCH_DONE</code> will be returned and
+* the iterator will be adjusted to the index <code>USEARCH_DONE</code>
 * @param strsrch search iterator data struct
 * @param status for errors if it occurs
 * @return The index of the next match after the current position, or 
-*         <tt>USEARCH_DONE</tt> if there are no more matches.
+*         <code>USEARCH_DONE</code> if there are no more matches.
 * @see #usearch_first
 * @see #usearch_getOffset
 * @see #USEARCH_DONE
@@ -738,14 +755,14 @@ U_CAPI int32_t U_EXPORT2 usearch_next(UStringSearch *strsrch,
 * Returns the index of the previous point at which the string text matches
 * the search pattern, starting at the current position.
 * The iterator is adjusted so that its current 
-* index (as returned by <tt>usearch_getOffset</tt>) is the match position if 
+* index (as returned by <code>usearch_getOffset</code>) is the match position if 
 * one was found.
-* If a match is not found, <tt>USEARCH_DONE</tt> will be returned and
-* the iterator will be adjusted to the index <tt>USEARCH_DONE</tt>
+* If a match is not found, <code>USEARCH_DONE</code> will be returned and
+* the iterator will be adjusted to the index <code>USEARCH_DONE</code>
 * @param strsrch search iterator data struct
 * @param status for errors if it occurs
 * @return The index of the previous match before the current position,
-*         or <tt>USEARCH_DONE</tt> if there are no more matches.
+*         or <code>USEARCH_DONE</code> if there are no more matches.
 * @see #usearch_last
 * @see #usearch_getOffset
 * @see #USEARCH_DONE


### PR DESCRIPTION
This change adds notes to the API documentation in `ucoleiter.h` and `usearch.h` that the input string arguments must not be deleted and/or changed while the ICU objects are still potentially using them.

I tried to use wording for this that is similar to existing wording on other APIs in order to have consistency in the library.

Some existing examples:
https://github.com/unicode-org/icu/blob/master/icu4c/source/common/unicode/brkiter.h#L178
```
     * The BreakIterator will retain a reference to the supplied string.
     * The caller must not modify or delete the text while the BreakIterator
     * retains the reference.
```
https://github.com/unicode-org/icu/blob/master/icu4c/source/common/unicode/ubrk.h#L364
```
 * The break iterator retains a pointer to the supplied text.
 * The caller must not modify or delete the text while the BreakIterator
 * retains the reference.
```

This change also fixes a few minor typos in the headers as well.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21196
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [x] Documentation is changed or added
