### PR TITLE
ICU-21267 stop using FALSE & TRUE macros in most library-internal hea…

### DIFF
--- a/icu4c/source/common/bmpset.h
+++ b/icu4c/source/common/bmpset.h
@@ -101,7 +101,7 @@ private:
      */
     UBool latin1Contains[0x100];
 
-    /* TRUE if contains(U+FFFD). */
+    /* true if contains(U+FFFD). */
     UBool containsFFFD;
 
     /*

--- a/icu4c/source/common/brkeng.h
+++ b/icu4c/source/common/brkeng.h
@@ -54,7 +54,7 @@ class LanguageBreakEngine : public UMemory {
   * a particular kind of break.</p>
   *
   * @param c A character which begins a run that the engine might handle
-  * @return TRUE if this engine handles the particular character and break
+  * @return true if this engine handles the particular character and break
   * type.
   */
   virtual UBool handles(UChar32 c) const = 0;
@@ -171,7 +171,7 @@ class UnhandledEngine : public LanguageBreakEngine {
   * a particular kind of break.</p>
   *
   * @param c A character which begins a run that the engine might handle
-  * @return TRUE if this engine handles the particular character and break
+  * @return true if this engine handles the particular character and break
   * type.
   */
   virtual UBool handles(UChar32 c) const;

--- a/icu4c/source/common/bytesinkutil.h
+++ b/icu4c/source/common/bytesinkutil.h
@@ -45,9 +45,9 @@ public:
     static UBool appendUnchanged(const uint8_t *s, int32_t length,
                                  ByteSink &sink, uint32_t options, Edits *edits,
                                  UErrorCode &errorCode) {
-        if (U_FAILURE(errorCode)) { return FALSE; }
+        if (U_FAILURE(errorCode)) { return false; }
         if (length > 0) { appendNonEmptyUnchanged(s, length, sink, options, edits); }
-        return TRUE;
+        return true;
     }
 
     static UBool appendUnchanged(const uint8_t *s, const uint8_t *limit,

--- a/icu4c/source/common/dictbe.h
+++ b/icu4c/source/common/dictbe.h
@@ -59,7 +59,7 @@ class DictionaryBreakEngine : public LanguageBreakEngine {
    * a particular kind of break.</p>
    *
    * @param c A character which begins a run that the engine might handle
-   * @return TRUE if this engine handles the particular character and break
+   * @return true if this engine handles the particular character and break
    * type.
    */
   virtual UBool handles(UChar32 c) const;

--- a/icu4c/source/common/messageimpl.h
+++ b/icu4c/source/common/messageimpl.h
@@ -33,7 +33,7 @@ U_NAMESPACE_BEGIN
 class U_COMMON_API MessageImpl {
 public:
     /**
-     * @return TRUE if getApostropheMode()==UMSGPAT_APOS_DOUBLE_REQUIRED
+     * @return true if getApostropheMode()==UMSGPAT_APOS_DOUBLE_REQUIRED
      */
     static UBool jdkAposMode(const MessagePattern &msgPattern) {
         return msgPattern.getApostropheMode()==UMSGPAT_APOS_DOUBLE_REQUIRED;

--- a/icu4c/source/common/norm2allmodes.h
+++ b/icu4c/source/common/norm2allmodes.h
@@ -65,13 +65,13 @@ public:
     normalizeSecondAndAppend(UnicodeString &first,
                              const UnicodeString &second,
                              UErrorCode &errorCode) const {
-        return normalizeSecondAndAppend(first, second, TRUE, errorCode);
+        return normalizeSecondAndAppend(first, second, true, errorCode);
     }
     virtual UnicodeString &
     append(UnicodeString &first,
            const UnicodeString &second,
            UErrorCode &errorCode) const {
-        return normalizeSecondAndAppend(first, second, FALSE, errorCode);
+        return normalizeSecondAndAppend(first, second, false, errorCode);
     }
     UnicodeString &
     normalizeSecondAndAppend(UnicodeString &first,
@@ -112,14 +112,14 @@ public:
         int32_t length;
         const UChar *d=impl.getDecomposition(c, buffer, length);
         if(d==NULL) {
-            return FALSE;
+            return false;
         }
         if(d==buffer) {
             decomposition.setTo(buffer, length);  // copy the string (Jamos from Hangul syllable c)
         } else {
-            decomposition.setTo(FALSE, d, length);  // read-only alias
+            decomposition.setTo(false, d, length);  // read-only alias
         }
-        return TRUE;
+        return true;
     }
     virtual UBool
     getRawDecomposition(UChar32 c, UnicodeString &decomposition) const {
@@ -127,14 +127,14 @@ public:
         int32_t length;
         const UChar *d=impl.getRawDecomposition(c, buffer, length);
         if(d==NULL) {
-            return FALSE;
+            return false;
         }
         if(d==buffer) {
             decomposition.setTo(buffer, length);  // copy the string (algorithmic decomposition)
         } else {
-            decomposition.setTo(FALSE, d, length);  // read-only alias
+            decomposition.setTo(false, d, length);  // read-only alias
         }
-        return TRUE;
+        return true;
     }
     virtual UChar32
     composePair(UChar32 a, UChar32 b) const {
@@ -150,12 +150,12 @@ public:
     virtual UBool
     isNormalized(const UnicodeString &s, UErrorCode &errorCode) const {
         if(U_FAILURE(errorCode)) {
-            return FALSE;
+            return false;
         }
         const UChar *sArray=s.getBuffer();
         if(sArray==NULL) {
             errorCode=U_ILLEGAL_ARGUMENT_ERROR;
-            return FALSE;
+            return false;
         }
         const UChar *sLimit=sArray+s.length();
         return sLimit==spanQuickCheckYes(sArray, sLimit, errorCode);
@@ -227,7 +227,7 @@ private:
     virtual void
     normalize(const UChar *src, const UChar *limit,
               ReorderingBuffer &buffer, UErrorCode &errorCode) const U_OVERRIDE {
-        impl.compose(src, limit, onlyContiguous, TRUE, buffer, errorCode);
+        impl.compose(src, limit, onlyContiguous, true, buffer, errorCode);
     }
     using Normalizer2WithImpl::normalize;  // Avoid warning about hiding base class function.
 
@@ -256,24 +256,24 @@ private:
     virtual UBool
     isNormalized(const UnicodeString &s, UErrorCode &errorCode) const U_OVERRIDE {
         if(U_FAILURE(errorCode)) {
-            return FALSE;
+            return false;
         }
         const UChar *sArray=s.getBuffer();
         if(sArray==NULL) {
             errorCode=U_ILLEGAL_ARGUMENT_ERROR;
-            return FALSE;
+            return false;
         }
         UnicodeString temp;
         ReorderingBuffer buffer(impl, temp);
         if(!buffer.init(5, errorCode)) {  // small destCapacity for substring normalization
-            return FALSE;
+            return false;
         }
-        return impl.compose(sArray, sArray+s.length(), onlyContiguous, FALSE, buffer, errorCode);
+        return impl.compose(sArray, sArray+s.length(), onlyContiguous, false, buffer, errorCode);
     }
     virtual UBool
     isNormalizedUTF8(StringPiece sp, UErrorCode &errorCode) const U_OVERRIDE {
         if(U_FAILURE(errorCode)) {
-            return FALSE;
+            return false;
         }
         const uint8_t *s = reinterpret_cast<const uint8_t *>(sp.data());
         return impl.composeUTF8(0, onlyContiguous, s, s + sp.length(), nullptr, nullptr, errorCode);
@@ -343,7 +343,7 @@ private:
 
 struct Norm2AllModes : public UMemory {
     Norm2AllModes(Normalizer2Impl *i)
-            : impl(i), comp(*i, FALSE), decomp(*i), fcd(*i), fcc(*i, TRUE) {}
+            : impl(i), comp(*i, false), decomp(*i), fcd(*i), fcc(*i, true) {}
     ~Norm2AllModes();
 
     static Norm2AllModes *createInstance(Normalizer2Impl *impl, UErrorCode &errorCode);

--- a/icu4c/source/common/normalizer2impl.h
+++ b/icu4c/source/common/normalizer2impl.h
@@ -359,7 +359,7 @@ public:
         return getFCD16FromNormData(c);
     }
 
-    /** Returns TRUE if the single-or-lead code unit c might have non-zero FCD data. */
+    /** Returns true if the single-or-lead code unit c might have non-zero FCD data. */
     UBool singleLeadMightHaveNonZeroFCD16(UChar32 lead) const {
         // 0<=lead<=0xffff
         uint8_t bits=smallFCD[lead>>8];
@@ -397,8 +397,8 @@ public:
         MIN_YES_YES_WITH_CC=0xfe02,
         JAMO_VT=0xfe00,
         MIN_NORMAL_MAYBE_YES=0xfc00,
-        JAMO_L=2,  // offset=1 hasCompBoundaryAfter=FALSE
-        INERT=1,  // offset=0 hasCompBoundaryAfter=TRUE
+        JAMO_L=2,  // offset=1 hasCompBoundaryAfter=false
+        INERT=1,  // offset=0 hasCompBoundaryAfter=true
 
         // norm16 bit 0 is comp-boundary-after.
         HAS_COMP_BOUNDARY_AFTER=1,

--- a/icu4c/source/common/patternprops.h
+++ b/icu4c/source/common/patternprops.h
@@ -44,17 +44,17 @@ U_NAMESPACE_BEGIN
 class U_COMMON_API PatternProps {
 public:
     /**
-     * @return TRUE if c is a Pattern_Syntax code point.
+     * @return true if c is a Pattern_Syntax code point.
      */
     static UBool isSyntax(UChar32 c);
 
     /**
-     * @return TRUE if c is a Pattern_Syntax or Pattern_White_Space code point.
+     * @return true if c is a Pattern_Syntax or Pattern_White_Space code point.
      */
     static UBool isSyntaxOrWhiteSpace(UChar32 c);
 
     /**
-     * @return TRUE if c is a Pattern_White_Space character.
+     * @return true if c is a Pattern_White_Space character.
      */
     static UBool isWhiteSpace(UChar32 c);
 
@@ -78,7 +78,7 @@ public:
     /**
      * Tests whether the string contains a "pattern identifier", that is,
      * whether it contains only non-Pattern_White_Space, non-Pattern_Syntax characters.
-     * @return TRUE if there are no Pattern_White_Space or Pattern_Syntax characters in s.
+     * @return true if there are no Pattern_White_Space or Pattern_Syntax characters in s.
      */
     static UBool isIdentifier(const UChar *s, int32_t length);
 

--- a/icu4c/source/common/pluralmap.h
+++ b/icu4c/source/common/pluralmap.h
@@ -234,7 +234,7 @@ public:
     }
 
     /**
-     * Returns TRUE if this object equals rhs.
+     * Returns true if this object equals rhs.
      */
     UBool equals(
             const PluralMap<T> &rhs,
@@ -244,13 +244,13 @@ public:
                 continue;
             }
             if (fVariants[i] == NULL || rhs.fVariants[i] == NULL) {
-                return FALSE;
+                return false;
             }
             if (!eqFunc(*fVariants[i], *rhs.fVariants[i])) {
-                return FALSE;
+                return false;
             }
         }
-        return TRUE;
+        return true;
     }
 
 private:

--- a/icu4c/source/common/punycode.h
+++ b/icu4c/source/common/punycode.h
@@ -50,7 +50,7 @@ http://www.nicemice.net/amc/
  * @param caseFlags Vector of boolean values, one per input UChar,
  *                  indicating that the corresponding character is to be
  *                  marked for the decoder optionally
- *                  uppercasing (TRUE) or lowercasing (FALSE)
+ *                  uppercasing (true) or lowercasing (false)
  *                  the character.
  *                  ASCII characters are output directly in the case as marked.
  *                  Flags corresponding to trail surrogates are ignored.
@@ -83,10 +83,10 @@ u_strToPunycode(const UChar *src, int32_t srcLength,
  *                     and of caseFlags in numbers of UBools.
  * @param caseFlags Output array for case flags as
  *                  defined by the Punycode string.
- *                  The caller should uppercase (TRUE) or lowercase (FASLE)
+ *                  The caller should uppercase (true) or lowercase (FASLE)
  *                  the corresponding character in dest.
  *                  For supplementary characters, only the lead surrogate
- *                  is marked, and FALSE is stored for the trail surrogate.
+ *                  is marked, and false is stored for the trail surrogate.
  *                  This is redundant and not necessary for ASCII characters
  *                  because they are already in the case indicated.
  *                  Can be NULL if the case flags are not needed.

--- a/icu4c/source/common/putilimp.h
+++ b/icu4c/source/common/putilimp.h
@@ -463,7 +463,7 @@ U_CAPI UDate U_EXPORT2 uprv_getRawUTCtime(void);
 /**
  * Determine whether a pathname is absolute or not, as defined by the platform.
  * @param path Pathname to test
- * @return TRUE if the path is absolute
+ * @return true if the path is absolute
  * @internal (ICU 3.0)
  */
 U_CAPI UBool U_EXPORT2 uprv_pathIsAbsolute(const char *path);

--- a/icu4c/source/common/rbbi_cache.h
+++ b/icu4c/source/common/rbbi_cache.h
@@ -126,13 +126,13 @@ class RuleBasedBreakIterator::BreakCache: public UMemory {
      * Additional boundaries, either preceding or following, may be added
      * to the cache as a side effect.
      *
-     * Return FALSE if the operation failed.
+     * Return false if the operation failed.
      */
     UBool populateNear(int32_t position, UErrorCode &status);
 
     /**
      *  Add boundary(s) to the cache following the current last boundary.
-     *  Return FALSE if at the end of the text, and no more boundaries can be added.
+     *  Return false if at the end of the text, and no more boundaries can be added.
      *  Leave iteration position at the first newly added boundary, or unchanged if no boundary was added.
      */
     UBool populateFollowing();
@@ -170,7 +170,7 @@ class RuleBasedBreakIterator::BreakCache: public UMemory {
      *  Fails if the requested position is outside of the range of boundaries currently held by the cache.
      *  The startPosition must be on a code point boundary.
      *
-     *  Return TRUE if successful, FALSE if the specified position is after
+     *  Return true if successful, false if the specified position is after
      *  the last cached boundary or before the first.
      */
     UBool                   seek(int32_t startPosition);

--- a/icu4c/source/common/rbbinode.h
+++ b/icu4c/source/common/rbbinode.h
@@ -79,7 +79,7 @@ class RBBINode : public UMemory {
                                             //   corresponds to columns in the final
                                             //   state transition table.
 
-        UBool         fLookAheadEnd;        // For endMark nodes, set TRUE if
+        UBool         fLookAheadEnd;        // For endMark nodes, set true if
                                             //   marking the end of a look-ahead rule.
 
         UBool         fRuleRoot;            // True if this node is the root of a rule.

--- a/icu4c/source/common/rbbiscan.h
+++ b/icu4c/source/common/rbbiscan.h
@@ -54,7 +54,7 @@ public:
     struct RBBIRuleChar {
         UChar32             fChar;
         UBool               fEscaped;
-        RBBIRuleChar() : fChar(0), fEscaped(FALSE) {}
+        RBBIRuleChar() : fChar(0), fEscaped(false) {}
     };
 
     RBBIRuleScanner(RBBIRuleBuilder  *rb);

--- a/icu4c/source/common/ruleiter.h
+++ b/icu4c/source/common/ruleiter.h
@@ -114,7 +114,7 @@ public:
      * character.
      * @param options one or more of the following options, bitwise-OR-ed
      * together: PARSE_VARIABLES, PARSE_ESCAPES, SKIP_WHITESPACE.
-     * @param isEscaped output parameter set to TRUE if the character
+     * @param isEscaped output parameter set to true if the character
      * was escaped
      * @param ec input-output error code.  An error will only be set by
      * this routing if options includes PARSE_VARIABLES and an unknown

--- a/icu4c/source/common/serv.h
+++ b/icu4c/source/common/serv.h
@@ -138,16 +138,16 @@ class U_COMMON_API ICUServiceKey : public UObject {
   * must eventually return false.  This implementation has no fallbacks
   * and always returns false.</p>
   *
-  * @return TRUE if the ICUServiceKey changed to a valid fallback value.
+  * @return true if the ICUServiceKey changed to a valid fallback value.
   */
   virtual UBool fallback();
 
  /**
-  * <p>Return TRUE if a key created from id matches, or would eventually
+  * <p>Return true if a key created from id matches, or would eventually
   * fallback to match, the canonical ID of this ICUServiceKey.</p>
   *
   * @param id the id to test.
-  * @return TRUE if this ICUServiceKey's canonical ID is a fallback of id.
+  * @return true if this ICUServiceKey's canonical ID is a fallback of id.
   */
   virtual UBool isFallbackOf(const UnicodeString& id) const;
 
@@ -291,15 +291,15 @@ class U_COMMON_API SimpleFactory : public ICUServiceFactory {
  public:
   /**
    * <p>Construct a SimpleFactory that maps a single ID to a single 
-   * service instance.  If visible is TRUE, the ID will be visible.
+   * service instance.  If visible is true, the ID will be visible.
    * The instance must not be NULL.  The SimpleFactory will adopt
    * the instance, which must not be changed subsequent to this call.</p>
    *
    * @param instanceToAdopt the service instance to adopt.
    * @param id the ID to assign to this service instance.
-   * @param visible if TRUE, the ID will be visible.
+   * @param visible if true, the ID will be visible.
    */
-  SimpleFactory(UObject* instanceToAdopt, const UnicodeString& id, UBool visible = TRUE);
+  SimpleFactory(UObject* instanceToAdopt, const UnicodeString& id, UBool visible = true);
 
   /**
    * <p>Destructor.</p>
@@ -318,7 +318,7 @@ class U_COMMON_API SimpleFactory : public ICUServiceFactory {
   virtual UObject* create(const ICUServiceKey& key, const ICUService* service, UErrorCode& status) const;
 
   /**
-   * <p>This implementation adds a mapping from ID -> this to result if visible is TRUE, 
+   * <p>This implementation adds a mapping from ID -> this to result if visible is true, 
    * otherwise it removes ID from result.</p>
    *
    * @param result the mapping table to update.
@@ -327,7 +327,7 @@ class U_COMMON_API SimpleFactory : public ICUServiceFactory {
   virtual void updateVisibleIDs(Hashtable& result, UErrorCode& status) const;
 
   /**
-   * <p>This implementation returns the factory ID if it equals id and visible is TRUE,
+   * <p>This implementation returns the factory ID if it equals id and visible is true,
    * otherwise it returns the empty string.  (This implementation provides
    * no localized id information.)</p>
    *
@@ -427,8 +427,8 @@ public:
                             UErrorCode& status);
 
   /**
-   * <p>Return TRUE if either string of the pair is bogus.</p>
-   * @return TRUE if either string of the pair is bogus.
+   * <p>Return true if either string of the pair is bogus.</p>
+   * @return true if either string of the pair is bogus.
    */
   UBool isBogus() const;
 
@@ -761,7 +761,7 @@ class U_COMMON_API ICUService : public ICUNotifier {
 
     /**
      * <p>A convenience override of registerInstance(UObject*, const UnicodeString&, UBool)
-     * that defaults visible to TRUE.</p>
+     * that defaults visible to true.</p>
      *
      * @param objToAdopt the object to register and adopt.
      * @param id the ID to assign to this object.
@@ -774,7 +774,7 @@ class U_COMMON_API ICUService : public ICUNotifier {
     /**
      * <p>Register a service instance with the provided ID.  The ID will be 
      * canonicalized.  The canonicalized ID will be returned by
-     * getVisibleIDs if visible is TRUE.  The service instance will be adopted and
+     * getVisibleIDs if visible is true.  The service instance will be adopted and
      * must not be modified subsequent to this call.</p>
      *
      * <p>This issues a serviceChanged notification to registered listeners.</p>
@@ -784,7 +784,7 @@ class U_COMMON_API ICUService : public ICUNotifier {
      *
      * @param objToAdopt the object to register and adopt.
      * @param id the ID to assign to this object.
-     * @param visible TRUE if getVisibleIDs is to return this ID.
+     * @param visible true if getVisibleIDs is to return this ID.
      * @param status the error code status.
      * @return a registry key that can be passed to unregister() to unregister
      * (and discard) this instance.
@@ -820,7 +820,7 @@ class U_COMMON_API ICUService : public ICUNotifier {
      *
      * @param rkey the registry key.
      * @param status the error code status.  
-     * @return TRUE if the call successfully unregistered the factory.
+     * @return true if the call successfully unregistered the factory.
      */
     virtual UBool unregister(URegistryKey rkey, UErrorCode& status);
 
@@ -833,9 +833,9 @@ class U_COMMON_API ICUService : public ICUNotifier {
     virtual void reset(void);
 
     /**
-     * <p>Return TRUE if the service is in its default state.</p>
+     * <p>Return true if the service is in its default state.</p>
      *
-     * <p>The default implementation returns TRUE if there are no 
+     * <p>The default implementation returns true if there are no 
      * factories registered.</p>
      */
     virtual UBool isDefault(void) const;
@@ -877,7 +877,7 @@ class U_COMMON_API ICUService : public ICUNotifier {
      *
      * @param instanceToAdopt the service instance to adopt.
      * @param id the ID to assign to this service instance.
-     * @param visible if TRUE, the ID will be visible.
+     * @param visible if true, the ID will be visible.
      * @param status the error code status.
      * @return an instance of ICUServiceFactory that maps this instance to the provided ID.
      */
@@ -885,7 +885,7 @@ class U_COMMON_API ICUService : public ICUNotifier {
 
     /**
      * <p>Reinitialize the factory list to its default state.  After this call, isDefault()
-     * must return TRUE.</p>
+     * must return true.</p>
      *
      * <p>This issues a serviceChanged notification to registered listeners.</p>
      *
@@ -928,7 +928,7 @@ class U_COMMON_API ICUService : public ICUNotifier {
      * different listeners.</p>
      *
      * @param l the listener to test.
-     * @return TRUE if the service accepts the listener.
+     * @return true if the service accepts the listener.
      */
     virtual UBool acceptsListener(const EventListener& l) const;
 

--- a/icu4c/source/common/servnotf.h
+++ b/icu4c/source/common/servnotf.h
@@ -105,7 +105,7 @@ public:
     
 protected: 
     /**
-     * Subclasses implement this to return TRUE if the listener is
+     * Subclasses implement this to return true if the listener is
      * of the appropriate type.
      */
     virtual UBool acceptsListener(const EventListener& l) const = 0;

--- a/icu4c/source/common/sharedobject.h
+++ b/icu4c/source/common/sharedobject.h
@@ -90,13 +90,13 @@ public:
     int32_t getRefCount() const;
 
     /**
-     * If noHardReferences() == TRUE then this object has no hard references.
+     * If noHardReferences() == true then this object has no hard references.
      * Must be called only from within the internals of UnifiedCache.
      */
     inline UBool noHardReferences() const { return getRefCount() == 0; }
 
     /**
-     * If hasHardReferences() == TRUE then this object has hard references.
+     * If hasHardReferences() == true then this object has hard references.
      * Must be called only from within the internals of UnifiedCache.
      */
     inline UBool hasHardReferences() const { return getRefCount() != 0; }

--- a/icu4c/source/common/ubidiimp.h
+++ b/icu4c/source/common/ubidiimp.h
@@ -451,26 +451,26 @@ ubidi_getMemory(BidiMemoryForAllocation *pMemory, int32_t *pSize, UBool mayAlloc
 /* additional macros used by ubidi_open() - always allow allocation */
 #define getInitialDirPropsMemory(pBiDi, length) \
         ubidi_getMemory((BidiMemoryForAllocation *)&(pBiDi)->dirPropsMemory, &(pBiDi)->dirPropsSize, \
-                        TRUE, (length))
+                        true, (length))
 
 #define getInitialLevelsMemory(pBiDi, length) \
         ubidi_getMemory((BidiMemoryForAllocation *)&(pBiDi)->levelsMemory, &(pBiDi)->levelsSize, \
-                        TRUE, (length))
+                        true, (length))
 
 #define getInitialOpeningsMemory(pBiDi, length) \
         ubidi_getMemory((BidiMemoryForAllocation *)&(pBiDi)->openingsMemory, &(pBiDi)->openingsSize, \
-                        TRUE, (length)*sizeof(Opening))
+                        true, (length)*sizeof(Opening))
 
 #define getInitialParasMemory(pBiDi, length) \
         ubidi_getMemory((BidiMemoryForAllocation *)&(pBiDi)->parasMemory, &(pBiDi)->parasSize, \
-                        TRUE, (length)*sizeof(Para))
+                        true, (length)*sizeof(Para))
 
 #define getInitialRunsMemory(pBiDi, length) \
         ubidi_getMemory((BidiMemoryForAllocation *)&(pBiDi)->runsMemory, &(pBiDi)->runsSize, \
-                        TRUE, (length)*sizeof(Run))
+                        true, (length)*sizeof(Run))
 
 #define getInitialIsolatesMemory(pBiDi, length) \
         ubidi_getMemory((BidiMemoryForAllocation *)&(pBiDi)->isolatesMemory, &(pBiDi)->isolatesSize, \
-                        TRUE, (length)*sizeof(Isolate))
+                        true, (length)*sizeof(Isolate))
 
 #endif

--- a/icu4c/source/common/ucase.h
+++ b/icu4c/source/common/ucase.h
@@ -118,7 +118,7 @@ ucase_addCaseClosure(UChar32 c, const USetAdder *sa);
  * the string itself is added as well as part of its code points' closure.
  * It must be length>=0.
  *
- * @return TRUE if the string was found
+ * @return true if the string was found
  */
 U_CFUNC UBool U_EXPORT2
 ucase_addStringCaseClosure(const UChar *s, int32_t length, const USetAdder *sa);

--- a/icu4c/source/common/ucasemap_imp.h
+++ b/icu4c/source/common/ucasemap_imp.h
@@ -68,15 +68,15 @@ class BreakIterator;        // unicode/brkiter.h
 class ByteSink;
 class Locale;               // unicode/locid.h
 
-/** Returns TRUE if the options are valid. Otherwise FALSE, and sets an error. */
+/** Returns true if the options are valid. Otherwise false, and sets an error. */
 inline UBool ustrcase_checkTitleAdjustmentOptions(uint32_t options, UErrorCode &errorCode) {
-    if (U_FAILURE(errorCode)) { return FALSE; }
+    if (U_FAILURE(errorCode)) { return false; }
     if ((options & U_TITLECASE_ADJUSTMENT_MASK) == U_TITLECASE_ADJUSTMENT_MASK) {
         // Both options together.
         errorCode = U_ILLEGAL_ARGUMENT_ERROR;
-        return FALSE;
+        return false;
     }
-    return TRUE;
+    return true;
 }
 
 inline UBool ustrcase_isLNS(UChar32 c) {

--- a/icu4c/source/common/ucln_imp.h
+++ b/icu4c/source/common/ucln_imp.h
@@ -78,7 +78,7 @@
  * Use the ANSI C 'atexit' function. Note that this mechanism does not
  * guarantee the order of cleanup relative to other users of ICU!
  */
-static UBool gAutoCleanRegistered = FALSE;
+static UBool gAutoCleanRegistered = false;
 
 static void ucln_atexit_handler()
 {
@@ -88,7 +88,7 @@ static void ucln_atexit_handler()
 static void ucln_registerAutomaticCleanup()
 {
     if(!gAutoCleanRegistered) {
-        gAutoCleanRegistered = TRUE;
+        gAutoCleanRegistered = true;
         atexit(&ucln_atexit_handler);
     }
 }
@@ -135,7 +135,7 @@ U_CAPI void U_EXPORT2 UCLN_FINI ()
  */
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
-    BOOL status = TRUE;
+    BOOL status = true;
 
     switch(fdwReason) {
         case DLL_PROCESS_ATTACH:

--- a/icu4c/source/common/ucnv_bld.h
+++ b/icu4c/source/common/ucnv_bld.h
@@ -101,8 +101,8 @@ struct UConverterSharedData {
 
     const UConverterStaticData *staticData; /* pointer to the static (non changing) data. */
 
-    UBool                sharedDataCached;   /* TRUE:  shared data is in cache, don't destroy on ucnv_close() if 0 ref.  FALSE: shared data isn't in the cache, do attempt to clean it up if the ref is 0 */
-    /** If FALSE, then referenceCounter is not used. Must not change after initialization. */
+    UBool                sharedDataCached;   /* true:  shared data is in cache, don't destroy on ucnv_close() if 0 ref.  false: shared data isn't in the cache, do attempt to clean it up if the ref is 0 */
+    /** If false, then referenceCounter is not used. Must not change after initialization. */
     UBool isReferenceCounted;
 
     const UConverterImpl *impl;     /* vtable-style struct of mostly function pointers */
@@ -128,7 +128,7 @@ struct UConverterSharedData {
 #define UCNV_IMMUTABLE_SHARED_DATA_INITIALIZER(pStaticData, pImpl) \
     { \
         sizeof(UConverterSharedData), ~((uint32_t)0), \
-        NULL, pStaticData, FALSE, FALSE, pImpl, \
+        NULL, pStaticData, false, false, pImpl, \
         0, UCNV_MBCS_TABLE_INITIALIZER \
     }
 
@@ -181,9 +181,9 @@ struct UConverter {
 
     uint32_t options; /* options flags from UConverterOpen, may contain additional bits */
 
-    UBool sharedDataIsCached;  /* TRUE:  shared data is in cache, don't destroy on ucnv_close() if 0 ref.  FALSE: shared data isn't in the cache, do attempt to clean it up if the ref is 0 */
-    UBool isCopyLocal;  /* TRUE if UConverter is not owned and not released in ucnv_close() (stack-allocated, safeClone(), etc.) */
-    UBool isExtraLocal; /* TRUE if extraInfo is not owned and not released in ucnv_close() (stack-allocated, safeClone(), etc.) */
+    UBool sharedDataIsCached;  /* true:  shared data is in cache, don't destroy on ucnv_close() if 0 ref.  false: shared data isn't in the cache, do attempt to clean it up if the ref is 0 */
+    UBool isCopyLocal;  /* true if UConverter is not owned and not released in ucnv_close() (stack-allocated, safeClone(), etc.) */
+    UBool isExtraLocal; /* true if extraInfo is not owned and not released in ucnv_close() (stack-allocated, safeClone(), etc.) */
 
     UBool  useFallback;
     int8_t toULength;                   /* number of bytes in toUBytes */

--- a/icu4c/source/common/ucnv_cnv.h
+++ b/icu4c/source/common/ucnv_cnv.h
@@ -59,7 +59,7 @@ typedef struct {
 } UConverterLoadArgs;
 
 #define UCNV_LOAD_ARGS_INITIALIZER \
-    { (int32_t)sizeof(UConverterLoadArgs), 0, FALSE, FALSE, 0, 0, NULL, NULL, NULL }
+    { (int32_t)sizeof(UConverterLoadArgs), 0, false, false, 0, 0, NULL, NULL, NULL }
 
 typedef void (*UConverterLoad) (UConverterSharedData *sharedData,
                                 UConverterLoadArgs *pArgs,
@@ -267,8 +267,8 @@ extern const UConverterSharedData
 U_CDECL_END
 
 /** Always use fallbacks from codepage to Unicode */
-#define TO_U_USE_FALLBACK(useFallback) TRUE
-#define UCNV_TO_U_USE_FALLBACK(cnv) TRUE
+#define TO_U_USE_FALLBACK(useFallback) true
+#define UCNV_TO_U_USE_FALLBACK(cnv) true
 
 /** Use fallbacks from Unicode to codepage when cnv->useFallback or for private-use code points */
 #define IS_PRIVATE_USE(c) ((uint32_t)((c)-0xe000)<0x1900 || (uint32_t)((c)-0xf0000)<0x20000)

--- a/icu4c/source/common/ucnvmbcs.h
+++ b/icu4c/source/common/ucnvmbcs.h
@@ -420,7 +420,7 @@ typedef struct UConverterMBCSTable {
     NULL, \
     0, \
     0, 0, \
-    FALSE, \
+    false, \
     0, \
      \
     /* roundtrips */ \

--- a/icu4c/source/common/uelement.h
+++ b/icu4c/source/common/uelement.h
@@ -46,7 +46,7 @@ typedef union UElement UElement;
  * An element-equality (boolean) comparison function.
  * @param e1 An element (object or integer)
  * @param e2 An element (object or integer)
- * @return TRUE if the two elements are equal.
+ * @return true if the two elements are equal.
  */
 typedef UBool U_CALLCONV UElementsAreEqual(const UElement e1, const UElement e2);
 

--- a/icu4c/source/common/uinvchar.h
+++ b/icu4c/source/common/uinvchar.h
@@ -33,7 +33,7 @@
  *
  * @param s Input string pointer.
  * @param length Length of the string, can be -1 if NUL-terminated.
- * @return TRUE if s contains only invariant characters.
+ * @return true if s contains only invariant characters.
  *
  * @internal (ICU 2.8)
  */
@@ -46,7 +46,7 @@ uprv_isInvariantString(const char *s, int32_t length);
  *
  * @param s Input string pointer.
  * @param length Length of the string, can be -1 if NUL-terminated.
- * @return TRUE if s contains only invariant characters.
+ * @return true if s contains only invariant characters.
  *
  * @internal (ICU 2.8)
  */

--- a/icu4c/source/common/ulocimp.h
+++ b/icu4c/source/common/ulocimp.h
@@ -40,7 +40,7 @@ uloc_getTableStringWithFallback(
     int32_t *pLength,
     UErrorCode *pErrorCode);
 
-/*returns TRUE if a is an ID separator FALSE otherwise*/
+/*returns true if a is an ID separator false otherwise*/
 #define _isIDSeparator(a) (a == '_' || a == '-')
 
 U_CFUNC const char* 
@@ -95,9 +95,9 @@ ulocimp_getKeywordValue(const char* localeID,
 /**
  * Writes a well-formed language tag for this locale ID.
  *
- * **Note**: When `strict` is FALSE, any locale fields which do not satisfy the
+ * **Note**: When `strict` is false, any locale fields which do not satisfy the
  * BCP47 syntax requirement will be omitted from the result.  When `strict` is
- * TRUE, this function sets U_ILLEGAL_ARGUMENT_ERROR to the `err` if any locale
+ * true, this function sets U_ILLEGAL_ARGUMENT_ERROR to the `err` if any locale
  * fields do not satisfy the BCP47 syntax requirement.
  *
  * @param localeID  the input locale ID
@@ -154,7 +154,7 @@ ulocimp_forLanguageTag(const char* langtag,
  * Get the region to use for supplemental data lookup. Uses
  * (1) any region specified by locale tag "rg"; if none then
  * (2) any unicode_region_tag in the locale ID; if none then
- * (3) if inferRegion is TRUE, the region suggested by
+ * (3) if inferRegion is true, the region suggested by
  * getLikelySubtags on the localeID.
  * If no region is found, returns length 0.
  * 
@@ -162,7 +162,7 @@ ulocimp_forLanguageTag(const char* langtag,
  *     The complete locale ID (with keywords) from which
  *     to get the region to use for supplemental data.
  * @param inferRegion
- *     If TRUE, will try to infer region from localeID if
+ *     If true, will try to infer region from localeID if
  *     no other region is found.
  * @param region
  *     Buffer in which to put the region ID found; should

--- a/icu4c/source/common/unifiedcache.h
+++ b/icu4c/source/common/unifiedcache.h
@@ -34,13 +34,13 @@ class UnifiedCache;
  */
 class U_COMMON_API CacheKeyBase : public UObject {
  public:
-   CacheKeyBase() : fCreationStatus(U_ZERO_ERROR), fIsPrimary(FALSE) {}
+   CacheKeyBase() : fCreationStatus(U_ZERO_ERROR), fIsPrimary(false) {}
 
    /**
     * Copy constructor. Needed to support cloning.
     */
    CacheKeyBase(const CacheKeyBase &other) 
-           : UObject(other), fCreationStatus(other.fCreationStatus), fIsPrimary(FALSE) { }
+           : UObject(other), fCreationStatus(other.fCreationStatus), fIsPrimary(false) { }
    virtual ~CacheKeyBase();
 
    /**
@@ -147,10 +147,10 @@ class LocaleCacheKey : public CacheKey<T> {
    virtual UBool operator == (const CacheKeyBase &other) const {
        // reflexive
        if (this == &other) {
-           return TRUE;
+           return true;
        }
        if (!CacheKey<T>::operator == (other)) {
-           return FALSE;
+           return false;
        }
        // We know this and other are of same class because operator== on
        // CacheKey returned true.
@@ -359,7 +359,7 @@ class U_COMMON_API UnifiedCache : public UnifiedCacheBase {
    
    /**
     * Flushes the contents of the cache. If cache values hold references to other
-    * cache values then _flush should be called in a loop until it returns FALSE.
+    * cache values then _flush should be called in a loop until it returns false.
     * 
     * On entry, gCacheMutex must be held.
     * On exit, those values with are evictable are flushed.
@@ -370,7 +370,7 @@ class U_COMMON_API UnifiedCache : public UnifiedCacheBase {
     *                     hard (external) references are not deleted, but are detached from
     *                     the cache, so that a subsequent removeRefs can delete them.
     *                     _flush is not thread safe when all is true.
-    *   @return TRUE if any value in cache was flushed or FALSE otherwise.
+    *   @return true if any value in cache was flushed or false otherwise.
     */
    UBool _flush(UBool all) const;
    
@@ -395,11 +395,11 @@ class U_COMMON_API UnifiedCache : public UnifiedCacheBase {
      * Attempts to fetch value and status for key from cache.
      * On entry, gCacheMutex must not be held value must be NULL and status must
      * be U_ZERO_ERROR.
-     * On exit, either returns FALSE (In this
-     * case caller should try to create the object) or returns TRUE with value
+     * On exit, either returns false (In this
+     * case caller should try to create the object) or returns true with value
      * pointing to the fetched value and status set to fetched status. When
-     * FALSE is returned status may be set to failure if an in progress hash
-     * entry could not be made but value will remain unchanged. When TRUE is
+     * false is returned status may be set to failure if an in progress hash
+     * entry could not be made but value will remain unchanged. When true is
      * returned, caller must call removeRef() on value.
      */
     UBool _poll(

--- a/icu4c/source/common/unisetspan.h
+++ b/icu4c/source/common/unisetspan.h
@@ -65,8 +65,8 @@ public:
 
     /*
      * Do the strings need to be checked in span() etc.?
-     * @return TRUE if strings need to be checked (call span() here),
-     *         FALSE if not (use a BMPSet for best performance).
+     * @return true if strings need to be checked (call span() here),
+     *         false if not (use a BMPSet for best performance).
      */
     inline UBool needsStringSpanUTF16();
     inline UBool needsStringSpanUTF8();

--- a/icu4c/source/common/unormimp.h
+++ b/icu4c/source/common/unormimp.h
@@ -418,7 +418,7 @@ enum {
  * The same bit is used for NFC and NFKC; (c) differs for them.
  * As usual, we build the "not skippable" flags so that unassigned
  * code points get a 0 bit.
- * This bit is only valid after (a)..(e) test FALSE; test NFD_NO before (f) as well.
+ * This bit is only valid after (a)..(e) test false; test NFD_NO before (f) as well.
  * Test Hangul LV syllables entirely in code.
  *
  *

--- a/icu4c/source/common/uresimp.h
+++ b/icu4c/source/common/uresimp.h
@@ -157,7 +157,7 @@ U_CFUNC const char* ures_getName(const UResourceBundle* resB);
 U_CFUNC const char* ures_getPath(const UResourceBundle* resB);
 /**
  * If anything was in the RB cache, dump it to the screen.
- * @return TRUE if there was anything into the cache
+ * @return true if there was anything into the cache
  */
 U_CAPI UBool U_EXPORT2 ures_dumpCacheContents(void);
 #endif
@@ -218,7 +218,7 @@ ures_findSubResource(const UResourceBundle *resB,
  * @param isAvailable If non-null, pointer to fillin parameter that indicates whether the 
  * requested locale was available. The locale is defined as 'available' if it physically 
  * exists within the specified tree.
- * @param omitDefault if TRUE, omit keyword and value if default. 'de_DE\@collation=standard' -> 'de_DE'
+ * @param omitDefault if true, omit keyword and value if default. 'de_DE\@collation=standard' -> 'de_DE'
  * @param status error code
  * @return  the actual buffer size needed for the full locale.  If it's greater 
  * than resultCapacity, the returned full name will be truncated and an error code will be returned.

--- a/icu4c/source/common/ustr_imp.h
+++ b/icu4c/source/common/ustr_imp.h
@@ -29,7 +29,7 @@
 /**
  * Compare two strings in code point order or code unit order.
  * Works in strcmp style (both lengths -1),
- * strncmp style (lengths equal and >=0, flag TRUE),
+ * strncmp style (lengths equal and >=0, flag true),
  * and memcmp/UnicodeString style (at least one length >=0).
  */
 U_CFUNC int32_t U_EXPORT2
@@ -133,7 +133,7 @@ public:
      * @param t The i-th byte following the lead byte.
      * @param i The index (1..3) of byte t in the byte sequence. 0<i<length
      * @param length The length (2..4) of the byte sequence according to the lead byte.
-     * @return TRUE if t is a valid trail byte in this context.
+     * @return true if t is a valid trail byte in this context.
      */
     static inline UBool isValidTrail(int32_t prev, uint8_t t, int32_t i, int32_t length) {
         // The first trail byte after a 3- or 4-byte lead byte

--- a/icu4c/source/common/util.h
+++ b/icu4c/source/common/util.h
@@ -64,8 +64,8 @@ class U_COMMON_API ICU_Utility /* not : public UObject because all methods are s
     /**
      * Escape unprintable characters using \uxxxx notation for U+0000 to
      * U+FFFF and \Uxxxxxxxx for U+10000 and above.  If the character is
-     * printable ASCII, then do nothing and return FALSE.  Otherwise,
-     * append the escaped notation and return TRUE.
+     * printable ASCII, then do nothing and return false.  Otherwise,
+     * append the escaped notation and return true.
      */
     static UBool escapeUnprintable(UnicodeString& result, UChar32 c);
 
@@ -95,7 +95,7 @@ class U_COMMON_API ICU_Utility /* not : public UObject because all methods are s
      * after pos, or str.length(), if there is none.
      */
     static int32_t skipWhitespace(const UnicodeString& str, int32_t& pos,
-                                  UBool advance = FALSE);
+                                  UBool advance = false);
 
     /**
      * Skip over Pattern_White_Space in a Replaceable.

--- a/icu4c/source/common/utrie.h
+++ b/icu4c/source/common/utrie.h
@@ -460,13 +460,13 @@ UTrieEnumValue(const void *context, uint32_t value);
  * of code points with the same value as retrieved from the trie and
  * transformed by the UTrieEnumValue function.
  *
- * The callback function can stop the enumeration by returning FALSE.
+ * The callback function can stop the enumeration by returning false.
  *
  * @param context an opaque pointer, as passed into utrie_enum()
  * @param start the first code point in a contiguous range with value
  * @param limit one past the last code point in a contiguous range with value
  * @param value the value that is set for all code points in [start..limit[
- * @return FALSE to stop the enumeration
+ * @return false to stop the enumeration
  */
 typedef UBool U_CALLCONV
 UTrieEnumRange(const void *context, UChar32 start, UChar32 limit, uint32_t value);
@@ -667,7 +667,7 @@ utrie_getData(UNewTrie *trie, int32_t *pLength);
  * @param trie the build-time trie
  * @param c the code point
  * @param value the value
- * @return FALSE if a failure occurred (illegal argument or data array overrun)
+ * @return false if a failure occurred (illegal argument or data array overrun)
  */
 U_CAPI UBool U_EXPORT2
 utrie_set32(UNewTrie *trie, UChar32 c, uint32_t value);
@@ -677,7 +677,7 @@ utrie_set32(UNewTrie *trie, UChar32 c, uint32_t value);
  *
  * @param trie the build-time trie
  * @param c the code point
- * @param pInBlockZero if not NULL, then *pInBlockZero is set to TRUE
+ * @param pInBlockZero if not NULL, then *pInBlockZero is set to true
  *                     iff the value is retrieved from block 0;
  *                     block 0 is the all-initial-value initial block
  * @return the value
@@ -688,14 +688,14 @@ utrie_get32(UNewTrie *trie, UChar32 c, UBool *pInBlockZero);
 /**
  * Set a value in a range of code points [start..limit[.
  * All code points c with start<=c<limit will get the value if
- * overwrite is TRUE or if the old value is 0.
+ * overwrite is true or if the old value is 0.
  *
  * @param trie the build-time trie
  * @param start the first code point to get the value
  * @param limit one past the last code point to get the value
  * @param value the value
  * @param overwrite flag for whether old non-initial values are to be overwritten
- * @return FALSE if a failure occurred (illegal argument or data array overrun)
+ * @return false if a failure occurred (illegal argument or data array overrun)
  */
 U_CAPI UBool U_EXPORT2
 utrie_setRange32(UNewTrie *trie, UChar32 start, UChar32 limit, uint32_t value, UBool overwrite);

--- a/icu4c/source/common/utrie2.h
+++ b/icu4c/source/common/utrie2.h
@@ -161,13 +161,13 @@ UTrie2EnumValue(const void *context, uint32_t value);
  * of code points with the same value as retrieved from the trie and
  * transformed by the UTrie2EnumValue function.
  *
- * The callback function can stop the enumeration by returning FALSE.
+ * The callback function can stop the enumeration by returning false.
  *
  * @param context an opaque pointer, as passed into utrie2_enum()
  * @param start the first code point in a contiguous range with value
  * @param end the last code point in a contiguous range with value (inclusive)
  * @param value the value that is set for all code points in [start..end]
- * @return FALSE to stop the enumeration
+ * @return false to stop the enumeration
  */
 typedef UBool U_CALLCONV
 UTrie2EnumRange(const void *context, UChar32 start, UChar32 end, uint32_t value);
@@ -256,7 +256,7 @@ utrie2_set32(UTrie2 *trie, UChar32 c, uint32_t value, UErrorCode *pErrorCode);
 /**
  * Set a value in a range of code points [start..end].
  * All code points c with start<=c<=end will get the value if
- * overwrite is TRUE or if the old value is the initial value.
+ * overwrite is true or if the old value is the initial value.
  *
  * @param trie the unfrozen trie
  * @param start the first code point to get the value
@@ -298,7 +298,7 @@ utrie2_freeze(UTrie2 *trie, UTrie2ValueBits valueBits, UErrorCode *pErrorCode);
  * Test if the trie is frozen. (See utrie2_freeze().)
  *
  * @param trie the trie
- * @return TRUE if the trie is frozen, that is, immutable, ready for serialization
+ * @return true if the trie is frozen, that is, immutable, ready for serialization
  *         and for use with fast macros
  */
 U_CAPI UBool U_EXPORT2
@@ -670,7 +670,7 @@ struct UTrie2 {
     /* private: used by builder and unserialization functions */
     void *memory;           /* serialized bytes; NULL if not frozen yet */
     int32_t length;         /* number of serialized bytes at memory; 0 if not frozen yet */
-    UBool isMemoryOwned;    /* TRUE if the trie owns the memory */
+    UBool isMemoryOwned;    /* true if the trie owns the memory */
     UBool padding1;
     int16_t padding2;
     UNewTrie2 *newTrie;     /* builder object; NULL when frozen */

--- a/icu4c/source/common/uvector.h
+++ b/icu4c/source/common/uvector.h
@@ -64,7 +64,7 @@ U_NAMESPACE_BEGIN
  * uses a comparison function, or "comparer."  If the comparer is not
  * set, or is set to zero, then all such methods will act as if the
  * vector contains no element.  That is, indexOf() will always return
- * -1, contains() will always return FALSE, etc.
+ * -1, contains() will always return false, etc.
  *
  * <p><b>To do</b>
  *

--- a/icu4c/source/common/uvectr32.h
+++ b/icu4c/source/common/uvectr32.h
@@ -214,7 +214,7 @@ public:
 
 inline UBool UVector32::ensureCapacity(int32_t minimumCapacity, UErrorCode &status) {
     if ((minimumCapacity >= 0) && (capacity >= minimumCapacity)) {
-        return TRUE;
+        return true;
     } else {
         return expandCapacity(minimumCapacity, status);
     }
@@ -233,7 +233,7 @@ inline void UVector32::addElement(int32_t elem, UErrorCode &status) {
 }
 
 inline int32_t *UVector32::reserveBlock(int32_t size, UErrorCode &status) {
-    if (ensureCapacity(count+size, status) == FALSE) {
+    if (ensureCapacity(count+size, status) == false) {
         return NULL;
     }
     int32_t  *rp = elements+count;

--- a/icu4c/source/common/uvectr64.h
+++ b/icu4c/source/common/uvectr64.h
@@ -203,7 +203,7 @@ public:
 
 inline UBool UVector64::ensureCapacity(int32_t minimumCapacity, UErrorCode &status) {
     if ((minimumCapacity >= 0) && (capacity >= minimumCapacity)) {
-        return TRUE;
+        return true;
     } else {
         return expandCapacity(minimumCapacity, status);
     }
@@ -222,7 +222,7 @@ inline void UVector64::addElement(int64_t elem, UErrorCode &status) {
 }
 
 inline int64_t *UVector64::reserveBlock(int32_t size, UErrorCode &status) {
-    if (ensureCapacity(count+size, status) == FALSE) {
+    if (ensureCapacity(count+size, status) == false) {
         return NULL;
     }
     int64_t  *rp = elements+count;

--- a/icu4c/source/i18n/buddhcal.h
+++ b/icu4c/source/i18n/buddhcal.h
@@ -174,7 +174,7 @@ private:
                                             UBool useMonth) const;
 
     /**
-     * Returns TRUE because the Buddhist Calendar does have a default century
+     * Returns true because the Buddhist Calendar does have a default century
      * @internal
      */
     virtual UBool haveDefaultCentury() const;

--- a/icu4c/source/i18n/cecal.h
+++ b/icu4c/source/i18n/cecal.h
@@ -88,7 +88,7 @@ protected:
     virtual UBool inDaylightTime(UErrorCode&) const;
 
     /**
-     * Returns TRUE because Coptic/Ethiopic Calendar does have a default century
+     * Returns true because Coptic/Ethiopic Calendar does have a default century
      * @internal
      */
     virtual UBool haveDefaultCentury() const;

--- a/icu4c/source/i18n/chnsecal.h
+++ b/icu4c/source/i18n/chnsecal.h
@@ -242,7 +242,7 @@ class U_I18N_API ChineseCalendar : public Calendar {
 
 
   /**
-   * Returns TRUE because the Islamic Calendar does have a default century
+   * Returns true because the Islamic Calendar does have a default century
    * @internal
    */
   virtual UBool haveDefaultCentury() const;

--- a/icu4c/source/i18n/collation.h
+++ b/icu4c/source/i18n/collation.h
@@ -356,7 +356,7 @@ public:
     }
 
     /**
-     * @return TRUE if the ce32 yields one or more CEs without further data lookups
+     * @return true if the ce32 yields one or more CEs without further data lookups
      */
     static UBool isSelfContainedCE32(uint32_t ce32) {
         return !isSpecialCE32(ce32) ||

--- a/icu4c/source/i18n/collationbuilder.h
+++ b/icu4c/source/i18n/collationbuilder.h
@@ -42,7 +42,7 @@ public:
     CollationBuilder(const CollationTailoring *base, UErrorCode &errorCode);
     virtual ~CollationBuilder();
 
-    void disableFastLatin() { fastLatinEnabled = FALSE; }
+    void disableFastLatin() { fastLatinEnabled = false; }
 
     CollationTailoring *parseAndBuild(const UnicodeString &ruleString,
                                       const UVersionInfo rulesVersion,

--- a/icu4c/source/i18n/collationdatabuilder.h
+++ b/icu4c/source/i18n/collationdatabuilder.h
@@ -73,12 +73,12 @@ public:
     }
 
     /**
-     * @return TRUE if this builder has mappings (e.g., add() has been called)
+     * @return true if this builder has mappings (e.g., add() has been called)
      */
     UBool hasMappings() const { return modified; }
 
     /**
-     * @return TRUE if c has CEs in this builder
+     * @return true if c has CEs in this builder
      */
     UBool isAssigned(UChar32 c) const;
 
@@ -118,7 +118,7 @@ public:
      * @param primary primary weight for 'start'
      * @param step per-code point primary-weight increment
      * @param errorCode ICU in/out error code
-     * @return TRUE if an OFFSET_TAG range was used for start..end
+     * @return true if an OFFSET_TAG range was used for start..end
      */
     UBool maybeSetPrimaryRange(UChar32 start, UChar32 end,
                                uint32_t primary, int32_t step,
@@ -150,7 +150,7 @@ public:
     void optimize(const UnicodeSet &set, UErrorCode &errorCode);
     void suppressContractions(const UnicodeSet &set, UErrorCode &errorCode);
 
-    void enableFastLatin() { fastLatinEnabled = TRUE; }
+    void enableFastLatin() { fastLatinEnabled = true; }
     virtual void build(CollationData &data, UErrorCode &errorCode);
 
     /**

--- a/icu4c/source/i18n/collationfcd.h
+++ b/icu4c/source/i18n/collationfcd.h
@@ -101,7 +101,7 @@ public:
      * This is a fast and imprecise test.
      *
      * @param c a code point
-     * @return TRUE if c is U+0F73, U+0F75 or U+0F81 or one of several other Tibetan characters
+     * @return true if c is U+0F73, U+0F75 or U+0F81 or one of several other Tibetan characters
      */
     static inline UBool maybeTibetanCompositeVowel(UChar32 c) {
         return (c & 0x1fff01) == 0xf01;
@@ -116,7 +116,7 @@ public:
      * They have distinct lccc/tccc combinations: 129/130 or 129/132.
      *
      * @param fcd16 the FCD value (lccc/tccc combination) of a code point
-     * @return TRUE if fcd16 is from U+0F73, U+0F75 or U+0F81
+     * @return true if fcd16 is from U+0F73, U+0F75 or U+0F81
      */
     static inline UBool isFCD16OfTibetanCompositeVowel(uint16_t fcd16) {
         return fcd16 == 0x8182 || fcd16 == 0x8184;

--- a/icu4c/source/i18n/collationiterator.h
+++ b/icu4c/source/i18n/collationiterator.h
@@ -251,9 +251,9 @@ protected:
     virtual UBool foundNULTerminator();
 
     /**
-     * @return FALSE if surrogate code points U+D800..U+DFFF
+     * @return false if surrogate code points U+D800..U+DFFF
      *         map to their own implicit primary weights (for UTF-16),
-     *         or TRUE if they map to CE(U+FFFD) (for UTF-8)
+     *         or true if they map to CE(U+FFFD) (for UTF-8)
      */
     virtual UBool forbidSurrogateCodePoints() const;
 

--- a/icu4c/source/i18n/collationkeys.h
+++ b/icu4c/source/i18n/collationkeys.h
@@ -65,7 +65,7 @@ public:
     }
 
     UBool Overflowed() const { return appended_ > capacity_; }
-    /** @return FALSE if memory allocation failed */
+    /** @return false if memory allocation failed */
     UBool IsOk() const { return buffer_ != NULL; }
 
 protected:
@@ -94,8 +94,8 @@ public:
         virtual ~LevelCallback();
         /**
          * @param level The next level about to be written to the ByteSink.
-         * @return TRUE if the level is to be written
-         *         (the base class implementation always returns TRUE)
+         * @return true if the level is to be written
+         *         (the base class implementation always returns true)
          */
         virtual UBool needToWrite(Collation::Level level);
     };
@@ -103,7 +103,7 @@ public:
     /**
      * Writes the sort key bytes for minLevel up to the iterator data's strength.
      * Optionally writes the case level.
-     * Stops writing levels when callback.needToWrite(level) returns FALSE.
+     * Stops writing levels when callback.needToWrite(level) returns false.
      * Separates levels with the LEVEL_SEPARATOR_BYTE
      * but does not write a TERMINATOR_BYTE.
      */

--- a/icu4c/source/i18n/collationtailoring.h
+++ b/icu4c/source/i18n/collationtailoring.h
@@ -50,7 +50,7 @@ struct U_I18N_API CollationTailoring : public SharedObject {
     virtual ~CollationTailoring();
 
     /**
-     * Returns TRUE if the constructor could not initialize properly.
+     * Returns true if the constructor could not initialize properly.
      */
     UBool isBogus() { return settings == NULL; }
 

--- a/icu4c/source/i18n/collationweights.h
+++ b/icu4c/source/i18n/collationweights.h
@@ -62,7 +62,7 @@ public:
      *                   weights less than this one.
      * @param n          The number of collation element weights w necessary such that
      *                   lowerLimit<w<upperLimit in lexical order.
-     * @return TRUE if it is possible to fit n elements between the limits
+     * @return true if it is possible to fit n elements between the limits
      */
     UBool allocWeights(uint32_t lowerLimit, uint32_t upperLimit, int32_t n);
 

--- a/icu4c/source/i18n/cpdtrans.h
+++ b/icu4c/source/i18n/cpdtrans.h
@@ -131,7 +131,7 @@ public:
      * to recreate this transliterator.
      * @param result the string to receive the rules.  Previous
      * contents will be deleted.
-     * @param escapeUnprintable if TRUE then convert unprintable
+     * @param escapeUnprintable if true then convert unprintable
      * character to their hex escape representations, \uxxxx or
      * \Uxxxxxxxx.  Unprintable characters are those other than
      * U+000A, U+0020..U+007E.

--- a/icu4c/source/i18n/csrecog.h
+++ b/icu4c/source/i18n/csrecog.h
@@ -43,8 +43,8 @@ class CharsetRecognizer : public UMemory
      * Try the given input text against this Charset, and fill in the results object
      * with the quality of the match plus other information related to the match.
      *
-     * Return TRUE if the the input bytes are a potential match, and
-     * FALSE if the input data is not compatible with, or illegal in this charset.
+     * Return true if the the input bytes are a potential match, and
+     * false if the input data is not compatible with, or illegal in this charset.
      */
     virtual UBool match(InputText *textIn, CharsetMatch *results) const = 0;
 

--- a/icu4c/source/i18n/dayperiodrules.h
+++ b/icu4c/source/i18n/dayperiodrules.h
@@ -66,7 +66,7 @@ private:
     // Sets period type for all hours in [startHour, limitHour).
     void add(int32_t startHour, int32_t limitHour, DayPeriod period);
 
-    // Returns TRUE if for all i, DayPeriodForHour[i] has a type other than UNKNOWN.
+    // Returns true if for all i, DayPeriodForHour[i] has a type other than UNKNOWN.
     // Values of HasNoon and HasMidnight do not affect the return value.
     UBool allHoursAreSet();
 

--- a/icu4c/source/i18n/dtptngen_impl.h
+++ b/icu4c/source/i18n/dtptngen_impl.h
@@ -195,7 +195,7 @@ public:
     void getQuoteLiteral(UnicodeString& quote, int32_t *itemIndex);
     UBool isPatternSeparator(const UnicodeString& field) const;
     static UBool isQuoteLiteral(const UnicodeString& s);
-    static int32_t getCanonicalIndex(const UnicodeString& s) { return getCanonicalIndex(s, TRUE); }
+    static int32_t getCanonicalIndex(const UnicodeString& s) { return getCanonicalIndex(s, true); }
     static int32_t getCanonicalIndex(const UnicodeString& s, UBool strict);
 
 private:

--- a/icu4c/source/i18n/formattedval_impl.h
+++ b/icu4c/source/i18n/formattedval_impl.h
@@ -231,7 +231,7 @@ struct UFormattedValueImpl : public UMemory, public UFormattedValueApiHelper {
         return fData->appendTo(appendable, status); \
     } \
     UBool Name::nextPosition(ConstrainedFieldPosition& cfpos, UErrorCode& status) const { \
-        UPRV_FORMATTED_VALUE_METHOD_GUARD(FALSE) \
+        UPRV_FORMATTED_VALUE_METHOD_GUARD(false) \
         return fData->nextPosition(cfpos, status); \
     }
 

--- a/icu4c/source/i18n/gregoimp.h
+++ b/icu4c/source/i18n/gregoimp.h
@@ -148,9 +148,9 @@ class ClockMath {
 class Grego {
  public:
     /**
-     * Return TRUE if the given year is a leap year.
+     * Return true if the given year is a leap year.
      * @param year Gregorian year, with 0 == 1 BCE, -1 == 2 BCE, etc.
-     * @return TRUE if the year is a leap year
+     * @return true if the year is a leap year
      */
     static inline UBool isLeapYear(int32_t year);
 

--- a/icu4c/source/i18n/hebrwcal.h
+++ b/icu4c/source/i18n/hebrwcal.h
@@ -386,7 +386,7 @@ public:
   virtual UBool inDaylightTime(UErrorCode& status) const;
 
     /**
-     * Returns TRUE because the Hebrew Calendar does have a default century
+     * Returns true because the Hebrew Calendar does have a default century
      * @internal
      */
     virtual UBool haveDefaultCentury() const;

--- a/icu4c/source/i18n/indiancal.h
+++ b/icu4c/source/i18n/indiancal.h
@@ -147,7 +147,7 @@ public:
    * @param aLocale  The given locale.
    * @param success  Indicates the status of IndianCalendar object construction.
    *                 Returns U_ZERO_ERROR if constructed successfully.
-   * @param beCivil  Whether the calendar should be civil (default-TRUE) or religious (FALSE)
+   * @param beCivil  Whether the calendar should be civil (default-true) or religious (false)
    * @internal
    */
   IndianCalendar(const Locale& aLocale, UErrorCode &success);
@@ -303,7 +303,7 @@ protected:
 
 
   /**
-   * Returns TRUE because the Indian Calendar does have a default century
+   * Returns true because the Indian Calendar does have a default century
    * @internal
    */
   virtual UBool haveDefaultCentury() const;

--- a/icu4c/source/i18n/islamcal.h
+++ b/icu4c/source/i18n/islamcal.h
@@ -395,7 +395,7 @@ class U_I18N_API IslamicCalendar : public Calendar {
 
 
   /**
-   * Returns TRUE because the Islamic Calendar does have a default century
+   * Returns true because the Islamic Calendar does have a default century
    * @internal
    */
   virtual UBool haveDefaultCentury() const;

--- a/icu4c/source/i18n/japancal.h
+++ b/icu4c/source/i18n/japancal.h
@@ -167,7 +167,7 @@ public:
     virtual const char * getType() const;
 
     /**
-     * @return FALSE - no default century in Japanese
+     * @return false - no default century in Japanese
      * @internal 
      */
     virtual UBool haveDefaultCentury() const;

--- a/icu4c/source/i18n/nfrs.h
+++ b/icu4c/source/i18n/nfrs.h
@@ -36,7 +36,7 @@ public:
     void parseRules(UnicodeString& rules, UErrorCode& status);
     void setNonNumericalRule(NFRule *rule);
     void setBestFractionRule(int32_t originalIndex, NFRule *newRule, UBool rememberRule);
-    void makeIntoFractionRuleSet() { fIsFractionRuleSet = TRUE; }
+    void makeIntoFractionRuleSet() { fIsFractionRuleSet = true; }
 
     ~NFRuleSet();
 
@@ -93,11 +93,11 @@ int64_t util64_fromDouble(double d);
 uint64_t util64_pow(uint32_t radix, uint16_t exponent);
 
 // convert n to digit string in buffer, return length of string
-uint32_t util64_tou(int64_t n, UChar* buffer, uint32_t buflen, uint32_t radix = 10, UBool raw = FALSE);
+uint32_t util64_tou(int64_t n, UChar* buffer, uint32_t buflen, uint32_t radix = 10, UBool raw = false);
 
 #ifdef RBNF_DEBUG
 int64_t util64_utoi(const UChar* str, uint32_t radix = 10);
-uint32_t util64_toa(int64_t n, char* buffer, uint32_t buflen, uint32_t radix = 10, UBool raw = FALSE);
+uint32_t util64_toa(int64_t n, char* buffer, uint32_t buflen, uint32_t radix = 10, UBool raw = false);
 int64_t util64_atoi(const char* str, uint32_t radix);
 #endif
 

--- a/icu4c/source/i18n/olsontz.h
+++ b/icu4c/source/i18n/olsontz.h
@@ -208,7 +208,7 @@ class U_I18N_API OlsonTimeZone: public BasicTimeZone {
     /**
      * TimeZone API.  For a historical zone, whether DST is used or
      * not varies over time.  In order to approximate expected
-     * behavior, this method returns TRUE if DST is observed at any
+     * behavior, this method returns true if DST is observed at any
      * point in the current year.
      */
     virtual UBool useDaylightTime() const;
@@ -234,7 +234,7 @@ class U_I18N_API OlsonTimeZone: public BasicTimeZone {
      * @param base      The base time.
      * @param inclusive Whether the base time is inclusive or not.
      * @param result    Receives the first transition after the base time.
-     * @return  TRUE if the transition is found.
+     * @return  true if the transition is found.
      */
     virtual UBool getNextTransition(UDate base, UBool inclusive, TimeZoneTransition& result) const;
 
@@ -244,7 +244,7 @@ class U_I18N_API OlsonTimeZone: public BasicTimeZone {
      * @param base      The base time.
      * @param inclusive Whether the base time is inclusive or not.
      * @param result    Receives the most recent transition before the base time.
-     * @return  TRUE if the transition is found.
+     * @return  true if the transition is found.
      */
     virtual UBool getPreviousTransition(UDate base, UBool inclusive, TimeZoneTransition& result) const;
 

--- a/icu4c/source/i18n/persncal.h
+++ b/icu4c/source/i18n/persncal.h
@@ -295,7 +295,7 @@ class PersianCalendar : public Calendar {
   virtual UBool inDaylightTime(UErrorCode& status) const;
 
   /**
-   * Returns TRUE because the Persian Calendar does have a default century
+   * Returns true because the Persian Calendar does have a default century
    * @internal
    */
   virtual UBool haveDefaultCentury() const;

--- a/icu4c/source/i18n/plurrule_impl.h
+++ b/icu4c/source/i18n/plurrule_impl.h
@@ -295,7 +295,7 @@ class U_I18N_API FixedDecimal: public IFixedDecimal, public UObject {
     void init(double n, int32_t v, int64_t f);
     void init(double n);
     UBool quickInit(double n);  // Try a fast-path only initialization,
-                                //    return TRUE if successful.
+                                //    return true if successful.
     void adjustForMinFractionDigits(int32_t min);
     static int64_t getFractionalDigits(double n, int32_t v);
     static int32_t decimals(double n);

--- a/icu4c/source/i18n/quant.h
+++ b/icu4c/source/i18n/quant.h
@@ -62,11 +62,11 @@ class Quantifier : public UnicodeFunctor, public UnicodeMatcher {
      * considered for matching will be text.charAt(limit-1) in the
      * forward direction or text.charAt(limit+1) in the backward
      * direction.
-     * @param incremental  if TRUE, then assume further characters may
+     * @param incremental  if true, then assume further characters may
      * be inserted at limit and check for partial matching.  Otherwise
      * assume the text as given is complete.
      * @return a match degree value indicating a full match, a partial
-     * match, or a mismatch.  If incremental is FALSE then
+     * match, or a mismatch.  If incremental is false then
      * U_PARTIAL_MATCH should never be returned.
      */
     virtual UMatchDegree matches(const Replaceable& text,
@@ -81,7 +81,7 @@ class Quantifier : public UnicodeFunctor, public UnicodeMatcher {
      * @return                  A reference to 'result'.
      */
     virtual UnicodeString& toPattern(UnicodeString& result,
-                                     UBool escapeUnprintable = FALSE) const;
+                                     UBool escapeUnprintable = false) const;
 
     /**
      * Implement UnicodeMatcher

--- a/icu4c/source/i18n/quantityformatter.h
+++ b/icu4c/source/i18n/quantityformatter.h
@@ -74,18 +74,18 @@ public:
      * @param variant "zero", "one", "two", "few", "many", "other"
      * @param rawPattern the pattern for the variant e.g "{0} meters"
      * @param status any error returned here.
-     * @return TRUE on success; FALSE if status was set to a non zero error.
+     * @return true on success; false if status was set to a non zero error.
      */
     UBool addIfAbsent(const char *variant, const UnicodeString &rawPattern, UErrorCode &status);
 
     /**
-     * returns TRUE if this object has at least the "other" variant.
+     * returns true if this object has at least the "other" variant.
      */
     UBool isValid() const;
 
     /**
      * Gets the pattern formatter that would be used for a particular variant.
-     * If isValid() returns TRUE, this method is guaranteed to return a
+     * If isValid() returns true, this method is guaranteed to return a
      * non-NULL value.
      */
     const SimpleFormatter *getByVariant(const char *variant) const;

--- a/icu4c/source/i18n/rbt.h
+++ b/icu4c/source/i18n/rbt.h
@@ -161,7 +161,7 @@ public:
      * to construct a new transliterator.
      * @param result the string to receive the rules.  Previous
      * contents will be deleted.
-     * @param escapeUnprintable if TRUE then convert unprintable
+     * @param escapeUnprintable if true then convert unprintable
      * character to their hex escape representations, \uxxxx or
      * \Uxxxxxxxx.  Unprintable characters are those other than
      * U+000A, U+0020..U+007E.

--- a/icu4c/source/i18n/rbt_pars.h
+++ b/icu4c/source/i18n/rbt_pars.h
@@ -210,7 +210,7 @@ private:
 
     /**
      * Assert that the given character is NOT within the variable range.
-     * If it is, return FALSE.  This is neccesary to ensure that the
+     * If it is, return false.  This is neccesary to ensure that the
      * variable range does not overlap characters used in a rule.
      * @param ch     the given character.
      * @return       True, if the given character is NOT within the variable range.

--- a/icu4c/source/i18n/rbt_rule.h
+++ b/icu4c/source/i18n/rbt_rule.h
@@ -172,9 +172,9 @@ public:
      *                       segments, or null if there are none.  The array itself is adopted,
      *                       but the pointers within it are not.
      * @param segsCount      number of elements in segs[].
-     * @param anchorStart    TRUE if the the rule is anchored on the left to
+     * @param anchorStart    true if the the rule is anchored on the left to
      *                       the context start.
-     * @param anchorEnd      TRUE if the rule is anchored on the right to the
+     * @param anchorEnd      true if the rule is anchored on the right to the
      *                       context limit.
      * @param data           the rule data.
      * @param status         Output parameter filled in with success or failure status.
@@ -267,11 +267,11 @@ public:
      * 
      * @param text the text
      * @param pos the position indices
-     * @param incremental if TRUE, test for partial matches that may
+     * @param incremental if true, test for partial matches that may
      * be completed by additional text inserted at pos.limit.
      * @return one of <code>U_MISMATCH</code>,
      * <code>U_PARTIAL_MATCH</code>, or <code>U_MATCH</code>.  If
-     * incremental is FALSE then U_PARTIAL_MATCH will not be returned.
+     * incremental is false then U_PARTIAL_MATCH will not be returned.
      */
     UMatchDegree matchAndReplace(Replaceable& text,
                                  UTransPosition& pos,

--- a/icu4c/source/i18n/rbt_set.h
+++ b/icu4c/source/i18n/rbt_set.h
@@ -123,14 +123,14 @@ public:
     
     /**
      * Transliterate the given text with the given UTransPosition
-     * indices.  Return TRUE if the transliteration should continue
-     * or FALSE if it should halt (because of a U_PARTIAL_MATCH match).
-     * Note that FALSE is only ever returned if isIncremental is TRUE.
+     * indices.  Return true if the transliteration should continue
+     * or false if it should halt (because of a U_PARTIAL_MATCH match).
+     * Note that false is only ever returned if isIncremental is true.
      * @param text the text to be transliterated
      * @param index the position indices, which will be updated
-     * @param isIncremental if TRUE, assume new text may be inserted
-     * at index.limit, and return FALSE if thre is a partial match.
-     * @return TRUE unless a U_PARTIAL_MATCH has been obtained,
+     * @param isIncremental if true, assume new text may be inserted
+     * at index.limit, and return false if thre is a partial match.
+     * @return true unless a U_PARTIAL_MATCH has been obtained,
      * indicating that transliteration should stop until more text
      * arrives.
      */

--- a/icu4c/source/i18n/regexcmp.h
+++ b/icu4c/source/i18n/regexcmp.h
@@ -104,7 +104,7 @@ private:
                                int32_t LoopOp);
     UBool       compileInlineInterval();             // Generate inline code for a {min,max} quantifier
     void        literalChar(UChar32 c);              // Compile a literal char
-    void        fixLiterals(UBool split=FALSE);      // Generate code for pending literal characters.
+    void        fixLiterals(UBool split=false);      // Generate code for pending literal characters.
     void        insertOp(int32_t where);             // Open up a slot for a new op in the
                                                      //   generated code at the specified location.
     void        appendOp(int32_t op);                // Append a new op to the compiled pattern.

--- a/icu4c/source/i18n/regextxt.h
+++ b/icu4c/source/i18n/regextxt.h
@@ -29,7 +29,7 @@ U_NAMESPACE_BEGIN
 #endif
 
 #ifdef REGEX_DISABLE_CHUNK_MODE
-#  define UTEXT_FULL_TEXT_IN_CHUNK(ut,len) (FALSE)
+#  define UTEXT_FULL_TEXT_IN_CHUNK(ut,len) (false)
 #else
 #  define UTEXT_FULL_TEXT_IN_CHUNK(ut,len) ((0==((ut)->chunkNativeStart))&&((len)==((ut)->chunkNativeLimit))&&((len)==((ut)->nativeIndexingLimit)))
 #endif

--- a/icu4c/source/i18n/strmatch.h
+++ b/icu4c/source/i18n/strmatch.h
@@ -109,11 +109,11 @@ class StringMatcher : public UnicodeFunctor, public UnicodeMatcher, public Unico
      * considered for matching will be text.charAt(limit-1) in the
      * forward direction or text.charAt(limit+1) in the backward
      * direction.
-     * @param incremental  if TRUE, then assume further characters may
+     * @param incremental  if true, then assume further characters may
      * be inserted at limit and check for partial matching.  Otherwise
      * assume the text as given is complete.
      * @return a match degree value indicating a full match, a partial
-     * match, or a mismatch.  If incremental is FALSE then
+     * match, or a mismatch.  If incremental is false then
      * U_PARTIAL_MATCH should never be returned.
      */
     virtual UMatchDegree matches(const Replaceable& text,
@@ -128,16 +128,16 @@ class StringMatcher : public UnicodeFunctor, public UnicodeMatcher, public Unico
      * @return                  A reference to 'result'.
      */
     virtual UnicodeString& toPattern(UnicodeString& result,
-                                     UBool escapeUnprintable = FALSE) const;
+                                     UBool escapeUnprintable = false) const;
 
     /**
      * Implement UnicodeMatcher
-     * Returns TRUE if this matcher will match a character c, where c
+     * Returns true if this matcher will match a character c, where c
      * & 0xFF == v, at offset, in the forward direction (with limit >
      * offset).  This is used by <tt>RuleBasedTransliterator</tt> for
      * indexing.
      * @param v    the given value
-     * @return     TRUE if this matcher will match a character c, 
+     * @return     true if this matcher will match a character c, 
      *             where c & 0xFF == v
      */
     virtual UBool matchesIndexValue(uint8_t v) const;
@@ -181,7 +181,7 @@ class StringMatcher : public UnicodeFunctor, public UnicodeMatcher, public Unico
      * replacer that is equal to this one.
      * @param result the string to receive the pattern.  Previous
      * contents will be deleted.
-     * @param escapeUnprintable if TRUE then convert unprintable
+     * @param escapeUnprintable if true then convert unprintable
      * character to their hex escape representations, \\uxxxx or
      * \\Uxxxxxxxx.  Unprintable characters are defined by
      * Utility.isUnprintable().

--- a/icu4c/source/i18n/taiwncal.h
+++ b/icu4c/source/i18n/taiwncal.h
@@ -156,7 +156,7 @@ private:
     virtual int32_t handleGetLimit(UCalendarDateFields field, ELimitType limitType) const;
 
     /**
-     * Returns TRUE because the Taiwan Calendar does have a default century
+     * Returns true because the Taiwan Calendar does have a default century
      * @internal
      */
     virtual UBool haveDefaultCentury() const;

--- a/icu4c/source/i18n/transreg.h
+++ b/icu4c/source/i18n/transreg.h
@@ -69,7 +69,7 @@ class TransliteratorAlias : public UMemory {
      * it when the registry mutex is NOT held, to prevent deadlock.
      * It may only be called once.
      *
-     * Note: Only call create() if isRuleBased() returns FALSE.
+     * Note: Only call create() if isRuleBased() returns false.
      *
      * This method must be called *outside* of the TransliteratorRegistry
      * mutex.
@@ -77,17 +77,17 @@ class TransliteratorAlias : public UMemory {
     Transliterator* create(UParseError&, UErrorCode&);
 
     /**
-     * Return TRUE if this alias is rule-based.  If so, the caller
+     * Return true if this alias is rule-based.  If so, the caller
      * must call parse() on it, then call TransliteratorRegistry::reget().
      */
     UBool isRuleBased() const;
 
     /**
-     * If isRuleBased() returns TRUE, then the caller must call this
+     * If isRuleBased() returns true, then the caller must call this
      * method, followed by TransliteratorRegistry::reget().  The latter
      * method must be called inside the TransliteratorRegistry mutex.
      *
-     * Note: Only call parse() if isRuleBased() returns TRUE.
+     * Note: Only call parse() if isRuleBased() returns true.
      *
      * This method must be called *outside* of the TransliteratorRegistry
      * mutex, because it can instantiate Transliterators embedded in

--- a/icu4c/source/i18n/tridpars.h
+++ b/icu4c/source/i18n/tridpars.h
@@ -222,7 +222,7 @@ class TransliteratorIDParser /* not : public UObject because all methods are sta
      * @param source          the given source.
      * @param target          the given target.
      * @param variant         the given variant
-     * @param isSourcePresent If TRUE then the source is present. 
+     * @param isSourcePresent If true then the source is present. 
      *                        If the source is not present, ANY will be
      *                        given as the source, and isSourcePresent will be null
      * @return an array of 4 strings: source, target, variant, and

--- a/icu4c/source/i18n/tznames_impl.h
+++ b/icu4c/source/i18n/tznames_impl.h
@@ -92,9 +92,9 @@ struct CharacterNode {
     UBool    fHasValuesVector;
     UBool    fPadding;
 
-    // No value:   fValues == NULL               and  fHasValuesVector == FALSE
-    // One value:  fValues == value              and  fHasValuesVector == FALSE
-    // >=2 values: fValues == UVector of values  and  fHasValuesVector == TRUE
+    // No value:   fValues == NULL               and  fHasValuesVector == false
+    // One value:  fValues == value              and  fHasValuesVector == false
+    // >=2 values: fValues == UVector of values  and  fHasValuesVector == true
 };
 
 inline UBool CharacterNode::hasValues() const {

--- a/icu4c/source/i18n/ucol_imp.h
+++ b/icu4c/source/i18n/ucol_imp.h
@@ -41,7 +41,7 @@
  *  rules must be equivalent.
  *  @param source first collator
  *  @param target second collator
- *  @return TRUE or FALSE
+ *  @return true or false
  *  @internal ICU 3.0
  */
 U_CAPI UBool U_EXPORT2

--- a/icu4c/source/i18n/uitercollationiterator.h
+++ b/icu4c/source/i18n/uitercollationiterator.h
@@ -96,7 +96,7 @@ private:
 
     /**
      * Extends the FCD text segment forward or normalizes around pos.
-     * @return TRUE if success
+     * @return true if success
      */
     UBool nextSegment(UErrorCode &errorCode);
 
@@ -107,7 +107,7 @@ private:
 
     /**
      * Extends the FCD text segment backward or normalizes around pos.
-     * @return TRUE if success
+     * @return true if success
      */
     UBool previousSegment(UErrorCode &errorCode);
 

--- a/icu4c/source/i18n/uspoof_impl.h
+++ b/icu4c/source/i18n/uspoof_impl.h
@@ -222,7 +222,7 @@ class SpoofData: public UMemory {
     SpoofData(const void *serializedData, int32_t length, UErrorCode &status);
 
     //  Check raw Spoof Data Version compatibility.
-    //  Return TRUE it looks good.
+    //  Return true it looks good.
     UBool validateDataVersion(UErrorCode &status) const;
 
     ~SpoofData();                    // Destructor not normally used.

--- a/icu4c/source/i18n/usrchimp.h
+++ b/icu4c/source/i18n/usrchimp.h
@@ -206,7 +206,7 @@ struct UStringSearch {
 * the text "\u00e6" 
 * @param strsrch string search data
 * @param status error status if any
-* @return TRUE if an exact match is found, FALSE otherwise
+* @return true if an exact match is found, false otherwise
 */
 U_CFUNC
 UBool usearch_handleNextExact(UStringSearch *strsrch, UErrorCode *status);
@@ -217,7 +217,7 @@ UBool usearch_handleNextExact(UStringSearch *strsrch, UErrorCode *status);
 * of beginning and ending accents if it overlaps that region.
 * @param strsrch string search data
 * @param status error status if any
-* @return TRUE if a canonical match is found, FALSE otherwise
+* @return true if a canonical match is found, false otherwise
 */
 U_CFUNC
 UBool usearch_handleNextCanonical(UStringSearch *strsrch, UErrorCode *status);
@@ -227,7 +227,7 @@ UBool usearch_handleNextCanonical(UStringSearch *strsrch, UErrorCode *status);
 * Comments follows from handleNextExact
 * @param strsrch string search data
 * @param status error status if any
-* @return True if a exact math is found, FALSE otherwise.
+* @return True if a exact math is found, false otherwise.
 */
 U_CFUNC
 UBool usearch_handlePreviousExact(UStringSearch *strsrch, UErrorCode *status);
@@ -238,7 +238,7 @@ UBool usearch_handlePreviousExact(UStringSearch *strsrch, UErrorCode *status);
 * of beginning and ending accents if it overlaps that region.
 * @param strsrch string search data
 * @param status error status if any
-* @return TRUE if a canonical match is found, FALSE otherwise
+* @return true if a canonical match is found, false otherwise
 */
 U_CFUNC
 UBool usearch_handlePreviousCanonical(UStringSearch *strsrch, 

--- a/icu4c/source/i18n/utf16collationiterator.h
+++ b/icu4c/source/i18n/utf16collationiterator.h
@@ -125,7 +125,7 @@ private:
     /**
      * Extend the FCD text segment forward or normalize around pos.
      * To be called when checkDir > 0 && pos != limit.
-     * @return TRUE if success, checkDir == 0 and pos != limit
+     * @return true if success, checkDir == 0 and pos != limit
      */
     UBool nextSegment(UErrorCode &errorCode);
 
@@ -139,7 +139,7 @@ private:
     /**
      * Extend the FCD text segment backward or normalize around pos.
      * To be called when checkDir < 0 && pos != start.
-     * @return TRUE if success, checkDir == 0 and pos != start
+     * @return true if success, checkDir == 0 and pos != start
      */
     UBool previousSegment(UErrorCode &errorCode);
 

--- a/icu4c/source/i18n/utf8collationiterator.h
+++ b/icu4c/source/i18n/utf8collationiterator.h
@@ -54,7 +54,7 @@ protected:
      * together with a bogus code point. The caller will ignore that code point.
      *
      * Special values may be returned for surrogate code points, which are also illegal in UTF-8,
-     * but the caller will treat them like U+FFFD because forbidSurrogateCodePoints() returns TRUE.
+     * but the caller will treat them like U+FFFD because forbidSurrogateCodePoints() returns true.
      *
      * Valid lead surrogates are returned from inside a normalized text segment,
      * where handleGetTrailSurrogate() will return the matching trail surrogate.
@@ -117,7 +117,7 @@ private:
 
     /**
      * Extends the FCD text segment forward or normalizes around pos.
-     * @return TRUE if success
+     * @return true if success
      */
     UBool nextSegment(UErrorCode &errorCode);
 
@@ -128,7 +128,7 @@ private:
 
     /**
      * Extends the FCD text segment backward or normalizes around pos.
-     * @return TRUE if success
+     * @return true if success
      */
     UBool previousSegment(UErrorCode &errorCode);
 

--- a/icu4c/source/i18n/vzone.h
+++ b/icu4c/source/i18n/vzone.h
@@ -91,7 +91,7 @@ vzone_equals(const VZone* zone1, const VZone* zone2);
  * @param zone, the vzone to use
  * @param url Receives the RFC2445 TZURL property value.
  * @param urlLength, length of the url
- * @return TRUE if TZURL attribute is available and value is set.
+ * @return true if TZURL attribute is available and value is set.
  */
 U_CAPI UBool U_EXPORT2
 vzone_getTZURL(VZone* zone, UChar* & url, int32_t & urlLength);
@@ -112,7 +112,7 @@ vzone_setTZURL(VZone* zone, UChar* url, int32_t urlLength);
  * is not set.
  * @param zone, the vzone to use
  * @param lastModified Receives the last modified date.
- * @return TRUE if lastModified attribute is available and value is set.
+ * @return true if lastModified attribute is available and value is set.
  */
 U_CAPI UBool U_EXPORT2
 vzone_getLastModified(VZone* zone, UDate& lastModified);
@@ -303,7 +303,7 @@ vzone_hasSameRules(VZone* zone, const VZone* other);
  * @param base      The base time.
  * @param inclusive Whether the base time is inclusive or not.
  * @param result    Receives the first transition after the base time.
- * @return  TRUE if the transition is found.
+ * @return  true if the transition is found.
  */
 U_CAPI UBool U_EXPORT2
 vzone_getNextTransition(VZone* zone, UDate base, UBool inclusive, ZTrans* result);
@@ -314,7 +314,7 @@ vzone_getNextTransition(VZone* zone, UDate base, UBool inclusive, ZTrans* result
  * @param base      The base time.
  * @param inclusive Whether the base time is inclusive or not.
  * @param result    Receives the most recent transition before the base time.
- * @return  TRUE if the transition is found.
+ * @return  true if the transition is found.
  */
 U_CAPI UBool U_EXPORT2
 vzone_getPreviousTransition(VZone* zone, UDate base, UBool inclusive, ZTrans* result);

--- a/icu4c/source/i18n/zonemeta.h
+++ b/icu4c/source/i18n/zonemeta.h
@@ -59,7 +59,7 @@ public:
      * is not associated with a country, return bogus string.
      * @param tzid Zone ID
      * @param country [output] Country code
-     * @param isPrimary [output] TRUE if the zone is the primary zone for the country
+     * @param isPrimary [output] true if the zone is the primary zone for the country
      * @return A reference to the result country
      */
     static UnicodeString& U_EXPORT2 getCanonicalCountry(const UnicodeString &tzid, UnicodeString &country, UBool *isPrimary = NULL);

--- a/icu4c/source/io/ufile.h
+++ b/icu4c/source/io/ufile.h
@@ -74,7 +74,7 @@ struct UFILE {
 
     UChar       fUCBuffer[UFILE_UCHARBUFFER_SIZE];/* buffer used for toUnicode */
 
-    UBool       fOwnFile;       /* TRUE if fFile should be closed */
+    UBool       fOwnFile;       /* true if fFile should be closed */
 
     int32_t     fFileno;        /* File number. Useful to determine if it's stdin. */
 };
@@ -100,7 +100,7 @@ ufile_fill_uchar_buffer(UFILE *f);
  * Get one code unit and detect whether the end of file has been reached.
  * @param f The UFILE containing the characters.
  * @param ch The read in character
- * @return TRUE if the character is valid, or FALSE when EOF has been detected
+ * @return true if the character is valid, or false when EOF has been detected
  */
 U_CFUNC UBool U_EXPORT2
 ufile_getch(UFILE *f, UChar *ch);
@@ -109,7 +109,7 @@ ufile_getch(UFILE *f, UChar *ch);
  * Get one character and detect whether the end of file has been reached.
  * @param f The UFILE containing the characters.
  * @param ch The read in character
- * @return TRUE if the character is valid, or FALSE when EOF has been detected
+ * @return true if the character is valid, or false when EOF has been detected
  */
 U_CFUNC UBool U_EXPORT2
 ufile_getch32(UFILE *f, UChar32 *ch);

--- a/icu4c/source/io/ufmt_cmn.h
+++ b/icu4c/source/io/ufmt_cmn.h
@@ -82,7 +82,7 @@ ufmt_digitvalue(UChar c);
  * Determine if a UChar is a digit for a specified radix.
  * @param c The UChar to check.
  * @param radix The desired radix.
- * @return TRUE if <TT>c</TT> is a digit in <TT>radix</TT>, FALSE otherwise.
+ * @return true if <TT>c</TT> is a digit in <TT>radix</TT>, false otherwise.
  */
 UBool
 ufmt_isdigit(UChar     c,
@@ -95,7 +95,7 @@ ufmt_isdigit(UChar     c,
  * the number of UChars written to <TT>buffer</TT>.
  * @param value The value to be converted
  * @param radix The desired radix
- * @param uselower TRUE means lower case will be used, FALSE means upper case
+ * @param uselower true means lower case will be used, false means upper case
  * @param minDigits The minimum number of digits for for the formatted number,
  * which will be padded with zeroes. -1 means do not pad.
  */

--- a/icu4c/source/io/unicode/ustdio.h
+++ b/icu4c/source/io/unicode/ustdio.h
@@ -364,7 +364,7 @@ U_NAMESPACE_END
  * Tests if the UFILE is at the end of the file stream.
  * @param f The UFILE from which to read.
  * @return Returns true after the first read operation that attempts to
- * read past the end of the file. It returns FALSE if the current position is
+ * read past the end of the file. It returns false if the current position is
  * not end of file.
  * @stable ICU 3.0
 */

--- a/icu4c/source/test/hdrtst/testinternalheaders.sh
+++ b/icu4c/source/test/hdrtst/testinternalheaders.sh
@@ -15,21 +15,21 @@ for file in `ls common/*.h`; do
     echo $file
     echo '#include "'$file'"' > ht_temp.cpp ;
     echo 'void noop() {}' >> ht_temp.cpp ;
-    $CXX -c -std=c++11 -I common -O0 ht_temp.cpp ;
+    $CXX -c -std=c++11 -I common -DU_COMMON_IMPLEMENTATION -O0 ht_temp.cpp ;
 done ;
 
 for file in `ls i18n/*.h`; do
     echo $file
     echo '#include "'$file'"' > ht_temp.cpp ;
     echo 'void noop() {}' >> ht_temp.cpp ;
-    $CXX -c -std=c++11 -I common -I i18n -O0 ht_temp.cpp ;
+    $CXX -c -std=c++11 -I common -I i18n -DU_I18N_IMPLEMENTATION -O0 ht_temp.cpp ;
 done ;
 
 for file in `ls io/*.h`; do
     echo $file
     echo '#include "'$file'"' > ht_temp.cpp ;
     echo 'void noop() {}' >> ht_temp.cpp ;
-    $CXX -c -std=c++11 -I common -I i18n -I io -O0 ht_temp.cpp ;
+    $CXX -c -std=c++11 -I common -I i18n -I io -DU_IO_IMPLEMENTATION -O0 ht_temp.cpp ;
 done ;
 
 # layout is removed.

--- a/icu4c/source/tools/ctestfw/unicode/utimer.h
+++ b/icu4c/source/tools/ctestfw/unicode/utimer.h
@@ -207,7 +207,7 @@ static    double uprv_delta(UTimer* timer1, UTimer* timer2){
         return (t2-t1);
     }
 static    UBool uprv_compareFrequency(UTimer* /*timer1*/, UTimer* /*timer2*/){
-        return TRUE;
+        return true;
     }
 
 #endif

--- a/icu4c/source/tools/toolutil/filetools.h
+++ b/icu4c/source/tools/toolutil/filetools.h
@@ -26,7 +26,7 @@
 #include "unicode/utypes.h"
 
 U_CAPI UBool U_EXPORT2
-isFileModTimeLater(const char *filePath, const char *checkAgainst, UBool isDir=FALSE);
+isFileModTimeLater(const char *filePath, const char *checkAgainst, UBool isDir=false);
 
 U_CAPI void U_EXPORT2
 swapFileSepChar(char *filePath, const char oldFileSepChar, const char newFileSepChar);

--- a/icu4c/source/tools/toolutil/package.h
+++ b/icu4c/source/tools/toolutil/package.h
@@ -57,13 +57,13 @@ public:
      * Uses the prefix of the first entry of the package in readPackage(),
      * rather than the package basename.
      */
-    void setAutoPrefix() { doAutoPrefix=TRUE; }
+    void setAutoPrefix() { doAutoPrefix=true; }
     /**
      * Same as setAutoPrefix(), plus the prefix must end with the platform type letter.
      */
     void setAutoPrefixWithType() {
-        doAutoPrefix=TRUE;
-        prefixEndsWithType=TRUE;
+        doAutoPrefix=true;
+        prefixEndsWithType=true;
     }
     void setPrefix(const char *p);
 
@@ -128,7 +128,7 @@ public:
     const Item *getItem(int32_t idx) const;
 
     /*
-     * Check dependencies and return TRUE if all dependencies are fulfilled.
+     * Check dependencies and return true if all dependencies are fulfilled.
      */
     UBool checkDependencies();
 


### PR DESCRIPTION
…ders

- use standard false & true
- in library-internal headers except some generated ones
- also make the internal-header-test script say it's "inside ICU" so that the generated headers continue to work
  (after which it is probably less necessary to replace FALSE/TRUE but it's a step forward)
- change a few test/tools headers to use false/true as well for the header test to work there

https://unicode-org.atlassian.net/browse/ICU-21267