### PR TITLE
ICU-21248 Adds internal header check to Travis Continued Integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -186,3 +186,12 @@ matrix:
       cache:
         directories:
         - $HOME/.m2
+
+    # Check compilation of internal headers.
+    - name: "internal header compilation check"
+      language: cpp
+      os:       linux
+      before_script:
+        - cd icu4c/source
+      script:
+        - test/hdrtst/testinternalheaders.sh

--- a/icu4c/source/test/hdrtst/testinternalheaders.sh
+++ b/icu4c/source/test/hdrtst/testinternalheaders.sh
@@ -9,6 +9,8 @@
 CC=clang
 CXX=clang++
 
+ERROR_EXIT=0
+
 # Runtime libraries
 
 for file in `ls common/*.h`; do
@@ -16,6 +18,9 @@ for file in `ls common/*.h`; do
     echo '#include "'$file'"' > ht_temp.cpp ;
     echo 'void noop() {}' >> ht_temp.cpp ;
     $CXX -c -std=c++11 -I common -DU_COMMON_IMPLEMENTATION -O0 ht_temp.cpp ;
+    if [ $? != 0 ] ; then
+        ERROR_EXIT=1
+    fi
 done ;
 
 for file in `ls i18n/*.h`; do
@@ -23,6 +28,9 @@ for file in `ls i18n/*.h`; do
     echo '#include "'$file'"' > ht_temp.cpp ;
     echo 'void noop() {}' >> ht_temp.cpp ;
     $CXX -c -std=c++11 -I common -I i18n -DU_I18N_IMPLEMENTATION -O0 ht_temp.cpp ;
+    if [ $? != 0 ] ; then
+        ERROR_EXIT=1
+    fi
 done ;
 
 for file in `ls io/*.h`; do
@@ -30,6 +38,9 @@ for file in `ls io/*.h`; do
     echo '#include "'$file'"' > ht_temp.cpp ;
     echo 'void noop() {}' >> ht_temp.cpp ;
     $CXX -c -std=c++11 -I common -I i18n -I io -DU_IO_IMPLEMENTATION -O0 ht_temp.cpp ;
+    if [ $? != 0 ] ; then
+        ERROR_EXIT=1
+    fi
 done ;
 
 # layout is removed.
@@ -51,6 +62,9 @@ for file in `ls tools/toolutil/*.h`; do
     echo '#include "'$file'"' > ht_temp.cpp ;
     echo 'void noop() {}' >> ht_temp.cpp ;
     $CXX -c -std=c++11 -I common -I i18n -I io -I tools/toolutil -O0 ht_temp.cpp ;
+    if [ $? != 0 ] ; then
+        ERROR_EXIT=1
+    fi
 done ;
 
 # Exclude tzcode: tools/tzcode/private.h uses an argument "new" in a function declaration.
@@ -65,6 +79,9 @@ for tool in escapesrc genccode gencmn gencolusb gennorm2 genren gentest icupkg i
         echo '#include "'$file'"' > ht_temp.cpp ;
         echo 'void noop() {}' >> ht_temp.cpp ;
         $CXX -c -std=c++11 -I common -I i18n -I io -I tools/toolutil -I tools/$tool -O0 ht_temp.cpp ;
+        if [ $? != 0 ] ; then
+            ERROR_EXIT=1
+        fi
     done ;
 done ;
 
@@ -75,6 +92,9 @@ for file in `ls tools/ctestfw/unicode/*.h`; do
     echo '#include "'$file'"' > ht_temp.cpp ;
     echo 'void noop() {}' >> ht_temp.cpp ;
     $CXX -c -std=c++11 -I common -I i18n -I io -I tools/toolutil -I tools/ctestfw -O0 ht_temp.cpp ;
+    if [ $? != 0 ] ; then
+        ERROR_EXIT=1
+    fi
 done ;
 
 # C not C++ for cintltst
@@ -83,6 +103,9 @@ for file in `ls test/cintltst/*.h`; do
     echo '#include "'$file'"' > ht_temp.c ;
     echo 'void noop() {}' >> ht_temp.c ;
     $CC -c -std=c11 -I common -I i18n -I io -I tools/toolutil -I tools/ctestfw -I test/cintltst -O0 ht_temp.c ;
+    if [ $? != 0 ] ; then
+        ERROR_EXIT=1
+    fi
 done ;
 
 for test in intltest iotest testmap thaitest fuzzer; do
@@ -91,6 +114,9 @@ for test in intltest iotest testmap thaitest fuzzer; do
         echo '#include "'$file'"' > ht_temp.cpp ;
         echo 'void noop() {}' >> ht_temp.cpp ;
         $CXX -c -std=c++11 -I common -I i18n -I io -I tools/toolutil -I tools/ctestfw -I test/$test -O0 ht_temp.cpp ;
+        if [ $? != 0 ] ; then
+            ERROR_EXIT=1
+        fi
     done ;
 done ;
 
@@ -106,3 +132,6 @@ done ;
 # TODO: perf/*/*.h
 
 rm ht_temp.cpp ht_temp.c ht_temp.o
+
+echo $ERROR_EXIT
+exit $ERROR_EXIT


### PR DESCRIPTION
Updates test script to return an non zero exit code in case of a
compilation error.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21248
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

