### PR TITLE
ICU-21249 Adds #if !UCONFIG_NO_FORMATTING around all code in number_s…

### DIFF
--- a/icu4c/source/i18n/number_symbolswrapper.cpp
+++ b/icu4c/source/i18n/number_symbolswrapper.cpp
@@ -1,6 +1,10 @@
 // © 2020 and later: Unicode, Inc. and others.
 // License & terms of use: http://www.unicode.org/copyright.html
 
+#include "unicode/utypes.h"
+
+#if !UCONFIG_NO_FORMATTING
+
 #include "number_microprops.h"
 #include "unicode/numberformatter.h"
 
@@ -123,3 +127,5 @@ const NumberingSystem *SymbolsWrapper::getNumberingSystem() const {
     U_ASSERT(fType == SYMPTR_NS);
     return fPtr.ns;
 }
+
+#endif /* #if !UCONFIG_NO_FORMATTING */


### PR DESCRIPTION
…ymbolswrapper.cpp.

If UCONFIG_NO_FORMATTING is set to 1 in uconfig.h nothing in
number_symbolswrapper.cpp compiles. Note, for example, that the entirety
of the included numberformatter.h header file is inclosed in
!UCONFIG_NO_FORMATTING.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21249
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

