### PR TITLE
ICU-21291 Increase the timeout for the Exhaustive Test CI builds

### DIFF
--- a/.ci-builds/.azure-exhaustive-tests.yml
+++ b/.ci-builds/.azure-exhaustive-tests.yml
@@ -16,6 +16,9 @@ trigger:
     include:
     - '*'
     exclude:
+    - .github/*
+    - .ci-builds/.azure-pipelines.yml
+    - .ci-builds/.azure-valgrind.yml
     - docs/*
     - tools/*
     - vendor/*
@@ -27,11 +30,10 @@ trigger:
 
 jobs:
 #-------------------------------------------------------------------------
-# Note: The exhaustive tests for J take longer than the C tests. They 
-# take roughly 85 min to complete on the Azure VMs.
+# Note: The exhaustive tests can take more than 1 hour to complete.
 - job: ICU4J_OpenJDK_Ubuntu_1604
   displayName: 'J: Linux OpenJDK (Ubuntu 16.04)'
-  timeoutInMinutes: 100
+  timeoutInMinutes: 120
   pool:
     vmImage: 'Ubuntu 16.04'
     demands: ant
@@ -50,11 +52,10 @@ jobs:
       displayName: 'List failures (if any)'
       timeoutInMinutes: 2
 #-------------------------------------------------------------------------
-# Note: The exhaustive tests take roughly 65 mins to complete on the
-# Azure VMs.
+# Note: The exhaustive tests can take more than 1 hour to complete.
 - job: ICU4C_Clang_Exhaustive_Ubuntu_1604
   displayName: 'C: Linux Clang Exhaustive Tests (Ubuntu 16.04)'
-  timeoutInMinutes: 80
+  timeoutInMinutes: 120
   pool:
     vmImage: 'Ubuntu 16.04'
   steps:


### PR DESCRIPTION
It seems that recent additional test cases for Exhaustive Mode are running up against the current time limit for the Exhaustive Tests that run on master, leading to timeouts which causes build failures.

This change increases the timeout for the builds, and filters out a few more unrelated files to avoid churn.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21291
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

