### PR TITLE
ICU-21259 Adds a filter to pseudolocale generator to switch a particular

### DIFF
--- a/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/PseudoLocales.java
+++ b/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/PseudoLocales.java
@@ -190,6 +190,9 @@ public final class PseudoLocales {
         private static final PathMatcher NUMBERING_SYSTEM =
             ldml("numbers/defaultNumberingSystem");
 
+        private static final PathMatcher GREGORIAN_SHORT_STANDARD_PATTERN =
+            ldml("dates/calendars/calendar[@type=\"gregorian\"]/timeFormats/timeFormatLength[@type=\"short\"]/timeFormat[@type=\"standard\"]/pattern[@type=\"standard\"]");
+
         // These paths were mostly derived from looking at the previous implementation's behaviour
         // and can be modified as needed.
         private static final Predicate<CldrPath> IS_PSEUDO_PATH =
@@ -283,7 +286,15 @@ public final class PseudoLocales {
             if (IS_NARROW.test(fullPath)) {
                 return defaultReturnValue;
             }
+            // Explicitly return 24 hrs format pattern for the Gregorian short standard pattern
+            // entry to be consistent with the time cycle specified in supplemental.xml for
+            // region 001. 001 is the region the pseudolocales en_XA/ar_XB default to.
+            // This prevents ICU unit test failure.
+            if (GREGORIAN_SHORT_STANDARD_PATTERN.matches(path)) {
+                return CldrValue.parseValue(fullPath, "[H:mm]");
+            }
             String text = createMessage(value.getValue(), IS_PATTERN_PATH.test(path));
+
             return CldrValue.parseValue(fullPath, text);
         }
 


### PR DESCRIPTION
datetime pattern item from 12 hrs to 24 hrs format to prevent a unit
test failure.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21259
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

