### PR TITLE
ICU-21249 BRS68RC: Fixes and changes for the ICU4C Samples.

### DIFF
--- a/icu4c/source/samples/all/samplecheck.bat
+++ b/icu4c/source/samples/all/samplecheck.bat
@@ -34,6 +34,10 @@ if not exist "%ICU_BINDIR%" (
  goto :eof
 )
 
+REM Change the codepage to UTF-8 in order to better handle non-ASCII characters from the samples.
+echo Setting codepage to UTF-8
+chcp 65001
+
 echo Testing ICU samples in %ICU_ICUDIR%  arch=%ICU_ARCH% type=%ICU_DBRL%
 set PATH=%ICU_BINDIR%;%PATH%
 pushd %ICU_BINDIR%

--- a/icu4c/source/samples/coll/coll.cpp
+++ b/icu4c/source/samples/coll/coll.cpp
@@ -47,13 +47,13 @@ const char gHelpString[] =
  */
 char * opt_locale     = "en_US";
 char * opt_rules      = 0;
-UBool  opt_help       = FALSE;
-UBool  opt_norm       = FALSE;
-UBool  opt_french     = FALSE;
-UBool  opt_shifted    = FALSE;
-UBool  opt_lower      = FALSE;
-UBool  opt_upper      = FALSE;
-UBool  opt_case       = FALSE;
+UBool  opt_help       = false;
+UBool  opt_norm       = false;
+UBool  opt_french     = false;
+UBool  opt_shifted    = false;
+UBool  opt_lower      = false;
+UBool  opt_upper      = false;
+UBool  opt_case       = false;
 int    opt_level      = 0;
 char * opt_source     = "abc";
 char * opt_target     = "abd";
@@ -97,14 +97,14 @@ UBool processOptions(int argc, const char **argv, OptSpec opts[])
             if (strcmp(pOpt->name, pArgName) == 0) {
                 switch (pOpt->type) {
                 case OptSpec::FLAG:
-                    *(UBool *)(pOpt->pVar) = TRUE;
+                    *(UBool *)(pOpt->pVar) = true;
                     break;
                 case OptSpec::STRING:
                     argNum ++;
                     if (argNum >= argc) {
                         fprintf(stderr, "value expected for \"%s\" option.\n", 
 							    pOpt->name);
-                        return FALSE;
+                        return false;
                     }
                     *(const char **)(pOpt->pVar) = argv[argNum];
                     break;
@@ -113,7 +113,7 @@ UBool processOptions(int argc, const char **argv, OptSpec opts[])
                     if (argNum >= argc) {
                         fprintf(stderr, "value expected for \"%s\" option.\n", 
 							    pOpt->name);
-                        return FALSE;
+                        return false;
                     }
                     char *endp;
                     int i = strtol(argv[argNum], &endp, 0);
@@ -121,7 +121,7 @@ UBool processOptions(int argc, const char **argv, OptSpec opts[])
                         fprintf(stderr, 
 							    "integer value expected for \"%s\" option.\n", 
 								pOpt->name);
-                        return FALSE;
+                        return false;
                     }
                     *(int *)(pOpt->pVar) = i;
                 }
@@ -131,10 +131,10 @@ UBool processOptions(int argc, const char **argv, OptSpec opts[])
         if (pOpt->name == 0)
         {
             fprintf(stderr, "Unrecognized option \"%s\"\n", pArgName);
-            return FALSE;
+            return false;
         }
     }
-	return TRUE;
+	return true;
 }
 
 /**
@@ -175,7 +175,7 @@ UBool processCollator()
     }
 	if (U_FAILURE(status)) {
         fprintf(stderr, "Collator creation failed.: %d\n", status);
-        return FALSE;
+        return false;
     }
     if (status == U_USING_DEFAULT_WARNING) {
         fprintf(stderr, "Warning, U_USING_DEFAULT_WARNING for %s\n", 
@@ -228,14 +228,14 @@ UBool processCollator()
             break;
         default:
             fprintf(stderr, "-level param must be between 1 and 5\n");
-            return FALSE;
+            return false;
         }
     }
     if (U_FAILURE(status)) {
         fprintf(stderr, "Collator attribute setting failed.: %d\n", status);
-        return FALSE;
+        return false;
     }
-	return TRUE;
+	return true;
 }
 
 /** 
@@ -244,12 +244,12 @@ UBool processCollator()
  */
 int main(int argc, const char** argv) 
 {
-    if (processOptions(argc, argv, opts) != TRUE || opt_help) {
+    if (!static_cast<bool>(processOptions(argc, argv, opts)) || static_cast<bool>(opt_help)) {
         printf(gHelpString);
         return -1;
     }
 
-    if (processCollator() != TRUE) {
+    if (!static_cast<bool>(processCollator())) {
 		fprintf(stderr, "Error creating collator for comparison\n");
 		return -1;
 	}

--- a/icu4c/source/samples/numfmt/main.cpp
+++ b/icu4c/source/samples/numfmt/main.cpp
@@ -35,8 +35,8 @@ int main(int argc, char **argv) {
     printf("C API\n");
     capi();
 
-    showCurrencyFormatting(FALSE);
-    showCurrencyFormatting(TRUE);
+    showCurrencyFormatting(false);
+    showCurrencyFormatting(true);
 
     u_cleanup();    // Release any additional storage held by ICU.  
 

--- a/icu4c/source/samples/strsrch/strsrch.cpp
+++ b/icu4c/source/samples/strsrch/strsrch.cpp
@@ -49,15 +49,15 @@ const char gHelpString[] =
  */
 char * opt_locale      = "en_US";
 char * opt_rules       = 0;
-UBool  opt_help        = FALSE;
-UBool  opt_norm        = FALSE;
-UBool  opt_french      = FALSE;
-UBool  opt_shifted     = FALSE;
-UBool  opt_lower       = FALSE;
-UBool  opt_upper       = FALSE;
-UBool  opt_case        = FALSE;
-UBool  opt_overlap     = FALSE;
-UBool  opt_canonical   = FALSE;
+UBool  opt_help        = false;
+UBool  opt_norm        = false;
+UBool  opt_french      = false;
+UBool  opt_shifted     = false;
+UBool  opt_lower       = false;
+UBool  opt_upper       = false;
+UBool  opt_case        = false;
+UBool  opt_overlap     = false;
+UBool  opt_canonical   = false;
 int    opt_level       = 0;
 char * opt_source      = "International Components for Unicode";
 char * opt_pattern     = "Unicode";
@@ -107,14 +107,14 @@ UBool processOptions(int argc, const char **argv, OptSpec opts[])
             if (strcmp(pOpt->name, pArgName) == 0) {
                 switch (pOpt->type) {
                 case OptSpec::FLAG:
-                    *(UBool *)(pOpt->pVar) = TRUE;
+                    *(UBool *)(pOpt->pVar) = true;
                     break;
                 case OptSpec::STRING:
                     argNum ++;
                     if (argNum >= argc) {
                         fprintf(stderr, "value expected for \"%s\" option.\n", 
 							    pOpt->name);
-                        return FALSE;
+                        return false;
                     }
                     *(const char **)(pOpt->pVar) = argv[argNum];
                     break;
@@ -123,7 +123,7 @@ UBool processOptions(int argc, const char **argv, OptSpec opts[])
                     if (argNum >= argc) {
                         fprintf(stderr, "value expected for \"%s\" option.\n", 
 							    pOpt->name);
-                        return FALSE;
+                        return false;
                     }
                     char *endp;
                     int i = strtol(argv[argNum], &endp, 0);
@@ -131,7 +131,7 @@ UBool processOptions(int argc, const char **argv, OptSpec opts[])
                         fprintf(stderr, 
 							    "integer value expected for \"%s\" option.\n", 
 								pOpt->name);
-                        return FALSE;
+                        return false;
                     }
                     *(int *)(pOpt->pVar) = i;
                 }
@@ -141,10 +141,10 @@ UBool processOptions(int argc, const char **argv, OptSpec opts[])
         if (pOpt->name == 0)
         {
             fprintf(stderr, "Unrecognized option \"%s\"\n", pArgName);
-            return FALSE;
+            return false;
         }
     }
-	return TRUE;
+	return true;
 }
 
 /**
@@ -165,7 +165,7 @@ UBool processCollator()
     }
 	if (U_FAILURE(status)) {
         fprintf(stderr, "Collator creation failed.: %d\n", status);
-        return FALSE;
+        return false;
     }
     if (status == U_USING_DEFAULT_WARNING) {
         fprintf(stderr, "Warning, U_USING_DEFAULT_WARNING for %s\n", 
@@ -218,14 +218,14 @@ UBool processCollator()
             break;
         default:
             fprintf(stderr, "-level param must be between 1 and 5\n");
-            return FALSE;
+            return false;
         }
     }
     if (U_FAILURE(status)) {
         fprintf(stderr, "Collator attribute setting failed.: %d\n", status);
-        return FALSE;
+        return false;
     }
-	return TRUE;
+	return true;
 }
 
 /**
@@ -239,20 +239,20 @@ UBool processStringSearch()
 	search = usearch_openFromCollator(pattern, -1, source, -1, collator, NULL, 
 		                              &status);
 	if (U_FAILURE(status)) {
-		return FALSE;
+		return false;
 	}
-	if (opt_overlap == TRUE) {
+	if (static_cast<bool>(opt_overlap)) {
 		usearch_setAttribute(search, USEARCH_OVERLAP, USEARCH_ON, &status);
 	}
-	if (opt_canonical == TRUE) {
+	if (static_cast<bool>(opt_canonical)) {
 		usearch_setAttribute(search, USEARCH_CANONICAL_MATCH, USEARCH_ON, 
 			                 &status);
 	}
 	if (U_FAILURE(status)) {
 		fprintf(stderr, "Error setting search attributes\n");
-		return FALSE;
+		return false;
 	}
-	return TRUE;
+	return true;
 }
 
 UBool findPattern()
@@ -269,10 +269,10 @@ UBool findPattern()
 	}
 	if (U_FAILURE(status)) {
 		fprintf(stderr, "Error in searching for pattern %d\n", status);
-		return FALSE;
+		return false;
 	}
 	fprintf(stdout, "End of search\n");
-	return TRUE;
+	return true;
 }
 
 /** 
@@ -281,17 +281,17 @@ UBool findPattern()
  */
 int main(int argc, const char** argv) 
 {
-    if (processOptions(argc, argv, opts) != TRUE || opt_help) {
+    if (!static_cast<bool>(processOptions(argc, argv, opts)) || static_cast<bool>(opt_help)) {
         printf(gHelpString);
         return -1;
     }
 
-    if (processCollator() != TRUE) {
+    if (!static_cast<bool>(processCollator())) {
 		fprintf(stderr, "Error creating collator\n");
 		return -1;
 	}
 
-	if (processStringSearch() != TRUE) {
+	if (!static_cast<bool>(processStringSearch())) {
 		fprintf(stderr, "Error creating string search\n");
 		return -1;
 	}

--- a/icu4c/source/samples/uciter8/uciter8.c
+++ b/icu4c/source/samples/uciter8/uciter8.c
@@ -113,7 +113,7 @@ compareIterators(UCharIterator *iter1, const char *n1,
         return;
     }
     if(!iter1->hasNext(iter1)) {
-        log_err("%s->hasNext() at the start returns FALSE\n", n1);
+        log_err("%s->hasNext() at the start returns false\n", n1);
         return;
     }
 
@@ -123,7 +123,7 @@ compareIterators(UCharIterator *iter1, const char *n1,
         return;
     }
     if(!iter2->hasNext(iter2)) {
-        log_err("%s->hasNext() at the start returns FALSE\n", n2);
+        log_err("%s->hasNext() at the start returns false\n", n2);
         return;
     }
 
@@ -137,11 +137,11 @@ compareIterators(UCharIterator *iter1, const char *n1,
     } while(c1>=0);
 
     if(iter1->hasNext(iter1)) {
-        log_err("%s->hasNext() at the end returns TRUE\n", n1);
+        log_err("%s->hasNext() at the end returns true\n", n1);
         return;
     }
     if(iter2->hasNext(iter2)) {
-        log_err("%s->hasNext() at the end returns TRUE\n", n2);
+        log_err("%s->hasNext() at the end returns true\n", n2);
         return;
     }
 
@@ -178,7 +178,7 @@ compareIterators(UCharIterator *iter1, const char *n1,
         return;
     }
     if(!iter1->hasPrevious(iter1)) {
-        log_err("%s->hasPrevious() at the end returns FALSE\n", n1);
+        log_err("%s->hasPrevious() at the end returns false\n", n1);
         return;
     }
 
@@ -188,7 +188,7 @@ compareIterators(UCharIterator *iter1, const char *n1,
         return;
     }
     if(!iter2->hasPrevious(iter2)) {
-        log_err("%s->hasPrevious() at the end returns FALSE\n", n2);
+        log_err("%s->hasPrevious() at the end returns false\n", n2);
         return;
     }
 
@@ -202,11 +202,11 @@ compareIterators(UCharIterator *iter1, const char *n1,
     } while(c1>=0);
 
     if(iter1->hasPrevious(iter1)) {
-        log_err("%s->hasPrevious() at the start returns TRUE\n", n1);
+        log_err("%s->hasPrevious() at the start returns true\n", n1);
         return;
     }
     if(iter2->hasPrevious(iter2)) {
-        log_err("%s->hasPrevious() at the start returns TRUE\n", n2);
+        log_err("%s->hasPrevious() at the start returns true\n", n2);
         return;
     }
 }

--- a/icu4c/source/samples/uciter8/uit_len8.c
+++ b/icu4c/source/samples/uciter8/uit_len8.c
@@ -217,24 +217,24 @@ lenient8IteratorMove(UCharIterator *iter, int32_t delta, UCharIteratorOrigin ori
     case UITER_ZERO:
     case UITER_START:
         pos=delta;
-        havePos=TRUE;
+        havePos=true;
         /* iter->index<0 (unknown) is possible */
         break;
     case UITER_CURRENT:
         if(iter->index>=0) {
             pos=iter->index+delta;
-            havePos=TRUE;
+            havePos=true;
         } else {
             /* the current UTF-16 index is unknown after setState(), use only delta */
             pos=0;
-            havePos=FALSE;
+            havePos=false;
         }
         break;
     case UITER_LIMIT:
     case UITER_LENGTH:
         if(iter->length>=0) {
             pos=iter->length+delta;
-            havePos=TRUE;
+            havePos=true;
         } else {
             /* pin to the end, avoid counting the length */
             iter->index=-1;
@@ -245,7 +245,7 @@ lenient8IteratorMove(UCharIterator *iter, int32_t delta, UCharIteratorOrigin ori
             } else {
                 /* the current UTF-16 index is unknown, use only delta */
                 pos=0;
-                havePos=FALSE;
+                havePos=false;
             }
         }
         break;

--- a/icu4c/source/samples/ucnv/convsamp.cpp
+++ b/icu4c/source/samples/ucnv/convsamp.cpp
@@ -342,7 +342,7 @@ UErrorCode convsample_05()
         
         ucnv_toUnicode(conv, &target, targetLimit, 
                        &source, sourceLimit, NULL,
-                       feof(f)?TRUE:FALSE,         /* pass 'flush' when eof */
+                       feof(f)?true:false,         /* pass 'flush' when eof */
                                    /* is true (when no more data will come) */
                        &status);
       
@@ -719,7 +719,7 @@ UBool convsample_21_didSubstitute(const char *source)
   UConverter *conv = NULL, *cloneCnv = NULL;
   UErrorCode status = U_ZERO_ERROR;
   uint32_t len, len2;
-  UBool  flagVal = FALSE;
+  UBool  flagVal = false;
   UConverterFromUCallback junkCB;
   
   FromUFLAGContext *flagCtx = NULL, 
@@ -930,7 +930,7 @@ UErrorCode convsample_40()
         
         ucnv_toUnicode( conv, &target, targetLimit, 
                        &source, sourceLimit, NULL,
-                       feof(f)?TRUE:FALSE,         /* pass 'flush' when eof */
+                       feof(f)?true:false,         /* pass 'flush' when eof */
                                    /* is true (when no more data will come) */
                          &status);
       
@@ -1035,7 +1035,7 @@ UErrorCode convsample_46()
         
         ucnv_fromUnicode( conv, &target, targetLimit, 
                        &source, sourceLimit, NULL,
-                       feof(f)?TRUE:FALSE,         /* pass 'flush' when eof */
+                       feof(f)?true:false,         /* pass 'flush' when eof */
                                    /* is true (when no more data will come) */
                          &status);
       
@@ -1079,7 +1079,7 @@ void convsample_50() {
 
   //! [ucnv_detectUnicodeSignature]
   UErrorCode err = U_ZERO_ERROR;
-  UBool discardSignature = TRUE; /* set to TRUE to throw away the initial U+FEFF */
+  UBool discardSignature = true; /* set to true to throw away the initial U+FEFF */
   char input[] = { '\xEF','\xBB', '\xBF','\x41','\x42','\x43' };
   int32_t signatureLength = 0;
   const char *encoding = ucnv_detectUnicodeSignature(input,sizeof(input),&signatureLength,&err);
@@ -1094,7 +1094,7 @@ void convsample_50() {
     ucnv_toUnicode(conv,
                    &target, output + UPRV_LENGTHOF(output),
                    &source, input + sizeof(input),
-                   NULL, TRUE, &err);
+                   NULL, true, &err);
     out = output;
     if (discardSignature){
       ++out; // ignore initial U+FEFF

--- a/icu4c/source/samples/ucnv/flagcb.c
+++ b/icu4c/source/samples/ucnv/flagcb.c
@@ -25,7 +25,7 @@ U_CAPI FromUFLAGContext* U_EXPORT2  flagCB_fromU_openContext()
 
     ctx->subCallback = NULL;
     ctx->subContext  = NULL;
-    ctx->flag        = FALSE;
+    ctx->flag        = false;
 
     return ctx;
 }
@@ -42,7 +42,7 @@ U_CAPI void U_EXPORT2 flagCB_fromU(
   /* First step - based on the reason code, take action */
 
   if(reason == UCNV_UNASSIGNED) { /* whatever set should be trapped here */
-    ((FromUFLAGContext*)context)->flag = TRUE;
+    ((FromUFLAGContext*)context)->flag = true;
   }
 
   if(reason == UCNV_CLONE) {

--- a/icu4c/source/samples/udata/reader.c
+++ b/icu4c/source/samples/udata/reader.c
@@ -69,9 +69,9 @@ isAcceptable(void *context,
         pInfo->dataFormat[3]==0x74 &&
         pInfo->formatVersion[0]==1 &&
         pInfo->dataVersion[0]==1   ) {
-        return TRUE;
+        return true;
     } else {
-        return FALSE;
+        return false;
     }
 
 

--- a/icu4c/source/samples/ufortune/ufortune.c
+++ b/icu4c/source/samples/ufortune/ufortune.c
@@ -58,9 +58,9 @@ void u_write(const UChar *what, int len);
  */
 int main(int argc, char **argv)
 {
-    UBool              displayUsage  = FALSE;    /* Set true if command line err or help      */
+    UBool              displayUsage  = false;    /* Set true if command line err or help      */
                                                  /*   option was requested.                   */
-    UBool              verbose       = FALSE;    /* Set true if -v command line option.       */
+    UBool              verbose       = false;    /* Set true if -v command line option.       */
     char              *optionError   = NULL;     /* If command line contains an unrecognized  */
                                                  /*   option, this will point to it.          */
     char              *locale=NULL;              /* Locale name.  Null for system default,    */
@@ -95,14 +95,14 @@ int main(int argc, char **argv)
             continue;
         }
         if (strcmp(argv[i], "-v") == 0) {
-            verbose = TRUE;
+            verbose = true;
             continue;}
         if (strcmp(argv[i], "-?") == 0 ||
             strcmp(argv[i], "--help") == 0) {
-            displayUsage = TRUE;
+            displayUsage = true;
             continue;}
         optionError = argv[i];
-        displayUsage = TRUE;
+        displayUsage = true;
         break;
     }
 

--- a/icu4c/source/samples/ufortune/ufortune.vcxproj
+++ b/icu4c/source/samples/ufortune/ufortune.vcxproj
@@ -1,99 +1,73 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|Win32">
-      <Configuration>Debug</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|Win32">
-      <Configuration>Release</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{25F534DF-93C9-4853-A88E-DB7D8CF74042}</ProjectGuid>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <!-- The following import will include the 'default' configuration options for VS projects. -->
+  <Import Project="..\..\allinone\Build.Windows.ProjectConfiguration.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>.\x86\Debug\</OutDir>
-    <IntDir>.\x86\Debug\</IntDir>
-    <TargetName>$(ProjectName)</TargetName>
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <OutDir>.\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>.\$(Platform)\$(Configuration)\</IntDir>
+    <!-- The ICU projects use "Win32" to mean "x86", so we need to special case it. -->
+    <OutDir Condition="'$(Platform)'=='Win32'">.\x86\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Platform)'=='Win32'">.\x86\$(Configuration)\</IntDir>
+    <!-- Disable Incremental Linking for Release builds as it prevents Link-time Code Generation -->
+    <LinkIncremental Condition="'$(Configuration)'=='Debug'">true</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)'=='Release'">false</LinkIncremental>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>.\x86\Release\</OutDir>
-    <IntDir>.\x86\Release\</IntDir>
-    <TargetName>$(ProjectName)</TargetName>
-  </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  <!-- Options that are common to *all* project configurations -->
+  <ItemDefinitionGroup>
     <Midl>
-      <TypeLibraryName>.\x86\Debug/ufortune.tlb</TypeLibraryName>
+      <TypeLibraryName>$(OutDir)\ufortune.tlb</TypeLibraryName>
     </Midl>
     <ClCompile>
-      <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;WIN32;_DEBUG;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
-      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>
-      <SuppressStartupBanner>true</SuppressStartupBanner>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
-      <PrecompiledHeaderFile />
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <PrecompiledHeaderOutputFile>$(OutDir)/ufortune.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>$(OutDir)/</AssemblerListingLocation>
+      <ObjectFileName>$(OutDir)/</ObjectFileName>
+      <ProgramDataBaseFileName>$(OutDir)/ufortune.pdb</ProgramDataBaseFileName>
     </ClCompile>
     <ResourceCompile>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <Culture>0x0409</Culture>
+      <AdditionalIncludeDirectories>..\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>icuucd.lib;resources\fortune_resources.lib;icuiod.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>../../../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SubSystem>Console</SubSystem>
-      <DataExecutionPrevention>
-      </DataExecutionPrevention>
+      <AdditionalLibraryDirectories>..\..\..\$(IcuLibOutputDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Midl>
-      <TypeLibraryName>.\x86\Release/ufortune.tlb</TypeLibraryName>
-    </Midl>
+  <!-- Options that are common to all 'Debug' project configurations -->
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
-      <AdditionalIncludeDirectories>..\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;WIN32;NDEBUG;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <StringPooling>true</StringPooling>
+      <BrowseInformation>true</BrowseInformation>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>icuucd.lib;resources\fortune_resources.lib;icuiod.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <!-- Options that are common to all 'Release' project configurations -->
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
-      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
-      <WarningLevel>Level3</WarningLevel>
-      <SuppressStartupBanner>true</SuppressStartupBanner>
-      <CompileAs>Default</CompileAs>
-      <PrecompiledHeaderFile />
     </ClCompile>
-    <ResourceCompile>
-      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <Culture>0x0409</Culture>
-    </ResourceCompile>
     <Link>
       <AdditionalDependencies>icuuc.lib;resources\fortune_resources.lib;icuio.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>../../../lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <SubSystem>Console</SubSystem>
-      <DataExecutionPrevention>
-      </DataExecutionPrevention>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/icu4c/source/samples/ugrep/ugrep.cpp
+++ b/icu4c/source/samples/ugrep/ugrep.cpp
@@ -42,8 +42,8 @@ using namespace icu;
 //
 const char *pattern = NULL;     // The regular expression
 int        firstFileNum;        //  argv index of the first file name
-UBool      displayFileName = FALSE;
-UBool      displayLineNum  = FALSE;
+UBool      displayFileName = false;
+UBool      displayLineNum  = false;
 
 
 //
@@ -93,7 +93,7 @@ void readFile(const char *name);
 //
 //------------------------------------------------------------------------------------------
 int main(int argc, const char** argv) {
-    UBool     matchFound = FALSE;
+    UBool     matchFound = false;
 
     //
     //  Process the command line options.
@@ -141,10 +141,10 @@ int main(int argc, const char** argv) {
         //  Loop through the lines of a file, trying to match the regex pattern on each.
         //
         for (nextLine(0); lineStart<fileLen; nextLine(lineEnd)) {
-            UnicodeString s(FALSE, ucharBuf+lineStart, lineEnd-lineStart);
+            UnicodeString s(false, ucharBuf+lineStart, lineEnd-lineStart);
             matcher->reset(s);
             if (matcher->find()) {
-                matchFound = TRUE;
+                matchFound = true;
                 printMatch();
             }
         }
@@ -177,8 +177,8 @@ int main(int argc, const char** argv) {
 //------------------------------------------------------------------------------------------
 void processOptions(int argc, const char **argv) {
     int            optInd;
-    UBool          doUsage   = FALSE;
-    UBool          doVersion = FALSE;
+    UBool          doUsage   = false;
+    UBool          doVersion = false;
     const char    *arg;
 
 
@@ -187,14 +187,14 @@ void processOptions(int argc, const char **argv) {
         
         /* version info */
         if(strcmp(arg, "-V") == 0 || strcmp(arg, "--version") == 0) {
-            doVersion = TRUE;
+            doVersion = true;
         }
         /* usage info */
         else if(strcmp(arg, "--help") == 0) {
-            doUsage = TRUE;
+            doUsage = true;
         }
         else if(strcmp(arg, "-n") == 0 || strcmp(arg, "--line-number") == 0) {
-            displayLineNum = TRUE;
+            displayLineNum = true;
         }
         /* POSIX.1 says all arguments after -- are not options */
         else if(strcmp(arg, "--") == 0) {
@@ -205,7 +205,7 @@ void processOptions(int argc, const char **argv) {
         /* unrecognized option */
         else if(strncmp(arg, "-", strlen("-")) == 0) {
             printf("ugrep: invalid option -- %s\n", arg+1);
-            doUsage = TRUE;
+            doUsage = true;
         }
         /* done with options */
         else {
@@ -234,7 +234,7 @@ void processOptions(int argc, const char **argv) {
 
     if (remainingArgs > 2) {
         // More than one file to be processed.   Display file names with match output.
-        displayFileName = TRUE;
+        displayFileName = true;
     }
 
     pattern      = argv[optInd];

--- a/icu4c/source/samples/ugrep/ugrep.vcxproj
+++ b/icu4c/source/samples/ugrep/ugrep.vcxproj
@@ -17,16 +17,14 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">.\x86\Release\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">.\x86\Release\</IntDir>
-    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\x64\Release\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\x64\Release\</IntDir>
-    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkIncremental>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">.\x86\Debug\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">.\x86\Debug\</IntDir>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.\x64\Debug\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.\x64\Debug\</IntDir>
+    <OutDir>.\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>.\$(Platform)\$(Configuration)\</IntDir>
+    <!-- The ICU projects use "Win32" to mean "x86", so we need to special case it. -->
+    <OutDir Condition="'$(Platform)'=='Win32'">.\x86\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Platform)'=='Win32'">.\x86\$(Configuration)\</IntDir>
+    <!-- Disable Incremental Linking for Release builds as it prevents Link-time Code Generation -->
+    <LinkIncremental Condition="'$(Configuration)'=='Debug'">true</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)'=='Release'">false</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Midl>

--- a/icu4c/source/samples/uresb/uresb.c
+++ b/icu4c/source/samples/uresb/uresb.c
@@ -55,7 +55,7 @@ static const char *resPath = NULL;
 static const int32_t indentsize = 4;
 static UFILE *outerr = NULL;
 static int32_t truncsize = URESB_DEFAULTTRUNC;
-static UBool trunc = FALSE;
+static UBool trunc = false;
 
 const UChar baderror[] = { 0x0042, 0x0041, 0x0044, 0x0000 };
 
@@ -76,7 +76,7 @@ static UOption options[]={
     UOPTION_VERBOSE
 };
 
-static UBool VERBOSE = FALSE;
+static UBool VERBOSE = false;
 
 extern int
 main(int argc, char* argv[]) {
@@ -134,18 +134,18 @@ main(int argc, char* argv[]) {
     }
 
     if(options[5].doesOccur) {
-        trunc = TRUE;
+        trunc = true;
         if(options[5].value != NULL) {
             truncsize = atoi(options[5].value); /* user defined printable size */
         } else {
             truncsize = URESB_DEFAULTTRUNC; /* we'll use default omitting size */
         }
     } else {
-        trunc = FALSE;
+        trunc = false;
     }
 
     if(options[6].doesOccur) {
-        VERBOSE = TRUE;
+        VERBOSE = true;
     }
 
     outerr = u_finit(stderr, locale, encoding);

--- a/icu4c/source/samples/ustring/ustring.cpp
+++ b/icu4c/source/samples/ustring/ustring.cpp
@@ -135,7 +135,7 @@ demo_utf_h_macros() {
 
     puts("");
 
-    isError=FALSE;
+    isError=false;
     i=1; /* write position, gets post-incremented so needs to be in an l-value */
     U16_APPEND(input, i, UPRV_LENGTHOF(input), 0x0062, isError);
 
@@ -226,7 +226,7 @@ static void demoCaseMapInC() {
     printUString("input string: ", input, -1);
 
     /* uppercase */
-    isError=FALSE;
+    isError=false;
     for(i=j=0; j<UPRV_LENGTHOF(buffer) && !isError; /* U16_NEXT post-increments */) {
         U16_NEXT(input, i, INT32_MAX, c); /* without length because NUL-terminated */
         if(c==0) {
@@ -237,7 +237,7 @@ static void demoCaseMapInC() {
     }
     printUString("simple-uppercased: ", buffer, j);
     /* lowercase */
-    isError=FALSE;
+    isError=false;
     for(i=j=0; j<UPRV_LENGTHOF(buffer) && !isError; /* U16_NEXT post-increments */) {
         U16_NEXT(input, i, INT32_MAX, c); /* without length because NUL-terminated */
         if(c==0) {
@@ -248,7 +248,7 @@ static void demoCaseMapInC() {
     }
     printUString("simple-lowercased: ", buffer, j);
     /* titlecase */
-    isError=FALSE;
+    isError=false;
     for(i=j=0; j<UPRV_LENGTHOF(buffer) && !isError; /* U16_NEXT post-increments */) {
         U16_NEXT(input, i, INT32_MAX, c); /* without length because NUL-terminated */
         if(c==0) {
@@ -259,7 +259,7 @@ static void demoCaseMapInC() {
     }
     printUString("simple-titlecased: ", buffer, j);
     /* case-fold/default */
-    isError=FALSE;
+    isError=false;
     for(i=j=0; j<UPRV_LENGTHOF(buffer) && !isError; /* U16_NEXT post-increments */) {
         U16_NEXT(input, i, INT32_MAX, c); /* without length because NUL-terminated */
         if(c==0) {
@@ -270,7 +270,7 @@ static void demoCaseMapInC() {
     }
     printUString("simple-case-folded/default: ", buffer, j);
     /* case-fold/Turkic */
-    isError=FALSE;
+    isError=false;
     for(i=j=0; j<UPRV_LENGTHOF(buffer) && !isError; /* U16_NEXT post-increments */) {
         U16_NEXT(input, i, INT32_MAX, c); /* without length because NUL-terminated */
         if(c==0) {
@@ -456,7 +456,7 @@ demoUnicodeStringStorage() {
 
     // * UnicodeString using readonly-alias to a const UChar array
     // construct a string that aliases a readonly buffer
-    UnicodeString three(FALSE, readonly, UPRV_LENGTHOF(readonly));
+    UnicodeString three(false, readonly, UPRV_LENGTHOF(readonly));
     printUnicodeString("readonly-alias string: ", three);
     // copy-on-write: any modification to the string results in
     // a copy to either the internal buffer or to a newly allocated one
@@ -468,7 +468,7 @@ demoUnicodeStringStorage() {
                i, readonly[i]);
     }
     // setTo() readonly alias
-    one.setTo(FALSE, writeable, UPRV_LENGTHOF(writeable));
+    one.setTo(false, writeable, UPRV_LENGTHOF(writeable));
     // copying the readonly-alias object with fastCopyFrom() (new in ICU 2.4)
     // will readonly-alias the same buffer
     two.fastCopyFrom(one);
@@ -549,7 +549,7 @@ demoUnicodeStringInit() {
     U_STRING_INIT(invString, "such characters are safe 123 %-.", 32);
 
     // compare the C and C++ strings
-    printf("C and C++ Unicode strings are equal: %d\n", invariantOnly==UnicodeString(TRUE, invString, 32));
+    printf("C and C++ Unicode strings are equal: %d\n", invariantOnly==UnicodeString(true, invString, 32));
 
     /*
      * convert between char * and UChar * strings that


### PR DESCRIPTION
This PR makes changes/fixes for the ICU 68 BRS task for "ICU4C Samples", in order to get the samples to compile with some of the changes made in ICU 68. (The change to use C++/C99 `true`/`false` instead of of the custom ICU macros for them).

Changes in this PR include:
- Change to use `true`/`false` instead of the custom `TRUE`/`FALSE` macros in order to fix compilation errors.
- Adding casts to prevent/silence warnings.
- Some clean-up to the "ufortune" and "ugrep" Visual Studio project `.vcxproj` files.
- Setting the codepage to UTF-8 in `samplecheck.bat` in order to prevent garbled output when running the samples.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21249
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added
