### PR TITLE
ICU-21028 Modifies ICU data generator so that the CLDR version is

### DIFF
--- a/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/LdmlConverter.java
+++ b/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/LdmlConverter.java
@@ -348,7 +348,9 @@ public final class LdmlConverter {
                 });
 
                 if (!splitData.getPaths().isEmpty() || isBaseLanguage || dir.includeEmpty()) {
-                    splitData.setVersion(cldrVersion);
+                    if (id.equals("root")) {
+                        splitData.setVersion(cldrVersion);
+                    }
                     write(splitData, outDir, false);
                     writtenLocaleIds.put(dir, id);
                 }
@@ -561,7 +563,7 @@ public final class LdmlConverter {
         } else {
             // These empty files only exist because the target of an alias has a parent locale
             // which is itself not in the set of written ICU files. An "indirect alias target".
-            icuData.setVersion(config.getVersionInfo().getCldrVersion());
+            // No need to add data: Just write a resource bundle with an empty top-level table.
         }
         write(icuData, dir, false);
     }


### PR DESCRIPTION
no longer added to the .txt data files with the exception of the
root.txt files. This will drastically limit the number of changed
files during a version upgrade because the version change is the
only change in many of the data files.

ICU-21028 Fixed an indent.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21028
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

