### PR TITLE
ICU-21249 Adds check of result string for NULL to prevent segmentation fault if

### DIFF
--- a/icu4c/source/test/cintltst/unumberrangeformattertst.c
+++ b/icu4c/source/test/cintltst/unumberrangeformattertst.c
@@ -65,10 +65,10 @@ static void TestExampleCode() {
     // Get the result string:
     int32_t len;
     const UChar* str = ufmtval_getString(unumrf_resultAsValue(uresult, &ec), &len, &ec);
-    if (assertSuccessCheck("There should not be a failure in the example code", &ec, TRUE)) {
-        assertUEquals("Should produce expected string result", u"$3 – $5", str);
-        assertIntEquals("Length should be as expected", u_strlen(str), len);
-    }
+    assertSuccessCheck("There should not be a failure in the example code", &ec, TRUE);
+    assertUEquals("Should produce expected string result", u"$3 – $5", str);
+    int32_t resultLength = str != NULL ? u_strlen(str) : 0;
+    assertIntEquals("Length should be as expected", resultLength, len);
 
     // Cleanup:
     unumrf_close(uformatter);


### PR DESCRIPTION
ICU runs with stubdata only.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21249
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

