### PR TITLE
ICU-21249 restore tests of Version resources

### DIFF
--- a/icu4c/source/test/cintltst/cldrtest.c
+++ b/icu4c/source/test/cintltst/cldrtest.c
@@ -555,22 +555,18 @@ TestLocaleStructure(void) {
             ures_close(currentLocale);
             continue;
         }
-        // Per ICU-21028 the Version resource no longer exists in most files, so the
-        // Version tests below are obsolete. For now just comment out...
-        //
-        //ures_getStringByKey(currentLocale, "Version", NULL, &errorCode);
-        //if(errorCode != U_ZERO_ERROR) {
-        //    log_err("No version information is available for locale %s, and it should be!\n",
-        //        currLoc);
-        //}
-        //else if (ures_getStringByKey(currentLocale, "Version", NULL, &errorCode)[0] == (UChar)(0x78)) {
-        //    log_verbose("WARNING: The locale %s is experimental! It shouldn't be listed as an installed locale.\n",
-        //        currLoc);
-        //}
+        const UChar *version = ures_getStringByKey(currentLocale, "Version", NULL, &errorCode);
+        if(U_FAILURE(errorCode)) {
+            log_err("No version information is available for locale %s, and it should be!\n",
+                currLoc);
+        }
+        else if (version[0] == u'x') {
+            log_verbose("WARNING: The locale %s is experimental! "
+                        "It shouldn't be listed as an installed locale.\n",
+                        currLoc);
+        }
         resolvedLoc = ures_getLocaleByType(currentLocale, ULOC_ACTUAL_LOCALE, &errorCode);
         if (strcmp(resolvedLoc, currLoc) != 0) {
-            /* All locales have at least a Version resource.
-               If it's absolutely empty, then the previous test will fail too.*/
             log_err("Locale resolves to different locale. Is %s an alias of %s?\n",
                 currLoc, resolvedLoc);
         }

--- a/icu4c/source/test/cintltst/creststn.c
+++ b/icu4c/source/test/cintltst/creststn.c
@@ -2160,27 +2160,27 @@ static void TestFallback()
     /* Test Jitterbug 552 fallback mechanism of aliased data */
     {
         UErrorCode err =U_ZERO_ERROR;
-        // Per ICU-21028 the Version resource no longer exists in most files, so the
-        // Version tests below are obsolete. For now just comment out...
-        //
-        //UResourceBundle* myResB = ures_open(NULL,"no_NO_NY",&err);
-        //UResourceBundle* resLocID = ures_getByKey(myResB, "Version", NULL, &err);
-        //const UChar* version = NULL;
-        //static const UChar versionStr[] = u"38"; // 38 in nn_NO
+        UResourceBundle* myResB = ures_open(NULL,"no_NO_NY",&err);
+        UResourceBundle* resLocID = ures_getByKey(myResB, "Version", NULL, &err);
+        const UChar* version = NULL;
+        static const UChar versionStr[] = u"38"; // 38 in nn_NO or in a parent bundle/root
 
-        //if(err != U_ZERO_ERROR){
-        //    log_data_err("Expected U_ZERO_ERROR when trying to test no_NO_NY aliased to nn_NO for Version err=%s\n",u_errorName(err));
-        //    return;
-        //}
-        //version = tres_getString(resLocID, -1, NULL, &resultLen, &err);
-        //if(u_strcmp(version, versionStr) != 0){
-        //    char x[100];
-        //    char g[100];
-        //    u_austrcpy(x, versionStr);
-        //    u_austrcpy(g, version);
-        //    log_data_err("ures_getString(resLocID, &resultLen, &err) returned an unexpected version value. Expected '%s', but got '%s'\n",
-        //            x, g);
-        //}
+        if(U_FAILURE(err)) {
+            log_data_err("Expected success when trying to test no_NO_NY aliased to nn_NO for Version "
+                         "err=%s\n",
+                         u_errorName(err));
+            return;
+        }
+        version = tres_getString(resLocID, -1, NULL, &resultLen, &err);
+        if(u_strcmp(version, versionStr) != 0){
+            char x[100];
+            char g[100];
+            u_austrcpy(x, versionStr);
+            u_austrcpy(g, version);
+            log_data_err("ures_getString(resLocID, &resultLen, &err) returned an unexpected "
+                         "version value. Expected '%s', but got '%s'\n",
+                         x, g);
+        }
         UResourceBundle* zoneResource = ures_open(U_ICUDATA_ZONE, "no_NO_NY", &err);
         UResourceBundle* tResB = ures_getByKey(zoneResource, "zoneStrings", NULL, &err);
         if(err != U_USING_FALLBACK_WARNING){
@@ -2188,8 +2188,8 @@ static void TestFallback()
         }
         ures_close(tResB);
         ures_close(zoneResource);
-        //ures_close(resLocID);
-        //ures_close(myResB);
+        ures_close(resLocID);
+        ures_close(myResB);
     }
 
 }

--- a/icu4c/source/test/intltest/restsnew.cpp
+++ b/icu4c/source/test/intltest/restsnew.cpp
@@ -535,32 +535,28 @@ NewResourceBundleTest::TestOtherAPI(){
         errln("copy construction failed\n");
     }
 
-    // Due to ICU-21028 the following tests involving defaultSub are no longer valid.
-    // defaultresource is typically en_US; this used to be empty except for a Version resource
-    // (which is what would be returned by defaultresource.get(0, err) ). However:
-    // In ICU-21028 the Version resource was removed; and now defaultresource.get(0, err)
-    // sets U_MISSING_RESOURCE_ERROR and returns an invalide resource in defaultSub.
-    // For now just comment out...
-    //ResourceBundle defaultSub = defaultresource.get((int32_t)0, err);
-    //ResourceBundle defSubCopy(defaultSub);
-    //if(strcmp(defSubCopy.getName(), defaultSub.getName() ) !=0  ||
-    //    strcmp(defSubCopy.getLocale().getName(), defaultSub.getLocale().getName() ) !=0  ){
-    //    errln("copy construction for subresource failed\n");
-    //}
-
-    ResourceBundle *p;
-
-    p = defaultresource.clone();
-    if(p == &defaultresource || !equalRB(*p, defaultresource)) {
-        errln("ResourceBundle.clone() failed");
+    {
+        LocalPointer<ResourceBundle> p(defaultresource.clone());
+        if(p.getAlias() == &defaultresource || !equalRB(*p, defaultresource)) {
+            errln("ResourceBundle.clone() failed");
+        }
     }
-    delete p;
 
-    //p = defaultSub.clone();
-    //if(p == &defaultSub || !equalRB(*p, defaultSub)) {
-    //    errln("2nd ResourceBundle.clone() failed");
-    //}
-    //delete p;
+    // The following tests involving defaultSub may no longer be exercised if
+    // defaultresource is for a locale like en_US with an empty resource bundle.
+    // (Before ICU-21028 such a bundle would have contained at least a Version string.)
+    if(defaultresource.getSize() != 0) {
+        ResourceBundle defaultSub = defaultresource.get((int32_t)0, err);
+        ResourceBundle defSubCopy(defaultSub);
+        if(strcmp(defSubCopy.getName(), defaultSub.getName()) != 0 ||
+                strcmp(defSubCopy.getLocale().getName(), defaultSub.getLocale().getName() ) != 0) {
+            errln("copy construction for subresource failed\n");
+        }
+        LocalPointer<ResourceBundle> p(defaultSub.clone());
+        if(p.getAlias() == &defaultSub || !equalRB(*p, defaultSub)) {
+            errln("2nd ResourceBundle.clone() failed");
+        }
+    }
 
     UVersionInfo ver;
     copyRes.getVersion(ver);

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/ICUResourceBundleTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/ICUResourceBundleTest.java
@@ -699,7 +699,7 @@ public final class ICUResourceBundleTest extends TestFmwk {
     public void TestLocaleDisplayNames() {
         ULocale[] locales = ULocale.getAvailableLocales();
 
-        Set<String> localCountryExceptions = new HashSet<String>();
+        Set<String> localCountryExceptions = new HashSet<>();
         if (logKnownIssue("cldrbug:8903",
                 "No localized region name for lrc_IQ, lrc_IR, nus_SS, nds_DE, su_Latn_ID")) {
             localCountryExceptions.add("lrc_IQ");
@@ -710,7 +710,7 @@ public final class ICUResourceBundleTest extends TestFmwk {
             localCountryExceptions.add("su_Latn_ID");
         }
 
-        Set<String> localLangExceptions = new HashSet<String>();
+        Set<String> localLangExceptions = new HashSet<>();
         if (logKnownIssue("cldrbug:8903", "No localized language name for nmg, nds")) {
             localLangExceptions.add("nmg");
             localLangExceptions.add("nds");
@@ -986,7 +986,7 @@ public final class ICUResourceBundleTest extends TestFmwk {
         }
     }
     private Set<String> setFromEnumeration(Enumeration<String> e) {
-        TreeSet<String> set = new TreeSet<String>();
+        TreeSet<String> set = new TreeSet<>();
         while (e.hasMoreElements()) {
             set.add(e.nextElement());
         }
@@ -1117,14 +1117,12 @@ public final class ICUResourceBundleTest extends TestFmwk {
         if (rb7.getKey() != null) {
             errln("getKey() call should have returned null.");
         }
-        // Due to ICU-21028 the following test is no longer valid.
-        // rb1 would typically be en_US; this used to be empty except for a Version
-        // resource (which is what would be returned by findTopLevel(0) ). However:
-        // In ICU-21028 the Version resource was removed; and now even index=0 is
-        // out of range. For now just comment out the test...
-        //if (((ICUResourceBundle)rb1).findTopLevel(0) == null) {
-        //    errln("Error calling findTopLevel().");
-        //}
+        // The following test may no longer be exercised if
+        // rb1 is for a locale like en_US with an empty resource bundle.
+        // (Before ICU-21028 such a bundle would have contained at least a Version string.)
+        if (rb1.getSize() != 0 && ((ICUResourceBundle)rb1).findTopLevel(0) == null) {
+            errln("Error calling findTopLevel().");
+        }
         if (ICUResourceBundle.getFullLocaleNameSet() == null) {
             errln("Error calling getFullLocaleNameSet().");
         }


### PR DESCRIPTION
... which PR #1365 commented out to work around ICU-21028 removing the Version string resource from most locale data bundles. The root bundles in each locale data tree still have a Version string, so this PR restores the test cases with a little more leniency.

https://unicode-org.atlassian.net/browse/ICU-21249 (ICU 68rc BRS)