### PR TITLE
ICU-21249 Update copy of LICENSE file in icu4j tree

### DIFF
--- a/icu4j/main/shared/licenses/LICENSE
+++ b/icu4j/main/shared/licenses/LICENSE
@@ -284,9 +284,9 @@ property of their respective owners.
  #  Copyright (c) 2013 International Business Machines Corporation
  #  and others. All Rights Reserved.
  #
- # Project: http://code.google.com/p/lao-dictionary/
- # Dictionary: http://lao-dictionary.googlecode.com/git/Lao-Dictionary.txt
- # License: http://lao-dictionary.googlecode.com/git/Lao-Dictionary-LICENSE.txt
+ # Project: https://github.com/veer66/lao-dictionary
+ # Dictionary: https://github.com/veer66/lao-dictionary/blob/master/Lao-Dictionary.txt
+ # License: https://github.com/veer66/lao-dictionary/blob/master/Lao-Dictionary-LICENSE.txt
  #              (copied below)
  #
  #  This file is derived from the above dictionary, with slight


### PR DESCRIPTION
Lao dictionary repo location was updated in LICENSE file in icu4c, but a copy in icu4j tree was not. Sync the icu4j copy with the icu4c one.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21249
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

