### PR TITLE
ICU-21307 Java 7 compatibility support in ULocale.java

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/Utility.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/Utility.java
@@ -10,6 +10,7 @@ package com.ibm.icu.impl;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.Locale;
 import java.util.regex.Pattern;
 
@@ -1857,5 +1858,33 @@ public final class Utility {
         } catch (IOException e) {
             throw new ICUUncheckedIOException(e);
         }
+    }
+
+    /**
+     * Java 8+ String#join(CharSequence, Iterable<? extends CharSequence>) compatible method for Java 7 env.
+     * @param delimiter the delimiter that separates each element
+     * @param elements the elements to join together.
+     * @return a new String that is composed of the elements separated by the delimiter
+     * @throws NullPointerException If delimiter or elements is null
+     */
+    public static String joinStrings(CharSequence delimiter, Iterable<? extends CharSequence> elements) {
+        if (delimiter == null || elements == null) {
+            throw new NullPointerException("Delimiter or elements is null");
+        }
+        StringBuilder buf = new StringBuilder();
+        Iterator<? extends CharSequence> itr = elements.iterator();
+        boolean isFirstElem = true;
+        while (itr.hasNext()) {
+            CharSequence element = itr.next();
+            if (element != null) {
+                if (!isFirstElem) {
+                    buf.append(delimiter);
+                } else {
+                    isFirstElem = false;
+                }
+                buf.append(element);
+            }
+        }
+        return buf.toString();
     }
 }

--- a/icu4j/main/classes/core/src/com/ibm/icu/util/ULocale.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/util/ULocale.java
@@ -37,6 +37,7 @@ import com.ibm.icu.impl.ICUResourceTableAccess;
 import com.ibm.icu.impl.LocaleIDParser;
 import com.ibm.icu.impl.LocaleIDs;
 import com.ibm.icu.impl.SoftCache;
+import com.ibm.icu.impl.Utility;
 import com.ibm.icu.impl.locale.AsciiUtil;
 import com.ibm.icu.impl.locale.BaseLocale;
 import com.ibm.icu.impl.locale.Extension;
@@ -1245,7 +1246,7 @@ public final class ULocale implements Serializable, Comparable<ULocale> {
                     throw new IllegalArgumentException(
                         "Have problem to resolve locale alias of " +
                         lscvToID(language, script, region,
-                            ((variants == null) ? "" : String.join("_", variants))) +
+                            ((variants == null) ? "" : Utility.joinStrings("_", variants))) +
                         extensions);
                 }
                 // Anytime we replace something, we need to start over again.
@@ -1268,7 +1269,7 @@ public final class ULocale implements Serializable, Comparable<ULocale> {
             }  // while(1)
             if (changed) {
                 String result =  lscvToID(language, script, region,
-                    ((variants == null) ? "" : String.join("_", variants)));
+                    ((variants == null) ? "" : Utility.joinStrings("_", variants)));
                 if (extensions != null) {
                     result += extensions;
                 }

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/UtilityTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/UtilityTest.java
@@ -12,6 +12,7 @@
 */
 package com.ibm.icu.dev.test.util;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -290,5 +291,31 @@ public class UtilityTest extends TestFmwk {
             sb.append(RANDOM_CHARS.charAt(RANDOM.nextInt(RANDOM_CHARS.length())));
         }
         return sb;
+    }
+
+    @Test
+    public void TestJoinStrings() {
+        final String data[][] = {
+            //  {"<expected>", "<delimiter>", "<element1>", "<element2>", ...}
+                {"abc-def", "-", "abc", "def"},
+                {"abc-def-ghi", "-", "abc", "def", "ghi"},
+                {"abc--def", "--", "abc", "def"},
+                {"abc", "-", "abc"},
+                {"def", "_", null, "def"},
+                {"abc_def", "_", null, "abc", null, "def", null},
+                {"", "-", null},
+        };
+
+        for (int i = 0; i < data.length; i++) {
+            String expected = data[i][0];
+            String delim = data[i][1];
+            List<String> elements = new ArrayList<>(data.length - 2);
+            for (int j = 2; j < data[i].length; j++) {
+                elements.add(data[i][j]);
+            }
+
+            String actual = Utility.joinStrings(delim, elements);
+            assertEquals("data[" + i + "]", expected, actual);
+        }
     }
 }


### PR DESCRIPTION
Recent code changes introduced String#join(...) method, which is available in Java 8 or newer release. We still need to support Java 7 as minimum runtime, we need to replace the method call with equivalent code. I added Utility#joinStrings(...) as temporary alternative until we change minimum Java version to 8 or later.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21307
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

