### PR TITLE
ICU-21278 Add Ubuntu 20.04 build bot with GCC to CI builds.

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -96,6 +96,22 @@ jobs:
         CC: clang
         CXX: clang++
 #-------------------------------------------------------------------------
+- job: ICU4C_GCC_Ubuntu_2004
+  displayName: 'C: Linux GCC (Ubuntu 20.04)'
+  timeoutInMinutes: 30
+  pool:
+    vmImage: 'ubuntu-20.04'
+  steps:
+    - checkout: self
+      lfs: true
+      fetchDepth: 10
+    - script: |
+        cd icu4c/source && ./runConfigureICU Linux && make -j2 check
+      displayName: 'Build and Test'
+      env:
+        CC: gcc
+        CXX: g++
+#-------------------------------------------------------------------------
 # VS 2019 Builds
 #-------------------------------------------------------------------------
 - job: ICU4C_MSVC_x64_Release_Distrelease


### PR DESCRIPTION
No code changes in this PR. This is adding another CI build bot that builds on Ubuntu 20.04 with GCC.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21278
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

