### PR TITLE
ICU-21249 Fix warnings about uninitialized variables in locid.cpp

### DIFF
--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -1252,11 +1252,11 @@ AliasReplacer::replaceLanguage(
             continue;
         }
 
-        const char* replacedLanguage;
-        const char* replacedScript;
-        const char* replacedRegion;
-        const char* replacedVariant;
-        const char* replacedExtensions;
+        const char* replacedLanguage = nullptr;
+        const char* replacedScript = nullptr;
+        const char* replacedRegion = nullptr;
+        const char* replacedVariant = nullptr;
+        const char* replacedExtensions = nullptr;
         parseLanguageReplacement(replacement,
                                  replacedLanguage,
                                  replacedScript,
@@ -1266,7 +1266,7 @@ AliasReplacer::replaceLanguage(
                                  toBeFreed,
                                  status);
         replacedLanguage =
-            uprv_strcmp(replacedLanguage, "und") == 0 ?
+            (replacedLanguage != nullptr && uprv_strcmp(replacedLanguage, "und") == 0) ?
             language : replacedLanguage;
         replacedScript = deleteOrReplace(script, nullptr, replacedScript);
         replacedRegion = deleteOrReplace(region, searchRegion, replacedRegion);


### PR DESCRIPTION
This fixes new warnings in `locid.cpp` that were introduced by the recent changes for ICU-21236.

Warnings:
```
locid.cpp: In member function `bool icu_68::{anonymous}::AliasReplacer::replaceLanguage(bool, bool, bool, icu_68::UVector&, UErrorCode&)`:
locid.cpp:1255:21: warning: `replacedLanguage` may be used uninitialized in this function [-Wmaybe-uninitialized]
locid.cpp:1279:54: warning: `replacedExtensions` may be used uninitialized in this function [-Wmaybe-uninitialized]
locid.cpp:1043:28: warning: `replacedVariant` may be used uninitialized in this function [-Wmaybe-uninitialized]
locid.cpp:1043:20: warning: `replacedRegion` may be used uninitialized in this function [-Wmaybe-uninitialized]
locid.cpp:1043:20: warning: `replacedScript` may be used uninitialized in this function [-Wmaybe-uninitialized]
```

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21249
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

