### PR TITLE
ICU-20853 undef Solaris x86 register macros where they conflict

### DIFF
--- a/icu4c/source/common/ubidiimp.h
+++ b/icu4c/source/common/ubidiimp.h
@@ -26,6 +26,14 @@
 
 /* miscellaneous definitions ---------------------------------------------- */
 
+// ICU-20853=ICU-20935 Solaris #defines CS and ES in sys/regset.h
+#ifdef CS
+#   undef CS
+#endif
+#ifdef ES
+#   undef ES
+#endif
+
 typedef uint8_t DirProp;
 typedef uint32_t Flags;
 

--- a/icu4c/source/test/intltest/numbertest.h
+++ b/icu4c/source/test/intltest/numbertest.h
@@ -16,6 +16,11 @@
 #include "unicode/numberformatter.h"
 #include "unicode/numberrangeformatter.h"
 
+// ICU-20241 Solaris #defines ESP in sys/regset.h
+#ifdef ESP
+#   undef ESP
+#endif
+
 using namespace icu::number;
 using namespace icu::number::impl;
 using namespace icu::numparse;


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-20853

Fixes [ICU-20853] = [ICU-20935].

Also fixes [ICU-20241] and replaces its PR #467.

[ICU-20853]: https://unicode-org.atlassian.net/browse/ICU-20853
[ICU-20935]: https://unicode-org.atlassian.net/browse/ICU-20935
[ICU-20241]: https://unicode-org.atlassian.net/browse/ICU-20241