### PR TITLE
ICU-21249 Add new U_HIDE_INTERNAL_API guards

### DIFF
--- a/icu4c/source/i18n/unicode/numberformatter.h
+++ b/icu4c/source/i18n/unicode/numberformatter.h
@@ -1309,13 +1309,13 @@ class U_I18N_API Grouper : public UMemory {
               fGrouping2(grouping2),
               fMinGrouping(minGrouping),
               fStrategy(strategy) {}
-#endif  // U_HIDE_INTERNAL_API
 
     /** @internal */
     int16_t getPrimary() const;
 
     /** @internal */
     int16_t getSecondary() const;
+#endif  // U_HIDE_INTERNAL_API
 
   private:
     /**
@@ -1379,10 +1379,10 @@ class U_I18N_API Padder : public UMemory {
 
     /** @internal */
     static Padder codePoints(UChar32 cp, int32_t targetWidth, UNumberFormatPadPosition position);
-#endif  // U_HIDE_INTERNAL_API
 
     /** @internal */
     static Padder forProperties(const DecimalFormatProperties& properties);
+#endif  // U_HIDE_INTERNAL_API
 
   private:
     UChar32 fWidth;  // -3 = error; -2 = bogus; -1 = no padding

--- a/icu4c/source/i18n/unicode/plurfmt.h
+++ b/icu4c/source/i18n/unicode/plurfmt.h
@@ -587,7 +587,7 @@ private:
      */
     static int32_t findSubMessage(
          const MessagePattern& pattern, int32_t partIndex,
-         const PluralSelector& selector, void *context, double number, UErrorCode& ec); /**< @internal */
+         const PluralSelector& selector, void *context, double number, UErrorCode& ec);
 
     void parseType(const UnicodeString& source, const NFRule *rbnfLenientScanner,
         Formattable& result, FieldPosition& pos) const;

--- a/icu4c/source/i18n/unicode/timezone.h
+++ b/icu4c/source/i18n/unicode/timezone.h
@@ -317,6 +317,7 @@ public:
      */
     static TimeZone* U_EXPORT2 createDefault(void);
 
+#ifndef U_HIDE_INTERNAL_API
     /**
      * If the locale contains the timezone keyword, creates a copy of that TimeZone.
      * Otherwise, create the default timezone.
@@ -327,6 +328,7 @@ public:
      * @internal
      */
     static TimeZone* U_EXPORT2 forLocaleOrDefault(const Locale& locale);
+#endif  /* U_HIDE_INTERNAL_API */
 
     /**
      * Sets the default time zone (i.e., what's returned by createDefault()) to be the


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21249
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

Added U_HIDE_INTERNAL_API guards around new `@internal` APIs.

This is the first time I've done this, so it's possible that I've done it wrong.  I can say that `make check` in `test/hdrtst` still passes with these changes.  I also didn't do anything about `@internal` stuff in `stringtriebuilder.h` and `ucptrie.h`, because these seemed to be long-standing API additions and seemed to have other things guarding them.  (It's also entirely possible that some of the stuff I found when I prepped for `@internal` and didn't include here was stuff I just missed, although I tried hard to make sure the only things I skipped were for clear reasons listed in the guidelines for this task.)
