### PR TITLE
ICU-20677 Fixing cygwin/MSVC build

### DIFF
--- a/icu4c/source/data/Makefile.in
+++ b/icu4c/source/data/Makefile.in
@@ -240,8 +240,7 @@ include $(top_builddir)/$(subdir)/rules.mk
 ifeq ($(ENABLE_SO_VERSION_DATA),1)
 ifeq ($(PKGDATA_MODE),dll)
 SO_VERSION_DATA = $(OUTTMPDIR)/icudata.res
-$(SO_VERSION_DATA) : $(MISCSRCDIR)/icudata.rc
-	mkdir -p $(@D)
+$(SO_VERSION_DATA) : $(MISCSRCDIR)/icudata.rc | $(TMP_DIR)/dirs.timestamp
 ifeq ($(MSYS_RC_MODE),1)
 	rc.exe -i$(srcdir)/../common -i$(top_builddir)/common -fo$@ $(CPPFLAGS) $<
 else

--- a/icu4c/source/extra/scrptrun/Makefile.in
+++ b/icu4c/source/extra/scrptrun/Makefile.in
@@ -12,9 +12,6 @@ top_builddir = ../..
 
 include $(top_builddir)/icudefs.mk
 
-## Platform-specific setup
-include @platform_make_fragment@
-
 ## Build directory information
 subdir = extra/scrptrun
 
@@ -22,7 +19,7 @@ subdir = extra/scrptrun
 CLEANFILES = *~ $(DEPS)
 
 ## Target information
-TARGET = srtest
+TARGET = srtest$(EXEEXT)
 
 DEFS = @DEFS@
 CPPFLAGS = @CPPFLAGS@ -I$(top_srcdir)/common -I$(top_srcdir) 

--- a/icu4c/source/tools/toolutil/toolutil.cpp
+++ b/icu4c/source/tools/toolutil/toolutil.cpp
@@ -166,14 +166,11 @@ findBasename(const char *filename) {
     const char *basename=uprv_strrchr(filename, U_FILE_SEP_CHAR);
 
 #if U_FILE_ALT_SEP_CHAR!=U_FILE_SEP_CHAR
-#if !(U_PLATFORM == U_PF_CYGWIN && U_PLATFORM_USES_ONLY_WIN32_API)
-    if(basename==NULL)
-#endif
-    {
-        /* Use lenient matching on Windows, which can accept either \ or /
-           This is useful for environments like Win32+CygWin which have both.
-        */
-        basename=uprv_strrchr(filename, U_FILE_ALT_SEP_CHAR);
+    //be lenient about pathname separators on Windows, like official implementation of C++17 std::filesystem in MSVC
+    //would be convenient to merge this loop with the one above, but alas, there is no such solution in the standard library
+    const char *alt_basename=uprv_strrchr(filename, U_FILE_ALT_SEP_CHAR);
+    if(alt_basename>basename) {
+        basename=alt_basename;
     }
 #endif
 


### PR DESCRIPTION
Dear Maintainers

I have fixed multiple failures preventing normal building with cygwin/MSVC. Could you consider also merging those into next release alpha?

- Fixed genrb (and all other utils) not recognizing alternative file separators on windows, which previously prevented generation of data in out-of-source build. Officially distributed binaries have the same issue. f402ff9; Now checks for last occurrence of both the separator and alternative separator are run before returning the one which is furthest into the string.
- Added few more fixes to the makefile of a new component  (extra/scrptrun), it had a redundant inculde of platform setup duplicating suffices in names of libraries (i.e. requiring compiler to find 'libicuucd**d**.lib' along with some other possible ill side-effects) 065f559;
- Changed earlier fix to depend on already built-in directory creation script, instead of doing it one more time. 8dc2c9c

Both debug and release were compiled on windows and 'check-exhaustive' was run successfully. Build on linux is tested from debian/testing running on WSL in win10. Both logs are appended.

Kind regards,
Artem

[icu_build.log](https://github.com/unicode-org/icu/files/5342653/icu_build.log)
[icu-build-linux.log](https://github.com/unicode-org/icu/files/5342656/icu-build-linux.log)

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20677
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

