### PR TITLE
ICU-21249 Use parallel build for AppVeyor again.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,7 +66,7 @@ for:
       - "%CYG_ROOT%\\bin\\sh -lc 'uname -a'"
 
     build_script:
-      - '%CYG_ROOT%\\bin\\bash -lc "cd $(cygpath ${APPVEYOR_BUILD_FOLDER}) && cd icu4c/source && ./runConfigureICU Cygwin && make check"'
+      - '%CYG_ROOT%\\bin\\bash -lc "cd $(cygpath ${APPVEYOR_BUILD_FOLDER}) && cd icu4c/source && ./runConfigureICU Cygwin && make -j2 check"'
 
 #  -
 #    matrix:


### PR DESCRIPTION
Recently we switched to using a single-threaded build for AppVeyor to avoid the flakiness issues with Cygwin.
However, we are now running up against the build timeout limit of 60 minutes on AppVeyor.
This changes the AppVeyor build back to using a parallel build.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21249
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

