### PR TITLE
ICU-21336 Fix format string to use long instead of int in common/wintz.cpp

### DIFF
--- a/icu4c/source/common/wintz.cpp
+++ b/icu4c/source/common/wintz.cpp
@@ -86,7 +86,7 @@ uprv_detectWindowsTimeZone()
             // Note '-' before 'utcOffsetMin'. The timezone ID's sign convention
             // is that a timezone ahead of UTC is Etc/GMT-<offset> and a timezone
             // behind UTC is Etc/GMT+<offset>.
-            int ret = snprintf(gmtOffsetTz, UPRV_LENGTHOF(gmtOffsetTz), "Etc/GMT%+d", -utcOffsetMins / 60);
+            int ret = snprintf(gmtOffsetTz, UPRV_LENGTHOF(gmtOffsetTz), "Etc/GMT%+ld", -utcOffsetMins / 60);
             if (ret > 0 && ret < UPRV_LENGTHOF(gmtOffsetTz)) {
                 return uprv_strdup(gmtOffsetTz);
             }


### PR DESCRIPTION
This is related to PR #1362. 

Thanks to @FrankYFTang for catching this issue, and sorry for the build break.

The variable `utcOffsetMins` is type `long` (via a typedef for `LONG`), so the calculation of `-utcOffsetMins/60` is also a `long` as well. This leads to an error as the format string uses `d` which is only for `int`.

(Aside: A possible alternate fix would be to use `static_cast<int>(-utcOffsetMins/60)` in order to make it an `int` as the value should never require the full range of `long`.)

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21336
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

