### PR TITLE
ICU-20941 Support formatting joule-per-furlong (builtin-per-builtin).

### DIFF
--- a/icu4c/source/i18n/number_formatimpl.cpp
+++ b/icu4c/source/i18n/number_formatimpl.cpp
@@ -389,8 +389,12 @@ NumberFormatterImpl::macrosToMicroGenerator(const MacroProps& macros, bool safe,
                 fMixedUnitLongNameHandler.getAlias(), status);
             chain = fMixedUnitLongNameHandler.getAlias();
         } else {
+            MeasureUnit unit = macros.unit;
+            if (!utils::unitIsBaseUnit(macros.perUnit)) {
+                unit = unit.product(macros.perUnit.reciprocal(status), status);
+            }
             fLongNameHandler.adoptInsteadAndCheckErrorCode(new LongNameHandler(), status);
-            LongNameHandler::forMeasureUnit(macros.locale, macros.unit, macros.perUnit, unitWidth,
+            LongNameHandler::forMeasureUnit(macros.locale, unit, unitWidth,
                                             resolvePluralRules(macros.rules, macros.locale, status),
                                             chain, fLongNameHandler.getAlias(), status);
             chain = fLongNameHandler.getAlias();

--- a/icu4c/source/i18n/number_longnames.h
+++ b/icu4c/source/i18n/number_longnames.h
@@ -38,9 +38,6 @@ class LongNameHandler : public MicroPropsGenerator, public ModifierStore, public
     /**
      * Construct a localized LongNameHandler for the specified MeasureUnit.
      *
-     * Compound units can be constructed via `unit` and `perUnit`. Both of these
-     * must then be built-in units.
-     *
      * Mixed units are not supported, use MixedUnitLongNameHandler::forMeasureUnit.
      *
      * This function uses a fillIn intead of returning a pointer, because we
@@ -48,15 +45,13 @@ class LongNameHandler : public MicroPropsGenerator, public ModifierStore, public
      * didn't create itself).
      *
      * @param loc The desired locale.
-     * @param unit The measure unit to construct a LongNameHandler for. If
-     *     `perUnit` is also defined, `unit` must not be a mixed unit.
-     * @param perUnit If `unit` is a mixed unit, `perUnit` must be "none".
+     * @param unitRef The measure unit to construct a LongNameHandler for.
      * @param width Specifies the desired unit rendering.
      * @param rules Does not take ownership.
      * @param parent Does not take ownership.
      * @param fillIn Required.
      */
-    static void forMeasureUnit(const Locale &loc, const MeasureUnit &unit, const MeasureUnit &perUnit,
+    static void forMeasureUnit(const Locale &loc, const MeasureUnit &unitRef,
                                const UNumberUnitWidth &width, const PluralRules *rules,
                                const MicroPropsGenerator *parent, LongNameHandler *fillIn,
                                UErrorCode &status);

--- a/icu4c/source/test/intltest/numbertest_api.cpp
+++ b/icu4c/source/test/intltest/numbertest_api.cpp
@@ -867,22 +867,21 @@ void NumberFormatterApiTest::unitCompoundMeasure() {
             u"0.008765 J/fur",
             u"0 J/fur");
 
-    // TODO(ICU-20941): Support constructions such as this one.
-    // assertFormatDescending(
-    //         u"Joules Per Furlong Short with unit identifier via API",
-    //         u"measure-unit/energy-joule per-measure-unit/length-furlong",
-    //         u"unit/joule-per-furlong",
-    //         NumberFormatter::with().unit(MeasureUnit::forIdentifier("joule-per-furlong", status)),
-    //         Locale::getEnglish(),
-    //         u"87,650 J/fur",
-    //         u"8,765 J/fur",
-    //         u"876.5 J/fur",
-    //         u"87.65 J/fur",
-    //         u"8.765 J/fur",
-    //         u"0.8765 J/fur",
-    //         u"0.08765 J/fur",
-    //         u"0.008765 J/fur",
-    //         u"0 J/fur");
+    assertFormatDescending(
+            u"Joules Per Furlong Short with unit identifier via API",
+            u"measure-unit/energy-joule per-measure-unit/length-furlong",
+            u"unit/joule-per-furlong",
+            NumberFormatter::with().unit(MeasureUnit::forIdentifier("joule-per-furlong", status)),
+            Locale::getEnglish(),
+            u"87,650 J/fur",
+            u"8,765 J/fur",
+            u"876.5 J/fur",
+            u"87.65 J/fur",
+            u"8.765 J/fur",
+            u"0.8765 J/fur",
+            u"0.08765 J/fur",
+            u"0.008765 J/fur",
+            u"0 J/fur");
 
     assertFormatDescending(
             u"Pounds per Square Inch: composed",

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/LongNameMultiplexer.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/LongNameMultiplexer.java
@@ -8,7 +8,6 @@ import java.util.List;
 import com.ibm.icu.number.NumberFormatter;
 import com.ibm.icu.text.PluralRules;
 import com.ibm.icu.util.MeasureUnit;
-import com.ibm.icu.util.NoUnit;
 import com.ibm.icu.util.ULocale;
 
 /**
@@ -64,8 +63,7 @@ public class LongNameMultiplexer implements MicroPropsGenerator {
                         .forMeasureUnit(locale, unit, width, rules, null);
                 result.fHandlers.add(mlnh);
             } else {
-                LongNameHandler lnh = LongNameHandler
-                        .forMeasureUnit(locale, unit, NoUnit.BASE, width, rules, null);
+                LongNameHandler lnh = LongNameHandler.forMeasureUnit(locale, unit, width, rules, null);
                 result.fHandlers.add(lnh);
             }
         }

--- a/icu4j/main/classes/core/src/com/ibm/icu/number/NumberFormatterImpl.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/number/NumberFormatterImpl.java
@@ -400,12 +400,11 @@ class NumberFormatterImpl {
                         pluralRules,
                         chain);
             } else {
-                chain = LongNameHandler.forMeasureUnit(macros.loc,
-                        macros.unit,
-                        macros.perUnit,
-                        unitWidth,
-                        pluralRules,
-                        chain);
+                MeasureUnit unit = macros.unit;
+                if (macros.perUnit != null) {
+                    unit = unit.product(macros.perUnit.reciprocal());
+                }
+                chain = LongNameHandler.forMeasureUnit(macros.loc, unit, unitWidth, pluralRules, chain);
             }
         } else if (isCurrency && unitWidth == UnitWidth.FULL_NAME) {
             if (rules == null) {

--- a/icu4j/main/classes/core/src/com/ibm/icu/util/MeasureUnit.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/util/MeasureUnit.java
@@ -542,7 +542,7 @@ public class MeasureUnit implements Serializable {
             return implCopy.build();
         }
 
-        final MeasureUnitImpl otherImplRef = other.getMayBeReferenceOfMeasureUnitImpl();
+        final MeasureUnitImpl otherImplRef = other.getMaybeReferenceOfMeasureUnitImpl();
         if (implCopy.getComplexity() == Complexity.MIXED || otherImplRef.getComplexity() == Complexity.MIXED) {
             throw new UnsupportedOperationException();
         }
@@ -571,7 +571,8 @@ public class MeasureUnit implements Serializable {
      * @provisional This API might change or be removed in a future release.
      */
     public List<MeasureUnit> splitToSingleUnits() {
-        final ArrayList<SingleUnitImpl> singleUnits = getMayBeReferenceOfMeasureUnitImpl().getSingleUnits();
+        final ArrayList<SingleUnitImpl> singleUnits =
+            getMaybeReferenceOfMeasureUnitImpl().getSingleUnits();
         List<MeasureUnit> result = new ArrayList<>(singleUnits.size());
         for (SingleUnitImpl singleUnit : singleUnits) {
             result.add(singleUnit.build());
@@ -1993,8 +1994,11 @@ public class MeasureUnit implements Serializable {
     /**
      *
      * @return this object in a MeasureUnitImpl form.
+     * @internal
+     * @deprecated This API is ICU internal only.
      */
-    private MeasureUnitImpl getCopyOfMeasureUnitImpl() {
+    @Deprecated
+    public MeasureUnitImpl getCopyOfMeasureUnitImpl() {
         return this.measureUnitImpl == null ?
                 MeasureUnitImpl.forIdentifier(getIdentifier()) :
                 this.measureUnitImpl.copy();
@@ -2004,7 +2008,7 @@ public class MeasureUnit implements Serializable {
      *
      * @return this object in a MeasureUnitImpl form.
      */
-    private MeasureUnitImpl getMayBeReferenceOfMeasureUnitImpl(){
+    private MeasureUnitImpl getMaybeReferenceOfMeasureUnitImpl() {
         return this.measureUnitImpl == null ?
                 MeasureUnitImpl.forIdentifier(getIdentifier()) :
                 this.measureUnitImpl;

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
@@ -824,22 +824,21 @@ public class NumberFormatterApiTest extends TestFmwk {
                 "0.008765 J/fur",
                 "0 J/fur");
 
-        // // TODO(ICU-20941): Support constructions such as this one.
-        // assertFormatDescending(
-        //         "Joules Per Furlong Short with unit identifier via API",
-        //         "measure-unit/energy-joule per-measure-unit/length-furlong",
-        //         "unit/joule-per-furlong",
-        //         NumberFormatter.with().unit(MeasureUnit.forIdentifier("joule-per-furlong")),
-        //         ULocale.ENGLISH,
-        //         "87,650 J/fur",
-        //         "8,765 J/fur",
-        //         "876.5 J/fur",
-        //         "87.65 J/fur",
-        //         "8.765 J/fur",
-        //         "0.8765 J/fur",
-        //         "0.08765 J/fur",
-        //         "0.008765 J/fur",
-        //         "0 J/fur");
+        assertFormatDescending(
+                "Joules Per Furlong Short with unit identifier via API",
+                "measure-unit/energy-joule per-measure-unit/length-furlong",
+                "unit/joule-per-furlong",
+                NumberFormatter.with().unit(MeasureUnit.forIdentifier("joule-per-furlong")),
+                ULocale.ENGLISH,
+                "87,650 J/fur",
+                "8,765 J/fur",
+                "876.5 J/fur",
+                "87.65 J/fur",
+                "8.765 J/fur",
+                "0.8765 J/fur",
+                "0.08765 J/fur",
+                "0.008765 J/fur",
+                "0 J/fur");
 
         assertFormatDescending(
                 "Pounds per Square Inch: composed",


### PR DESCRIPTION
Small step in the direction of ICU-20941 - contributes to icu-units#27.

With this change:
* LongNameHandler constructors no longer take "unit" and "perUnit" - they take only one parameter.
  * Combining of "perUnit" into "unit" thus moved outside of the class, and
  * splitting of "unit" into numerator and denominator moved into the class.
* Skeleton handling is simpler, because we no longer care about "perUnit".

Joule per Furlong was already supported when specified separately. It's just when given as a single unit that it didn't automatically get split.

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20941
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [X] Tests included
- [ ] Documentation is changed or added

