### PR TITLE
ICU-21326 Changed res_findResource() so that it doesn't try index-bas…

### DIFF
--- a/icu4c/source/common/uresdata.cpp
+++ b/icu4c/source/common/uresdata.cpp
@@ -963,7 +963,7 @@ res_findResource(const ResourceData *pResData, Resource r, char** path, const ch
       if(t2 == RES_BOGUS) { 
         /* if we fail to get the resource by key, maybe we got an index */
         indexR = uprv_strtol(pathP, &closeIndex, 10);
-        if(indexR >= 0 && *closeIndex == 0) {
+        if(indexR >= 0 && *closeIndex == 0 && (*pathP != '0' || closeIndex - pathP == 1)) {
           /* if we indeed have an index, try to get the item by index */
           t2 = res_getTableItemByIndex(pResData, t1, indexR, key);
         } // else t2 is already RES_BOGUS

--- a/icu4c/source/test/intltest/locnmtst.cpp
+++ b/icu4c/source/test/intltest/locnmtst.cpp
@@ -82,6 +82,7 @@ void LocaleDisplayNamesTest::runIndexedTest(int32_t index, UBool exec, const cha
         TESTCASE(12, TestUldnDisplayContext);
         TESTCASE(13, TestUldnWithGarbage);
         TESTCASE(14, TestSubstituteHandling);
+        TESTCASE(15, TestNumericRegionID);
 #endif
         default:
             name = "";
@@ -418,6 +419,23 @@ void LocaleDisplayNamesTest::TestRootEtc() {
   test_assert_equal("en_GB", temp);
 
   delete ldn;
+}
+
+void LocaleDisplayNamesTest::TestNumericRegionID() {
+    UErrorCode err = U_ZERO_ERROR;
+    ULocaleDisplayNames* ldn = uldn_open("es_MX", ULDN_STANDARD_NAMES, &err);
+    UChar displayName[200];
+    int32_t displayNameLength = uldn_regionDisplayName(ldn, "019", displayName, 200, &err);
+    test_assert(U_SUCCESS(err));
+    test_assert_equal(UnicodeString(u"América"), UnicodeString(displayName));
+    uldn_close(ldn);    
+
+    err = U_ZERO_ERROR; // reset in case the test above returned an error code
+    ldn = uldn_open("en_AU", ULDN_STANDARD_NAMES, &err);
+    displayNameLength = uldn_regionDisplayName(ldn, "002", displayName, 200, &err);
+    test_assert(U_SUCCESS(err));
+    test_assert_equal(UnicodeString(u"Africa"), UnicodeString(displayName));
+    uldn_close(ldn);    
 }
 
 static const char unknown_region[] = "wx";

--- a/icu4c/source/test/intltest/locnmtst.h
+++ b/icu4c/source/test/intltest/locnmtst.h
@@ -38,6 +38,7 @@ public:
     void TestUldnDisplayContext(void);
     void TestUldnWithGarbage(void);
     void TestSubstituteHandling(void);
+    void TestNumericRegionID(void);
 
     void VerifySubstitute(LocaleDisplayNames* ldn);
     void VerifyNoSubstitute(LocaleDisplayNames* ldn);


### PR DESCRIPTION
…ed lookup in a table resource if the resource ID has a leading zero

(cherry picked from commit af7ed1f6d2298013dc303628438ec4abe1f16479 on master)

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21326
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

This just merges the approved commit from master to maint/maint-68