### PR TITLE
ICU-21340 Add tests verify getNextPosition()

### DIFF
--- a/icu4c/source/test/intltest/listformattertest.cpp
+++ b/icu4c/source/test/intltest/listformattertest.cpp
@@ -48,6 +48,7 @@ void ListFormatterTest::runIndexedTest(int32_t index, UBool exec,
     TESTCASE_AUTO(TestBadStylesFail);
     TESTCASE_AUTO(TestCreateStyled);
     TESTCASE_AUTO(TestContextual);
+    TESTCASE_AUTO(TestNextPosition);
     TESTCASE_AUTO_END;
 }
 
@@ -694,6 +695,52 @@ void ListFormatterTest::TestContextual() {
                     const UnicodeString inputs3[] = { cas.data1, cas.data2, cas.data3 };
                     FormattedList result = fmt->formatStringsToValue(inputs3, UPRV_LENGTHOF(inputs3), status);
                     assertEquals(message, cas.expected, result.toTempString(status));
+                }
+            }
+        }
+    }
+}
+
+void ListFormatterTest::TestNextPosition() {
+    IcuTestErrorCode status(*this, "TestNextPosition");
+    std::vector<std::string> locales = { "en", "es", "zh", "ja" };
+    UListFormatterWidth widths [] = {
+        ULISTFMT_WIDTH_WIDE, ULISTFMT_WIDTH_SHORT, ULISTFMT_WIDTH_NARROW
+    };
+    const char* widthStr [] = {"wide", "short", "narrow"};
+    UListFormatterType types [] = {
+        ULISTFMT_TYPE_AND, ULISTFMT_TYPE_OR, ULISTFMT_TYPE_UNITS
+    };
+    const char* typeStr [] = {"and", "or", "units"};
+    const UnicodeString inputs[] = { u"A1", u"B2", u"C3", u"D4" };
+    for (auto width : widths) {
+        for (auto type : types) {
+            for (auto locale : locales) {
+                LocalPointer<ListFormatter> fmt(
+                        ListFormatter::createInstance(locale.c_str(), type, width, status),
+                    status);
+                if (status.errIfFailureAndReset()) {
+                    continue;
+                }
+                for (int32_t n = 1; n <= UPRV_LENGTHOF(inputs); n++) {
+                    FormattedList result = fmt->formatStringsToValue(
+                        inputs, n, status);
+                    int32_t elements = 0;
+                    icu::ConstrainedFieldPosition cfpos;
+                    cfpos.constrainCategory(UFIELD_CATEGORY_LIST);
+                    while (result.nextPosition(cfpos, status) && U_SUCCESS(status)) {
+                        if (cfpos.getField() == ULISTFMT_ELEMENT_FIELD) {
+                            elements++;
+                        }
+                    }
+                    std::string msg = locale;
+                    // Test that if there are n elements (n=1..4) in the input, then the
+                    // nextPosition() should iterate through exactly n times
+                    // with field == ULISTFMT_ELEMENT_FIELD.
+                    assertEquals((msg
+                                  .append(" w=").append(widthStr[width])
+                                  .append(" t=").append(typeStr[type])).c_str(),
+                                 n, elements);
                 }
             }
         }

--- a/icu4c/source/test/intltest/listformattertest.h
+++ b/icu4c/source/test/intltest/listformattertest.h
@@ -55,6 +55,7 @@ class ListFormatterTest : public IntlTestWithFieldPosition {
     void TestBadStylesFail();
     void TestCreateStyled();
     void TestContextual();
+    void TestNextPosition();
 
   private:
     void CheckFormatting(


### PR DESCRIPTION
getNextPosition() for n items should have element exactly n times.

This is just intended for the one who is going to fix (Shane?) to see the expectation of test we need in v8.
