### PR TITLE
ICU-21250 Update Apache Ant to 1.10.9

### DIFF
--- a/tools/cldr/cldr-to-icu/pom.xml
+++ b/tools/cldr/cldr-to-icu/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.10.8</version>
+            <version>1.10.9</version>
         </dependency>
 
         <!-- Testing only dependencies. -->


### PR DESCRIPTION
The GtiHub automated scanning flagged an issue with an older version of Apache Ant.

This change updates the version of Apache Ant from 1.10.8 to 1.10.9 in order pick up the fix for CVE-2020-1945.

#### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21250
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

