### PR TITLE
ICU-21356 Fix memory handling in MemoryPool::operator=()

### DIFF
--- a/icu4c/source/test/intltest/units_test.cpp
+++ b/icu4c/source/test/intltest/units_test.cpp
@@ -415,26 +415,25 @@ void UnitsTest::testComplexUnitsConverter() {
         assertEquals("1.9999: measures[0] value", 1.0, measures[0]->getNumber().getDouble(status));
         assertEquals("1.9999: measures[0] unit", MeasureUnit::getFoot().getIdentifier(),
                      measures[0]->getUnit().getIdentifier());
-        assertEqualsNear("1.9999: measures[1] value", 11.9988, measures[1]->getNumber().getDouble(status), 0.0001);
+        assertEqualsNear("1.9999: measures[1] value", 11.9988,
+                         measures[1]->getNumber().getDouble(status), 0.0001);
         assertEquals("1.9999: measures[1] unit", MeasureUnit::getInch().getIdentifier(),
                      measures[1]->getUnit().getIdentifier());
     }
 
     // TODO(icu-units#100): consider factoring out the set of tests to make this function more
-    // data-driven, *after* dealing appropriately with the memory leaks that can
-    // be demonstrated by this code.
+    // data-driven.
 
-    // TODO(icu-units#100): reusing measures results in a leak.
     // A minimal nudge under 2.0.
-    MaybeStackVector<Measure> measures2 = converter.convert((2.0 - DBL_EPSILON), nullptr, status);
-    assertEquals("measures length", 2, measures2.length());
-    if (2 == measures2.length()) {
-        assertEquals("1 - eps: measures[0] value", 2.0, measures2[0]->getNumber().getDouble(status));
+    measures = converter.convert((2.0 - DBL_EPSILON), nullptr, status);
+    assertEquals("measures length", 2, measures.length());
+    if (2 == measures.length()) {
+        assertEquals("1 - eps: measures[0] value", 2.0, measures[0]->getNumber().getDouble(status));
         assertEquals("1 - eps: measures[0] unit", MeasureUnit::getFoot().getIdentifier(),
-                     measures2[0]->getUnit().getIdentifier());
-        assertEquals("1 - eps: measures[1] value", 0.0, measures2[1]->getNumber().getDouble(status));
+                     measures[0]->getUnit().getIdentifier());
+        assertEquals("1 - eps: measures[1] value", 0.0, measures[1]->getNumber().getDouble(status));
         assertEquals("1 - eps: measures[1] unit", MeasureUnit::getInch().getIdentifier(),
-                     measures2[1]->getUnit().getIdentifier());
+                     measures[1]->getUnit().getIdentifier());
     }
 
     // Testing precision with meter and light-year. 1e-16 light years is
@@ -444,51 +443,51 @@ void UnitsTest::testComplexUnitsConverter() {
     // An epsilon's nudge under one light-year: should give 1 ly, 0 m.
     input = MeasureUnit::getLightYear();
     output = MeasureUnit::forIdentifier("light-year-and-meter", status);
-    // TODO(icu-units#100): reusing tempInput and tempOutput results in a leak.
-    MeasureUnitImpl tempInput3, tempOutput3;
-    const MeasureUnitImpl &inputImpl3 = MeasureUnitImpl::forMeasureUnit(input, tempInput3, status);
-    const MeasureUnitImpl &outputImpl3 = MeasureUnitImpl::forMeasureUnit(output, tempOutput3, status);
-    // TODO(icu-units#100): reusing converter results in a leak.
-    ComplexUnitsConverter converter3 = ComplexUnitsConverter(inputImpl3, outputImpl3, rates, status);
-    // TODO(icu-units#100): reusing measures results in a leak.
-    MaybeStackVector<Measure> measures3 = converter3.convert((2.0 - DBL_EPSILON), nullptr, status);
-    assertEquals("measures length", 2, measures3.length());
-    if (2 == measures3.length()) {
-        assertEquals("light-year test: measures[0] value", 2.0, measures3[0]->getNumber().getDouble(status));
+    const MeasureUnitImpl &inputImpl3 = MeasureUnitImpl::forMeasureUnit(input, tempInput, status);
+    const MeasureUnitImpl &outputImpl3 = MeasureUnitImpl::forMeasureUnit(output, tempOutput, status);
+    converter = ComplexUnitsConverter(inputImpl3, outputImpl3, rates, status);
+    measures = converter.convert((2.0 - DBL_EPSILON), nullptr, status);
+    assertEquals("measures length", 2, measures.length());
+    if (2 == measures.length()) {
+        assertEquals("light-year test: measures[0] value", 2.0,
+                     measures[0]->getNumber().getDouble(status));
         assertEquals("light-year test: measures[0] unit", MeasureUnit::getLightYear().getIdentifier(),
-                     measures3[0]->getUnit().getIdentifier());
-        assertEquals("light-year test: measures[1] value", 0.0, measures3[1]->getNumber().getDouble(status));
+                     measures[0]->getUnit().getIdentifier());
+        assertEquals("light-year test: measures[1] value", 0.0,
+                     measures[1]->getNumber().getDouble(status));
         assertEquals("light-year test: measures[1] unit", MeasureUnit::getMeter().getIdentifier(),
-                     measures3[1]->getUnit().getIdentifier());
+                     measures[1]->getUnit().getIdentifier());
     }
 
     // 1e-15 light years is 9.46073 meters (calculated using "bc" and the CLDR
     // conversion factor). With double-precision maths, we get 10.5. In this
     // case, we're off by almost 1 meter.
-    MaybeStackVector<Measure> measures4 = converter3.convert((1.0 + 1e-15), nullptr, status);
-    assertEquals("measures length", 2, measures4.length());
-    if (2 == measures4.length()) {
-        assertEquals("light-year test: measures[0] value", 1.0, measures4[0]->getNumber().getDouble(status));
+    measures = converter.convert((1.0 + 1e-15), nullptr, status);
+    assertEquals("measures length", 2, measures.length());
+    if (2 == measures.length()) {
+        assertEquals("light-year test: measures[0] value", 1.0,
+                     measures[0]->getNumber().getDouble(status));
         assertEquals("light-year test: measures[0] unit", MeasureUnit::getLightYear().getIdentifier(),
-                     measures4[0]->getUnit().getIdentifier());
+                     measures[0]->getUnit().getIdentifier());
         assertEqualsNear("light-year test: measures[1] value", 10,
-                         measures4[1]->getNumber().getDouble(status), 1);
+                         measures[1]->getNumber().getDouble(status), 1);
         assertEquals("light-year test: measures[1] unit", MeasureUnit::getMeter().getIdentifier(),
-                     measures4[1]->getUnit().getIdentifier());
+                     measures[1]->getUnit().getIdentifier());
     }
 
     // 2e-16 light years is 1.892146 meters. We consider this in the noise, and
     // thus expect a 0. (This test fails when 2e-16 is increased to 4e-16.)
-    MaybeStackVector<Measure> measures5 = converter3.convert((1.0 + 2e-16), nullptr, status);
-    assertEquals("measures length", 2, measures5.length());
-    if (2 == measures5.length()) {
-        assertEquals("light-year test: measures[0] value", 1.0, measures5[0]->getNumber().getDouble(status));
+    measures = converter.convert((1.0 + 2e-16), nullptr, status);
+    assertEquals("measures length", 2, measures.length());
+    if (2 == measures.length()) {
+        assertEquals("light-year test: measures[0] value", 1.0,
+                     measures[0]->getNumber().getDouble(status));
         assertEquals("light-year test: measures[0] unit", MeasureUnit::getLightYear().getIdentifier(),
-                     measures5[0]->getUnit().getIdentifier());
+                     measures[0]->getUnit().getIdentifier());
         assertEquals("light-year test: measures[1] value", 0.0,
-                         measures5[1]->getNumber().getDouble(status));
+                     measures[1]->getNumber().getDouble(status));
         assertEquals("light-year test: measures[1] unit", MeasureUnit::getMeter().getIdentifier(),
-                     measures5[1]->getUnit().getIdentifier());
+                     measures[1]->getUnit().getIdentifier());
     }
 
     // TODO(icu-units#63): test negative numbers!


### PR DESCRIPTION
**Question to reviewer:** indirectly testing this via MeasureUnitImpl: sufficient? Or should I produce a unit test specifically for a MemoryPool instance?

The old array can't simply be deallocated, their pointers still need to be deallcoated too.

Using swap() ensures that the destructor can take care of it when `other` is deallocated.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21356
- [X] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [X] Tests included
- [ ] Documentation is changed or added

