### PR TITLE
ICU-21377 Add Google Analytics to the ICU User Guide.

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -93,3 +93,7 @@ gh_edit_view_mode: "tree"
 exclude:
   - Gemfile
   - Gemfile.lock
+
+# Google Analytics
+ga_tracking: UA-7670256-1
+ga_tracking_anonymize_ip: true # Use GDPR compliant Google Analytics settings


### PR DESCRIPTION
The older ICU User Guide (hosted on the Google Sites pages) had Google Analytics (GA) setup.

This PR adds the same GA tracking to the new GitHub pages-based ICU User Guide site as well (using the Jekyll config for it).

#### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21377
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

