### PR TITLE
ICU-21366 testConverter: allow some double-precision error for 0.0

### DIFF
--- a/icu4c/source/test/intltest/units_test.cpp
+++ b/icu4c/source/test/intltest/units_test.cpp
@@ -247,9 +247,12 @@ void UnitsTest::testConverter() {
             continue;
         }
 
+        double maxDelta = 1e-6 * uprv_fabs(testCase.expectedValue);
+        if (testCase.expectedValue == 0) {
+            maxDelta = 1e-12;
+        }
         assertEqualsNear(UnicodeString("testConverter: ") + testCase.source + " to " + testCase.target,
-                         testCase.expectedValue, converter.convert(testCase.inputValue),
-                         0.0001 * uprv_fabs(testCase.expectedValue));
+                         testCase.expectedValue, converter.convert(testCase.inputValue), maxDelta);
     }
 }
 


### PR DESCRIPTION
Java not included in this PR because Java doesn't have the same unit tests yet: icu-units#92 tracks that.
Closes: icu-units#112

This also takes the testConverter "maxDelta" from `1e-4*expected` to `1e-6*expected`. (Tests start failing for me at 1e-7.)

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21366
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [X] Tests included
- [ ] Documentation is changed or added

