### PR TITLE
ICU-10997 Port test case for currency formatting to icu4c

### DIFF
--- a/icu4c/source/test/intltest/numfmtst.cpp
+++ b/icu4c/source/test/intltest/numfmtst.cpp
@@ -248,6 +248,7 @@ void NumberFormatTest::runIndexedTest( int32_t index, UBool exec, const char* &n
   TESTCASE_AUTO(Test21134_ToNumberFormatter);
   TESTCASE_AUTO(Test13733_StrictAndLenient);
   TESTCASE_AUTO(Test21232_ParseTimeout);
+  TESTCASE_AUTO(Test10997_FormatCurrency);
   TESTCASE_AUTO_END;
 }
 
@@ -9183,7 +9184,7 @@ void NumberFormatTest::Test13055_PercentageRounding() {
   pFormat->format(2.155, actual);
   assertEquals("Should round percent toward even number", "216%", actual);
 }
-  
+
 void NumberFormatTest::Test11839() {
     IcuTestErrorCode errorCode(*this, "Test11839");
     // Ticket #11839: DecimalFormat does not respect custom plus sign
@@ -10061,6 +10062,29 @@ void NumberFormatTest::Test21232_ParseTimeout() {
     Formattable result;
     df.parse(input, result, status);
     // Should not hang
+}
+
+void NumberFormatTest::Test10997_FormatCurrency() {
+    IcuTestErrorCode status(*this, "Test10997_FormatCurrency");
+
+    UErrorCode error = U_ZERO_ERROR;
+    NumberFormat* fmt = NumberFormat::createCurrencyInstance(Locale::getUS(), error);
+    fmt->setMinimumFractionDigits(4);
+    fmt->setMaximumFractionDigits(4);
+
+    FieldPosition fp;
+
+    UnicodeString str;
+    Formattable usdAmnt(new CurrencyAmount(123.45, u"USD", status));
+    fmt->format(usdAmnt, str, fp, status);
+    assertEquals("minFrac 4 should be respected in default currency", u"$123.4500", str);
+
+    UnicodeString str2;
+    Formattable eurAmnt(new CurrencyAmount(123.45, u"EUR", status));
+    fmt->format(eurAmnt, str2, fp, status);
+    assertEquals("minFrac 4 should be respected in different currency", u"€123.4500", str2);
+
+    delete fmt;
 }
 
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/test/intltest/numfmtst.h
+++ b/icu4c/source/test/intltest/numfmtst.h
@@ -304,6 +304,7 @@ class NumberFormatTest: public CalendarTimeZoneTest {
     void Test21134_ToNumberFormatter();
     void Test13733_StrictAndLenient();
     void Test21232_ParseTimeout();
+    void Test10997_FormatCurrency();
 
  private:
     UBool testFormattableAsUFormattable(const char *file, int line, Formattable &f);


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-10997
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

This port was requested to confirm functionality for icu4c for php to use.