### PR TITLE
ICU-21349 Remove a potential 0/0 (=NaN). Align C++ & Java better.

### DIFF
--- a/icu4c/source/test/intltest/units_test.cpp
+++ b/icu4c/source/test/intltest/units_test.cpp
@@ -402,6 +402,13 @@ void UnitsTest::testConverterWithCLDRTests() {
 void UnitsTest::testComplexUnitsConverter() {
     IcuTestErrorCode status(*this, "UnitsTest::testComplexUnitsConverter");
 
+    // DBL_EPSILON is aproximately 2.22E-16, and is the precision of double for
+    // values in the range [1.0, 2.0), but half the precision of double for
+    // [2.0, 4.0).
+    U_ASSERT(1.0 + DBL_EPSILON > 1.0);
+    U_ASSERT(2.0 - DBL_EPSILON < 2.0);
+    U_ASSERT(2.0 + DBL_EPSILON == 2.0);
+
     struct TestCase {
         const char* msg;
         const char* input;
@@ -422,7 +429,6 @@ void UnitsTest::testComplexUnitsConverter() {
          2,
          0},
 
-        // TODO(icu-units#108): reconsider whether desireable to round up:
         // A minimal nudge under 2.0, rounding up to 2.0 ft, 0 in.
         {"2-eps",
          "foot",
@@ -433,12 +439,27 @@ void UnitsTest::testComplexUnitsConverter() {
          2,
          0},
 
-        // Testing precision with meter and light-year. 1e-16 light years is
-        // 0.946073 meters, and double precision can provide only ~15 decimal
-        // digits, so we don't expect to get anything less than 1 meter.
+        // A slightly bigger nudge under 2.0, *not* rounding up to 2.0 ft!
+        {"2-3eps",
+         "foot",
+         "foot-and-inch",
+         2.0 - 3 * DBL_EPSILON,
+         {Measure(1, MeasureUnit::createFoot(status), status),
+          // We expect 12*3*DBL_EPSILON inches (7.92e-15) less than 12.
+          Measure(12 - 36 * DBL_EPSILON, MeasureUnit::createInch(status), status)},
+         2,
+         // Might accuracy be lacking with some compilers or on some systems? In
+         // case it is somehow lacking, we'll allow a delta of 12 * DBL_EPSILON.
+         12 * DBL_EPSILON},
 
-        // TODO(icu-units#108): reconsider whether desireable to round up:
-        // A nudge under 2.0 light years, rounding up to 2.0 ly, 0 m.
+        // Testing precision with meter and light-year.
+        //
+        // DBL_EPSILON light-years, ~2.22E-16 light-years, is ~2.1 meters
+        // (maximum precision when exponent is 0).
+        //
+        // 1e-16 light years is 0.946073 meters.
+
+        // A 2.1 meter nudge under 2.0 light years, rounding up to 2.0 ly, 0 m.
         {"2-eps",
          "light-year",
          "light-year-and-meter",
@@ -448,8 +469,7 @@ void UnitsTest::testComplexUnitsConverter() {
          2,
          0},
 
-        // TODO(icu-units#108): reconsider whether desireable to round up:
-        // A nudge under 1.0 light years, rounding up to 1.0 ly, 0 m.
+        // A 2.1 meter nudge under 1.0 light years, rounding up to 1.0 ly, 0 m.
         {"1-eps",
          "light-year",
          "light-year-and-meter",
@@ -472,20 +492,15 @@ void UnitsTest::testComplexUnitsConverter() {
          2,
          1.5 /* meters, precision */},
 
-        // TODO(icu-units#108): reconsider whether epsilon rounding is desirable:
-        //
-        // 2e-16 light years is 1.892146 meters. For C++ double, we consider
-        // this in the noise, and thus expect a 0. (This test fails when
-        // 2e-16 is increased to 4e-16.) For Java, using BigDecimal, we
-        // actually get a good result.
-        {"1 + 2e-16",
+        // 2.1 meters more than 1 light year is not rounded away.
+        {"1 + eps",
          "light-year",
          "light-year-and-meter",
-         1.0 + 2e-16,
+         1.0 + DBL_EPSILON,
          {Measure(1, MeasureUnit::createLightYear(status), status),
-          Measure(0, MeasureUnit::createMeter(status), status)},
+          Measure(2.1, MeasureUnit::createMeter(status), status)},
          2,
-         0},
+         0.001},
     };
     status.assertSuccess();
 

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/units/ComplexUnitsConverter.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/units/ComplexUnitsConverter.java
@@ -129,15 +129,17 @@ public class ComplexUnitsConverter {
                 // decision is made. However after the thresholding, we use the
                 // original values to ensure unbiased accuracy (to the extent of
                 // double's capabilities).
-                BigDecimal roundedQuantity =
+                BigDecimal flooredQuantity =
                     quantity.multiply(EPSILON_MULTIPLIER).setScale(0, RoundingMode.FLOOR);
-                intValues.add(roundedQuantity);
+                intValues.add(flooredQuantity);
 
                 // Keep the residual of the quantity.
                 //   For example: `3.6 feet`, keep only `0.6 feet`
-                quantity = quantity.subtract(roundedQuantity);
-                if (quantity.compareTo(BigDecimal.ZERO) == -1) {
+                BigDecimal remainder = quantity.subtract(flooredQuantity);
+                if (remainder.compareTo(BigDecimal.ZERO) == -1) {
                     quantity = BigDecimal.ZERO;
+                } else {
+                    quantity = remainder;
                 }
             } else { // LAST ELEMENT
                 if (rounder == null) {

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/impl/UnitsTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/impl/UnitsTest.java
@@ -64,16 +64,35 @@ public class UnitsTest {
                 0),
 
             // A minimal nudge under 2.0, rounding up to 2.0 ft, 0 in.
+            // TODO(icu-units#108): this matches double precision calculations
+            // from C++, but BigDecimal is in use: do we want Java to be more
+            // precise than C++?
             new TestCase(
                 "foot", "foot-and-inch", BigDecimal.valueOf(2.0).subtract(ComplexUnitsConverter.EPSILON),
                 new Measure[] {new Measure(2, MeasureUnit.FOOT), new Measure(0, MeasureUnit.INCH)}, 0),
 
-            // Testing precision with meter and light-year. 1e-16 light years is
-            // 0.946073 meters, and double precision can provide only ~15 decimal
-            // digits, so we don't expect to get anything less than 1 meter.
+            // A slightly bigger nudge under 2.0, *not* rounding up to 2.0 ft!
+            new TestCase("foot", "foot-and-inch",
+                         BigDecimal.valueOf(2.0).subtract(
+                             ComplexUnitsConverter.EPSILON.multiply(BigDecimal.valueOf(3.0))),
+                         new Measure[] {new Measure(1, MeasureUnit.FOOT),
+                                        new Measure(BigDecimal.valueOf(12.0).subtract(
+                                                        ComplexUnitsConverter.EPSILON.multiply(
+                                                            BigDecimal.valueOf(36.0))),
+                                                    MeasureUnit.INCH)},
+                         0),
 
-            // TODO(icu-units#108): figure out precision thresholds for BigDecimal?
-            // A nudge under 2.0 light years, rounding up to 2.0 ly, 0 m.
+            // Testing precision with meter and light-year.
+            //
+            // DBL_EPSILON light-years, ~2.22E-16 light-years, is ~2.1 meters
+            // (maximum precision when exponent is 0).
+            //
+            // 1e-16 light years is 0.946073 meters.
+
+            // A 2.1 meter nudge under 2.0 light years, rounding up to 2.0 ly, 0 m.
+            // TODO(icu-units#108): this matches double precision calculations
+            // from C++, but BigDecimal is in use: do we want Java to be more
+            // precise than C++?
             new TestCase("light-year", "light-year-and-meter",
                          BigDecimal.valueOf(2.0).subtract(ComplexUnitsConverter.EPSILON),
                          new Measure[] {new Measure(2, MeasureUnit.LIGHT_YEAR),
@@ -81,8 +100,8 @@ public class UnitsTest {
                          0),
 
             // // TODO(icu-units#108): figure out precision thresholds for BigDecimal?
-            // // This test is passing in C++ but failing in Java:
-            // // A nudge under 1.0 light years, rounding up to 1.0 ly, 0 m.
+            // // This test passes in C++ due to double-precision rounding.
+            // // A 2.1 meter nudge under 1.0 light years, rounding up to 1.0 ly, 0 m.
             // new TestCase("light-year", "light-year-and-meter",
             //              BigDecimal.valueOf(1.0).subtract(ComplexUnitsConverter.EPSILON),
             //              new Measure[] {new Measure(1, MeasureUnit.LIGHT_YEAR),


### PR DESCRIPTION
This improves some unit tests and makes C++ and Java code more similar, with an edge-case improvement in C++ complex number conversion accuracy.

I was considering tackling icu-units#108, but I think we should discuss what precision-handling differences we want between C++ and Java.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21349
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [X] Tests included
- [ ] Documentation is changed or added

