### PR TITLE
ICU-21295 Fix for Java version number overflow problem in 66

### DIFF
--- a/icu4j/main/classes/charset/src/com/ibm/icu/charset/CharsetUTF16.java
+++ b/icu4j/main/classes/charset/src/com/ibm/icu/charset/CharsetUTF16.java
@@ -17,7 +17,6 @@ import java.nio.charset.CoderResult;
 
 import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
-import com.ibm.icu.util.VersionInfo;
 
 /**
  * @author Niti Hantaweepant
@@ -65,13 +64,10 @@ class CharsetUTF16 extends CharsetICU {
             this.endianXOR = ENDIAN_XOR_LE;
         }
 
-        /* UnicodeBig and UnicodeLittle requires maxBytesPerChar set to 4 in Java 5 or less */
-        if ((VersionInfo.javaVersion().getMajor() == 1 && VersionInfo.javaVersion().getMinor() <= 5)
-                && (isEndianSpecified && version == 1)) {
-            maxBytesPerChar = 4;
-        } else {
-            maxBytesPerChar = 2;
-        }
+        // UnicodeBig and UnicodeLittle used to require maxBytesPerChar set to 4 in Java 5 or less,
+        // but it's no longer necessary for newer Java versions. Java 5 or older runtime is no
+        // longer supported.
+        maxBytesPerChar = 2;
 
         minBytesPerChar = 2;
         maxCharsPerByte = 1;

--- a/icu4j/main/classes/core/src/com/ibm/icu/util/VersionInfo.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/util/VersionInfo.java
@@ -372,56 +372,6 @@ public final class VersionInfo implements Comparable<VersionInfo>
         return getInstance(major, 0, 0, 0);
     }
 
-    private static volatile VersionInfo javaVersion;
-
-    /**
-     * @internal
-     * @deprecated This API is ICU internal only.
-     */
-    @Deprecated
-    public static VersionInfo javaVersion() {
-        if (javaVersion == null) {
-            synchronized(VersionInfo.class) {
-                if (javaVersion == null) {
-                    String s = System.getProperty("java.version");
-                    // clean string
-                    // preserve only digits, separated by single '.'
-                    // ignore over 4 digit sequences
-                    // does not test < 255, very odd...
-
-                    char[] chars = s.toCharArray();
-                    int r = 0, w = 0, count = 0;
-                    boolean numeric = false; // ignore leading non-numerics
-                    while (r < chars.length) {
-                        char c = chars[r++];
-                        if (c < '0' || c > '9') {
-                            if (numeric) {
-                                if (count == 3) {
-                                    // only four digit strings allowed
-                                    break;
-                                }
-                                numeric = false;
-                                chars[w++] = '.';
-                                ++count;
-                            }
-                        } else {
-                            numeric = true;
-                            chars[w++] = c;
-                        }
-                    }
-                    while (w > 0 && chars[w-1] == '.') {
-                        --w;
-                    }
-
-                    String vs = new String(chars, 0, w);
-
-                    javaVersion = VersionInfo.getInstance(vs);
-                }
-            }
-        }
-        return javaVersion;
-    }
-
     /**
      * Returns the String representative of VersionInfo in the format of
      * "major.minor.milli.micro"


### PR DESCRIPTION
Merging the fix for ICU-21219 (PR #1245) to ICU 66.

Internal API VersionInfo.javaVersion() maps Java version number to  4 integer fields. Each field must be up to 255. However, recent OpenJDK 8 update exceed this range.

Luckily, we have only one reference in our code base for checking Java version. CharsetUTF16 uses maxBytePerChar = 4 for Java 5 and older, maxBytePerChar = 2 for newer Java version. Because we no longer support Java 5 runtime, we don't need this conditional check.

We don't have any other uses of VersionInfo.javaVersion(). Java's version range is not what we can control, so I decided to delete the internal use only API completely.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21295
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

