### PR TITLE
ICU-21349 Fix confusing names of exponent variables.

### DIFF
--- a/icu4c/source/i18n/units_converter.h
+++ b/icu4c/source/i18n/units_converter.h
@@ -20,11 +20,12 @@ namespace units {
 
 /* Internal Structure */
 
+// Constants corresponding to unitConstants in CLDR's units.xml.
 enum Constants {
-    CONSTANT_FT2M,    // ft2m stands for foot to meter.
-    CONSTANT_PI,      // PI
-    CONSTANT_GRAVITY, // Gravity
-    CONSTANT_G,
+    CONSTANT_FT2M,       // ft_to_m
+    CONSTANT_PI,         // PI
+    CONSTANT_GRAVITY,    // Gravity of earth (9.80665 m/s^2), "g".
+    CONSTANT_G,          // Newtonian constant of gravitation, "G".
     CONSTANT_GAL_IMP2M3, // Gallon imp to m3
     CONSTANT_LB2KG,      // Pound to Kilogram
 
@@ -36,6 +37,7 @@ enum Constants {
 // resources file. A unit test checks that all constants in the resource
 // file are at least recognised by the code. Derived constants' values or
 // hard-coded derivations are not checked.
+// In ICU4J, these constants live in UnitConverter.Factor.getConversionRate().
 static const double constantsValues[CONSTANTS_COUNT] = {
     0.3048,                    // CONSTANT_FT2M
     411557987.0 / 131002976.0, // CONSTANT_PI
@@ -56,7 +58,9 @@ struct U_I18N_API Factor {
     double factorDen = 1;
     double offset = 0;
     bool reciprocal = false;
-    int32_t constants[CONSTANTS_COUNT] = {};
+
+    // Exponents for the symbolic constants
+    int32_t constantExponents[CONSTANTS_COUNT] = {};
 
     void multiplyBy(const Factor &rhs);
     void divideBy(const Factor &rhs);
@@ -64,11 +68,13 @@ struct U_I18N_API Factor {
     // Apply the power to the factor.
     void power(int32_t power);
 
-    // Flip the `Factor`, for example, factor= 2/3, flippedFactor = 3/2
-    void flip();
-
     // Apply SI prefix to the `Factor`
     void applySiPrefix(UMeasureSIPrefix siPrefix);
+
+    // Does an in-place substition of the "symbolic constants" based on
+    // constantExponents (resetting the exponents).
+    //
+    // In ICU4J, see UnitConverter.Factor.getConversionRate().
     void substituteConstants();
 };
 


### PR DESCRIPTION
Addresses feedback given on unicode-org#1279 and sffc#21.

(These names were still confusing me - every time I dealt with the Java code in particular. On #1279 we had agreement that they needed to be fixed, so I'm fixing them.)

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21349
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

