### PR TITLE
ICU-21392 Fix Windows Time Zone detection when more than one possible time zone.

### DIFF
--- a/icu4c/source/common/wintz.cpp
+++ b/icu4c/source/common/wintz.cpp
@@ -280,18 +280,29 @@ uprv_detectWindowsTimeZone()
     int regionCodeLen = GetGeoInfoW(geoId, GEO_ISO2, regionCodeW, UPRV_LENGTHOF(regionCodeW), 0);
 
     const UChar *icuTZ16 = nullptr;
-    int32_t tzLen;
+    int32_t tzListLen = 0;
 
     if (regionCodeLen != 0) {
         for (int i = 0; i < UPRV_LENGTHOF(regionCodeW); i++) {
             regionCode[i] = static_cast<char>(regionCodeW[i]);
         }
-        icuTZ16 = ures_getStringByKey(winTZBundle.getAlias(), regionCode, &tzLen, &status);
+        icuTZ16 = ures_getStringByKey(winTZBundle.getAlias(), regionCode, &tzListLen, &status);
     }
     if (regionCodeLen == 0 || U_FAILURE(status)) {
         // fallback to default "001" (world)
         status = U_ZERO_ERROR;
-        icuTZ16 = ures_getStringByKey(winTZBundle.getAlias(), "001", &tzLen, &status);
+        icuTZ16 = ures_getStringByKey(winTZBundle.getAlias(), "001", &tzListLen, &status);
+    }
+
+    // Note: We want the first entry in the string returned by ures_getStringByKey.
+    // However this string can be a space delimited list of timezones:
+    //  Ex: "America/New_York America/Detroit America/Indiana/Petersburg ..."
+    // We need to stop at the first space, so we pass tzLen (instead of tzListLen) to appendInvariantChars below.
+    int32_t tzLen = 0;
+    if (tzListLen > 0) {
+        while (!(icuTZ16[tzLen] == u'\0' || icuTZ16[tzLen] == u' ')) {
+            tzLen++;
+        }
     }
 
     // Note: cloneData returns nullptr if the status is a failure, so this


### PR DESCRIPTION
This PR is a fix for the regression caused by the change in PR #1326.

The list of possible time zones returned is a space-delimited list in some cases.
The change in PR #1362 was only stopping at the null-terminator. Instead we need to stop at the first space.

I missed this when reviewing the changes in PR https://github.com/unicode-org/icu/pull/1297.

The issue is due to the removal of the check here on this line which was stopping at the null or space:
https://github.com/unicode-org/icu/pull/1297/files#diff-04dfe6b718cf7d1421df2b6ff3aa89d0b95a7e2d468f5eb323e3698557a3a936L106

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21392
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added
