### PR TITLE
ICU-21401 Fix C++ canonicalize cel-gaulish to xtg

### DIFF
--- a/icu4c/source/common/uloc_tag.cpp
+++ b/icu4c/source/common/uloc_tag.cpp
@@ -129,7 +129,6 @@ static const char* const LEGACY[] = {
     // Legacy tags with no preferred value in the IANA
     // registry. Kept for now for the backward compatibility
     // because ICU has mapped them this way.
-    "cel-gaulish",  "xtg-x-cel-gaulish",
     "i-default",    "en-x-i-default",
     "i-enochian",   "und-x-i-enochian",
     "i-mingo",      "see-x-i-mingo",

--- a/icu4c/source/test/intltest/loctest.cpp
+++ b/icu4c/source/test/intltest/loctest.cpp
@@ -4915,6 +4915,9 @@ void LocaleTest::TestCanonicalize(void)
 
         // ICU-21344
         { "ku-Arab-NT", "ku-Arab-IQ"},
+
+        // ICU-21401
+        { "cel-gaulish", "xtg"},
     };
     int32_t i;
     for (i=0; i < UPRV_LENGTHOF(testCases); i++) {

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/ULocaleTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/ULocaleTest.java
@@ -5215,6 +5215,9 @@ public class ULocaleTest extends TestFmwk {
 
         // ICU-21344
         Assert.assertEquals("ku-Arab-IQ", canonicalTag("ku-Arab-NT"));
+
+        // ICU-21401
+        Assert.assertEquals("xtg", canonicalTag("cel-gaulish"));
     }
 
     @Test


### PR DESCRIPTION
Java is already doing so. Just add the same test to also assure it.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21401
- [X] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [X] Tests included
- [X] Documentation is changed or added

