### PR TITLE
ICU-21388 Use a read-only alias string in ucol_openElements and ucol_setText

### DIFF
--- a/icu4c/source/i18n/rulebasedcollator.cpp
+++ b/icu4c/source/i18n/rulebasedcollator.cpp
@@ -1631,6 +1631,19 @@ RuleBasedCollator::createCollationElementIterator(const UnicodeString& source) c
     return cei;
 }
 
+// Same as the above method, but uses a real-only alias of the input source string.
+CollationElementIterator *
+RuleBasedCollator::createCollationElementIteratorReadOnlyAlias(const UnicodeString& source) const {
+    UErrorCode errorCode = U_ZERO_ERROR;
+    if(!initMaxExpansions(errorCode)) { return NULL; }
+    CollationElementIterator *cei = new CollationElementIterator(source, true, this, errorCode);
+    if(U_FAILURE(errorCode)) {
+        delete cei;
+        return NULL;
+    }
+    return cei;
+}
+
 CollationElementIterator *
 RuleBasedCollator::createCollationElementIterator(const CharacterIterator& source) const {
     UErrorCode errorCode = U_ZERO_ERROR;

--- a/icu4c/source/i18n/ucoleitr.cpp
+++ b/icu4c/source/i18n/ucoleitr.cpp
@@ -289,8 +289,11 @@ ucol_openElements(const UCollator  *coll,
         return NULL;
     }
 
+    // Note: This is the UnicodeString readonly-aliasing constructor.
     UnicodeString s((UBool)(textLength < 0), text, textLength);
-    CollationElementIterator *cei = rbc->createCollationElementIterator(s);
+    // The caller must not modify or delete the input text while being used, so we use
+    // the read-only alias CollationElementIterator.
+    CollationElementIterator *cei = rbc->createCollationElementIteratorReadOnlyAlias(s);
     if (cei == NULL) {
         *status = U_MEMORY_ALLOCATION_ERROR;
         return NULL;
@@ -298,7 +301,6 @@ ucol_openElements(const UCollator  *coll,
 
     return cei->toUCollationElements();
 }
-
 
 U_CAPI void U_EXPORT2
 ucol_closeElements(UCollationElements *elems)
@@ -488,8 +490,11 @@ ucol_setText(      UCollationElements *elems,
         *status = U_ILLEGAL_ARGUMENT_ERROR;
         return;
     }
+    // Note: This is the UnicodeString readonly-aliasing constructor.
     UnicodeString s((UBool)(textLength < 0), text, textLength);
-    return CollationElementIterator::fromUCollationElements(elems)->setText(s, *status);
+    // The caller must not modify or delete the input text while being used, so we set readOnly
+    // to true when calling setText.
+    return CollationElementIterator::fromUCollationElements(elems)->setText(s, true, *status);
 }
 
 U_CAPI int32_t U_EXPORT2

--- a/icu4c/source/i18n/unicode/coleitr.h
+++ b/icu4c/source/i18n/unicode/coleitr.h
@@ -242,6 +242,19 @@ public:
     */
     void setText(const UnicodeString& str, UErrorCode& status);
 
+#ifndef U_HIDE_INTERNAL_API
+    /**
+    * Sets the source string. Same as the above setText method, but if readOnly
+    * is true then it uses a read-only alias of the input str string.
+    * The str string must outlive this object's lifetime.
+    * @param str the source string.
+    * @param readOnly use a read-only alias of the str string.
+    * @param status the error code status.
+    * @internal
+    */
+    void setText(const UnicodeString &str, UBool readOnly, UErrorCode &status);
+#endif
+
     /**
     * Sets the source string.
     * @param str the source character iterator.
@@ -322,6 +335,19 @@ private:
     */
     CollationElementIterator(const UnicodeString& sourceText,
         const RuleBasedCollator* order, UErrorCode& status);
+
+   /**
+    * CollationElementIterator read-only alias constructor. Same as the above constructor,
+    * but if readOnly is true then it uses a read-only alias of the sourceText string.
+    * The input source string must outlive this object's lifetime.
+    * @param sourceText    the source string.
+    * @param readOnly      if true, uses a read-only alias of sourceText.
+    * @param order         the collation object.
+    * @param status        the error code status.
+    */
+    CollationElementIterator(const UnicodeString& sourceText, UBool readOnly,
+        const RuleBasedCollator* order, UErrorCode& status);
+
     // Note: The constructors should take settings & tailoring, not a collator,
     // to avoid circular dependencies.
     // However, for operator==() we would need to be able to compare tailoring data for equality

--- a/icu4c/source/i18n/unicode/tblcoll.h
+++ b/icu4c/source/i18n/unicode/tblcoll.h
@@ -234,8 +234,8 @@ public:
 
     /**
      * Creates a collation element iterator for the source string. The caller of
-     * this method is responsible for the memory management of the return
-     * pointer.
+     * this method is responsible for the memory management of the returned pointer.
+     * 
      * @param source the string over which the CollationElementIterator will
      *        iterate.
      * @return the collation element iterator of the source string using this as
@@ -244,6 +244,25 @@ public:
      */
     virtual CollationElementIterator* createCollationElementIterator(
                                            const UnicodeString& source) const;
+
+#ifndef U_HIDE_INTERNAL_API
+     /**
+     * Creates a collation element iterator for the source string. The caller of
+     * this method is responsible for the memory management of the returned pointer.
+     * 
+     * This method is like the above createCollationElementIterator, but instead uses
+     * a read-only alias of the input source string.
+     * The input source string must outlive the returned object's lifetime.
+     * 
+     * @param source the string over which the CollationElementIterator will
+     *        iterate.
+     * @return the collation element iterator of the source string using this as
+     *         the based Collator.
+     * @internal
+     */
+    virtual CollationElementIterator* createCollationElementIteratorReadOnlyAlias(
+                                           const UnicodeString& source) const;
+#endif
 
     /**
      * Creates a collation element iterator for the source. The caller of this


### PR DESCRIPTION
The ICU APIs `ucol_openElements` and `ucol_setText` both are documented as requiring the caller to not modify or change the input string while the respective object is being used to iterate over the text.
(The API docs say "The caller must not modify or delete the text..." while they are being used. See https://github.com/unicode-org/icu/blob/master/icu4c/source/i18n/unicode/ucoleitr.h#L106 for example.)

In other words, they are documented as using a read-only alias of the input string from the caller. 

Both functions already use the `UnicodeString`'s read-only aliasing constructor for the input string arguments. However, some of the implementation methods that they call actually end up unfortunately making full copies of the input string, which hurts performance.

This change adds internal read-only alias methods to the `CollationElementIterator` and `RuleBasedCollator` classes, so that we can avoid making copies of the input string for the `ucol_openElements` and `ucol_setText` APIs.

This helps to improve the performance of not just the `ucol_openElements` and `ucol_setText` APIs, but also the `usearch_*` API, as it relies on the two previous APIs.

----

Note: This change is ported from some performance changes that I made a few months ago in the branch [here](https://github.com/microsoft/icu/tree/user/jefgen/perf-changes-collation).
This PR is for this commit: https://github.com/microsoft/icu/commit/e6301ffbf704ec7b7fb20b006618f0e843c70754
(I thought that splitting up the commits into separate PRs would be easier to review the changes.)

I made these changes while investigating some performance issues for .NET Core. The JIRA ticket has some more info on the observed performance improvements seen when running some of the .NET Core benchmarks (with all of the changes).
[cc: @tarekgh as FYI.]

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21388
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added
