### PR TITLE
ICU-21388 Remove test case that does nothing so RuleBasedCollator can be marked as final.

### DIFF
--- a/icu4c/source/i18n/unicode/tblcoll.h
+++ b/icu4c/source/i18n/unicode/tblcoll.h
@@ -112,7 +112,7 @@ class UVector64;
  * Note, RuleBasedCollator is not to be subclassed.
  * @see        Collator
  */
-class U_I18N_API RuleBasedCollator : public Collator {
+class U_I18N_API RuleBasedCollator U_FINAL : public Collator {
 public:
     /**
      * RuleBasedCollator constructor. This takes the table rules and builds a

--- a/icu4c/source/test/intltest/regcoll.cpp
+++ b/icu4c/source/test/intltest/regcoll.cpp
@@ -984,96 +984,6 @@ void CollationRegressionTest::Test4139572(/* char* par */)
 
     delete col;
 }
-/* HSYS : RuleBasedCollator::compare() performance enhancements
-          compare() does not create CollationElementIterator() anymore.*/
-
-class My4146160Collator : public RuleBasedCollator
-{
-public:
-    My4146160Collator(RuleBasedCollator &rbc, UErrorCode &status);
-    ~My4146160Collator();
-
-    CollationElementIterator *createCollationElementIterator(const UnicodeString &text) const;
-
-    CollationElementIterator *createCollationElementIterator(const CharacterIterator &text) const;
-
-    static int32_t count;
-};
-
-int32_t My4146160Collator::count = 0;
-
-My4146160Collator::My4146160Collator(RuleBasedCollator &rbc, UErrorCode &status)
-  : RuleBasedCollator(rbc.getRules(), status)
-{
-}
-
-My4146160Collator::~My4146160Collator()
-{
-}
-
-CollationElementIterator *My4146160Collator::createCollationElementIterator(const UnicodeString &text) const
-{
-    count += 1;
-    return RuleBasedCollator::createCollationElementIterator(text);
-}
-
-CollationElementIterator *My4146160Collator::createCollationElementIterator(const CharacterIterator &text) const
-{
-    count += 1;
-    return RuleBasedCollator::createCollationElementIterator(text);
-}
-
-// @bug 4146160
-//
-// RuleBasedCollator doesn't use createCollationElementIterator internally
-//
-void CollationRegressionTest::Test4146160(/* char* par */)
-{
-#if 0
-    //
-    // Use a custom collator class whose createCollationElementIterator
-    // methods increment a count....
-    //
-    UErrorCode status = U_ZERO_ERROR;
-    CollationKey key;
-
-    My4146160Collator::count = 0;
-    My4146160Collator *mc = NULL;
-
-    mc = new My4146160Collator(*en_us, status);
-
-    if (mc == NULL || U_FAILURE(status))
-    {
-        errln("Failed to create a My4146160Collator.");
-        delete mc;
-        return;
-    }
-
-    mc->getCollationKey("1", key, status);
-
-    if (key.isBogus() || U_FAILURE(status))
-    {
-        errln("Failure to get a CollationKey from a My4146160Collator.");
-        delete mc;
-        return;
-    }
-
-    if (My4146160Collator::count < 1)
-    {
-        errln("My4146160Collator::createCollationElementIterator not called for getCollationKey");
-    }
-
-    My4146160Collator::count = 0;
-    mc->compare("1", "2");
-
-    if (My4146160Collator::count < 1)
-    {
-        errln("My4146160Collator::createtCollationElementIterator not called for compare");
-    }
-
-    delete mc;
-#endif
-}
 
 void CollationRegressionTest::Test4179216() {
     // you can position a CollationElementIterator in the middle of
@@ -1472,7 +1382,6 @@ void CollationRegressionTest::runIndexedTest(int32_t index, UBool exec, const ch
     TESTCASE_AUTO(Test4133509);
     TESTCASE_AUTO(Test4139572);
     TESTCASE_AUTO(Test4141640);
-    TESTCASE_AUTO(Test4146160);
     TESTCASE_AUTO(Test4179216);
     TESTCASE_AUTO(TestT7189);
     TESTCASE_AUTO(TestCaseFirstCompression);

--- a/icu4c/source/test/intltest/regcoll.h
+++ b/icu4c/source/test/intltest/regcoll.h
@@ -219,12 +219,6 @@ public:
     // Support for Swedish gone in 1.1.6 (Can't create Swedish collator) 
     //
     void Test4141640(/* char* par */);
-    
-    // @bug 4146160
-    //
-    // RuleBasedCollator doesn't use getCollationElementIterator internally
-    //
-    void Test4146160(/* char* par */);
 
     void Test4179216();
 


### PR DESCRIPTION
The `RuleBasedCollator` class isn't marked as `U_FINAL`.

It appears as though the only reason the class isn't marked as final is due to test code in the `intltest` suite which subclasses the `RuleBasedCollator` class.
This is despite the fact that the `RuleBasedCollator` is documented as "not to be subclassed". (See: https://github.com/unicode-org/icu/blob/master/icu4c/source/i18n/unicode/tblcoll.h#L112).

However, the test code calling the test-only subclass has actually been commented out since 1999... see: https://github.com/unicode-org/icu/commit/256f5b22ad48ebcf6e1ec9350d4c7b31579176b9

It appears as though the only intent of the test case was to ensure that the `RuleBasedCollator` called `createCollationElementIterator` (and it did this by adding a `count` member), but the comment from 1999 notes that `RuleBasedCollator` doesn't call `createCollationElementIterator` anymore.

Removing this unused test code allows us to mark the `RuleBasedCollator` class as `U_FINAL` -- which can help the compiler to better optimize things by providing more opportunities for devirtualization.

----

Note: This change is ported from some performance changes that I made a few months ago in the branch [here](https://github.com/microsoft/icu/tree/user/jefgen/perf-changes-collation).
This PR is for this commit: https://github.com/microsoft/icu/commit/45cf36afec69d101b591632ee3d0ed9ba75d3943

I thought that splitting up the commits into separate PRs would be easier to review the changes.
Link to other PRs with perf changes: #1471 #1473

I made these changes while investigating some performance issues for .NET Core. The JIRA ticket has some more info on the observed performance improvements seen when running some of the .NET Core benchmarks (with all of the changes).
[cc: @tarekgh as FYI.]

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21388
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added
