### PR TITLE
ICU-21533 Lazily create the internal break iterator used in StringSearch & improve error handling

### DIFF
--- a/icu4c/source/i18n/usrchimp.h
+++ b/icu4c/source/i18n/usrchimp.h
@@ -135,8 +135,8 @@ struct USearch {
           UBool               isOverlap;
           UBool               isCanonicalMatch;
           int16_t             elementComparisonType;
-          UBreakIterator     *internalBreakIter;  //internal character breakiterator
-          UBreakIterator     *breakIter;
+          UBreakIterator     *internalBreakIter;  // internal character breakiterator, lazily created.
+          UBreakIterator     *breakIter;          // caller provided character breakiterator
     // value USEARCH_DONE is the default value
     // if we are not at the start of the text or the end of the text, 
     // depending on the iteration direction and matchedIndex is USEARCH_DONE 


### PR DESCRIPTION
The `usearch_*` API has an internal character break iterator that it uses for handling combining characters or sequences.

However, the internal break iterator isn't always strictly needed or used though -- for example when matching with pure ASCII text. Creating the break iterator is a somewhat non-trivial operation though...

I did some profiling using ICU 64 on Windows with a test program that called the usearch APIs in a loop (calling `usearch_open`, then `usearch_first`), and on average, anywhere from 7-10% of the time was spent on just creating the break iterator (which wasn't actually ever used).

By lazily creating the break iterator when needed we can improve the performance of the `usearch_*` API for cases where it isn't used.

Additionally, I noticed that there were several places in the code that performed memory allocation(s) without any error checking for OOM. This PR also adds/improves the error checking as well.

----

Note: This change is ported from some performance changes that I made a few months ago in the branch [here](https://github.com/microsoft/icu/tree/user/jefgen/perf-changes-collation).
This PR is for this commit: https://github.com/microsoft/icu/commit/5e4e9b5a2914015710b21647b40ec028dec8a808

I thought that splitting up the commits into separate PRs would be easier to review the changes.
Link to other PRs with perf changes: #1471 #1472

I made these changes while investigating some performance issues for .NET Core. The JIRA ticket has some more info on the observed performance improvements seen when running some of the .NET Core benchmarks (with all of the changes).
[cc: @tarekgh as FYI.]

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21533
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added
