### PR TITLE
ICU-21381 AppVeyor CI Builds: Speed up the Cygwin setup download.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,7 +4,7 @@ image: Visual Studio 2017
 platform: x64
 
 # Don't clone the entire repo.
-clone_depth: 10
+clone_depth: 5
 
 # Cache things between builds to speed things up and save bandwidth.
 cache:
@@ -54,8 +54,14 @@ for:
           if ( !(Test-Path "${env:CYG_CACHED_SETUP}" -NewerThan (Get-Date).AddDays(-7)) )
           {
             Write-Host "Cached Cygwin setup does not exist or is older than 7 days, downloading from external site."
+            
             New-Item -Force -Type Directory $env:CYG_CACHE
-            Invoke-WebRequest $env:CYG_URL -OutFile $env:CYG_CACHED_SETUP
+            Write-Host "Downloading Cygwin setup..."
+            
+            $start_time = Get-Date
+            (New-Object System.Net.WebClient).DownloadFile($env:CYG_URL, $env:CYG_CACHED_SETUP)
+
+            Write-Output "Download took: $((Get-Date).Subtract($start_time).Seconds) second(s)."
           }
       - cmd: >-
           %CYG_CACHED_SETUP% --no-verify --quiet-mode --no-shortcuts --no-startmenu --no-desktop --upgrade-also --only-site --site "%CYG_MIRROR%" --root "%CYG_ROOT%"  --local-package-dir "%CYG_CACHE%" --packages "%CYG_PACKAGES%"


### PR DESCRIPTION
While working on other things, I noticed that the AppVeyor CI setup uses the `Invoke-WebRequest` method to download the Cygwin installer setup program.

Based on experimentation and reading other reports online, it turns out that this is _really_ very slow way to download things. It takes several minutes+ to download files that are only a few megabytes in size. If we use `System.Net.WebClient.DownloadFile` method instead then the download only takes _seconds_.

Changing this should help a bit to speed up the AppVeyor builds.
They have been timing out and failing recently as they are now regularly running up against the 60 minute hard limit on AppVeyor.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21381
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added
