### PR TITLE
ICU-21425 build: updates to maven/publication

### DIFF
--- a/icu4j/maven/icu4j-charset/pom.xml
+++ b/icu4j/maven/icu4j-charset/pom.xml
@@ -20,8 +20,9 @@
 
   <licenses>
     <license>
-      <name>Unicode/ICU License</name>
-      <url>https://raw.githubusercontent.com/unicode-org/icu/master/icu4c/LICENSE</url>
+      <name>Unicode-DFS-2016</name>
+      <url>https://www.unicode.org/copyright.html</url>
+      <comments>Unicode License Agreement - Data Files and Software (2016)</comments>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -62,7 +63,6 @@
     <developer>
       <id>srl295</id>
       <name>Steven Loomis</name>
-      <organization>IBM Corporation</organization>
       <roles>
         <role>PMC Member</role>
       </roles>

--- a/icu4j/maven/icu4j-localespi/pom.xml
+++ b/icu4j/maven/icu4j-localespi/pom.xml
@@ -20,8 +20,9 @@
 
   <licenses>
     <license>
-      <name>Unicode/ICU License</name>
-      <url>https://raw.githubusercontent.com/unicode-org/icu/master/icu4c/LICENSE</url>
+      <name>Unicode-DFS-2016</name>
+      <url>https://www.unicode.org/copyright.html</url>
+      <comment>Unicode License Agreement - Data Files and Software (2016)</comment>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -62,7 +63,6 @@
     <developer>
       <id>srl295</id>
       <name>Steven Loomis</name>
-      <organization>IBM Corporation</organization>
       <roles>
         <role>PMC Member</role>
       </roles>

--- a/icu4j/maven/icu4j/pom.xml
+++ b/icu4j/maven/icu4j/pom.xml
@@ -25,8 +25,9 @@
 
   <licenses>
     <license>
-      <name>Unicode/ICU License</name>
-      <url>https://raw.githubusercontent.com/unicode-org/icu/master/icu4c/LICENSE</url>
+      <name>Unicode-DFS-2016</name>
+      <url>https://www.unicode.org/copyright.html</url>
+      <comments>Unicode License Agreement - Data Files and Software (2016)</comments>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -67,7 +68,6 @@
     <developer>
       <id>srl295</id>
       <name>Steven Loomis</name>
-      <organization>IBM Corporation</organization>
       <roles>
         <role>PMC Member</role>
       </roles>


### PR DESCRIPTION
ICU-21425

- use SPDX license rather than raw license file
- minor srl update
- upload a full pom.xml instead of a generated one

NOTE: this is on the head fork, because it tests workflow stuff.