### PR TITLE
ICU-21363 Resurrect support for IBM's XL compiler

### DIFF
--- a/icu4c/source/runConfigureICU
+++ b/icu4c/source/runConfigureICU
@@ -36,7 +36,7 @@ the runConfigureICU command:
 
 The following names can be supplied as the argument for platform:
 
-    AIX                 Use the IBM Visual Age xlc_r/xlC_r compilers on AIX
+    AIX                 Use the IBM XL xlclang/xlclang compilers on AIX
     AIX/GCC             Use the GNU gcc/g++ compilers on AIX
     Cygwin              Use the GNU gcc/g++ compilers on Cygwin
     Cygwin/MSVC         Use the Microsoft Visual C++ compiler on Cygwin
@@ -49,7 +49,7 @@ The following names can be supplied as the argument for platform:
     Linux/gcc           Use the GNU gcc/g++ compilers on Linux
     Linux/ECC           Use the Intel ECC compiler on Linux
     Linux/ICC           Use the Intel ICC compiler on Linux
-    Linux/VA            Use the IBM Visual Age compiler on Power PC Linux
+    Linux/VA            Use the IBM XL compiler on Power PC Linux
     MacOSX              Use the default compilers on MacOS X (Darwin)
     MacOSX/GCC          Use the GNU gcc/g++ compilers on MacOSX (Darwin)
     MinGW               Use the GNU gcc/g++ compilers on MinGW
@@ -134,17 +134,17 @@ fi
 case $platform in
     AIX)
         THE_OS=AIX
-        THE_COMP="xlC_r"
-        CC=`which xlc_r`; export CC
+        THE_COMP="xlclang"
+        CC=`which xlclang`; export CC
         if [ ! -x $CC ]; then
-           echo "ERROR: xlc_r was not found, please check the PATH to make sure it is correct."; exit 1
+           echo "ERROR: xlclang was not found, please check the PATH to make sure it is correct."; exit 1
         fi
-        CXX=`which xlC_r`; export CXX
+        CXX=`which xlclang++`; export CXX
         if [ ! -x $CXX ]; then
-           echo "ERROR: xlC_r was not found, please check the PATH to make sure it is correct."; exit 1
+           echo "ERROR: xlclang++ was not found, please check the PATH to make sure it is correct."; exit 1
         fi
-        RELEASE_CFLAGS="-O2 -qmaxmem=-1"
-        RELEASE_CXXFLAGS="-O2 -qmaxmem=-1"
+        RELEASE_CFLAGS="-O3"
+        RELEASE_CXXFLAGS="-O3"
         ;;
     AIX/GCC)
         THE_OS=AIX
@@ -228,11 +228,11 @@ case $platform in
         ;;
     Linux/VA)
         THE_OS="Linux"
-        THE_COMP="IBM Visual Age C++ Compiler"
-        CC=`which xlc_r`; export CC
-        CXX=`which xlC_r`; export CXX
-        RELEASE_CFLAGS="-O2 -qmaxmem=-1"
-        RELEASE_CXXFLAGS="-O2 -qmaxmem=-1"
+        THE_COMP="IBM XL C++ Compiler"
+        CC=`which xlclang`; export CC
+        CXX=`which xlclang++`; export CXX
+        RELEASE_CFLAGS="-O3"
+        RELEASE_CXXFLAGS="-O3"
         ;;
     Linux/gcc)
         THE_OS="Linux"


### PR DESCRIPTION
Yoshito is making this change on behalf of @datalogics-robb.
IBM's XL compiler can only support c++11 when the 'clang front end' is used.
This change modifies the configure step to use xlclang and  xlclang++
Change readme.html reference to xlC to refer to xlclang++ instead.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21363
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

