### PR TITLE
ICU-21427 Don't ignore already checked-in files under "tools/cldr/lib".

### DIFF
--- a/tools/cldr/.gitignore
+++ b/tools/cldr/.gitignore
@@ -1,6 +1,8 @@
-# Exclude the Maven local repository but keep the lib directory and the top-level readme.
+# Exclude the Maven local repository but keep the lib directory and the top-level readme, scripts and build config.
 /lib/**
 !/lib/README.txt
+!/lib/install-cldr-jars.sh
+!/lib/pom.xml
 
 # Ignore the default Maven target directory.
 /cldr-to-icu/target


### PR DESCRIPTION
I recently ran into trouble trying to mirror/copy files from one ICU clone to another clone due to there being already checked-in files that were ignored by the `.gitignore` file under `tools/cldr`

The problem is that it excludes everything under the lib folder:
```
/lib/**
```

However, there are 3 checked in files in that folder which likely shouldn't be `gitignored`:
```
install-cldr-jars.txt
README.txt
pom.xml
```

The `README.txt` file is already _excluded_ by the `.gitignore` file:
```
!/lib/README.txt
```
We should likely add the other two files to the `.gitignore` file as well.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21427
- [x] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

