### PR TITLE
ICU-21431 Adds a check to an ICU4C unit test to prevent a segmentatio…

### DIFF
--- a/icu4c/source/test/intltest/numfmtst.cpp
+++ b/icu4c/source/test/intltest/numfmtst.cpp
@@ -10069,6 +10069,9 @@ void NumberFormatTest::Test10997_FormatCurrency() {
 
     UErrorCode error = U_ZERO_ERROR;
     NumberFormat* fmt = NumberFormat::createCurrencyInstance(Locale::getUS(), error);
+    if (U_FAILURE(error)) {
+        return;
+    }
     fmt->setMinimumFractionDigits(4);
     fmt->setMaximumFractionDigits(4);
 


### PR DESCRIPTION
…n fault

if this test runs without ICU data.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21431
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

