### PR TITLE
ICU-21435 Remove -Bsymbolic flag for mingw targets

### DIFF
--- a/icu4c/source/config/mh-mingw
+++ b/icu4c/source/config/mh-mingw
@@ -57,7 +57,7 @@ LINK.c=       $(CXX) $(CXXFLAGS) $(LDFLAGS)
 #LINK.cc=      $(CXX) $(CXXFLAGS) $(LDFLAGS)
 
 ## Shared library options
-LD_SOOPTIONS= -Wl,-Bsymbolic
+LD_SOOPTIONS=
 
 ## Commands to make a shared library
 SHLIB.c=	$(CC) $(CFLAGS) $(LDFLAGS) -shared $(LD_SOOPTIONS) -Wl,--enable-auto-import -Wl,--out-implib=$(dir $@)lib$(notdir $(@:$(SO_TARGET_VERSION_MAJOR).$(SO)=))$(IMPORT_LIB_EXT)#M#

--- a/icu4c/source/config/mh-mingw64
+++ b/icu4c/source/config/mh-mingw64
@@ -57,7 +57,7 @@ LINK.c=       $(CXX) $(CXXFLAGS) $(LDFLAGS)
 #LINK.cc=      $(CXX) $(CXXFLAGS) $(LDFLAGS)
 
 ## Shared library options
-LD_SOOPTIONS= -Wl,-Bsymbolic
+LD_SOOPTIONS=
 
 ## Commands to make a shared library
 SHLIB.c=	$(CC) $(CFLAGS) $(LDFLAGS) -shared $(LD_SOOPTIONS) -Wl,--enable-auto-import -Wl,--out-implib=$(dir $@)lib$(notdir $(@:$(SO_TARGET_VERSION_MAJOR).$(SO)=))$(IMPORT_LIB_EXT)#M#


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21435
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

After doing some research, it seems that the -Bsymbolic flag only makes sense on ELF platforms. The mingw linker driver for lld also doesn't support this flag either, so it should be removed.