### PR TITLE
ICU-13705 Move BasicTimeZone::getOffsetFromLocal() to its parent Timezone

### DIFF
--- a/icu4c/source/i18n/smpdtfmt.cpp
+++ b/icu4c/source/i18n/smpdtfmt.cpp
@@ -2551,18 +2551,12 @@ SimpleDateFormat::parse(const UnicodeString& text, Calendar& cal, ParsePosition&
             // Make sure parsed time zone type (Standard or Daylight)
             // matches the rule used by the parsed time zone.
             int32_t raw, dst;
-            if (btz != NULL) {
-                if (tzTimeType == UTZFMT_TIME_TYPE_STANDARD) {
-                    btz->getOffsetFromLocal(localMillis,
-                        BasicTimeZone::kStandard, BasicTimeZone::kStandard, raw, dst, status);
-                } else {
-                    btz->getOffsetFromLocal(localMillis,
-                        BasicTimeZone::kDaylight, BasicTimeZone::kDaylight, raw, dst, status);
-                }
+            if (tzTimeType == UTZFMT_TIME_TYPE_STANDARD) {
+                tz.getOffsetFromLocal(localMillis,
+                    BasicTimeZone::kStandard, BasicTimeZone::kStandard, raw, dst, status);
             } else {
-                // No good way to resolve ambiguous time at transition,
-                // but following code work in most case.
-                tz.getOffset(localMillis, TRUE, raw, dst, status);
+                tz.getOffsetFromLocal(localMillis,
+                    BasicTimeZone::kDaylight, BasicTimeZone::kDaylight, raw, dst, status);
             }
 
             // Now, compare the results with parsed type, either standard or daylight saving time

--- a/icu4c/source/i18n/unicode/basictz.h
+++ b/icu4c/source/i18n/unicode/basictz.h
@@ -152,24 +152,6 @@ public:
     virtual void getSimpleRulesNear(UDate date, InitialTimeZoneRule*& initial,
         AnnualTimeZoneRule*& std, AnnualTimeZoneRule*& dst, UErrorCode& status) const;
 
-
-#ifndef U_HIDE_INTERNAL_API
-    /**
-     * The time type option bit flags used by getOffsetFromLocal
-     * @internal
-     */
-    enum {
-        kStandard = 0x01,
-        kDaylight = 0x03,
-        kFormer = 0x04,
-        kLatter = 0x0C
-    };
-#endif  /* U_HIDE_INTERNAL_API */
-
-    /**
-     * Get time zone offsets from local wall time.
-     * @internal
-     */
     virtual void getOffsetFromLocal(UDate date, int32_t nonExistingTimeOpt, int32_t duplicatedTimeOpt,
         int32_t& rawOffset, int32_t& dstOffset, UErrorCode& status) const;
 

--- a/icu4c/source/i18n/unicode/timezone.h
+++ b/icu4c/source/i18n/unicode/timezone.h
@@ -829,6 +829,24 @@ public:
     static int32_t U_EXPORT2 getRegion(const UnicodeString& id, 
         char *region, int32_t capacity, UErrorCode& status); 
 
+    /**
+     * The time type option bit flags used by getOffsetFromLocal
+     * @internal
+     */
+    enum {
+        kStandard = 0x01,
+        kDaylight = 0x03,
+        kFormer = 0x04,
+        kLatter = 0x0C
+    };
+
+    /**
+     * Get time zone offsets from local wall time.
+     * @internal
+     */
+    virtual void getOffsetFromLocal(UDate date, int32_t nonExistingTimeOpt, int32_t duplicatedTimeOpt,
+        int32_t& rawOffset, int32_t& dstOffset, UErrorCode& status) const;
+
 protected:
 
     /**


### PR DESCRIPTION
 - Hoist getOffsetFromLocal() to Timezone class from BasicTimezone (Drop 'internal only' bit.)
 - Make the following enums public to control the behavior
   { kStandard, kDaylight, kFormer, kLatter}

 TimeZone implementation of the above method can only support kFormer
 and kLatter (moving what's in Calendar class to TimeZone class).
 Other child classes of BasicTimeZone can support all 4 options as they do
 now.

 This move will simplify some of callers (no need to dynamic_cast to
 BasicTimeZone and branch based on the result of dynamic_cast).

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

