### PR TITLE
ICU-21279 decompose (NFD/NFKD) UTF-8 with Edits

### DIFF
--- a/icu4c/source/common/normalizer2impl.cpp
+++ b/icu4c/source/common/normalizer2impl.cpp
@@ -731,9 +731,131 @@ UBool Normalizer2Impl::decompose(UChar32 c, uint16_t norm16,
     return buffer.append((const UChar *)mapping+1, length, TRUE, leadCC, trailCC, errorCode);
 }
 
+// Dual functionality:
+// sink != nullptr: normalize
+// sink == nullptr: isNormalized/spanQuickCheckYes
+const uint8_t *
+Normalizer2Impl::decomposeUTF8(uint32_t options,
+                               const uint8_t *src, const uint8_t *limit,
+                               ByteSink *sink, Edits *edits, UErrorCode &errorCode) const {
+    U_ASSERT(limit != nullptr);
+    UnicodeString s16;
+    uint8_t minNoLead = leadByteForCP(minDecompNoCP);
+
+    const uint8_t *prevBoundary = src;
+    // only for quick check
+    uint8_t prevCC = 0;
+
+    for (;;) {
+        // Fast path: Scan over a sequence of characters below the minimum "no" code point,
+        // or with (decompYes && ccc==0) properties.
+        const uint8_t *fastStart = src;
+        const uint8_t *prevSrc;
+        uint16_t norm16 = 0;
+
+        for (;;) {
+            if (src == limit) {
+                if (prevBoundary != limit && sink != nullptr) {
+                    ByteSinkUtil::appendUnchanged(prevBoundary, limit,
+                                                  *sink, options, edits, errorCode);
+                }
+                return src;
+            }
+            if (*src < minNoLead) {
+                ++src;
+            } else {
+                prevSrc = src;
+                UCPTRIE_FAST_U8_NEXT(normTrie, UCPTRIE_16, src, limit, norm16);
+                if (!isMostDecompYesAndZeroCC(norm16)) {
+                    break;
+                }
+            }
+        }
+        // isMostDecompYesAndZeroCC(norm16) is false, that is, norm16>=minYesNo,
+        // and the current character at [prevSrc..src[ is not a common case with cc=0
+        // (MIN_NORMAL_MAYBE_YES or JAMO_VT).
+        // It could still be a maybeYes with cc=0.
+        if (prevSrc != fastStart) {
+            // The fast path looped over yes/0 characters before the current one.
+            if (sink != nullptr &&
+                    !ByteSinkUtil::appendUnchanged(prevBoundary, prevSrc,
+                                                   *sink, options, edits, errorCode)) {
+                break;
+            }
+            prevBoundary = prevSrc;
+            prevCC = 0;
+        }
+
+        // Medium-fast path: Quick check.
+        if (isMaybeOrNonZeroCC(norm16)) {
+            // Does not decompose.
+            uint8_t cc = getCCFromYesOrMaybe(norm16);
+            if (prevCC <= cc || cc == 0) {
+                prevCC = cc;
+                if (cc <= 1) {
+                    if (sink != nullptr &&
+                            !ByteSinkUtil::appendUnchanged(prevBoundary, src,
+                                                           *sink, options, edits, errorCode)) {
+                        break;
+                    }
+                    prevBoundary = src;
+                }
+                continue;
+            }
+        }
+        if (sink == nullptr) {
+            return prevBoundary;  // quick check: "no" or cc out of order
+        }
+
+        // Slow path
+        // Decompose up to and including the current character.
+        if (prevBoundary != prevSrc && norm16HasDecompBoundaryBefore(norm16)) {
+            if (!ByteSinkUtil::appendUnchanged(prevBoundary, prevSrc,
+                                               *sink, options, edits, errorCode)) {
+                break;
+            }
+            prevBoundary = prevSrc;
+        }
+        ReorderingBuffer buffer(*this, s16, errorCode);
+        if (U_FAILURE(errorCode)) {
+            break;
+        }
+        decomposeShort(prevBoundary, src, STOP_AT_LIMIT, FALSE /* onlyContiguous */,
+                       buffer, errorCode);
+        // Decompose until the next boundary.
+        if (buffer.getLastCC() > 1) {
+            src = decomposeShort(src, limit, STOP_AT_DECOMP_BOUNDARY, FALSE /* onlyContiguous */,
+                                 buffer, errorCode);
+        }
+        if (U_FAILURE(errorCode)) {
+            break;
+        }
+        if ((src - prevSrc) > INT32_MAX) {  // guard before buffer.equals()
+            errorCode = U_INDEX_OUTOFBOUNDS_ERROR;
+            break;
+        }
+        // We already know there was a change if the original character decomposed;
+        // otherwise compare.
+        if (isMaybeOrNonZeroCC(norm16) && buffer.equals(prevBoundary, src)) {
+            if (!ByteSinkUtil::appendUnchanged(prevBoundary, src,
+                                               *sink, options, edits, errorCode)) {
+                break;
+            }
+        } else {
+            if (!ByteSinkUtil::appendChange(prevBoundary, src, buffer.getStart(), buffer.length(),
+                                            *sink, edits, errorCode)) {
+                break;
+            }
+        }
+        prevBoundary = src;
+        prevCC = 0;
+    }
+    return src;
+}
+
 const uint8_t *
 Normalizer2Impl::decomposeShort(const uint8_t *src, const uint8_t *limit,
-                                UBool stopAtCompBoundary, UBool onlyContiguous,
+                                StopAt stopAt, UBool onlyContiguous,
                                 ReorderingBuffer &buffer, UErrorCode &errorCode) const {
     if (U_FAILURE(errorCode)) {
         return nullptr;
@@ -746,21 +868,28 @@ Normalizer2Impl::decomposeShort(const uint8_t *src, const uint8_t *limit,
         UChar32 c = U_SENTINEL;
         if (norm16 >= limitNoNo) {
             if (isMaybeOrNonZeroCC(norm16)) {
-                // No boundaries around this character.
+                // No comp boundaries around this character.
+                uint8_t cc = getCCFromYesOrMaybe(norm16);
+                if (cc == 0 && stopAt == STOP_AT_DECOMP_BOUNDARY) {
+                    return prevSrc;
+                }
                 c = codePointFromValidUTF8(prevSrc, src);
-                if (!buffer.append(c, getCCFromYesOrMaybe(norm16), errorCode)) {
+                if (!buffer.append(c, cc, errorCode)) {
                     return nullptr;
+                }
+                if (stopAt == STOP_AT_DECOMP_BOUNDARY && buffer.getLastCC() <= 1) {
+                    return src;
                 }
                 continue;
             }
             // Maps to an isCompYesAndZeroCC.
-            if (stopAtCompBoundary) {
+            if (stopAt != STOP_AT_LIMIT) {
                 return prevSrc;
             }
             c = codePointFromValidUTF8(prevSrc, src);
             c = mapAlgorithmic(c, norm16);
             norm16 = getRawNorm16(c);
-        } else if (stopAtCompBoundary && norm16 < minNoNoCompNoMaybeCC) {
+        } else if (stopAt != STOP_AT_LIMIT && norm16 < minNoNoCompNoMaybeCC) {
             return prevSrc;
         }
         // norm16!=INERT guarantees that [prevSrc, src[ is valid UTF-8.
@@ -768,7 +897,8 @@ Normalizer2Impl::decomposeShort(const uint8_t *src, const uint8_t *limit,
         // its norm16==INERT is normalization-inert,
         // so it gets copied unchanged in the fast path,
         // and we stop the slow path where invalid UTF-8 begins.
-        U_ASSERT(norm16 != INERT);
+        // c >= 0 is the result of an algorithmic mapping.
+        U_ASSERT(c >= 0 || norm16 != INERT);
         if (norm16 < minYesNo) {
             if (c < 0) {
                 c = codePointFromValidUTF8(prevSrc, src);
@@ -798,11 +928,15 @@ Normalizer2Impl::decomposeShort(const uint8_t *src, const uint8_t *limit,
             } else {
                 leadCC = 0;
             }
+            if (leadCC == 0 && stopAt == STOP_AT_DECOMP_BOUNDARY) {
+                return prevSrc;
+            }
             if (!buffer.append((const char16_t *)mapping+1, length, TRUE, leadCC, trailCC, errorCode)) {
                 return nullptr;
             }
         }
-        if (stopAtCompBoundary && norm16HasCompBoundaryAfter(norm16, onlyContiguous)) {
+        if ((stopAt == STOP_AT_COMP_BOUNDARY && norm16HasCompBoundaryAfter(norm16, onlyContiguous)) ||
+                (stopAt == STOP_AT_DECOMP_BOUNDARY && buffer.getLastCC() <= 1)) {
             return src;
         }
     }
@@ -1954,10 +2088,10 @@ Normalizer2Impl::composeUTF8(uint32_t options, UBool onlyContiguous,
             break;
         }
         // We know there is not a boundary here.
-        decomposeShort(prevSrc, src, FALSE /* !stopAtCompBoundary */, onlyContiguous,
+        decomposeShort(prevSrc, src, STOP_AT_LIMIT, onlyContiguous,
                        buffer, errorCode);
         // Decompose until the next boundary.
-        src = decomposeShort(src, limit, TRUE /* stopAtCompBoundary */, onlyContiguous,
+        src = decomposeShort(src, limit, STOP_AT_COMP_BOUNDARY, onlyContiguous,
                              buffer, errorCode);
         if (U_FAILURE(errorCode)) {
             break;

--- a/icu4c/source/common/normalizer2impl.h
+++ b/icu4c/source/common/normalizer2impl.h
@@ -491,6 +491,12 @@ public:
                             UnicodeString &safeMiddle,
                             ReorderingBuffer &buffer,
                             UErrorCode &errorCode) const;
+
+    /** sink==nullptr: isNormalized()/spanQuickCheckYes() */
+    const uint8_t *decomposeUTF8(uint32_t options,
+                                 const uint8_t *src, const uint8_t *limit,
+                                 ByteSink *sink, Edits *edits, UErrorCode &errorCode) const;
+
     UBool compose(const UChar *src, const UChar *limit,
                   UBool onlyContiguous,
                   UBool doCompose,
@@ -649,6 +655,9 @@ private:
                                                 UChar32 minNeedDataCP,
                                                 ReorderingBuffer *buffer,
                                                 UErrorCode &errorCode) const;
+
+    enum StopAt { STOP_AT_LIMIT, STOP_AT_DECOMP_BOUNDARY, STOP_AT_COMP_BOUNDARY };
+
     const UChar *decomposeShort(const UChar *src, const UChar *limit,
                                 UBool stopAtCompBoundary, UBool onlyContiguous,
                                 ReorderingBuffer &buffer, UErrorCode &errorCode) const;
@@ -656,7 +665,7 @@ private:
                     ReorderingBuffer &buffer, UErrorCode &errorCode) const;
 
     const uint8_t *decomposeShort(const uint8_t *src, const uint8_t *limit,
-                                  UBool stopAtCompBoundary, UBool onlyContiguous,
+                                  StopAt stopAt, UBool onlyContiguous,
                                   ReorderingBuffer &buffer, UErrorCode &errorCode) const;
 
     static int32_t combine(const uint16_t *list, UChar32 trail);

--- a/icu4c/source/common/unicode/normalizer2.h
+++ b/icu4c/source/common/unicode/normalizer2.h
@@ -225,10 +225,8 @@ public:
      * Normalizes a UTF-8 string and optionally records how source substrings
      * relate to changed and unchanged result substrings.
      *
-     * Currently implemented completely only for "compose" modes,
-     * such as for NFC, NFKC, and NFKC_Casefold
-     * (UNORM2_COMPOSE and UNORM2_COMPOSE_CONTIGUOUS).
-     * Otherwise currently converts to & from UTF-16 and does not support edits.
+     * Implemented completely for all built-in modes except for FCD.
+     * The base class implementation converts to & from UTF-16 and does not support edits.
      *
      * @param options   Options bit set, usually 0. See U_OMIT_UNCHANGED_TEXT and U_EDITS_NO_RESET.
      * @param src       Source UTF-8 string.
@@ -381,11 +379,9 @@ public:
      * resolves to "yes" or "no" to provide a definitive result,
      * at the cost of doing more work in those cases.
      *
-     * This works for all normalization modes,
-     * but it is currently optimized for UTF-8 only for "compose" modes,
-     * such as for NFC, NFKC, and NFKC_Casefold
-     * (UNORM2_COMPOSE and UNORM2_COMPOSE_CONTIGUOUS).
-     * For other modes it currently converts to UTF-16 and calls isNormalized().
+     * This works for all normalization modes.
+     * It is optimized for UTF-8 for all built-in modes except for FCD.
+     * The base class implementation converts to UTF-16 and calls isNormalized().
      *
      * @param s UTF-8 input string
      * @param errorCode Standard ICU error code. Its input value must
@@ -543,10 +539,8 @@ public:
      * Normalizes a UTF-8 string and optionally records how source substrings
      * relate to changed and unchanged result substrings.
      *
-     * Currently implemented completely only for "compose" modes,
-     * such as for NFC, NFKC, and NFKC_Casefold
-     * (UNORM2_COMPOSE and UNORM2_COMPOSE_CONTIGUOUS).
-     * Otherwise currently converts to & from UTF-16 and does not support edits.
+     * Implemented completely for most built-in modes except for FCD.
+     * The base class implementation converts to & from UTF-16 and does not support edits.
      *
      * @param options   Options bit set, usually 0. See U_OMIT_UNCHANGED_TEXT and U_EDITS_NO_RESET.
      * @param src       Source UTF-8 string.
@@ -676,11 +670,9 @@ public:
      * resolves to "yes" or "no" to provide a definitive result,
      * at the cost of doing more work in those cases.
      *
-     * This works for all normalization modes,
-     * but it is currently optimized for UTF-8 only for "compose" modes,
-     * such as for NFC, NFKC, and NFKC_Casefold
-     * (UNORM2_COMPOSE and UNORM2_COMPOSE_CONTIGUOUS).
-     * For other modes it currently converts to UTF-16 and calls isNormalized().
+     * This works for all normalization modes.
+     * It is optimized for UTF-8 for all built-in modes except for FCD.
+     * The base class implementation converts to UTF-16 and calls isNormalized().
      *
      * @param s UTF-8 input string
      * @param errorCode Standard ICU error code. Its input value must

--- a/icu4c/source/test/intltest/normconf.cpp
+++ b/icu4c/source/test/intltest/normconf.cpp
@@ -365,6 +365,10 @@ UBool NormalizerConformanceTest::checkConformance(const UnicodeString* field,
             pass = FALSE;
         }
     }
+    if(options==0 && !isNormalizedUTF8(*nfd, field[2], status)) {
+        dataerrln("Normalizer error: nfd.isNormalizedUTF8(NFD(s)) is FALSE");
+        pass = FALSE;
+    }
     if(!Normalizer::isNormalized(field[3], UNORM_NFKC, options, status)) {
         dataerrln("Normalizer error: isNormalized(NFKC(s), UNORM_NFKC) is FALSE");
         pass = FALSE;
@@ -383,6 +387,10 @@ UBool NormalizerConformanceTest::checkConformance(const UnicodeString* field,
                 pass = FALSE;
             }
         }
+    }
+    if(options==0 && !isNormalizedUTF8(*nfkd, field[4], status)) {
+        dataerrln("Normalizer error: nfkd.isNormalizedUTF8(NFKD(s)) is FALSE");
+        pass = FALSE;
     }
 
     // test FCD quick check and "makeFCD"
@@ -481,7 +489,7 @@ UBool NormalizerConformanceTest::checkNorm(UNormalizationMode mode, int32_t opti
     exp.toUTF8String(exp8);
     std::string out8;
     Edits edits;
-    Edits *editsPtr = (mode == UNORM_NFC || mode == UNORM_NFKC) ? &edits : nullptr;
+    Edits *editsPtr = mode != UNORM_FCD ? &edits : nullptr;
     StringByteSink<std::string> sink(&out8, static_cast<int32_t>(exp8.length()));
     norm2->normalizeUTF8(0, s8, sink, editsPtr, errorCode);
     if (U_FAILURE(errorCode)) {

--- a/icu4c/source/test/intltest/tstnorm.h
+++ b/icu4c/source/test/intltest/tstnorm.h
@@ -47,7 +47,8 @@ public:
     void TestCustomComp();
     void TestCustomFCC();
     void TestFilteredNormalizer2Coverage();
-    void TestNormalizeUTF8WithEdits();
+    void TestComposeUTF8WithEdits();
+    void TestDecomposeUTF8WithEdits();
     void TestLowMappingToEmpty_D();
     void TestLowMappingToEmpty_FCD();
     void TestNormalizeIllFormedText();


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-21279

This replaces the Normalizer2::normalizeUTF8() base class default implementation for NFD/NFKD. The base class converts to UTF-16, normalizes, and converts back; and it does not support Edits.

This PR adds a dedicated Normalizer2Impl::decomposeUTF8() that only converts substrings that do need normalization changes. As usual, the same code is also written to perform the isNormalizedUTF8() and spanQuickCheckYes() operations, but note that there is no public API for the UTF-8 version of spanQuickCheckYes().

There are some changes in the UTF-8 version of decomposeShort() which is now shared with composeUTF8().

There are some changes for wiring this into the Normalizer2 implementation class hierarchy.

The new code is called from the normalization conformance test, and there is a specific test function that covers various edge cases.

## Code review

This is tricky code. I would be happy to walk you through it.

It does logically the same as the UTF-16 `decompose(const UChar *s, ...)` function, especially with a fast path loop that skips over a sequence of characters with NFD_Quick_Check=Yes and ccc=0.

However, the UTF-8 version is significantly different:
In UTF-16, we append to the ReorderingBuffer which wraps the output string object and also takes care of canonical reordering; it can rewrite the last few characters of the output string directly.
By contrast, for UTF-8 we append to a ByteSink, and we cannot rewrite anything that has been committed to there.
We decompose a minimal substring into the UTF-16 ReorderingBuffer and then convert that to UTF-8 on the fly together with writing to the sink.

Also, with Edits support, we want to be precise about which substrings are copied unchanged vs. which are changed.

In these ways, the new decomposeUTF8() is more similar to the existing composeUTF8().

For the nitty-gritty details about the data structure, and especially about how we encode many normalization properties into the 16-bit `norm16` values, see the table in the design doc:
http://site.icu-project.org/design/normalization/custom#TOC-Per-character-lookup-values-.nrm-formatVersion-3