### PR TITLE
ICU-20698 C++ Hashtable allow integer value zero

### DIFF
--- a/icu4c/source/common/hash.h
+++ b/icu4c/source/common/hash.h
@@ -85,15 +85,21 @@ public:
 
     inline int32_t puti(const UnicodeString& key, int32_t value, UErrorCode& status);
 
+    inline int32_t putiAllowZero(const UnicodeString& key, int32_t value, UErrorCode& status);
+
     inline void* get(const UnicodeString& key) const;
 
     inline int32_t geti(const UnicodeString& key) const;
+
+    inline int32_t getiAndFound(const UnicodeString& key, UBool &found) const;
 
     inline void* remove(const UnicodeString& key);
 
     inline int32_t removei(const UnicodeString& key);
 
     inline void removeAll(void);
+
+    inline UBool containsKey(const UnicodeString& key) const;
 
     inline const UHashElement* find(const UnicodeString& key) const;
 
@@ -203,6 +209,11 @@ inline int32_t Hashtable::puti(const UnicodeString& key, int32_t value, UErrorCo
     return uhash_puti(hash, new UnicodeString(key), value, &status);
 }
 
+inline int32_t Hashtable::putiAllowZero(const UnicodeString& key, int32_t value,
+                                        UErrorCode& status) {
+    return uhash_putiAllowZero(hash, new UnicodeString(key), value, &status);
+}
+
 inline void* Hashtable::get(const UnicodeString& key) const {
     return uhash_get(hash, &key);
 }
@@ -211,12 +222,20 @@ inline int32_t Hashtable::geti(const UnicodeString& key) const {
     return uhash_geti(hash, &key);
 }
 
+inline int32_t Hashtable::getiAndFound(const UnicodeString& key, UBool &found) const {
+    return uhash_getiAndFound(hash, &key, &found);
+}
+
 inline void* Hashtable::remove(const UnicodeString& key) {
     return uhash_remove(hash, &key);
 }
 
 inline int32_t Hashtable::removei(const UnicodeString& key) {
     return uhash_removei(hash, &key);
+}
+
+inline UBool Hashtable::containsKey(const UnicodeString& key) const {
+    return uhash_containsKey(hash, &key);
 }
 
 inline const UHashElement* Hashtable::find(const UnicodeString& key) const {

--- a/icu4c/source/common/localeprioritylist.cpp
+++ b/icu4c/source/common/localeprioritylist.cpp
@@ -187,17 +187,18 @@ bool LocalePriorityList::add(const Locale &locale, int32_t weight, UErrorCode &e
         if (U_FAILURE(errorCode)) { return false; }
     }
     LocalPointer<Locale> clone;
-    int32_t index = uhash_geti(map, &locale);
-    if (index != 0) {
+    UBool found = false;
+    int32_t index = uhash_getiAndFound(map, &locale, &found);
+    if (found) {
         // Duplicate: Remove the old item and append it anew.
-        LocaleAndWeight &lw = list->array[index - 1];
+        LocaleAndWeight &lw = list->array[index];
         clone.adoptInstead(lw.locale);
         lw.locale = nullptr;
         lw.weight = 0;
         ++numRemoved;
     }
     if (weight <= 0) {  // do not add q=0
-        if (index != 0) {
+        if (found) {
             // Not strictly necessary but cleaner.
             uhash_removei(map, &locale);
         }
@@ -217,7 +218,7 @@ bool LocalePriorityList::add(const Locale &locale, int32_t weight, UErrorCode &e
             return false;
         }
     }
-    uhash_puti(map, clone.getAlias(), listLength + 1, &errorCode);
+    uhash_putiAllowZero(map, clone.getAlias(), listLength, &errorCode);
     if (U_FAILURE(errorCode)) { return false; }
     LocaleAndWeight &lw = list->array[listLength];
     lw.locale = clone.orphan();

--- a/icu4c/source/tools/gennorm2/extradata.cpp
+++ b/icu4c/source/tools/gennorm2/extradata.cpp
@@ -92,17 +92,18 @@ int32_t ExtraData::writeNoNoMapping(UChar32 c, const Norm &norm,
                                     Hashtable &previousMappings) {
     UnicodeString newMapping;
     int32_t offset=writeMapping(c, norm, newMapping);
-    int32_t previousOffset=previousMappings.geti(newMapping);
-    if(previousOffset!=0) {
+    UBool found=false;
+    int32_t previousOffset=previousMappings.getiAndFound(newMapping, found);
+    if(found) {
         // Duplicate, point to the identical mapping that has already been stored.
-        offset=previousOffset-1;
+        offset=previousOffset;
     } else {
         // Append this new mapping and
         // enter it into the hashtable, avoiding value 0 which is "not found".
         offset=dataString.length()+offset;
         dataString.append(newMapping);
-        IcuToolErrorCode errorCode("gennorm2/writeExtraData()/Hashtable.puti()");
-        previousMappings.puti(newMapping, offset+1, errorCode);
+        IcuToolErrorCode errorCode("gennorm2/writeExtraData()/Hashtable.putiAllowZero()");
+        previousMappings.putiAllowZero(newMapping, offset, errorCode);
     }
     return offset;
 }


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-20698

Same additions for the C++ wrapper as in PR #1521 for the C implementation.

Also change two more callers to use the new functionality.