### PR TITLE
ICU-21116 Fix ListFormatterTest on Android

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/FormattedValueStringBuilderImpl.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/FormattedValueStringBuilderImpl.java
@@ -144,7 +144,8 @@ public class FormattedValueStringBuilderImpl {
                     int end = i - self.zero;
                     // Handle span fields; don't trim them
                     if (currField instanceof SpanFieldPlaceholder) {
-                        assert handleSpan(currField, cfpos, fieldStart, end);
+                        boolean handleResult = handleSpan(currField, cfpos, fieldStart, end);
+                        assert handleResult;
                         return true;
                     }
                     // Grouping separators can be whitespace; don't throw them out!


### PR DESCRIPTION
Android ignores assert statement by default.
The test also failed when running with ant and on OpenJDK runtime
on release-67-1. But no longer fails on master branch.
