### PR TITLE
ICU-21284 More MeasureFormatTest and NumberFormatterApiTest test cases

### DIFF
--- a/icu4c/source/i18n/unicode/measfmt.h
+++ b/icu4c/source/i18n/unicode/measfmt.h
@@ -91,7 +91,8 @@ class DateFormat;
 /**
  * <p><strong>IMPORTANT:</strong> New users are strongly encouraged to see if
  * numberformatter.h fits their use case.  Although not deprecated, this header
- * is provided for backwards compatibility only.
+ * is provided for backwards compatibility only, and has much more limited
+ * capabilities.
  *
  * @see Format
  * @author Alan Liu

--- a/icu4c/source/i18n/units_complexconverter.cpp
+++ b/icu4c/source/i18n/units_complexconverter.cpp
@@ -10,6 +10,7 @@
 #include "cmemory.h"
 #include "number_decimalquantity.h"
 #include "number_roundingutils.h"
+#include "putilimp.h"
 #include "uarrsort.h"
 #include "uassert.h"
 #include "unicode/fmtable.h"
@@ -149,6 +150,12 @@ MaybeStackVector<Measure> ComplexUnitsConverter::convert(double quantity,
             // If quantity is at the limits of double's precision from an
             // integer value, we take that integer value.
             int64_t flooredQuantity = floor(quantity * (1 + DBL_EPSILON));
+            if (uprv_isNaN(quantity)) {
+                // With clang on Linux: floor does not support NaN, resulting in
+                // a giant negative number. For now, we produce "0 feet, NaN
+                // inches". TODO(icu-units#131): revisit desired output.
+                flooredQuantity = 0;
+            }
             intValues[i] = flooredQuantity;
 
             // Keep the residual of the quantity.

--- a/icu4j/main/classes/core/src/com/ibm/icu/text/MeasureFormat.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/MeasureFormat.java
@@ -62,7 +62,8 @@ import com.ibm.icu.util.UResourceBundle;
  * <p>
  * <strong>IMPORTANT:</strong> New users are strongly encouraged to see if
  * {@link NumberFormatter} fits their use case.  Although not deprecated, this
- * class, MeasureFormat, is provided for backwards compatibility only.
+ * class, MeasureFormat, is provided for backwards compatibility only, and has
+ * much more limited capabilities.
  * <hr>
  *
  * <p>

--- a/icu4j/main/classes/core/src/com/ibm/icu/util/MeasureUnit.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/util/MeasureUnit.java
@@ -695,7 +695,8 @@ public class MeasureUnit implements Serializable {
      */
     @Override
     public String toString() {
-        return type + "-" + subType;
+        String result = measureUnitImpl == null ? type + "-" + subType : measureUnitImpl.getIdentifier();
+        return result == null ? "" : result;
     }
 
     /**

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/MeasureUnitTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/MeasureUnitTest.java
@@ -3494,8 +3494,16 @@ public class MeasureUnitTest extends TestFmwk {
             new TestCase("pow2-foot-and-pow2-mile", "square-foot-and-square-mile"),
             new TestCase("gram-square-gram-per-dekagram", "cubic-gram-per-dekagram"),
             new TestCase("kilogram-per-meter-per-second", "kilogram-per-meter-second"),
+            new TestCase("kilometer-per-second-per-megaparsec", "kilometer-per-megaparsec-second"),
 
             // TODO(ICU-21284): Add more test cases once the proper ranking is available.
+            // TODO(ICU-21284,icu-units#70): These cases are the wrong way around:
+            new TestCase("pound-force-foot", "foot-pound-force"),
+            new TestCase("foot-pound-force", "foot-pound-force"),
+            new TestCase("kilowatt-hour", "hour-kilowatt"),
+            new TestCase("hour-kilowatt", "hour-kilowatt"),
+            new TestCase("newton-meter", "meter-newton"),
+            new TestCase("meter-newton", "meter-newton"),
 
             // Testing prefixes are parsed and produced correctly (ensures no
             // collisions in the enum values)
@@ -3661,6 +3669,35 @@ public class MeasureUnitTest extends TestFmwk {
             MeasureUnit m = MeasureUnit.AMPERE.withPrefix(testCase.prefix);
             assertEquals("getPrefixPower()", testCase.expectedPower, m.getPrefix().getPower());
             assertEquals("getPrefixBase()", testCase.expectedBase, m.getPrefix().getBase());
+        }
+    }
+
+    @Test
+    public void TestParseBuiltIns() {
+        for (MeasureUnit unit : MeasureUnit.getAvailable()) {
+            System.out.println("unit ident: " + unit.getIdentifier() + ", type: " + unit.getType());
+            if (unit.getType() == "currency") {
+                continue;
+            }
+
+            // TODO(ICU-21284,icu-units#70): fix normalization. Until then, ignore:
+            if (unit.getIdentifier() == "pound-force-foot") continue;
+            if (unit.getIdentifier() == "kilowatt-hour") continue;
+            if (unit.getIdentifier() == "newton-meter") continue;
+
+            // Prove that all built-in units are parseable, except "generic" temperature:
+            if (unit == MeasureUnit.GENERIC_TEMPERATURE) {
+                try {
+                    MeasureUnit.forIdentifier(unit.getIdentifier());
+                    Assert.fail("GENERIC_TEMPERATURE should not be parseable");
+                } catch (IllegalArgumentException e) {
+                    continue;
+                }
+            } else {
+                MeasureUnit parsed = MeasureUnit.forIdentifier(unit.getIdentifier());
+                assertTrue("parsed MeasureUnit '" + parsed + "'' should equal built-in '" + unit + "'",
+                           unit.equals(parsed));
+            }
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21284
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [X] Tests included
- N/A Documentation is changed or added
- [x] Decide what to do with MeasureFormat (leave as is, or update docs a bit? Test what it can and cannot handle?)
- [x] Test inverse input unit behaviour - **_taken care of by #1565_**
- [x] Test whether (almost) all unit identifiers in the validity file can be parsed

Closes: https://github.com/icu-units/icu/issues/38