### PR TITLE
ICU-21462 ICULocaleService.java has a race condition

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/ICULocaleService.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/ICULocaleService.java
@@ -612,9 +612,9 @@ public class ICULocaleService extends ICUService {
         if (loc != fallbackLocale) {
             synchronized (this) {
                 if (loc != fallbackLocale) {
-                    fallbackLocale = loc;
                     fallbackLocaleName = loc.getBaseName();
                     clearServiceCache();
+                    fallbackLocale = loc;
                 }
             }
         }


### PR DESCRIPTION
##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21462
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

I'm reordering the assignment that gets into this double check synchronized block to be the last step within the block. We want to avoid a scenario where loc is assigned to fallbackLocale before returning the fallbackLocaleName from this function.
