### PR TITLE
ICU-21464 Modifies comments to address warnings when Doxygen 1.8.20 i…

### DIFF
--- a/icu4c/source/Doxyfile.in
+++ b/icu4c/source/Doxyfile.in
@@ -1677,7 +1677,7 @@ COMPACT_LATEX          = NO
 # The default value is: a4.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-PAPER_TYPE             = a4wide
+PAPER_TYPE             = a4
 
 # The EXTRA_PACKAGES tag can be used to specify one or more LaTeX package names
 # that should be included in the LaTeX output. The package can be specified just

--- a/icu4c/source/common/unicode/icuplug.h
+++ b/icu4c/source/common/unicode/icuplug.h
@@ -117,14 +117,13 @@
 /* === Basic types === */
 
 #ifndef U_HIDE_INTERNAL_API
+struct UPlugData;
 /**
  * @{
- * Opaque structure passed to/from a plugin. 
- * use the APIs to access it.
+ * Typedef for opaque structure passed to/from a plugin. 
+ * Use the APIs to access it.
  * @internal ICU 4.4 Technology Preview
  */
-
-struct UPlugData;
 typedef struct UPlugData UPlugData;
 
 /** @} */

--- a/icu4c/source/common/unicode/platform.h
+++ b/icu4c/source/common/unicode/platform.h
@@ -880,6 +880,6 @@ namespace std {
 #else
 #    define U_CALLCONV_FPTR
 #endif
-/* @} */
+/** @} */
 
 #endif  // _PLATFORM_H

--- a/icu4c/source/common/unicode/ucnvsel.h
+++ b/icu4c/source/common/unicode/ucnvsel.h
@@ -45,11 +45,11 @@
  * from the serialized form.
  */
 
+struct UConverterSelector;
 /**
  * @{
- * The selector data structure
+ * Typedef for selector data structure.
  */
-struct UConverterSelector;
 typedef struct UConverterSelector UConverterSelector;
 /** @} */
 

--- a/icu4c/source/common/unicode/unifilt.h
+++ b/icu4c/source/common/unicode/unifilt.h
@@ -40,8 +40,8 @@ U_NAMESPACE_BEGIN
  *
  * <code>UnicodeFilter</code> defines a protocol for selecting a
  * subset of the full range (U+0000 to U+10FFFF) of Unicode characters.
- * Currently, filters are used in conjunction with classes like {@link
- * Transliterator} to only process selected characters through a
+ * Currently, filters are used in conjunction with classes like
+ * {@link Transliterator} to only process selected characters through a
  * transformation.
  *
  * <p>Note: UnicodeFilter currently stubs out two pure virtual methods

--- a/icu4c/source/common/unicode/unistr.h
+++ b/icu4c/source/common/unicode/unistr.h
@@ -44,9 +44,10 @@ struct UConverter;          // unicode/ucnv.h
 #ifndef USTRING_H
 /**
  * \ingroup ustring_ustrlen
+ * @param s Pointer to sequence of UChars.
+ * @return Length of sequence.
  */
-U_CAPI int32_t U_EXPORT2
-u_strlen(const UChar *s);
+U_CAPI int32_t U_EXPORT2 u_strlen(const UChar *s);
 #endif
 
 U_NAMESPACE_BEGIN
@@ -2766,7 +2767,6 @@ public:
    * @param options   Options bit set, usually 0. See U_TITLECASE_NO_LOWERCASE,
    *                  U_TITLECASE_NO_BREAK_ADJUSTMENT, U_TITLECASE_ADJUST_TO_CASED,
    *                  U_TITLECASE_WHOLE_STRING, U_TITLECASE_SENTENCES.
-   * @param options Options bit set, see ucasemap_open().
    * @return A reference to this.
    * @stable ICU 3.8
    */

--- a/icu4c/source/i18n/unicode/translit.h
+++ b/icu4c/source/i18n/unicode/translit.h
@@ -683,8 +683,8 @@ public:
      * unambiguous transliterations.  After the last call to this
      * method, there may be untransliterated text that is waiting for
      * more input to resolve an ambiguity.  In order to perform these
-     * pending transliterations, clients should call {@link
-     * #finishTransliteration } after the last call to this
+     * pending transliterations, clients should call
+     * {@link #finishTransliteration } after the last call to this
      * method has been made.
      *
      * @param text the buffer holding transliterated and untransliterated text
@@ -741,8 +741,7 @@ public:
     /**
      * Transliterates the portion of the text buffer that can be
      * transliterated unambiguosly.  This is a convenience method; see
-     * {@link
-     * #transliterate(Replaceable&, UTransPosition&, const UnicodeString&, UErrorCode&) const }
+     * {@link #transliterate(Replaceable&, UTransPosition&, const UnicodeString&, UErrorCode&) const }
      * for details.
      * @param text the buffer holding transliterated and
      * untransliterated text
@@ -761,8 +760,7 @@ public:
      * <code>transliterate()</code>.
      * @param text the buffer holding transliterated and
      * untransliterated text.
-     * @param index the array of indices previously passed to {@link
-     * #transliterate }
+     * @param index the array of indices previously passed to {@link #transliterate }
      * @stable ICU 2.0
      */
     virtual void finishTransliteration(Replaceable& text,
@@ -968,8 +966,8 @@ public:
 
     /**
      * Returns a name for this transliterator that is appropriate for
-     * display to the user in the default locale.  See {@link
-     * #getDisplayName } for details.
+     * display to the user in the default locale.  See {@link #getDisplayName }
+     * for details.
      * @param ID     the string identifier for this transliterator
      * @param result Output param to receive the display name
      * @return       A reference to 'result'.
@@ -1168,8 +1166,8 @@ public:
      * input text by this Transliterator.  This incorporates this
      * object's current filter; if the filter is changed, the return
      * value of this function will change.  The default implementation
-     * returns an empty set.  Some subclasses may override {@link
-     * #handleGetSourceSet } to return a more precise result.  The
+     * returns an empty set.  Some subclasses may override
+     * {@link #handleGetSourceSet } to return a more precise result. The
      * return result is approximate in any case and is intended for
      * use by tests, tools, or utilities.
      * @param result receives result set; previous contents lost

--- a/icu4c/source/layoutex/layout/playout.h
+++ b/icu4c/source/layoutex/layout/playout.h
@@ -164,11 +164,6 @@ U_CAPI UBiDiDirection U_EXPORT2
 pl_getTextDirection(pl_paragraph *paragraph);
 
 /**
- * Get the max ascent value for all the fonts
- * in the paragraph.
- *
- * @param paragraph the <code>pl_paragraph</code>
- *
  * Return the max ascent value for all the fonts
  * in the paragraph.
  *


### PR DESCRIPTION
…s used to build the ICU4C docs. Typical changes: avoid linebreaks in `{@link ...}`
declarations, remove duplicate `@param` declaration.

The document building task in GHA CI is designed to fail upon warnings but currently
still passes because GHA uses an older version of Doxygen.

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21464
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

