### PR TITLE
ICU-21465 Cherry-pick: Fix Windows Time Zone mapping when the Automatic DST setting is OFF to ICU 68.

### DIFF
--- a/icu4c/source/common/wintz.cpp
+++ b/icu4c/source/common/wintz.cpp
@@ -124,10 +124,26 @@ uprv_detectWindowsTimeZone()
         // No way to support when DST is turned off and the offset in minutes is not a multiple of 60.
         if (utcOffsetMins % 60 == 0) {
             char gmtOffsetTz[11] = {}; // "Etc/GMT+dd" is 11-char long with a terminal null.
-            // Note '-' before 'utcOffsetMin'. The timezone ID's sign convention
-            // is that a timezone ahead of UTC is Etc/GMT-<offset> and a timezone
-            // behind UTC is Etc/GMT+<offset>.
-            int ret = snprintf(gmtOffsetTz, UPRV_LENGTHOF(gmtOffsetTz), "Etc/GMT%+ld", -utcOffsetMins / 60);
+            // Important note on the sign convention for zones:
+            //
+            // From https://en.wikipedia.org/wiki/Tz_database#Area
+            //   "In order to conform with the POSIX style, those zone names beginning with "Etc/GMT" have their sign reversed
+            //   from the standard ISO 8601 convention. In the "Etc" area, zones west of GMT have a positive sign and those
+            //   east have a negative sign in their name (e.g "Etc/GMT-14" is 14 hours ahead of GMT)."
+            //
+            // Regarding the POSIX style, from https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html
+            //   "The offset specifies the time value you must add to the local time to get a Coordinated Universal Time value."
+            //
+            // However, the Bias value in DYNAMIC_TIME_ZONE_INFORMATION *already* follows the POSIX convention.
+            // 
+            // From https://docs.microsoft.com/en-us/windows/win32/api/timezoneapi/ns-timezoneapi-dynamic_time_zone_information
+            //   "The bias is the difference, in minutes, between Coordinated Universal Time (UTC) and
+            //   local time. All translations between UTC and local time are based on the following formula:
+            //      UTC = local time + bias"
+            //
+            // For example, a time zone that is 3 hours ahead of UTC (UTC+03:00) would have a Bias value of -180, and the
+            // corresponding time zone ID would be "Etc/GMT-3". (So there is no need to negate utcOffsetMins below.)
+            int ret = snprintf(gmtOffsetTz, UPRV_LENGTHOF(gmtOffsetTz), "Etc/GMT%+ld", utcOffsetMins / 60);
             if (ret > 0 && ret < UPRV_LENGTHOF(gmtOffsetTz)) {
                 return uprv_strdup(gmtOffsetTz);
             }


### PR DESCRIPTION
This PR is cherry-picking the change from PR #1539 into the `maint/maint-68` branch. (Cherry-picked from commit a1a1fafb7d1a0e1c9beee626b6b57e63c27b901b).

#### From the other PR description:

This PR fixes a bug in the changes for ICU-13845, for handling when the "Automatic DST" setting is OFF in the Control Panel.

It turns out that the offset value for the calculated time zone when the "Automatic DST" setting is turn off is wrong. The sign for the time zone offset is flipped. (It's positive when it should be negative, and vice-versa).

I think this was perhaps due to confusion about the value for the UTC offset, how POSIX style offsets are handled, and what is reported by the Win32 API `GetDynamicTimeZoneInformation`.
It seems that this issue was actually present in the original PR for ICU-13845 here: https://github.com/unicode-org/icu/pull/1297 , and it was missed in the reviews on the other PR for the ticket here: https://github.com/unicode-org/icu/pull/1362 .

I also missed this when I was manually testing out the changes, as I was expecting the wrong values for the offset to be reported. (For example, `Etc/GMT-8` instead of `Etc/GMT+8`). 

Note: The actual change here is only one character. The rest are comments that I added in order to help explain things for others in the future.

#### Testing:
I created a document that has different manual test cases that exercise various scenarios for most of the code paths for the Windows TZ mapping in ICU. (I also added notes on what the various test cases are exercising in the code.)
Link: https://docs.google.com/document/d/17Y_Ns4EBV8wnHioJNFc-dJCRRpJ3hpJZDYmTq6ekIsM
(The test case 7 in the document reproduces the issue that this PR fixes).

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21465
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

