### PR TITLE
ICU-21472 Update ICU to support latest CLDR units updates (ofglucose, new constants)

### DIFF
--- a/icu4c/source/data/misc/units.txt
+++ b/icu4c/source/data/misc/units.txt
@@ -279,7 +279,7 @@ units:table(nofallback){
             target{"second"}
         }
         mole{
-            factor{"6.02214076E+23"}
+            factor{"item_per_mole"}
             target{"item"}
         }
         month{
@@ -297,6 +297,10 @@ units:table(nofallback){
         newton{
             factor{"1"}
             target{"kilogram-meter-per-square-second"}
+        }
+        ofglucose{
+            factor{"1000*item_per_mole/glucose_molar_mass"}
+            target{"item-per-kilogram"}
         }
         ofhg{
             factor{"13595.1*gravity"}
@@ -459,8 +463,10 @@ units:table(nofallback){
         ft_to_m{"0.3048"}
         gal_imp_to_m3{"0.00454609"}
         gal_to_m3{"231*in3_to_m3"}
+        glucose_molar_mass{"180.1557"}
         gravity{"9.80665"}
         in3_to_m3{"ft3_to_m3/12*12*12"}
+        item_per_mole{"6.02214076E+23"}
         lb_to_kg{"0.45359237"}
     }
     unitPreferenceData{
@@ -546,6 +552,11 @@ units:table(nofallback){
         }
         "concentration"{
             "blood-glucose"{
+                001{
+                    {
+                        unit{"milligram-ofglucose-per-deciliter"}
+                    }
+                }
                 AG{
                     {
                         unit{"millimole-per-liter"}
@@ -1543,13 +1554,6 @@ units:table(nofallback){
             }
         }
         "mass-density"{
-            "blood-glucose"{
-                001{
-                    {
-                        unit{"milligram-per-deciliter"}
-                    }
-                }
-            }
             "default"{
                 001{
                     {
@@ -1912,9 +1916,9 @@ units:table(nofallback){
         em{"typewidth"}
         item{"substance-amount"}
         item-per-cubic-meter{"concentration"}
+        item-per-kilogram{"concentration-mass"}
         kelvin{"temperature"}
         kilogram{"mass"}
-        kilogram-meter-per-meter-square-second{"torque"}
         kilogram-meter-per-square-second{"force"}
         kilogram-per-cubic-meter{"mass-density"}
         kilogram-per-kilogram{"mass-fraction"}

--- a/icu4c/source/i18n/units_converter.cpp
+++ b/icu4c/source/i18n/units_converter.cpp
@@ -384,6 +384,10 @@ void U_I18N_API addSingleFactorConstant(StringPiece baseStr, int32_t power, Sign
         factor.constantExponents[CONSTANT_GRAVITY] += power * signum;
     } else if (baseStr == "lb_to_kg") {
         factor.constantExponents[CONSTANT_LB2KG] += power * signum;
+    } else if (baseStr == "glucose_molar_mass") {
+        factor.constantExponents[CONSTANT_GLUCOSE_MOLAR_MASS] += power * signum;
+    } else if (baseStr == "item_per_mole") {
+        factor.constantExponents[CONSTANT_ITEM_PER_MOLE] += power * signum;
     } else if (baseStr == "PI") {
         factor.constantExponents[CONSTANT_PI] += power * signum;
     } else {

--- a/icu4c/source/i18n/units_converter.h
+++ b/icu4c/source/i18n/units_converter.h
@@ -28,6 +28,8 @@ enum Constants {
     CONSTANT_G,          // Newtonian constant of gravitation, "G".
     CONSTANT_GAL_IMP2M3, // Gallon imp to m3
     CONSTANT_LB2KG,      // Pound to Kilogram
+    CONSTANT_GLUCOSE_MOLAR_MASS,
+    CONSTANT_ITEM_PER_MOLE,
 
     // Must be the last element.
     CONSTANTS_COUNT
@@ -45,6 +47,8 @@ static const double constantsValues[CONSTANTS_COUNT] = {
     6.67408E-11,               // CONSTANT_G
     0.00454609,                // CONSTANT_GAL_IMP2M3
     0.45359237,                // CONSTANT_LB2KG
+    180.1557,                  // CONSTANT_GLUCOSE_MOLAR_MASS
+    6.02214076E+23,            // CONSTANT_ITEM_PER_MOLE
 };
 
 typedef enum Signum {

--- a/icu4c/source/test/testdata/cldr/units/unitPreferencesTest.txt
+++ b/icu4c/source/test/testdata/cldr/units/unitPreferencesTest.txt
@@ -1,5 +1,5 @@
 # Test data for unit preferences
-#  Copyright © 1991-2020 Unicode, Inc.
+#  Copyright © 1991-2021 Unicode, Inc.
 #  For terms of use, see http://www.unicode.org/copyright.html
 #  Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 #  CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -62,6 +62,10 @@ area;	land;	GB;	1422722961 / 390625;	3642.17078016;	square-meter;	9 / 10;	0.9;	a
 concentration;	blood-glucose;	AG;	662435483600000000000000;	6.624354836E23;	item-per-cubic-meter;	11 / 10;	1.1;	millimole-per-liter
 concentration;	blood-glucose;	AG;	602214076000000000000000;	6.02214076E23;	item-per-cubic-meter;	1;	1.0;	millimole-per-liter
 concentration;	blood-glucose;	AG;	541992668400000000000000;	5.419926684E23;	item-per-cubic-meter;	9 / 10;	0.9;	millimole-per-liter
+
+concentration;	blood-glucose;	001;	66243548360000000000000000000 / 1801557;	3.67701651182838E22;	item-per-cubic-meter;	11 / 10;	1.1;	milligram-ofglucose-per-deciliter
+concentration;	blood-glucose;	001;	60221407600000000000000000000 / 1801557;	3.342742283480345E22;	item-per-cubic-meter;	1;	1.0;	milligram-ofglucose-per-deciliter
+concentration;	blood-glucose;	001;	6022140760000000000000000000 / 200173;	3.008468055132311E22;	item-per-cubic-meter;	9 / 10;	0.9;	milligram-ofglucose-per-deciliter
 
 concentration;	default;	001;	11 / 10;	1.1;	item-per-cubic-meter;	11 / 10;	1.1;	item-per-cubic-meter
 concentration;	default;	001;	1;	1.0;	item-per-cubic-meter;	1;	1.0;	item-per-cubic-meter
@@ -188,6 +192,8 @@ length;	road;	001;	900;	900.0;	meter;	9 / 10;	0.9;	kilometer
 length;	road;	001;	800;	800.0;	meter;	800;	800.0;	meter
 length;	road;	001;	300;	300.0;	meter;	300;	300.0;	meter
 length;	road;	001;	2999 / 10;	299.9;	meter;	2999 / 10;	299.9;	meter
+length;	road;	001;	10;	10.0;	meter;	10;	10.0;	meter
+length;	road;	001;	99 / 10;	9.9;	meter;	99 / 10;	9.9;	meter
 length;	road;	001;	1;	1.0;	meter;	1;	1.0;	meter
 length;	road;	001;	9 / 10;	0.9;	meter;	9 / 10;	0.9;	meter
 
@@ -196,6 +202,8 @@ length;	road;	US;	100584 / 125;	804.672;	meter;	1 / 2;	0.5;	mile
 length;	road;	US;	402336 / 625;	643.7376;	meter;	2112;	2112.0;	foot
 length;	road;	US;	762 / 25;	30.48;	meter;	100;	100.0;	foot
 length;	road;	US;	380619 / 12500;	30.44952;	meter;	999 / 10;	99.9;	foot
+length;	road;	US;	381 / 125;	3.048;	meter;	10;	10.0;	foot
+length;	road;	US;	37719 / 12500;	3.01752;	meter;	99 / 10;	9.9;	foot
 length;	road;	US;	381 / 1250;	0.3048;	meter;	1;	1.0;	foot
 length;	road;	US;	3429 / 12500;	0.27432;	meter;	9 / 10;	0.9;	foot
 
@@ -204,6 +212,8 @@ length;	road;	GB;	100584 / 125;	804.672;	meter;	1 / 2;	0.5;	mile
 length;	road;	GB;	402336 / 625;	643.7376;	meter;	704;	704.0;	yard
 length;	road;	GB;	2286 / 25;	91.44;	meter;	100;	100.0;	yard
 length;	road;	GB;	1141857 / 12500;	91.34856;	meter;	999 / 10;	99.9;	yard
+length;	road;	GB;	1143 / 125;	9.144;	meter;	10;	10.0;	yard
+length;	road;	GB;	113157 / 12500;	9.05256;	meter;	99 / 10;	9.9;	yard
 length;	road;	GB;	1143 / 1250;	0.9144;	meter;	1;	1.0;	yard
 length;	road;	GB;	10287 / 12500;	0.82296;	meter;	9 / 10;	0.9;	yard
 
@@ -214,6 +224,8 @@ length;	road;	SE;	1000;	1000.0;	meter;	1;	1.0;	kilometer
 length;	road;	SE;	900;	900.0;	meter;	900;	900.0;	meter
 length;	road;	SE;	300;	300.0;	meter;	300;	300.0;	meter
 length;	road;	SE;	2999 / 10;	299.9;	meter;	2999 / 10;	299.9;	meter
+length;	road;	SE;	10;	10.0;	meter;	10;	10.0;	meter
+length;	road;	SE;	99 / 10;	9.9;	meter;	99 / 10;	9.9;	meter
 length;	road;	SE;	1;	1.0;	meter;	1;	1.0;	meter
 length;	road;	SE;	9 / 10;	0.9;	meter;	9 / 10;	0.9;	meter
 
@@ -296,10 +308,6 @@ mass;	person;	GB;	408233133 / 1000000000;	0.408233133;	kilogram;	0;	pound;	72 / 
 mass;	person;	HK;	498951607 / 1000000000;	0.498951607;	kilogram;	1;	pound;	8 / 5;	1.6;	ounce
 mass;	person;	HK;	45359237 / 100000000;	0.45359237;	kilogram;	1;	pound;	0;	0.0;	ounce
 mass;	person;	HK;	408233133 / 1000000000;	0.408233133;	kilogram;	0;	pound;	72 / 5;	14.4;	ounce
-
-mass-density;	blood-glucose;	001;	11 / 1000;	0.011;	kilogram-per-cubic-meter;	11 / 10;	1.1;	milligram-per-deciliter
-mass-density;	blood-glucose;	001;	1 / 100;	0.01;	kilogram-per-cubic-meter;	1;	1.0;	milligram-per-deciliter
-mass-density;	blood-glucose;	001;	9 / 1000;	0.009;	kilogram-per-cubic-meter;	9 / 10;	0.9;	milligram-per-deciliter
 
 mass-density;	default;	001;	11 / 10;	1.1;	kilogram-per-cubic-meter;	11 / 10;	1.1;	kilogram-per-cubic-meter
 mass-density;	default;	001;	1;	1.0;	kilogram-per-cubic-meter;	1;	1.0;	kilogram-per-cubic-meter

--- a/icu4c/source/test/testdata/cldr/units/unitsTest.txt
+++ b/icu4c/source/test/testdata/cldr/units/unitsTest.txt
@@ -1,5 +1,5 @@
 # Test data for unit conversions
-#  Copyright © 1991-2020 Unicode, Inc.
+#  Copyright © 1991-2021 Unicode, Inc.
 #  For terms of use, see http://www.unicode.org/copyright.html
 #  Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 #  CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -31,7 +31,9 @@ area	;	acre	;	square-meter	;	4,046.8564224 * x	;	4046856.0
 area	;	hectare	;	square-meter	;	10,000 * x	;	1.0E7
 area	;	square-kilometer	;	square-meter	;	1,000,000 * x	;	1.0E9
 area	;	square-mile	;	square-meter	;	2,589,988.110336 * x	;	2.589988E9
+concentration	;	milligram-ofglucose-per-deciliter	;	kilogram-item-per-kilogram-cubic-meter	;	60,221,407,600,000,000,000,000,000,000/1,801,557 * x	;	3.342742E25
 concentration	;	millimole-per-liter	;	item-per-cubic-meter	;	602,214,076,000,000,000,000,000 * x	;	6.022141E26
+concentration-mass	;	ofglucose	;	item-per-kilogram	;	6,022,140,760,000,000,000,000,000,000,000/1,801,557 * x	;	3.342742E27
 consumption	;	liter-per-100-kilometer	;	cubic-meter-per-meter	;	0.00000001 * x	;	1.0E-5
 consumption	;	liter-per-kilometer	;	cubic-meter-per-meter	;	0.000001 * x	;	0.001
 consumption-inverse	;	mile-per-gallon-imperial	;	meter-per-cubic-meter	;	160,934,400,000/454,609 * x	;	3.540062E8
@@ -121,7 +123,6 @@ mass	;	ton	;	kilogram	;	907.18474 * x	;	907184.7
 mass	;	metric-ton	;	kilogram	;	1,000 * x	;	1000000.0
 mass	;	earth-mass	;	kilogram	;	5,972,200,000,000,000,000,000,000 * x	;	5.9722E27
 mass	;	solar-mass	;	kilogram	;	1,988,470,000,000,000,000,000,000,000,000 * x	;	1.98847E33
-mass-density	;	milligram-per-deciliter	;	kilogram-per-cubic-meter	;	0.01 * x	;	10.0
 portion	;	permillion	;	portion	;	0.000001 * x	;	0.001
 portion	;	permyriad	;	portion	;	0.0001 * x	;	0.1
 portion	;	permille	;	portion	;	0.001 * x	;	1.0

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/units/UnitConverter.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/units/UnitConverter.java
@@ -119,6 +119,8 @@ public class UnitConverter {
         private int exponentGalImpToM3 = 0;
         /** Exponent for the pound to kilogram conversion rate constant */
         private int exponentLbToKg = 0;
+        private int exponentGlucoseMolarMass = 0;
+        private int exponentItemPerMole = 0;
 
         /**
          * Creates Empty Factor
@@ -170,6 +172,8 @@ public class UnitConverter {
             result.exponentG = this.exponentG;
             result.exponentGalImpToM3 = this.exponentGalImpToM3;
             result.exponentLbToKg = this.exponentLbToKg;
+            result.exponentGlucoseMolarMass = this.exponentGlucoseMolarMass;
+            result.exponentItemPerMole = this.exponentItemPerMole;
 
             return result;
         }
@@ -195,6 +199,8 @@ public class UnitConverter {
             resultCollector.multiply(new BigDecimal("6.67408E-11"), this.exponentG);
             resultCollector.multiply(new BigDecimal("0.00454609"), this.exponentGalImpToM3);
             resultCollector.multiply(new BigDecimal("0.45359237"), this.exponentLbToKg);
+            resultCollector.multiply(new BigDecimal("180.1557"), this.exponentGlucoseMolarMass);
+            resultCollector.multiply(new BigDecimal("6.02214076E+23"), this.exponentItemPerMole);
 
             return resultCollector.factorNum.divide(resultCollector.factorDen, DECIMAL128);
         }
@@ -249,6 +255,8 @@ public class UnitConverter {
             result.exponentG = this.exponentG * power;
             result.exponentGalImpToM3 = this.exponentGalImpToM3 * power;
             result.exponentLbToKg = this.exponentLbToKg * power;
+            result.exponentGlucoseMolarMass = this.exponentGlucoseMolarMass * power;
+            result.exponentItemPerMole = this.exponentItemPerMole * power;
 
             return result;
         }
@@ -264,6 +272,9 @@ public class UnitConverter {
             result.exponentG = this.exponentG - other.exponentG;
             result.exponentGalImpToM3 = this.exponentGalImpToM3 - other.exponentGalImpToM3;
             result.exponentLbToKg = this.exponentLbToKg - other.exponentLbToKg;
+            result.exponentGlucoseMolarMass =
+                this.exponentGlucoseMolarMass - other.exponentGlucoseMolarMass;
+            result.exponentItemPerMole = this.exponentItemPerMole - other.exponentItemPerMole;
 
             return result;
         }
@@ -279,6 +290,9 @@ public class UnitConverter {
             result.exponentG = this.exponentG + other.exponentG;
             result.exponentGalImpToM3 = this.exponentGalImpToM3 + other.exponentGalImpToM3;
             result.exponentLbToKg = this.exponentLbToKg + other.exponentLbToKg;
+            result.exponentGlucoseMolarMass =
+                this.exponentGlucoseMolarMass + other.exponentGlucoseMolarMass;
+            result.exponentItemPerMole = this.exponentItemPerMole + other.exponentItemPerMole;
 
             return result;
         }
@@ -318,6 +332,10 @@ public class UnitConverter {
                 this.exponentGravity += power;
             } else if ("lb_to_kg".equals(entity)) {
                 this.exponentLbToKg += power;
+            } else if ("glucose_molar_mass".equals(entity)) {
+                this.exponentGlucoseMolarMass += power;
+            } else if ("item_per_mole".equals(entity)) {
+                this.exponentItemPerMole += power;
             } else if ("PI".equals(entity)) {
                 this.exponentPi += power;
             } else {

--- a/icu4j/main/shared/data/icudata.jar
+++ b/icu4j/main/shared/data/icudata.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a06cc5edfa390f101ee383d479e647467eda4ba3abc28ac548d36b41e3403e3
-size 13294453
+oid sha256:a4adc39da0522d36906b035fe47aa7a9becfefaa4a5ccef2cdf6f5c23d194777
+size 13306768

--- a/icu4j/main/shared/data/icutzdata.jar
+++ b/icu4j/main/shared/data/icutzdata.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b111cd4ab31c64de1c37fc7a7237f9bd5538469b86aaa3a75e5e24ffa20a81a8
-size 95086
+oid sha256:4dce4d778b403e5b91fbe11eba9e0b342c9fe28f2c8d39c7ae8641b311c9a71f
+size 95083

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/data/cldr/units/unitPreferencesTest.txt
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/data/cldr/units/unitPreferencesTest.txt
@@ -1,5 +1,5 @@
 # Test data for unit preferences
-#  Copyright © 1991-2020 Unicode, Inc.
+#  Copyright © 1991-2021 Unicode, Inc.
 #  For terms of use, see http://www.unicode.org/copyright.html
 #  Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 #  CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -62,6 +62,10 @@ area;	land;	GB;	1422722961 / 390625;	3642.17078016;	square-meter;	9 / 10;	0.9;	a
 concentration;	blood-glucose;	AG;	662435483600000000000000;	6.624354836E23;	item-per-cubic-meter;	11 / 10;	1.1;	millimole-per-liter
 concentration;	blood-glucose;	AG;	602214076000000000000000;	6.02214076E23;	item-per-cubic-meter;	1;	1.0;	millimole-per-liter
 concentration;	blood-glucose;	AG;	541992668400000000000000;	5.419926684E23;	item-per-cubic-meter;	9 / 10;	0.9;	millimole-per-liter
+
+concentration;	blood-glucose;	001;	66243548360000000000000000000 / 1801557;	3.67701651182838E22;	item-per-cubic-meter;	11 / 10;	1.1;	milligram-ofglucose-per-deciliter
+concentration;	blood-glucose;	001;	60221407600000000000000000000 / 1801557;	3.342742283480345E22;	item-per-cubic-meter;	1;	1.0;	milligram-ofglucose-per-deciliter
+concentration;	blood-glucose;	001;	6022140760000000000000000000 / 200173;	3.008468055132311E22;	item-per-cubic-meter;	9 / 10;	0.9;	milligram-ofglucose-per-deciliter
 
 concentration;	default;	001;	11 / 10;	1.1;	item-per-cubic-meter;	11 / 10;	1.1;	item-per-cubic-meter
 concentration;	default;	001;	1;	1.0;	item-per-cubic-meter;	1;	1.0;	item-per-cubic-meter
@@ -188,6 +192,8 @@ length;	road;	001;	900;	900.0;	meter;	9 / 10;	0.9;	kilometer
 length;	road;	001;	800;	800.0;	meter;	800;	800.0;	meter
 length;	road;	001;	300;	300.0;	meter;	300;	300.0;	meter
 length;	road;	001;	2999 / 10;	299.9;	meter;	2999 / 10;	299.9;	meter
+length;	road;	001;	10;	10.0;	meter;	10;	10.0;	meter
+length;	road;	001;	99 / 10;	9.9;	meter;	99 / 10;	9.9;	meter
 length;	road;	001;	1;	1.0;	meter;	1;	1.0;	meter
 length;	road;	001;	9 / 10;	0.9;	meter;	9 / 10;	0.9;	meter
 
@@ -196,6 +202,8 @@ length;	road;	US;	100584 / 125;	804.672;	meter;	1 / 2;	0.5;	mile
 length;	road;	US;	402336 / 625;	643.7376;	meter;	2112;	2112.0;	foot
 length;	road;	US;	762 / 25;	30.48;	meter;	100;	100.0;	foot
 length;	road;	US;	380619 / 12500;	30.44952;	meter;	999 / 10;	99.9;	foot
+length;	road;	US;	381 / 125;	3.048;	meter;	10;	10.0;	foot
+length;	road;	US;	37719 / 12500;	3.01752;	meter;	99 / 10;	9.9;	foot
 length;	road;	US;	381 / 1250;	0.3048;	meter;	1;	1.0;	foot
 length;	road;	US;	3429 / 12500;	0.27432;	meter;	9 / 10;	0.9;	foot
 
@@ -204,6 +212,8 @@ length;	road;	GB;	100584 / 125;	804.672;	meter;	1 / 2;	0.5;	mile
 length;	road;	GB;	402336 / 625;	643.7376;	meter;	704;	704.0;	yard
 length;	road;	GB;	2286 / 25;	91.44;	meter;	100;	100.0;	yard
 length;	road;	GB;	1141857 / 12500;	91.34856;	meter;	999 / 10;	99.9;	yard
+length;	road;	GB;	1143 / 125;	9.144;	meter;	10;	10.0;	yard
+length;	road;	GB;	113157 / 12500;	9.05256;	meter;	99 / 10;	9.9;	yard
 length;	road;	GB;	1143 / 1250;	0.9144;	meter;	1;	1.0;	yard
 length;	road;	GB;	10287 / 12500;	0.82296;	meter;	9 / 10;	0.9;	yard
 
@@ -214,6 +224,8 @@ length;	road;	SE;	1000;	1000.0;	meter;	1;	1.0;	kilometer
 length;	road;	SE;	900;	900.0;	meter;	900;	900.0;	meter
 length;	road;	SE;	300;	300.0;	meter;	300;	300.0;	meter
 length;	road;	SE;	2999 / 10;	299.9;	meter;	2999 / 10;	299.9;	meter
+length;	road;	SE;	10;	10.0;	meter;	10;	10.0;	meter
+length;	road;	SE;	99 / 10;	9.9;	meter;	99 / 10;	9.9;	meter
 length;	road;	SE;	1;	1.0;	meter;	1;	1.0;	meter
 length;	road;	SE;	9 / 10;	0.9;	meter;	9 / 10;	0.9;	meter
 
@@ -296,10 +308,6 @@ mass;	person;	GB;	408233133 / 1000000000;	0.408233133;	kilogram;	0;	pound;	72 / 
 mass;	person;	HK;	498951607 / 1000000000;	0.498951607;	kilogram;	1;	pound;	8 / 5;	1.6;	ounce
 mass;	person;	HK;	45359237 / 100000000;	0.45359237;	kilogram;	1;	pound;	0;	0.0;	ounce
 mass;	person;	HK;	408233133 / 1000000000;	0.408233133;	kilogram;	0;	pound;	72 / 5;	14.4;	ounce
-
-mass-density;	blood-glucose;	001;	11 / 1000;	0.011;	kilogram-per-cubic-meter;	11 / 10;	1.1;	milligram-per-deciliter
-mass-density;	blood-glucose;	001;	1 / 100;	0.01;	kilogram-per-cubic-meter;	1;	1.0;	milligram-per-deciliter
-mass-density;	blood-glucose;	001;	9 / 1000;	0.009;	kilogram-per-cubic-meter;	9 / 10;	0.9;	milligram-per-deciliter
 
 mass-density;	default;	001;	11 / 10;	1.1;	kilogram-per-cubic-meter;	11 / 10;	1.1;	kilogram-per-cubic-meter
 mass-density;	default;	001;	1;	1.0;	kilogram-per-cubic-meter;	1;	1.0;	kilogram-per-cubic-meter

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/data/cldr/units/unitsTest.txt
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/data/cldr/units/unitsTest.txt
@@ -1,5 +1,5 @@
 # Test data for unit conversions
-#  Copyright © 1991-2020 Unicode, Inc.
+#  Copyright © 1991-2021 Unicode, Inc.
 #  For terms of use, see http://www.unicode.org/copyright.html
 #  Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 #  CLDR data files are interpreted according to the LDML specification (http://unicode.org/reports/tr35/)
@@ -31,7 +31,9 @@ area	;	acre	;	square-meter	;	4,046.8564224 * x	;	4046856.0
 area	;	hectare	;	square-meter	;	10,000 * x	;	1.0E7
 area	;	square-kilometer	;	square-meter	;	1,000,000 * x	;	1.0E9
 area	;	square-mile	;	square-meter	;	2,589,988.110336 * x	;	2.589988E9
+concentration	;	milligram-ofglucose-per-deciliter	;	kilogram-item-per-kilogram-cubic-meter	;	60,221,407,600,000,000,000,000,000,000/1,801,557 * x	;	3.342742E25
 concentration	;	millimole-per-liter	;	item-per-cubic-meter	;	602,214,076,000,000,000,000,000 * x	;	6.022141E26
+concentration-mass	;	ofglucose	;	item-per-kilogram	;	6,022,140,760,000,000,000,000,000,000,000/1,801,557 * x	;	3.342742E27
 consumption	;	liter-per-100-kilometer	;	cubic-meter-per-meter	;	0.00000001 * x	;	1.0E-5
 consumption	;	liter-per-kilometer	;	cubic-meter-per-meter	;	0.000001 * x	;	0.001
 consumption-inverse	;	mile-per-gallon-imperial	;	meter-per-cubic-meter	;	160,934,400,000/454,609 * x	;	3.540062E8
@@ -121,7 +123,6 @@ mass	;	ton	;	kilogram	;	907.18474 * x	;	907184.7
 mass	;	metric-ton	;	kilogram	;	1,000 * x	;	1000000.0
 mass	;	earth-mass	;	kilogram	;	5,972,200,000,000,000,000,000,000 * x	;	5.9722E27
 mass	;	solar-mass	;	kilogram	;	1,988,470,000,000,000,000,000,000,000,000 * x	;	1.98847E33
-mass-density	;	milligram-per-deciliter	;	kilogram-per-cubic-meter	;	0.01 * x	;	10.0
 portion	;	permillion	;	portion	;	0.000001 * x	;	0.001
 portion	;	permyriad	;	portion	;	0.0001 * x	;	0.1
 portion	;	permille	;	portion	;	0.001 * x	;	1.0


### PR DESCRIPTION
This updates ICU code to match [CLDR-14232 Change blood glucose measures to be compatible](https://github.com/unicode-org/cldr/pull/951) and [CLDR-14232 regenerate unit test data](https://github.com/unicode-org/cldr/pull/987).

* This units.txt was generated from units.xml in cldr, not in cldr-staging, because cldr-staging has not been updated since 16 December.

Closes: icu-units#126

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21472
- [X] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

