### PR TITLE
ICU-21473 Backport GitHub Actions (GHA) script to ICU 68 (replaces Travis CI)

### DIFF
--- a/.github/workflows/icu_ci.yml
+++ b/.github/workflows/icu_ci.yml
@@ -1,0 +1,197 @@
+# Copyright (C) 2016 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
+#
+# GitHub Action configuration script for ICU continuous integration tasks.
+
+name: GHA CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: '*'
+
+jobs:
+
+  # ICU4C docs build using doxygen..
+  icu4c-docs-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: ICU4C doc
+        run: |
+          sudo apt-get -y install doxygen;
+          cd icu4c/source;
+          ./runConfigureICU Linux --disable-renaming;
+           # Fail if 'warning:' appears in doxygen's output, but ignore warnings from file Doxyfile.
+           # Regex note: (?! ... ) is a negative lookahead. Succeed if the pattern is not present. 
+          set +o pipefail && make doc 2>&1 | tee doxygen.log && ( ! grep -P 'warning:(?! .* file .?Doxyfile)' doxygen.log )
+
+  # ICU4J build and unit test
+  icu4j-build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout and setup
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+      - name: Checkout lfs objects
+        run: git lfs pull
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - name: ICU4J
+        run: |
+          cd icu4j;
+          ant init;
+          ant check;
+
+  # gcc debug build.
+  # Includes dependency checker.
+  # Note - the dependency checker needs to be run on both a debug and an optimized build.
+  # This one (gcc) for debug, and linux clang (see job below) for optimized.
+  #
+  # Test both out-of-source and in-source builds. This one (gcc) for out-of-source,
+  # and linux clang (below) for in-source.
+  #
+  # Invokes test/hdrtst to check public headers compliance.
+  gcc-debug-build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: ICU4C with gcc
+        env:
+          PREFIX: /tmp/icu-prefix
+        run: |
+          mkdir build;
+          cd build;
+          ../icu4c/source/runConfigureICU --enable-debug --disable-release Linux/gcc --prefix=$PREFIX --enable-tracing;
+          make -j2;
+          make -j2 check;
+          ( cd ../icu4c/source/test/depstest && ./depstest.py ../../../../build/ );
+          make install;
+          PATH=$PREFIX/bin:$PATH make -C test/hdrtst check
+
+  # clang release build with some options to enforce useful constraints.
+  # Includes dependency checker on an in-source, optimized build.
+  # Includes checking @draft etc. API tags vs. ifndef guards like
+  # U_HIDE_DRAFT_API and U_FORCE_HIDE_DRAFT_API.
+  # (FORCE guards make this tool pass but won't compile to working code.
+  # See the testtagsguards.sh script for details.)
+  clang-release-build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: ICU4C with clang
+        env:
+          CPPFLAGS: -DU_NO_DEFAULT_INCLUDE_UTF_HEADERS=1
+          CFLAGS: -Wimplicit-fallthrough
+          CXXFLAGS: -Wimplicit-fallthrough
+        run: |
+          sudo apt-get -y install doxygen;
+          cd icu4c/source;
+          ./runConfigureICU Linux;
+          make -j 2;
+          make -j 2 check;
+          ( cd test/depstest && python3 depstest.py ../../../source/ );
+          ( cd .. && source/test/hdrtst/testtagsguards.sh );
+          make dist
+
+  # Out of source build with gcc 10, c++14, and extra warnings; executes icuinfo.
+  gcc-10-stdlib14:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: ICU4C with gcc 10 and c++14 and extra warnings.
+        env:
+          PREFIX: /tmp/icu-prefix
+          CC: gcc-10
+          CXX: g++-10
+          CXXFLAGS: -std=c++14 -Wextra
+        run: |
+          mkdir build;
+          cd build;
+          ../icu4c/source/runConfigureICU Linux --disable-layout --disable-layoutex --prefix=$PREFIX;
+          make -j2;
+          make -j2 check;
+          make install;
+          cd $PREFIX/bin;
+          LD_LIBRARY_PATH=../lib ./icuinfo
+
+  # Clang Linux with address sanitizer.
+  clang-asan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: ICU4C with clang and asan
+        run: |
+          cd icu4c/source;
+          ./runConfigureICU --enable-debug --disable-release Linux --disable-renaming --enable-tracing;
+          make -j2;
+          make -j2 check
+        env:
+          CPPFLAGS: -fsanitize=address
+          LDFLAGS: -fsanitize=address
+
+  # Clang Linux with thread sanitizer.
+  clang-tsan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: ICU4C with clang and tsan
+        run: |
+          cd icu4c/source;
+          ./runConfigureICU --enable-debug --disable-release Linux --disable-renaming
+          make -j2;
+          make -j2 -C test;
+          make -j2 -C test/intltest check
+        env:
+          INTLTEST_OPTS: utility/MultithreadTest
+          CPPFLAGS: -fsanitize=thread
+          LDFLAGS: -fsanitize=thread
+
+  # MacOS with clang
+  macos-clang:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: ICU4C with clang on MacOS
+        run: |
+          cd icu4c/source;
+          PYTHON=python3 ./runConfigureICU MacOSX;
+          make -j2 check
+
+  # Copyright scan
+  copyright-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: perl tools/scripts/cpysearch/cpyscan.pl
+
+  # Check compilation of internal headers.
+  internal-header-compilation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: cd icu4c/source; test/hdrtst/testinternalheaders.sh
+
+  # Check source files for valid UTF-8 and for absence of BOM.
+  valid-UTF-8-and-no-BOM-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: tools/scripts/icu-file-utf8-check.py
+
+  # Verify icu4c release tools buildability.
+  icu4c-release-tools:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: mvn -f tools/release/java/pom.xml package dependency:analyze

--- a/.github/workflows/icu_ci.yml
+++ b/.github/workflows/icu_ci.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           mkdir build;
           cd build;
-          ../icu4c/source/runConfigureICU --enable-debug --disable-release Linux/gcc --prefix=$PREFIX --enable-tracing;
+          ../icu4c/source/runConfigureICU --enable-debug --disable-release Linux/gcc --enable-layoutex=no --prefix=$PREFIX --enable-tracing;
           make -j2;
           make -j2 check;
           ( cd ../icu4c/source/test/depstest && ./depstest.py ../../../../build/ );
@@ -95,7 +95,7 @@ jobs:
         run: |
           sudo apt-get -y install doxygen;
           cd icu4c/source;
-          ./runConfigureICU Linux;
+          ./runConfigureICU Linux --enable-layoutex=no;
           make -j 2;
           make -j 2 check;
           ( cd test/depstest && python3 depstest.py ../../../source/ );
@@ -133,7 +133,7 @@ jobs:
       - name: ICU4C with clang and asan
         run: |
           cd icu4c/source;
-          ./runConfigureICU --enable-debug --disable-release Linux --disable-renaming --enable-tracing;
+          ./runConfigureICU --enable-debug --disable-release Linux --enable-layoutex=no --disable-renaming --enable-tracing;
           make -j2;
           make -j2 check
         env:
@@ -149,7 +149,7 @@ jobs:
       - name: ICU4C with clang and tsan
         run: |
           cd icu4c/source;
-          ./runConfigureICU --enable-debug --disable-release Linux --disable-renaming
+          ./runConfigureICU --enable-debug --disable-release Linux --enable-layoutex=no --disable-renaming
           make -j2;
           make -j2 -C test;
           make -j2 -C test/intltest check

--- a/.github/workflows/icu_ci.yml
+++ b/.github/workflows/icu_ci.yml
@@ -7,9 +7,11 @@ name: GHA CI
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - 'maint/maint*'
   pull_request:
-    branches: '*'
+    branches: '**'
 
 jobs:
 

--- a/icu4c/source/test/depstest/dependencies.txt
+++ b/icu4c/source/test/depstest/dependencies.txt
@@ -59,6 +59,8 @@ group: c_strings
     strlen strchr strrchr strstr strcmp strncmp strcpy strncpy strcat strncat
     memchr memcmp memcpy memmove memset
     # Additional symbols in an optimized build.
+    # BSD version of memcmp().
+    bcmp
     __strcpy_chk __strncpy_chk __strcat_chk __strncat_chk
     __rawmemchr __memcpy_chk __memmove_chk __memset_chk
 


### PR DESCRIPTION
This change backports the new GitHub Actions script to the `maint/maint-68` branch, which replaces the Travis CI builds.
(Thanks to @gnrunge for porting the Travis builds!)

This change ports the changes from the following two ICU tickets:
- https://unicode-org.atlassian.net/browse/ICU-21434
- https://unicode-org.atlassian.net/browse/ICU-21450

This PR includes changes from the following commits:
- 8078ae4937ac507b20dc613fb739d29a1c887d15
- 38125f3c5065791e5e396556cb9b4c67ed97898a
- e5a3f2baa7af6cfd7488b5e0144b1a5f562b085b
- c7ea02fccadc29ffdf3ad24c70dddd1ddffea2f8

Note: There are multiple commits in this PR, as I needed to adjust the branch settings to enable running the GHA CI on the `maint/maint-68` branches, and also disable the LayoutEx build, which was disabled by default in ICU 69.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21473
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

ALLOW_MANY_COMMITS=true