### PR TITLE
ICU-21473 Enable GHA CI on maint/maint* branches and on any pull-requests

### DIFF
--- a/.github/workflows/icu_ci.yml
+++ b/.github/workflows/icu_ci.yml
@@ -7,9 +7,11 @@ name: GHA CI
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - 'maint/maint*'
   pull_request:
-    branches: '*'
+    branches: '**'
 
 jobs:
 


### PR DESCRIPTION
This change modifies the GHA CI script in order to enable running on branches other than `master`, as we'll want to enable running the GHA CI on other `maint/maint-*` branches going forward (i.e.: for ICU 69).

Related PR which back-ports to ICU 68 is here: #1546 

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21473
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

