### PR TITLE
ICU-21474 Update top-level README status badge to replace Travis CI with GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The ICU project is under the stewardship of [The Unicode Consortium](https://www
 
 Build | Status
 ------|-------
-TravisCI | [![Build Status](https://travis-ci.org/unicode-org/icu.svg?branch=master)](https://travis-ci.org/unicode-org/icu)
+GitHub Actions | [![GHA CI](https://github.com/unicode-org/icu/workflows/GHA%20CI/badge.svg)](https://github.com/unicode-org/icu/actions?query=workflow%3A%22GHA+CI%22)
 Azure Pipelines | [![Build Status](https://dev.azure.com/ms/icu/_apis/build/status/unicode-org/CI?branchName=master)](https://dev.azure.com/ms/icu/_build/latest?definitionId=360&branchName=master)
 Azure Pipelines (Exhaustive Tests) | [![Build Status](https://dev.azure.com/ms/icu/_apis/build/status/unicode-org/CI-Exhaustive-Main?branchName=master)](https://dev.azure.com/ms/icu/_build/latest?definitionId=361&branchName=master)
 Azure Pipelines (Valgrind ICU4C) | [![Build Status](https://dev.azure.com/ms/icu/_apis/build/status/unicode-org/CI-Valgrind-Main?branchName=master)](https://dev.azure.com/ms/icu/_build/latest?definitionId=362&branchName=master)


### PR DESCRIPTION
Since Travis CI is no longer used, the status badge in the top-level README should be replaced with one for GitHub Actions.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21474
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

