### PR TITLE
ICU-21372 Add ucal_getTimeZoneOffsetFromLocal for C & C++ API

### DIFF
--- a/icu4c/source/i18n/basictz.cpp
+++ b/icu4c/source/i18n/basictz.cpp
@@ -547,12 +547,23 @@ error:
 }
 
 void
-BasicTimeZone::getOffsetFromLocal(UDate /*date*/, int32_t /*nonExistingTimeOpt*/, int32_t /*duplicatedTimeOpt*/,
-                            int32_t& /*rawOffset*/, int32_t& /*dstOffset*/, UErrorCode& status) const {
+BasicTimeZone::getOffsetFromLocal(UDate /*date*/, UTimeZoneLocalOption /*nonExistingTimeOpt*/,
+                                  UTimeZoneLocalOption /*duplicatedTimeOpt*/,
+                                  int32_t& /*rawOffset*/, int32_t& /*dstOffset*/,
+                                  UErrorCode& status) const {
     if (U_FAILURE(status)) {
         return;
     }
     status = U_UNSUPPORTED_ERROR;
+    return;
+}
+
+void
+BasicTimeZone::getOffsetFromLocal(UDate date, int32_t nonExistingTimeOpt, int32_t duplicatedTimeOpt,
+                                  int32_t& rawOffset, int32_t& dstOffset,
+                                  UErrorCode& status) const {
+    getOffsetFromLocal(date, (UTimeZoneLocalOption)nonExistingTimeOpt,
+                       (UTimeZoneLocalOption)duplicatedTimeOpt, rawOffset, dstOffset, status);
 }
 
 U_NAMESPACE_END

--- a/icu4c/source/i18n/olsontz.cpp
+++ b/icu4c/source/i18n/olsontz.cpp
@@ -400,8 +400,10 @@ void OlsonTimeZone::getOffset(UDate date, UBool local, int32_t& rawoff,
 }
 
 void
-OlsonTimeZone::getOffsetFromLocal(UDate date, int32_t nonExistingTimeOpt, int32_t duplicatedTimeOpt,
-                                  int32_t& rawoff, int32_t& dstoff, UErrorCode& ec) const {
+OlsonTimeZone::getOffsetFromLocal(UDate date, UTimeZoneLocalOption nonExistingTimeOpt,
+                                  UTimeZoneLocalOption duplicatedTimeOpt,
+                                  int32_t& rawoff, int32_t& dstoff,
+                                  UErrorCode& ec) const {
     if (U_FAILURE(ec)) {
         return;
     }

--- a/icu4c/source/i18n/olsontz.h
+++ b/icu4c/source/i18n/olsontz.h
@@ -187,8 +187,10 @@ class U_I18N_API OlsonTimeZone: public BasicTimeZone {
     /**
      * BasicTimeZone API.
      */
-    virtual void getOffsetFromLocal(UDate date, int32_t nonExistingTimeOpt, int32_t duplicatedTimeOpt,
-        int32_t& rawoff, int32_t& dstoff, UErrorCode& ec) const;
+    virtual void getOffsetFromLocal(
+        UDate date, UTimeZoneLocalOption nonExistingTimeOpt,
+        UTimeZoneLocalOption duplicatedTimeOpt,
+        int32_t& rawOffset, int32_t& dstOffset, UErrorCode& status) const;
 
     /**
      * TimeZone API.  This method has no effect since objects of this

--- a/icu4c/source/i18n/rbtz.cpp
+++ b/icu4c/source/i18n/rbtz.cpp
@@ -404,7 +404,8 @@ RuleBasedTimeZone::getOffset(UDate date, UBool local, int32_t& rawOffset,
 }
 
 void
-RuleBasedTimeZone::getOffsetFromLocal(UDate date, int32_t nonExistingTimeOpt, int32_t duplicatedTimeOpt,
+RuleBasedTimeZone::getOffsetFromLocal(UDate date, UTimeZoneLocalOption nonExistingTimeOpt,
+                                      UTimeZoneLocalOption duplicatedTimeOpt,
                                       int32_t& rawOffset, int32_t& dstOffset, UErrorCode& status) const {
     getOffsetInternal(date, TRUE, nonExistingTimeOpt, duplicatedTimeOpt, rawOffset, dstOffset, status);
 }

--- a/icu4c/source/i18n/simpletz.cpp
+++ b/icu4c/source/i18n/simpletz.cpp
@@ -509,8 +509,10 @@ SimpleTimeZone::getOffset(uint8_t era, int32_t year, int32_t month, int32_t day,
 }
 
 void
-SimpleTimeZone::getOffsetFromLocal(UDate date, int32_t nonExistingTimeOpt, int32_t duplicatedTimeOpt,
-                                   int32_t& rawOffsetGMT, int32_t& savingsDST, UErrorCode& status) const {
+SimpleTimeZone::getOffsetFromLocal(
+        UDate date, UTimeZoneLocalOption nonExistingTimeOpt,
+        UTimeZoneLocalOption duplicatedTimeOpt,
+        int32_t& rawOffsetGMT, int32_t& savingsDST, UErrorCode& status) const {
     if (U_FAILURE(status)) {
         return;
     }

--- a/icu4c/source/i18n/ucal.cpp
+++ b/icu4c/source/i18n/ucal.cpp
@@ -768,7 +768,32 @@ ucal_getKeywordValuesForLocale(const char * /* key */, const char* locale, UBool
     return en;
 }
 
-U_CAPI UBool U_EXPORT2 
+U_CAPI void U_EXPORT2
+ucal_getTimeZoneOffsetFromLocal(
+    const UCalendar* cal,
+    UTimeZoneLocalOption nonExistingTimeOpt,
+    UTimeZoneLocalOption duplicatedTimeOpt,
+    int32_t* rawOffset, int32_t* dstOffset, UErrorCode* status)
+{
+    if (U_FAILURE(*status)) {
+        return;
+    }
+    UDate date = ((Calendar*)cal)->getTime(*status);
+    if (U_FAILURE(*status)) {
+        return;
+    }
+    const TimeZone& tz = ((Calendar*)cal)->getTimeZone();
+    const BasicTimeZone * btz = dynamic_cast<const BasicTimeZone *>(&tz);
+    if (btz == nullptr) {
+        *status = U_ILLEGAL_ARGUMENT_ERROR;
+        return;
+    }
+    btz->getOffsetFromLocal(
+        date, nonExistingTimeOpt, duplicatedTimeOpt,
+        *rawOffset, *dstOffset, *status);
+}
+
+U_CAPI UBool U_EXPORT2
 ucal_getTimeZoneTransitionDate(const UCalendar* cal, UTimeZoneTransitionType type,
                                UDate* transition, UErrorCode* status)
 {

--- a/icu4c/source/i18n/unicode/basictz.h
+++ b/icu4c/source/i18n/unicode/basictz.h
@@ -23,6 +23,7 @@
 #include "unicode/timezone.h"
 #include "unicode/tzrule.h"
 #include "unicode/tztrans.h"
+#include "unicode/ucal.h"
 
 U_NAMESPACE_BEGIN
 
@@ -153,6 +154,18 @@ public:
         AnnualTimeZoneRule*& std, AnnualTimeZoneRule*& dst, UErrorCode& status) const;
 
 
+#ifndef U_HIDE_DRAFT_API
+    /**
+     * Get time zone offsets from local wall time.
+     * @draft ICU 69
+     */
+    virtual void getOffsetFromLocal(
+        UDate date, UTimeZoneLocalOption nonExistingTimeOpt,
+        UTimeZoneLocalOption duplicatedTimeOpt,
+        int32_t& rawOffset, int32_t& dstOffset, UErrorCode& status) const;
+
+#endif  /* U_HIDE_DRAFT_API */
+
 #ifndef U_HIDE_INTERNAL_API
     /**
      * The time type option bit flags used by getOffsetFromLocal
@@ -170,8 +183,8 @@ public:
      * Get time zone offsets from local wall time.
      * @internal
      */
-    virtual void getOffsetFromLocal(UDate date, int32_t nonExistingTimeOpt, int32_t duplicatedTimeOpt,
-        int32_t& rawOffset, int32_t& dstOffset, UErrorCode& status) const;
+    void getOffsetFromLocal(UDate date, int32_t nonExistingTimeOpt, int32_t duplicatedTimeOpt,
+            int32_t& rawOffset, int32_t& dstOffset, UErrorCode& status) const;
 
 protected:
 

--- a/icu4c/source/i18n/unicode/rbtz.h
+++ b/icu4c/source/i18n/unicode/rbtz.h
@@ -302,12 +302,16 @@ public:
     virtual void getTimeZoneRules(const InitialTimeZoneRule*& initial,
         const TimeZoneRule* trsrules[], int32_t& trscount, UErrorCode& status) const;
 
+#ifndef U_HIDE_DRAFT_API
     /**
      * Get time zone offsets from local wall time.
-     * @internal
+     * @draft ICU 69
      */
-    virtual void getOffsetFromLocal(UDate date, int32_t nonExistingTimeOpt, int32_t duplicatedTimeOpt,
+    virtual void getOffsetFromLocal(
+        UDate date, UTimeZoneLocalOption nonExistingTimeOpt,
+        UTimeZoneLocalOption duplicatedTimeOpt,
         int32_t& rawOffset, int32_t& dstOffset, UErrorCode& status) const;
+#endif  /* U_HIDE_DRAFT_API */
 
 private:
     void deleteRules(void);

--- a/icu4c/source/i18n/unicode/simpletz.h
+++ b/icu4c/source/i18n/unicode/simpletz.h
@@ -620,12 +620,16 @@ public:
     virtual void getOffset(UDate date, UBool local, int32_t& rawOffset,
                            int32_t& dstOffset, UErrorCode& ec) const;
 
+#ifndef U_HIDE_DRAFT_API
     /**
      * Get time zone offsets from local wall time.
-     * @internal
+     * @draft ICU 69
      */
-    virtual void getOffsetFromLocal(UDate date, int32_t nonExistingTimeOpt, int32_t duplicatedTimeOpt,
+    virtual void getOffsetFromLocal(
+        UDate date, UTimeZoneLocalOption nonExistingTimeOpt,
+        UTimeZoneLocalOption duplicatedTimeOpt,
         int32_t& rawOffset, int32_t& dstOffset, UErrorCode& status) const;
+#endif  /* U_HIDE_DRAFT_API */
 
     /**
      * Returns the TimeZone's raw GMT offset (i.e., the number of milliseconds to add

--- a/icu4c/source/i18n/unicode/ucal.h
+++ b/icu4c/source/i18n/unicode/ucal.h
@@ -1538,6 +1538,74 @@ enum UTimeZoneTransitionType {
 
 typedef enum UTimeZoneTransitionType UTimeZoneTransitionType; /**< @stable ICU 50 */
 
+#ifndef U_HIDE_DRAFT_API
+/**
+ * Time zone local option for ucal_getTimeZoneOffsetFromLocal
+ * @draft ICU 69
+ */
+enum UTimeZoneLocalOption {
+    /**
+     * The time type option for standard time used by
+     * ucal_getTimeZoneLocal().
+     * @draft ICU 69
+     */
+    UCAL_TZ_LOCAL_STANDARD = 0x01,
+    /**
+     * The time type option for daylight saving time used by
+     * ucal_getTimeZoneLocal().
+     * @draft ICU 69
+     */
+    UCAL_TZ_LOCAL_DAYLIGHT = 0x03,
+    /**
+     * The option designate former time to be used by
+     * ucal_getTimeZoneLocal().
+     * @draft ICU 69
+     */
+    UCAL_TZ_LOCAL_FORMER = 0x04,
+    /**
+     * The option designate latter time to be used by
+     * ucal_getTimeZoneLocal().
+     * @draft ICU 69
+     */
+    UCAL_TZ_LOCAL_LATTER = 0x0C,
+};
+typedef enum UTimeZoneLocalOption UTimeZoneLocalOption; /**< @draft ICU 69 */
+
+/**
+* Returns the time zone raw and GMT offset for the given moment
+* in time.  Upon return, local-millis = GMT-millis + rawOffset +
+* dstOffset.  All computations are performed in the proleptic
+* Gregorian calendar.
+*
+* @param cal The UCalendar which specify the local date and time value to query.
+* @param nonExistingTimeOpt The option to indicate how to interpret the date and
+* time in the calendar represent a local time that skipped at a positive time
+* zone transitions (e.g. when the daylight saving time starts or the time zone
+* offset is increased due to a time zone rule change).
+* @param duplicatedTimeOpt The option to indicate how to interpret the date and
+* time in the calendar represent a local time that repeating multiple times at a
+* negative time zone transition (e.g. when the daylight saving time ends or the
+* time zone offset is decreased due to a time zone rule change)
+* @param rawOffset output parameter to receive the raw offset, that
+* is, the offset not including DST adjustments.
+* If the status is set to one of the error code, the value set is unspecified.
+* @param dstOffset output parameter to receive the DST offset,
+* that is, the offset to be added to `rawOffset' to obtain the
+* total offset between local and GMT time. If DST is not in
+* effect, this value is zero; otherwise it is a positive value,
+* typically one hour.
+* If the status is set to one of the error code, the value set is unspecified.
+* @param status A pointer to a UErrorCode to receive any errors.
+* @draft ICU 69
+*/
+U_CAPI void U_EXPORT2
+ucal_getTimeZoneOffsetFromLocal(
+    const UCalendar* cal,
+    UTimeZoneLocalOption nonExistingTimeOpt,
+    UTimeZoneLocalOption duplicatedTimeOpt,
+    int32_t* rawOffset, int32_t* dstOffset, UErrorCode* status);
+#endif  /* U_HIDE_DRAFT_API */
+
 /**
 * Get the UDate for the next/previous time zone transition relative to
 * the calendar's current date, in the time zone to which the calendar

--- a/icu4c/source/i18n/unicode/vtzone.h
+++ b/icu4c/source/i18n/unicode/vtzone.h
@@ -282,6 +282,17 @@ public:
      */
     virtual int32_t getRawOffset(void) const;
 
+#ifndef U_HIDE_DRAFT_API
+    /**
+     * Get time zone offsets from local wall time.
+     * @draft ICU 69
+     */
+    virtual void getOffsetFromLocal(
+        UDate date, UTimeZoneLocalOption nonExistingTimeOpt,
+        UTimeZoneLocalOption duplicatedTimeOpt,
+        int32_t& rawOffset, int32_t& dstOffset, UErrorCode& status) const;
+#endif  /* U_HIDE_DRAFT_API */
+
     /**
      * Queries if this time zone uses daylight savings time.
      * @return true if this time zone uses daylight savings time,

--- a/icu4c/source/i18n/vtzone.cpp
+++ b/icu4c/source/i18n/vtzone.cpp
@@ -1217,6 +1217,15 @@ VTimeZone::getOffset(UDate date, UBool local, int32_t& rawOffset,
     return tz->getOffset(date, local, rawOffset, dstOffset, status);
 }
 
+void VTimeZone::getOffsetFromLocal(
+        UDate date, UTimeZoneLocalOption nonExistingTimeOpt,
+        UTimeZoneLocalOption duplicatedTimeOpt,
+        int32_t& rawOffset, int32_t& dstOffset, UErrorCode& status) const
+{
+    tz->getOffsetFromLocal(date, nonExistingTimeOpt, duplicatedTimeOpt,
+                           rawOffset, dstOffset, status);
+}
+
 void
 VTimeZone::setRawOffset(int32_t offsetMillis) {
     tz->setRawOffset(offsetMillis);

--- a/icu4c/source/test/cintltst/ccaltst.c
+++ b/icu4c/source/test/cintltst/ccaltst.c
@@ -41,6 +41,7 @@ void TestGetWindowsTimeZoneID(void);
 void TestGetTimeZoneIDByWindowsID(void);
 void TestJpnCalAddSetNextEra(void);
 void TestUcalOpenBufferRead(void);
+void TestGetTimeZoneOffsetFromLocal(void);
 
 void addCalTest(TestNode** root);
 
@@ -65,6 +66,7 @@ void addCalTest(TestNode** root)
     addTest(root, &TestGetTimeZoneIDByWindowsID, "tsformat/ccaltst/TestGetTimeZoneIDByWindowsID");
     addTest(root, &TestJpnCalAddSetNextEra, "tsformat/ccaltst/TestJpnCalAddSetNextEra");
     addTest(root, &TestUcalOpenBufferRead, "tsformat/ccaltst/TestUcalOpenBufferRead");
+    addTest(root, &TestGetTimeZoneOffsetFromLocal, "tsformat/ccaltst/TestGetTimeZoneOffsetFromLocal");
 }
 
 /* "GMT" */
@@ -2550,6 +2552,223 @@ void TestUcalOpenBufferRead() {
     // string length: 157 + 1 + 100 = 258
     const char *localeID = "x-privatebutreallylongtagfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobar-foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoorbarfoobarfoo";
     UCalendar *cal = ucal_open(NULL, 0, localeID, UCAL_GREGORIAN, &status);
+    ucal_close(cal);
+}
+
+
+#define NUM_DATES 10
+/*
+ * Testing ucal_getTimeZoneOffsetFromLocal
+ */
+void
+TestGetTimeZoneOffsetFromLocal() {
+    static const UChar utc[] = { 0x45, 0x74, 0x63, 0x2f, 0x47, 0x4d, 0x54, 0 }; /* "Etc/GMT" */
+
+    const int32_t HOUR = 60*60*1000;
+    const int32_t MINUTE = 60*1000;
+
+    const int32_t DATES[][6] = {
+        {2006, UCAL_APRIL, 2, 1, 30, 1*HOUR+30*MINUTE},
+        {2006, UCAL_APRIL, 2, 2, 00, 2*HOUR},
+        {2006, UCAL_APRIL, 2, 2, 30, 2*HOUR+30*MINUTE},
+        {2006, UCAL_APRIL, 2, 3, 00, 3*HOUR},
+        {2006, UCAL_APRIL, 2, 3, 30, 3*HOUR+30*MINUTE},
+        {2006, UCAL_OCTOBER, 29, 0, 30, 0*HOUR+30*MINUTE},
+        {2006, UCAL_OCTOBER, 29, 1, 00, 1*HOUR},
+        {2006, UCAL_OCTOBER, 29, 1, 30, 1*HOUR+30*MINUTE},
+        {2006, UCAL_OCTOBER, 29, 2, 00, 2*HOUR},
+        {2006, UCAL_OCTOBER, 29, 2, 30, 2*HOUR+30*MINUTE},
+    };
+
+    // Expected offsets by
+    // void U_ucal_getTimeZoneOffsetFromLocal(
+    //   const UCalendar* cal,
+    //   UTimeZoneLocalOption nonExistingTimeOpt,
+    //   UTimeZoneLocalOption duplicatedTimeOpt,
+    //   int32_t* rawOffset, int32_t* dstOffset, UErrorCode* status);
+    // with nonExistingTimeOpt=UCAL_TZ_LOCAL_STANDARD and
+    // duplicatedTimeOpt=UCAL_TZ_LOCAL_STANDARD
+    const int32_t OFFSETS2[][2] = {
+        // April 2, 2006
+        {-8*HOUR, 0},
+        {-8*HOUR, 0},
+        {-8*HOUR, 0},
+        {-8*HOUR, 1*HOUR},
+        {-8*HOUR, 1*HOUR},
+
+        // Oct 29, 2006
+        {-8*HOUR, 1*HOUR},
+        {-8*HOUR, 0},
+        {-8*HOUR, 0},
+        {-8*HOUR, 0},
+        {-8*HOUR, 0},
+    };
+
+    // Expected offsets by
+    // void U_ucal_getTimeZoneOffsetFromLocal(
+    //   const UCalendar* cal,
+    //   UTimeZoneLocalOption nonExistingTimeOpt,
+    //   UTimeZoneLocalOption duplicatedTimeOpt,
+    //   int32_t* rawOffset, int32_t* dstOffset, UErrorCode* status);
+    // with nonExistingTimeOpt=UCAL_TZ_LOCAL_DAYLIGHT and
+    // duplicatedTimeOpt=UCAL_TZ_LOCAL_DAYLIGHT
+    const int32_t OFFSETS3[][2] = {
+        // April 2, 2006
+        {-8*HOUR, 0},
+        {-8*HOUR, 1*HOUR},
+        {-8*HOUR, 1*HOUR},
+        {-8*HOUR, 1*HOUR},
+        {-8*HOUR, 1*HOUR},
+
+        // October 29, 2006
+        {-8*HOUR, 1*HOUR},
+        {-8*HOUR, 1*HOUR},
+        {-8*HOUR, 1*HOUR},
+        {-8*HOUR, 0},
+        {-8*HOUR, 0},
+    };
+
+    UErrorCode status = U_ZERO_ERROR;
+
+    int32_t rawOffset, dstOffset;
+    UCalendar *cal = ucal_open(utc, -1, "en", UCAL_GREGORIAN, &status);
+    if (U_FAILURE(status)) {
+        log_data_err("ucal_open: %s", u_errorName(status));
+        return;
+    }
+
+    // Calculate millis
+    UDate MILLIS[NUM_DATES];
+    for (int32_t i = 0; i < NUM_DATES; i++) {
+        ucal_setDateTime(cal, DATES[i][0], DATES[i][1], DATES[i][2],
+                         DATES[i][3], DATES[i][4], 0, &status);
+        MILLIS[i] = ucal_getMillis(cal, &status);
+        if (U_FAILURE(status)) {
+            log_data_err("ucal_getMillis failed");
+            return;
+        }
+    }
+    ucal_setTimeZone(cal, AMERICA_LOS_ANGELES, -1, &status);
+
+    // Test void ucal_getTimeZoneOffsetFromLocal(
+    // const UCalendar* cal,
+    // UTimeZoneLocalOption nonExistingTimeOpt,
+    // UTimeZoneLocalOption duplicatedTimeOpt,
+    // int32_t* rawOffset, int32_t* dstOffset, UErrorCode* status);
+    // with nonExistingTimeOpt=UCAL_TZ_LOCAL_STANDARD and
+    // duplicatedTimeOpt=UCAL_TZ_LOCAL_STANDARD
+    for (int m = 0; m < NUM_DATES; m++) {
+        status = U_ZERO_ERROR;
+        ucal_setMillis(cal, MILLIS[m], &status);
+        if (U_FAILURE(status)) {
+            log_data_err("ucal_setMillis: %s\n", u_errorName(status));
+        }
+
+        ucal_getTimeZoneOffsetFromLocal(cal, UCAL_TZ_LOCAL_STANDARD, UCAL_TZ_LOCAL_STANDARD,
+            &rawOffset, &dstOffset, &status);
+        if (U_FAILURE(status)) {
+            log_err("ERROR: ucal_getTimeZoneOffsetFromLocal((%d-%d-%d %d:%d:0),"
+                    "UCAL_TZ_LOCAL_STANDARD, UCAL_TZ_LOCAL_STANDARD: %s\n",
+                    DATES[m][0], DATES[m][1], DATES[m][2], DATES[m][3], DATES[m][4],
+                    u_errorName(status));
+        } else if (rawOffset != OFFSETS2[m][0] || dstOffset != OFFSETS2[m][1]) {
+            log_err("Bad offset returned at (%d-%d-%d %d:%d:0) "
+                    "(wall/UCAL_TZ_LOCAL_STANDARD/UCAL_TZ_LOCAL_STANDARD) \n- Got: %d / %d "
+                    " Expected %d / %d\n",
+                    DATES[m][0], DATES[m][1], DATES[m][2], DATES[m][3], DATES[m][4],
+                    rawOffset, dstOffset, OFFSETS2[m][0], OFFSETS2[m][1]);
+        }
+    }
+
+    // Test void ucal_getTimeZoneOffsetFromLocal(
+    // const UCalendar* cal,
+    // UTimeZoneLocalOption nonExistingTimeOpt,
+    // UTimeZoneLocalOption duplicatedTimeOpt,
+    // int32_t* rawOffset, int32_t* dstOffset, UErrorCode* status);
+    // with nonExistingTimeOpt=UCAL_TZ_LOCAL_DAYLIGHT and
+    // duplicatedTimeOpt=UCAL_TZ_LOCAL_DAYLIGHT
+    for (int m = 0; m < NUM_DATES; m++) {
+        status = U_ZERO_ERROR;
+        ucal_setMillis(cal, MILLIS[m], &status);
+        if (U_FAILURE(status)) {
+            log_data_err("ucal_setMillis: %s\n", u_errorName(status));
+        }
+
+        ucal_getTimeZoneOffsetFromLocal(cal, UCAL_TZ_LOCAL_DAYLIGHT, UCAL_TZ_LOCAL_DAYLIGHT,
+            &rawOffset, &dstOffset, &status);
+        if (U_FAILURE(status)) {
+            log_err("ERROR: ucal_getTimeZoneOffsetFromLocal((%d-%d-%d %d:%d:0),"
+                    "UCAL_TZ_LOCAL_DAYLIGHT, UCAL_TZ_LOCAL_DAYLIGHT: %s\n",
+                    DATES[m][0], DATES[m][1], DATES[m][2], DATES[m][3], DATES[m][4],
+                    u_errorName(status));
+        } else if (rawOffset != OFFSETS3[m][0] || dstOffset != OFFSETS3[m][1]) {
+            log_err("Bad offset returned at (%d-%d-%d %d:%d:0) "
+                    "(wall/UCAL_TZ_LOCAL_DAYLIGHT/UCAL_TZ_LOCAL_DAYLIGHT) \n- Got: %d / %d "
+                    " Expected %d / %d\n",
+                    DATES[m][0], DATES[m][1], DATES[m][2], DATES[m][3], DATES[m][4],
+                    rawOffset, dstOffset, OFFSETS3[m][0], OFFSETS3[m][1]);
+        }
+    }
+
+    // Test void ucal_getTimeZoneOffsetFromLocal(
+    // const UCalendar* cal,
+    // UTimeZoneLocalOption nonExistingTimeOpt,
+    // UTimeZoneLocalOption duplicatedTimeOpt,
+    // int32_t* rawOffset, int32_t* dstOffset, UErrorCode* status);
+    // with nonExistingTimeOpt=UCAL_TZ_LOCAL_FORMER and
+    // duplicatedTimeOpt=UCAL_TZ_LOCAL_LATTER
+    for (int m = 0; m < NUM_DATES; m++) {
+        status = U_ZERO_ERROR;
+        ucal_setMillis(cal, MILLIS[m], &status);
+        if (U_FAILURE(status)) {
+            log_data_err("ucal_setMillis: %s\n", u_errorName(status));
+        }
+
+        ucal_getTimeZoneOffsetFromLocal(cal, UCAL_TZ_LOCAL_FORMER, UCAL_TZ_LOCAL_LATTER,
+            &rawOffset, &dstOffset, &status);
+        if (U_FAILURE(status)) {
+            log_err("ERROR: ucal_getTimeZoneOffsetFromLocal((%d-%d-%d %d:%d:0),"
+                    "UCAL_TZ_LOCAL_FORMER, UCAL_TZ_LOCAL_LATTER: %s\n",
+                    DATES[m][0], DATES[m][1], DATES[m][2], DATES[m][3], DATES[m][4],
+                    u_errorName(status));
+        } else if (rawOffset != OFFSETS2[m][0] || dstOffset != OFFSETS2[m][1]) {
+            log_err("Bad offset returned at (%d-%d-%d %d:%d:0) "
+                    "(wall/UCAL_TZ_LOCAL_FORMER/UCAL_TZ_LOCAL_LATTER) \n- Got: %d / %d "
+                    " Expected %d / %d\n",
+                    DATES[m][0], DATES[m][1], DATES[m][2], DATES[m][3], DATES[m][4],
+                    rawOffset, dstOffset, OFFSETS2[m][0], OFFSETS2[m][1]);
+        }
+    }
+
+    // Test void ucal_getTimeZoneOffsetFromLocal(
+    // const UCalendar* cal,
+    // UTimeZoneLocalOption nonExistingTimeOpt,
+    // UTimeZoneLocalOption duplicatedTimeOpt,
+    // int32_t* rawOffset, int32_t* dstOffset, UErrorCode* status);
+    // with nonExistingTimeOpt=UCAL_TZ_LOCAL_LATTER and
+    // duplicatedTimeOpt=UCAL_TZ_LOCAL_FORMER
+    for (int m = 0; m < NUM_DATES; m++) {
+        status = U_ZERO_ERROR;
+        ucal_setMillis(cal, MILLIS[m], &status);
+        if (U_FAILURE(status)) {
+            log_data_err("ucal_setMillis: %s\n", u_errorName(status));
+        }
+
+        ucal_getTimeZoneOffsetFromLocal(cal, UCAL_TZ_LOCAL_LATTER, UCAL_TZ_LOCAL_FORMER,
+            &rawOffset, &dstOffset, &status);
+        if (U_FAILURE(status)) {
+            log_err("ERROR: ucal_getTimeZoneOffsetFromLocal((%d-%d-%d %d:%d:0),"
+                    "UCAL_TZ_LOCAL_LATTER, UCAL_TZ_LOCAL_FORMER: %s\n",
+                    DATES[m][0], DATES[m][1], DATES[m][2], DATES[m][3], DATES[m][4],
+                    u_errorName(status));
+        } else if (rawOffset != OFFSETS3[m][0] || dstOffset != OFFSETS3[m][1]) {
+            log_err("Bad offset returned at (%d-%d-%d %d:%d:0) "
+                    "(wall/UCAL_TZ_LOCAL_LATTER/UCAL_TZ_LOCAL_FORMER) \n- Got: %d / %d "
+                    " Expected %d / %d\n",
+                    DATES[m][0], DATES[m][1], DATES[m][2], DATES[m][3], DATES[m][4],
+                    rawOffset, dstOffset, OFFSETS3[m][0], OFFSETS3[m][1]);
+        }
+    }
     ucal_close(cal);
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21372
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [x] Tests included
- [x] Documentation is changed or added

Define enum UTimeZoneLocalType and UTimeZoneLocalOption for both C and C++ API
Add C API ucal_getTimeZoneOffsetFromLocal
Add C++ API virtual UTimeZoneLocalType getOffsetFromLocal(
        UDate date, UTimeZoneLocalOption nonExistingTimeOpt,
        UTimeZoneLocalOption duplicatedTimeOpt,
        int32_t& rawOffset, int32_t& dstOffset, UErrorCode& status) const;
For BasicTimeZone and all it's public subclasses