### PR TITLE
ICU-21275 Remove obsolete functions from numberrangeformatter.h

### DIFF
--- a/icu4c/source/i18n/number_output.cpp
+++ b/icu4c/source/i18n/number_output.cpp
@@ -52,16 +52,6 @@ UPRV_FORMATTED_VALUE_SUBCLASS_AUTO_IMPL(FormattedNumberRange)
 
 #define UPRV_NOARG
 
-UnicodeString FormattedNumberRange::getFirstDecimal(UErrorCode& status) const {
-    UPRV_FORMATTED_VALUE_METHOD_GUARD(ICU_Utility::makeBogusString())
-    return fData->quantity1.toScientificString();
-}
-
-UnicodeString FormattedNumberRange::getSecondDecimal(UErrorCode& status) const {
-    UPRV_FORMATTED_VALUE_METHOD_GUARD(ICU_Utility::makeBogusString())
-    return fData->quantity2.toScientificString();
-}
-
 void FormattedNumberRange::getDecimalNumbers(ByteSink& sink1, ByteSink& sink2, UErrorCode& status) const {
     UPRV_FORMATTED_VALUE_METHOD_GUARD(UPRV_NOARG)
     impl::DecNum decnum1;

--- a/icu4c/source/i18n/unicode/numberrangeformatter.h
+++ b/icu4c/source/i18n/unicode/numberrangeformatter.h
@@ -608,49 +608,6 @@ class U_I18N_API FormattedNumberRange : public UMemory, public FormattedValue {
     /** @copydoc FormattedValue::nextPosition() */
     UBool nextPosition(ConstrainedFieldPosition& cfpos, UErrorCode& status) const U_OVERRIDE;
 
-#ifndef U_HIDE_DEPRECATED_API
-    /**
-     * Export the first formatted number as a decimal number. This endpoint
-     * is useful for obtaining the exact number being printed after scaling
-     * and rounding have been applied by the number range formatting pipeline.
-     *
-     * The syntax of the unformatted number is a "numeric string"
-     * as defined in the Decimal Arithmetic Specification, available at
-     * http://speleotrove.com/decimal
-     *
-     * TODO(ICU-21275): This function will be removed in ICU 69.
-     * Use getDecimalNumbers() instead.
-     *
-     * @param status Set if an error occurs.
-     * @return A decimal representation of the first formatted number.
-     * @deprecated ICU 68 Use getDecimalNumbers instead.
-     * @see NumberRangeFormatter
-     * @see #getSecondDecimal
-     */
-    UnicodeString getFirstDecimal(UErrorCode& status) const;
-
-    /**
-     * Export the second formatted number as a decimal number. This endpoint
-     * is useful for obtaining the exact number being printed after scaling
-     * and rounding have been applied by the number range formatting pipeline.
-     *
-     * The syntax of the unformatted number is a "numeric string"
-     * as defined in the Decimal Arithmetic Specification, available at
-     * http://speleotrove.com/decimal
-     *
-     * TODO(ICU-21275): This function will be removed in ICU 69.
-     * Use getDecimalNumbers() instead.
-     *
-     * @param status Set if an error occurs.
-     * @return A decimal representation of the second formatted number.
-     * @deprecated ICU 68 Use getDecimalNumbers instead.
-     * @see NumberRangeFormatter
-     * @see #getFirstDecimal
-     */
-    UnicodeString getSecondDecimal(UErrorCode& status) const;
-#endif // U_HIDE_DEPRECATED_API
-
-
 #ifndef U_HIDE_DRAFT_API
     /**
      * Extracts the formatted range as a pair of decimal numbers. This endpoint


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21275
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [x] Documentation is changed or added

