### PR TITLE
ICU-21351 Don't coalesce adjacent list formatter fields in ICU4J

### DIFF
--- a/icu4c/source/i18n/formattedval_sbimpl.cpp
+++ b/icu4c/source/i18n/formattedval_sbimpl.cpp
@@ -170,7 +170,10 @@ bool FormattedValueStringBuilderImpl::nextPositionImpl(ConstrainedFieldPosition&
             auto elementField = fString.getFieldPtr()[i-1];
             if (elementField == Field(UFIELD_CATEGORY_LIST, ULISTFMT_ELEMENT_FIELD)
                     && cfpos.matchesField(elementField.getCategory(), elementField.getField())
-                    && (cfpos.getLimit() < i - fString.fZero || cfpos.getCategory() != elementField.getCategory())) {
+                    && (
+                        cfpos.getLimit() < i - fString.fZero
+                        || cfpos.getCategory() != elementField.getCategory()
+                        || cfpos.getField() != elementField.getField())) {
                 int64_t si = cfpos.getInt64IterationContext() - 1;
                 cfpos.setState(
                     elementField.getCategory(),

--- a/icu4j/main/classes/core/src/com/ibm/icu/text/ListFormatter.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/ListFormatter.java
@@ -724,14 +724,16 @@ final public class ListFormatter {
         }
 
         private void appendElement(Object element, int position) {
+            String elementString = element.toString();
             if (needsFields) {
                 SpanFieldPlaceholder field = new SpanFieldPlaceholder();
                 field.spanField = SpanField.LIST_SPAN;
                 field.normalField = Field.ELEMENT;
                 field.value = position;
-                string.append(element.toString(), field);
+                field.length = elementString.length();
+                string.append(elementString, field);
             } else {
-                string.append(element.toString(), null);
+                string.append(elementString, null);
             }
         }
 

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/ListFormatterTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/ListFormatterTest.java
@@ -262,15 +262,15 @@ public class ListFormatterTest extends TestFmwk {
                 {ListFormatter.Field.ELEMENT, 2, 9},
                 {ListFormatter.SpanField.LIST_SPAN, 9, 12, 2},
                 {ListFormatter.Field.ELEMENT, 9, 12}};
-            if (!logKnownIssue("21351", "Java still coalesces adjacent elements")) {
-                FormattedValueTest.checkFormattedValue(
-                    message,
-                    result,
-                    expectedString,
-                    expectedFieldPositions);
-            }
+            FormattedValueTest.checkFormattedValue(
+                message,
+                result,
+                expectedString,
+                expectedFieldPositions,
+                // Adjacent fields: skip AttributedCharacterIterator test
+                true);
         }
-    
+
         {
             ListFormatter fmt = ListFormatter.getInstance(ULocale.ENGLISH, Type.UNITS, Width.SHORT);
             String message = "ICU-21383 Long list";


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

This PR ports https://github.com/unicode-org/icu/pull/1425 to ICU4J.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21351
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [ ] Documentation is changed or added

