### PR TITLE
ICU-21123 Support unit inflections in ICU4C

### DIFF
--- a/icu4c/source/i18n/number_fluent.cpp
+++ b/icu4c/source/i18n/number_fluent.cpp
@@ -289,6 +289,20 @@ Derived NumberFormatterSettings<Derived>::usage(const StringPiece usage)&& {
 }
 
 template<typename Derived>
+Derived NumberFormatterSettings<Derived>::unitDisplayCase(const StringPiece unitDisplayCase) const& {
+    Derived copy(*this);
+    copy.fMacros.unitDisplayCase.set(unitDisplayCase);
+    return copy;
+}
+
+template<typename Derived>
+Derived NumberFormatterSettings<Derived>::unitDisplayCase(const StringPiece unitDisplayCase)&& {
+    Derived move(std::move(*this));
+    move.fMacros.unitDisplayCase.set(unitDisplayCase);
+    return move;
+}
+
+template<typename Derived>
 Derived NumberFormatterSettings<Derived>::padding(const Padder& padder) const& {
     Derived copy(*this);
     copy.fMacros.padder = padder;

--- a/icu4c/source/i18n/number_formatimpl.cpp
+++ b/icu4c/source/i18n/number_formatimpl.cpp
@@ -39,6 +39,7 @@ int32_t NumberFormatterImpl::formatStatic(const MacroProps &macros, UFormattedNu
     int32_t length = writeNumber(micros, inValue, outString, 0, status);
     length += writeAffixes(micros, outString, 0, length, status);
     results->outputUnit = std::move(micros.outputUnit);
+    results->gender = micros.gender;
     return length;
 }
 
@@ -63,6 +64,7 @@ int32_t NumberFormatterImpl::format(UFormattedNumberData *results, UErrorCode &s
     int32_t length = writeNumber(micros, inValue, outString, 0, status);
     length += writeAffixes(micros, outString, 0, length, status);
     results->outputUnit = std::move(micros.outputUnit);
+    results->gender = micros.gender;
     return length;
 }
 
@@ -177,6 +179,9 @@ NumberFormatterImpl::macrosToMicroGenerator(const MacroProps& macros, bool safe,
     uprv_strncpy(fMicros.nsName, nsName, 8);
     fMicros.nsName[8] = 0; // guarantee NUL-terminated
 
+    // Default gender: none.
+    fMicros.gender = "";
+
     // Resolve the symbols. Do this here because currency may need to customize them.
     if (macros.symbols.isDecimalFormatSymbols()) {
         fMicros.symbols = macros.symbols.getDecimalFormatSymbols();
@@ -246,7 +251,7 @@ NumberFormatterImpl::macrosToMicroGenerator(const MacroProps& macros, bool safe,
             return nullptr;
         }
         auto usagePrefsHandler =
-            new UsagePrefsHandler(macros.locale, macros.unit, macros.usage.fUsage, chain, status);
+            new UsagePrefsHandler(macros.locale, macros.unit, macros.usage.fValue, chain, status);
         fUsagePrefsHandler.adoptInsteadAndCheckErrorCode(usagePrefsHandler, status);
         chain = fUsagePrefsHandler.getAlias();
     } else if (isMixedUnit) {
@@ -370,10 +375,14 @@ NumberFormatterImpl::macrosToMicroGenerator(const MacroProps& macros, bool safe,
 
     // Outer modifier (CLDR units and currency long names)
     if (isCldrUnit) {
+        StringPiece unitDisplayCase("");
+        if (macros.unitDisplayCase.isSet()) {
+            unitDisplayCase = macros.unitDisplayCase.fValue;
+        }
         if (macros.usage.isSet()) {
             fLongNameMultiplexer.adoptInsteadAndCheckErrorCode(
                 LongNameMultiplexer::forMeasureUnits(
-                    macros.locale, *fUsagePrefsHandler->getOutputUnits(), unitWidth,
+                    macros.locale, *fUsagePrefsHandler->getOutputUnits(), unitWidth, unitDisplayCase,
                     resolvePluralRules(macros.rules, macros.locale, status), chain, status),
                 status);
             chain = fLongNameMultiplexer.getAlias();
@@ -381,7 +390,7 @@ NumberFormatterImpl::macrosToMicroGenerator(const MacroProps& macros, bool safe,
             fMixedUnitLongNameHandler.adoptInsteadAndCheckErrorCode(new MixedUnitLongNameHandler(),
                                                                     status);
             MixedUnitLongNameHandler::forMeasureUnit(
-                macros.locale, macros.unit, unitWidth,
+                macros.locale, macros.unit, unitWidth, unitDisplayCase,
                 resolvePluralRules(macros.rules, macros.locale, status), chain,
                 fMixedUnitLongNameHandler.getAlias(), status);
             chain = fMixedUnitLongNameHandler.getAlias();
@@ -391,7 +400,7 @@ NumberFormatterImpl::macrosToMicroGenerator(const MacroProps& macros, bool safe,
                 unit = unit.product(macros.perUnit.reciprocal(status), status);
             }
             fLongNameHandler.adoptInsteadAndCheckErrorCode(new LongNameHandler(), status);
-            LongNameHandler::forMeasureUnit(macros.locale, unit, unitWidth,
+            LongNameHandler::forMeasureUnit(macros.locale, unit, unitWidth, unitDisplayCase,
                                             resolvePluralRules(macros.rules, macros.locale, status),
                                             chain, fLongNameHandler.getAlias(), status);
             chain = fLongNameHandler.getAlias();

--- a/icu4c/source/i18n/number_microprops.h
+++ b/icu4c/source/i18n/number_microprops.h
@@ -83,6 +83,11 @@ struct MicroProps : public MicroPropsGenerator {
     bool useCurrency;
     char nsName[9];
 
+    // No ownership: must point at a string which will outlive MicroProps
+    // instances, e.g. a string with static storage duration, or just a string
+    // that will never be deallocated or modified.
+    const char *gender;
+
     // Note: This struct has no direct ownership of the following pointers.
     const DecimalFormatSymbols* symbols;
 

--- a/icu4c/source/i18n/number_output.cpp
+++ b/icu4c/source/i18n/number_output.cpp
@@ -39,6 +39,11 @@ MeasureUnit FormattedNumber::getOutputUnit(UErrorCode& status) const {
     return fData->outputUnit;
 }
 
+const char *FormattedNumber::getGender(UErrorCode &status) const {
+    UPRV_FORMATTED_VALUE_METHOD_GUARD("")
+    return fData->gender;
+}
+
 void FormattedNumber::getDecimalQuantity(impl::DecimalQuantity& output, UErrorCode& status) const {
     UPRV_FORMATTED_VALUE_METHOD_GUARD(UPRV_NOARG)
     output = fData->quantity;

--- a/icu4c/source/i18n/number_roundingutils.h
+++ b/icu4c/source/i18n/number_roundingutils.h
@@ -204,7 +204,7 @@ class RoundingImpl {
  * - see blueprint_helpers::parseIncrementOption().
  *
  * Referencing MacroProps means needing to pull in the .o files that have the
- * destructors for the SymbolsWrapper, Usage, and Scale classes.
+ * destructors for the SymbolsWrapper, StringProp, and Scale classes.
  */
 void parseIncrementOption(const StringSegment &segment, Precision &outPrecision, UErrorCode &status);
 

--- a/icu4c/source/i18n/number_skeletons.cpp
+++ b/icu4c/source/i18n/number_skeletons.cpp
@@ -890,6 +890,10 @@ void GeneratorHelpers::generateSkeleton(const MacroProps& macros, UnicodeString&
         status = U_UNSUPPORTED_ERROR;
         return;
     }
+    if (macros.unitDisplayCase.isSet()) {
+        status = U_UNSUPPORTED_ERROR;
+        return;
+    }
     if (macros.affixProvider != nullptr) {
         status = U_UNSUPPORTED_ERROR;
         return;
@@ -1512,7 +1516,7 @@ bool GeneratorHelpers::unit(const MacroProps& macros, UnicodeString& sb, UErrorC
 bool GeneratorHelpers::usage(const MacroProps& macros, UnicodeString& sb, UErrorCode& /* status */) {
     if (macros.usage.isSet()) {
         sb.append(u"usage/", -1);
-        sb.append(UnicodeString(macros.usage.fUsage, -1, US_INV));
+        sb.append(UnicodeString(macros.usage.fValue, -1, US_INV));
         return true;
     }
     return false;

--- a/icu4c/source/i18n/number_usageprefs.cpp
+++ b/icu4c/source/i18n/number_usageprefs.cpp
@@ -28,79 +28,81 @@ using icu::StringSegment;
 using icu::units::ConversionRates;
 
 // Copy constructor
-Usage::Usage(const Usage &other) : Usage() {
+StringProp::StringProp(const StringProp &other) : StringProp() {
     this->operator=(other);
 }
 
 // Copy assignment operator
-Usage &Usage::operator=(const Usage &other) {
+StringProp &StringProp::operator=(const StringProp &other) {
     fLength = 0;
     fError = other.fError;
-    if (fUsage != nullptr) {
-        uprv_free(fUsage);
-        fUsage = nullptr;
+    if (fValue != nullptr) {
+        uprv_free(fValue);
+        fValue = nullptr;
     }
-    if (other.fUsage == nullptr) {
+    if (other.fValue == nullptr) {
         return *this;
     }
     if (U_FAILURE(other.fError)) {
         // We don't bother trying to allocating memory if we're in any case busy
-        // copying an errored Usage.
+        // copying an errored StringProp.
         return *this;
     }
-    fUsage = (char *)uprv_malloc(other.fLength + 1);
-    if (fUsage == nullptr) {
+    fValue = (char *)uprv_malloc(other.fLength + 1);
+    if (fValue == nullptr) {
         fError = U_MEMORY_ALLOCATION_ERROR;
         return *this;
     }
     fLength = other.fLength;
-    uprv_strncpy(fUsage, other.fUsage, fLength + 1);
+    uprv_strncpy(fValue, other.fValue, fLength + 1);
     return *this;
 }
 
 // Move constructor
-Usage::Usage(Usage &&src) U_NOEXCEPT : fUsage(src.fUsage), fLength(src.fLength), fError(src.fError) {
+StringProp::StringProp(StringProp &&src) U_NOEXCEPT : fValue(src.fValue),
+                                                      fLength(src.fLength),
+                                                      fError(src.fError) {
     // Take ownership away from src if necessary
-    src.fUsage = nullptr;
+    src.fValue = nullptr;
 }
 
 // Move assignment operator
-Usage &Usage::operator=(Usage &&src) U_NOEXCEPT {
+StringProp &StringProp::operator=(StringProp &&src) U_NOEXCEPT {
     if (this == &src) {
         return *this;
     }
-    if (fUsage != nullptr) {
-        uprv_free(fUsage);
+    if (fValue != nullptr) {
+        uprv_free(fValue);
     }
-    fUsage = src.fUsage;
+    fValue = src.fValue;
     fLength = src.fLength;
     fError = src.fError;
     // Take ownership away from src if necessary
-    src.fUsage = nullptr;
+    src.fValue = nullptr;
     return *this;
 }
 
-Usage::~Usage() {
-    if (fUsage != nullptr) {
-        uprv_free(fUsage);
-        fUsage = nullptr;
+StringProp::~StringProp() {
+    if (fValue != nullptr) {
+        uprv_free(fValue);
+        fValue = nullptr;
     }
 }
 
-void Usage::set(StringPiece value) {
-    if (fUsage != nullptr) {
-        uprv_free(fUsage);
-        fUsage = nullptr;
+void StringProp::set(StringPiece value) {
+    if (fValue != nullptr) {
+        uprv_free(fValue);
+        fValue = nullptr;
     }
     fLength = value.length();
-    fUsage = (char *)uprv_malloc(fLength + 1);
-    if (fUsage == nullptr) {
+    fValue = (char *)uprv_malloc(fLength + 1);
+    if (fValue == nullptr) {
         fLength = 0;
         fError = U_MEMORY_ALLOCATION_ERROR;
         return;
     }
-    uprv_strncpy(fUsage, value.data(), fLength);
-    fUsage[fLength] = 0;
+    uprv_strncpy(fValue, value.data(), fLength);
+    fValue[fLength] = 0;
 }
 
 // Populates micros.mixedMeasures and modifies quantity, based on the values in

--- a/icu4c/source/i18n/number_utypes.h
+++ b/icu4c/source/i18n/number_utypes.h
@@ -42,6 +42,9 @@ public:
     // TODO(units,hugovdm): populate this correctly for the general case - it's
     // currently only implemented for the .usage() use case.
     MeasureUnit outputUnit;
+
+    // The gender of the formatted output.
+    const char *gender = "";
 };
 
 

--- a/icu4c/source/i18n/unicode/numberformatter.h
+++ b/icu4c/source/i18n/unicode/numberformatter.h
@@ -1131,33 +1131,35 @@ class U_I18N_API Scale : public UMemory {
 
 namespace impl {
 
-// Do not enclose entire Usage with #ifndef U_HIDE_INTERNAL_API, needed for a protected field
+// Do not enclose entire StringProp with #ifndef U_HIDE_INTERNAL_API, needed for a protected field
 /**
  * Manages NumberFormatterSettings::usage()'s char* instance on the heap.
  * @internal
  */
-class U_I18N_API Usage : public UMemory {
+class U_I18N_API StringProp : public UMemory {
 
 #ifndef U_HIDE_INTERNAL_API
 
   public:
     /** @internal */
-    Usage(const Usage& other);
+    StringProp(const StringProp &other);
 
     /** @internal */
-    Usage& operator=(const Usage& other);
+    StringProp &operator=(const StringProp &other);
 
     /** @internal */
-    Usage(Usage &&src) U_NOEXCEPT;
+    StringProp(StringProp &&src) U_NOEXCEPT;
 
     /** @internal */
-    Usage& operator=(Usage&& src) U_NOEXCEPT;
+    StringProp &operator=(StringProp &&src) U_NOEXCEPT;
 
     /** @internal */
-    ~Usage();
+    ~StringProp();
 
     /** @internal */
-    int16_t length() const { return fLength; }
+    int16_t length() const {
+        return fLength;
+    }
 
     /** @internal
      * Makes a copy of value. Set to "" to unset.
@@ -1165,16 +1167,19 @@ class U_I18N_API Usage : public UMemory {
     void set(StringPiece value);
 
     /** @internal */
-    bool isSet() const { return fLength > 0; }
+    bool isSet() const {
+        return fLength > 0;
+    }
 
 #endif // U_HIDE_INTERNAL_API
 
   private:
-    char *fUsage;
+    char *fValue;
     int16_t fLength;
     UErrorCode fError;
 
-    Usage() : fUsage(nullptr), fLength(0), fError(U_ZERO_ERROR) {}
+    StringProp() : fValue(nullptr), fLength(0), fError(U_ZERO_ERROR) {
+    }
 
     /** @internal */
     UBool copyErrorTo(UErrorCode &status) const {
@@ -1185,7 +1190,7 @@ class U_I18N_API Usage : public UMemory {
         return false;
     }
 
-    // Allow NumberFormatterImpl to access fUsage.
+    // Allow NumberFormatterImpl to access fValue.
     friend class impl::NumberFormatterImpl;
 
     // Allow skeleton generation code to access private members.
@@ -1480,7 +1485,10 @@ struct U_I18N_API MacroProps : public UMemory {
     Scale scale;  // = Scale();  (benign value)
 
     /** @internal */
-    Usage usage;  // = Usage();  (no usage)
+    StringProp usage;  // = StringProp();  (no usage)
+
+    /** @internal */
+    StringProp unitDisplayCase;  // = StringProp();  (nominative)
 
     /** @internal */
     const AffixPatternProvider* affixProvider = nullptr;  // no ownership
@@ -1503,7 +1511,8 @@ struct U_I18N_API MacroProps : public UMemory {
     bool copyErrorTo(UErrorCode &status) const {
         return notation.copyErrorTo(status) || precision.copyErrorTo(status) ||
                padder.copyErrorTo(status) || integerWidth.copyErrorTo(status) ||
-               symbols.copyErrorTo(status) || scale.copyErrorTo(status) || usage.copyErrorTo(status);
+               symbols.copyErrorTo(status) || scale.copyErrorTo(status) || usage.copyErrorTo(status) ||
+               unitDisplayCase.copyErrorTo(status);
     }
 };
 
@@ -2169,6 +2178,21 @@ class U_I18N_API NumberFormatterSettings {
      * @draft ICU 68
      */
     Derived usage(StringPiece usage) &&;
+
+    /**
+     * Specifies the desired case for a unit formatter's output (e.g.
+     * accusative, dative, genitive).
+     *
+     * @internal ICU 69 technology preview
+     */
+    Derived unitDisplayCase(StringPiece unitDisplayCase) const &;
+
+    /**
+     * Overload of unitDisplayCase() for use on an rvalue reference.
+     *
+     * @internal ICU 69 technology preview
+     */
+    Derived unitDisplayCase(StringPiece unitDisplayCase) &&;
 #endif // U_HIDE_DRAFT_API
 
 #ifndef U_HIDE_INTERNAL_API
@@ -2658,6 +2682,14 @@ class U_I18N_API FormattedNumber : public UMemory, public FormattedValue {
      * @draft ICU 68
      */
     MeasureUnit getOutputUnit(UErrorCode& status) const;
+
+    /**
+     * Gets the gender of the formatted output. Returns "" when the gender is
+     * unknown, or for ungendered languages.
+     *
+     * @internal ICU 69 technology preview.
+     */
+    const char *getGender(UErrorCode& status) const;
 #endif // U_HIDE_DRAFT_API
 
 #ifndef U_HIDE_INTERNAL_API

--- a/icu4c/source/test/intltest/intltest.cpp
+++ b/icu4c/source/test/intltest/intltest.cpp
@@ -1974,6 +1974,8 @@ UBool IntlTest::assertEquals(const char* message,
 UBool IntlTest::assertEquals(const char* message,
                              const char* expected,
                              const char* actual) {
+    U_ASSERT(expected != nullptr);
+    U_ASSERT(actual != nullptr);
     if (uprv_strcmp(expected, actual) != 0) {
         errln((UnicodeString)"FAIL: " + message + "; got \"" +
               actual +

--- a/icu4c/source/test/intltest/numbertest.h
+++ b/icu4c/source/test/intltest/numbertest.h
@@ -64,6 +64,8 @@ class NumberFormatterApiTest : public IntlTestWithFieldPosition {
     void unitUsageErrorCodes();
     void unitUsageSkeletons();
     void unitCurrency();
+    void unitInflections();
+    void unitGender();
     void unitPercent();
     void percentParity();
     void roundingFraction();
@@ -170,6 +172,19 @@ class NumberFormatterApiTest : public IntlTestWithFieldPosition {
       const FormattedNumber& formattedNumber,
       const UFieldPosition* expectedFieldPositions,
       int32_t length);
+
+    struct UnitInflectionTestCase {
+        const char *locale;
+        const char *unitDisplayCase;
+        double value;
+        const UChar *expected;
+    };
+
+    void runUnitInflectionsTestCases(UnlocalizedNumberFormatter unf,
+                                     const UChar *skeleton,
+                                     const UChar *conciseSkeleton,
+                                     const UnitInflectionTestCase *cases,
+                                     int32_t numCases);
 };
 
 class DecimalQuantityTest : public IntlTest {

--- a/tools/cldr/cldr-to-icu/src/main/resources/ldml2icu_locale.txt
+++ b/tools/cldr/cldr-to-icu/src/main/resources/ldml2icu_locale.txt
@@ -320,6 +320,7 @@
 //ldml/units/unitLength[@type="short"]/unit[@type="(\w++)-(%A)"]/displayName ; /unitsShort/$1/$2/dnam
 //ldml/units/unitLength[@type="long"]/unit[@type="(\w++)-(%A)"]/displayName ; /units/$1/$2/dnam
 
+# TODO(icu-units#138): homogenize with compoundUnitPattern1 rules below by using "_" as case when case is absent in XML.
 //ldml/units/unitLength[@type="narrow"]/unit[@type="(\w++)-(%A)"]/unitPattern[@count="(%A)"][@case="(%A)"] ; /unitsNarrow/$1/$2/case/$4/$3
 //ldml/units/unitLength[@type="short"]/unit[@type="(\w++)-(%A)"]/unitPattern[@count="(%A)"][@case="(%A)"] ; /unitsShort/$1/$2/case/$4/$3
 //ldml/units/unitLength[@type="long"]/unit[@type="(\w++)-(%A)"]/unitPattern[@count="(%A)"][@case="(%A)"] ; /units/$1/$2/case/$4/$3
@@ -338,6 +339,7 @@
 //ldml/units/unitLength[@type="short"]/compoundUnit[@type="(%A)"]/compoundUnitPattern ; /unitsShort/compound/$1
 //ldml/units/unitLength[@type="long"]/compoundUnit[@type="(%A)"]/compoundUnitPattern ; /units/compound/$1
 
+# TODO(icu-units#138): the style of output paths used in these rules is the proposed format for all count/gender/case lateral inheritance rules.
 //ldml/units/unitLength[@type="narrow"]/compoundUnit[@type="(%A)"]/compoundUnitPattern1[@count="(%A)"][@gender="(%A)"][@case="(%A)"] ; /unitsNarrow/compound/$1/$2/$3/$4
 //ldml/units/unitLength[@type="short"]/compoundUnit[@type="(%A)"]/compoundUnitPattern1[@count="(%A)"][@gender="(%A)"][@case="(%A)"] ; /unitsShort/compound/$1/$2/$3/$4
 //ldml/units/unitLength[@type="long"]/compoundUnit[@type="(%A)"]/compoundUnitPattern1[@count="(%A)"][@gender="(%A)"][@case="(%A)"] ; /units/compound/$1/$2/$3/$4


### PR DESCRIPTION
Closes: icu-units#111

Progress:
- [x] inflect built-in units
- [x] support built-in unit gender
- [x] inflect builtin-per-builtin compound units
- [x] support builtin-per-builtin compound unit gender
- [x] inflect mixed units - CLDR-14502 filed to find out if I'm inflecting correctly
- N/A support mixed unit gender - ICU-21494
- icu-units#138: correctly implement Lateral Inheritance (current implementation is a shortcut adequate for CLDR 39 data)
- icu-units#139: implement deriveComponent plural per rules (currently hard-coded, matches all CLDR 39 rules)
- icu-units#140: support gender when not using unit-width-full-name
- icu-units#141: support gender for built-in compound units (treat as not-builtin to get the builtin-per-builtin gender)

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21123
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [X] Tests included
- [x] Documentation is changed or added

