### PR TITLE
ICU-21499 Suppress warning about non-NULL addresses in uprv_memcpy and uprv_memmove

### DIFF
--- a/icu4c/source/common/cmemory.h
+++ b/icu4c/source/common/cmemory.h
@@ -37,19 +37,57 @@
 #include <stdio.h>
 #endif
 
-
+// uprv_memcpy and uprv_memmove
+#if defined(__clang__)
+#define uprv_memcpy(dst, src, size) UPRV_BLOCK_MACRO_BEGIN { \
+    /* Suppress warnings about addresses that will never be NULL */ \
+    _Pragma("clang diagnostic push") \
+    _Pragma("clang diagnostic ignored \"-Waddress\"") \
+    U_ASSERT(dst != NULL); \
+    U_ASSERT(src != NULL); \
+    _Pragma("clang diagnostic pop") \
+    U_STANDARD_CPP_NAMESPACE memcpy(dst, src, size); \
+} UPRV_BLOCK_MACRO_END
+#define uprv_memmove(dst, src, size) UPRV_BLOCK_MACRO_BEGIN { \
+    /* Suppress warnings about addresses that will never be NULL */ \
+    _Pragma("clang diagnostic push") \
+    _Pragma("clang diagnostic ignored \"-Waddress\"") \
+    U_ASSERT(dst != NULL); \
+    U_ASSERT(src != NULL); \
+    _Pragma("clang diagnostic pop") \
+    U_STANDARD_CPP_NAMESPACE memmove(dst, src, size); \
+} UPRV_BLOCK_MACRO_END
+#elif defined(__GNUC__)
+#define uprv_memcpy(dst, src, size) UPRV_BLOCK_MACRO_BEGIN { \
+    /* Suppress warnings about addresses that will never be NULL */ \
+    _Pragma("GCC diagnostic push") \
+    _Pragma("GCC diagnostic ignored \"-Waddress\"") \
+    U_ASSERT(dst != NULL); \
+    U_ASSERT(src != NULL); \
+    _Pragma("GCC diagnostic pop") \
+    U_STANDARD_CPP_NAMESPACE memcpy(dst, src, size); \
+} UPRV_BLOCK_MACRO_END
+#define uprv_memmove(dst, src, size) UPRV_BLOCK_MACRO_BEGIN { \
+    /* Suppress warnings about addresses that will never be NULL */ \
+    _Pragma("GCC diagnostic push") \
+    _Pragma("GCC diagnostic ignored \"-Waddress\"") \
+    U_ASSERT(dst != NULL); \
+    U_ASSERT(src != NULL); \
+    _Pragma("GCC diagnostic pop") \
+    U_STANDARD_CPP_NAMESPACE memmove(dst, src, size); \
+} UPRV_BLOCK_MACRO_END
+#else
 #define uprv_memcpy(dst, src, size) UPRV_BLOCK_MACRO_BEGIN { \
     U_ASSERT(dst != NULL); \
     U_ASSERT(src != NULL); \
     U_STANDARD_CPP_NAMESPACE memcpy(dst, src, size); \
 } UPRV_BLOCK_MACRO_END
-
 #define uprv_memmove(dst, src, size) UPRV_BLOCK_MACRO_BEGIN { \
     U_ASSERT(dst != NULL); \
     U_ASSERT(src != NULL); \
     U_STANDARD_CPP_NAMESPACE memmove(dst, src, size); \
 } UPRV_BLOCK_MACRO_END
-
+#endif
 
 /**
  * \def UPRV_LENGTHOF


### PR DESCRIPTION
Both Clang and GCC will output warnings when they know a variable cannot be `NULL`/`nullptr`.
This causes the two `U_ASSERT` macros added to `uprv_memcpy` and `uprv_memmove` in ICU-21118 to generate a number of noisy warnings.

We can suppress these warnings for Clang and GCC. Though doing so is a bit tricky, as we can't use `#ifdef` or `#pragma` inside of a macro `#define` token-string. The resulting output from the #define isn't processed by the preprocessor again, so if we have anything like `#pragma` in the token-string, it effectively gets ignored.
However, it turns out that we can use the C99 `_Pragma` [feature ](https://gcc.gnu.org/onlinedocs/cpp/Pragmas.html)for this (thanks to @erik0686 for this tip!).

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21499
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

