### PR TITLE
ICU-21502 Adds status checks to test to prevent segmentation fault when

### DIFF
--- a/icu4c/source/test/intltest/units_test.cpp
+++ b/icu4c/source/test/intltest/units_test.cpp
@@ -708,10 +708,26 @@ void UnitsTest::testComplexUnitsConverterSorting() {
 
     for (const auto &testCase : testCases) {
         MeasureUnitImpl inputImpl = MeasureUnitImpl::forIdentifier(testCase.input, status);
+        if (status.errIfFailureAndReset()) {
+            continue;
+        }
         MeasureUnitImpl outputImpl = MeasureUnitImpl::forIdentifier(testCase.output, status);
+        if (status.errIfFailureAndReset()) {
+            continue;
+        }
         ComplexUnitsConverter converter(inputImpl, outputImpl, conversionRates, status);
+        if (status.errIfFailureAndReset()) {
+            continue;
+        }
 
         auto actual = converter.convert(testCase.inputValue, nullptr, status);
+        if (status.errIfFailureAndReset()) {
+            continue;
+        }
+        if (actual.length() < testCase.expectedCount) {
+            errln("converter.convert(...) returned too few Measures");
+            continue;
+        }
 
         for (int i = 0; i < testCase.expectedCount; i++) {
             assertEquals(testCase.msg, testCase.expected[i].getUnit().getIdentifier(),


### PR DESCRIPTION
test runs with ICU stub data only.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21502
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

