### PR TITLE
ICU-21503 Adds status checks to prevent segmentation fault when test …

### DIFF
--- a/icu4c/source/test/intltest/normconf.cpp
+++ b/icu4c/source/test/intltest/normconf.cpp
@@ -282,9 +282,12 @@ void NormalizerConformanceTest::TestConformance(FileStream *input, int32_t optio
 
 namespace {
 
-UBool isNormalizedUTF8(const Normalizer2 &norm2, const UnicodeString &s, UErrorCode &errorCode) {
+UBool isNormalizedUTF8(const Normalizer2 *norm2, const UnicodeString &s, UErrorCode &errorCode) {
+    if (norm2 == nullptr) {
+        return true;
+    }
     std::string s8;
-    return norm2.isNormalizedUTF8(s.toUTF8String(s8), errorCode);
+    return norm2->isNormalizedUTF8(s.toUTF8String(s8), errorCode);
 }
 
 }  // namespace
@@ -351,7 +354,7 @@ UBool NormalizerConformanceTest::checkConformance(const UnicodeString* field,
         dataerrln("Normalizer error: isNormalized(NFC(s), UNORM_NFC) is FALSE");
         pass = FALSE;
     }
-    if(options==0 && !isNormalizedUTF8(*nfc, field[1], status)) {
+    if(options==0 && !isNormalizedUTF8(nfc, field[1], status)) {
         dataerrln("Normalizer error: nfc.isNormalizedUTF8(NFC(s)) is FALSE");
         pass = FALSE;
     }
@@ -360,12 +363,12 @@ UBool NormalizerConformanceTest::checkConformance(const UnicodeString* field,
             errln("Normalizer error: isNormalized(s, UNORM_NFC) is TRUE");
             pass = FALSE;
         }
-        if(isNormalizedUTF8(*nfc, field[0], status)) {
+        if(isNormalizedUTF8(nfc, field[0], status)) {
             errln("Normalizer error: nfc.isNormalizedUTF8(s) is TRUE");
             pass = FALSE;
         }
     }
-    if(options==0 && !isNormalizedUTF8(*nfd, field[2], status)) {
+    if(options==0 && !isNormalizedUTF8(nfd, field[2], status)) {
         dataerrln("Normalizer error: nfd.isNormalizedUTF8(NFD(s)) is FALSE");
         pass = FALSE;
     }
@@ -373,7 +376,7 @@ UBool NormalizerConformanceTest::checkConformance(const UnicodeString* field,
         dataerrln("Normalizer error: isNormalized(NFKC(s), UNORM_NFKC) is FALSE");
         pass = FALSE;
     } else {
-        if(options==0 && !isNormalizedUTF8(*nfkc, field[3], status)) {
+        if(options==0 && !isNormalizedUTF8(nfkc, field[3], status)) {
             dataerrln("Normalizer error: nfkc.isNormalizedUTF8(NFKC(s)) is FALSE");
             pass = FALSE;
         }
@@ -382,13 +385,13 @@ UBool NormalizerConformanceTest::checkConformance(const UnicodeString* field,
                 errln("Normalizer error: isNormalized(s, UNORM_NFKC) is TRUE");
                 pass = FALSE;
             }
-            if(options==0 && isNormalizedUTF8(*nfkc, field[0], status)) {
+            if(options==0 && isNormalizedUTF8(nfkc, field[0], status)) {
                 errln("Normalizer error: nfkc.isNormalizedUTF8(s) is TRUE");
                 pass = FALSE;
             }
         }
     }
-    if(options==0 && !isNormalizedUTF8(*nfkd, field[4], status)) {
+    if(options==0 && !isNormalizedUTF8(nfkd, field[4], status)) {
         dataerrln("Normalizer error: nfkd.isNormalizedUTF8(NFKD(s)) is FALSE");
         pass = FALSE;
     }


### PR DESCRIPTION
…runs

with stubdata only.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21503
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

