### PR TITLE
ICU-21480 integrate CLDR release-39-alpha3 to ICU trunk

### DIFF
--- a/icu4c/source/data/locales/nn.txt
+++ b/icu4c/source/data/locales/nn.txt
@@ -3,9 +3,7 @@
 // Generated using tools/cldr/cldr-to-icu/build-icu-data.xml
 nn{
     %%Parent{"no"}
-    AuxExemplarCharacters{"[á ǎ ä č ç đ è ê ń ñ ŋ ö š ŧ ü ž]"}
-    ExemplarCharacters{"[a à å æ b c d e é f g h i j k l m n o ó ò ô ø p q r s t u v w x y z]"}
-    ExemplarCharactersIndex{"[A Å Æ B C D E F G H I J K L M N O Ø P Q R S T U V W X Y Z]"}
+    AuxExemplarCharacters{"[á ǎ č ç đ è ê ń ñ ŋ š ŧ ü ž ä ö]"}
     ExemplarCharactersPunctuation{
         "[\\- ‐ ‑ – — , ; \\: ! ? . … ' ‘ ’ \u0022 “ ” ( ) \\[ \\] § @ * / \\& # † ‡ "
         "′ ″]"

--- a/icu4c/source/data/unit/eu.txt
+++ b/icu4c/source/data/unit/eu.txt
@@ -1069,7 +1069,7 @@ eu{
             1024p7{"Zi{0}"}
             1024p8{"Yi{0}"}
             per{"{0}/{1}"}
-            times{"{0}{1}"}
+            times{"{0}-{1}"}
         }
         concentr{
             percent{
@@ -1372,7 +1372,7 @@ eu{
             1024p7{"Zi{0}"}
             1024p8{"Yi{0}"}
             per{"{0}/{1}"}
-            times{"{0}{1}"}
+            times{"{0}-{1}"}
         }
         concentr{
             karat{

--- a/icu4c/source/data/unit/fr.txt
+++ b/icu4c/source/data/unit/fr.txt
@@ -1178,7 +1178,7 @@ fr{
         }
         compound{
             per{"{0}/{1}"}
-            times{"{0}{1}"}
+            times{"{0}-{1}"}
         }
         concentr{
             percent{
@@ -1665,7 +1665,7 @@ fr{
         }
         compound{
             per{"{0}/{1}"}
-            times{"{0}{1}"}
+            times{"{0}-{1}"}
         }
         concentr{
             karat{

--- a/icu4c/source/data/unit/ro.txt
+++ b/icu4c/source/data/unit/ro.txt
@@ -1311,7 +1311,7 @@ ro{
             10p6{"M{0}"}
             10p9{"G{0}"}
             per{"{0}/{1}"}
-            times{"{0}{1}"}
+            times{"{0} {1}"}
         }
         concentr{
             percent{
@@ -1848,7 +1848,7 @@ ro{
             10p6{"M{0}"}
             10p9{"G{0}"}
             per{"{0}/{1}"}
-            times{"{0}{1}"}
+            times{"{0} {1}"}
         }
         concentr{
             karat{

--- a/icu4j/main/shared/data/icudata.jar
+++ b/icu4j/main/shared/data/icudata.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aebd0c04ef6afb8216af2311390705a5442122de92b9e6498e3edb0567ee865e
-size 13303001
+oid sha256:9f438270baa10fbae595a2c84184276867437c2c414331ccdc0939e1af530cd3
+size 13302830

--- a/icu4j/main/shared/data/icutzdata.jar
+++ b/icu4j/main/shared/data/icutzdata.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0c5b1243d882ac085227f99d8e25b75639e481694d4a027c57b42fbbd73957cd
+oid sha256:7ca9c9bb368c6d12e8c5e0a973f8147bb3a5b69282b273b7f676174386face31
 size 95094


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21480
- [x] Updated PR title and link in previous line to include Issue number
- [x] Issue accepted
- [x] Tests included
- [x] Documentation is changed or added

This integrates CLDR release-39-alpha3. The difference from CLDR release-39-alpha2 is really just:
- Some BRS passes, which normalized exemplars for "nn" (and then removed some as redundant). (The BRS passes also affected production data such as annotations, but those are not in ICU)
- The result of fixing [CLDR-14533](https://unicode-org.atlassian.net/browse/CLDR-14533),  which corrected some unit patterns

