### PR TITLE
ICU-20941 Fix uninitialized values: DerivedComponents' compound0_ and compound1_

### DIFF
--- a/icu4c/source/i18n/number_longnames.cpp
+++ b/icu4c/source/i18n/number_longnames.cpp
@@ -658,7 +658,7 @@ class DerivedComponents {
     UErrorCode status = U_ZERO_ERROR;
 
     // Holds strings referred to by value0 and value1;
-    bool compound0_, compound1_;
+    bool compound0_ = false, compound1_ = false;
     CharString value0_, value1_;
 };
 


### PR DESCRIPTION
Waiting for https://github.com/unicode-org/icu/pull/1601 to fix French compound unit formatting.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-20941
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

