### PR TITLE
ICU-21480 Update French unit-times pattern in unit tests

### DIFF
--- a/icu4c/source/test/intltest/numbertest_api.cpp
+++ b/icu4c/source/test/intltest/numbertest_api.cpp
@@ -2216,9 +2216,8 @@ void NumberFormatterApiTest::unitInflections() {
             // singular like German), and "pow2" prefixes have different forms
             //   <deriveComponent feature="plural" structure="times" value0="compound"  value1="compound"/>
             //   <deriveComponent feature="plural" structure="power" value0="compound"  value1="compound"/>
-            // TODO: this looks wrong, and will change if CLDR-14533 causes a change:
-            {"square-decimeter-square-second", "fr", nullptr, 1, u"1\u00A0décimètre carréseconde carrée"},
-            {"square-decimeter-square-second", "fr", nullptr, 2, u"2\u00A0décimètres carréssecondes carrées"},
+            {"square-decimeter-square-second", "fr", nullptr, 1, u"1\u00A0décimètre carré-seconde carrée"},
+            {"square-decimeter-square-second", "fr", nullptr, 2, u"2\u00A0décimètres carrés-secondes carrées"},
         };
         runUnitInflectionsTestCases(unf, skeleton, meterCases, UPRV_LENGTHOF(meterCases), status);
     }


### PR DESCRIPTION
This PR touches only ICU4C, because the equivalent ICU4J PR is nr 1597, which is not finished yet.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Issue filed: https://unicode-org.atlassian.net/browse/ICU-21480
- [X] Updated PR title and link in previous line to include Issue number
- [X] Issue accepted
- [X] Tests included
- [ ] Documentation is changed or added

