### PR TITLE
ICU-21480 Update GitHub pull request template to prevent autolinking example ticket number.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,9 +12,9 @@ You will be automatically asked to sign the contributors license agreement (CLA)
 ##### Checklist
 
 - [ ] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
-- [ ] Required: The PR title must be prefixed with a JIRA Issue number. For example: "ICU-1234 Fix xyz"
+- [ ] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
 - [ ] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
-- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. For example: "ICU-1234 Fix xyz"
+- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
 - [ ] Issue accepted (done by Technical Committee after discussion)
 - [ ] Tests included, if applicable
 - [ ] API docs and/or User Guide docs changed or added, if applicable


### PR DESCRIPTION
The change added in PR #1600 updated the GitHub PR template. However, the example ticket numbers used in the PR template end up getting turned into automatic links on every PR. 

This makes the comments instead, so the PR author can still see them, but now they won't get autolinked to the JIRA ticket.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21480
- [x] Required: The PR title must be prefixed with a JIRA Issue number. 
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. 
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
