### PR TITLE
ICU-21349 ICU4J units cleanup: eclipse warnings, unsuppress one warning

### DIFF
--- a/icu4c/source/i18n/units_complexconverter.h
+++ b/icu4c/source/i18n/units_complexconverter.h
@@ -86,7 +86,7 @@ class U_I18N_API ComplexUnitsConverter : public UMemory {
      *
      * @param inputUnit represents the source unit. (should be single or compound unit).
      * @param outputUnits represents the output unit. could be any type. (single, compound or mixed).
-     * @param ratesInfo
+     * @param ratesInfo a ConversionRates instance containing the unit conversion rates.
      * @param status
      */
     ComplexUnitsConverter(const MeasureUnitImpl &inputUnit, const MeasureUnitImpl &outputUnits,

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/number/UnitConversionHandler.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/number/UnitConversionHandler.java
@@ -2,12 +2,9 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 package com.ibm.icu.impl.number;
 
-import java.util.List;
-
 import com.ibm.icu.impl.units.ComplexUnitsConverter;
 import com.ibm.icu.impl.units.ConversionRates;
 import com.ibm.icu.impl.units.MeasureUnitImpl;
-import com.ibm.icu.util.Measure;
 import com.ibm.icu.util.MeasureUnit;
 
 /**

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/units/ComplexUnitsConverter.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/units/ComplexUnitsConverter.java
@@ -86,6 +86,7 @@ public class ComplexUnitsConverter {
      * @param outputUnits
      *            represents the output unit. could be any type. (single, compound or mixed).
      * @param conversionRates
+     *            a ConversionRates instance containing the unit conversion rates.
      */
     public ComplexUnitsConverter(MeasureUnitImpl inputUnit, MeasureUnitImpl outputUnits,
             ConversionRates conversionRates) {

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/units/UnitsRouter.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/units/UnitsRouter.java
@@ -9,7 +9,6 @@ import java.util.List;
 import com.ibm.icu.impl.IllegalIcuArgumentException;
 import com.ibm.icu.impl.number.MicroProps;
 import com.ibm.icu.number.Precision;
-import com.ibm.icu.util.Measure;
 import com.ibm.icu.util.MeasureUnit;
 
 /**

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/impl/UnitsTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/impl/UnitsTest.java
@@ -64,7 +64,7 @@ public class UnitsTest {
                 for (Measure measure : measures) {
                     double accuracy = 0.0;
                     if (i == expected.length - 1) {
-                        accuracy = accuracy;
+                        accuracy = this.accuracy;
                     }
                     assertTrue("input " + value + ", output measure " + i + ": expected " +
                                     expected[i] + ", expected unit " +
@@ -572,7 +572,6 @@ public class UnitsTest {
             /**
              * Test Case Data
              */
-            @SuppressWarnings("unused")
             String category;
             String usage;
             String region;
@@ -622,6 +621,7 @@ public class UnitsTest {
                 }
             }
 
+            @Override
             public String toString() {
                 ArrayList<MeasureUnitImpl> outputUnits = new ArrayList<>();
                 for (Pair<String, MeasureUnitImpl> unit : outputUnitInOrder) {


### PR DESCRIPTION
toString() now uses category, so `@SuppressWarnings("unused")` is no longer needed.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21349
- [X] Required: The PR title must be prefixed with a JIRA Issue number. For example: "ICU-1234 Fix xyz"
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. For example: "ICU-1234 Fix xyz"
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
