### PR TITLE
ICU-21349 calling .usage("") should unset the existing usage

### DIFF
--- a/icu4c/source/test/intltest/numbertest_api.cpp
+++ b/icu4c/source/test/intltest/numbertest_api.cpp
@@ -1719,6 +1719,43 @@ void NumberFormatterApiTest::unitUsage() {
             30500,
             u"350 m");
 
+    // Test calling `.usage("")` should unset the existing usage.
+    // First: without usage
+    assertFormatSingle(u"Rounding Mode propagates: rounding up",
+                       u"measure-unit/length-centimeter rounding-mode-ceiling",
+                       u"unit/centimeter rounding-mode-ceiling",
+                       NumberFormatter::with()
+                           .unit(MeasureUnit::forIdentifier("centimeter", status))
+                           .roundingMode(UNUM_ROUND_CEILING),
+                       Locale("en-US"), //
+                       3048,            //
+                       u"3,048 cm");
+
+    // Second: with "road" usage
+    assertFormatSingle(u"Rounding Mode propagates: rounding up",
+                       u"usage/road measure-unit/length-centimeter rounding-mode-ceiling",
+                       u"usage/road unit/centimeter rounding-mode-ceiling",
+                       NumberFormatter::with()
+                           .unit(MeasureUnit::forIdentifier("centimeter", status))
+                           .usage("road")
+                           .roundingMode(UNUM_ROUND_CEILING),
+                       Locale("en-US"), //
+                       3048,            //
+                       u"100 ft");
+
+    // Third: with "road" usage, then the usage unsetted by calling .usage("")
+    assertFormatSingle(u"Rounding Mode propagates: rounding up",
+                       u"measure-unit/length-centimeter rounding-mode-ceiling",
+                       u"unit/centimeter rounding-mode-ceiling",
+                       NumberFormatter::with()
+                           .unit(MeasureUnit::forIdentifier("centimeter", status))
+                           .usage("road")
+                           .roundingMode(UNUM_ROUND_CEILING)
+                           .usage(""),  // unset
+                       Locale("en-US"), //
+                       3048,            //
+                       u"3,048 cm");
+
     // TODO(icu-units#38): improve unit testing coverage. E.g. add vehicle-fuel
     // triggering inversion conversion code. Test with 0 too, to see
     // divide-by-zero behaviour.

--- a/icu4j/main/classes/core/src/com/ibm/icu/number/NumberFormatterSettings.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/number/NumberFormatterSettings.java
@@ -546,6 +546,10 @@ public abstract class NumberFormatterSettings<T extends NumberFormatterSettings<
      * @provisional This API might change or be removed in a future release.
      */
     public T usage(String usage) {
+        if (usage != null && usage.isEmpty()) {
+            return create(KEY_USAGE, null);
+        }
+
         return create(KEY_USAGE, usage);
     }
 

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
@@ -1652,6 +1652,57 @@ public class NumberFormatterApiTest extends TestFmwk {
                 30500,
                 "350 m");
 
+        // Test calling .usage("") or .usage(null) should unset the existing usage.
+        // First: without usage
+        assertFormatSingle("Rounding Mode propagates: rounding up",
+                "measure-unit/length-centimeter rounding-mode-ceiling",
+                "unit/centimeter rounding-mode-ceiling",
+                NumberFormatter.with()
+                        .unit(MeasureUnit.forIdentifier("centimeter"))
+                        .roundingMode(RoundingMode.CEILING),
+                new ULocale("en-US"),
+                3048,
+                "3,048 cm");
+
+        // Second: with "road" usage
+        assertFormatSingle("Rounding Mode propagates: rounding up",
+                "usage/road measure-unit/length-centimeter rounding-mode-ceiling",
+                "usage/road unit/centimeter rounding-mode-ceiling",
+                NumberFormatter.with()
+                        .unit(MeasureUnit.forIdentifier("centimeter"))
+                        .usage("road")
+                        .roundingMode(RoundingMode.CEILING),
+                new ULocale("en-US"),
+                3048,
+                "100 ft");
+
+        // Third: with "road" usage, then the usage unsetted by calling .usage("")
+        assertFormatSingle("Rounding Mode propagates: rounding up",
+                "measure-unit/length-centimeter rounding-mode-ceiling",
+                "unit/centimeter rounding-mode-ceiling",
+                NumberFormatter.with()
+                        .unit(MeasureUnit.forIdentifier("centimeter"))
+                        .usage("road")
+                        .roundingMode(RoundingMode.CEILING)
+                        .usage(""), // unset
+                new ULocale("en-US"),
+                3048,
+                "3,048 cm");
+
+        // Fourth: with "road" usage, then the usage unsetted by calling .usage(nul)
+        assertFormatSingle("Rounding Mode propagates: rounding up",
+                "measure-unit/length-centimeter rounding-mode-ceiling",
+                "unit/centimeter rounding-mode-ceiling",
+                NumberFormatter.with()
+                        .unit(MeasureUnit.forIdentifier("centimeter"))
+                        .usage("road")
+                        .roundingMode(RoundingMode.CEILING)
+                        .usage(null), // unset
+                new ULocale("en-US"),
+                3048,
+                "3,048 cm");
+
+
         // TODO(icu-units#38): improve unit testing coverage. E.g. add
         // vehicle-fuel triggering inversion conversion code. Test with 0 too,
         // to see divide-by-zero behaviour.


### PR DESCRIPTION
closes: https://github.com/icu-units/icu/issues/144

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21349
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
