### PR TITLE
ICU-21123 Support FormattedNumber::getGender() for "short" and "narrow" formatting too

### DIFF
--- a/icu4c/source/test/intltest/numbertest_api.cpp
+++ b/icu4c/source/test/intltest/numbertest_api.cpp
@@ -2287,15 +2287,14 @@ void NumberFormatterApiTest::unitGender() {
     LocalizedNumberFormatter formatter;
     FormattedNumber fn;
     for (const TestCase &t : cases) {
-        // TODO(icu-units#140): make this work for more than just UNUM_UNIT_WIDTH_FULL_NAME
-        // formatter = NumberFormatter::with()
-        //                 .unit(MeasureUnit::forIdentifier(t.unitIdentifier, status))
-        //                 .locale(Locale(t.locale));
-        // fn = formatter.formatDouble(1.1, status);
-        // assertEquals(UnicodeString("Testing gender with default width, unit: ") + t.unitIdentifier +
-        //                  ", locale: " + t.locale,
-        //              t.expectedGender, fn.getGender(status));
-        // status.assertSuccess();
+        formatter = NumberFormatter::with()
+                        .unit(MeasureUnit::forIdentifier(t.unitIdentifier, status))
+                        .locale(Locale(t.locale));
+        fn = formatter.formatDouble(1.1, status);
+        assertEquals(UnicodeString("Testing gender with default width, unit: ") + t.unitIdentifier +
+                         ", locale: " + t.locale,
+                     t.expectedGender, fn.getGender(status));
+        status.assertSuccess();
 
         formatter = NumberFormatter::with()
                         .unit(MeasureUnit::forIdentifier(t.unitIdentifier, status))

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
@@ -2277,14 +2277,13 @@ public class NumberFormatterApiTest extends TestFmwk {
         LocalizedNumberFormatter formatter;
         FormattedNumber fn;
         for (TestCase t : cases) {
-            // // TODO(icu-units#140): make this work for more than just UnitWidth.FULL_NAME
-            // formatter = NumberFormatter.with()
-            //                 .unit(MeasureUnit.forIdentifier(t.unitIdentifier))
-            //                 .locale(new ULocale(t.locale));
-            // fn = formatter.format(1.1);
-            // assertEquals("Testing gender with default width, unit: " + t.unitIdentifier +
-            //                  ", locale: " + t.locale,
-            //              t.expectedGender, fn.getGender());
+            formatter = NumberFormatter.with()
+                            .unit(MeasureUnit.forIdentifier(t.unitIdentifier))
+                            .locale(new ULocale(t.locale));
+            fn = formatter.format(1.1);
+            assertEquals("Testing gender with default width, unit: " + t.unitIdentifier +
+                             ", locale: " + t.locale,
+                         t.expectedGender, fn.getGender());
 
             formatter = NumberFormatter.with()
                             .unit(MeasureUnit.forIdentifier(t.unitIdentifier))


### PR DESCRIPTION
Fixes icu-units#140.

Individual commits were:
1. fe6e96c486 Add (failing) tests for gender for not-full-width
2. 5b11e64881 Opportunistically flesh out getInflectedMeasureData docs.
3. 99356c448f ICU4J: catch MissingResourceException only, instead of all Exceptions
4. b24232f8df (tag: pr1617/presquash) Explicitly fetch gender for all MeasureUnit data loads

Arguably 2 and 3 are a little bit out of scope for this PR - piggybacking? We talked about the Exception vs MissingResourceException thing before: I clearly changed my mind, opting for more idiomatic Java, and aiming for a bit more consistency within the file too (no generic Exception catching).

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21123
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
