### PR TITLE
ICU-21207 Remove unnecessary reflection call

### DIFF
--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/timezone/TimeZoneTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/timezone/TimeZoneTest.java
@@ -14,7 +14,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -1083,31 +1082,7 @@ public class TimeZoneTest extends TestFmwk
     public void TestFractionalDST() {
         String tzName = "Australia/Lord_Howe"; // 30 min offset
         java.util.TimeZone tz_java = java.util.TimeZone.getTimeZone(tzName);
-        int dst_java = 0;
-        try {
-            // hack so test compiles and runs in both JDK 1.3 and JDK 1.4
-            final Object[] args = new Object[0];
-            final Class[] argtypes = new Class[0];
-            java.lang.reflect.Method m = tz_java.getClass().getMethod("getDSTSavings", argtypes);
-            dst_java = ((Integer) m.invoke(tz_java, args)).intValue();
-            if (dst_java <= 0 || dst_java >= 3600000) { // didn't get the fractional time zone we wanted
-            errln("didn't get fractional time zone!");
-            }
-        } catch (NoSuchMethodException e) {
-            // see JDKTimeZone for the reason for this code
-            dst_java = 3600000;
-        } catch (IllegalAccessException e) {
-            // see JDKTimeZone for the reason for this code
-            errln(e.getMessage());
-            dst_java = 3600000;
-        } catch (InvocationTargetException e) {
-            // see JDKTimeZone for the reason for this code
-            errln(e.getMessage());
-            dst_java = 3600000;
-        } catch (SecurityException e) {
-            warnln(e.getMessage());
-            return;
-        }
+        int dst_java = tz_java.getDSTSavings();
 
         com.ibm.icu.util.TimeZone tz_icu = com.ibm.icu.util.TimeZone.getTimeZone(tzName);
         int dst_icu = tz_icu.getDSTSavings();


### PR DESCRIPTION
The test code was written long time ago. Java 1.3 TimeZone did not have getDSTSavings() method. The test code compares DST saving of Lord_Howe between ICU and JDK, and calling getDSTSavings() through reflection for 1.3 compatibility. This is no longer necessary and replaced with regular method call.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21207
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
