### PR TITLE
ICU-20918 ucal_openTimeZones() to call ucal_openTimeZoneIDEnumeration()

### DIFF
--- a/icu4c/source/i18n/ucal.cpp
+++ b/icu4c/source/i18n/ucal.cpp
@@ -33,8 +33,8 @@ U_NAMESPACE_USE
 
 static TimeZone*
 _createTimeZone(const UChar* zoneID, int32_t len, UErrorCode* ec) {
-    TimeZone* zone = NULL;
-    if (ec != NULL && U_SUCCESS(*ec)) {
+    TimeZone* zone = nullptr;
+    if (ec != nullptr && U_SUCCESS(*ec)) {
         // Note that if zoneID is invalid, we get back GMT. This odd
         // behavior is by design and goes back to the JDK. The only
         // failure we will see is a memory allocation failure.
@@ -42,7 +42,7 @@ _createTimeZone(const UChar* zoneID, int32_t len, UErrorCode* ec) {
         UnicodeString zoneStrID;
         zoneStrID.setTo((UBool)(len < 0), zoneID, l); /* temporary read-only alias */
         zone = TimeZone::createTimeZone(zoneStrID);
-        if (zone == NULL) {
+        if (zone == nullptr) {
             *ec = U_MEMORY_ALLOCATION_ERROR;
         }
     }
@@ -58,20 +58,20 @@ ucal_openTimeZoneIDEnumeration(USystemTimeZoneType zoneType, const char* region,
 
 U_CAPI UEnumeration* U_EXPORT2
 ucal_openTimeZones(UErrorCode* ec) {
-    return uenum_openFromStringEnumeration(TimeZone::createEnumeration(), ec);
+    return ucal_openTimeZoneIDEnumeration(UCAL_ZONE_TYPE_ANY, nullptr, nullptr, ec);
 }
 
 U_CAPI UEnumeration* U_EXPORT2
 ucal_openCountryTimeZones(const char* country, UErrorCode* ec) {
-    return uenum_openFromStringEnumeration(TimeZone::createEnumeration(country), ec);
+    return ucal_openTimeZoneIDEnumeration(UCAL_ZONE_TYPE_ANY, country, nullptr, ec);
 }
 
 U_CAPI int32_t U_EXPORT2
 ucal_getDefaultTimeZone(UChar* result, int32_t resultCapacity, UErrorCode* ec) {
     int32_t len = 0;
-    if (ec != NULL && U_SUCCESS(*ec)) {
+    if (ec != nullptr && U_SUCCESS(*ec)) {
         TimeZone* zone = TimeZone::createDefault();
-        if (zone == NULL) {
+        if (zone == nullptr) {
             *ec = U_MEMORY_ALLOCATION_ERROR;
         } else {
             UnicodeString id;
@@ -86,7 +86,7 @@ ucal_getDefaultTimeZone(UChar* result, int32_t resultCapacity, UErrorCode* ec) {
 U_CAPI void U_EXPORT2
 ucal_setDefaultTimeZone(const UChar* zoneID, UErrorCode* ec) {
     TimeZone* zone = _createTimeZone(zoneID, -1, ec);
-    if (zone != NULL) {
+    if (zone != nullptr) {
         TimeZone::adoptDefault(zone);
     }
 }
@@ -94,9 +94,9 @@ ucal_setDefaultTimeZone(const UChar* zoneID, UErrorCode* ec) {
 U_CAPI int32_t U_EXPORT2
 ucal_getHostTimeZone(UChar* result, int32_t resultCapacity, UErrorCode* ec) {
     int32_t len = 0;
-    if (ec != NULL && U_SUCCESS(*ec)) {
+    if (ec != nullptr && U_SUCCESS(*ec)) {
         TimeZone *zone = TimeZone::detectHostTimeZone();
-        if (zone == NULL) {
+        if (zone == nullptr) {
             *ec = U_MEMORY_ALLOCATION_ERROR;
         } else {
             UnicodeString id;
@@ -114,7 +114,7 @@ ucal_getDSTSavings(const UChar* zoneID, UErrorCode* ec) {
     TimeZone* zone = _createTimeZone(zoneID, -1, ec);
     if (U_SUCCESS(*ec)) {
         SimpleTimeZone* stz = dynamic_cast<SimpleTimeZone*>(zone);
-        if (stz != NULL) {
+        if (stz != nullptr) {
             result = stz->getDSTSavings();
         } else {
             // Since there is no getDSTSavings on TimeZone, we use a
@@ -219,10 +219,10 @@ ucal_setTimeZone(    UCalendar*      cal,
   if(U_FAILURE(*status))
     return;
 
-  TimeZone* zone = (zoneID==NULL) ? TimeZone::createDefault()
+  TimeZone* zone = (zoneID==nullptr) ? TimeZone::createDefault()
       : _createTimeZone(zoneID, len, status);
 
-  if (zone != NULL) {
+  if (zone != nullptr) {
       ((Calendar*)cal)->adoptTimeZone(zone);
   }
 }
@@ -255,8 +255,8 @@ ucal_getTimeZoneDisplayName(const     UCalendar*                 cal,
 
     const TimeZone& tz = ((Calendar*)cal)->getTimeZone();
     UnicodeString id;
-    if(!(result==NULL && resultLength==0)) {
-        // NULL destination for pure preflighting: empty dummy string
+    if (!(result == nullptr && resultLength == 0)) {
+        // Null destination for pure preflighting: empty dummy string
         // otherwise, alias the destination buffer
         id.setTo(result, 0, resultLength);
     }
@@ -298,12 +298,12 @@ ucal_setGregorianChange(UCalendar *cal, UDate date, UErrorCode *pErrorCode) {
     }
     Calendar *cpp_cal = (Calendar *)cal;
     GregorianCalendar *gregocal = dynamic_cast<GregorianCalendar *>(cpp_cal);
-    // Not if(gregocal == NULL) {
+    // Not if(gregocal == nullptr) {
     // because we really want to work only with a GregorianCalendar, not with
     // its subclasses like BuddhistCalendar.
-    if (cpp_cal == NULL) {
-        // We normally don't check "this" pointers for NULL, but this here avoids
-        // compiler-generated exception-throwing code in case cal == NULL.
+    if (cpp_cal == nullptr) {
+        // We normally don't check "this" pointers for nullptr, but this here avoids
+        // compiler-generated exception-throwing code in case cal == nullptr.
         *pErrorCode = U_ILLEGAL_ARGUMENT_ERROR;
         return;
     }
@@ -321,11 +321,11 @@ ucal_getGregorianChange(const UCalendar *cal, UErrorCode *pErrorCode) {
     }
     const Calendar *cpp_cal = (const Calendar *)cal;
     const GregorianCalendar *gregocal = dynamic_cast<const GregorianCalendar *>(cpp_cal);
-    // Not if(gregocal == NULL) {
+    // Not if(gregocal == nullptr) {
     // see comments in ucal_setGregorianChange().
-    if (cpp_cal == NULL) {
-        // We normally don't check "this" pointers for NULL, but this here avoids
-        // compiler-generated exception-throwing code in case cal == NULL.
+    if (cpp_cal == nullptr) {
+        // We normally don't check "this" pointers for nullptr, but this here avoids
+        // compiler-generated exception-throwing code in case cal == nullptr.
         *pErrorCode = U_ILLEGAL_ARGUMENT_ERROR;
         return (UDate)0;
     }
@@ -572,11 +572,11 @@ ucal_getLimit(    const    UCalendar*              cal,
 U_CAPI const char * U_EXPORT2
 ucal_getLocaleByType(const UCalendar *cal, ULocDataLocaleType type, UErrorCode* status) 
 {
-    if (cal == NULL) {
+    if (cal == nullptr) {
         if (U_SUCCESS(*status)) {
             *status = U_ILLEGAL_ARGUMENT_ERROR;
         }
-        return NULL;
+        return nullptr;
     }
     return ((Calendar*)cal)->getLocaleID(type, *status);
 }
@@ -617,7 +617,7 @@ U_CAPI const char * U_EXPORT2
 ucal_getType(const UCalendar *cal, UErrorCode* status)
 {
     if (U_FAILURE(*status)) {
-        return NULL;
+        return nullptr;
     }
     return ((Calendar*)cal)->getType();
 }
@@ -662,8 +662,8 @@ ucal_getFieldDifference(UCalendar* cal, UDate target,
 
 
 static const UEnumeration defaultKeywordValues = {
-    NULL,
-    NULL,
+    nullptr,
+    nullptr,
     ulist_close_keyword_values_iterator,
     ulist_count_keyword_values,
     uenum_unextDefault,
@@ -690,7 +690,7 @@ static const char * const CAL_TYPES[] = {
         "islamic-umalqura",
         "islamic-tbla",
         "islamic-rgsa",
-        NULL
+        nullptr
 };
 
 U_CAPI UEnumeration* U_EXPORT2
@@ -700,16 +700,16 @@ ucal_getKeywordValuesForLocale(const char * /* key */, const char* locale, UBool
     (void)ulocimp_getRegionForSupplementalData(locale, TRUE, prefRegion, sizeof(prefRegion), status);
     
     // Read preferred calendar values from supplementalData calendarPreference
-    UResourceBundle *rb = ures_openDirect(NULL, "supplementalData", status);
+    UResourceBundle *rb = ures_openDirect(nullptr, "supplementalData", status);
     ures_getByKey(rb, "calendarPreferenceData", rb, status);
-    UResourceBundle *order = ures_getByKey(rb, prefRegion, NULL, status);
-    if (*status == U_MISSING_RESOURCE_ERROR && rb != NULL) {
+    UResourceBundle *order = ures_getByKey(rb, prefRegion, nullptr, status);
+    if (*status == U_MISSING_RESOURCE_ERROR && rb != nullptr) {
         *status = U_ZERO_ERROR;
-        order = ures_getByKey(rb, "001", NULL, status);
+        order = ures_getByKey(rb, "001", nullptr, status);
     }
 
     // Create a list of calendar type strings
-    UList *values = NULL;
+    UList *values = nullptr;
     if (U_SUCCESS(*status)) {
         values = ulist_createEmptyList(status);
         if (U_SUCCESS(*status)) {
@@ -717,7 +717,7 @@ ucal_getKeywordValuesForLocale(const char * /* key */, const char* locale, UBool
                 int32_t len;
                 const UChar *type = ures_getStringByIndex(order, i, &len, status);
                 char *caltype = (char*)uprv_malloc(len + 1);
-                if (caltype == NULL) {
+                if (caltype == nullptr) {
                     *status = U_MEMORY_ALLOCATION_ERROR;
                     break;
                 }
@@ -732,7 +732,7 @@ ucal_getKeywordValuesForLocale(const char * /* key */, const char* locale, UBool
 
             if (U_SUCCESS(*status) && !commonlyUsed) {
                 // If not commonlyUsed, add other available values
-                for (int32_t i = 0; CAL_TYPES[i] != NULL; i++) {
+                for (int32_t i = 0; CAL_TYPES[i] != nullptr; i++) {
                     if (!ulist_containsString(values, CAL_TYPES[i], (int32_t)uprv_strlen(CAL_TYPES[i]))) {
                         ulist_addItemEndList(values, CAL_TYPES[i], FALSE, status);
                         if (U_FAILURE(*status)) {
@@ -743,7 +743,7 @@ ucal_getKeywordValuesForLocale(const char * /* key */, const char* locale, UBool
             }
             if (U_FAILURE(*status)) {
                 ulist_deleteList(values);
-                values = NULL;
+                values = nullptr;
             }
         }
     }
@@ -751,16 +751,16 @@ ucal_getKeywordValuesForLocale(const char * /* key */, const char* locale, UBool
     ures_close(order);
     ures_close(rb);
 
-    if (U_FAILURE(*status) || values == NULL) {
-        return NULL;
+    if (U_FAILURE(*status) || values == nullptr) {
+        return nullptr;
     }
 
     // Create string enumeration
     UEnumeration *en = (UEnumeration*)uprv_malloc(sizeof(UEnumeration));
-    if (en == NULL) {
+    if (en == nullptr) {
         *status = U_MEMORY_ALLOCATION_ERROR;
         ulist_deleteList(values);
-        return NULL;
+        return nullptr;
     }
     ulist_resetList(values);
     memcpy(en, &defaultKeywordValues, sizeof(UEnumeration));
@@ -778,7 +778,7 @@ ucal_getTimeZoneTransitionDate(const UCalendar* cal, UTimeZoneTransitionType typ
     UDate base = ((Calendar*)cal)->getTime(*status);
     const TimeZone& tz = ((Calendar*)cal)->getTimeZone();
     const BasicTimeZone * btz = dynamic_cast<const BasicTimeZone *>(&tz);
-    if (btz != NULL && U_SUCCESS(*status)) {
+    if (btz != nullptr && U_SUCCESS(*status)) {
         TimeZoneTransition tzt;
         UBool inclusive = (type == UCAL_TZ_TRANSITION_NEXT_INCLUSIVE || type == UCAL_TZ_TRANSITION_PREVIOUS_INCLUSIVE);
         UBool result = (type == UCAL_TZ_TRANSITION_NEXT || type == UCAL_TZ_TRANSITION_NEXT_INCLUSIVE)?


### PR DESCRIPTION
ucal_openTimeZones(UErrorCode*) used to call TimeZone::createEnumeration(), which does not return UErrorCode. TimeZone::createEnumeration() internally calls TZEnumeration::create(USystemTimeZoneType, const char*, const int32_t*, UErrorCode&), but it internally defines and eats UErrorCode. To set error status properly in ucal_openTimeZones(UErrorCode*), we should use TimeZone::createTimeZoneIDEnumeration(USystemTimeZoneType, const char*, const int32_t*, UErrorCode&), which is wrapped by ucal_openTimeZoneIDEnumeration(USystemTimeZoneType, const char*, const int32_t*, UErrorCode*), with UCAL_ZONE_TYPE_ANY, null region/offset.

Same thing applied to ucal_openCountryTimeZones(const char*, UErrorCode*).

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-20918
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
