### PR TITLE
ICU-21480 brs 69rc, add tests to verify that rbnf spellout is the same for no,nb

### DIFF
--- a/icu4c/source/test/intltest/itrbnf.cpp
+++ b/icu4c/source/test/intltest/itrbnf.cpp
@@ -77,6 +77,7 @@ void IntlTestRBNF::runIndexedTest(int32_t index, UBool exec, const char* &name, 
         TESTCASE(25, TestCompactDecimalFormatStyle);
         TESTCASE(26, TestParseFailure);
         TESTCASE(27, TestMinMaxIntegerDigitsIgnored);
+        TESTCASE(28, TestNorwegianSpellout);
 #else
         TESTCASE(0, TestRBNFDisabled);
 #endif
@@ -1602,6 +1603,38 @@ IntlTestRBNF::TestThaiSpellout()
         doTest(formatter, testData, TRUE);
     }
     delete formatter;
+}
+
+void
+IntlTestRBNF::TestNorwegianSpellout()
+{
+    UErrorCode status = U_ZERO_ERROR;
+    RuleBasedNumberFormat* noFormatter
+        = new RuleBasedNumberFormat(URBNF_SPELLOUT, Locale("no"), status);
+    RuleBasedNumberFormat* nbFormatter
+        = new RuleBasedNumberFormat(URBNF_SPELLOUT, Locale("nb"), status);
+
+    if (U_FAILURE(status)) {
+        errcheckln(status, "FAIL: could not construct formatter - %s", u_errorName(status));
+    } else {
+        static const char* testDataDefault[][2] = {
+            { "1", "\\u00E9n" },
+            { "2", "to" },
+            { "3", "tre" },
+            { "4", "fire" },
+            { "101", "hundre og \\u00E9n" },
+            { "123", "hundre og tjue\\u00ADtre" },
+            { "1,001", "tusen og \\u00E9n" },
+            { "1,100", "tusen hundre" },
+            { "6.789", "seks komma sju \\u00E5tte ni" },
+            { "-5.678", "minus fem komma seks sju \\u00E5tte" },
+            { NULL, NULL }
+        };
+        doTest(noFormatter, testDataDefault, TRUE);
+        doTest(nbFormatter, testDataDefault, TRUE);
+    }
+    delete nbFormatter;
+    delete noFormatter;
 }
 
 void

--- a/icu4c/source/test/intltest/itrbnf.h
+++ b/icu4c/source/test/intltest/itrbnf.h
@@ -102,6 +102,11 @@ class IntlTestRBNF : public IntlTest {
   void TestThaiSpellout();
 
   /**
+   * Perform a simple spot check on the Norwegian (no,nb) spellout rules
+   */
+  void TestNorwegianSpellout();
+
+  /**
    * Perform a simple spot check on the Swedish spellout rules
    */
   void TestSwedishSpellout();

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/RbnfTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/RbnfTest.java
@@ -821,6 +821,35 @@ public class RbnfTest extends TestFmwk {
     }
 
     @Test
+    public void TestNorwegianSpellout()
+    {
+        Locale noLocale = new Locale("no", "", "");
+        Locale nbLocale = new Locale("nb", "", "");
+        RuleBasedNumberFormat noFormatter = new RuleBasedNumberFormat(noLocale,
+                RuleBasedNumberFormat.SPELLOUT);
+        RuleBasedNumberFormat nbFormatter = new RuleBasedNumberFormat(nbLocale,
+                RuleBasedNumberFormat.SPELLOUT);
+
+        String[][] testDataDefault = {
+                { "1", "\u00E9n" },
+                { "2", "to" },
+                { "3", "tre" },
+                { "4", "fire" },
+                { "101", "hundre og \u00E9n" },
+                { "123", "hundre og tjue\u00ADtre" },
+                { "1,001", "tusen og \u00E9n" },
+                { "1,100", "tusen hundre" },
+                { "6.789", "seks komma sju \u00E5tte ni" },
+                { "-5.678", "minus fem komma seks sju \u00E5tte" },
+        };
+
+        logln("testing default rules");
+        doTest(noFormatter, testDataDefault, true);
+        doTest(nbFormatter, testDataDefault, true);
+
+    }
+
+    @Test
     public void TestSwedishSpellout()
     {
         Locale locale = new Locale("sv", "", "");


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21480
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

Per suggestion from George Rhoten, add tests to verify that RBNF spellout behaves the same way for "no" and "nb" after the parent change in earlier CLDR data integrations. Apparently aliasing does not work normally for RBNF, but parent inheritance does seem to, in this case at  least.