### PR TITLE
ICU-21532 In UTimeZoneLocalOption enum, add dummy value if U_HIDE_DRAFT_API

### DIFF
--- a/icu4c/source/i18n/unicode/ucal.h
+++ b/icu4c/source/i18n/unicode/ucal.h
@@ -1674,6 +1674,13 @@ enum UTimeZoneLocalOption {
      * @draft ICU 69
      */
     UCAL_TZ_LOCAL_DAYLIGHT_LATTER = UCAL_TZ_LOCAL_LATTER | 0x03,
+#else /* U_HIDE_DRAFT_API */
+    /**
+     * Dummy value to prevent empty enum if U_HIDE_DRAFT_API.
+     * This will go away when draft conditionals are removed.
+     * @internal
+     */
+    UCAL_TZ_LOCAL_NONE = 0,
 #endif /* U_HIDE_DRAFT_API */
 };
 typedef enum UTimeZoneLocalOption UTimeZoneLocalOption; /**< @draft ICU 69 */


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21532
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

In UTimeZoneLocalOption enum, when U_HIDE_DRAFT_API is defined, provide a dummy internal value so enum is not empty. I did not see a precedent for this anywhere else.