### PR TITLE
ICU-21480 brs 69rc, adjust nonstable API macros

### DIFF
--- a/icu4c/source/i18n/unicode/basictz.h
+++ b/icu4c/source/i18n/unicode/basictz.h
@@ -175,7 +175,6 @@ public:
         kFormer = 0x04, /* UCAL_TZ_LOCAL_FORMER */
         kLatter = 0x0C  /* UCAL_TZ_LOCAL_LATTER */
     };
-#endif  /* U_HIDE_INTERNAL_API */
 
     /**
      * Get time zone offsets from local wall time.
@@ -183,6 +182,7 @@ public:
      */
     void getOffsetFromLocal(UDate date, int32_t nonExistingTimeOpt, int32_t duplicatedTimeOpt,
         int32_t& rawOffset, int32_t& dstOffset, UErrorCode& status) const;
+#endif  /* U_HIDE_INTERNAL_API */
 
 protected:
 

--- a/icu4c/source/i18n/unicode/calendar.h
+++ b/icu4c/source/i18n/unicode/calendar.h
@@ -47,6 +47,8 @@ U_NAMESPACE_BEGIN
 
 class ICUServiceFactory;
 
+// Do not conditionalize the following with #ifndef U_HIDE_INTERNAL_API,
+// it is a return type for a virtual method (@internal)
 /**
  * @internal
  */
@@ -1849,7 +1851,7 @@ private:
      * @param startValue starting (least max) value of field
      * @param endValue ending (greatest max) value of field
      * @param status return type
-     * @internal
+     * @internal (private)
      */
     int32_t getActualHelper(UCalendarDateFields field, int32_t startValue, int32_t endValue, UErrorCode &status) const;
 

--- a/icu4c/source/i18n/unicode/measunit.h
+++ b/icu4c/source/i18n/unicode/measunit.h
@@ -247,13 +247,17 @@ typedef enum UMeasurePrefix {
      */
     UMEASURE_PREFIX_YOCTO = UMEASURE_PREFIX_ONE + -24,
 
+#ifndef U_HIDE_INTERNAL_API
     /**
      * ICU use only.
      * Used to determine the set of base-10 SI prefixes.
      * @internal
      */
     UMEASURE_PREFIX_INTERNAL_MIN_SI = UMEASURE_PREFIX_YOCTO,
+#endif  // U_HIDE_INTERNAL_API
 
+    // Cannot conditionalize the following with #ifndef U_HIDE_INTERNAL_API,
+    // used in definitions of non-internal enum values
     /**
      * ICU use only.
      * Sets the arbitrary offset of the base-1024 binary prefixes' enum values.
@@ -268,12 +272,14 @@ typedef enum UMeasurePrefix {
      */
     UMEASURE_PREFIX_KIBI = UMEASURE_PREFIX_INTERNAL_ONE_BIN + 1,
 
+#ifndef U_HIDE_INTERNAL_API
     /**
      * ICU use only.
      * Used to determine the set of base-1024 binary prefixes.
      * @internal
      */
     UMEASURE_PREFIX_INTERNAL_MIN_BIN = UMEASURE_PREFIX_KIBI,
+#endif  // U_HIDE_INTERNAL_API
 
     /**
      * Binary prefix: mebi, 1024^2.
@@ -324,12 +330,14 @@ typedef enum UMeasurePrefix {
      */
     UMEASURE_PREFIX_YOBI = UMEASURE_PREFIX_INTERNAL_ONE_BIN + 8,
 
+#ifndef U_HIDE_INTERNAL_API
     /**
      * ICU use only.
      * Used to determine the set of base-1024 binary prefixes.
      * @internal
      */
     UMEASURE_PREFIX_INTERNAL_MAX_BIN = UMEASURE_PREFIX_YOBI,
+#endif  // U_HIDE_INTERNAL_API
 } UMeasurePrefix;
 
 /**
@@ -3716,7 +3724,8 @@ private:
     friend class number::impl::LongNameHandler;
 };
 
-#ifndef U_HIDE_DRAFT_API  // @draft ICU 68
+#ifndef U_HIDE_DRAFT_API
+// inline impl of @draft ICU 68 method
 inline std::pair<LocalArray<MeasureUnit>, int32_t>
 MeasureUnit::splitToSingleUnits(UErrorCode& status) const {
     int32_t length;

--- a/icu4c/source/i18n/unicode/numberformatter.h
+++ b/icu4c/source/i18n/unicode/numberformatter.h
@@ -346,15 +346,15 @@ class U_I18N_API Notation : public UMemory {
 
     union NotationUnion {
         // For NTN_SCIENTIFIC
-        /** @internal */
+        /** @internal (private) */
         struct ScientificSettings {
-            /** @internal */
+            /** @internal (private) */
             int8_t fEngineeringInterval;
-            /** @internal */
+            /** @internal (private) */
             bool fRequireMinInt;
-            /** @internal */
+            /** @internal (private) */
             impl::digits_t fMinExponentDigits;
-            /** @internal */
+            /** @internal (private) */
             UNumberSignDisplay fExponentSignDisplay;
         } scientific;
 
@@ -694,28 +694,28 @@ class U_I18N_API Precision : public UMemory {
     } fType;
 
     union PrecisionUnion {
-        /** @internal */
+        /** @internal (private) */
         struct FractionSignificantSettings {
             // For RND_FRACTION, RND_SIGNIFICANT, and RND_FRACTION_SIGNIFICANT
-            /** @internal */
+            /** @internal (private) */
             impl::digits_t fMinFrac;
-            /** @internal */
+            /** @internal (private) */
             impl::digits_t fMaxFrac;
-            /** @internal */
+            /** @internal (private) */
             impl::digits_t fMinSig;
-            /** @internal */
+            /** @internal (private) */
             impl::digits_t fMaxSig;
-            /** @internal */
+            /** @internal (private) */
             UNumberRoundingPriority fPriority;
         } fracSig;
-        /** @internal */
+        /** @internal (private) */
         struct IncrementSettings {
             // For RND_INCREMENT, RND_INCREMENT_ONE, and RND_INCREMENT_FIVE
-            /** @internal */
+            /** @internal (private) */
             double fIncrement;
-            /** @internal */
+            /** @internal (private) */
             impl::digits_t fMinFrac;
-            /** @internal */
+            /** @internal (private) */
             impl::digits_t fMaxFrac;
         } increment;
         UCurrencyUsage currencyUsage; // For RND_CURRENCY
@@ -1220,7 +1220,7 @@ class U_I18N_API StringProp : public UMemory {
     StringProp() : fValue(nullptr), fLength(0), fError(U_ZERO_ERROR) {
     }
 
-    /** @internal */
+    /** @internal (private) */
     UBool copyErrorTo(UErrorCode &status) const {
         if (U_FAILURE(fError)) {
             status = fError;
@@ -2217,7 +2217,10 @@ class U_I18N_API NumberFormatterSettings {
      * @draft ICU 68
      */
     Derived usage(StringPiece usage) &&;
+#endif // U_HIDE_DRAFT_API
 
+#ifndef U_HIDE_DRAFT_API
+#ifndef U_HIDE_INTERNAL_API
     /**
      * Specifies the desired case for a unit formatter's output (e.g.
      * accusative, dative, genitive).
@@ -2232,6 +2235,7 @@ class U_I18N_API NumberFormatterSettings {
      * @internal ICU 69 technology preview
      */
     Derived unitDisplayCase(StringPiece unitDisplayCase) &&;
+#endif // U_HIDE_INTERNAL_API
 #endif // U_HIDE_DRAFT_API
 
 #ifndef U_HIDE_INTERNAL_API
@@ -2759,7 +2763,7 @@ class U_I18N_API FormattedNumber : public UMemory, public FormattedValue {
 
     /**
      * Internal constructor from data type. Adopts the data pointer.
-     * @internal
+     * @internal (private)
      */
     explicit FormattedNumber(impl::UFormattedNumberData *results)
         : fData(results), fErrorCode(U_ZERO_ERROR) {}
@@ -2776,8 +2780,6 @@ class U_I18N_API FormattedNumber : public UMemory, public FormattedValue {
     friend struct impl::UFormattedNumberImpl;
 };
 
-#ifndef U_HIDE_DRAFT_API
-// Note: This is draft ICU 65
 template<typename StringClass>
 StringClass FormattedNumber::toDecimalNumber(UErrorCode& status) const {
     StringClass result;
@@ -2785,7 +2787,6 @@ StringClass FormattedNumber::toDecimalNumber(UErrorCode& status) const {
     toDecimalNumber(sink, status);
     return result;
 }
-#endif // U_HIDE_DRAFT_API
 
 /**
  * See the main description in numberformatter.h for documentation and examples.

--- a/icu4c/source/i18n/unicode/numberrangeformatter.h
+++ b/icu4c/source/i18n/unicode/numberrangeformatter.h
@@ -706,7 +706,7 @@ class U_I18N_API FormattedNumberRange : public UMemory, public FormattedValue {
 };
 
 #ifndef U_HIDE_DRAFT_API
-// Note: This is draft ICU 68
+// inline impl of @draft ICU 68 method
 template<typename StringClass>
 std::pair<StringClass, StringClass> FormattedNumberRange::getDecimalNumbers(UErrorCode& status) const {
     StringClass str1;

--- a/icu4c/source/i18n/unicode/unum.h
+++ b/icu4c/source/i18n/unicode/unum.h
@@ -319,7 +319,7 @@ typedef enum UNumberFormatRoundingMode {
      * @draft ICU 69
      */
     UNUM_ROUND_HALF_FLOOR,
-#endif
+#endif  // U_HIDE_DRAFT_API
 } UNumberFormatRoundingMode;
 
 /** The possible number format pad positions. 

--- a/icu4c/source/i18n/unicode/unumberformatter.h
+++ b/icu4c/source/i18n/unicode/unumberformatter.h
@@ -164,7 +164,7 @@ typedef enum UNumberUnitWidth {
      *
      * @stable ICU 60
      */
-            UNUM_UNIT_WIDTH_NARROW,
+            UNUM_UNIT_WIDTH_NARROW = 0,
 
     /**
      * Print an abbreviated version of the unit name. Similar to NARROW, but use a slightly wider abbreviation or
@@ -180,7 +180,7 @@ typedef enum UNumberUnitWidth {
      *
      * @stable ICU 60
      */
-            UNUM_UNIT_WIDTH_SHORT,
+            UNUM_UNIT_WIDTH_SHORT = 1,
 
     /**
      * Print the full name of the unit, without any abbreviations.
@@ -191,7 +191,7 @@ typedef enum UNumberUnitWidth {
      *
      * @stable ICU 60
      */
-            UNUM_UNIT_WIDTH_FULL_NAME,
+            UNUM_UNIT_WIDTH_FULL_NAME = 2,
 
     /**
      * Use the three-digit ISO XXX code in place of the symbol for displaying currencies. The behavior of this
@@ -202,7 +202,7 @@ typedef enum UNumberUnitWidth {
      *
      * @stable ICU 60
      */
-            UNUM_UNIT_WIDTH_ISO_CODE,
+            UNUM_UNIT_WIDTH_ISO_CODE = 3,
 
 #ifndef U_HIDE_DRAFT_API
     /**
@@ -214,7 +214,7 @@ typedef enum UNumberUnitWidth {
      *
      * @draft ICU 68
      */
-            UNUM_UNIT_WIDTH_FORMAL,
+            UNUM_UNIT_WIDTH_FORMAL = 4,
 
     /**
      * Use the alternate variant of the currency symbol; for example, "TL" for the Turkish
@@ -225,7 +225,7 @@ typedef enum UNumberUnitWidth {
      *
      * @draft ICU 68
      */
-            UNUM_UNIT_WIDTH_VARIANT,
+            UNUM_UNIT_WIDTH_VARIANT = 5,
 #endif  // U_HIDE_DRAFT_API
 
     /**
@@ -235,14 +235,16 @@ typedef enum UNumberUnitWidth {
      *
      * @stable ICU 60
      */
-            UNUM_UNIT_WIDTH_HIDDEN,
+            UNUM_UNIT_WIDTH_HIDDEN = 6,
 
+    // Do not conditionalize the following with #ifndef U_HIDE_INTERNAL_API,
+    // needed for unconditionalized struct MacroProps
     /**
      * One more than the highest UNumberUnitWidth value.
      *
      * @internal ICU 60: The numeric value may change over time; see ICU ticket #12420.
      */
-            UNUM_UNIT_WIDTH_COUNT
+            UNUM_UNIT_WIDTH_COUNT = 7
 } UNumberUnitWidth;
 
 /**
@@ -451,6 +453,8 @@ typedef enum UNumberSignDisplay {
     UNUM_SIGN_ACCOUNTING_NEGATIVE,
 #endif // U_HIDE_DRAFT_API
 
+    // Do not conditionalize the following with #ifndef U_HIDE_INTERNAL_API,
+    // needed for unconditionalized struct MacroProps
     /**
      * One more than the highest UNumberSignDisplay value.
      *
@@ -486,6 +490,8 @@ typedef enum UNumberDecimalSeparatorDisplay {
      */
             UNUM_DECIMAL_SEPARATOR_ALWAYS,
 
+    // Do not conditionalize the following with #ifndef U_HIDE_INTERNAL_API,
+    // needed for unconditionalized struct MacroProps
     /**
      * One more than the highest UNumberDecimalSeparatorDisplay value.
      *

--- a/icu4c/source/i18n/unicode/unumberrangeformatter.h
+++ b/icu4c/source/i18n/unicode/unumberrangeformatter.h
@@ -354,7 +354,6 @@ unumrf_resultGetIdentityResult(
     UErrorCode* ec);
 
 
-#ifndef U_HIDE_DRAFT_API
 /**
  * Extracts the first formatted number as a decimal number. This endpoint
  * is useful for obtaining the exact number being printed after scaling
@@ -407,7 +406,6 @@ unumrf_resultGetSecondDecimalNumber(
     char* dest,
     int32_t destCapacity,
     UErrorCode* ec);
-#endif // U_HIDE_DRAFT_API
 
 
 /**

--- a/icu4c/source/i18n/unicode/vtzone.h
+++ b/icu4c/source/i18n/unicode/vtzone.h
@@ -264,7 +264,7 @@ public:
     virtual void getOffset(UDate date, UBool local, int32_t& rawOffset,
                            int32_t& dstOffset, UErrorCode& ec) const;
 
- #ifndef U_FORCE_HIDE_DRAFT_API
+#ifndef U_FORCE_HIDE_DRAFT_API
     /**
      * Get time zone offsets from local wall time.
      * @draft ICU 69


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21480
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

Adjusted nonstable API guard conditionals.
- Included more items in #ifndef U_HIDE_INTERNAL_API
- Broke some #ifndef U_HIDE_DRAFT_API into multiple sections for (likely) different version tags; removed redundant #ifndef U_HIDE_DRAFT_API
- Gave explicit numeric values to UNumberUnitWidth enum values to prevent problems when new enum values are added or when compiling with U_HIDE_DRAFT_API defined.
- Removed no-longer-applicable #ifndef U_HIDE_DRAFT_API around inline impl of a @stable method