### PR TITLE
ICU-21520 Housekeeping: Fixes typos in name of test data file; removes a regex that

### DIFF
--- a/icu4c/source/test/perf/normperf/NormPerf.pl
+++ b/icu4c/source/test/perf/normperf/NormPerf.pl
@@ -53,7 +53,7 @@ my $dataFiles = {
         "TestNames_SerbianSH.txt",
         "TestNames_SerbianSR.txt",
         "TestNames_Thai.txt",
-        "Testnames_Russian.txt",
+        "TestNames_Russian.txt",
         "th18057.txt",
         "thesis.txt",
         "vfear11a.txt",

--- a/icu4c/source/test/perf/normperf/NormPerf_r.pl
+++ b/icu4c/source/test/perf/normperf/NormPerf_r.pl
@@ -55,7 +55,7 @@ my $dataFiles = {
         "TestNames_SerbianSH.txt",
         "TestNames_SerbianSR.txt",
         "TestNames_Thai.txt",
-        "Testnames_Russian.txt",
+        "TestNames_Russian.txt",
         "th18057.txt",
         "thesis.txt",
         "vfear11a.txt",

--- a/icu4c/source/test/perf/perldriver/Output.pm
+++ b/icu4c/source/test/perf/perldriver/Output.pm
@@ -190,8 +190,6 @@ sub setupOutput {
   @headers = split(/ /, $headers);
   my ($t, $rest);
   ($t, $rest) = split(/\.\w+/, $0);
-  $t =~ /^.*\W(\w+)$/;
-  $t = $1;
   if($outType eq 'HTML') {
     $html = $date;
     $html =~ s/://g; # ':' illegal

--- a/icu4c/source/test/perf/ubrkperf/UBrkPerf_r.pl
+++ b/icu4c/source/test/perf/ubrkperf/UBrkPerf_r.pl
@@ -72,7 +72,7 @@ my $dataFiles = {
         "TestNames_SerbianSH.txt",
         "TestNames_SerbianSR.txt",
         "TestNames_Thai.txt",
-        "Testnames_Russian.txt",
+        "TestNames_Russian.txt",
     ],
     "th",
     [

--- a/icu4c/source/test/perf/ustrperf/StringPerf.pl
+++ b/icu4c/source/test/perf/ustrperf/StringPerf.pl
@@ -68,7 +68,7 @@ my $dataFiles = {
         "TestNames_SerbianSH.txt",
         "TestNames_SerbianSR.txt",
         "TestNames_Thai.txt",
-        "Testnames_Russian.txt",
+        "TestNames_Russian.txt",
         "th18057.txt",
     ]
 };

--- a/icu4c/source/test/perf/ustrperf/StringPerf_r.pl
+++ b/icu4c/source/test/perf/ustrperf/StringPerf_r.pl
@@ -54,7 +54,7 @@ my $dataFiles = {
         "TestNames_SerbianSH.txt",
         "TestNames_SerbianSR.txt",
         "TestNames_Thai.txt",
-        "Testnames_Russian.txt",
+        "TestNames_Russian.txt",
         "th18057.txt",
         "thesis.txt",
         "vfear11a.txt",


### PR DESCRIPTION
evaluates to the empty string and the result files are missing the
perf test name as a result. E.g. '_Mar_16_155820.html' instead of
'unisetperf_Mar_16_155820.html'.
Not obvious why the regex was even created since it doesn't seem
necessary because the name of the caller doesn't require additional
parsing. The particular code is from 2002, maybe changes in Perl
account for the issue(?)

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [ ] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21520
- [ ] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
