### PR TITLE
ICU-21577 doc/layoutengine: update harfbuzz link; + icu-le-hb link

### DIFF
--- a/docs/userguide/layoutengine/index.md
+++ b/docs/userguide/layoutengine/index.md
@@ -28,13 +28,14 @@ License & terms of use: http://www.unicode.org/copyright.html
 >
 > Users of ICU Layout are **strongly** encouraged to consider the HarfBuzz project
 > as a replacement for the ICU Layout Engine. An ICU team member responsible for
-> the Layout Engine is contributing fixes and features to HarfBuzz, and a drop in
-> wrapper is available to allow use of HarfBuzz as a direct replacement for the
-> ICU layout engine.
+> the Layout Engine is contributing fixes and features to HarfBuzz, and a 
+> [drop in wrapper](https://github.com/harfbuzz/icu-le-hb) is available to allow
+> use of HarfBuzz as a direct replacement for the ICU layout engine.
 >
 > HarfBuzz has its own active mailing lists, please use those for discussion of
 > HarfBuzz and its use as a replacement for the ICU layout engine.
-> See: [http://www.freedesktop.org/wiki/Software/HarfBuzz](http://www.freedesktop.org/wiki/Software/HarfBuzz)
+> See: [https://harfbuzz.github.io/](https://harfbuzz.github.io/).
+> 
 
 
 > :point_right: **Users of the "layoutex" ParagraphLayout library**: Please see information


### PR DESCRIPTION
The fd.o harfbuzz link currently goes to the github repo, which is a bit less documentation-ish than the github.io page.

Add link to icu-le-hb.

Wait, JIRA?

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21577 
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
