### PR TITLE
ICU-21561 rename StringSegment.equals() to contentEquals()

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/StringSegment.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/StringSegment.java
@@ -202,23 +202,13 @@ public class StringSegment implements CharSequence {
     }
 
     /**
-     * Equals any CharSequence with the same chars as this segment.
+     * Returns true if this segment contains the same characters as the other CharSequence.
      *
-     * <p>
-     * This method does not perform case folding; if you want case-insensitive equality, use
+     * <p>This method does not perform case folding; if you want case-insensitive equality, use
      * {@link #getCommonPrefixLength}.
      */
-    @Override
-    public boolean equals(Object other) {
-        if (!(other instanceof CharSequence))
-            return false;
-        return Utility.charSequenceEquals(this, (CharSequence) other);
-    }
-
-    /** Returns a hash code equivalent to calling .toString().hashCode() */
-    @Override
-    public int hashCode() {
-        return Utility.charSequenceHashCode(this);
+    public boolean contentEquals(CharSequence other) {
+        return Utility.charSequenceEquals(this, other);
     }
 
     /** Returns a string representation useful for debugging. */

--- a/icu4j/main/classes/core/src/com/ibm/icu/number/NumberSkeletonImpl.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/number/NumberSkeletonImpl.java
@@ -1368,7 +1368,7 @@ class NumberSkeletonImpl {
 
         /** @return Whether we successfully found and parsed a trailing zero option. */
         private static boolean parseTrailingZeroOption(StringSegment segment, MacroProps macros) {
-            if (segment.equals("w")) {
+            if (segment.contentEquals("w")) {
                 macros.precision = macros.precision.trailingZeroDisplay(TrailingZeroDisplay.HIDE_IF_WHOLE);
                 return true;
             }

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/impl/StringSegmentTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/impl/StringSegmentTest.java
@@ -3,6 +3,8 @@
 package com.ibm.icu.dev.test.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -47,10 +49,15 @@ public class StringSegmentTest {
     public void testCharAt() {
         StringSegment segment = new StringSegment(SAMPLE_STRING, false);
         assertCharSequenceEquals(SAMPLE_STRING, segment);
+        assertTrue(segment.contentEquals(SAMPLE_STRING));
         segment.adjustOffset(3);
         assertCharSequenceEquals("radio 📻", segment);
+        assertTrue(segment.contentEquals("radio 📻"));
+        assertFalse(segment.contentEquals(SAMPLE_STRING));
         segment.setLength(5);
         assertCharSequenceEquals("radio", segment);
+        assertTrue(segment.contentEquals("radio"));
+        assertFalse(segment.contentEquals(SAMPLE_STRING));
     }
 
     @Test


### PR DESCRIPTION
and remove hashCode() because of now-missing equals() and because
StringSegment is mutable and documented as not suitable for HashMaps

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21561
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
