### PR TITLE
ICU-21569 Update testdata and icudata jar

### DIFF
--- a/icu4c/source/data/brkitr/root.txt
+++ b/icu4c/source/data/brkitr/root.txt
@@ -23,7 +23,7 @@ root{
         Thai:process(dependency){"thaidict.dict"}
     }
     lstm{
-        Thai:process(dependency){"Thai_graphclust_model4_heavy.res"}
-        Mymr:process(dependency){"Burmese_graphclust_model5_heavy.res"}
+        Thai{"Thai_graphclust_model4_heavy.res"}
+        Mymr{"Burmese_graphclust_model5_heavy.res"}
     }
 }

--- a/icu4j/main/shared/data/icudata.jar
+++ b/icu4j/main/shared/data/icudata.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8f02ab2967eaf73b6d28c8340d70b20d5f194f6c0ac24fe8464b25fd56763b04
-size 13383786
+oid sha256:6faf92e7e9f7072d1626b4631c612ddb2dab90cb5ad36272667e0b014b77ca41
+size 13383850

--- a/icu4j/main/shared/data/testdata.jar
+++ b/icu4j/main/shared/data/testdata.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:26a032e0c9492cd986546eefb5ba54687598eb431caed531ccb00b12469421ca
-size 726547
+oid sha256:e1ab65fbc4943e7b80cfa95c1bd6a5dd5830d1727983901f06af7e3747aa862f
+size 825810


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21569
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

##### Content of PR
Update testdata.jar and icudata.jar
Need to change the icu4c/source/data/brkiter/root.txt to avoid build breakage while building jar file.

Size diff of jar file
diff --git a/icu4j/main/shared/data/icudata.jar b/icu4j/main/shared/data/icudata.jar
index 31762473f6..e02dfa8180 100644
--- a/icu4j/main/shared/data/icudata.jar
+++ b/icu4j/main/shared/data/icudata.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8f02ab2967eaf73b6d28c8340d70b20d5f194f6c0ac24fe8464b25fd56763b04
-size 13383786
+oid sha256:6faf92e7e9f7072d1626b4631c612ddb2dab90cb5ad36272667e0b014b77ca41
+size 13383850
diff --git a/icu4j/main/shared/data/testdata.jar b/icu4j/main/shared/data/testdata.jar
index c0b07c2cf0..2b62b73fb9 100644
--- a/icu4j/main/shared/data/testdata.jar
+++ b/icu4j/main/shared/data/testdata.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:26a032e0c9492cd986546eefb5ba54687598eb431caed531ccb00b12469421ca
-size 726547
+oid sha256:e1ab65fbc4943e7b80cfa95c1bd6a5dd5830d1727983901f06af7e3747aa862f
+size 825810
