### PR TITLE
ICU-21600 Increase timeout and separate build/test in Cygwin CI

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -402,7 +402,7 @@ jobs:
 #-------------------------------------------------------------------------
 - job: ICU4C_Cygwin_GCC_x86_64_Release
   displayName: 'C: Cygwin GCC x86_64 Release'
-  timeoutInMinutes: 120
+  timeoutInMinutes: 180
   pool:
     vmImage: 'windows-2019'
   variables:
@@ -456,8 +456,14 @@ jobs:
         %CYG_ROOT%\\bin\\sh -lc 'echo Hello' && %CYG_ROOT%\\bin\\sh -lc 'uname -a'
       displayName: 'Check Cygwin environment'
     - script: |
-        %CYG_ROOT%\\bin\\bash -lc "cd $(cygpath \"$(Build.SourcesDirectory)\") && cd icu4c/source && ./runConfigureICU Cygwin && make check"
-      displayName: 'Build and test'
+        %CYG_ROOT%\\bin\\bash -lc "cd $(cygpath \"$(Build.SourcesDirectory)\") && cd icu4c/source && ./runConfigureICU Cygwin && make tests"
+      displayName: 'Build ICU (source and test)'
+      env:
+        CC: gcc
+        CXX: g++
+    - script: |
+        %CYG_ROOT%\\bin\\bash -lc "cd $(cygpath \"$(Build.SourcesDirectory)\") && cd icu4c/source && make check"
+      displayName: 'Run Tests'
       env:
         CC: gcc
         CXX: g++


### PR DESCRIPTION
This increases the timeout to 3 hours and separates the build/test steps in the Cygwin CI build. This attempts to address the potential timeouts and more clearly see what step is timing out.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21600
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
