### PR TITLE
ICU-21615 Work-around Azure CI build bot issue on Ubuntu 18.04

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -90,6 +90,11 @@ jobs:
     - checkout: self
       lfs: true
       fetchDepth: 10
+    # This is to work-around issue: https://github.com/actions/virtual-environments/issues/3376
+    # Once the Ubuntu 18.04 build bot image is fixed, we can remove this work-around.
+    - script: |
+        sudo apt remove libgcc-11-dev gcc-11
+      displayName: Remove GCC 11 (work-around)
     - script: |
         export CXXFLAGS="-std=c++14 -Winvalid-constexpr" && cd icu4c/source && ./runConfigureICU --enable-debug --disable-release Linux && make -j2 check
       displayName: 'Build and Test C++14'


### PR DESCRIPTION
There was a recent update the Azure CI Ubuntu 18.04 build bot image which causes the C++14 Debug build bot to fail in the tests with a segfault.

We initially thought this was related to ICU-changes, but it turns out that it was a change to the build bot image itself.

Using the work-around from this thread to remove GCC 11 fixes the issue.
See: https://github.com/actions/virtual-environments/issues/3376

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21615
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
