### PR TITLE
ICU-21621 Fixing TestCharset/TestInvalidInput failure on Java 16 runt…

### DIFF
--- a/icu4j/main/tests/charset/src/com/ibm/icu/dev/test/charset/TestCharset.java
+++ b/icu4j/main/tests/charset/src/com/ibm/icu/dev/test/charset/TestCharset.java
@@ -16,6 +16,7 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderMalfunctionError;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.UnsupportedCharsetException;
@@ -5053,12 +5054,22 @@ public class TestCharset extends TestFmwk {
         try {
             encoder.encode(CharBuffer.allocate(10), null, true);
             errln("Illegal argument exception should have been thrown due to null target.");
+        } catch (CoderMalfunctionError err) {
+            // Java 16 updated handling of Exception thrown by encodeLoop(CharBuffer,ByteBuffer).
+            // Previously when encodeLoop is called with null input/output buffer, it throws
+            // IllegalArgumentException, and Java CharsetEncoder does not catch the exception.
+            // In Java 16, a runtime exception thrown by encodeLoop implementation is caught
+            // and wrapped by CoderMalfunctionError. This block is required because CoderMalfunctionError
+            // is not an Exception.
         } catch (Exception ex) {
+            // IllegalArgumentException is thrown by encodeLoop(CharBuffer,ByteBuffer) implementation
+            // is not wrapped by CharsetEncoder up to Java 15.
         }
 
         try {
             decoder.decode(ByteBuffer.allocate(10), null, true);
             errln("Illegal argument exception should have been thrown due to null target.");
+        } catch (CoderMalfunctionError err) {
         } catch (Exception ex) {
         }
     }


### PR DESCRIPTION
…ime.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21621
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
