### PR TITLE
ICU-21641 Fix "emoji" and "eor" for Collator::getKeywordValues

### DIFF
--- a/icu4c/source/common/uresbund.cpp
+++ b/icu4c/source/common/uresbund.cpp
@@ -2954,7 +2954,7 @@ ures_getKeywordValues(const char *path, const char *keyword, UErrorCode *status)
         UResourceBundle   *bund = NULL;
         UResourceBundle   *subPtr = NULL;
         UErrorCode subStatus = U_ZERO_ERROR; /* don't fail if a bundle is unopenable */
-        bund = ures_openDirect(path, locale, &subStatus);
+        bund = ures_open(path, locale, &subStatus);
         
 #if defined(URES_TREE_DEBUG)
         if(!bund || U_FAILURE(subStatus)) {

--- a/icu4c/source/test/intltest/svccoll.cpp
+++ b/icu4c/source/test/intltest/svccoll.cpp
@@ -560,7 +560,9 @@ static const int32_t KW_COUNT = UPRV_LENGTHOF(KW);
 
 static const char* KWVAL[] = {
     "phonebook",
-    "stroke"
+    "stroke",
+    "emoji",
+    "eor"
 };
 static const int32_t KWVAL_COUNT = UPRV_LENGTHOF(KWVAL);
 

--- a/icu4j/main/tests/collate/src/com/ibm/icu/dev/test/collator/CollationServiceTest.java
+++ b/icu4j/main/tests/collate/src/com/ibm/icu/dev/test/collator/CollationServiceTest.java
@@ -341,7 +341,9 @@ public class CollationServiceTest extends TestFmwk {
 
     private static final String KWVAL[] = {
         "phonebook",
-        "stroke"
+        "stroke",
+        "emoji",
+        "eor",
     };
 
     @Test


### PR DESCRIPTION
icu::Collator::getKeywordValues("collation", status) does not report "emoji" and "eor"

Use res_open intead of ures_openDirect  inside ures_getKeywordValues so it access the fallback resource in "root". This make it align to Java and will also count "emoji" and "eor" which is specified in "root" 
Also add test for both C++ and Java
Java behavior correctly without any fix.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21641
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [X] API docs and/or User Guide docs changed or added, if applicable
