### PR TITLE
ICU-21525 UnicodeSet.hasString(), UnicodeSetIterator.skipToStrings() & C API

### DIFF
--- a/icu4c/source/common/unicode/uniset.h
+++ b/icu4c/source/common/unicode/uniset.h
@@ -771,8 +771,12 @@ public:
      * Note than the elements of a set may include both individual
      * codepoints and strings.
      *
+     * This is slower than getRangeCount() because
+     * it counts the code points of all ranges.
+     *
      * @return the number of elements in this set (its cardinality).
      * @stable ICU 2.0
+     * @see getRangeCount
      */
     virtual int32_t size(void) const;
 
@@ -783,6 +787,14 @@ public:
      * @stable ICU 2.0
      */
     virtual UBool isEmpty(void) const;
+
+#ifndef U_HIDE_DRAFT_API
+    /**
+     * @return true if this set contains multi-character strings or the empty string.
+     * @draft ICU 70
+     */
+    UBool hasStrings() const;
+#endif  // U_HIDE_DRAFT_API
 
     /**
      * Returns true if this set contains the given character.
@@ -1064,8 +1076,14 @@ public:
     /**
      * Returns the character at the given index within this set, where
      * the set is ordered by ascending code point.  If the index is
-     * out of range, return (UChar32)-1.  The inverse of this method is
-     * <code>indexOf()</code>.
+     * out of range for characters, returns (UChar32)-1.
+     * The inverse of this method is <code>indexOf()</code>.
+     *
+     * For iteration, this is slower than UnicodeSetIterator or
+     * getRangeCount()/getRangeStart()/getRangeEnd(),
+     * because for each call it skips linearly over <code>index</code>
+     * characters in the ranges.
+     *
      * @param index an index from 0..size()-1
      * @return the character at the given index, or (UChar32)-1.
      * @stable ICU 2.4
@@ -1567,7 +1585,6 @@ private:
     void swapBuffers(void);
 
     UBool allocateStrings(UErrorCode &status);
-    UBool hasStrings() const;
     int32_t stringsSize() const;
     UBool stringsContains(const UnicodeString &s) const;
 

--- a/icu4c/source/common/unicode/uset.h
+++ b/icu4c/source/common/unicode/uset.h
@@ -851,6 +851,16 @@ uset_removeAllStrings(USet* set);
 U_CAPI UBool U_EXPORT2
 uset_isEmpty(const USet* set);
 
+#ifndef U_HIDE_DRAFT_API
+/**
+ * @param set the set
+ * @return true if this set contains multi-character strings or the empty string.
+ * @draft ICU 70
+ */
+U_CAPI UBool U_EXPORT2
+uset_hasStrings(const USet *set);
+#endif  // U_HIDE_DRAFT_API
+
 /**
  * Returns true if the given USet contains the given character.
  * This function works faster with a frozen set.
@@ -901,8 +911,13 @@ uset_indexOf(const USet* set, UChar32 c);
 /**
  * Returns the character at the given index within this set, where
  * the set is ordered by ascending code point.  If the index is
- * out of range, return (UChar32)-1.  The inverse of this method is
- * <code>indexOf()</code>.
+ * out of range for characters, returns (UChar32)-1.
+ * The inverse of this method is <code>indexOf()</code>.
+ *
+ * For iteration, this is slower than uset_getRangeCount()/uset_getItemCount()
+ * with uset_getItem(), because for each call it skips linearly over <code>index</code>
+ * characters in the ranges.
+ *
  * @param set the set
  * @param charIndex an index from 0..size()-1 to obtain the char for
  * @return the character at the given index, or (UChar32)-1.
@@ -912,15 +927,33 @@ U_CAPI UChar32 U_EXPORT2
 uset_charAt(const USet* set, int32_t charIndex);
 
 /**
- * Returns the number of characters and strings contained in the given
- * USet.
+ * Returns the number of characters and strings contained in this set.
+ * The last (uset_getItemCount() - uset_getRangeCount()) items are strings.
+ *
+ * This is slower than uset_getRangeCount() and uset_getItemCount() because
+ * it counts the code points of all ranges.
+ *
  * @param set the set
  * @return a non-negative integer counting the characters and strings
  * contained in set
  * @stable ICU 2.4
+ * @see uset_getRangeCount
  */
 U_CAPI int32_t U_EXPORT2
 uset_size(const USet* set);
+
+#ifndef U_HIDE_DRAFT_API
+/**
+ * @param set the set
+ * @return the number of ranges in this set.
+ * @draft ICU 70
+ * @see uset_getItemCount
+ * @see uset_getItem
+ * @see uset_size
+ */
+U_CAPI int32_t U_EXPORT2
+uset_getRangeCount(const USet *set);
+#endif  // U_HIDE_DRAFT_API
 
 /**
  * Returns the number of items in this set.  An item is either a range
@@ -935,20 +968,30 @@ uset_getItemCount(const USet* set);
 
 /**
  * Returns an item of this set.  An item is either a range of
- * characters or a single multicharacter string.
+ * characters or a single multicharacter string (which can be the empty string).
+ *
+ * If <code>itemIndex</code> is less than uset_getRangeCount(), then this function returns 0,
+ * and the range is <code>*start</code>..<code>*end</code>.
+ *
+ * If <code>itemIndex</code> is at least uset_getRangeCount() and less than uset_getItemCount(), then
+ * this function copies the string into <code>str[strCapacity]</code> and
+ * returns the length of the string (0 for the empty string).
+ *
+ * If <code>itemIndex</code> is out of range, then this function returns -1.
+ *
+ * Note that 0 is returned for each range as well as for the empty string.
+ *
  * @param set the set
- * @param itemIndex a non-negative integer in the range 0..
- * uset_getItemCount(set)-1
- * @param start pointer to variable to receive first character
- * in range, inclusive
- * @param end pointer to variable to receive last character in range,
- * inclusive
+ * @param itemIndex a non-negative integer in the range 0..uset_getItemCount(set)-1
+ * @param start pointer to variable to receive first character in range, inclusive;
+ *              can be NULL for a string item
+ * @param end pointer to variable to receive last character in range, inclusive;
+ *            can be NULL for a string item
  * @param str buffer to receive the string, may be NULL
  * @param strCapacity capacity of str, or 0 if str is NULL
- * @param ec error code
- * @return the length of the string (>= 2), or 0 if the item is a
- * range, in which case it is the range *start..*end, or -1 if
- * itemIndex is out of range
+ * @param ec error code; U_INDEX_OUTOFBOUNDS_ERROR if the itemIndex is out of range
+ * @return the length of the string (0 or >= 2), or 0 if the item is a range,
+ *         or -1 if the itemIndex is out of range
  * @stable ICU 2.4
  */
 U_CAPI int32_t U_EXPORT2

--- a/icu4c/source/common/unicode/usetiter.h
+++ b/icu4c/source/common/unicode/usetiter.h
@@ -60,6 +60,9 @@ class UnicodeString;
  *   }
  * }
  * </pre>
+ *
+ * To iterate over only the strings, start with <code>skipToStrings()</code>.
+ *
  * @author M. Davis
  * @stable ICU 2.4
  */
@@ -169,6 +172,25 @@ class U_COMMON_API UnicodeSetIterator : public UObject {
      * @stable ICU 2.4
      */
     const UnicodeString& getString();
+
+#ifndef U_HIDE_DRAFT_API
+    /**
+     * Skips over the remaining code points/ranges, if any.
+     * A following call to next() or nextRange() will yield a string, if there is one.
+     * No-op if next() would return false, or if it would yield a string anyway.
+     *
+     * @return *this
+     * @draft ICU 70
+     * @see UnicodeSet#strings()
+     */
+    inline UnicodeSetIterator &skipToStrings() {
+        // Finish code point/range iteration.
+        range = endRange;
+        endElement = -1;
+        nextElement = 0;
+        return *this;
+    }
+#endif  // U_HIDE_DRAFT_API
 
     /**
      * Advances the iteration position to the next element in the set, 
@@ -281,12 +303,15 @@ class U_COMMON_API UnicodeSetIterator : public UObject {
      */
     int32_t stringCount;
 
+ private:
+
     /**
      *  Points to the string to use when the caller asks for a
      *  string and the current iteration item is a code point, not a string.
-     *  @internal
      */
     UnicodeString *cpString;
+
+ protected:
 
     /** Copy constructor. Disallowed.
      * @stable ICU 2.4
@@ -306,7 +331,7 @@ class U_COMMON_API UnicodeSetIterator : public UObject {
 };
 
 inline UBool UnicodeSetIterator::isString() const {
-    return codepoint == (UChar32)IS_STRING;
+    return codepoint < 0;
 }
 
 inline UChar32 UnicodeSetIterator::getCodepoint() const {

--- a/icu4c/source/common/uset.cpp
+++ b/icu4c/source/common/uset.cpp
@@ -197,6 +197,11 @@ uset_isEmpty(const USet* set) {
 }
 
 U_CAPI UBool U_EXPORT2
+uset_hasStrings(const USet* set) {
+    return ((const UnicodeSet*) set)->UnicodeSet::hasStrings();
+}
+
+U_CAPI UBool U_EXPORT2
 uset_contains(const USet* set, UChar32 c) {
     return ((const UnicodeSet*) set)->UnicodeSet::contains(c);
 }
@@ -297,6 +302,11 @@ private:
 U_NAMESPACE_END
 
 U_CAPI int32_t U_EXPORT2
+uset_getRangeCount(const USet *set) {
+    return ((const UnicodeSet *)set)->UnicodeSet::getRangeCount();
+}
+
+U_CAPI int32_t U_EXPORT2
 uset_getItemCount(const USet* uset) {
     const UnicodeSet& set = *(const UnicodeSet*)uset;
     return set.getRangeCount() + USetAccess::getStringCount(set);
@@ -330,11 +340,6 @@ uset_getItem(const USet* uset, int32_t itemIndex,
     }
 }
 
-//U_CAPI int32_t U_EXPORT2
-//uset_getRangeCount(const USet* set) {
-//    return ((const UnicodeSet*) set)->getRangeCount();
-//}
-//
 //U_CAPI UBool U_EXPORT2
 //uset_getRange(const USet* set, int32_t rangeIndex,
 //              UChar32* pStart, UChar32* pEnd) {

--- a/icu4c/source/test/intltest/csdetest.cpp
+++ b/icu4c/source/test/intltest/csdetest.cpp
@@ -780,7 +780,7 @@ void CharsetDetectionTest::Ticket6394Test() {
         return;
     }
 
-    UnicodeSet  setOfCharsetNames;    // UnicodSets can hold strings.
+    UnicodeSet  setOfCharsetNames;    // UnicodeSets can hold strings.
     int32_t i;
     for (i=0; i<matchCount; i++) {
         UnicodeString charSetName(ucsdet_getName(matches[i], &status));

--- a/icu4c/source/test/intltest/usettest.h
+++ b/icu4c/source/test/intltest/usettest.h
@@ -19,6 +19,7 @@
 #include "unicode/unistr.h"
 #include "unicode/uniset.h"
 #include "unicode/ucnv_err.h"
+#include "unicode/usetiter.h"
 #include "intltest.h"
 #include "cmemory.h"
 
@@ -95,6 +96,9 @@ private:
     void TestUnusedCcc();
     void TestDeepPattern();
     void TestEmptyString();
+
+    void assertNext(UnicodeSetIterator &iter, const UnicodeString &expected);
+    void TestSkipToStrings();
 
 private:
 

--- a/icu4j/main/classes/core/src/com/ibm/icu/number/NumberFormatter.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/number/NumberFormatter.java
@@ -487,9 +487,8 @@ public final class NumberFormatter {
      * <li>AUTO: 0.90, 1.00, 1.10
      * <li>HIDE_IF_WHOLE: 0.90, 1, 1.10
      * </ul>
-     * 
+     *
      * @draft ICU 69
-     * @provisional This API might change or be removed in a future release.
      */
     public static enum TrailingZeroDisplay {
         /**
@@ -498,7 +497,7 @@ public final class NumberFormatter {
          * @draft ICU 69
          */
         AUTO,
-    
+
         /**
          * Same as AUTO, but hide trailing zeros after the decimal separator if they are all zero.
          *

--- a/icu4j/main/classes/core/src/com/ibm/icu/text/UnicodeSet.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/UnicodeSet.java
@@ -829,10 +829,6 @@ public class UnicodeSet extends UnicodeFilter implements Iterable<String>, Compa
         }
     }
 
-    boolean hasStrings() {
-        return !strings.isEmpty();
-    }
-
     /**
      * Returns the number of elements in this set (its cardinality)
      * Note than the elements of a set may include both individual
@@ -858,6 +854,14 @@ public class UnicodeSet extends UnicodeFilter implements Iterable<String>, Compa
      */
     public boolean isEmpty() {
         return len == 1 && !hasStrings();
+    }
+
+    /**
+     * @return true if this set contains multi-character strings or the empty string.
+     * @draft ICU 70
+     */
+    public boolean hasStrings() {
+        return !strings.isEmpty();
     }
 
     /**

--- a/icu4j/main/classes/core/src/com/ibm/icu/text/UnicodeSetIterator.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/UnicodeSetIterator.java
@@ -14,7 +14,7 @@ import java.util.Iterator;
  * UnicodeSetIterator iterates over the contents of a UnicodeSet.  It
  * iterates over either code points or code point ranges.  After all
  * code points or ranges have been returned, it returns the
- * multicharacter strings of the UnicodSet, if any.
+ * multicharacter strings of the UnicodeSet, if any.
  *
  * <p>To iterate over code points and multicharacter strings,
  * use a loop like this:
@@ -34,10 +34,16 @@ import java.util.Iterator;
  *   }
  * }
  * </pre>
+ *
+ * <p>To iterate over only the strings, start with <code>new UnicodeSetIterator(set).skipToStrings()</code>.
+ *
  * <p><b>Warning: </b>For speed, UnicodeSet iteration does not check for concurrent modification.
  * Do not alter the UnicodeSet while iterating.
  * @author M. Davis
  * @stable ICU 2.0
+ * @see UnicodeSet#ranges()
+ * @see UnicodeSet#strings()
+ * @see UnicodeSet#iterator()
  */
 public class UnicodeSetIterator {
 
@@ -92,6 +98,23 @@ public class UnicodeSetIterator {
      */
     public UnicodeSetIterator() {
         reset(new UnicodeSet());
+    }
+
+    /**
+     * Skips over the remaining code points/ranges, if any.
+     * A following call to next() or nextRange() will yield a string, if there is one.
+     * No-op if next() would return false, or if it would yield a string anyway.
+     *
+     * @return this
+     * @draft ICU 70
+     * @see UnicodeSet#strings()
+     */
+    public UnicodeSetIterator skipToStrings() {
+        // Finish code point/range iteration.
+        range = endRange;
+        endElement = -1;
+        nextElement = 0;
+        return this;
     }
 
     /**
@@ -234,39 +257,15 @@ public class UnicodeSetIterator {
     private int endRange = 0;
     private int range = 0;
 
-    /**
-     * @internal
-     * @deprecated This API is ICU internal only.
-     */
-    @Deprecated
-    public UnicodeSet getSet() {
-        return set;
-    }
-
-    /**
-     * @internal
-     * @deprecated This API is ICU internal only.
-     */
-    @Deprecated
-    protected int endElement;
-    /**
-     * @internal
-     * @deprecated This API is ICU internal only.
-     */
-    @Deprecated
-    protected int nextElement;
-    private Iterator<String> stringIterator = null;
+    private int endElement;
+    private int nextElement;
 
     /**
      * Invariant: stringIterator is null when there are no (more) strings remaining
      */
+    private Iterator<String> stringIterator = null;
 
-    /**
-     * @internal
-     * @deprecated This API is ICU internal only.
-     */
-    @Deprecated
-    protected void loadRange(int aRange) {
+    private void loadRange(int aRange) {
         nextElement = set.getRangeStart(aRange);
         endElement = set.getRangeEnd(aRange);
     }

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/lang/UnicodeSetTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/lang/UnicodeSetTest.java
@@ -819,6 +819,8 @@ public class UnicodeSetTest extends TestFmwk {
                             {new UnicodeSet('a','z').add('A', 'Z').retain('M','m').complement('X'),
                                 new UnicodeSet("[[a-zA-Z]&[M-m]-[X]]")},
         };
+        assertFalse("[a-c].hasStrings()", testList[0][0].hasStrings());
+        assertTrue("[{ll}{ch}a-z].hasStrings()", testList[1][0].hasStrings());
 
         for (int i = 0; i < testList.length; ++i) {
             if (!testList[i][0].equals(testList[i][1])) {
@@ -2420,17 +2422,6 @@ public class UnicodeSetTest extends TestFmwk {
         return Utility.unescape(s);
     }
 
-    /* Test the method public UnicodeSet getSet() */
-    @Test
-    public void TestGetSet() {
-        UnicodeSetIterator us = new UnicodeSetIterator();
-        try {
-            us.getSet();
-        } catch (Exception e) {
-            errln("UnicodeSetIterator.getSet() was not suppose to given an " + "an exception.");
-        }
-    }
-
     /* Tests the method public UnicodeSet add(Collection<?> source) */
     @Test
     public void TestAddCollection() {
@@ -2839,5 +2830,51 @@ public class UnicodeSetTest extends TestFmwk {
         assertEquals("frozen spanBack", 2, set.spanBack("abc", SpanCondition.SIMPLE));
         assertTrue("frozen containsNone", set.containsNone("def"));
         assertFalse("frozen containsSome", set.containsSome("def"));
+    }
+
+    private void assertNext(UnicodeSetIterator iter, String expected) {
+        assertTrue(expected + ".next()", iter.next());
+        assertEquals(expected + ".getString()", expected, iter.getString());
+    }
+
+    @Test
+    public void TestSkipToStrings() {
+        UnicodeSet set = new UnicodeSet("[0189{}{ch}]");
+        UnicodeSetIterator iter = new UnicodeSetIterator(set).skipToStrings();
+        assertNext(iter, "");
+        assertNext(iter, "ch");
+        assertFalse("no next", iter.next());
+
+        iter.reset();
+        assertNext(iter, "0");
+        assertNext(iter, "1");
+        assertNext(iter, "8");
+        assertNext(iter, "9");
+        assertNext(iter, "");
+        assertNext(iter, "ch");
+        assertFalse("no next", iter.next());
+
+        iter.reset();
+        assertNext(iter, "0");
+        iter.skipToStrings();
+        assertNext(iter, "");
+        assertNext(iter, "ch");
+        assertFalse("no next", iter.next());
+
+        iter.reset();
+        iter.nextRange();
+        assertNext(iter, "8");
+        iter.skipToStrings();
+        assertNext(iter, "");
+        assertNext(iter, "ch");
+        assertFalse("no next", iter.next());
+
+        iter.reset();
+        iter.nextRange();
+        iter.nextRange();
+        iter.nextRange();
+        iter.skipToStrings();
+        assertNext(iter, "ch");
+        assertFalse("no next", iter.next());
     }
 }

--- a/icu4j/main/tests/framework/src/com/ibm/icu/dev/util/UnicodeMapIterator.java
+++ b/icu4j/main/tests/framework/src/com/ibm/icu/dev/util/UnicodeMapIterator.java
@@ -17,7 +17,7 @@ import com.ibm.icu.text.UTF16;
  * UnicodeSetIterator iterates over the contents of a UnicodeSet.  It
  * iterates over either code points or code point ranges.  After all
  * code points or ranges have been returned, it returns the
- * multicharacter strings of the UnicodSet, if any.
+ * multicharacter strings of the UnicodeSet, if any.
  *
  * <p>To iterate over code points, use a loop like this:
  * <pre>
@@ -106,7 +106,7 @@ public class UnicodeMapIterator<T> {
      * false.  If <tt>codepoint == IS_STRING</tt>, the value is a
      * string in the <tt>string</tt> field.  Otherwise the value is a
      * single code point in the <tt>codepoint</tt> field.
-     * 
+     *
      * <p>The order of iteration is all code points in sorted order,
      * followed by all strings sorted order.  <tt>codepointEnd</tt> is
      * undefined after calling this method.  <tt>string</tt> is
@@ -135,7 +135,7 @@ public class UnicodeMapIterator<T> {
 
         if (stringIterator == null) return false;
         codepoint = IS_STRING; // signal that value is actually a string
-        string = (String)stringIterator.next();
+        string = stringIterator.next();
         if (!stringIterator.hasNext()) stringIterator = null;
         return true;
     }
@@ -147,7 +147,7 @@ public class UnicodeMapIterator<T> {
      * string in the <tt>string</tt> field.  Otherwise the value is a
      * range of one or more code points from <tt>codepoint</tt> to
      * <tt>codepointeEnd</tt> inclusive.
-     * 
+     *
      * <p>The order of iteration is all code points ranges in sorted
      * order, followed by all strings sorted order.  Ranges are
      * disjoint and non-contiguous.  <tt>string</tt> is undefined
@@ -180,7 +180,7 @@ public class UnicodeMapIterator<T> {
 
         if (stringIterator == null) return false;
         codepoint = IS_STRING; // signal that value is actually a string
-        string = (String)stringIterator.next();
+        string = stringIterator.next();
         if (!stringIterator.hasNext()) stringIterator = null;
         return true;
     }
@@ -198,13 +198,13 @@ public class UnicodeMapIterator<T> {
 
     /**
      * Resets this iterator to the start of the set.
-     * @return 
+     * @return
      */
     public UnicodeMapIterator<T> reset() {
         endRange = map.getRangeCount() - 1;
         // both next*() methods will test: if (nextElement <= endElement)
         // we set them to fail this test, which will cause them to load the first range
-        nextElement = 0; 
+        nextElement = 0;
         endElement = -1;
         range = -1;
 


### PR DESCRIPTION
Also, UnicodeSetIterator is not intended for public subclassing, but there was one subclass in a unit test (in each of Java & C++). I rewrote that to compute a modified set rather than fiddle with the iterator, and removed protected @internal access in Java. In C++ we should discuss whether that's ok: ICU-21663 "UnicodeSetIterator: make protected members private"

This PR also addresses ICU-6553 "uset_charAt() / uset_size() inconsistent" via documentation and adding uset_getRangeCount().

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21525
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
