### PR TITLE
ICU-21657 Update Azure CI build bots to use Ubuntu 18.04

### DIFF
--- a/.ci-builds/.azure-exhaustive-tests.yml
+++ b/.ci-builds/.azure-exhaustive-tests.yml
@@ -30,11 +30,11 @@ trigger:
 jobs:
 #-------------------------------------------------------------------------
 # Note: The exhaustive tests can take more than 1 hour to complete.
-- job: ICU4J_OpenJDK_Ubuntu_1604
-  displayName: 'J: Linux OpenJDK (Ubuntu 16.04)'
+- job: ICU4J_OpenJDK_Ubuntu_1804
+  displayName: 'J: Linux OpenJDK (Ubuntu 18.04)'
   timeoutInMinutes: 120
   pool:
-    vmImage: 'Ubuntu 16.04'
+    vmImage: 'ubuntu-18.04'
     demands: ant
   steps:
     - checkout: self
@@ -52,11 +52,11 @@ jobs:
       timeoutInMinutes: 2
 #-------------------------------------------------------------------------
 # Note: The exhaustive tests can take more than 1 hour to complete.
-- job: ICU4C_Clang_Exhaustive_Ubuntu_1604
-  displayName: 'C: Linux Clang Exhaustive Tests (Ubuntu 16.04)'
+- job: ICU4C_Clang_Exhaustive_Ubuntu_1804
+  displayName: 'C: Linux Clang Exhaustive Tests (Ubuntu 18.04)'
   timeoutInMinutes: 120
   pool:
-    vmImage: 'Ubuntu 16.04'
+    vmImage: 'ubuntu-18.04'
   steps:
     - checkout: self
       lfs: true

--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -2,11 +2,11 @@
 
 jobs:
 #-------------------------------------------------------------------------
-- job: ICU4J_OpenJDK_Ubuntu_1604
-  displayName: 'J: Linux OpenJDK (Ubuntu 16.04)'
+- job: ICU4J_OpenJDK_Ubuntu_1804
+  displayName: 'J: Linux OpenJDK (Ubuntu 18.04)'
   timeoutInMinutes: 20
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
     demands: ant
   steps:
     - checkout: self
@@ -23,11 +23,11 @@ jobs:
       condition: failed() # only run if the build fails.
       displayName: 'List failures (if any)'
 #-------------------------------------------------------------------------
-- job: ICU4C_Clang_Ubuntu_1604
-  displayName: 'C: Linux Clang (Ubuntu 16.04)'
+- job: ICU4C_Clang_Ubuntu_1804
+  displayName: 'C: Linux Clang (Ubuntu 18.04)'
   timeoutInMinutes: 30
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   steps:
     - checkout: self
       lfs: true
@@ -45,11 +45,11 @@ jobs:
         cd icu4c/source/test/cintltst && LANG=C.UTF-8 LD_LIBRARY_PATH=../../lib:../../tools/ctestfw ./cintltst /tsutil/cloctst/TestCDefaultLocale
       displayName: 'Test C.UTF-8 Default locale'
 #-------------------------------------------------------------------------
-- job: ICU4C_Clang_Ubuntu_1604_WarningsAsErrors
-  displayName: 'C: Linux Clang WarningsAsErrors (Ubuntu 16.04)'
+- job: ICU4C_Clang_Ubuntu_1804_WarningsAsErrors
+  displayName: 'C: Linux Clang WarningsAsErrors (Ubuntu 18.04)'
   timeoutInMinutes: 30
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   steps:
     - checkout: self
       lfs: true
@@ -61,11 +61,11 @@ jobs:
         CC: clang
         CXX: clang++
 #-------------------------------------------------------------------------
-- job: ICU4C_Clang_Ubuntu_DataFilter_1604
-  displayName: 'C: Linux Clang DataFilter (Ubuntu 16.04)'
+- job: ICU4C_Clang_Ubuntu_DataFilter_1804
+  displayName: 'C: Linux Clang DataFilter (Ubuntu 18.04)'
   timeoutInMinutes: 30
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   steps:
     - checkout: self
       lfs: true

--- a/.ci-builds/.azure-valgrind.yml
+++ b/.ci-builds/.azure-valgrind.yml
@@ -28,11 +28,11 @@ pr:
 
 jobs:
 #-------------------------------------------------------------------------
-- job: ICU4C_Clang_Valgrind_Ubuntu_1604
-  displayName: 'C: Linux Clang Valgrind (Ubuntu 16.04)'
+- job: ICU4C_Clang_Valgrind_Ubuntu_1804
+  displayName: 'C: Linux Clang Valgrind (Ubuntu 18.04)'
   timeoutInMinutes: 60
   pool:
-    vmImage: 'Ubuntu 16.04'
+    vmImage: 'ubuntu-18.04'
   steps:
     - checkout: self
       lfs: true


### PR DESCRIPTION
This is related to the upstream issue: https://github.com/actions/virtual-environments/issues/3287

> Traditional 5-years support of Ubuntu 16.04 by Canonical ends in April, 2021. To keep our environment updated and secured, we will remove Ubuntu 16.04 on September 20, 2021.

This change migrates the Azure CI build bots to use Ubuntu 18.04.

From discussion in the ICU-TC call, we'll use Ubuntu 18.04 for Azure CI. The GitHub Actions builds will continue to use the `ubuntu-latest`, which is Ubuntu 20.04.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21657
- [x] Required: The PR title must be prefixed with a JIRA Issue number.
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number.
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
