### PR TITLE
ICU-21662 Rename UVector::addElement().

### DIFF
--- a/icu4c/source/common/localematcher.cpp
+++ b/icu4c/source/common/localematcher.cpp
@@ -187,7 +187,7 @@ LocaleMatcher::Builder &LocaleMatcher::Builder::setSupportedLocalesFromListStrin
     for (int32_t i = 0; i < length; ++i) {
         Locale *locale = list.orphanLocaleAt(i);
         if (locale == nullptr) { continue; }
-        supportedLocales_->addElement(locale, errorCode_);
+        supportedLocales_->addElementX(locale, errorCode_);
         if (U_FAILURE(errorCode_)) {
             delete locale;
             break;
@@ -207,7 +207,7 @@ LocaleMatcher::Builder &LocaleMatcher::Builder::setSupportedLocales(Locale::Iter
             errorCode_ = U_MEMORY_ALLOCATION_ERROR;
             break;
         }
-        supportedLocales_->addElement(clone, errorCode_);
+        supportedLocales_->addElementX(clone, errorCode_);
         if (U_FAILURE(errorCode_)) {
             delete clone;
             break;
@@ -223,7 +223,7 @@ LocaleMatcher::Builder &LocaleMatcher::Builder::addSupportedLocale(const Locale 
         errorCode_ = U_MEMORY_ALLOCATION_ERROR;
         return *this;
     }
-    supportedLocales_->addElement(clone, errorCode_);
+    supportedLocales_->addElementX(clone, errorCode_);
     if (U_FAILURE(errorCode_)) {
         delete clone;
     }

--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -1211,7 +1211,7 @@ AliasReplacer::parseLanguageReplacement(
         status = U_MEMORY_ALLOCATION_ERROR;
         return;
     }
-    toBeFreed.addElement(str, status);
+    toBeFreed.addElementX(str, status);
     char* data = str->data();
     replacedLanguage = (const char*) data;
     char* endOfField = uprv_strchr(data, '_');
@@ -1425,7 +1425,7 @@ AliasReplacer::replaceTerritory(UVector& toBeFreed, UErrorCode& status)
             return false;
         }
         replacedRegion = item->data();
-        toBeFreed.addElement(item.orphan(), status);
+        toBeFreed.addElementX(item.orphan(), status);
     }
     U_ASSERT(!same(region, replacedRegion));
     region = replacedRegion;
@@ -1659,10 +1659,10 @@ AliasReplacer::replace(const Locale& locale, CharString& out, UErrorCode& status
         while ((end = uprv_strchr(start, SEP_CHAR)) != nullptr &&
                U_SUCCESS(status)) {
             *end = NULL_CHAR;  // null terminate inside variantsBuff
-            variants.addElement(start, status);
+            variants.addElementX(start, status);
             start = end + 1;
         }
-        variants.addElement(start, status);
+        variants.addElementX(start, status);
     }
     if (U_FAILURE(status)) { return false; }
 

--- a/icu4c/source/common/normalizer2impl.cpp
+++ b/icu4c/source/common/normalizer2impl.cpp
@@ -2504,7 +2504,7 @@ void CanonIterData::addToStartSet(UChar32 origin, UChar32 decompLead, UErrorCode
             UChar32 firstOrigin=(UChar32)(canonValue&CANON_VALUE_MASK);
             canonValue=(canonValue&~CANON_VALUE_MASK)|CANON_HAS_SET|(uint32_t)canonStartSets.size();
             umutablecptrie_set(mutableTrie, decompLead, canonValue, &errorCode);
-            canonStartSets.addElement(set, errorCode);
+            canonStartSets.addElementX(set, errorCode);
             if(firstOrigin!=0) {
                 set->add(firstOrigin);
             }

--- a/icu4c/source/common/rbbinode.cpp
+++ b/icu4c/source/common/rbbinode.cpp
@@ -267,7 +267,7 @@ void   RBBINode::findNodes(UVector *dest, RBBINode::NodeType kind, UErrorCode &s
         return;
     }
     if (fType == kind) {
-        dest->addElement(this, status);
+        dest->addElementX(this, status);
     }
     if (fLeftChild != NULL) {
         fLeftChild->findNodes(dest, kind, status);

--- a/icu4c/source/common/rbbiscan.cpp
+++ b/icu4c/source/common/rbbiscan.cpp
@@ -775,7 +775,7 @@ void RBBIRuleScanner::findSetFor(const UnicodeString &s, RBBINode *node, Unicode
     //
     // Add the new uset node to the list of all uset nodes.
     //
-    fRB->fUSetNodes->addElement(usetNode, *fRB->fStatus);
+    fRB->fUSetNodes->addElementX(usetNode, *fRB->fStatus);
 
 
     //

--- a/icu4c/source/common/rbbisetb.cpp
+++ b/icu4c/source/common/rbbisetb.cpp
@@ -172,7 +172,7 @@ void RBBISetBuilder::buildRanges() {
             // The current rlRange is now entirely within the UnicodeSet range.
             // Add this unicode set to the list of sets for this rlRange
             if (rlRange->fIncludesSets->indexOf(usetNode) == -1) {
-                rlRange->fIncludesSets->addElement(usetNode, *fStatus);
+                rlRange->fIncludesSets->addElementX(usetNode, *fStatus);
                 if (U_FAILURE(*fStatus)) {
                     return;
                 }
@@ -600,7 +600,7 @@ RangeDescriptor::RangeDescriptor(const RangeDescriptor &other, UErrorCode &statu
     }
 
     for (int32_t i=0; i<other.fIncludesSets->size(); i++) {
-        this->fIncludesSets->addElement(other.fIncludesSets->elementAt(i), status);
+        this->fIncludesSets->addElementX(other.fIncludesSets->elementAt(i), status);
     }
 }
 

--- a/icu4c/source/common/rbbitblb.cpp
+++ b/icu4c/source/common/rbbitblb.cpp
@@ -261,7 +261,7 @@ void RBBITableBuilder::calcFirstPos(RBBINode *n) {
         // Note: In order to maintain the sort invariant on the set,
         // this function should only be called on a node whose set is
         // empty to start with.
-        n->fFirstPosSet->addElement(n, *fStatus);
+        n->fFirstPosSet->addElementX(n, *fStatus);
         return;
     }
 
@@ -307,7 +307,7 @@ void RBBITableBuilder::calcLastPos(RBBINode *n) {
         // Note: In order to maintain the sort invariant on the set,
         // this function should only be called on a node whose set is
         // empty to start with.
-        n->fLastPosSet->addElement(n, *fStatus);
+        n->fLastPosSet->addElementX(n, *fStatus);
         return;
     }
 
@@ -391,7 +391,7 @@ void RBBITableBuilder::addRuleRootNodes(UVector *dest, RBBINode *node) {
         return;
     }
     if (node->fRuleRoot) {
-        dest->addElement(node, *fStatus);
+        dest->addElementX(node, *fStatus);
         // Note: rules cannot nest. If we found a rule start node,
         //       no child node can also be a start node.
         return;
@@ -583,7 +583,7 @@ void RBBITableBuilder::buildStateTable() {
     if (failState->fPositions == NULL || U_FAILURE(*fStatus)) {
         goto ExitBuildSTdeleteall;
     }
-    fDStates->addElement(failState, *fStatus);
+    fDStates->addElementX(failState, *fStatus);
     if (U_FAILURE(*fStatus)) {
         goto ExitBuildSTdeleteall;
     }
@@ -605,7 +605,7 @@ void RBBITableBuilder::buildStateTable() {
         goto ExitBuildSTdeleteall;
     }
     setAdd(initialState->fPositions, fTree->fFirstPosSet);
-    fDStates->addElement(initialState, *fStatus);
+    fDStates->addElementX(initialState, *fStatus);
     if (U_FAILURE(*fStatus)) {
         goto ExitBuildSTdeleteall;
     }
@@ -681,7 +681,7 @@ void RBBITableBuilder::buildStateTable() {
                         goto ExitBuildSTdeleteall;
                     }
                     newState->fPositions = U;
-                    fDStates->addElement(newState, *fStatus);
+                    fDStates->addElementX(newState, *fStatus);
                     if (U_FAILURE(*fStatus)) {
                         return;
                     }
@@ -1499,7 +1499,7 @@ void RBBITableBuilder::buildSafeReverseTable(UErrorCode &status) {
     U_ASSERT(fSafeTable == nullptr);
     fSafeTable = new UVector(uprv_deleteUObject, uhash_compareUnicodeString, numCharClasses + 2, status);
     for (int32_t row=0; row<numCharClasses + 2; ++row) {
-        fSafeTable->addElement(new UnicodeString(numCharClasses, 0, numCharClasses+4), status);
+        fSafeTable->addElementX(new UnicodeString(numCharClasses, 0, numCharClasses+4), status);
     }
 
     // From the start state, each input char class transitions to the state for that input.

--- a/icu4c/source/common/serv.cpp
+++ b/icu4c/source/common/serv.cpp
@@ -534,7 +534,7 @@ ICUService::getKey(ICUServiceKey& key, UnicodeString* actualReturn, const ICUSer
                 status = U_MEMORY_ALLOCATION_ERROR;
                 return NULL;
             }
-            cacheDescriptorList->addElement(idToCache.getAlias(), status);
+            cacheDescriptorList->addElementX(idToCache.getAlias(), status);
             if (U_FAILURE(status)) {
                 return NULL;
             }
@@ -638,7 +638,7 @@ ICUService::getVisibleIDs(UVector& result, const UnicodeString* matchID, UErrorC
                     status = U_MEMORY_ALLOCATION_ERROR;
                     break;
                 }
-                result.addElement(idClone, status);
+                result.addElementX(idClone, status);
                 if (U_FAILURE(status)) {
                     delete idClone;
                     break;
@@ -797,7 +797,7 @@ ICUService::getDisplayNames(UVector& result,
         }
         const UnicodeString* dn = (const UnicodeString*)entry->key.pointer;
         StringPair* sp = StringPair::create(*id, *dn, status);
-        result.addElement(sp, status);
+        result.addElementX(sp, status);
         if (U_FAILURE(status)) {
             result.removeAllElements();
             break;

--- a/icu4c/source/common/servls.cpp
+++ b/icu4c/source/common/servls.cpp
@@ -179,7 +179,7 @@ private:
 
             length = other._ids.size();
             for(i = 0; i < length; ++i) {
-                _ids.addElement(((UnicodeString *)other._ids.elementAt(i))->clone(), status);
+                _ids.addElementX(((UnicodeString *)other._ids.elementAt(i))->clone(), status);
             }
 
             if(U_SUCCESS(status)) {

--- a/icu4c/source/common/servnotf.cpp
+++ b/icu4c/source/common/servnotf.cpp
@@ -59,7 +59,7 @@ ICUNotifier::addListener(const EventListener* l, UErrorCode& status)
                 }
             }
 
-            listeners->addElement((void*)l, status); // cast away const
+            listeners->addElementX((void*)l, status); // cast away const
         }
 #ifdef NOTIFIER_DEBUG
         else {

--- a/icu4c/source/common/uvector.cpp
+++ b/icu4c/source/common/uvector.cpp
@@ -96,7 +96,7 @@ UVector::~UVector() {
  * Use the 'assign' function to assign each element.
  */
 void UVector::assign(const UVector& other, UElementAssigner *assign, UErrorCode &ec) {
-    if (ensureCapacity(other.count, ec)) {
+    if (ensureCapacityX(other.count, ec)) {
         setSize(other.count, ec);
         if (U_SUCCESS(ec)) {
             for (int32_t i=0; i<other.count; ++i) {
@@ -124,14 +124,14 @@ UBool UVector::operator==(const UVector& other) {
     return TRUE;
 }
 
-void UVector::addElement(void* obj, UErrorCode &status) {
-    if (ensureCapacity(count + 1, status)) {
+void UVector::addElementX(void* obj, UErrorCode &status) {
+    if (ensureCapacityX(count + 1, status)) {
         elements[count++].pointer = obj;
     }
 }
 
 void UVector::addElement(int32_t elem, UErrorCode &status) {
-    if (ensureCapacity(count + 1, status)) {
+    if (ensureCapacityX(count + 1, status)) {
         elements[count].pointer = NULL;     // Pointers may be bigger than ints.
         elements[count].integer = elem;
         count++;
@@ -162,7 +162,7 @@ void UVector::setElementAt(int32_t elem, int32_t index) {
 
 void UVector::insertElementAt(void* obj, int32_t index, UErrorCode &status) {
     // must have 0 <= index <= count
-    if (0 <= index && index <= count && ensureCapacity(count + 1, status)) {
+    if (0 <= index && index <= count && ensureCapacityX(count + 1, status)) {
         for (int32_t i=count; i>index; --i) {
             elements[i] = elements[i-1];
         }
@@ -174,7 +174,7 @@ void UVector::insertElementAt(void* obj, int32_t index, UErrorCode &status) {
 
 void UVector::insertElementAt(int32_t elem, int32_t index, UErrorCode &status) {
     // must have 0 <= index <= count
-    if (0 <= index && index <= count && ensureCapacity(count + 1, status)) {
+    if (0 <= index && index <= count && ensureCapacityX(count + 1, status)) {
         for (int32_t i=count; i>index; --i) {
             elements[i] = elements[i-1];
         }
@@ -328,7 +328,7 @@ int32_t UVector::indexOf(UElement key, int32_t startIndex, int8_t hint) const {
     return -1;
 }
 
-UBool UVector::ensureCapacity(int32_t minimumCapacity, UErrorCode &status) {
+UBool UVector::ensureCapacityX(int32_t minimumCapacity, UErrorCode &status) {
 	if (minimumCapacity < 0) {
         status = U_ILLEGAL_ARGUMENT_ERROR;
         return FALSE;
@@ -371,7 +371,7 @@ void UVector::setSize(int32_t newSize, UErrorCode &status) {
         return;
     }
     if (newSize > count) {
-        if (!ensureCapacity(newSize, status)) {
+        if (!ensureCapacityX(newSize, status)) {
             return;
         }
         UElement empty;
@@ -474,7 +474,7 @@ void UVector::sortedInsert(UElement e, UElementComparator *compare, UErrorCode& 
             min = probe + 1;
         }
     }
-    if (ensureCapacity(count + 1, ec)) {
+    if (ensureCapacityX(count + 1, ec)) {
         for (int32_t i=count; i>min; --i) {
             elements[i] = elements[i-1];
         }

--- a/icu4c/source/common/uvector.h
+++ b/icu4c/source/common/uvector.h
@@ -124,7 +124,11 @@ public:
     // java.util.Vector API
     //------------------------------------------------------------
 
-    void addElement(void* obj, UErrorCode &status);
+    /*
+     * Old version of addElement, with non-standard error handling.
+     * Will be removed once all uses have been switched to the new addElement().
+     */
+    void addElementX(void* obj, UErrorCode &status);
 
     void addElement(int32_t elem, UErrorCode &status);
 
@@ -172,7 +176,11 @@ public:
 
     inline UBool isEmpty(void) const;
 
-    UBool ensureCapacity(int32_t minimumCapacity, UErrorCode &status);
+    /*
+     * Old version of ensureCapacity, with non-standard error handling.
+     * Will be removed once all uses have been switched to the new ensureCapacity().
+     */
+    UBool ensureCapacityX(int32_t minimumCapacity, UErrorCode &status);
 
     /**
      * Change the size of this vector as follows: If newSize is
@@ -401,7 +409,7 @@ inline int32_t UStack::peeki(void) const {
 }
 
 inline void* UStack::push(void* obj, UErrorCode &status) {
-    addElement(obj, status);
+    addElementX(obj, status);
     return obj;
 }
 

--- a/icu4c/source/i18n/alphaindex.cpp
+++ b/icu4c/source/i18n/alphaindex.cpp
@@ -455,7 +455,7 @@ BucketList *AlphabeticIndex::createBucketList(UErrorCode &errorCode) const {
         errorCode = U_MEMORY_ALLOCATION_ERROR;
         return NULL;
     }
-    bucketList->addElement(bucket, errorCode);
+    bucketList->addElementX(bucket, errorCode);
     if (U_FAILURE(errorCode)) { return NULL; }
 
     UnicodeString temp;
@@ -485,7 +485,7 @@ BucketList *AlphabeticIndex::createBucketList(UErrorCode &errorCode) const {
                     errorCode = U_MEMORY_ALLOCATION_ERROR;
                     return NULL;
                 }
-                bucketList->addElement(bucket, errorCode);
+                bucketList->addElementX(bucket, errorCode);
             }
         }
         // Add a bucket with the current label.
@@ -494,7 +494,7 @@ BucketList *AlphabeticIndex::createBucketList(UErrorCode &errorCode) const {
             errorCode = U_MEMORY_ALLOCATION_ERROR;
             return NULL;
         }
-        bucketList->addElement(bucket, errorCode);
+        bucketList->addElementX(bucket, errorCode);
         // Remember ASCII and Pinyin buckets for Pinyin redirects.
         UChar c;
         if (current.length() == 1 && 0x41 <= (c = current.charAt(0)) && c <= 0x5A) {  // A-Z
@@ -533,7 +533,7 @@ BucketList *AlphabeticIndex::createBucketList(UErrorCode &errorCode) const {
                         return NULL;
                     }
                     bucket->displayBucket_ = singleBucket;
-                    bucketList->addElement(bucket, errorCode);
+                    bucketList->addElementX(bucket, errorCode);
                     hasInvisibleBuckets = TRUE;
                     break;
                 }
@@ -557,7 +557,7 @@ BucketList *AlphabeticIndex::createBucketList(UErrorCode &errorCode) const {
         errorCode = U_MEMORY_ALLOCATION_ERROR;
         return NULL;
     }
-    bucketList->addElement(bucket, errorCode); // final
+    bucketList->addElementX(bucket, errorCode); // final
 
     if (hasPinyin) {
         // Redirect Pinyin buckets.
@@ -610,7 +610,7 @@ BucketList *AlphabeticIndex::createBucketList(UErrorCode &errorCode) const {
     for (int32_t j = 0; j < bucketList->size(); ++j) {
         bucket = getBucket(*bucketList, j);
         if (bucket->displayBucket_ == NULL) {
-            publicBucketList->addElement(bucket, errorCode);
+            publicBucketList->addElementX(bucket, errorCode);
         }
     }
     if (U_FAILURE(errorCode)) { return NULL; }
@@ -684,7 +684,7 @@ void AlphabeticIndex::initBuckets(UErrorCode &errorCode) {
                 return;
             }
         }
-        bucket->records_->addElement(r, errorCode);
+        bucket->records_->addElementX(r, errorCode);
     }
 }
 
@@ -1015,7 +1015,7 @@ UVector *AlphabeticIndex::firstStringsInScript(UErrorCode &status) {
             status = U_MEMORY_ALLOCATION_ERROR;
             return NULL;
         }
-        dest->addElement(s, status);
+        dest->addElementX(s, status);
     }
     return dest.orphan();
 }
@@ -1078,7 +1078,7 @@ AlphabeticIndex & AlphabeticIndex::addRecord(const UnicodeString &name, const vo
         status = U_MEMORY_ALLOCATION_ERROR;
         return *this;
     }
-    inputList_->addElement(r, status);
+    inputList_->addElementX(r, status);
     clearBuckets();
     //std::string ss;
     //std::string ss2;

--- a/icu4c/source/i18n/basictz.cpp
+++ b/icu4c/source/i18n/basictz.cpp
@@ -328,7 +328,7 @@ BasicTimeZone::getTimeZoneRulesAfter(UDate start, InitialTimeZoneRule*& initial,
         goto error;
     }
     for (i = 0; i < ruleCount; i++) {
-        orgRules->addElement(orgtrs[i]->clone(), status);
+        orgRules->addElementX(orgtrs[i]->clone(), status);
         if (U_FAILURE(status)) {
             goto error;
         }
@@ -418,7 +418,7 @@ BasicTimeZone::getTimeZoneRulesAfter(UDate start, InitialTimeZoneRule*& initial,
                 tar->getFirstStart(tzt.getFrom()->getRawOffset(), tzt.getFrom()->getDSTSavings(), firstStart);
                 if (firstStart > start) {
                     // Just add the rule as is
-                    filteredRules->addElement(tar->clone(), status);
+                    filteredRules->addElementX(tar->clone(), status);
                     if (U_FAILURE(status)) {
                         goto error;
                     }
@@ -461,7 +461,7 @@ BasicTimeZone::getTimeZoneRulesAfter(UDate start, InitialTimeZoneRule*& initial,
                         TimeArrayTimeZoneRule *newTar = new TimeArrayTimeZoneRule(name,
                             tar->getRawOffset(), tar->getDSTSavings(), newTimes, asize, timeType);
                         uprv_free(newTimes);
-                        filteredRules->addElement(newTar, status);
+                        filteredRules->addElementX(newTar, status);
                         if (U_FAILURE(status)) {
                             goto error;
                         }
@@ -472,7 +472,7 @@ BasicTimeZone::getTimeZoneRulesAfter(UDate start, InitialTimeZoneRule*& initial,
             ar->getFirstStart(tzt.getFrom()->getRawOffset(), tzt.getFrom()->getDSTSavings(), firstStart);
             if (firstStart == tzt.getTime()) {
                 // Just add the rule as is
-                filteredRules->addElement(ar->clone(), status);
+                filteredRules->addElementX(ar->clone(), status);
                 if (U_FAILURE(status)) {
                     goto error;
                 }
@@ -484,7 +484,7 @@ BasicTimeZone::getTimeZoneRulesAfter(UDate start, InitialTimeZoneRule*& initial,
                 ar->getName(name);
                 AnnualTimeZoneRule *newAr = new AnnualTimeZoneRule(name, ar->getRawOffset(), ar->getDSTSavings(),
                     *(ar->getRule()), year, ar->getEndYear());
-                filteredRules->addElement(newAr, status);
+                filteredRules->addElementX(newAr, status);
                 if (U_FAILURE(status)) {
                     goto error;
                 }

--- a/icu4c/source/i18n/collationdatabuilder.cpp
+++ b/icu4c/source/i18n/collationdatabuilder.cpp
@@ -527,7 +527,7 @@ CollationDataBuilder::addConditionalCE32(const UnicodeString &context, uint32_t 
         errorCode = U_MEMORY_ALLOCATION_ERROR;
         return -1;
     }
-    conditionalCE32s.addElement(cond, errorCode);
+    conditionalCE32s.addElementX(cond, errorCode);
     return index;
 }
 

--- a/icu4c/source/i18n/dtfmtsym.cpp
+++ b/icu4c/source/i18n/dtfmtsym.cpp
@@ -1571,7 +1571,7 @@ struct CalendarDataSink : public ResourceSink {
                     if (U_FAILURE(errorCode)) { return; }
                 }
                 LocalPointer<UnicodeString> aliasRelativePathCopy(new UnicodeString(aliasRelativePath), errorCode);
-                resourcesToVisitNext->addElement(aliasRelativePathCopy.getAlias(), errorCode);
+                resourcesToVisitNext->addElementX(aliasRelativePathCopy.getAlias(), errorCode);
                 if (U_FAILURE(errorCode)) { return; }
                 // Only release ownership after resourcesToVisitNext takes it (no error happened):
                 aliasRelativePathCopy.orphan();
@@ -1581,12 +1581,12 @@ struct CalendarDataSink : public ResourceSink {
                 // Register same-calendar alias
                 if (arrays.get(aliasRelativePath) == NULL && maps.get(aliasRelativePath) == NULL) {
                     LocalPointer<UnicodeString> aliasRelativePathCopy(new UnicodeString(aliasRelativePath), errorCode);
-                    aliasPathPairs.addElement(aliasRelativePathCopy.getAlias(), errorCode);
+                    aliasPathPairs.addElementX(aliasRelativePathCopy.getAlias(), errorCode);
                     if (U_FAILURE(errorCode)) { return; }
                     // Only release ownership after aliasPathPairs takes it (no error happened):
                     aliasRelativePathCopy.orphan();
                     LocalPointer<UnicodeString> keyUStringCopy(new UnicodeString(keyUString), errorCode);
-                    aliasPathPairs.addElement(keyUStringCopy.getAlias(), errorCode);
+                    aliasPathPairs.addElementX(keyUStringCopy.getAlias(), errorCode);
                     if (U_FAILURE(errorCode)) { return; }
                     // Only release ownership after aliasPathPairs takes it (no error happened):
                     keyUStringCopy.orphan();
@@ -1757,12 +1757,12 @@ struct CalendarDataSink : public ResourceSink {
             if (aliasType == SAME_CALENDAR) {
                 // Store the alias path and the current path on aliasPathPairs
                 LocalPointer<UnicodeString> aliasRelativePathCopy(new UnicodeString(aliasRelativePath), errorCode);
-                aliasPathPairs.addElement(aliasRelativePathCopy.getAlias(), errorCode);
+                aliasPathPairs.addElementX(aliasRelativePathCopy.getAlias(), errorCode);
                 if (U_FAILURE(errorCode)) { return; }
                 // Only release ownership after aliasPathPairs takes it (no error happened):
                 aliasRelativePathCopy.orphan();
                 LocalPointer<UnicodeString> pathCopy(new UnicodeString(path), errorCode);
-                aliasPathPairs.addElement(pathCopy.getAlias(), errorCode);
+                aliasPathPairs.addElementX(pathCopy.getAlias(), errorCode);
                 if (U_FAILURE(errorCode)) { return; }
                 // Only release ownership after aliasPathPairs takes it (no error happened):
                 pathCopy.orphan();

--- a/icu4c/source/i18n/dtptngen.cpp
+++ b/icu4c/source/i18n/dtptngen.cpp
@@ -2807,7 +2807,7 @@ DTSkeletonEnumeration::DTSkeletonEnumeration(PatternMap& patternMap, dtStrEnum t
                 if (U_FAILURE(status)) { 
                     return;
                 }
-                fSkeletons->addElement(newElem.getAlias(), status);
+                fSkeletons->addElementX(newElem.getAlias(), status);
                 if (U_FAILURE(status)) {
                     fSkeletons.adoptInstead(nullptr);
                     return;
@@ -2880,7 +2880,7 @@ DTRedundantEnumeration::add(const UnicodeString& pattern, UErrorCode& status) {
     if (U_FAILURE(status)) {
         return;
     }
-    fPatterns->addElement(newElem.getAlias(), status);
+    fPatterns->addElementX(newElem.getAlias(), status);
     if (U_FAILURE(status)) {
         fPatterns.adoptInstead(nullptr);
         return;

--- a/icu4c/source/i18n/msgfmt.cpp
+++ b/icu4c/source/i18n/msgfmt.cpp
@@ -862,7 +862,7 @@ MessageFormat::getFormatNames(UErrorCode& status) {
     fFormatNames->setDeleter(uprv_deleteUObject);
 
     for (int32_t partIndex = 0; (partIndex = nextTopLevelArgStart(partIndex)) >= 0;) {
-        fFormatNames->addElement(new UnicodeString(getArgName(partIndex + 1)), status);
+        fFormatNames->addElementX(new UnicodeString(getArgName(partIndex + 1)), status);
     }
 
     StringEnumeration* nameEnumerator = new FormatNameEnumeration(fFormatNames, status);

--- a/icu4c/source/i18n/number_compact.cpp
+++ b/icu4c/source/i18n/number_compact.cpp
@@ -158,7 +158,7 @@ void CompactData::getUniquePatterns(UVector &output, UErrorCode &status) const {
 
         // The string was not found; add it to the UVector.
         // ANDY: This requires a const_cast.  Why?
-        output.addElement(const_cast<UChar *>(pattern), status);
+        output.addElementX(const_cast<UChar *>(pattern), status);
 
         continue_outer:
         continue;

--- a/icu4c/source/i18n/numsys.cpp
+++ b/icu4c/source/i18n/numsys.cpp
@@ -314,7 +314,7 @@ U_CFUNC void initNumsysNames(UErrorCode &status) {
         const char *nsName = ures_getKey(nsCurrent.getAlias());
         LocalPointer<UnicodeString> newElem(new UnicodeString(nsName, -1, US_INV), status);
         if (U_SUCCESS(status)) {
-            numsysNames->addElement(newElem.getAlias(), status);
+            numsysNames->addElementX(newElem.getAlias(), status);
             if (U_SUCCESS(status)) {
                 newElem.orphan(); // on success, the numsysNames vector owns newElem.
             }

--- a/icu4c/source/i18n/plurrule.cpp
+++ b/icu4c/source/i18n/plurrule.cpp
@@ -1545,7 +1545,7 @@ PluralKeywordEnumeration::PluralKeywordEnumeration(RuleChain *header, UErrorCode
             status = U_MEMORY_ALLOCATION_ERROR;
             return;
         }
-        fKeywordNames.addElement(newElem, status);
+        fKeywordNames.addElementX(newElem, status);
         if (U_FAILURE(status)) {
             delete newElem;
             return;
@@ -1562,7 +1562,7 @@ PluralKeywordEnumeration::PluralKeywordEnumeration(RuleChain *header, UErrorCode
             status = U_MEMORY_ALLOCATION_ERROR;
             return;
         }
-        fKeywordNames.addElement(newElem, status);
+        fKeywordNames.addElementX(newElem, status);
         if (U_FAILURE(status)) {
             delete newElem;
             return;

--- a/icu4c/source/i18n/rbt_pars.cpp
+++ b/icu4c/source/i18n/rbt_pars.cpp
@@ -976,7 +976,7 @@ void TransliteratorParser::parseRules(const UnicodeString& rule,
             if (!parsingIDs) {
                 if (curData != NULL) {
                     if (direction == UTRANS_FORWARD)
-                        dataVector.addElement(curData, status);
+                        dataVector.addElementX(curData, status);
                     else
                         dataVector.insertElementAt(curData, 0, status);
                     curData = NULL;
@@ -1032,7 +1032,7 @@ void TransliteratorParser::parseRules(const UnicodeString& rule,
                     return;
                 }
                 if (direction == UTRANS_FORWARD)
-                    idBlockVector.addElement(tempstr, status);
+                    idBlockVector.addElementX(tempstr, status);
                 else
                     idBlockVector.insertElementAt(tempstr, 0, status);
                 idBlockResult.remove();
@@ -1073,13 +1073,13 @@ void TransliteratorParser::parseRules(const UnicodeString& rule,
             return;
         }
         if (direction == UTRANS_FORWARD)
-            idBlockVector.addElement(tempstr, status);
+            idBlockVector.addElementX(tempstr, status);
         else
             idBlockVector.insertElementAt(tempstr, 0, status);
     }
     else if (!parsingIDs && curData != NULL) {
         if (direction == UTRANS_FORWARD)
-            dataVector.addElement(curData, status);
+            dataVector.addElementX(curData, status);
         else
             dataVector.insertElementAt(curData, 0, status);
     }
@@ -1537,7 +1537,7 @@ UChar TransliteratorParser::generateStandInFor(UnicodeFunctor* adopted, UErrorCo
         status = U_VARIABLE_RANGE_EXHAUSTED;
         return 0;
     }
-    variablesVector.addElement(adopted, status);
+    variablesVector.addElementX(adopted, status);
     return variableNext++;
 }
 
@@ -1560,7 +1560,7 @@ UChar TransliteratorParser::getSegmentStandin(int32_t seg, UErrorCode& status) {
         // Set a placeholder in the primary variables vector that will be
         // filled in later by setSegmentObject().  We know that we will get
         // called first because setSegmentObject() will call us.
-        variablesVector.addElement((void*) NULL, status);
+        variablesVector.addElementX((void*) NULL, status);
         segmentStandins.setCharAt(seg-1, c);
     }
     return c;

--- a/icu4c/source/i18n/rbt_set.cpp
+++ b/icu4c/source/i18n/rbt_set.cpp
@@ -197,7 +197,7 @@ TransliterationRuleSet::TransliterationRuleSet(const TransliterationRuleSet& oth
                 status = U_MEMORY_ALLOCATION_ERROR;
                 break;
             }
-            ruleVector->addElement(tempTranslitRule, status);
+            ruleVector->addElementX(tempTranslitRule, status);
             if (U_FAILURE(status)) {
                 break;
             }
@@ -251,7 +251,7 @@ void TransliterationRuleSet::addRule(TransliterationRule* adoptedRule,
         delete adoptedRule;
         return;
     }
-    ruleVector->addElement(adoptedRule, status);
+    ruleVector->addElementX(adoptedRule, status);
 
     int32_t len;
     if ((len = adoptedRule->getContextLength()) > maxContextLength) {
@@ -316,7 +316,7 @@ void TransliterationRuleSet::freeze(UParseError& parseError,UErrorCode& status) 
         for (j=0; j<n; ++j) {
             if (indexValue[j] >= 0) {
                 if (indexValue[j] == x) {
-                    v.addElement(ruleVector->elementAt(j), status);
+                    v.addElementX(ruleVector->elementAt(j), status);
                 }
             } else {
                 // If the indexValue is < 0, then the first key character is
@@ -325,7 +325,7 @@ void TransliterationRuleSet::freeze(UParseError& parseError,UErrorCode& status) 
                 // rarely, so we seldom treat this code path.
                 TransliterationRule* r = (TransliterationRule*) ruleVector->elementAt(j);
                 if (r->matchesIndexValue((uint8_t)x)) {
-                    v.addElement(r, status);
+                    v.addElementX(r, status);
                 }
             }
         }

--- a/icu4c/source/i18n/rbtz.cpp
+++ b/icu4c/source/i18n/rbtz.cpp
@@ -131,7 +131,7 @@ RuleBasedTimeZone::addTransitionRule(TimeZoneRule* rule, UErrorCode& status) {
             status = U_INVALID_STATE_ERROR;
             return;
         }
-        fFinalRules->addElement((void*)rule, status);
+        fFinalRules->addElementX((void*)rule, status);
     } else {
         // Non-final rule
         if (fHistoricRules == NULL) {
@@ -140,7 +140,7 @@ RuleBasedTimeZone::addTransitionRule(TimeZoneRule* rule, UErrorCode& status) {
                 return;
             }
         }
-        fHistoricRules->addElement((void*)rule, status);
+        fHistoricRules->addElementX((void*)rule, status);
     }
     // Mark dirty, so transitions are recalculated at next complete() call
     fUpToDate = FALSE;
@@ -280,7 +280,7 @@ RuleBasedTimeZone::complete(UErrorCode& status) {
                 trst->time = nextTransitionTime;
                 trst->from = curRule;
                 trst->to = nextRule;
-                fHistoricTransitions->addElement(trst, status);
+                fHistoricTransitions->addElementX(trst, status);
                 if (U_FAILURE(status)) {
                     goto cleanup;
                 }
@@ -332,11 +332,11 @@ RuleBasedTimeZone::complete(UErrorCode& status) {
                 final1->from = rule1;
                 final1->to = rule0;
             }
-            fHistoricTransitions->addElement(final0, status);
+            fHistoricTransitions->addElementX(final0, status);
             if (U_FAILURE(status)) {
                 goto cleanup;
             }
-            fHistoricTransitions->addElement(final1, status);
+            fHistoricTransitions->addElementX(final1, status);
             if (U_FAILURE(status)) {
                 goto cleanup;
             }
@@ -669,7 +669,7 @@ RuleBasedTimeZone::copyRules(UVector* source) {
     }
     int32_t i;
     for (i = 0; i < size; i++) {
-        rules->addElement(((TimeZoneRule*)source->elementAt(i))->clone(), ec);
+        rules->addElementX(((TimeZoneRule*)source->elementAt(i))->clone(), ec);
         if (U_FAILURE(ec)) {
             break;
         }

--- a/icu4c/source/i18n/regexcmp.cpp
+++ b/icu4c/source/i18n/regexcmp.cpp
@@ -2427,7 +2427,7 @@ void        RegexCompile::compileSet(UnicodeSet *theSet)
             //  Put it into the compiled pattern as a set.
             theSet->freeze();
             int32_t setNumber = fRXPat->fSets->size();
-            fRXPat->fSets->addElement(theSet, *fStatus);
+            fRXPat->fSets->addElementX(theSet, *fStatus);
             appendOp(URX_SETREF, setNumber);
         }
     }

--- a/icu4c/source/i18n/region.cpp
+++ b/icu4c/source/i18n/region.cpp
@@ -128,12 +128,12 @@ void U_CALLCONV Region::loadRegionData(UErrorCode &status) {
             buf[rangeMarkerLocation] = 0;
             while ( buf[rangeMarkerLocation-1] <= endRange ) {
                 LocalPointer<UnicodeString> newRegion(new UnicodeString(buf), status);
-                allRegions->addElement(newRegion.orphan(),status);
+                allRegions->addElementX(newRegion.orphan(),status);
                 buf[rangeMarkerLocation-1]++;
             }
         } else {
             LocalPointer<UnicodeString> newRegion(new UnicodeString(regionName), status);
-            allRegions->addElement(newRegion.orphan(),status);
+            allRegions->addElementX(newRegion.orphan(),status);
         }
     }
 
@@ -147,23 +147,23 @@ void U_CALLCONV Region::loadRegionData(UErrorCode &status) {
             buf[rangeMarkerLocation] = 0;
             while ( buf[rangeMarkerLocation-1] <= endRange ) {
                 LocalPointer<UnicodeString> newRegion(new UnicodeString(buf), status);
-                allRegions->addElement(newRegion.orphan(),status);
+                allRegions->addElementX(newRegion.orphan(),status);
                 buf[rangeMarkerLocation-1]++;
             }
         } else {
             LocalPointer<UnicodeString> newRegion(new UnicodeString(regionName), status);
-            allRegions->addElement(newRegion.orphan(),status);
+            allRegions->addElementX(newRegion.orphan(),status);
         }
     }
 
     while ( ures_hasNext(regionUnknown.getAlias()) ) {
         LocalPointer<UnicodeString> regionName (new UnicodeString(ures_getNextUnicodeString(regionUnknown.getAlias(),NULL,&status),status));
-        allRegions->addElement(regionName.orphan(),status);
+        allRegions->addElementX(regionName.orphan(),status);
     }
 
     while ( ures_hasNext(worldContainment.getAlias()) ) {
         UnicodeString *continentName = new UnicodeString(ures_getNextUnicodeString(worldContainment.getAlias(),NULL,&status));
-        continents->addElement(continentName,status);
+        continents->addElementX(continentName,status);
     }
 
     for ( int32_t i = 0 ; i < allRegions->size() ; i++ ) {
@@ -197,7 +197,7 @@ void U_CALLCONV Region::loadRegionData(UErrorCode &status) {
             break;
         }
         UnicodeString *groupingName = new UnicodeString(ures_getKey(groupingBundle), -1, US_INV);
-        groupings->addElement(groupingName,status);
+        groupings->addElementX(groupingName,status);
         Region *grouping = (Region *) uhash_get(newRegionIDMap.getAlias(),groupingName);
         if (grouping != NULL) {
             for (int32_t i = 0; i < ures_getSize(groupingBundle); i++) {
@@ -206,7 +206,7 @@ void U_CALLCONV Region::loadRegionData(UErrorCode &status) {
                     if (grouping->containedRegions == NULL) {
                         grouping->containedRegions = new UVector(uprv_deleteUObject, uhash_compareUnicodeString, status);
                     }
-                    grouping->containedRegions->addElement(new UnicodeString(child), status);
+                    grouping->containedRegions->addElementX(new UnicodeString(child), status);
                 }
             }
         }
@@ -267,7 +267,7 @@ void U_CALLCONV Region::loadRegionData(UErrorCode &status) {
                     Region *target = (Region *)uhash_get(newRegionIDMap.getAlias(),(void *)&currentRegion);
                     if (target) {
                         LocalPointer<UnicodeString> preferredValue(new UnicodeString(target->idStr), status);
-                        aliasFromRegion->preferredValues->addElement((void *)preferredValue.orphan(),status);  // may add null if err
+                        aliasFromRegion->preferredValues->addElementX((void *)preferredValue.orphan(),status);  // may add null if err
                     }
                     currentRegion.remove();
                 }
@@ -364,7 +364,7 @@ void U_CALLCONV Region::loadRegionData(UErrorCode &status) {
                     return;  // error out
                 }
                 childStr->fastCopyFrom(childRegion->idStr);
-                parentRegion->containedRegions->addElement((void *)childStr.orphan(),status);
+                parentRegion->containedRegions->addElementX((void *)childStr.orphan(),status);
 
                 // Set the parent region to be the containing region of the child.
                 // Regions of type GROUPING can't be set as the parent, since another region
@@ -388,7 +388,7 @@ void U_CALLCONV Region::loadRegionData(UErrorCode &status) {
         if( U_FAILURE(status) ) {
             return;  // error out
         }
-        availableRegions[ar->fType]->addElement((void *)arString.orphan(),status);
+        availableRegions[ar->fType]->addElementX((void *)arString.orphan(),status);
     }
     
     ucln_i18n_registerCleanup(UCLN_I18N_REGION, region_cleanup);
@@ -627,13 +627,13 @@ Region::getContainedRegions( URegionType type, UErrorCode &status ) const {
         const char *regionId = cr->next(NULL,status);
         const Region *r = Region::getInstance(regionId,status);
         if ( r->getType() == type) {
-            result->addElement((void *)&r->idStr,status);
+            result->addElementX((void *)&r->idStr,status);
         } else {
             StringEnumeration *children = r->getContainedRegions(type, status);
             for ( int32_t j = 0 ; j < children->count(status) ; j++ ) {
                 const char *id2 = children->next(NULL,status);
                 const Region *r2 = Region::getInstance(id2,status);
-                result->addElement((void *)&r2->idStr,status);
+                result->addElementX((void *)&r2->idStr,status);
             }
             delete children;
         }
@@ -713,7 +713,7 @@ RegionNameEnumeration::RegionNameEnumeration(UVector *fNameList, UErrorCode& sta
         for ( int32_t i = 0 ; i < fNameList->size() ; i++ ) {
             UnicodeString* this_region_name = (UnicodeString *)fNameList->elementAt(i);
             UnicodeString* new_region_name = new UnicodeString(*this_region_name);
-            fRegionNames->addElement((void *)new_region_name,status);
+            fRegionNames->addElementX((void *)new_region_name,status);
         }
     }
     else {

--- a/icu4c/source/i18n/repattrn.cpp
+++ b/icu4c/source/i18n/repattrn.cpp
@@ -131,7 +131,7 @@ RegexPattern &RegexPattern::operator = (const RegexPattern &other) {
             fDeferredStatus = U_MEMORY_ALLOCATION_ERROR;
             break;
         }
-        fSets->addElement(newSet, fDeferredStatus);
+        fSets->addElementX(newSet, fDeferredStatus);
         fSets8[i] = other.fSets8[i];
     }
 

--- a/icu4c/source/i18n/tmutfmt.cpp
+++ b/icu4c/source/i18n/tmutfmt.cpp
@@ -327,7 +327,7 @@ TimeUnitFormat::setup(UErrorCode& err) {
     }
     UnicodeString* pluralCount;
     while ((pluralCount = const_cast<UnicodeString*>(keywords->snext(err))) != NULL) {
-      pluralCounts.addElement(pluralCount, err);
+      pluralCounts.addElementX(pluralCount, err);
     }
     readFromCurrentLocale(UTMUTFMT_FULL_STYLE, gUnitsTag, pluralCounts, err);
     checkConsistency(UTMUTFMT_FULL_STYLE, gUnitsTag, err);

--- a/icu4c/source/i18n/translit.cpp
+++ b/icu4c/source/i18n/translit.cpp
@@ -1109,7 +1109,7 @@ Transliterator::createFromRules(const UnicodeString& ID,
                         return nullptr;
                     }
                     if (temp != NULL && typeid(*temp) != typeid(NullTransliterator))
-                        transliterators.addElement(temp, status);
+                        transliterators.addElementX(temp, status);
                     else
                         delete temp;
                 }
@@ -1126,7 +1126,7 @@ Transliterator::createFromRules(const UnicodeString& ID,
                     }
                     return t;
                 }
-                transliterators.addElement(temprbt, status);
+                transliterators.addElementX(temprbt, status);
             }
         }
 

--- a/icu4c/source/i18n/transreg.cpp
+++ b/icu4c/source/i18n/transreg.cpp
@@ -161,15 +161,15 @@ Transliterator* TransliteratorAlias::create(UParseError& pe,
                 aliasesOrRules.extract(0, blockSeparatorPos, idBlock);
                 aliasesOrRules.remove(0, blockSeparatorPos + 1);
                 if (!idBlock.isEmpty())
-                    transliterators.addElement(Transliterator::createInstance(idBlock, UTRANS_FORWARD, pe, ec), ec);
+                    transliterators.addElementX(Transliterator::createInstance(idBlock, UTRANS_FORWARD, pe, ec), ec);
                 if (!transes->isEmpty())
-                    transliterators.addElement(transes->orphanElementAt(0), ec);
+                    transliterators.addElementX(transes->orphanElementAt(0), ec);
                 blockSeparatorPos = aliasesOrRules.indexOf((UChar)(0xffff));
             }
             if (!aliasesOrRules.isEmpty())
-                transliterators.addElement(Transliterator::createInstance(aliasesOrRules, UTRANS_FORWARD, pe, ec), ec);
+                transliterators.addElementX(Transliterator::createInstance(aliasesOrRules, UTRANS_FORWARD, pe, ec), ec);
             while (!transes->isEmpty())
-                transliterators.addElement(transes->orphanElementAt(0), ec);
+                transliterators.addElementX(transes->orphanElementAt(0), ec);
 
             if (U_SUCCESS(ec)) {
                 t = new CompoundTransliterator(ID, transliterators,
@@ -543,7 +543,7 @@ TransliteratorRegistry::TransliteratorRegistry(UErrorCode& status) :
     variantList.setComparer(uhash_compareCaselessUnicodeString);
     UnicodeString *emptyString = new UnicodeString();
     if (emptyString != NULL) {
-        variantList.addElement(emptyString, status);
+        variantList.addElementX(emptyString, status);
     }
     availableIDs.setDeleter(uprv_deleteUObject);
     availableIDs.setComparer(uhash_compareCaselessUnicodeString);
@@ -625,7 +625,7 @@ Transliterator* TransliteratorRegistry::reget(const UnicodeString& ID,
                 }
                 if (!parser.dataVector.isEmpty()) {
                     TransliterationRuleData* data = (TransliterationRuleData*)parser.dataVector.orphanElementAt(0);
-                    entry->u.dataVector->addElement(data, status);
+                    entry->u.dataVector->addElementX(data, status);
                     entry->stringArg += (UChar)0xffff;  // use U+FFFF to mark position of RBTs in ID block
                 }
             }
@@ -951,7 +951,7 @@ void TransliteratorRegistry::registerEntry(const UnicodeString& ID,
             if (newID != NULL) {
                 // NUL-terminate the ID string
                 newID->getTerminatedBuffer();
-                availableIDs.addElement(newID, status);
+                availableIDs.addElementX(newID, status);
             }
         }
     } else {
@@ -992,7 +992,7 @@ void TransliteratorRegistry::registerSTV(const UnicodeString& source,
         }
         UnicodeString *variantEntry = new UnicodeString(variant);
         if (variantEntry != NULL) {
-            variantList.addElement(variantEntry, status);
+            variantList.addElementX(variantEntry, status);
             if (U_SUCCESS(status)) {
                 variantListIndex = variantList.size() - 1;
             }
@@ -1334,7 +1334,7 @@ Transliterator* TransliteratorRegistry::instantiateEntry(const UnicodeString& ID
                 if (tl == 0)
                     status = U_MEMORY_ALLOCATION_ERROR;
                 else
-                    rbts->addElement(tl, status);
+                    rbts->addElementX(tl, status);
             }
             if (U_FAILURE(status)) {
                 delete rbts;

--- a/icu4c/source/i18n/tridpars.cpp
+++ b/icu4c/source/i18n/tridpars.cpp
@@ -392,7 +392,7 @@ UBool TransliteratorIDParser::parseCompoundID(const UnicodeString& id, int32_t d
             break;
         }
         if (dir == FORWARD) {
-            list.addElement(single, ec);
+            list.addElementX(single, ec);
         } else {
             list.insertElementAt(single, 0, ec);
         }
@@ -494,7 +494,7 @@ void TransliteratorIDParser::instantiateList(UVector& list,
                 ec = U_INVALID_ID;
                 goto RETURN;
             }
-            tlist.addElement(t, ec);
+            tlist.addElementX(t, ec);
             if (U_FAILURE(ec)) {
                 delete t;
                 goto RETURN;
@@ -509,7 +509,7 @@ void TransliteratorIDParser::instantiateList(UVector& list,
             // Should never happen
             ec = U_INTERNAL_TRANSLITERATOR_ERROR;
         }
-        tlist.addElement(t, ec);
+        tlist.addElementX(t, ec);
         if (U_FAILURE(ec)) {
             delete t;
         }
@@ -525,7 +525,7 @@ void TransliteratorIDParser::instantiateList(UVector& list,
 
         while (tlist.size() > 0) {
             t = (Transliterator*) tlist.orphanElementAt(0);
-            list.addElement(t, ec);
+            list.addElementX(t, ec);
             if (U_FAILURE(ec)) {
                 delete t;
                 list.removeAllElements();

--- a/icu4c/source/i18n/tzfmt.cpp
+++ b/icu4c/source/i18n/tzfmt.cpp
@@ -2459,7 +2459,7 @@ TimeZoneFormat::parseOffsetPattern(const UnicodeString& pattern, OffsetFields re
                 if (itemType != GMTOffsetField::TEXT) {
                     if (GMTOffsetField::isValid(itemType, itemLength)) {
                         GMTOffsetField* fld = GMTOffsetField::createTimeField(itemType, static_cast<uint8_t>(itemLength), status);
-                        result->addElement(fld, status);
+                        result->addElementX(fld, status);
                         if (U_FAILURE(status)) {
                             break;
                         }
@@ -2485,7 +2485,7 @@ TimeZoneFormat::parseOffsetPattern(const UnicodeString& pattern, OffsetFields re
                         if (itemType == GMTOffsetField::TEXT) {
                             if (text.length() > 0) {
                                 GMTOffsetField* textfld = GMTOffsetField::createText(text, status);
-                                result->addElement(textfld, status);
+                                result->addElementX(textfld, status);
                                 if (U_FAILURE(status)) {
                                     break;
                                 }
@@ -2494,7 +2494,7 @@ TimeZoneFormat::parseOffsetPattern(const UnicodeString& pattern, OffsetFields re
                         } else {
                             if (GMTOffsetField::isValid(itemType, itemLength)) {
                                 GMTOffsetField* fld = GMTOffsetField::createTimeField(itemType, static_cast<uint8_t>(itemLength), status);
-                                result->addElement(fld, status);
+                                result->addElementX(fld, status);
                                 if (U_FAILURE(status)) {
                                     break;
                                 }
@@ -2512,7 +2512,7 @@ TimeZoneFormat::parseOffsetPattern(const UnicodeString& pattern, OffsetFields re
                     if (itemType != GMTOffsetField::TEXT) {
                         if (GMTOffsetField::isValid(itemType, itemLength)) {
                             GMTOffsetField* fld = GMTOffsetField::createTimeField(itemType, static_cast<uint8_t>(itemLength), status);
-                            result->addElement(fld, status);
+                            result->addElementX(fld, status);
                             if (U_FAILURE(status)) {
                                 break;
                             }
@@ -2532,12 +2532,12 @@ TimeZoneFormat::parseOffsetPattern(const UnicodeString& pattern, OffsetFields re
         if (itemType == GMTOffsetField::TEXT) {
             if (text.length() > 0) {
                 GMTOffsetField* tfld = GMTOffsetField::createText(text, status);
-                result->addElement(tfld, status);
+                result->addElementX(tfld, status);
             }
         } else {
             if (GMTOffsetField::isValid(itemType, itemLength)) {
                 GMTOffsetField* fld = GMTOffsetField::createTimeField(itemType, static_cast<uint8_t>(itemLength), status);
-                result->addElement(fld, status);
+                result->addElementX(fld, status);
             } else {
                 status = U_ILLEGAL_ARGUMENT_ERROR;
             }

--- a/icu4c/source/i18n/tzgnames.cpp
+++ b/icu4c/source/i18n/tzgnames.cpp
@@ -244,7 +244,7 @@ GNameSearchHandler::handleMatch(int32_t matchLength, const CharacterNode *node, 
                         gmatch->gnameInfo = nameinfo;
                         gmatch->matchLength = matchLength;
                         gmatch->timeType = UTZFMT_TIME_TYPE_UNKNOWN;
-                        fResults->addElement(gmatch, status);
+                        fResults->addElementX(gmatch, status);
                         if (U_FAILURE(status)) {
                             uprv_free(gmatch);
                         } else {

--- a/icu4c/source/i18n/tznames.cpp
+++ b/icu4c/source/i18n/tznames.cpp
@@ -419,7 +419,7 @@ TimeZoneNames::MatchInfoCollection::addZone(UTimeZoneNameType nameType, int32_t 
         status = U_MEMORY_ALLOCATION_ERROR;
         return;
     }
-    matches(status)->addElement(matchInfo, status);
+    matches(status)->addElementX(matchInfo, status);
     if (U_FAILURE(status)) {
         delete matchInfo;
     }
@@ -436,7 +436,7 @@ TimeZoneNames::MatchInfoCollection::addMetaZone(UTimeZoneNameType nameType, int3
         status = U_MEMORY_ALLOCATION_ERROR;
         return;
     }
-    matches(status)->addElement(matchInfo, status);
+    matches(status)->addElementX(matchInfo, status);
     if (U_FAILURE(status)) {
         delete matchInfo;
     }

--- a/icu4c/source/i18n/tznames_impl.cpp
+++ b/icu4c/source/i18n/tznames_impl.cpp
@@ -155,12 +155,12 @@ CharacterNode::addValue(void *value, UObjectDeleter *valueDeleter, UErrorCode &s
                 }
                 return;
             }
-            values->addElement(fValues, status);
+            values->addElementX(fValues, status);
             fValues = values;
             fHasValuesVector = TRUE;
         }
         // Add the new value.
-        ((UVector *)fValues)->addElement(value, status);
+        ((UVector *)fValues)->addElementX(value, status);
     }
 }
 
@@ -233,7 +233,7 @@ TextTrieMap::put(const UChar *key, void *value, UErrorCode &status) {
     U_ASSERT(fLazyContents != NULL);
 
     UChar *s = const_cast<UChar *>(key);
-    fLazyContents->addElement(s, status);
+    fLazyContents->addElementX(s, status);
     if (U_FAILURE(status)) {
         if (fValueDeleter) {
             fValueDeleter((void*) key);
@@ -241,7 +241,7 @@ TextTrieMap::put(const UChar *key, void *value, UErrorCode &status) {
         return;
     }
 
-    fLazyContents->addElement(value, status);
+    fLazyContents->addElementX(value, status);
 }
 
 void
@@ -1165,7 +1165,7 @@ TimeZoneNamesImpl::_getAvailableMetaZoneIDs(const UnicodeString& tzID, UErrorCod
             OlsonToMetaMappingEntry *map = (OlsonToMetaMappingEntry *)mappings->elementAt(i);
             const UChar *mzID = map->mzid;
             if (!mzIDs->contains((void *)mzID)) {
-                mzIDs->addElement((void *)mzID, status);
+                mzIDs->addElementX((void *)mzID, status);
             }
         }
         if (U_SUCCESS(status)) {

--- a/icu4c/source/i18n/uspoof_conf.cpp
+++ b/icu4c/source/i18n/uspoof_conf.cpp
@@ -145,7 +145,7 @@ SPUString *SPUStringPool::addString(UnicodeString *src, UErrorCode &status) {
             return NULL;
         }
         uhash_put(fHash, src, hashedString, &status);
-        fVec->addElement(hashedString, status);
+        fVec->addElementX(hashedString, status);
     }
     return hashedString;
 }

--- a/icu4c/source/i18n/vtzone.cpp
+++ b/icu4c/source/i18n/vtzone.cpp
@@ -983,7 +983,7 @@ VTimeZone::VTimeZone(const VTimeZone& source)
         if (U_SUCCESS(status)) {
             for (int32_t i = 0; i < size; i++) {
                 UnicodeString *line = (UnicodeString*)source.vtzlines->elementAt(i);
-                vtzlines->addElement(line->clone(), status);
+                vtzlines->addElementX(line->clone(), status);
                 if (U_FAILURE(status)) {
                     break;
                 }
@@ -1028,7 +1028,7 @@ VTimeZone::operator=(const VTimeZone& right) {
             if (vtzlines != nullptr && U_SUCCESS(status)) {
                 for (int32_t i = 0; i < size; i++) {
                     UnicodeString *line = (UnicodeString*)right.vtzlines->elementAt(i);
-                    vtzlines->addElement(line->clone(), status);
+                    vtzlines->addElementX(line->clone(), status);
                     if (U_FAILURE(status)) {
                         break;
                     }
@@ -1293,7 +1293,7 @@ VTimeZone::load(VTZReader& reader, UErrorCode& status) {
                 if (U_FAILURE(status)) {
                     goto cleanupVtzlines;
                 }
-                vtzlines->addElement(element.getAlias(), status);
+                vtzlines->addElementX(element.getAlias(), status);
                 if (U_FAILURE(status)) {
                     goto cleanupVtzlines;
                 }
@@ -1315,7 +1315,7 @@ VTimeZone::load(VTZReader& reader, UErrorCode& status) {
                         if (U_FAILURE(status)) {
                             goto cleanupVtzlines;
                         }
-                        vtzlines->addElement(element.getAlias(), status);
+                        vtzlines->addElementX(element.getAlias(), status);
                         if (U_FAILURE(status)) {
                             goto cleanupVtzlines;
                         }
@@ -1338,7 +1338,7 @@ VTimeZone::load(VTZReader& reader, UErrorCode& status) {
                         if (U_FAILURE(status)) {
                             goto cleanupVtzlines;
                         }
-                        vtzlines->addElement(element.getAlias(), status);
+                        vtzlines->addElementX(element.getAlias(), status);
                         if (U_FAILURE(status)) {
                             goto cleanupVtzlines;
                         }
@@ -1352,7 +1352,7 @@ VTimeZone::load(VTZReader& reader, UErrorCode& status) {
                         if (U_FAILURE(status)) {
                             goto cleanupVtzlines;
                         }
-                        vtzlines->addElement(element.getAlias(), status);
+                        vtzlines->addElementX(element.getAlias(), status);
                         if (U_FAILURE(status)) {
                             goto cleanupVtzlines;
                         }
@@ -1527,7 +1527,7 @@ VTimeZone::parse(UErrorCode& status) {
                     if (dstr == nullptr) {
                         status = U_MEMORY_ALLOCATION_ERROR;
                     } else {
-                        dates->addElement(dstr, status);
+                        dates->addElementX(dstr, status);
                     }
                     if (U_FAILURE(status)) {
                         goto cleanupParse;
@@ -1544,7 +1544,7 @@ VTimeZone::parse(UErrorCode& status) {
                 if (U_FAILURE(status)) {
                     goto cleanupParse;
                 }
-                dates->addElement(element.getAlias(), status);
+                dates->addElementX(element.getAlias(), status);
                 if (U_FAILURE(status)) {
                     goto cleanupParse;
                 }
@@ -1626,7 +1626,7 @@ VTimeZone::parse(UErrorCode& status) {
                         }
                     }
                 }
-                rules->addElement(rule, status);
+                rules->addElementX(rule, status);
                 if (U_FAILURE(status)) {
                     goto cleanupParse;
                 }
@@ -1732,7 +1732,7 @@ VTimeZone::parse(UErrorCode& status) {
                 goto cleanupParse;
             }
             rules->removeElementAt(finalRuleIdx);
-            rules->addElement(newRule, status);
+            rules->addElementX(newRule, status);
             if (U_FAILURE(status)) {
                 delete newRule;
                 goto cleanupParse;
@@ -1809,7 +1809,7 @@ VTimeZone::write(VTZWriter& writer, UErrorCode& status) const {
             icutzprop.append(u'[');
             icutzprop.append(icutzver);
             icutzprop.append(u']');
-            customProps.addElement(&icutzprop, status);
+            customProps.addElementX(&icutzprop, status);
         }
         writeZone(writer, *tz, &customProps, status);
     }
@@ -1862,7 +1862,7 @@ VTimeZone::write(UDate start, VTZWriter& writer, UErrorCode& status) const {
         icutzprop->append(ICU_TZINFO_PARTIAL, -1);
         appendMillis(start, *icutzprop);
         icutzprop->append((UChar)0x005D/*']'*/);
-        customProps.addElement(icutzprop, status);
+        customProps.addElementX(icutzprop, status);
         if (U_FAILURE(status)) {
             delete icutzprop;
             goto cleanupWritePartial;
@@ -1921,7 +1921,7 @@ VTimeZone::writeSimple(UDate time, VTZWriter& writer, UErrorCode& status) const 
             icutzprop->append(ICU_TZINFO_SIMPLE, -1);
             appendMillis(time, *icutzprop);
             icutzprop->append((UChar)0x005D/*']'*/);
-            customProps.addElement(icutzprop, status);
+            customProps.addElementX(icutzprop, status);
             if (U_FAILURE(status)) {
                 delete icutzprop;
                 goto cleanupWriteSimple;

--- a/icu4c/source/i18n/zonemeta.cpp
+++ b/icu4c/source/i18n/zonemeta.cpp
@@ -477,11 +477,11 @@ ZoneMeta::getCanonicalCountry(const UnicodeString &tzid, UnicodeString &country,
                 UErrorCode ec = U_ZERO_ERROR;
                 if (singleZone) {
                     if (!gSingleZoneCountries->contains((void*)region)) {
-                        gSingleZoneCountries->addElement((void*)region, ec);
+                        gSingleZoneCountries->addElementX((void*)region, ec);
                     }
                 } else {
                     if (!gMultiZonesCountries->contains((void*)region)) {
-                        gMultiZonesCountries->addElement((void*)region, ec);
+                        gMultiZonesCountries->addElementX((void*)region, ec);
                     }
                 }
             }
@@ -696,7 +696,7 @@ ZoneMeta::createMetazoneMappings(const UnicodeString &tzid) {
                     }
                 }
 
-                mzMappings->addElement(entry, status);
+                mzMappings->addElementX(entry, status);
                 if (U_FAILURE(status)) {
                     break;
                 }
@@ -801,7 +801,7 @@ static void U_CALLCONV initAvailableMetaZoneIDs () {
         uMzID[len] = 0;
         UnicodeString *usMzID = new UnicodeString(uMzID);
         if (uhash_get(gMetaZoneIDTable, usMzID) == NULL) {
-            gMetaZoneIDs->addElement((void *)uMzID, status);
+            gMetaZoneIDs->addElementX((void *)uMzID, status);
             uhash_put(gMetaZoneIDTable, (void *)usMzID, (void *)uMzID, &status);
         } else {
             uprv_free(uMzID);

--- a/icu4c/source/test/intltest/icusvtst.cpp
+++ b/icu4c/source/test/intltest/icusvtst.cpp
@@ -558,7 +558,7 @@ class TestMultipleKeyStringFactory : public ICUServiceFactory {
         , _factoryID(factoryID + ": ") 
     {
         for (int i = 0; i < count; ++i) {
-            _ids.addElement(new UnicodeString(ids[i]), _status);
+            _ids.addElementX(new UnicodeString(ids[i]), _status);
         }
     }
   

--- a/icu4c/source/test/intltest/rbbimonkeytest.cpp
+++ b/icu4c/source/test/intltest/rbbimonkeytest.cpp
@@ -225,7 +225,7 @@ void BreakRules::addRule(const UnicodeString &name, const UnicodeString &definit
     }
 
     // Put this new rule into the vector of all Rules.
-    fBreakRules.addElement(thisRule.orphan(), status);
+    fBreakRules.addElementX(thisRule.orphan(), status);
 }
 
 
@@ -359,7 +359,7 @@ void BreakRules::compileRules(UCHARBUF *rules, UErrorCode &status) {
         if (*ccName == UnicodeString("dictionary")) {
             fDictionarySet = *set;
         } else {
-            fCharClassList->addElement(cclass, status);
+            fCharClassList->addElementX(cclass, status);
         }
     }
 
@@ -367,7 +367,7 @@ void BreakRules::compileRules(UCHARBUF *rules, UErrorCode &status) {
         // fprintf(stderr, "have an other set.\n");
         UnicodeString pattern;
         CharClass *cclass = addCharClass(UnicodeString("__Others"), otherSet.toPattern(pattern), status);
-        fCharClassList->addElement(cclass, status);
+        fCharClassList->addElementX(cclass, status);
     }
 }
 
@@ -962,7 +962,7 @@ void RBBIMonkeyTest::testMonkey() {
             break;
         }
         test->startTest();
-        startedTests.addElement(test.orphan(), status);
+        startedTests.addElementX(test.orphan(), status);
         if (U_FAILURE(status)) {
             errln("%s:%d: error %s while starting test %s.", __FILE__, __LINE__, u_errorName(status), tests[i]);
             break;

--- a/icu4c/source/test/intltest/rbbitst.cpp
+++ b/icu4c/source/test/intltest/rbbitst.cpp
@@ -1646,21 +1646,21 @@ RBBICharMonkey::RBBICharMonkey() {
     fSets             = new UVector(status);
 
     // Important: Keep class names the same as the class contents.
-    fSets->addElement(fCRLFSet, status); classNames.push_back("CRLF");
-    fSets->addElement(fControlSet, status); classNames.push_back("Control");
-    fSets->addElement(fExtendSet, status); classNames.push_back("Extended");
-    fSets->addElement(fRegionalIndicatorSet, status); classNames.push_back("RegionalIndicator");
+    fSets->addElementX(fCRLFSet, status); classNames.push_back("CRLF");
+    fSets->addElementX(fControlSet, status); classNames.push_back("Control");
+    fSets->addElementX(fExtendSet, status); classNames.push_back("Extended");
+    fSets->addElementX(fRegionalIndicatorSet, status); classNames.push_back("RegionalIndicator");
     if (!fPrependSet->isEmpty()) {
-        fSets->addElement(fPrependSet, status); classNames.push_back("Prepend");
+        fSets->addElementX(fPrependSet, status); classNames.push_back("Prepend");
     }
-    fSets->addElement(fSpacingSet, status); classNames.push_back("Spacing");
-    fSets->addElement(fHangulSet, status); classNames.push_back("Hangul");
-    fSets->addElement(fZWJSet, status); classNames.push_back("ZWJ");
-    fSets->addElement(fExtendedPictSet, status); classNames.push_back("ExtendedPict");
-    fSets->addElement(fViramaSet, status); classNames.push_back("Virama");
-    fSets->addElement(fLinkingConsonantSet, status); classNames.push_back("LinkingConsonant");
-    fSets->addElement(fExtCccZwjSet, status); classNames.push_back("ExtCcccZwj");
-    fSets->addElement(fAnySet, status); classNames.push_back("Any");
+    fSets->addElementX(fSpacingSet, status); classNames.push_back("Spacing");
+    fSets->addElementX(fHangulSet, status); classNames.push_back("Hangul");
+    fSets->addElementX(fZWJSet, status); classNames.push_back("ZWJ");
+    fSets->addElementX(fExtendedPictSet, status); classNames.push_back("ExtendedPict");
+    fSets->addElementX(fViramaSet, status); classNames.push_back("Virama");
+    fSets->addElementX(fLinkingConsonantSet, status); classNames.push_back("LinkingConsonant");
+    fSets->addElementX(fExtCccZwjSet, status); classNames.push_back("ExtCcccZwj");
+    fSets->addElementX(fAnySet, status); classNames.push_back("Any");
 
     if (U_FAILURE(status)) {
         deferredStatus = status;
@@ -1964,31 +1964,31 @@ RBBIWordMonkey::RBBIWordMonkey()
     fOtherSet->removeAll(*fDictionarySet);
 
     // Add classes and their names
-    fSets->addElement(fCRSet, status); classNames.push_back("CR");
-    fSets->addElement(fLFSet, status); classNames.push_back("LF");
-    fSets->addElement(fNewlineSet, status); classNames.push_back("Newline");
-    fSets->addElement(fRegionalIndicatorSet, status); classNames.push_back("RegionalIndicator");
-    fSets->addElement(fHebrew_LetterSet, status); classNames.push_back("Hebrew");
-    fSets->addElement(fALetterSet, status); classNames.push_back("ALetter");
-    fSets->addElement(fSingle_QuoteSet, status); classNames.push_back("Single Quote");
-    fSets->addElement(fDouble_QuoteSet, status); classNames.push_back("Double Quote");
+    fSets->addElementX(fCRSet, status); classNames.push_back("CR");
+    fSets->addElementX(fLFSet, status); classNames.push_back("LF");
+    fSets->addElementX(fNewlineSet, status); classNames.push_back("Newline");
+    fSets->addElementX(fRegionalIndicatorSet, status); classNames.push_back("RegionalIndicator");
+    fSets->addElementX(fHebrew_LetterSet, status); classNames.push_back("Hebrew");
+    fSets->addElementX(fALetterSet, status); classNames.push_back("ALetter");
+    fSets->addElementX(fSingle_QuoteSet, status); classNames.push_back("Single Quote");
+    fSets->addElementX(fDouble_QuoteSet, status); classNames.push_back("Double Quote");
     // Omit Katakana from fSets, which omits Katakana characters
     // from the test data. They are all in the dictionary set,
     // which this (old, to be retired) monkey test cannot handle.
     //fSets->addElement(fKatakanaSet, status);
 
-    fSets->addElement(fMidLetterSet, status); classNames.push_back("MidLetter");
-    fSets->addElement(fMidNumLetSet, status); classNames.push_back("MidNumLet");
-    fSets->addElement(fMidNumSet, status); classNames.push_back("MidNum");
-    fSets->addElement(fNumericSet, status); classNames.push_back("Numeric");
-    fSets->addElement(fFormatSet, status); classNames.push_back("Format");
-    fSets->addElement(fExtendSet, status); classNames.push_back("Extend");
-    fSets->addElement(fOtherSet, status); classNames.push_back("Other");
-    fSets->addElement(fExtendNumLetSet, status); classNames.push_back("ExtendNumLet");
-    fSets->addElement(fWSegSpaceSet, status); classNames.push_back("WSegSpace");
+    fSets->addElementX(fMidLetterSet, status); classNames.push_back("MidLetter");
+    fSets->addElementX(fMidNumLetSet, status); classNames.push_back("MidNumLet");
+    fSets->addElementX(fMidNumSet, status); classNames.push_back("MidNum");
+    fSets->addElementX(fNumericSet, status); classNames.push_back("Numeric");
+    fSets->addElementX(fFormatSet, status); classNames.push_back("Format");
+    fSets->addElementX(fExtendSet, status); classNames.push_back("Extend");
+    fSets->addElementX(fOtherSet, status); classNames.push_back("Other");
+    fSets->addElementX(fExtendNumLetSet, status); classNames.push_back("ExtendNumLet");
+    fSets->addElementX(fWSegSpaceSet, status); classNames.push_back("WSegSpace");
 
-    fSets->addElement(fZWJSet, status); classNames.push_back("ZWJ");
-    fSets->addElement(fExtendedPictSet, status); classNames.push_back("ExtendedPict");
+    fSets->addElementX(fZWJSet, status); classNames.push_back("ZWJ");
+    fSets->addElementX(fExtendedPictSet, status); classNames.push_back("ExtendedPict");
 
     if (U_FAILURE(status)) {
         deferredStatus = status;
@@ -2304,19 +2304,19 @@ RBBISentMonkey::RBBISentMonkey()
     fOtherSet->removeAll(*fCloseSet);
     fOtherSet->removeAll(*fExtendSet);
 
-    fSets->addElement(fSepSet, status); classNames.push_back("Sep");
-    fSets->addElement(fFormatSet, status); classNames.push_back("Format");
-    fSets->addElement(fSpSet, status); classNames.push_back("Sp");
-    fSets->addElement(fLowerSet, status); classNames.push_back("Lower");
-    fSets->addElement(fUpperSet, status); classNames.push_back("Upper");
-    fSets->addElement(fOLetterSet, status); classNames.push_back("OLetter");
-    fSets->addElement(fNumericSet, status); classNames.push_back("Numeric");
-    fSets->addElement(fATermSet, status); classNames.push_back("ATerm");
-    fSets->addElement(fSContinueSet, status); classNames.push_back("SContinue");
-    fSets->addElement(fSTermSet, status); classNames.push_back("STerm");
-    fSets->addElement(fCloseSet, status); classNames.push_back("Close");
-    fSets->addElement(fOtherSet, status); classNames.push_back("Other");
-    fSets->addElement(fExtendSet, status); classNames.push_back("Extend");
+    fSets->addElementX(fSepSet, status); classNames.push_back("Sep");
+    fSets->addElementX(fFormatSet, status); classNames.push_back("Format");
+    fSets->addElementX(fSpSet, status); classNames.push_back("Sp");
+    fSets->addElementX(fLowerSet, status); classNames.push_back("Lower");
+    fSets->addElementX(fUpperSet, status); classNames.push_back("Upper");
+    fSets->addElementX(fOLetterSet, status); classNames.push_back("OLetter");
+    fSets->addElementX(fNumericSet, status); classNames.push_back("Numeric");
+    fSets->addElementX(fATermSet, status); classNames.push_back("ATerm");
+    fSets->addElementX(fSContinueSet, status); classNames.push_back("SContinue");
+    fSets->addElementX(fSTermSet, status); classNames.push_back("STerm");
+    fSets->addElementX(fCloseSet, status); classNames.push_back("Close");
+    fSets->addElementX(fOtherSet, status); classNames.push_back("Other");
+    fSets->addElementX(fExtendSet, status); classNames.push_back("Extend");
 
     if (U_FAILURE(status)) {
         deferredStatus = status;
@@ -2705,50 +2705,50 @@ RBBILineMonkey::RBBILineMonkey() :
     fHH->add(u'\u2010');   // Hyphen, '‐'
 
     // Sets and names.
-    fSets->addElement(fBK, status); classNames.push_back("fBK");
-    fSets->addElement(fCR, status); classNames.push_back("fCR");
-    fSets->addElement(fLF, status); classNames.push_back("fLF");
-    fSets->addElement(fCM, status); classNames.push_back("fCM");
-    fSets->addElement(fNL, status); classNames.push_back("fNL");
-    fSets->addElement(fWJ, status); classNames.push_back("fWJ");
-    fSets->addElement(fZW, status); classNames.push_back("fZW");
-    fSets->addElement(fGL, status); classNames.push_back("fGL");
-    fSets->addElement(fCB, status); classNames.push_back("fCB");
-    fSets->addElement(fSP, status); classNames.push_back("fSP");
-    fSets->addElement(fB2, status); classNames.push_back("fB2");
-    fSets->addElement(fBA, status); classNames.push_back("fBA");
-    fSets->addElement(fBB, status); classNames.push_back("fBB");
-    fSets->addElement(fHY, status); classNames.push_back("fHY");
-    fSets->addElement(fH2, status); classNames.push_back("fH2");
-    fSets->addElement(fH3, status); classNames.push_back("fH3");
-    fSets->addElement(fCL, status); classNames.push_back("fCL");
-    fSets->addElement(fCP, status); classNames.push_back("fCP");
-    fSets->addElement(fEX, status); classNames.push_back("fEX");
-    fSets->addElement(fIN, status); classNames.push_back("fIN");
-    fSets->addElement(fJL, status); classNames.push_back("fJL");
-    fSets->addElement(fJT, status); classNames.push_back("fJT");
-    fSets->addElement(fJV, status); classNames.push_back("fJV");
-    fSets->addElement(fNS, status); classNames.push_back("fNS");
-    fSets->addElement(fOP, status); classNames.push_back("fOP");
-    fSets->addElement(fQU, status); classNames.push_back("fQU");
-    fSets->addElement(fIS, status); classNames.push_back("fIS");
-    fSets->addElement(fNU, status); classNames.push_back("fNU");
-    fSets->addElement(fPO, status); classNames.push_back("fPO");
-    fSets->addElement(fPR, status); classNames.push_back("fPR");
-    fSets->addElement(fSY, status); classNames.push_back("fSY");
-    fSets->addElement(fAI, status); classNames.push_back("fAI");
-    fSets->addElement(fAL, status); classNames.push_back("fAL");
-    fSets->addElement(fHL, status); classNames.push_back("fHL");
-    fSets->addElement(fID, status); classNames.push_back("fID");
-    fSets->addElement(fWJ, status); classNames.push_back("fWJ");
-    fSets->addElement(fRI, status); classNames.push_back("fRI");
-    fSets->addElement(fSG, status); classNames.push_back("fSG");
-    fSets->addElement(fEB, status); classNames.push_back("fEB");
-    fSets->addElement(fEM, status); classNames.push_back("fEM");
-    fSets->addElement(fZWJ, status); classNames.push_back("fZWJ");
+    fSets->addElementX(fBK, status); classNames.push_back("fBK");
+    fSets->addElementX(fCR, status); classNames.push_back("fCR");
+    fSets->addElementX(fLF, status); classNames.push_back("fLF");
+    fSets->addElementX(fCM, status); classNames.push_back("fCM");
+    fSets->addElementX(fNL, status); classNames.push_back("fNL");
+    fSets->addElementX(fWJ, status); classNames.push_back("fWJ");
+    fSets->addElementX(fZW, status); classNames.push_back("fZW");
+    fSets->addElementX(fGL, status); classNames.push_back("fGL");
+    fSets->addElementX(fCB, status); classNames.push_back("fCB");
+    fSets->addElementX(fSP, status); classNames.push_back("fSP");
+    fSets->addElementX(fB2, status); classNames.push_back("fB2");
+    fSets->addElementX(fBA, status); classNames.push_back("fBA");
+    fSets->addElementX(fBB, status); classNames.push_back("fBB");
+    fSets->addElementX(fHY, status); classNames.push_back("fHY");
+    fSets->addElementX(fH2, status); classNames.push_back("fH2");
+    fSets->addElementX(fH3, status); classNames.push_back("fH3");
+    fSets->addElementX(fCL, status); classNames.push_back("fCL");
+    fSets->addElementX(fCP, status); classNames.push_back("fCP");
+    fSets->addElementX(fEX, status); classNames.push_back("fEX");
+    fSets->addElementX(fIN, status); classNames.push_back("fIN");
+    fSets->addElementX(fJL, status); classNames.push_back("fJL");
+    fSets->addElementX(fJT, status); classNames.push_back("fJT");
+    fSets->addElementX(fJV, status); classNames.push_back("fJV");
+    fSets->addElementX(fNS, status); classNames.push_back("fNS");
+    fSets->addElementX(fOP, status); classNames.push_back("fOP");
+    fSets->addElementX(fQU, status); classNames.push_back("fQU");
+    fSets->addElementX(fIS, status); classNames.push_back("fIS");
+    fSets->addElementX(fNU, status); classNames.push_back("fNU");
+    fSets->addElementX(fPO, status); classNames.push_back("fPO");
+    fSets->addElementX(fPR, status); classNames.push_back("fPR");
+    fSets->addElementX(fSY, status); classNames.push_back("fSY");
+    fSets->addElementX(fAI, status); classNames.push_back("fAI");
+    fSets->addElementX(fAL, status); classNames.push_back("fAL");
+    fSets->addElementX(fHL, status); classNames.push_back("fHL");
+    fSets->addElementX(fID, status); classNames.push_back("fID");
+    fSets->addElementX(fWJ, status); classNames.push_back("fWJ");
+    fSets->addElementX(fRI, status); classNames.push_back("fRI");
+    fSets->addElementX(fSG, status); classNames.push_back("fSG");
+    fSets->addElementX(fEB, status); classNames.push_back("fEB");
+    fSets->addElementX(fEM, status); classNames.push_back("fEM");
+    fSets->addElementX(fZWJ, status); classNames.push_back("fZWJ");
     // TODO: fOP30 & fCP30 overlap with plain fOP. Probably OK, but fOP/CP chars will be over-represented.
-    fSets->addElement(fOP30, status); classNames.push_back("fOP30");
-    fSets->addElement(fCP30, status); classNames.push_back("fCP30");
+    fSets->addElementX(fOP30, status); classNames.push_back("fOP30");
+    fSets->addElementX(fCP30, status); classNames.push_back("fCP30");
 
     const char *rules =
             "((\\p{Line_Break=PR}|\\p{Line_Break=PO})(\\p{Line_Break=CM}|\\u200d)*)?"

--- a/icu4c/source/tools/toolutil/xmlparser.cpp
+++ b/icu4c/source/tools/toolutil/xmlparser.cpp
@@ -391,7 +391,7 @@ UXMLParser::parse(const UnicodeString &src, UErrorCode &status) {
             // Nested Element Start
             if (mXMLElemStart.lookingAt(fPos, status)) {
                 UXMLElement *t = createElement(mXMLElemStart, status);
-                el->fChildren.addElement(t, status);
+                el->fChildren.addElementX(t, status);
                 t->fParent = el;
                 fElementStack.push(el, status);
                 el = t;
@@ -407,7 +407,7 @@ UXMLParser::parse(const UnicodeString &src, UErrorCode &status) {
                     // This chunk of text contains something other than just
                     //  white space. Make a child node for it.
                     replaceCharRefs(s, status);
-                    el->fChildren.addElement(s.clone(), status);
+                    el->fChildren.addElementX(s.clone(), status);
                 }
                 mXMLSP.reset(src);    // The matchers need to stay set to the main input string.
                 continue;
@@ -445,7 +445,7 @@ UXMLParser::parse(const UnicodeString &src, UErrorCode &status) {
             // Empty Element.  Stored as a child of the current element, but not stacked.
             if (mXMLElemEmpty.lookingAt(fPos, status)) {
                 UXMLElement *t = createElement(mXMLElemEmpty, status);
-                el->fChildren.addElement(t, status);
+                el->fChildren.addElementX(t, status);
                 continue;
             }
 
@@ -521,8 +521,8 @@ UXMLParser::createElement(RegexMatcher  &mEl, UErrorCode &status) {
         replaceCharRefs(attValue, status);
 
         // Save the attribute name and value in our document structure.
-        el->fAttNames.addElement((void *)intern(attName, status), status);
-        el->fAttValues.addElement(attValue.clone(), status);
+        el->fAttNames.addElementX((void *)intern(attName, status), status);
+        el->fAttValues.addElementX(attValue.clone(), status);
         pos = mAttrValue.end(2, status);
     }
     fPos = mEl.end(0, status);


### PR DESCRIPTION
This is the first step towards improving the error handling and out-of-memory
behavior of UVector::addElement(). A followup PR will add back a new addElement()
with corrected error handling, then additional followups will switch call sites
from the original (renamed) function to the new addElement().

This commit includes no logic or behavior changes; it only renames the existing functions.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21662
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
