### PR TITLE
ICU-20973 Update equality operators to support C++20

### DIFF
--- a/docs/userguide/dev/codingguidelines.md
+++ b/docs/userguide/dev/codingguidelines.md
@@ -446,8 +446,10 @@ includes other header files. The most common types are `uint8_t`, `uint16_t`,
 The language built-in type `bool` and constants `true` and `false` may be used
 internally, for local variables and parameters of internal functions. The ICU
 type `UBool` must be used in public APIs and in the definition of any persistent
-data structures. `UBool` is guaranteed to be one byte in size and signed; `bool` is
-not.
+data structures. `UBool` is guaranteed to be one byte in size and signed; `bool`
+is not. **Except**: Starting with ICU 70 (2021q4), `operator==()` and
+`operator!=()` must return `bool`, not `UBool`, because of a change in C++20,
+see [ICU-20973](https://unicode-org.atlassian.net/browse/ICU-20973).
 
 Traditionally, ICU4C has defined its own `FALSE`=0 / `TRUE`=1 macros for use with `UBool`.
 Starting with ICU 68 (2020q4), we no longer define these in public header files
@@ -458,7 +460,8 @@ with these names.
 Instead, the versions of the C and C++ standards we require now do define type `bool`
 and values `false` & `true`, and we and our users can use these values.
 
-As of ICU 68, we are not changing ICU4C API from `UBool` to `bool`.
+As of ICU 70, we are not changing ICU4C API from `UBool` to `bool`, except on
+equality operators (see above).
 Doing so in C API, or in structs that cross the library boundary,
 would break binary compatibility.
 Doing so only in other places in C++ could be confusingly inconsistent.

--- a/icu4c/source/aclocal.m4
+++ b/icu4c/source/aclocal.m4
@@ -12,6 +12,60 @@
 # PARTICULAR PURPOSE.
 
 m4_ifndef([AC_CONFIG_MACRO_DIRS], [m4_defun([_AM_CONFIG_MACRO_DIRS], [])m4_defun([AC_CONFIG_MACRO_DIRS], [_AM_CONFIG_MACRO_DIRS($@)])])
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_COMPILE_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the current language's compiler
+#   or gives an error.  (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,LINK}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 6
+
+AC_DEFUN([AX_CHECK_COMPILE_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
+AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
+  ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+  AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_COMPILE_FLAGS
+
 dnl pkg.m4 - Macros to locate and utilise pkg-config.   -*- Autoconf -*-
 dnl serial 11 (pkg-config-0.29)
 dnl

--- a/icu4c/source/common/bytestriebuilder.cpp
+++ b/icu4c/source/common/bytestriebuilder.cpp
@@ -343,7 +343,7 @@ BytesTrieBuilder::BTLinearMatchNode::BTLinearMatchNode(const char *bytes, int32_
         static_cast<uint32_t>(hash)*37u + static_cast<uint32_t>(ustr_hashCharsN(bytes, len)));
 }
 
-UBool
+bool
 BytesTrieBuilder::BTLinearMatchNode::operator==(const Node &other) const {
     if(this==&other) {
         return TRUE;

--- a/icu4c/source/common/dtintrv.cpp
+++ b/icu4c/source/common/dtintrv.cpp
@@ -53,7 +53,7 @@ DateInterval::clone() const {
 }
 
 
-UBool 
+bool
 DateInterval::operator==(const DateInterval& other) const { 
     return ( fromDate == other.fromDate && toDate == other.toDate );
 }

--- a/icu4c/source/common/filteredbrk.cpp
+++ b/icu4c/source/common/filteredbrk.cpp
@@ -193,7 +193,7 @@ public:
   }
   virtual SimpleFilteredSentenceBreakIterator* clone() const { return new SimpleFilteredSentenceBreakIterator(*this); }
   virtual UClassID getDynamicClassID(void) const { return NULL; }
-  virtual UBool operator==(const BreakIterator& o) const { if(this==&o) return true; return false; }
+  virtual bool operator==(const BreakIterator& o) const { if(this==&o) return true; return false; }
 
   /* -- text modifying -- */
   virtual void setText(UText *text, UErrorCode &status) { fDelegate->setText(text,status); }

--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -483,7 +483,7 @@ Locale::clone() const {
     return new Locale(*this);
 }
 
-UBool
+bool
 Locale::operator==( const   Locale& other) const
 {
     return (uprv_strcmp(other.fullName, fullName) == 0);

--- a/icu4c/source/common/lsr.cpp
+++ b/icu4c/source/common/lsr.cpp
@@ -72,7 +72,7 @@ UBool LSR::isEquivalentTo(const LSR &other) const {
         (regionIndex > 0 || uprv_strcmp(region, other.region) == 0);
 }
 
-UBool LSR::operator==(const LSR &other) const {
+bool LSR::operator==(const LSR &other) const {
     return
         uprv_strcmp(language, other.language) == 0 &&
         uprv_strcmp(script, other.script) == 0 &&

--- a/icu4c/source/common/lsr.h
+++ b/icu4c/source/common/lsr.h
@@ -65,9 +65,9 @@ struct LSR final : public UMemory {
     static int32_t indexForRegion(const char *region);
 
     UBool isEquivalentTo(const LSR &other) const;
-    UBool operator==(const LSR &other) const;
+    bool operator==(const LSR &other) const;
 
-    inline UBool operator!=(const LSR &other) const {
+    inline bool operator!=(const LSR &other) const {
         return !operator==(other);
     }
 

--- a/icu4c/source/common/messagepattern.cpp
+++ b/icu4c/source/common/messagepattern.cpp
@@ -309,7 +309,7 @@ MessagePattern::clear() {
     numericValuesLength=0;
 }
 
-UBool
+bool
 MessagePattern::operator==(const MessagePattern &other) const {
     if(this==&other) {
         return TRUE;
@@ -387,7 +387,7 @@ MessagePattern::getPluralOffset(int32_t pluralStart) const {
 
 // MessagePattern::Part ---------------------------------------------------- ***
 
-UBool
+bool
 MessagePattern::Part::operator==(const Part &other) const {
     if(this==&other) {
         return TRUE;

--- a/icu4c/source/common/normlzr.cpp
+++ b/icu4c/source/common/normlzr.cpp
@@ -108,7 +108,7 @@ int32_t Normalizer::hashCode() const
     return text->hashCode() + fUMode + fOptions + buffer.hashCode() + bufferPos + currentIndex + nextIndex;
 }
     
-UBool Normalizer::operator==(const Normalizer& that) const
+bool Normalizer::operator==(const Normalizer& that) const
 {
     return
         this==&that ||

--- a/icu4c/source/common/rbbi.cpp
+++ b/icu4c/source/common/rbbi.cpp
@@ -366,10 +366,10 @@ RuleBasedBreakIterator::clone() const {
 }
 
 /**
- * Equality operator.  Returns TRUE if both BreakIterators are of the
+ * Equality operator.  Returns true if both BreakIterators are of the
  * same class, have the same behavior, and iterate over the same text.
  */
-UBool
+bool
 RuleBasedBreakIterator::operator==(const BreakIterator& that) const {
     if (typeid(*this) != typeid(that)) {
         return FALSE;

--- a/icu4c/source/common/rbbidata.cpp
+++ b/icu4c/source/common/rbbidata.cpp
@@ -170,7 +170,7 @@ RBBIDataWrapper::~RBBIDataWrapper() {
 //                  should still be ==.
 //
 //-----------------------------------------------------------------------------
-UBool RBBIDataWrapper::operator ==(const RBBIDataWrapper &other) const {
+bool RBBIDataWrapper::operator ==(const RBBIDataWrapper &other) const {
     if (fHeader == other.fHeader) {
         return TRUE;
     }

--- a/icu4c/source/common/rbbidata.h
+++ b/icu4c/source/common/rbbidata.h
@@ -171,7 +171,7 @@ public:
     void                  init(const RBBIDataHeader *data, UErrorCode &status);
     RBBIDataWrapper      *addReference();
     void                  removeReference();
-    UBool                 operator ==(const RBBIDataWrapper &other) const;
+    bool                  operator ==(const RBBIDataWrapper &other) const;
     int32_t               hashCode();
     const UnicodeString  &getRuleSourceString() const;
     void                  printData();

--- a/icu4c/source/common/rbbinode.h
+++ b/icu4c/source/common/rbbinode.h
@@ -108,7 +108,7 @@ class RBBINode : public UMemory {
 
     private:
         RBBINode &operator = (const RBBINode &other); // No defs.
-        UBool operator == (const RBBINode &other);    // Private, so these functions won't accidentally be used.
+        bool operator == (const RBBINode &other);     // Private, so these functions won't accidentally be used.
 
 #ifdef RBBI_DEBUG
     public:

--- a/icu4c/source/common/schriter.cpp
+++ b/icu4c/source/common/schriter.cpp
@@ -79,7 +79,7 @@ StringCharacterIterator::operator=(const StringCharacterIterator& that) {
     return *this;
 }
 
-UBool
+bool
 StringCharacterIterator::operator==(const ForwardCharacterIterator& that) const {
     if (this == &that) {
         return TRUE;

--- a/icu4c/source/common/stringtriebuilder.cpp
+++ b/icu4c/source/common/stringtriebuilder.cpp
@@ -383,7 +383,7 @@ StringTrieBuilder::equalNodes(const void *left, const void *right) {
     return *(const Node *)left==*(const Node *)right;
 }
 
-UBool
+bool
 StringTrieBuilder::Node::operator==(const Node &other) const {
     return this==&other || (typeid(*this)==typeid(other) && hash==other.hash);
 }
@@ -396,7 +396,7 @@ StringTrieBuilder::Node::markRightEdgesFirst(int32_t edgeNumber) {
     return edgeNumber;
 }
 
-UBool
+bool
 StringTrieBuilder::FinalValueNode::operator==(const Node &other) const {
     if(this==&other) {
         return TRUE;
@@ -413,7 +413,7 @@ StringTrieBuilder::FinalValueNode::write(StringTrieBuilder &builder) {
     offset=builder.writeValueAndFinal(value, TRUE);
 }
 
-UBool
+bool
 StringTrieBuilder::ValueNode::operator==(const Node &other) const {
     if(this==&other) {
         return TRUE;
@@ -425,7 +425,7 @@ StringTrieBuilder::ValueNode::operator==(const Node &other) const {
     return hasValue==o.hasValue && (!hasValue || value==o.value);
 }
 
-UBool
+bool
 StringTrieBuilder::IntermediateValueNode::operator==(const Node &other) const {
     if(this==&other) {
         return TRUE;
@@ -451,7 +451,7 @@ StringTrieBuilder::IntermediateValueNode::write(StringTrieBuilder &builder) {
     offset=builder.writeValueAndFinal(value, FALSE);
 }
 
-UBool
+bool
 StringTrieBuilder::LinearMatchNode::operator==(const Node &other) const {
     if(this==&other) {
         return TRUE;
@@ -471,7 +471,7 @@ StringTrieBuilder::LinearMatchNode::markRightEdgesFirst(int32_t edgeNumber) {
     return edgeNumber;
 }
 
-UBool
+bool
 StringTrieBuilder::ListBranchNode::operator==(const Node &other) const {
     if(this==&other) {
         return TRUE;
@@ -550,7 +550,7 @@ StringTrieBuilder::ListBranchNode::write(StringTrieBuilder &builder) {
     }
 }
 
-UBool
+bool
 StringTrieBuilder::SplitBranchNode::operator==(const Node &other) const {
     if(this==&other) {
         return TRUE;
@@ -584,7 +584,7 @@ StringTrieBuilder::SplitBranchNode::write(StringTrieBuilder &builder) {
     offset=builder.write(unit);
 }
 
-UBool
+bool
 StringTrieBuilder::BranchHeadNode::operator==(const Node &other) const {
     if(this==&other) {
         return TRUE;

--- a/icu4c/source/common/ucharstriebuilder.cpp
+++ b/icu4c/source/common/ucharstriebuilder.cpp
@@ -290,7 +290,7 @@ UCharsTrieBuilder::UCTLinearMatchNode::UCTLinearMatchNode(const UChar *units, in
     hash=hash*37u+ustr_hashUCharsN(units, len);
 }
 
-UBool
+bool
 UCharsTrieBuilder::UCTLinearMatchNode::operator==(const Node &other) const {
     if(this==&other) {
         return TRUE;

--- a/icu4c/source/common/uchriter.cpp
+++ b/icu4c/source/common/uchriter.cpp
@@ -66,7 +66,7 @@ UCharCharacterIterator::operator=(const UCharCharacterIterator& that) {
 UCharCharacterIterator::~UCharCharacterIterator() {
 }
 
-UBool
+bool
 UCharCharacterIterator::operator==(const ForwardCharacterIterator& that) const {
     if (this == &that) {
         return TRUE;

--- a/icu4c/source/common/unicode/brkiter.h
+++ b/icu4c/source/common/unicode/brkiter.h
@@ -124,7 +124,7 @@ public:
      * object, and styles are not considered.
      * @stable ICU 2.0
      */
-    virtual UBool operator==(const BreakIterator&) const = 0;
+    virtual bool operator==(const BreakIterator&) const = 0;
 
     /**
      * Returns the complement of the result of operator==
@@ -132,7 +132,7 @@ public:
      * @return the complement of the result of operator==
      * @stable ICU 2.0
      */
-    UBool operator!=(const BreakIterator& rhs) const { return !operator==(rhs); }
+    bool operator!=(const BreakIterator& rhs) const { return !operator==(rhs); }
 
     /**
      * Return a polymorphic copy of this object.  This is an abstract

--- a/icu4c/source/common/unicode/bytestriebuilder.h
+++ b/icu4c/source/common/unicode/bytestriebuilder.h
@@ -156,7 +156,7 @@ private:
     class BTLinearMatchNode : public LinearMatchNode {
     public:
         BTLinearMatchNode(const char *units, int32_t len, Node *nextNode);
-        virtual UBool operator==(const Node &other) const;
+        virtual bool operator==(const Node &other) const;
         virtual void write(StringTrieBuilder &builder);
     private:
         const char *s;

--- a/icu4c/source/common/unicode/chariter.h
+++ b/icu4c/source/common/unicode/chariter.h
@@ -114,7 +114,7 @@ public:
      * character in the same character-storage object
      * @stable ICU 2.0
      */
-    virtual UBool operator==(const ForwardCharacterIterator& that) const = 0;
+    virtual bool operator==(const ForwardCharacterIterator& that) const = 0;
     
     /**
      * Returns true when the iterators refer to different
@@ -126,7 +126,7 @@ public:
      * same text-storage object
      * @stable ICU 2.0
      */
-    inline UBool operator!=(const ForwardCharacterIterator& that) const;
+    inline bool operator!=(const ForwardCharacterIterator& that) const;
     
     /**
      * Generates a hash code for this iterator.  
@@ -692,7 +692,7 @@ protected:
     int32_t  end;
 };
 
-inline UBool
+inline bool
 ForwardCharacterIterator::operator!=(const ForwardCharacterIterator& that) const {
     return !operator==(that);
 }

--- a/icu4c/source/common/unicode/dtintrv.h
+++ b/icu4c/source/common/unicode/dtintrv.h
@@ -109,14 +109,14 @@ public:
      * @return true if the two DateIntervals are the same
      * @stable ICU 4.0
      */
-    virtual UBool operator==(const DateInterval& other) const;
+    virtual bool operator==(const DateInterval& other) const;
 
     /**
      * Non-equality operator
      * @return true if the two DateIntervals are not the same
      * @stable ICU 4.0
      */
-    inline UBool operator!=(const DateInterval& other) const;
+    inline bool operator!=(const DateInterval& other) const;
 
 
     /**
@@ -151,7 +151,7 @@ DateInterval::getToDate() const {
 }
 
 
-inline UBool 
+inline bool
 DateInterval::operator!=(const DateInterval& other) const { 
     return ( !operator==(other) );
 }

--- a/icu4c/source/common/unicode/locid.h
+++ b/icu4c/source/common/unicode/locid.h
@@ -326,20 +326,20 @@ public:
      * Checks if two locale keys are the same.
      *
      * @param other The locale key object to be compared with this.
-     * @return      True if the two locale keys are the same, false otherwise.
+     * @return      true if the two locale keys are the same, false otherwise.
      * @stable ICU 2.0
      */
-    UBool   operator==(const    Locale&     other) const;
+    bool    operator==(const    Locale&     other) const;
 
     /**
      * Checks if two locale keys are not the same.
      *
      * @param other The locale key object to be compared with this.
-     * @return      True if the two locale keys are not the same, false
+     * @return      true if the two locale keys are not the same, false
      *              otherwise.
      * @stable ICU 2.0
      */
-    inline UBool   operator!=(const    Locale&     other) const;
+    inline bool    operator!=(const    Locale&     other) const;
 
     /**
      * Clone this object.
@@ -1163,7 +1163,7 @@ private:
     friend void U_CALLCONV locale_available_init();
 };
 
-inline UBool
+inline bool
 Locale::operator!=(const    Locale&     other) const
 {
     return !operator==(other);

--- a/icu4c/source/common/unicode/messagepattern.h
+++ b/icu4c/source/common/unicode/messagepattern.h
@@ -526,14 +526,14 @@ public:
      * @return true if this object is equivalent to the other one.
      * @stable ICU 4.8
      */
-    UBool operator==(const MessagePattern &other) const;
+    bool operator==(const MessagePattern &other) const;
 
     /**
      * @param other another object to compare with.
      * @return false if this object is equivalent to the other one.
      * @stable ICU 4.8
      */
-    inline UBool operator!=(const MessagePattern &other) const {
+    inline bool operator!=(const MessagePattern &other) const {
         return !operator==(other);
     }
 
@@ -797,14 +797,14 @@ public:
          * @return true if this object is equivalent to the other one.
          * @stable ICU 4.8
          */
-        UBool operator==(const Part &other) const;
+        bool operator==(const Part &other) const;
 
         /**
          * @param other another object to compare with.
          * @return false if this object is equivalent to the other one.
          * @stable ICU 4.8
          */
-        inline UBool operator!=(const Part &other) const {
+        inline bool operator!=(const Part &other) const {
             return !operator==(other);
         }
 

--- a/icu4c/source/common/unicode/normlzr.h
+++ b/icu4c/source/common/unicode/normlzr.h
@@ -584,7 +584,7 @@ public:
    * @return comparison result
    * @deprecated ICU 56 Use Normalizer2 instead.
    */
-  UBool        operator==(const Normalizer& that) const;
+  bool         operator==(const Normalizer& that) const;
 
   /**
    * Returns false when both iterators refer to the same character in the same
@@ -594,7 +594,7 @@ public:
    * @return comparison result
    * @deprecated ICU 56 Use Normalizer2 instead.
    */
-  inline UBool        operator!=(const Normalizer& that) const;
+  inline bool         operator!=(const Normalizer& that) const;
 
   /**
    * Returns a pointer to a new Normalizer that is a clone of this one.
@@ -777,7 +777,7 @@ private:
 //-------------------------------------------------------------------------
 
 #ifndef U_HIDE_DEPRECATED_API
-inline UBool
+inline bool
 Normalizer::operator!= (const Normalizer& other) const
 { return ! operator==(other); }
 

--- a/icu4c/source/common/unicode/parsepos.h
+++ b/icu4c/source/common/unicode/parsepos.h
@@ -100,14 +100,14 @@ public:
      * @return true if the two parse positions are equal, false otherwise.
      * @stable ICU 2.0
      */
-    inline UBool              operator==(const ParsePosition& that) const;
+    inline bool               operator==(const ParsePosition& that) const;
 
     /**
      * Equality operator.
      * @return true if the two parse positions are not equal, false otherwise.
      * @stable ICU 2.0
      */
-    inline UBool              operator!=(const ParsePosition& that) const;
+    inline bool               operator!=(const ParsePosition& that) const;
 
     /**
      * Clone this object.
@@ -192,7 +192,7 @@ ParsePosition::operator=(const ParsePosition& copy)
   return *this;
 }
 
-inline UBool
+inline bool
 ParsePosition::operator==(const ParsePosition& copy) const
 {
   if(index != copy.index || errorIndex != copy.errorIndex)
@@ -201,7 +201,7 @@ ParsePosition::operator==(const ParsePosition& copy) const
   return true;
 }
 
-inline UBool
+inline bool
 ParsePosition::operator!=(const ParsePosition& copy) const
 {
   return !operator==(copy);

--- a/icu4c/source/common/unicode/rbbi.h
+++ b/icu4c/source/common/unicode/rbbi.h
@@ -260,7 +260,7 @@ public:
      * same class, have the same behavior, and iterate over the same text.
      *  @stable ICU 2.0
      */
-    virtual UBool operator==(const BreakIterator& that) const;
+    virtual bool operator==(const BreakIterator& that) const;
 
     /**
      * Not-equal operator.  If operator== returns true, this returns false,
@@ -269,7 +269,7 @@ public:
      * @return true if both BreakIterators are not same.
      *  @stable ICU 2.0
      */
-    inline UBool operator!=(const BreakIterator& that) const;
+    inline bool operator!=(const BreakIterator& that) const;
 
     /**
      * Returns a newly-constructed RuleBasedBreakIterator with the same
@@ -719,7 +719,7 @@ private:
 //
 //------------------------------------------------------------------------------
 
-inline UBool RuleBasedBreakIterator::operator!=(const BreakIterator& that) const {
+inline bool RuleBasedBreakIterator::operator!=(const BreakIterator& that) const {
     return !operator==(that);
 }
 

--- a/icu4c/source/common/unicode/schriter.h
+++ b/icu4c/source/common/unicode/schriter.h
@@ -124,7 +124,7 @@ public:
    * same string and are pointing at the same character.
    * @stable ICU 2.0
    */
-  virtual UBool          operator==(const ForwardCharacterIterator& that) const;
+  virtual bool           operator==(const ForwardCharacterIterator& that) const;
 
   /**
    * Returns a new StringCharacterIterator referring to the same

--- a/icu4c/source/common/unicode/strenum.h
+++ b/icu4c/source/common/unicode/strenum.h
@@ -199,7 +199,7 @@ public:
      * @return true if the enumerations are equal. false if not.
      * @stable ICU 3.6 
      */
-    virtual UBool operator==(const StringEnumeration& that)const;
+    virtual bool operator==(const StringEnumeration& that)const;
     /**
      * Compares this enumeration to other to check if both are not equal
      *
@@ -207,7 +207,7 @@ public:
      * @return true if the enumerations are equal. false if not.
      * @stable ICU 3.6 
      */
-    virtual UBool operator!=(const StringEnumeration& that)const;
+    virtual bool operator!=(const StringEnumeration& that)const;
 
 protected:
     /**

--- a/icu4c/source/common/unicode/stringpiece.h
+++ b/icu4c/source/common/unicode/stringpiece.h
@@ -332,7 +332,7 @@ operator==(const StringPiece& x, const StringPiece& y);
  * @return true if the string data is not equal
  * @stable ICU 4.8
  */
-inline UBool operator!=(const StringPiece& x, const StringPiece& y) {
+inline bool operator!=(const StringPiece& x, const StringPiece& y) {
   return !(x == y);
 }
 

--- a/icu4c/source/common/unicode/stringtriebuilder.h
+++ b/icu4c/source/common/unicode/stringtriebuilder.h
@@ -204,8 +204,8 @@ protected:
         // Handles node==NULL.
         static inline int32_t hashCode(const Node *node) { return node==NULL ? 0 : node->hashCode(); }
         // Base class operator==() compares the actual class types.
-        virtual UBool operator==(const Node &other) const;
-        inline UBool operator!=(const Node &other) const { return !operator==(other); }
+        virtual bool operator==(const Node &other) const;
+        inline bool operator!=(const Node &other) const { return !operator==(other); }
         /**
          * Traverses the Node graph and numbers branch edges, with rightmost edges first.
          * This is to avoid writing a duplicate node twice.
@@ -265,7 +265,7 @@ protected:
     class FinalValueNode : public Node {
     public:
         FinalValueNode(int32_t v) : Node(0x111111u*37u+v), value(v) {}
-        virtual UBool operator==(const Node &other) const;
+        virtual bool operator==(const Node &other) const;
         virtual void write(StringTrieBuilder &builder);
     protected:
         int32_t value;
@@ -280,7 +280,7 @@ protected:
     class ValueNode : public Node {
     public:
         ValueNode(int32_t initialHash) : Node(initialHash), hasValue(false), value(0) {}
-        virtual UBool operator==(const Node &other) const;
+        virtual bool operator==(const Node &other) const;
         void setValue(int32_t v) {
             hasValue=true;
             value=v;
@@ -299,7 +299,7 @@ protected:
     public:
         IntermediateValueNode(int32_t v, Node *nextNode)
                 : ValueNode(0x222222u*37u+hashCode(nextNode)), next(nextNode) { setValue(v); }
-        virtual UBool operator==(const Node &other) const;
+        virtual bool operator==(const Node &other) const;
         virtual int32_t markRightEdgesFirst(int32_t edgeNumber);
         virtual void write(StringTrieBuilder &builder);
     protected:
@@ -317,7 +317,7 @@ protected:
         LinearMatchNode(int32_t len, Node *nextNode)
                 : ValueNode((0x333333u*37u+len)*37u+hashCode(nextNode)),
                   length(len), next(nextNode) {}
-        virtual UBool operator==(const Node &other) const;
+        virtual bool operator==(const Node &other) const;
         virtual int32_t markRightEdgesFirst(int32_t edgeNumber);
     protected:
         int32_t length;
@@ -341,7 +341,7 @@ protected:
     class ListBranchNode : public BranchNode {
     public:
         ListBranchNode() : BranchNode(0x444444), length(0) {}
-        virtual UBool operator==(const Node &other) const;
+        virtual bool operator==(const Node &other) const;
         virtual int32_t markRightEdgesFirst(int32_t edgeNumber);
         virtual void write(StringTrieBuilder &builder);
         // Adds a unit with a final value.
@@ -376,7 +376,7 @@ protected:
                 : BranchNode(((0x555555u*37u+middleUnit)*37u+
                               hashCode(lessThanNode))*37u+hashCode(greaterOrEqualNode)),
                   unit(middleUnit), lessThan(lessThanNode), greaterOrEqual(greaterOrEqualNode) {}
-        virtual UBool operator==(const Node &other) const;
+        virtual bool operator==(const Node &other) const;
         virtual int32_t markRightEdgesFirst(int32_t edgeNumber);
         virtual void write(StringTrieBuilder &builder);
     protected:
@@ -392,7 +392,7 @@ protected:
         BranchHeadNode(int32_t len, Node *subNode)
                 : ValueNode((0x666666u*37u+len)*37u+hashCode(subNode)),
                   length(len), next(subNode) {}
-        virtual UBool operator==(const Node &other) const;
+        virtual bool operator==(const Node &other) const;
         virtual int32_t markRightEdgesFirst(int32_t edgeNumber);
         virtual void write(StringTrieBuilder &builder);
     protected:

--- a/icu4c/source/common/unicode/ucharstriebuilder.h
+++ b/icu4c/source/common/unicode/ucharstriebuilder.h
@@ -157,7 +157,7 @@ private:
     class UCTLinearMatchNode : public LinearMatchNode {
     public:
         UCTLinearMatchNode(const char16_t *units, int32_t len, Node *nextNode);
-        virtual UBool operator==(const Node &other) const;
+        virtual bool operator==(const Node &other) const;
         virtual void write(StringTrieBuilder &builder);
     private:
         const char16_t *s;

--- a/icu4c/source/common/unicode/uchriter.h
+++ b/icu4c/source/common/unicode/uchriter.h
@@ -119,7 +119,7 @@ public:
    * same string and are pointing at the same character.
    * @stable ICU 2.0
    */
-  virtual UBool          operator==(const ForwardCharacterIterator& that) const;
+  virtual bool           operator==(const ForwardCharacterIterator& that) const;
 
   /**
    * Generates a hash code for this iterator.

--- a/icu4c/source/common/unicode/uniset.h
+++ b/icu4c/source/common/unicode/uniset.h
@@ -485,14 +485,14 @@ public:
      * @return <tt>true</tt> if the specified set is equal to this set.
      * @stable ICU 2.0
      */
-    virtual UBool operator==(const UnicodeSet& o) const;
+    virtual bool operator==(const UnicodeSet& o) const;
 
     /**
      * Compares the specified object with this set for equality.  Returns
      * <tt>true</tt> if the specified set is not equal to this set.
      * @stable ICU 2.0
      */
-    inline UBool operator!=(const UnicodeSet& o) const;
+    inline bool operator!=(const UnicodeSet& o) const;
 
     /**
      * Returns a copy of this object.  All UnicodeFunctor objects have
@@ -1710,7 +1710,7 @@ private:
 
 
 
-inline UBool UnicodeSet::operator!=(const UnicodeSet& o) const {
+inline bool UnicodeSet::operator!=(const UnicodeSet& o) const {
     return !operator==(o);
 }
 

--- a/icu4c/source/common/unicode/unistr.h
+++ b/icu4c/source/common/unicode/unistr.h
@@ -325,7 +325,7 @@ public:
    * false otherwise.
    * @stable ICU 2.0
    */
-  inline UBool operator== (const UnicodeString& text) const;
+  inline bool operator== (const UnicodeString& text) const;
 
   /**
    * Inequality operator. Performs only bitwise comparison.
@@ -334,7 +334,7 @@ public:
    * true otherwise.
    * @stable ICU 2.0
    */
-  inline UBool operator!= (const UnicodeString& text) const;
+  inline bool operator!= (const UnicodeString& text) const;
 
   /**
    * Greater than operator. Performs only bitwise comparison.
@@ -3946,7 +3946,7 @@ UnicodeString::doCompare(int32_t start,
   }
 }
 
-inline UBool
+inline bool
 UnicodeString::operator== (const UnicodeString& text) const
 {
   if(isBogus()) {
@@ -3957,7 +3957,7 @@ UnicodeString::operator== (const UnicodeString& text) const
   }
 }
 
-inline UBool
+inline bool
 UnicodeString::operator!= (const UnicodeString& text) const
 { return (! operator==(text)); }
 

--- a/icu4c/source/common/unicode/uobject.h
+++ b/icu4c/source/common/unicode/uobject.h
@@ -262,8 +262,8 @@ protected:
     // UObject &operator=(const UObject &other) { return *this; }
 
     // comparison operators
-    virtual inline UBool operator==(const UObject &other) const { return this==&other; }
-    inline UBool operator!=(const UObject &other) const { return !operator==(other); }
+    virtual inline bool operator==(const UObject &other) const { return this==&other; }
+    inline bool operator!=(const UObject &other) const { return !operator==(other); }
 
     // clone() commented out from the base class:
     // some compilers do not support co-variant return types

--- a/icu4c/source/common/unifiedcache.h
+++ b/icu4c/source/common/unifiedcache.h
@@ -56,7 +56,7 @@ class U_COMMON_API CacheKeyBase : public UObject {
    /**
     * Equality operator.
     */
-   virtual UBool operator == (const CacheKeyBase &other) const = 0;
+   virtual bool operator == (const CacheKeyBase &other) const = 0;
 
    /**
     * Create a new object for this key. Called by cache on cache miss.
@@ -83,7 +83,7 @@ class U_COMMON_API CacheKeyBase : public UObject {
    /**
     * Inequality operator.
     */
-   UBool operator != (const CacheKeyBase &other) const {
+   bool operator != (const CacheKeyBase &other) const {
        return !(*this == other);
    }
  private:
@@ -123,7 +123,7 @@ class CacheKey : public CacheKeyBase {
    /**
     * Two objects are equal if they are of the same type.
     */
-   virtual UBool operator == (const CacheKeyBase &other) const {
+   virtual bool operator == (const CacheKeyBase &other) const {
        return typeid(*this) == typeid(other);
    }
 };
@@ -144,7 +144,7 @@ class LocaleCacheKey : public CacheKey<T> {
    virtual int32_t hashCode() const {
        return (int32_t)(37u * (uint32_t)CacheKey<T>::hashCode() + (uint32_t)fLoc.hashCode());
    }
-   virtual UBool operator == (const CacheKeyBase &other) const {
+   virtual bool operator == (const CacheKeyBase &other) const {
        // reflexive
        if (this == &other) {
            return true;

--- a/icu4c/source/common/unifiedcache.h
+++ b/icu4c/source/common/unifiedcache.h
@@ -13,6 +13,8 @@
 #ifndef __UNIFIED_CACHE_H__
 #define __UNIFIED_CACHE_H__
 
+#include <type_traits>
+
 #include "utypeinfo.h"  // for 'typeid' to work
 
 #include "unicode/uobject.h"
@@ -158,6 +160,17 @@ class LocaleCacheKey : public CacheKey<T> {
                static_cast<const LocaleCacheKey<T> *>(&other);
        return fLoc == fOther->fLoc;
    }
+
+#if defined(__cpp_impl_three_way_comparison) && \
+       __cpp_impl_three_way_comparison >= 201711
+    // Manually resolve C++20 reversed argument order ambiguity.
+    template <typename U,
+              typename = typename std::enable_if_t<!std::is_same_v<T, U>>>
+    inline bool operator==(const LocaleCacheKey<U>& other) const {
+        return operator==(static_cast<const CacheKeyBase&>(other));
+    }
+#endif
+
    virtual CacheKeyBase *clone() const {
        return new LocaleCacheKey<T>(*this);
    }

--- a/icu4c/source/common/uniset.cpp
+++ b/icu4c/source/common/uniset.cpp
@@ -278,7 +278,7 @@ UnicodeSet *UnicodeSet::cloneAsThawed() const {
  * @param o set to be compared for equality with this set.
  * @return <tt>true</tt> if the specified set is equal to this set.
  */
-UBool UnicodeSet::operator==(const UnicodeSet& o) const {
+bool UnicodeSet::operator==(const UnicodeSet& o) const {
     if (len != o.len) return FALSE;
     for (int32_t i = 0; i < len; ++i) {
         if (list[i] != o.list[i]) return FALSE;

--- a/icu4c/source/common/ustr_titlecase_brkiter.cpp
+++ b/icu4c/source/common/ustr_titlecase_brkiter.cpp
@@ -44,7 +44,7 @@ class WholeStringBreakIterator : public BreakIterator {
 public:
     WholeStringBreakIterator() : BreakIterator(), length(0) {}
     ~WholeStringBreakIterator() U_OVERRIDE;
-    UBool operator==(const BreakIterator&) const U_OVERRIDE;
+    bool operator==(const BreakIterator&) const U_OVERRIDE;
     WholeStringBreakIterator *clone() const U_OVERRIDE;
     static UClassID U_EXPORT2 getStaticClassID();
     UClassID getDynamicClassID() const U_OVERRIDE;
@@ -73,7 +73,7 @@ private:
 UOBJECT_DEFINE_RTTI_IMPLEMENTATION(WholeStringBreakIterator)
 
 WholeStringBreakIterator::~WholeStringBreakIterator() {}
-UBool WholeStringBreakIterator::operator==(const BreakIterator&) const { return FALSE; }
+bool WholeStringBreakIterator::operator==(const BreakIterator&) const { return FALSE; }
 WholeStringBreakIterator *WholeStringBreakIterator::clone() const { return nullptr; }
 
 CharacterIterator &WholeStringBreakIterator::getText() const {

--- a/icu4c/source/common/ustrenum.cpp
+++ b/icu4c/source/common/ustrenum.cpp
@@ -120,12 +120,12 @@ StringEnumeration::setChars(const char *s, int32_t length, UErrorCode &status) {
 
     return NULL;
 }
-UBool 
+bool
 StringEnumeration::operator==(const StringEnumeration& that)const {
     return typeid(*this) == typeid(that); 
 }
 
-UBool
+bool
 StringEnumeration::operator!=(const StringEnumeration& that)const {
     return !operator==(that);
 }

--- a/icu4c/source/common/uvector.cpp
+++ b/icu4c/source/common/uvector.cpp
@@ -110,7 +110,7 @@ void UVector::assign(const UVector& other, UElementAssigner *assign, UErrorCode 
 }
 
 // This only does something sensible if this object has a non-null comparer
-UBool UVector::operator==(const UVector& other) {
+bool UVector::operator==(const UVector& other) {
     int32_t i;
     if (count != other.count) return FALSE;
     if (comparer != NULL) {

--- a/icu4c/source/common/uvector.h
+++ b/icu4c/source/common/uvector.h
@@ -113,12 +113,12 @@ public:
      * equal if they are of the same size and all elements are equal,
      * as compared using this object's comparer.
      */
-    UBool operator==(const UVector& other);
+    bool operator==(const UVector& other);
 
     /**
      * Equivalent to !operator==()
      */
-    inline UBool operator!=(const UVector& other);
+    inline bool operator!=(const UVector& other);
 
     //------------------------------------------------------------
     // java.util.Vector API
@@ -390,7 +390,7 @@ inline void* UVector::operator[](int32_t index) const {
     return elementAt(index);
 }
 
-inline UBool UVector::operator!=(const UVector& other) {
+inline bool UVector::operator!=(const UVector& other) {
     return !operator==(other);
 }
 

--- a/icu4c/source/common/uvectr32.cpp
+++ b/icu4c/source/common/uvectr32.cpp
@@ -83,7 +83,7 @@ void UVector32::assign(const UVector32& other, UErrorCode &ec) {
 }
 
 
-UBool UVector32::operator==(const UVector32& other) {
+bool UVector32::operator==(const UVector32& other) {
     int32_t i;
     if (count != other.count) return FALSE;
     for (i=0; i<count; ++i) {

--- a/icu4c/source/common/uvectr32.h
+++ b/icu4c/source/common/uvectr32.h
@@ -86,12 +86,12 @@ public:
      * equal if they are of the same size and all elements are equal,
      * as compared using this object's comparer.
      */
-    UBool operator==(const UVector32& other);
+    bool operator==(const UVector32& other);
 
     /**
      * Equivalent to !operator==()
      */
-    inline UBool operator!=(const UVector32& other);
+    inline bool operator!=(const UVector32& other);
 
     //------------------------------------------------------------
     // java.util.Vector API
@@ -268,7 +268,7 @@ inline int32_t UVector32::lastElementi(void) const {
     return elementAti(count-1);
 }
 
-inline UBool UVector32::operator!=(const UVector32& other) {
+inline bool UVector32::operator!=(const UVector32& other) {
     return !operator==(other);
 }
 

--- a/icu4c/source/common/uvectr64.cpp
+++ b/icu4c/source/common/uvectr64.cpp
@@ -80,7 +80,7 @@ void UVector64::assign(const UVector64& other, UErrorCode &ec) {
 }
 
 
-UBool UVector64::operator==(const UVector64& other) {
+bool UVector64::operator==(const UVector64& other) {
     int32_t i;
     if (count != other.count) return FALSE;
     for (i=0; i<count; ++i) {

--- a/icu4c/source/common/uvectr64.h
+++ b/icu4c/source/common/uvectr64.h
@@ -85,12 +85,12 @@ public:
      * equal if they are of the same size and all elements are equal,
      * as compared using this object's comparer.
      */
-    UBool operator==(const UVector64& other);
+    bool operator==(const UVector64& other);
 
     /**
      * Equivalent to !operator==()
      */
-    inline UBool operator!=(const UVector64& other);
+    inline bool operator!=(const UVector64& other);
 
     //------------------------------------------------------------
     // subset of java.util.Vector API
@@ -249,7 +249,7 @@ inline int64_t UVector64::lastElementi(void) const {
     return elementAti(count-1);
 }
 
-inline UBool UVector64::operator!=(const UVector64& other) {
+inline bool UVector64::operator!=(const UVector64& other) {
     return !operator==(other);
 }
 

--- a/icu4c/source/configure
+++ b/icu4c/source/configure
@@ -7970,6 +7970,56 @@ fi
 # Now that we're done using CPPFLAGS etc. for tests, we can change it
 # for build.
 
+ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+# Silence a Clang warning about ambiguous operators with C++20 rewritten
+# expressions that possibly or maybe even probably is a mistake (ICU-20973).
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts -Wambiguous-reversed-operator" >&5
+$as_echo_n "checking whether C++ compiler accepts -Wambiguous-reversed-operator... " >&6; }
+if ${ax_cv_check_cxxflags__Werror__Wambiguous_reversed_operator+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+  ax_check_save_flags=$CXXFLAGS
+  CXXFLAGS="$CXXFLAGS -Werror -Wambiguous-reversed-operator"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  ax_cv_check_cxxflags__Werror__Wambiguous_reversed_operator=yes
+else
+  ax_cv_check_cxxflags__Werror__Wambiguous_reversed_operator=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CXXFLAGS=$ax_check_save_flags
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cxxflags__Werror__Wambiguous_reversed_operator" >&5
+$as_echo "$ax_cv_check_cxxflags__Werror__Wambiguous_reversed_operator" >&6; }
+if test "x$ax_cv_check_cxxflags__Werror__Wambiguous_reversed_operator" = xyes; then :
+  CXXFLAGS+=" -Wno-ambiguous-reversed-operator"
+else
+  :
+fi
+
+ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
 if test "${CC}" = "clang"; then
    CLANGCFLAGS="-Qunused-arguments -Wno-parentheses-equality"
 else

--- a/icu4c/source/configure.ac
+++ b/icu4c/source/configure.ac
@@ -1317,6 +1317,16 @@ fi
 # Now that we're done using CPPFLAGS etc. for tests, we can change it
 # for build.
 
+AC_LANG_PUSH([C++])
+# Silence a Clang warning about ambiguous operators with C++20 rewritten
+# expressions that possibly or maybe even probably is a mistake (ICU-20973).
+AX_CHECK_COMPILE_FLAG(
+  [-Wambiguous-reversed-operator],
+  [CXXFLAGS+=" -Wno-ambiguous-reversed-operator"],
+  [],
+  [-Werror])
+AC_LANG_POP([C++])
+
 if test "${CC}" = "clang"; then
    CLANGCFLAGS="-Qunused-arguments -Wno-parentheses-equality"
 else

--- a/icu4c/source/i18n/alphaindex.cpp
+++ b/icu4c/source/i18n/alphaindex.cpp
@@ -799,12 +799,12 @@ UnicodeString AlphabeticIndex::separated(const UnicodeString &item) {
 }
 
 
-UBool AlphabeticIndex::operator==(const AlphabeticIndex& /* other */) const {
+bool AlphabeticIndex::operator==(const AlphabeticIndex& /* other */) const {
     return FALSE;
 }
 
 
-UBool AlphabeticIndex::operator!=(const AlphabeticIndex& /* other */) const {
+bool AlphabeticIndex::operator!=(const AlphabeticIndex& /* other */) const {
     return FALSE;
 }
 

--- a/icu4c/source/i18n/calendar.cpp
+++ b/icu4c/source/i18n/calendar.cpp
@@ -1031,7 +1031,7 @@ Calendar::getCalendarTypeFromLocale(
     }
 }
 
-UBool
+bool
 Calendar::operator==(const Calendar& that) const
 {
     UErrorCode status = U_ZERO_ERROR;

--- a/icu4c/source/i18n/choicfmt.cpp
+++ b/icu4c/source/i18n/choicfmt.cpp
@@ -132,7 +132,7 @@ ChoiceFormat::ChoiceFormat(const UnicodeString& newPattern,
 }
 // -------------------------------------
 
-UBool
+bool
 ChoiceFormat::operator==(const Format& that) const
 {
     if (this == &that) return TRUE;

--- a/icu4c/source/i18n/coleitr.cpp
+++ b/icu4c/source/i18n/coleitr.cpp
@@ -137,13 +137,13 @@ int32_t CollationElementIterator::next(UErrorCode& status)
     return firstHalf;
 }
 
-UBool CollationElementIterator::operator!=(
+bool CollationElementIterator::operator!=(
                                   const CollationElementIterator& other) const
 {
     return !(*this == other);
 }
 
-UBool CollationElementIterator::operator==(
+bool CollationElementIterator::operator==(
                                     const CollationElementIterator& that) const
 {
     if (this == &that) {

--- a/icu4c/source/i18n/coll.cpp
+++ b/icu4c/source/i18n/coll.cpp
@@ -636,15 +636,15 @@ Collator::Collator(const Collator &other)
 {
 }
 
-UBool Collator::operator==(const Collator& other) const
+bool Collator::operator==(const Collator& other) const
 {
     // Subclasses: Call this method and then add more specific checks.
     return typeid(*this) == typeid(other);
 }
 
-UBool Collator::operator!=(const Collator& other) const
+bool Collator::operator!=(const Collator& other) const
 {
-    return (UBool)!(*this == other);
+    return !operator==(other);
 }
 
 int32_t U_EXPORT2 Collator::getBound(const uint8_t       *source,

--- a/icu4c/source/i18n/collationiterator.cpp
+++ b/icu4c/source/i18n/collationiterator.cpp
@@ -168,7 +168,7 @@ CollationIterator::~CollationIterator() {
     delete skipped;
 }
 
-UBool
+bool
 CollationIterator::operator==(const CollationIterator &other) const {
     // Subclasses: Call this method and then add more specific checks.
     // Compare the iterator state but not the collation data (trie & data fields):

--- a/icu4c/source/i18n/collationiterator.h
+++ b/icu4c/source/i18n/collationiterator.h
@@ -109,8 +109,8 @@ public:
 
     virtual ~CollationIterator();
 
-    virtual UBool operator==(const CollationIterator &other) const;
-    inline UBool operator!=(const CollationIterator &other) const {
+    virtual bool operator==(const CollationIterator &other) const;
+    inline bool operator!=(const CollationIterator &other) const {
         return !operator==(other);
     }
 

--- a/icu4c/source/i18n/collationsettings.cpp
+++ b/icu4c/source/i18n/collationsettings.cpp
@@ -48,7 +48,7 @@ CollationSettings::~CollationSettings() {
     }
 }
 
-UBool
+bool
 CollationSettings::operator==(const CollationSettings &other) const {
     if(options != other.options) { return FALSE; }
     if((options & ALTERNATE_MASK) != 0 && variableTop != other.variableTop) { return FALSE; }

--- a/icu4c/source/i18n/collationsettings.h
+++ b/icu4c/source/i18n/collationsettings.h
@@ -115,9 +115,9 @@ struct U_I18N_API CollationSettings : public SharedObject {
     CollationSettings(const CollationSettings &other);
     virtual ~CollationSettings();
 
-    UBool operator==(const CollationSettings &other) const;
+    bool operator==(const CollationSettings &other) const;
 
-    inline UBool operator!=(const CollationSettings &other) const {
+    inline bool operator!=(const CollationSettings &other) const {
         return !operator==(other);
     }
 

--- a/icu4c/source/i18n/currpinf.cpp
+++ b/icu4c/source/i18n/currpinf.cpp
@@ -145,7 +145,7 @@ CurrencyPluralInfo::~CurrencyPluralInfo() {
     fLocale = nullptr;
 }
 
-UBool
+bool
 CurrencyPluralInfo::operator==(const CurrencyPluralInfo& info) const {
 #ifdef CURRENCY_PLURAL_INFO_DEBUG
     if (*fPluralRules == *info.fPluralRules) {

--- a/icu4c/source/i18n/datefmt.cpp
+++ b/icu4c/source/i18n/datefmt.cpp
@@ -82,7 +82,7 @@ public:
     virtual int32_t hashCode() const {
         return (int32_t)(37u * (uint32_t)LocaleCacheKey<DateFmtBestPattern>::hashCode() + (uint32_t)fSkeleton.hashCode());
     }
-    virtual UBool operator==(const CacheKeyBase &other) const {
+    virtual bool operator==(const CacheKeyBase &other) const {
        // reflexive
        if (this == &other) { 	
            return TRUE;
@@ -174,7 +174,7 @@ DateFormat::~DateFormat()
 
 //----------------------------------------------------------------------
 
-UBool
+bool
 DateFormat::operator==(const Format& other) const
 {
     // This protected comparison operator should only be called by subclasses

--- a/icu4c/source/i18n/dcfmtsym.cpp
+++ b/icu4c/source/i18n/dcfmtsym.cpp
@@ -174,7 +174,7 @@ DecimalFormatSymbols::operator=(const DecimalFormatSymbols& rhs)
 
 // -------------------------------------
 
-UBool
+bool
 DecimalFormatSymbols::operator==(const DecimalFormatSymbols& that) const
 {
     if (this == &that) {

--- a/icu4c/source/i18n/decimfmt.cpp
+++ b/icu4c/source/i18n/decimfmt.cpp
@@ -497,7 +497,7 @@ DecimalFormat* DecimalFormat::clone() const {
     return nullptr;
 }
 
-UBool DecimalFormat::operator==(const Format& other) const {
+bool DecimalFormat::operator==(const Format& other) const {
     auto* otherDF = dynamic_cast<const DecimalFormat*>(&other);
     if (otherDF == nullptr) {
         return false;

--- a/icu4c/source/i18n/dtfmtsym.cpp
+++ b/icu4c/source/i18n/dtfmtsym.cpp
@@ -539,7 +539,7 @@ DateFormatSymbols::arrayCompare(const UnicodeString* array1,
     return TRUE;
 }
 
-UBool
+bool
 DateFormatSymbols::operator==(const DateFormatSymbols& other) const
 {
     // First do cheap comparisons

--- a/icu4c/source/i18n/dtitvfmt.cpp
+++ b/icu4c/source/i18n/dtitvfmt.cpp
@@ -229,7 +229,7 @@ DateIntervalFormat::clone() const {
 }
 
 
-UBool
+bool
 DateIntervalFormat::operator==(const Format& other) const {
     if (typeid(*this) != typeid(other)) {return FALSE;}
     const DateIntervalFormat* fmt = (DateIntervalFormat*)&other;

--- a/icu4c/source/i18n/dtitvinf.cpp
+++ b/icu4c/source/i18n/dtitvinf.cpp
@@ -165,7 +165,7 @@ DateIntervalInfo::~DateIntervalInfo() {
 }
 
 
-UBool
+bool
 DateIntervalInfo::operator==(const DateIntervalInfo& other) const {
     UBool equal = (
       fFallbackIntervalPattern == other.fFallbackIntervalPattern &&

--- a/icu4c/source/i18n/dtptngen.cpp
+++ b/icu4c/source/i18n/dtptngen.cpp
@@ -424,7 +424,7 @@ DateTimePatternGenerator::operator=(const DateTimePatternGenerator& other) {
 }
 
 
-UBool
+bool
 DateTimePatternGenerator::operator==(const DateTimePatternGenerator& other) const {
     if (this == &other) {
         return TRUE;
@@ -448,7 +448,7 @@ DateTimePatternGenerator::operator==(const DateTimePatternGenerator& other) cons
     }
 }
 
-UBool
+bool
 DateTimePatternGenerator::operator!=(const DateTimePatternGenerator& other) const {
     return  !operator==(other);
 }

--- a/icu4c/source/i18n/dtptngen_impl.h
+++ b/icu4c/source/i18n/dtptngen_impl.h
@@ -134,20 +134,20 @@ public:
     UnicodeString& appendTo(UnicodeString& string) const;
     UnicodeString& appendFieldTo(int32_t field, UnicodeString& string) const;
     UChar getFirstChar() const;
-    inline UBool operator==(const SkeletonFields& other) const;
-    inline UBool operator!=(const SkeletonFields& other) const;
+    inline bool operator==(const SkeletonFields& other) const;
+    inline bool operator!=(const SkeletonFields& other) const;
 
 private:
     int8_t chars[UDATPG_FIELD_COUNT];
     int8_t lengths[UDATPG_FIELD_COUNT];
 };
 
-inline UBool SkeletonFields::operator==(const SkeletonFields& other) const {
+inline bool SkeletonFields::operator==(const SkeletonFields& other) const {
     return (uprv_memcmp(chars, other.chars, sizeof(chars)) == 0
         && uprv_memcmp(lengths, other.lengths, sizeof(lengths)) == 0);
 }
 
-inline UBool SkeletonFields::operator!=(const SkeletonFields& other) const {
+inline bool SkeletonFields::operator!=(const SkeletonFields& other) const {
     return (! operator==(other));
 }
 

--- a/icu4c/source/i18n/dtrule.cpp
+++ b/icu4c/source/i18n/dtrule.cpp
@@ -81,7 +81,7 @@ DateTimeRule::operator=(const DateTimeRule& right) {
     return *this;
 }
 
-UBool
+bool
 DateTimeRule::operator==(const DateTimeRule& that) const {
     return ((this == &that) ||
             (typeid(*this) == typeid(that) &&
@@ -94,7 +94,7 @@ DateTimeRule::operator==(const DateTimeRule& that) const {
             fTimeRuleType == that.fTimeRuleType));
 }
 
-UBool
+bool
 DateTimeRule::operator!=(const DateTimeRule& that) const {
     return !operator==(that);
 }

--- a/icu4c/source/i18n/fmtable.cpp
+++ b/icu4c/source/i18n/fmtable.cpp
@@ -275,7 +275,7 @@ Formattable::operator=(const Formattable& source)
 
 // -------------------------------------
 
-UBool
+bool
 Formattable::operator==(const Formattable& that) const
 {
     int32_t i;

--- a/icu4c/source/i18n/format.cpp
+++ b/icu4c/source/i18n/format.cpp
@@ -155,7 +155,7 @@ Format::parseObject(const UnicodeString& source,
 
 // -------------------------------------
 
-UBool
+bool
 Format::operator==(const Format& that) const
 {
     // Subclasses: Call this method and then add more specific checks.

--- a/icu4c/source/i18n/fpositer.cpp
+++ b/icu4c/source/i18n/fpositer.cpp
@@ -45,7 +45,7 @@ FieldPositionIterator::FieldPositionIterator(const FieldPositionIterator &rhs)
   }
 }
 
-UBool FieldPositionIterator::operator==(const FieldPositionIterator &rhs) const {
+bool FieldPositionIterator::operator==(const FieldPositionIterator &rhs) const {
   if (&rhs == this) {
     return TRUE;
   }

--- a/icu4c/source/i18n/measfmt.cpp
+++ b/icu4c/source/i18n/measfmt.cpp
@@ -427,7 +427,7 @@ MeasureFormat::~MeasureFormat() {
     delete listFormatter;
 }
 
-UBool MeasureFormat::operator==(const Format &other) const {
+bool MeasureFormat::operator==(const Format &other) const {
     if (this == &other) { // Same object, equal
         return TRUE;
     }

--- a/icu4c/source/i18n/measunit.cpp
+++ b/icu4c/source/i18n/measunit.cpp
@@ -2196,7 +2196,7 @@ const char *MeasureUnit::getIdentifier() const {
     return fImpl ? fImpl->identifier.data() : gSubTypes[getOffset()];
 }
 
-UBool MeasureUnit::operator==(const UObject& other) const {
+bool MeasureUnit::operator==(const UObject& other) const {
     if (this == &other) {  // Same object, equal
         return TRUE;
     }

--- a/icu4c/source/i18n/measure.cpp
+++ b/icu4c/source/i18n/measure.cpp
@@ -60,7 +60,7 @@ Measure::~Measure() {
     delete unit;
 }
 
-UBool Measure::operator==(const UObject& other) const {
+bool Measure::operator==(const UObject& other) const {
     if (this == &other) {  // Same object, equal
         return TRUE;
     }

--- a/icu4c/source/i18n/msgfmt.cpp
+++ b/icu4c/source/i18n/msgfmt.cpp
@@ -389,7 +389,7 @@ MessageFormat::operator=(const MessageFormat& that)
     return *this;
 }
 
-UBool
+bool
 MessageFormat::operator==(const Format& rhs) const
 {
     if (this == &rhs) return TRUE;
@@ -1869,7 +1869,7 @@ UBool MessageFormat::equalFormats(const void* left, const void* right) {
 }
 
 
-UBool MessageFormat::DummyFormat::operator==(const Format&) const {
+bool MessageFormat::DummyFormat::operator==(const Format&) const {
     return TRUE;
 }
 

--- a/icu4c/source/i18n/nfrs.cpp
+++ b/icu4c/source/i18n/nfrs.cpp
@@ -344,7 +344,7 @@ util_equalRules(const NFRule* rule1, const NFRule* rule2)
     return FALSE;
 }
 
-UBool
+bool
 NFRuleSet::operator==(const NFRuleSet& rhs) const
 {
     if (rules.size() == rhs.rules.size() &&

--- a/icu4c/source/i18n/nfrs.h
+++ b/icu4c/source/i18n/nfrs.h
@@ -40,8 +40,8 @@ public:
 
     ~NFRuleSet();
 
-    UBool operator==(const NFRuleSet& rhs) const;
-    UBool operator!=(const NFRuleSet& rhs) const { return !operator==(rhs); }
+    bool operator==(const NFRuleSet& rhs) const;
+    bool operator!=(const NFRuleSet& rhs) const { return !operator==(rhs); }
 
     UBool isPublic() const { return fIsPublic; }
 

--- a/icu4c/source/i18n/nfrule.cpp
+++ b/icu4c/source/i18n/nfrule.cpp
@@ -631,7 +631,7 @@ util_equalSubstitutions(const NFSubstitution* sub1, const NFSubstitution* sub2)
 * @param that The rule to compare this one against
 * @return True is the two rules are functionally equivalent
 */
-UBool
+bool
 NFRule::operator==(const NFRule& rhs) const
 {
     return baseValue == rhs.baseValue

--- a/icu4c/source/i18n/nfrule.h
+++ b/icu4c/source/i18n/nfrule.h
@@ -54,8 +54,8 @@ public:
     NFRule(const RuleBasedNumberFormat* rbnf, const UnicodeString &ruleText, UErrorCode &status);
     ~NFRule();
 
-    UBool operator==(const NFRule& rhs) const;
-    UBool operator!=(const NFRule& rhs) const { return !operator==(rhs); }
+    bool operator==(const NFRule& rhs) const;
+    bool operator!=(const NFRule& rhs) const { return !operator==(rhs); }
 
     ERuleType getType() const { return (ERuleType)(baseValue <= kNoBase ? (ERuleType)baseValue : kOtherRule); }
     void setType(ERuleType ruleType) { baseValue = (int32_t)ruleType; }

--- a/icu4c/source/i18n/nfsubs.cpp
+++ b/icu4c/source/i18n/nfsubs.cpp
@@ -96,7 +96,7 @@ public:
         }
     }
 
-    virtual UBool operator==(const NFSubstitution& rhs) const;
+    virtual bool operator==(const NFSubstitution& rhs) const;
 
     virtual int64_t transformNumber(int64_t number) const {
         return number / divisor;
@@ -145,7 +145,7 @@ public:
         }
     }
 
-    virtual UBool operator==(const NFSubstitution& rhs) const;
+    virtual bool operator==(const NFSubstitution& rhs) const;
 
     virtual void doSubstitution(int64_t number, UnicodeString& toInsertInto, int32_t pos, int32_t recursionCount, UErrorCode& status) const;
     virtual void doSubstitution(double number, UnicodeString& toInsertInto, int32_t pos, int32_t recursionCount, UErrorCode& status) const;
@@ -213,7 +213,7 @@ public:
         UErrorCode& status);
     virtual ~FractionalPartSubstitution();
 
-    virtual UBool operator==(const NFSubstitution& rhs) const;
+    virtual bool operator==(const NFSubstitution& rhs) const;
 
     virtual void doSubstitution(double number, UnicodeString& toInsertInto, int32_t pos, int32_t recursionCount, UErrorCode& status) const;
     virtual void doSubstitution(int64_t /*number*/, UnicodeString& /*toInsertInto*/, int32_t /*_pos*/, int32_t /*recursionCount*/, UErrorCode& /*status*/) const {}
@@ -285,7 +285,7 @@ public:
     }
     virtual ~NumeratorSubstitution();
 
-    virtual UBool operator==(const NFSubstitution& rhs) const;
+    virtual bool operator==(const NFSubstitution& rhs) const;
 
     virtual int64_t transformNumber(int64_t number) const { return number * ldenominator; }
     virtual double transformNumber(double number) const { return uprv_round(number * denominator); }
@@ -515,7 +515,7 @@ UOBJECT_DEFINE_RTTI_IMPLEMENTATION(NFSubstitution)
  * @param The substitution to compare this one to
  * @return true if the two substitutions are functionally equivalent
  */
-UBool
+bool
 NFSubstitution::operator==(const NFSubstitution& rhs) const
 {
   // compare class and all of the fields all substitutions have
@@ -810,7 +810,7 @@ UOBJECT_DEFINE_RTTI_IMPLEMENTATION(SameValueSubstitution)
 
 UOBJECT_DEFINE_RTTI_IMPLEMENTATION(MultiplierSubstitution)
 
-UBool MultiplierSubstitution::operator==(const NFSubstitution& rhs) const
+bool MultiplierSubstitution::operator==(const NFSubstitution& rhs) const
 {
     return NFSubstitution::operator==(rhs) &&
         divisor == ((const MultiplierSubstitution*)&rhs)->divisor;
@@ -856,7 +856,7 @@ ModulusSubstitution::ModulusSubstitution(int32_t _pos,
 
 UOBJECT_DEFINE_RTTI_IMPLEMENTATION(ModulusSubstitution)
 
-UBool ModulusSubstitution::operator==(const NFSubstitution& rhs) const
+bool ModulusSubstitution::operator==(const NFSubstitution& rhs) const
 {
   return NFSubstitution::operator==(rhs) &&
   divisor == ((const ModulusSubstitution*)&rhs)->divisor &&
@@ -1195,7 +1195,7 @@ FractionalPartSubstitution::doParse(const UnicodeString& text,
     }
 }
 
-UBool
+bool
 FractionalPartSubstitution::operator==(const NFSubstitution& rhs) const
 {
   return NFSubstitution::operator==(rhs) &&
@@ -1327,7 +1327,7 @@ NumeratorSubstitution::doParse(const UnicodeString& text,
     return TRUE;
 }
 
-UBool
+bool
 NumeratorSubstitution::operator==(const NFSubstitution& rhs) const
 {
     return NFSubstitution::operator==(rhs) &&

--- a/icu4c/source/i18n/nfsubs.h
+++ b/icu4c/source/i18n/nfsubs.h
@@ -74,7 +74,7 @@ public:
      * @param rhs    the object to be compared with.
      * @return       true if the given Format objects are semantically equal.
      */
-    virtual UBool operator==(const NFSubstitution& rhs) const;
+    virtual bool operator==(const NFSubstitution& rhs) const;
 
     /**
      * Return true if the given Format objects are semantically unequal.
@@ -82,7 +82,7 @@ public:
      * @param rhs    the object to be compared with.
      * @return       true if the given Format objects are semantically unequal.
      */
-    UBool operator!=(const NFSubstitution& rhs) const { return !operator==(rhs); }
+    bool operator!=(const NFSubstitution& rhs) const { return !operator==(rhs); }
     
     /**
      * Sets the substitution's divisor.  Used by NFRule.setBaseValue().

--- a/icu4c/source/i18n/number_asformat.cpp
+++ b/icu4c/source/i18n/number_asformat.cpp
@@ -32,7 +32,7 @@ LocalizedNumberFormatterAsFormat::LocalizedNumberFormatterAsFormat(
 
 LocalizedNumberFormatterAsFormat::~LocalizedNumberFormatterAsFormat() = default;
 
-UBool LocalizedNumberFormatterAsFormat::operator==(const Format& other) const {
+bool LocalizedNumberFormatterAsFormat::operator==(const Format& other) const {
     auto* _other = dynamic_cast<const LocalizedNumberFormatterAsFormat*>(&other);
     if (_other == nullptr) {
         return false;

--- a/icu4c/source/i18n/number_asformat.h
+++ b/icu4c/source/i18n/number_asformat.h
@@ -39,7 +39,7 @@ class U_I18N_API LocalizedNumberFormatterAsFormat : public Format {
     /**
      * Equals operator.
      */
-    UBool operator==(const Format& other) const U_OVERRIDE;
+    bool operator==(const Format& other) const U_OVERRIDE;
 
     /**
      * Creates a copy of this object.

--- a/icu4c/source/i18n/numfmt.cpp
+++ b/icu4c/source/i18n/numfmt.cpp
@@ -285,7 +285,7 @@ NumberFormat::operator=(const NumberFormat& rhs)
 
 // -------------------------------------
 
-UBool
+bool
 NumberFormat::operator==(const Format& that) const
 {
     // Format::operator== guarantees this cast is safe

--- a/icu4c/source/i18n/olsontz.cpp
+++ b/icu4c/source/i18n/olsontz.cpp
@@ -311,7 +311,7 @@ OlsonTimeZone::~OlsonTimeZone() {
 /**
  * Returns true if the two TimeZone objects are equal.
  */
-UBool OlsonTimeZone::operator==(const TimeZone& other) const {
+bool OlsonTimeZone::operator==(const TimeZone& other) const {
     return ((this == &other) ||
             (typeid(*this) == typeid(other) &&
             TimeZone::operator==(other) &&

--- a/icu4c/source/i18n/olsontz.h
+++ b/icu4c/source/i18n/olsontz.h
@@ -146,7 +146,7 @@ class U_I18N_API OlsonTimeZone: public BasicTimeZone {
     /**
      * Returns true if the two TimeZone objects are equal.
      */
-    virtual UBool operator==(const TimeZone& other) const;
+    virtual bool operator==(const TimeZone& other) const;
 
     /**
      * TimeZone API.

--- a/icu4c/source/i18n/plurfmt.cpp
+++ b/icu4c/source/i18n/plurfmt.cpp
@@ -381,7 +381,7 @@ PluralFormat::operator=(const PluralFormat& other) {
     return *this;
 }
 
-UBool
+bool
 PluralFormat::operator==(const Format& other) const {
     if (this == &other) {
         return TRUE;
@@ -400,7 +400,7 @@ PluralFormat::operator==(const Format& other) const {
             *pluralRulesWrapper.pluralRules == *o.pluralRulesWrapper.pluralRules);
 }
 
-UBool
+bool
 PluralFormat::operator!=(const Format& other) const {
     return  !operator==(other);
 }

--- a/icu4c/source/i18n/plurrule.cpp
+++ b/icu4c/source/i18n/plurrule.cpp
@@ -547,7 +547,7 @@ PluralRules::getKeywordOther() const {
     return UnicodeString(TRUE, PLURAL_KEYWORD_OTHER, 5);
 }
 
-UBool
+bool
 PluralRules::operator==(const PluralRules& other) const  {
     const UnicodeString *ptrKeyword;
     UErrorCode status= U_ZERO_ERROR;

--- a/icu4c/source/i18n/rbnf.cpp
+++ b/icu4c/source/i18n/rbnf.cpp
@@ -99,8 +99,8 @@ public:
         return NULL;
     }
     
-    virtual UBool operator==(const LocalizationInfo* rhs) const;
-    inline  UBool operator!=(const LocalizationInfo* rhs) const { return !operator==(rhs); }
+    virtual bool operator==(const LocalizationInfo* rhs) const;
+    inline  bool operator!=(const LocalizationInfo* rhs) const { return !operator==(rhs); }
     
     virtual int32_t getNumberOfRuleSets(void) const = 0;
     virtual const UChar* getRuleSetName(int32_t index) const = 0;
@@ -131,7 +131,7 @@ streq(const UChar* lhs, const UChar* rhs) {
     return FALSE;
 }
 
-UBool
+bool
 LocalizationInfo::operator==(const LocalizationInfo* rhs) const {
     if (rhs) {
         if (this == rhs) {
@@ -936,7 +936,7 @@ RuleBasedNumberFormat::clone() const
     return new RuleBasedNumberFormat(*this);
 }
 
-UBool
+bool
 RuleBasedNumberFormat::operator==(const Format& other) const
 {
     if (this == &other) {

--- a/icu4c/source/i18n/rbtz.cpp
+++ b/icu4c/source/i18n/rbtz.cpp
@@ -88,7 +88,7 @@ RuleBasedTimeZone::operator=(const RuleBasedTimeZone& right) {
     return *this;
 }
 
-UBool
+bool
 RuleBasedTimeZone::operator==(const TimeZone& that) const {
     if (this == &that) {
         return TRUE;
@@ -108,7 +108,7 @@ RuleBasedTimeZone::operator==(const TimeZone& that) const {
     return FALSE;
 }
 
-UBool
+bool
 RuleBasedTimeZone::operator!=(const TimeZone& that) const {
     return !operator==(that);
 }

--- a/icu4c/source/i18n/region.cpp
+++ b/icu4c/source/i18n/region.cpp
@@ -449,7 +449,7 @@ Region::~Region () {
  * Returns true if the two regions are equal.
  * Per PMC, just use pointer compare, since we have at most one instance of each Region.
  */
-UBool
+bool
 Region::operator==(const Region &that) const {
     return (idStr == that.idStr);
 }
@@ -458,7 +458,7 @@ Region::operator==(const Region &that) const {
  * Returns true if the two regions are NOT equal; that is, if operator ==() returns false.
  * Per PMC, just use pointer compare, since we have at most one instance of each Region.
  */
-UBool
+bool
 Region::operator!=(const Region &that) const {
         return (idStr != that.idStr);
 }

--- a/icu4c/source/i18n/reldtfmt.cpp
+++ b/icu4c/source/i18n/reldtfmt.cpp
@@ -135,7 +135,7 @@ RelativeDateFormat* RelativeDateFormat::clone() const {
     return new RelativeDateFormat(*this);
 }
 
-UBool RelativeDateFormat::operator==(const Format& other) const {
+bool RelativeDateFormat::operator==(const Format& other) const {
     if(DateFormat::operator==(other)) {
         // The DateFormat::operator== check for fCapitalizationContext equality above
         //   is sufficient to check equality of all derived context-related data.

--- a/icu4c/source/i18n/reldtfmt.h
+++ b/icu4c/source/i18n/reldtfmt.h
@@ -80,7 +80,7 @@ public:
      * @return         true if the given Format objects are semantically equal.
      * @internal ICU 3.8
      */
-    virtual UBool operator==(const Format& other) const;
+    virtual bool operator==(const Format& other) const;
 
 
     using DateFormat::format;

--- a/icu4c/source/i18n/repattrn.cpp
+++ b/icu4c/source/i18n/repattrn.cpp
@@ -291,7 +291,7 @@ RegexPattern  *RegexPattern::clone() const {
 //                                 characters can still be considered different.
 //
 //--------------------------------------------------------------------------
-UBool   RegexPattern::operator ==(const RegexPattern &other) const {
+bool    RegexPattern::operator ==(const RegexPattern &other) const {
     if (this->fFlags == other.fFlags && this->fDeferredStatus == other.fDeferredStatus) {
         if (this->fPatternString != NULL && other.fPatternString != NULL) {
             return *(this->fPatternString) == *(other.fPatternString);

--- a/icu4c/source/i18n/rulebasedcollator.cpp
+++ b/icu4c/source/i18n/rulebasedcollator.cpp
@@ -239,7 +239,7 @@ RuleBasedCollator &RuleBasedCollator::operator=(const RuleBasedCollator &other) 
 
 UOBJECT_DEFINE_RTTI_IMPLEMENTATION(RuleBasedCollator)
 
-UBool
+bool
 RuleBasedCollator::operator==(const Collator& other) const {
     if(this == &other) { return TRUE; }
     if(!Collator::operator==(other)) { return FALSE; }

--- a/icu4c/source/i18n/scriptset.cpp
+++ b/icu4c/source/i18n/scriptset.cpp
@@ -44,7 +44,7 @@ ScriptSet & ScriptSet::operator =(const ScriptSet &other) {
     return *this;
 }
 
-UBool ScriptSet::operator == (const ScriptSet &other) const {
+bool ScriptSet::operator == (const ScriptSet &other) const {
     for (uint32_t i=0; i<UPRV_LENGTHOF(bits); i++) {
         if (bits[i] != other.bits[i]) {
             return FALSE;

--- a/icu4c/source/i18n/scriptset.h
+++ b/icu4c/source/i18n/scriptset.h
@@ -41,8 +41,8 @@ class U_I18N_API ScriptSet: public UMemory {
     ScriptSet(const ScriptSet &other);
     ~ScriptSet();
 
-    UBool operator == (const ScriptSet &other) const;
-    UBool operator != (const ScriptSet &other) const {return !(*this == other);}
+    bool operator == (const ScriptSet &other) const;
+    bool operator != (const ScriptSet &other) const {return !(*this == other);}
     ScriptSet & operator = (const ScriptSet &other);
 
     UBool      test(UScriptCode script, UErrorCode &status) const;

--- a/icu4c/source/i18n/search.cpp
+++ b/icu4c/source/i18n/search.cpp
@@ -178,7 +178,7 @@ const UnicodeString & SearchIterator::getText(void) const
 
 // operator overloading ----------------------------------------------
 
-UBool SearchIterator::operator==(const SearchIterator &that) const
+bool SearchIterator::operator==(const SearchIterator &that) const
 {
     if (this == &that) {
         return TRUE;

--- a/icu4c/source/i18n/selfmt.cpp
+++ b/icu4c/source/i18n/selfmt.cpp
@@ -164,7 +164,7 @@ SelectFormat::operator=(const SelectFormat& other) {
     return *this;
 }
 
-UBool
+bool
 SelectFormat::operator==(const Format& other) const {
     if (this == &other) {
         return TRUE;
@@ -176,7 +176,7 @@ SelectFormat::operator==(const Format& other) const {
     return msgPattern == o.msgPattern;
 }
 
-UBool
+bool
 SelectFormat::operator!=(const Format& other) const {
     return  !operator==(other);
 }

--- a/icu4c/source/i18n/simpletz.cpp
+++ b/icu4c/source/i18n/simpletz.cpp
@@ -231,7 +231,7 @@ SimpleTimeZone::operator=(const SimpleTimeZone &right)
 
 // -------------------------------------
 
-UBool
+bool
 SimpleTimeZone::operator==(const TimeZone& that) const
 {
     return ((this == &that) ||

--- a/icu4c/source/i18n/smpdtfmt.cpp
+++ b/icu4c/source/i18n/smpdtfmt.cpp
@@ -658,7 +658,7 @@ SimpleDateFormat::clone() const
 
 //----------------------------------------------------------------------
 
-UBool
+bool
 SimpleDateFormat::operator==(const Format& other) const
 {
     if (DateFormat::operator==(other)) {

--- a/icu4c/source/i18n/sortkey.cpp
+++ b/icu4c/source/i18n/sortkey.cpp
@@ -137,7 +137,7 @@ CollationKey::setToBogus()
     return *this;
 }
 
-UBool
+bool
 CollationKey::operator==(const CollationKey& source) const
 {
     return getLength() == source.getLength() &&

--- a/icu4c/source/i18n/stsearch.cpp
+++ b/icu4c/source/i18n/stsearch.cpp
@@ -205,7 +205,7 @@ StringSearch & StringSearch::operator=(const StringSearch &that)
     return *this;
 }
 
-UBool StringSearch::operator==(const SearchIterator &that) const
+bool StringSearch::operator==(const SearchIterator &that) const
 {
     if (this == &that) {
         return TRUE;

--- a/icu4c/source/i18n/timezone.cpp
+++ b/icu4c/source/i18n/timezone.cpp
@@ -376,7 +376,7 @@ TimeZone::operator=(const TimeZone &right)
 
 // -------------------------------------
 
-UBool
+bool
 TimeZone::operator==(const TimeZone& that) const
 {
     return typeid(*this) == typeid(that) &&

--- a/icu4c/source/i18n/tmutamt.cpp
+++ b/icu4c/source/i18n/tmutamt.cpp
@@ -45,7 +45,7 @@ TimeUnitAmount::operator=(const TimeUnitAmount& other) {
 }
 
 
-UBool
+bool
 TimeUnitAmount::operator==(const UObject& other) const {
     return Measure::operator==(other);
 }

--- a/icu4c/source/i18n/tzfmt.cpp
+++ b/icu4c/source/i18n/tzfmt.cpp
@@ -482,7 +482,7 @@ TimeZoneFormat::operator=(const TimeZoneFormat& other) {
 }
 
 
-UBool
+bool
 TimeZoneFormat::operator==(const Format& other) const {
     TimeZoneFormat* tzfmt = (TimeZoneFormat*)&other;
 

--- a/icu4c/source/i18n/tzgnames.cpp
+++ b/icu4c/source/i18n/tzgnames.cpp
@@ -1287,7 +1287,7 @@ TimeZoneGenericNames::createInstance(const Locale& locale, UErrorCode& status) {
     return instance;
 }
 
-UBool
+bool
 TimeZoneGenericNames::operator==(const TimeZoneGenericNames& other) const {
     // Just compare if the other object also use the same
     // ref entry

--- a/icu4c/source/i18n/tzgnames.h
+++ b/icu4c/source/i18n/tzgnames.h
@@ -45,8 +45,8 @@ public:
 
     static TimeZoneGenericNames* createInstance(const Locale& locale, UErrorCode& status);
 
-    virtual UBool operator==(const TimeZoneGenericNames& other) const;
-    virtual UBool operator!=(const TimeZoneGenericNames& other) const {return !operator==(other);}
+    virtual bool operator==(const TimeZoneGenericNames& other) const;
+    virtual bool operator!=(const TimeZoneGenericNames& other) const {return !operator==(other);}
     virtual TimeZoneGenericNames* clone() const;
 
     UnicodeString& getDisplayName(const TimeZone& tz, UTimeZoneGenericNameType type,

--- a/icu4c/source/i18n/tznames.cpp
+++ b/icu4c/source/i18n/tznames.cpp
@@ -104,8 +104,8 @@ public:
     TimeZoneNamesDelegate(const Locale& locale, UErrorCode& status);
     virtual ~TimeZoneNamesDelegate();
 
-    virtual UBool operator==(const TimeZoneNames& other) const;
-    virtual UBool operator!=(const TimeZoneNames& other) const {return !operator==(other);}
+    virtual bool operator==(const TimeZoneNames& other) const;
+    virtual bool operator!=(const TimeZoneNames& other) const {return !operator==(other);}
     virtual TimeZoneNamesDelegate* clone() const;
 
     StringEnumeration* getAvailableMetaZoneIDs(UErrorCode& status) const;
@@ -219,7 +219,7 @@ TimeZoneNamesDelegate::~TimeZoneNamesDelegate() {
     umtx_unlock(&gTimeZoneNamesLock);
 }
 
-UBool
+bool
 TimeZoneNamesDelegate::operator==(const TimeZoneNames& other) const {
     if (this == &other) {
         return TRUE;

--- a/icu4c/source/i18n/tznames_impl.cpp
+++ b/icu4c/source/i18n/tznames_impl.cpp
@@ -1104,7 +1104,7 @@ TimeZoneNamesImpl::cleanup() {
     }
 }
 
-UBool
+bool
 TimeZoneNamesImpl::operator==(const TimeZoneNames& other) const {
     if (this == &other) {
         return TRUE;
@@ -2156,7 +2156,7 @@ TZDBTimeZoneNames::TZDBTimeZoneNames(const Locale& locale)
 TZDBTimeZoneNames::~TZDBTimeZoneNames() {
 }
 
-UBool
+bool
 TZDBTimeZoneNames::operator==(const TimeZoneNames& other) const {
     if (this == &other) {
         return TRUE;

--- a/icu4c/source/i18n/tznames_impl.h
+++ b/icu4c/source/i18n/tznames_impl.h
@@ -173,7 +173,7 @@ public:
 
     virtual ~TimeZoneNamesImpl();
 
-    virtual UBool operator==(const TimeZoneNames& other) const;
+    virtual bool operator==(const TimeZoneNames& other) const;
     virtual TimeZoneNamesImpl* clone() const;
 
     StringEnumeration* getAvailableMetaZoneIDs(UErrorCode& status) const;
@@ -235,7 +235,7 @@ public:
     TZDBTimeZoneNames(const Locale& locale);
     virtual ~TZDBTimeZoneNames();
 
-    virtual UBool operator==(const TimeZoneNames& other) const;
+    virtual bool operator==(const TimeZoneNames& other) const;
     virtual TZDBTimeZoneNames* clone() const;
 
     StringEnumeration* getAvailableMetaZoneIDs(UErrorCode& status) const;

--- a/icu4c/source/i18n/tzrule.cpp
+++ b/icu4c/source/i18n/tzrule.cpp
@@ -53,7 +53,7 @@ TimeZoneRule::operator=(const TimeZoneRule& right) {
     return *this;
 }
 
-UBool
+bool
 TimeZoneRule::operator==(const TimeZoneRule& that) const {
     return ((this == &that) ||
             (typeid(*this) == typeid(that) &&
@@ -62,7 +62,7 @@ TimeZoneRule::operator==(const TimeZoneRule& that) const {
             fDSTSavings == that.fDSTSavings));
 }
 
-UBool
+bool
 TimeZoneRule::operator!=(const TimeZoneRule& that) const {
     return !operator==(that);
 }
@@ -120,14 +120,14 @@ InitialTimeZoneRule::operator=(const InitialTimeZoneRule& right) {
     return *this;
 }
 
-UBool
+bool
 InitialTimeZoneRule::operator==(const TimeZoneRule& that) const {
     return ((this == &that) ||
             (typeid(*this) == typeid(that) &&
             TimeZoneRule::operator==(that)));
 }
 
-UBool
+bool
 InitialTimeZoneRule::operator!=(const TimeZoneRule& that) const {
     return !operator==(that);
 }
@@ -226,7 +226,7 @@ AnnualTimeZoneRule::operator=(const AnnualTimeZoneRule& right) {
     return *this;
 }
 
-UBool
+bool
 AnnualTimeZoneRule::operator==(const TimeZoneRule& that) const {
     if (this == &that) {
         return TRUE;
@@ -240,7 +240,7 @@ AnnualTimeZoneRule::operator==(const TimeZoneRule& that) const {
             fEndYear == atzr->fEndYear);
 }
 
-UBool
+bool
 AnnualTimeZoneRule::operator!=(const TimeZoneRule& that) const {
     return !operator==(that);
 }
@@ -445,7 +445,7 @@ TimeArrayTimeZoneRule::operator=(const TimeArrayTimeZoneRule& right) {
     return *this;
 }
 
-UBool
+bool
 TimeArrayTimeZoneRule::operator==(const TimeZoneRule& that) const {
     if (this == &that) {
         return TRUE;
@@ -469,7 +469,7 @@ TimeArrayTimeZoneRule::operator==(const TimeZoneRule& that) const {
     return res;
 }
 
-UBool
+bool
 TimeArrayTimeZoneRule::operator!=(const TimeZoneRule& that) const {
     return !operator==(that);
 }

--- a/icu4c/source/i18n/tztrans.cpp
+++ b/icu4c/source/i18n/tztrans.cpp
@@ -63,7 +63,7 @@ TimeZoneTransition::operator=(const TimeZoneTransition& right) {
     return *this;
 }
 
-UBool
+bool
 TimeZoneTransition::operator==(const TimeZoneTransition& that) const {
     if (this == &that) {
         return TRUE;
@@ -84,7 +84,7 @@ TimeZoneTransition::operator==(const TimeZoneTransition& that) const {
     return FALSE;
 }
 
-UBool
+bool
 TimeZoneTransition::operator!=(const TimeZoneTransition& that) const {
     return !operator==(that);
 }

--- a/icu4c/source/i18n/unicode/alphaindex.h
+++ b/icu4c/source/i18n/unicode/alphaindex.h
@@ -660,13 +660,13 @@ private:
      * No Equality operators.
      * @internal
      */
-     virtual UBool operator==(const AlphabeticIndex& other) const;
+     virtual bool operator==(const AlphabeticIndex& other) const;
 
     /**
      * Inequality operator.
      * @internal
      */
-     virtual UBool operator!=(const AlphabeticIndex& other) const;
+     virtual bool operator!=(const AlphabeticIndex& other) const;
 
      // Common initialization, for use from all constructors.
      void init(const Locale *locale, UErrorCode &status);

--- a/icu4c/source/i18n/unicode/calendar.h
+++ b/icu4c/source/i18n/unicode/calendar.h
@@ -449,21 +449,21 @@ public:
      * represented time, use equals() instead.
      *
      * @param that  The Calendar object to be compared with.
-     * @return      True if the given Calendar is the same as this Calendar; false
+     * @return      true if the given Calendar is the same as this Calendar; false
      *              otherwise.
      * @stable ICU 2.0
      */
-    virtual UBool operator==(const Calendar& that) const;
+    virtual bool operator==(const Calendar& that) const;
 
     /**
      * Compares the inequality of two Calendar objects.
      *
      * @param that  The Calendar object to be compared with.
-     * @return      True if the given Calendar is not the same as this Calendar; false
+     * @return      true if the given Calendar is not the same as this Calendar; false
      *              otherwise.
      * @stable ICU 2.0
      */
-    UBool operator!=(const Calendar& that) const {return !operator==(that);}
+    bool operator!=(const Calendar& that) const {return !operator==(that);}
 
     /**
      * Returns true if the given Calendar object is equivalent to this

--- a/icu4c/source/i18n/unicode/choicfmt.h
+++ b/icu4c/source/i18n/unicode/choicfmt.h
@@ -261,7 +261,7 @@ public:
      * @return         true if other is the same as this.
      * @deprecated ICU 49 Use MessageFormat instead, with plural and select arguments.
      */
-    virtual UBool operator==(const Format& other) const;
+    virtual bool operator==(const Format& other) const;
 
     /**
      * Sets the pattern.

--- a/icu4c/source/i18n/unicode/coleitr.h
+++ b/icu4c/source/i18n/unicode/coleitr.h
@@ -156,7 +156,7 @@ public:
     * @return         true if "other" is the same as "this"
     * @stable ICU 2.0
     */
-    UBool operator==(const CollationElementIterator& other) const;
+    bool operator==(const CollationElementIterator& other) const;
 
     /**
     * Returns true if "other" is not the same as "this".
@@ -165,7 +165,7 @@ public:
     * @return         true if "other" is not the same as "this"
     * @stable ICU 2.0
     */
-    UBool operator!=(const CollationElementIterator& other) const;
+    bool operator!=(const CollationElementIterator& other) const;
 
     /**
     * Resets the cursor to the beginning of the string.

--- a/icu4c/source/i18n/unicode/coll.h
+++ b/icu4c/source/i18n/unicode/coll.h
@@ -253,7 +253,7 @@ public:
      * @return true if other is the same as this.
      * @stable ICU 2.0
      */
-    virtual UBool operator==(const Collator& other) const;
+    virtual bool operator==(const Collator& other) const;
 
     /**
      * Returns true if "other" is not the same as "this".
@@ -262,7 +262,7 @@ public:
      * @return true if other is not the same as this.
      * @stable ICU 2.0
      */
-    virtual UBool operator!=(const Collator& other) const;
+    virtual bool operator!=(const Collator& other) const;
 
     /**
      * Makes a copy of this object.

--- a/icu4c/source/i18n/unicode/currpinf.h
+++ b/icu4c/source/i18n/unicode/currpinf.h
@@ -92,7 +92,7 @@ public:
      *
      * @stable ICU 4.2
      */
-    UBool operator==(const CurrencyPluralInfo& info) const;
+    bool operator==(const CurrencyPluralInfo& info) const;
 
 
     /**
@@ -100,7 +100,7 @@ public:
      *
      * @stable ICU 4.2
      */
-    UBool operator!=(const CurrencyPluralInfo& info) const;
+    bool operator!=(const CurrencyPluralInfo& info) const;
 
 
     /**
@@ -259,7 +259,7 @@ private:
 };
 
 
-inline UBool
+inline bool
 CurrencyPluralInfo::operator!=(const CurrencyPluralInfo& info) const {
     return !operator==(info);
 }  

--- a/icu4c/source/i18n/unicode/datefmt.h
+++ b/icu4c/source/i18n/unicode/datefmt.h
@@ -235,7 +235,7 @@ public:
      * Equality operator.  Returns true if the two formats have the same behavior.
      * @stable ICU 2.0
      */
-    virtual UBool operator==(const Format&) const;
+    virtual bool operator==(const Format&) const;
 
 
     using Format::format;

--- a/icu4c/source/i18n/unicode/dcfmtsym.h
+++ b/icu4c/source/i18n/unicode/dcfmtsym.h
@@ -255,7 +255,7 @@ public:
      * @return         true if another object is semantically equal to this one.
      * @stable ICU 2.0
      */
-    UBool operator==(const DecimalFormatSymbols& other) const;
+    bool operator==(const DecimalFormatSymbols& other) const;
 
     /**
      * Return true if another object is semantically unequal to this one.
@@ -264,7 +264,7 @@ public:
      * @return         true if another object is semantically unequal to this one.
      * @stable ICU 2.0
      */
-    UBool operator!=(const DecimalFormatSymbols& other) const { return !operator==(other); }
+    bool operator!=(const DecimalFormatSymbols& other) const { return !operator==(other); }
 
     /**
      * Get one of the format symbols by its enum constant.

--- a/icu4c/source/i18n/unicode/decimfmt.h
+++ b/icu4c/source/i18n/unicode/decimfmt.h
@@ -909,7 +909,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * @return         true if the given Format objects are semantically equal.
      * @stable ICU 2.0
      */
-    UBool operator==(const Format& other) const U_OVERRIDE;
+    bool operator==(const Format& other) const U_OVERRIDE;
 
 
     using NumberFormat::format;

--- a/icu4c/source/i18n/unicode/dtfmtsym.h
+++ b/icu4c/source/i18n/unicode/dtfmtsym.h
@@ -174,7 +174,7 @@ public:
      * @return         true if other is semantically equal to this.
      * @stable ICU 2.0
      */
-    UBool operator==(const DateFormatSymbols& other) const;
+    bool operator==(const DateFormatSymbols& other) const;
 
     /**
      * Return true if another object is semantically unequal to this one.
@@ -183,7 +183,7 @@ public:
      * @return         true if other is semantically unequal to this.
      * @stable ICU 2.0
      */
-    UBool operator!=(const DateFormatSymbols& other) const { return !operator==(other); }
+    bool operator!=(const DateFormatSymbols& other) const { return !operator==(other); }
 
     /**
      * Gets abbreviated era strings. For example: "AD" and "BC".

--- a/icu4c/source/i18n/unicode/dtitvfmt.h
+++ b/icu4c/source/i18n/unicode/dtitvfmt.h
@@ -443,7 +443,7 @@ public:
      * @return         true if the given Format objects are semantically equal.
      * @stable ICU 4.0
      */
-    virtual UBool operator==(const Format& other) const;
+    virtual bool operator==(const Format& other) const;
 
     /**
      * Return true if the given Format objects are not semantically equal.
@@ -452,7 +452,7 @@ public:
      * @return      true if the given Format objects are not semantically equal.
      * @stable ICU 4.0
      */
-    UBool operator!=(const Format& other) const;
+    bool operator!=(const Format& other) const;
 
 
     using Format::format;
@@ -1197,7 +1197,7 @@ private:
     UDisplayContext fCapitalizationContext;
 };
 
-inline UBool
+inline bool
 DateIntervalFormat::operator!=(const Format& other) const  {
     return !operator==(other);
 }

--- a/icu4c/source/i18n/unicode/dtitvinf.h
+++ b/icu4c/source/i18n/unicode/dtitvinf.h
@@ -214,7 +214,7 @@ public:
      * @return         true if other is semantically equal to this.
      * @stable ICU 4.0
      */
-    virtual UBool operator==(const DateIntervalInfo& other) const;
+    virtual bool operator==(const DateIntervalInfo& other) const;
 
     /**
      * Return true if another object is semantically unequal to this one.
@@ -223,7 +223,7 @@ public:
      * @return         true if other is semantically unequal to this.
      * @stable ICU 4.0
      */
-    UBool operator!=(const DateIntervalInfo& other) const;
+    bool operator!=(const DateIntervalInfo& other) const;
 
 
 
@@ -508,7 +508,7 @@ private:
 };// end class DateIntervalInfo
 
 
-inline UBool
+inline bool
 DateIntervalInfo::operator!=(const DateIntervalInfo& other) const {
     return !operator==(other);
 }

--- a/icu4c/source/i18n/unicode/dtptngen.h
+++ b/icu4c/source/i18n/unicode/dtptngen.h
@@ -120,7 +120,7 @@ public:
       * @return         true if other is semantically equal to this.
       * @stable ICU 3.8
       */
-    UBool operator==(const DateTimePatternGenerator& other) const;
+    bool operator==(const DateTimePatternGenerator& other) const;
 
     /**
      * Return true if another object is semantically unequal to this one.
@@ -129,7 +129,7 @@ public:
      * @return         true if other is semantically unequal to this.
      * @stable ICU 3.8
      */
-    UBool operator!=(const DateTimePatternGenerator& other) const;
+    bool operator!=(const DateTimePatternGenerator& other) const;
 
     /**
      * Utility to return a unique skeleton from a given pattern. For example,

--- a/icu4c/source/i18n/unicode/dtrule.h
+++ b/icu4c/source/i18n/unicode/dtrule.h
@@ -144,7 +144,7 @@ public:
      * @return  true if the given DateTimeRule objects are semantically equal.
      * @stable ICU 3.8
      */
-    UBool operator==(const DateTimeRule& that) const;
+    bool operator==(const DateTimeRule& that) const;
 
     /**
      * Return true if the given DateTimeRule objects are semantically unequal. Objects
@@ -153,7 +153,7 @@ public:
      * @return  true if the given DateTimeRule objects are semantically unequal.
      * @stable ICU 3.8
      */
-    UBool operator!=(const DateTimeRule& that) const;
+    bool operator!=(const DateTimeRule& that) const;
 
     /**
      * Gets the date rule type, such as <code>DOM</code>

--- a/icu4c/source/i18n/unicode/fieldpos.h
+++ b/icu4c/source/i18n/unicode/fieldpos.h
@@ -164,7 +164,7 @@ public:
      * @return        true if the two field positions are equal, false otherwise.
      * @stable ICU 2.0
      */
-    UBool              operator==(const FieldPosition& that) const;
+    bool               operator==(const FieldPosition& that) const;
 
     /** 
      * Equality operator.
@@ -172,7 +172,7 @@ public:
      * @return        true if the two field positions are not equal, false otherwise.
      * @stable ICU 2.0
      */
-    UBool              operator!=(const FieldPosition& that) const;
+    bool               operator!=(const FieldPosition& that) const;
 
     /**
      * Clone this object.
@@ -274,7 +274,7 @@ FieldPosition::operator=(const FieldPosition& copy)
     return *this;
 }
 
-inline UBool
+inline bool
 FieldPosition::operator==(const FieldPosition& copy) const
 {
     return (fField == copy.fField &&
@@ -282,7 +282,7 @@ FieldPosition::operator==(const FieldPosition& copy) const
         fBeginIndex == copy.fBeginIndex);
 }
 
-inline UBool
+inline bool
 FieldPosition::operator!=(const FieldPosition& copy) const
 {
     return !operator==(copy);

--- a/icu4c/source/i18n/unicode/fmtable.h
+++ b/icu4c/source/i18n/unicode/fmtable.h
@@ -182,7 +182,7 @@ public:
      * @return        true if other are equal to this, false otherwise.
      * @stable ICU 2.0
      */
-    UBool          operator==(const Formattable &other) const;
+    bool           operator==(const Formattable &other) const;
 
     /**
      * Equality operator.
@@ -190,7 +190,7 @@ public:
      * @return        true if other are unequal to this, false otherwise.
      * @stable ICU 2.0
      */
-    UBool          operator!=(const Formattable& other) const
+    bool           operator!=(const Formattable& other) const
       { return !operator==(other); }
 
     /**

--- a/icu4c/source/i18n/unicode/format.h
+++ b/icu4c/source/i18n/unicode/format.h
@@ -111,7 +111,7 @@ public:
      *                 Objects of different subclasses are considered unequal.
      * @stable ICU 2.0
      */
-    virtual UBool operator==(const Format& other) const = 0;
+    virtual bool operator==(const Format& other) const = 0;
 
     /**
      * Return true if the given Format objects are not semantically
@@ -120,7 +120,7 @@ public:
      * @return         Return true if the given Format objects are not semantically.
      * @stable ICU 2.0
      */
-    UBool operator!=(const Format& other) const { return !operator==(other); }
+    bool operator!=(const Format& other) const { return !operator==(other); }
 
     /**
      * Clone this object polymorphically.  The caller is responsible

--- a/icu4c/source/i18n/unicode/fpositer.h
+++ b/icu4c/source/i18n/unicode/fpositer.h
@@ -84,7 +84,7 @@ public:
      * equal array of run values.
      * @stable ICU 4.4
      */
-    UBool operator==(const FieldPositionIterator&) const;
+    bool operator==(const FieldPositionIterator&) const;
 
     /**
      * Returns the complement of the result of operator==
@@ -92,7 +92,7 @@ public:
      * @return the complement of the result of operator==
      * @stable ICU 4.4
      */
-    UBool operator!=(const FieldPositionIterator& rhs) const { return !operator==(rhs); }
+    bool operator!=(const FieldPositionIterator& rhs) const { return !operator==(rhs); }
 
     /**
      * If the current position is valid, updates the FieldPosition values, advances the iterator,

--- a/icu4c/source/i18n/unicode/measfmt.h
+++ b/icu4c/source/i18n/unicode/measfmt.h
@@ -148,7 +148,7 @@ class U_I18N_API MeasureFormat : public Format {
      * Return true if given Format objects are semantically equal.
      * @stable ICU 53
      */
-    virtual UBool operator==(const Format &other) const;
+    virtual bool operator==(const Format &other) const;
 
     /**
      * Clones this object polymorphically.

--- a/icu4c/source/i18n/unicode/measunit.h
+++ b/icu4c/source/i18n/unicode/measunit.h
@@ -433,14 +433,14 @@ class U_I18N_API MeasureUnit: public UObject {
      * to the given object.
      * @stable ICU 3.0
      */
-    virtual UBool operator==(const UObject& other) const;
+    virtual bool operator==(const UObject& other) const;
 
     /**
      * Inequality operator.  Return true if this object is not equal
      * to the given object.
      * @stable ICU 53
      */
-    UBool operator!=(const UObject& other) const {
+    bool operator!=(const UObject& other) const {
         return !(*this == other);
     }
 

--- a/icu4c/source/i18n/unicode/measure.h
+++ b/icu4c/source/i18n/unicode/measure.h
@@ -87,7 +87,7 @@ class U_I18N_API Measure: public UObject {
      * to the given object.
      * @stable ICU 3.0
      */
-    UBool operator==(const UObject& other) const;
+    bool operator==(const UObject& other) const;
 
     /**
      * Return a reference to the numeric value of this object.  The

--- a/icu4c/source/i18n/unicode/msgfmt.h
+++ b/icu4c/source/i18n/unicode/msgfmt.h
@@ -429,7 +429,7 @@ public:
      * @return       true if the given Format objects are semantically equal.
      * @stable ICU 2.0
      */
-    virtual UBool operator==(const Format& other) const;
+    virtual bool operator==(const Format& other) const;
 
     /**
      * Sets the locale to be used for creating argument Format objects.
@@ -1088,7 +1088,7 @@ private:
      */
     class U_I18N_API DummyFormat : public Format {
     public:
-        virtual UBool operator==(const Format&) const;
+        virtual bool operator==(const Format&) const;
         virtual DummyFormat* clone() const;
         virtual UnicodeString& format(const Formattable& obj,
                               UnicodeString& appendTo,

--- a/icu4c/source/i18n/unicode/numfmt.h
+++ b/icu4c/source/i18n/unicode/numfmt.h
@@ -274,7 +274,7 @@ public:
      * @return    true if the given Format objects are semantically equal.
      * @stable ICU 2.0
      */
-    virtual UBool operator==(const Format& other) const;
+    virtual bool operator==(const Format& other) const;
 
 
     using Format::format;

--- a/icu4c/source/i18n/unicode/plurfmt.h
+++ b/icu4c/source/i18n/unicode/plurfmt.h
@@ -434,7 +434,7 @@ public:
       * @return         true if other is semantically equal to this.
       * @stable ICU 4.0
       */
-    virtual UBool operator==(const Format& other) const;
+    virtual bool operator==(const Format& other) const;
 
     /**
      * Return true if another object is semantically unequal to this one.
@@ -443,7 +443,7 @@ public:
      * @return         true if other is semantically unequal to this.
      * @stable ICU 4.0
      */
-    virtual UBool operator!=(const Format& other) const;
+    virtual bool operator!=(const Format& other) const;
 
     /**
      * Clones this Format object polymorphically.  The caller owns the

--- a/icu4c/source/i18n/unicode/plurrule.h
+++ b/icu4c/source/i18n/unicode/plurrule.h
@@ -532,21 +532,21 @@ public:
      * Compares the equality of two PluralRules objects.
      *
      * @param other The other PluralRules object to be compared with.
-     * @return      True if the given PluralRules is the same as this
+     * @return      true if the given PluralRules is the same as this
      *              PluralRules; false otherwise.
      * @stable ICU 4.0
      */
-    virtual UBool operator==(const PluralRules& other) const;
+    virtual bool operator==(const PluralRules& other) const;
 
     /**
      * Compares the inequality of two PluralRules objects.
      *
      * @param other The PluralRules object to be compared with.
-     * @return      True if the given PluralRules is not the same as this
+     * @return      true if the given PluralRules is not the same as this
      *              PluralRules; false otherwise.
      * @stable ICU 4.0
      */
-    UBool operator!=(const PluralRules& other) const  {return !operator==(other);}
+    bool operator!=(const PluralRules& other) const  {return !operator==(other);}
 
 
     /**

--- a/icu4c/source/i18n/unicode/rbnf.h
+++ b/icu4c/source/i18n/unicode/rbnf.h
@@ -707,7 +707,7 @@ public:
    * @return        true if the given Format objects are semantically equal.
    * @stable ICU 2.6
    */
-  virtual UBool operator==(const Format& other) const;
+  virtual bool operator==(const Format& other) const;
 
 //-----------------------------------------------------------------------
 // public API functions

--- a/icu4c/source/i18n/unicode/rbtz.h
+++ b/icu4c/source/i18n/unicode/rbtz.h
@@ -76,7 +76,7 @@ public:
       *semantically equal.
      * @stable ICU 3.8
      */
-    virtual UBool operator==(const TimeZone& that) const;
+    virtual bool operator==(const TimeZone& that) const;
 
     /**
      * Return true if the given <code>TimeZone</code> objects are
@@ -86,7 +86,7 @@ public:
      * semantically unequal.
      * @stable ICU 3.8
      */
-    virtual UBool operator!=(const TimeZone& that) const;
+    virtual bool operator!=(const TimeZone& that) const;
 
     /**
      * Adds the <code>TimeZoneRule</code> which represents time transitions.

--- a/icu4c/source/i18n/unicode/regex.h
+++ b/icu4c/source/i18n/unicode/regex.h
@@ -119,7 +119,7 @@ public:
      * @return true if the objects are equivalent.
      * @stable ICU 2.4
      */
-    UBool           operator==(const RegexPattern& that) const;
+    bool            operator==(const RegexPattern& that) const;
 
     /**
      * Comparison operator.  Two RegexPattern objects are considered equal if they
@@ -129,7 +129,7 @@ public:
      * @return true if the objects are different.
      * @stable ICU 2.4
      */
-    inline UBool    operator!=(const RegexPattern& that) const {return ! operator ==(that);}
+    inline bool     operator!=(const RegexPattern& that) const {return ! operator ==(that);}
 
     /**
      * Assignment operator.  After assignment, this RegexPattern will behave identically

--- a/icu4c/source/i18n/unicode/region.h
+++ b/icu4c/source/i18n/unicode/region.h
@@ -81,13 +81,13 @@ public:
      * Returns true if the two regions are equal.
      * @stable ICU 51
      */
-    UBool operator==(const Region &that) const;
+    bool operator==(const Region &that) const;
 
     /**
      * Returns true if the two regions are NOT equal; that is, if operator ==() returns false.
      * @stable ICU 51
      */
-    UBool operator!=(const Region &that) const;
+    bool operator!=(const Region &that) const;
  
     /**
      * Returns a pointer to a Region using the given region code.  The region code can be either 2-letter ISO code,

--- a/icu4c/source/i18n/unicode/search.h
+++ b/icu4c/source/i18n/unicode/search.h
@@ -272,7 +272,7 @@ public:
      *         attributes. false otherwise.
      * @stable ICU 2.0
      */
-    virtual UBool operator==(const SearchIterator &that) const;
+    virtual bool operator==(const SearchIterator &that) const;
 
     /**
      * Not-equal operator. 
@@ -280,7 +280,7 @@ public:
      * @return false if operator== returns true, and vice versa.
      * @stable ICU 2.0
      */
-    UBool operator!=(const SearchIterator &that) const;
+    bool operator!=(const SearchIterator &that) const;
 
     // public methods ----------------------------------------------------
 
@@ -566,7 +566,7 @@ protected:
     void setMatchNotFound();
 };
 
-inline UBool SearchIterator::operator!=(const SearchIterator &that) const
+inline bool SearchIterator::operator!=(const SearchIterator &that) const
 {
    return !operator==(that); 
 }

--- a/icu4c/source/i18n/unicode/selfmt.h
+++ b/icu4c/source/i18n/unicode/selfmt.h
@@ -259,7 +259,7 @@ public:
      * @return         true if other is semantically equal to this.
      * @stable ICU 4.4
      */
-    virtual UBool operator==(const Format& other) const;
+    virtual bool operator==(const Format& other) const;
 
     /**
      * Return true if another object is semantically unequal to this one.
@@ -268,7 +268,7 @@ public:
      * @return         true if other is semantically unequal to this.
      * @stable ICU 4.4
      */
-    virtual UBool operator!=(const Format& other) const;
+    virtual bool operator!=(const Format& other) const;
 
     /**
      * Clones this Format object polymorphically.  The caller owns the

--- a/icu4c/source/i18n/unicode/simpletz.h
+++ b/icu4c/source/i18n/unicode/simpletz.h
@@ -107,11 +107,11 @@ public:
      * the same ID, raw GMT offset, and DST rules.
      *
      * @param that  The SimpleTimeZone object to be compared with.
-     * @return      True if the given time zone is equal to this time zone; false
+     * @return      true if the given time zone is equal to this time zone; false
      *              otherwise.
      * @stable ICU 2.0
      */
-    virtual UBool operator==(const TimeZone& that) const;
+    virtual bool operator==(const TimeZone& that) const;
 
     /**
      * Constructs a SimpleTimeZone with the given raw GMT offset and time zone ID,

--- a/icu4c/source/i18n/unicode/smpdtfmt.h
+++ b/icu4c/source/i18n/unicode/smpdtfmt.h
@@ -876,7 +876,7 @@ public:
      * @return         true if the given Format objects are semantically equal.
      * @stable ICU 2.0
      */
-    virtual UBool operator==(const Format& other) const;
+    virtual bool operator==(const Format& other) const;
 
 
     using DateFormat::format;

--- a/icu4c/source/i18n/unicode/sortkey.h
+++ b/icu4c/source/i18n/unicode/sortkey.h
@@ -145,7 +145,7 @@ public:
     * @return Returns true if two collation keys are equal, false otherwise.
     * @stable ICU 2.0
     */
-    UBool                   operator==(const CollationKey& source) const;
+    bool                    operator==(const CollationKey& source) const;
 
     /**
     * Compare if two collation keys are not the same.
@@ -153,7 +153,7 @@ public:
     * @return Returns true if two collation keys are different, false otherwise.
     * @stable ICU 2.0
     */
-    UBool                   operator!=(const CollationKey& source) const;
+    bool                    operator!=(const CollationKey& source) const;
 
 
     /**
@@ -316,7 +316,7 @@ private:
     } fUnion;
 };
 
-inline UBool
+inline bool
 CollationKey::operator!=(const CollationKey& other) const
 {
     return !(*this == other);

--- a/icu4c/source/i18n/unicode/stsearch.h
+++ b/icu4c/source/i18n/unicode/stsearch.h
@@ -297,7 +297,7 @@ public:
      *         while looking for the same pattern.
      * @stable ICU 2.0
      */
-    virtual UBool operator==(const SearchIterator &that) const;
+    virtual bool operator==(const SearchIterator &that) const;
 
     // public get and set methods ----------------------------------------
 

--- a/icu4c/source/i18n/unicode/tblcoll.h
+++ b/icu4c/source/i18n/unicode/tblcoll.h
@@ -223,7 +223,7 @@ public:
      * @return true if arguments is the same as this object.
      * @stable ICU 2.0
      */
-    virtual UBool operator==(const Collator& other) const;
+    virtual bool operator==(const Collator& other) const;
 
     /**
      * Makes a copy of this object.

--- a/icu4c/source/i18n/unicode/timezone.h
+++ b/icu4c/source/i18n/unicode/timezone.h
@@ -454,22 +454,22 @@ public:
      * IDs, but subclasses are expected to also compare the fields they add.)
      *
      * @param that  The TimeZone object to be compared with.
-     * @return      True if the given TimeZone is equal to this TimeZone; false
+     * @return      true if the given TimeZone is equal to this TimeZone; false
      *              otherwise.
      * @stable ICU 2.0
      */
-    virtual UBool operator==(const TimeZone& that) const;
+    virtual bool operator==(const TimeZone& that) const;
 
     /**
      * Returns true if the two TimeZones are NOT equal; that is, if operator==() returns
      * false.
      *
      * @param that  The TimeZone object to be compared with.
-     * @return      True if the given TimeZone is not equal to this TimeZone; false
+     * @return      true if the given TimeZone is not equal to this TimeZone; false
      *              otherwise.
      * @stable ICU 2.0
      */
-    UBool operator!=(const TimeZone& that) const {return !operator==(that);}
+    bool operator!=(const TimeZone& that) const {return !operator==(that);}
 
     /**
      * Returns the TimeZone's adjusted GMT offset (i.e., the number of milliseconds to add

--- a/icu4c/source/i18n/unicode/tmutamt.h
+++ b/icu4c/source/i18n/unicode/tmutamt.h
@@ -103,7 +103,7 @@ public:
      * @return       true if this object is equal to the given object.
      * @stable ICU 4.2
      */
-    virtual UBool operator==(const UObject& other) const;
+    virtual bool operator==(const UObject& other) const;
 
 
     /** 
@@ -112,7 +112,7 @@ public:
      * @return       true if this object is not equal to the given object.
      * @stable ICU 4.2
      */
-    UBool operator!=(const UObject& other) const;
+    bool operator!=(const UObject& other) const;
 
 
     /**
@@ -160,7 +160,7 @@ public:
 
 
 
-inline UBool 
+inline bool
 TimeUnitAmount::operator!=(const UObject& other) const {
     return !operator==(other);
 }

--- a/icu4c/source/i18n/unicode/tmutfmt.h
+++ b/icu4c/source/i18n/unicode/tmutfmt.h
@@ -141,7 +141,7 @@ public:
      * @return      true if the given Format objects are not semantically equal.
      * @deprecated ICU 53
      */
-    UBool operator!=(const Format& other) const;
+    bool operator!=(const Format& other) const;
 
     /**
      * Set the locale used for formatting or parsing.
@@ -236,7 +236,7 @@ private:
     friend struct TimeUnitFormatReadSink;
 };
 
-inline UBool
+inline bool
 TimeUnitFormat::operator!=(const Format& other) const  {
     return !operator==(other);
 }

--- a/icu4c/source/i18n/unicode/tmutfmt.h
+++ b/icu4c/source/i18n/unicode/tmutfmt.h
@@ -143,6 +143,14 @@ public:
      */
     bool operator!=(const Format& other) const;
 
+#if defined(__cpp_impl_three_way_comparison) && \
+       __cpp_impl_three_way_comparison >= 201711
+    // Manually resolve C++20 reversed argument order ambiguity.
+    inline bool operator!=(const TimeUnitFormat& other) const {
+        return operator!=(static_cast<const Format&>(other));
+    }
+#endif
+
     /**
      * Set the locale used for formatting or parsing.
      * @param locale  the locale to be set

--- a/icu4c/source/i18n/unicode/tzfmt.h
+++ b/icu4c/source/i18n/unicode/tzfmt.h
@@ -299,7 +299,7 @@ public:
      *                Objects of different subclasses are considered unequal.
      * @stable ICU 50
      */
-    virtual UBool operator==(const Format& other) const;
+    virtual bool operator==(const Format& other) const;
 
     /**
      * Clone this object polymorphically. The caller is responsible

--- a/icu4c/source/i18n/unicode/tznames.h
+++ b/icu4c/source/i18n/unicode/tznames.h
@@ -142,7 +142,7 @@ public:
      * @return Return true if the given Format objects are semantically equal.
      * @stable ICU 50
      */
-    virtual UBool operator==(const TimeZoneNames& other) const = 0;
+    virtual bool operator==(const TimeZoneNames& other) const = 0;
 
     /**
      * Return true if the given TimeZoneNames objects are not semantically
@@ -151,7 +151,7 @@ public:
      * @return Return true if the given Format objects are not semantically equal.
      * @stable ICU 50
      */
-    UBool operator!=(const TimeZoneNames& other) const { return !operator==(other); }
+    bool operator!=(const TimeZoneNames& other) const { return !operator==(other); }
 
     /**
      * Clone this object polymorphically.  The caller is responsible

--- a/icu4c/source/i18n/unicode/tzrule.h
+++ b/icu4c/source/i18n/unicode/tzrule.h
@@ -56,7 +56,7 @@ public:
      * @return  true if the given <code>TimeZoneRule</code> objects are semantically equal.
      * @stable ICU 3.8
      */
-    virtual UBool operator==(const TimeZoneRule& that) const;
+    virtual bool operator==(const TimeZoneRule& that) const;
 
     /**
      * Return true if the given <code>TimeZoneRule</code> objects are semantically unequal. Objects
@@ -65,7 +65,7 @@ public:
      * @return  true if the given <code>TimeZoneRule</code> objects are semantically unequal.
      * @stable ICU 3.8
      */
-    virtual UBool operator!=(const TimeZoneRule& that) const;
+    virtual bool operator!=(const TimeZoneRule& that) const;
 
     /**
      * Fills in "name" with the name of this time zone.
@@ -247,7 +247,7 @@ public:
      * @return  true if the given <code>TimeZoneRule</code> objects are semantically equal.
      * @stable ICU 3.8
      */
-    virtual UBool operator==(const TimeZoneRule& that) const;
+    virtual bool operator==(const TimeZoneRule& that) const;
 
     /**
      * Return true if the given <code>TimeZoneRule</code> objects are semantically unequal. Objects
@@ -256,7 +256,7 @@ public:
      * @return  true if the given <code>TimeZoneRule</code> objects are semantically unequal.
      * @stable ICU 3.8
      */
-    virtual UBool operator!=(const TimeZoneRule& that) const;
+    virtual bool operator!=(const TimeZoneRule& that) const;
 
     /**
      * Gets the time when this rule takes effect in the given year.
@@ -458,7 +458,7 @@ public:
      * @return  true if the given <code>TimeZoneRule</code> objects are semantically equal.
      * @stable ICU 3.8
      */
-    virtual UBool operator==(const TimeZoneRule& that) const;
+    virtual bool operator==(const TimeZoneRule& that) const;
 
     /**
      * Return true if the given <code>TimeZoneRule</code> objects are semantically unequal. Objects
@@ -467,7 +467,7 @@ public:
      * @return  true if the given <code>TimeZoneRule</code> objects are semantically unequal.
      * @stable ICU 3.8
      */
-    virtual UBool operator!=(const TimeZoneRule& that) const;
+    virtual bool operator!=(const TimeZoneRule& that) const;
 
     /**
      * Gets the start date/time rule used by this rule.
@@ -674,7 +674,7 @@ public:
      * @return  true if the given <code>TimeZoneRule</code> objects are semantically equal.
      * @stable ICU 3.8
      */
-    virtual UBool operator==(const TimeZoneRule& that) const;
+    virtual bool operator==(const TimeZoneRule& that) const;
 
     /**
      * Return true if the given <code>TimeZoneRule</code> objects are semantically unequal. Objects
@@ -683,7 +683,7 @@ public:
      * @return  true if the given <code>TimeZoneRule</code> objects are semantically unequal.
      * @stable ICU 3.8
      */
-    virtual UBool operator!=(const TimeZoneRule& that) const;
+    virtual bool operator!=(const TimeZoneRule& that) const;
 
     /**
      * Gets the time type of the start times used by this rule.  The return value

--- a/icu4c/source/i18n/unicode/tztrans.h
+++ b/icu4c/source/i18n/unicode/tztrans.h
@@ -86,7 +86,7 @@ public:
      * @return  true if the given TimeZoneTransition objects are semantically equal.
      * @stable ICU 3.8
      */
-    UBool operator==(const TimeZoneTransition& that) const;
+    bool operator==(const TimeZoneTransition& that) const;
 
     /**
      * Return true if the given TimeZoneTransition objects are semantically unequal. Objects
@@ -95,7 +95,7 @@ public:
      * @return  true if the given TimeZoneTransition objects are semantically unequal.
      * @stable ICU 3.8
      */
-    UBool operator!=(const TimeZoneTransition& that) const;
+    bool operator!=(const TimeZoneTransition& that) const;
 
     /**
      * Returns the time of transition in milliseconds.

--- a/icu4c/source/i18n/unicode/vtzone.h
+++ b/icu4c/source/i18n/unicode/vtzone.h
@@ -72,7 +72,7 @@ public:
       *semantically equal.
      * @stable ICU 3.8
      */
-    virtual UBool operator==(const TimeZone& that) const;
+    virtual bool operator==(const TimeZone& that) const;
 
     /**
      * Return true if the given <code>TimeZone</code> objects are
@@ -82,7 +82,7 @@ public:
      * semantically unequal.
      * @stable ICU 3.8
      */
-    virtual UBool operator!=(const TimeZone& that) const;
+    virtual bool operator!=(const TimeZone& that) const;
 
     /**
      * Create a <code>VTimeZone</code> instance by the time zone ID.

--- a/icu4c/source/i18n/utf16collationiterator.cpp
+++ b/icu4c/source/i18n/utf16collationiterator.cpp
@@ -37,7 +37,7 @@ UTF16CollationIterator::UTF16CollationIterator(const UTF16CollationIterator &oth
 
 UTF16CollationIterator::~UTF16CollationIterator() {}
 
-UBool
+bool
 UTF16CollationIterator::operator==(const CollationIterator &other) const {
     if(!CollationIterator::operator==(other)) { return FALSE; }
     const UTF16CollationIterator &o = static_cast<const UTF16CollationIterator &>(other);
@@ -171,7 +171,7 @@ FCDUTF16CollationIterator::FCDUTF16CollationIterator(const FCDUTF16CollationIter
 
 FCDUTF16CollationIterator::~FCDUTF16CollationIterator() {}
 
-UBool
+bool
 FCDUTF16CollationIterator::operator==(const CollationIterator &other) const {
     // Skip the UTF16CollationIterator and call its parent.
     if(!CollationIterator::operator==(other)) { return FALSE; }

--- a/icu4c/source/i18n/utf16collationiterator.h
+++ b/icu4c/source/i18n/utf16collationiterator.h
@@ -42,7 +42,7 @@ public:
 
     virtual ~UTF16CollationIterator();
 
-    virtual UBool operator==(const CollationIterator &other) const;
+    virtual bool operator==(const CollationIterator &other) const;
 
     virtual void resetToOffset(int32_t newOffset);
 
@@ -95,7 +95,7 @@ public:
 
     virtual ~FCDUTF16CollationIterator();
 
-    virtual UBool operator==(const CollationIterator &other) const;
+    virtual bool operator==(const CollationIterator &other) const;
 
     virtual void resetToOffset(int32_t newOffset);
 

--- a/icu4c/source/i18n/vtzone.cpp
+++ b/icu4c/source/i18n/vtzone.cpp
@@ -1047,7 +1047,7 @@ VTimeZone::operator=(const VTimeZone& right) {
     return *this;
 }
 
-UBool
+bool
 VTimeZone::operator==(const TimeZone& that) const {
     if (this == &that) {
         return TRUE;
@@ -1066,7 +1066,7 @@ VTimeZone::operator==(const TimeZone& that) const {
     return FALSE;
 }
 
-UBool
+bool
 VTimeZone::operator!=(const TimeZone& that) const {
     return !operator==(that);
 }

--- a/icu4c/source/test/intltest/apicoll.cpp
+++ b/icu4c/source/test/intltest/apicoll.cpp
@@ -2045,7 +2045,7 @@ public:
     virtual int32_t getSortKey(const UChar*source, int32_t sourceLength,
                              uint8_t*result, int32_t resultLength) const;
     virtual UnicodeSet *getTailoredSet(UErrorCode &status) const;
-    virtual UBool operator==(const Collator& other) const;
+    virtual bool operator==(const Collator& other) const;
     // Collator::operator!= calls !Collator::operator== which works for all subclasses.
     virtual void setLocales(const Locale& requestedLocale, const Locale& validLocale, const Locale& actualLocale);
     TestCollator() : Collator() {}
@@ -2053,7 +2053,7 @@ public:
            UNormalizationMode decompositionMode) : Collator(collationStrength, decompositionMode) {}
 };
 
-inline UBool TestCollator::operator==(const Collator& other) const {
+inline bool TestCollator::operator==(const Collator& other) const {
     // TestCollator has no fields, so we test for identity.
     return this == &other;
 

--- a/icu4c/source/test/intltest/caltest.cpp
+++ b/icu4c/source/test/intltest/caltest.cpp
@@ -2475,8 +2475,8 @@ public:
     CalFields(const Calendar& cal, UErrorCode& status);
     void setTo(Calendar& cal) const;
     char* toString(char* buf, int32_t len) const;
-    UBool operator==(const CalFields& rhs) const;
-    UBool operator!=(const CalFields& rhs) const;
+    bool operator==(const CalFields& rhs) const;
+    bool operator!=(const CalFields& rhs) const;
     UBool isEquivalentTo(const Calendar& cal, UErrorCode& status) const;
 
 private:
@@ -2519,7 +2519,7 @@ CalFields::toString(char* buf, int32_t len) const {
     return buf;
 }
 
-UBool
+bool
 CalFields::operator==(const CalFields& rhs) const {
     return year == rhs.year
         && month == rhs.month
@@ -2530,7 +2530,7 @@ CalFields::operator==(const CalFields& rhs) const {
         && ms == rhs.ms;
 }
 
-UBool
+bool
 CalFields::operator!=(const CalFields& rhs) const {
     return !(*this == rhs);
 }

--- a/icu4c/source/test/intltest/citrtest.cpp
+++ b/icu4c/source/test/intltest/citrtest.cpp
@@ -53,8 +53,8 @@ public:
         return getStaticClassID(); 
     }
 
-    virtual UBool operator==(const ForwardCharacterIterator& /*that*/) const{
-        return TRUE;
+    virtual bool operator==(const ForwardCharacterIterator& /*that*/) const{
+        return true;
     }
 
     virtual SCharacterIterator* clone(void) const {
@@ -1082,7 +1082,7 @@ public:
     }
 
     // dummy implementations of other pure virtual base class functions
-    virtual UBool operator==(const ForwardCharacterIterator &that) const {
+    virtual bool operator==(const ForwardCharacterIterator &that) const {
         return
             this==&that ||
             (typeid(*this)==typeid(that) && pos==((SubCharIter &)that).pos);

--- a/icu4c/source/test/intltest/icusvtst.cpp
+++ b/icu4c/source/test/intltest/icusvtst.cpp
@@ -86,7 +86,7 @@ class Integer : public UObject {
         return getStaticClassID();
     }
 
-    virtual UBool operator==(const UObject& other) const 
+    virtual bool operator==(const UObject& other) const
     {
         return typeid(*this) == typeid(other) &&
             _val == ((Integer&)other)._val;

--- a/icu4c/source/test/intltest/pluralmaptest.cpp
+++ b/icu4c/source/test/intltest/pluralmaptest.cpp
@@ -17,7 +17,7 @@
 
 class PluralMapForPluralMapTest : public PluralMap<UnicodeString> {
 public:
-    UBool operator==(const PluralMapForPluralMapTest &other) {
+    bool operator==(const PluralMapForPluralMapTest &other) {
         return equals(other, strEqual);
     }
 private:

--- a/icu4c/source/test/intltest/sfwdchit.cpp
+++ b/icu4c/source/test/intltest/sfwdchit.cpp
@@ -70,24 +70,24 @@ SimpleFwdCharIterator::~SimpleFwdCharIterator() {
 }
 
 #if 0 // not used
-UBool SimpleFwdCharIterator::operator==(const ForwardCharacterIterator& that) const {
+bool SimpleFwdCharIterator::operator==(const ForwardCharacterIterator& that) const {
     if(this == &that) {
-        return TRUE;
+        return true;
     }
 /*
     if(that->fHashCode != kInvalidHashCode && this->fHashCode = that->fHashCode) {
-        return TRUE;
+        return true;
     }
 
     if(this->fStart == that->fStart) {
-        return TRUE;
+        return true;
     }
 
     if(this->fLen == that->fLen && uprv_memcmp(this->fStart, that->fStart, this->fLen) {
-        return TRUE;
+        return true;
     }
 */
-    return FALSE;
+    return false;
 }
 #endif
 

--- a/icu4c/source/test/intltest/sfwdchit.h
+++ b/icu4c/source/test/intltest/sfwdchit.h
@@ -23,7 +23,7 @@ public:
    * Returns true when both iterators refer to the same
    * character in the same character-storage object.  
    */
-  // not used -- virtual UBool operator==(const ForwardCharacterIterator& that) const;
+  // not used -- virtual bool operator==(const ForwardCharacterIterator& that) const;
         
   /**
    * Generates a hash code for this iterator.  

--- a/icu4c/source/test/intltest/srchtest.cpp
+++ b/icu4c/source/test/intltest/srchtest.cpp
@@ -2284,7 +2284,7 @@ public:
      */
     static inline UClassID getStaticClassID() { return (UClassID)&fgClassID; }
 
-    UBool operator!=(const TestSearch &that) const;
+    bool operator!=(const TestSearch &that) const;
 
     UnicodeString m_pattern_;
 
@@ -2347,7 +2347,7 @@ SearchIterator * TestSearch::safeClone() const
     return new TestSearch(m_text_, m_breakiterator_, m_pattern_);
 }
 
-UBool TestSearch::operator!=(const TestSearch &that) const
+bool TestSearch::operator!=(const TestSearch &that) const
 {
     if (SearchIterator::operator !=(that)) {
         return FALSE;


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-20973

- Change all equality operator return types from `UBool` to `bool`.
- Manually resolve C++20 reversed argument order ambiguity.
- Use the Clang `-Wno-ambiguous-reversed-operator` flag.
- Update configure files from `configure.ac` using `autoreconf`.
- Update the Coding Guidelines with bool equality operators.

Manually tested with Clang 13 and GCC 11 with `-std=c++20`.

ALLOW_MANY_COMMITS=true