### PR TITLE
ICU-13353 Fixed several problems preventing horizontal resource inher…

### DIFF
--- a/icu4c/source/common/uresimp.h
+++ b/icu4c/source/common/uresimp.h
@@ -264,7 +264,6 @@ ures_getByKeyWithFallback(const UResourceBundle *resB,
                           UResourceBundle *fillIn, 
                           UErrorCode *status);
 
-
 /**
  * Get a String with multi-level fallback. Normally only the top level resources will
  * fallback to its parent. This performs fallback on subresources. For example, when a table

--- a/icu4c/source/i18n/dtitvinf.cpp
+++ b/icu4c/source/i18n/dtitvinf.cpp
@@ -50,7 +50,6 @@ U_NAMESPACE_BEGIN
 UOBJECT_DEFINE_RTTI_IMPLEMENTATION(DateIntervalInfo)
 
 static const char gCalendarTag[]="calendar";
-static const char gGenericTag[]="generic";
 static const char gGregorianTag[]="gregorian";
 static const char gIntervalDateTimePatternTag[]="intervalFormats";
 static const char gFallbackPatternTag[]="fallback";
@@ -435,23 +434,6 @@ DateIntervalInfo::initializeData(const Locale& locale, UErrorCode& status)
         if ( U_SUCCESS(status) ) {
             resStr = ures_getStringByKeyWithFallback(itvDtPtnResource, gFallbackPatternTag,
                                                      &resStrLen, &status);
-            if ( U_FAILURE(status) ) {
-                // Try to find "fallback" from "generic" to work around the bug in
-                // ures_getByKeyWithFallback
-                UErrorCode localStatus = U_ZERO_ERROR;
-                UResourceBundle *genericCalBundle =
-                    ures_getByKeyWithFallback(calBundle, gGenericTag, nullptr, &localStatus);
-                UResourceBundle *genericItvDtPtnResource =
-                    ures_getByKeyWithFallback(
-                        genericCalBundle, gIntervalDateTimePatternTag, nullptr, &localStatus);
-                resStr = ures_getStringByKeyWithFallback(
-                    genericItvDtPtnResource, gFallbackPatternTag, &resStrLen, &localStatus);
-                ures_close(genericItvDtPtnResource);
-                ures_close(genericCalBundle);
-                if ( U_SUCCESS(localStatus) ) {
-                    status = U_USING_FALLBACK_WARNING;;
-                }
-            }
         }
 
         if ( U_SUCCESS(status) && (resStr != nullptr)) {

--- a/icu4c/source/i18n/number_longnames.cpp
+++ b/icu4c/source/i18n/number_longnames.cpp
@@ -259,20 +259,16 @@ class InflectedPluralSink : public ResourceSink {
 
     // See ResourceSink::put().
     void put(const char *key, ResourceValue &value, UBool /*noFallback*/, UErrorCode &status) U_OVERRIDE {
-        ResourceTable pluralsTable = value.getTable(status);
+        int32_t pluralIndex = getIndex(key, status);
         if (U_FAILURE(status)) { return; }
-        for (int32_t i = 0; pluralsTable.getKeyAndValue(i, key, value); ++i) {
-            int32_t pluralIndex = getIndex(key, status);
-            if (U_FAILURE(status)) { return; }
-            if (!outArray[pluralIndex].isBogus()) {
-                // We already have a pattern
-                continue;
-            }
-            ResourceTable genderTable = value.getTable(status);
-            ResourceTable caseTable; // This instance has to outlive `value`
-            if (loadForPluralForm(genderTable, caseTable, value, status)) {
-                outArray[pluralIndex] = value.getUnicodeString(status);
-            }
+        if (!outArray[pluralIndex].isBogus()) {
+            // We already have a pattern
+            return;
+        }
+        ResourceTable genderTable = value.getTable(status);
+        ResourceTable caseTable; // This instance has to outlive `value`
+        if (loadForPluralForm(genderTable, caseTable, value, status)) {
+            outArray[pluralIndex] = value.getUnicodeString(status);
         }
     }
 
@@ -370,18 +366,11 @@ void getInflectedMeasureData(StringPiece subKey,
     key.append(subKey, status);
 
     UErrorCode localStatus = status;
-    ures_getAllItemsWithFallback(unitsBundle.getAlias(), key.data(), sink, localStatus);
+    ures_getAllChildrenWithFallback(unitsBundle.getAlias(), key.data(), sink, localStatus);
     if (width == UNUM_UNIT_WIDTH_SHORT) {
         status = localStatus;
         return;
     }
-
-    // TODO(ICU-13353): The fallback to short does not work in ICU4C.
-    // Manually fall back to short (this is done automatically in Java).
-    key.clear();
-    key.append("unitsShort/", status);
-    key.append(subKey, status);
-    ures_getAllItemsWithFallback(unitsBundle.getAlias(), key.data(), sink, status);
 }
 
 class PluralTableSink : public ResourceSink {
@@ -396,20 +385,16 @@ class PluralTableSink : public ResourceSink {
     }
 
     void put(const char *key, ResourceValue &value, UBool /*noFallback*/, UErrorCode &status) U_OVERRIDE {
-        ResourceTable pluralsTable = value.getTable(status);
-        if (U_FAILURE(status)) { return; }
-        for (int32_t i = 0; pluralsTable.getKeyAndValue(i, key, value); ++i) {
-            if (uprv_strcmp(key, "case") == 0) {
-                continue;
-            }
-            int32_t index = getIndex(key, status);
-            if (U_FAILURE(status)) { return; }
-            if (!outArray[index].isBogus()) {
-                continue;
-            }
-            outArray[index] = value.getUnicodeString(status);
-            if (U_FAILURE(status)) { return; }
+        if (uprv_strcmp(key, "case") == 0) {
+            return;
         }
+        int32_t index = getIndex(key, status);
+        if (U_FAILURE(status)) { return; }
+        if (!outArray[index].isBogus()) {
+            return;
+        }
+        outArray[index] = value.getUnicodeString(status);
+        if (U_FAILURE(status)) { return; }
     }
 
   private:
@@ -490,7 +475,7 @@ void getMeasureData(const Locale &locale,
         // getInflectedMeasureData after homogenizing data format? Find a unit
         // test case that demonstrates the incorrect fallback logic (via
         // regional variant of an inflected language?)
-        ures_getAllItemsWithFallback(unitsBundle.getAlias(), caseKey.data(), sink, localStatus);
+        ures_getAllChildrenWithFallback(unitsBundle.getAlias(), caseKey.data(), sink, localStatus);
     }
 
     // TODO(icu-units#138): our fallback logic is not spec-compliant: we
@@ -499,20 +484,13 @@ void getMeasureData(const Locale &locale,
     // either get the spec changed, or add unit tests that warn us if
     // case="nominative" data differs from no-case data?
     UErrorCode localStatus = U_ZERO_ERROR;
-    ures_getAllItemsWithFallback(unitsBundle.getAlias(), key.data(), sink, localStatus);
+    ures_getAllChildrenWithFallback(unitsBundle.getAlias(), key.data(), sink, localStatus);
     if (width == UNUM_UNIT_WIDTH_SHORT) {
         if (U_FAILURE(localStatus)) {
             status = localStatus;
         }
         return;
     }
-
-    // TODO(ICU-13353): The fallback to short does not work in ICU4C.
-    // Manually fall back to short (this is done automatically in Java).
-    key.clear();
-    key.append("unitsShort", status);
-    key.append(subKey, status);
-    ures_getAllItemsWithFallback(unitsBundle.getAlias(), key.data(), sink, status);
 }
 
 // NOTE: outArray MUST have a length of at least ARRAY_LENGTH.
@@ -523,7 +501,7 @@ void getCurrencyLongNameData(const Locale &locale, const CurrencyUnit &currency,
     PluralTableSink sink(outArray);
     LocalUResourceBundlePointer unitsBundle(ures_open(U_ICUDATA_CURR, locale.getName(), &status));
     if (U_FAILURE(status)) { return; }
-    ures_getAllItemsWithFallback(unitsBundle.getAlias(), "CurrencyUnitPatterns", sink, status);
+    ures_getAllChildrenWithFallback(unitsBundle.getAlias(), "CurrencyUnitPatterns", sink, status);
     if (U_FAILURE(status)) { return; }
     for (int32_t i = 0; i < StandardPlural::Form::COUNT; i++) {
         UnicodeString &pattern = outArray[i];

--- a/icu4c/source/test/intltest/numbertest_api.cpp
+++ b/icu4c/source/test/intltest/numbertest_api.cpp
@@ -1232,7 +1232,7 @@ void NumberFormatterApiTest::unitArbitraryMeasureUnits() {
               .locale("en-ZA");
     lnf.operator=(lnf);  // self-assignment should be a no-op
     lnf.formatInt(1, status);
-    status.expectErrorAndReset(U_RESOURCE_TYPE_MISMATCH);
+    status.expectErrorAndReset(U_INTERNAL_PROGRAM_ERROR);
 
     assertFormatSingle(
             u"kibijoule-foot-per-cubic-gigafurlong-square-second unit-width-full-name",

--- a/icu4c/source/test/intltest/restsnew.cpp
+++ b/icu4c/source/test/intltest/restsnew.cpp
@@ -1399,22 +1399,10 @@ void NewResourceBundleTest::TestFilter() {
     }
 }
 
-/*
- * The following test for ICU-20706 has infinite loops on certain inputs for
- * locales and calendars.  In order to unblock the build (ICU-21055), those
- * specific values are temporarily removed.
- * The issue of the infinite loops and its blocking dependencies were captured
- * in ICU-21080.
- */
-
 void NewResourceBundleTest::TestIntervalAliasFallbacks() {
     const char* locales[] = {
-        // Thee will not cause infinity loop
         "en",
         "ja",
-
-        // These will cause infinity loop
-#if 0
         "fr_CA",
         "en_150",
         "es_419",
@@ -1426,15 +1414,10 @@ void NewResourceBundleTest::TestIntervalAliasFallbacks() {
         "zh_Hant",
         "zh_Hant_TW",
         "zh_TW",
-#endif
     };
     const char* calendars[] = {
-        // These won't cause infinity loop
         "gregorian",
         "chinese",
-
-        // These will cause infinity loop
-#if 0
         "islamic",
         "islamic-civil",
         "islamic-tbla",
@@ -1443,7 +1426,6 @@ void NewResourceBundleTest::TestIntervalAliasFallbacks() {
         "islamic-rgsa",
         "japanese",
         "roc",
-#endif
     };
 
     for (int lidx = 0; lidx < UPRV_LENGTHOF(locales); lidx++) {
@@ -1458,10 +1440,8 @@ void NewResourceBundleTest::TestIntervalAliasFallbacks() {
             key.append("calendar/", status);
             key.append(calendars[cidx], status);
             key.append("/intervalFormats/fallback", status);
-            if (! logKnownIssue("20400")) {
-                int32_t resStrLen = 0;
-                ures_getStringByKeyWithFallback(rb, key.data(), &resStrLen, &status);
-            }
+            int32_t resStrLen = 0;
+            ures_getStringByKeyWithFallback(rb, key.data(), &resStrLen, &status);
             if (U_FAILURE(status)) {
                 errln("Cannot ures_getStringByKeyWithFallback('%s') on locale %s",
                       key.data(), locales[lidx]);

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/DateTimeGeneratorTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/DateTimeGeneratorTest.java
@@ -1854,4 +1854,30 @@ public class DateTimeGeneratorTest extends TestFmwk {
         }
     }
 
+    // Test for ICU-21202: Make sure DateTimePatternGenerator supplies an era field for year formats using the
+    // Buddhist and Japanese calendars for all English-speaking locales.
+    @Test
+    public void testEras() {
+        String[] localeIDs = {
+            "en_US@calendar=japanese",
+            "en_GB@calendar=japanese",
+            "en_150@calendar=japanese",
+            "en_001@calendar=japanese",
+            "en@calendar=japanese",
+            "en_US@calendar=buddhist",
+            "en_GB@calendar=buddhist",
+            "en_150@calendar=buddhist",
+            "en_001@calendar=buddhist",
+            "en@calendar=buddhist",
+        };
+
+        for (String localeID : localeIDs) {
+            DateTimePatternGenerator dtpg = DateTimePatternGenerator.getInstance(new Locale(localeID));
+            String pattern = dtpg.getBestPattern("y");
+
+            if (pattern.indexOf('G') < 0) {
+                errln("missing era field for locale " + localeID);
+            }
+        }
+    }
 }


### PR DESCRIPTION
…itance from working as intended.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-13353
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

[I've edited the original description here to describe the current state of this PR...]

This PR fixes a number of problems with horizontal resource inheritance in ICU4C.  As a rule (with one exception I've found so far), horizontal inheritance works correctly in ICU4J, so this is about getting ICU4C to work the same as ICU4J.  The basic problem is that the internal implementation of resource bundles in ICU4C is completely different from ICU4J, making it difficult-to-impossible to simply port the code or algorithm from Java to C++.  Fortunately, porting the entire algorithm over doesn't appear to be necessary-- the problems I've found so far seem to be due to clear bugs in the ICU4C code.  I suspect there still are some bugs in here, but this is what I've found so far:

- Corrected an error in `ures_getByKeyWithFallback()` that kept us from properly following an alias when you start with the root resource bundle and ask for a path that doesn't exist but has a containing path that's an alias (e.g., you ask for `"unitsNarrow/mass/pound"` when all "root" has is an alias from `unitsNarrow` to `unitsShort`).
- Corrected an error in `ures_getByKeyWithFallback()` that was causing us to calculate the key path wrong when we followed an alias (we were getting things like `unitsShort/unitsNarrow/mass/pound` when we just wanted `unitsShort/mass/pound`).
- Removed some now-obsolete code in `DateIntervalInfo::initializeData()`.  This code was rendered obsolete by PR #1770.
- Removed workarounds for these issues in `getInflectedMeasureData()` and `getMeasureData()` in `number_longnames.cpp`.
- Changed the expected error code in one test in `number test_api.cpp` to match what the new implementation is giving us (not sure this is the _right_ error code, but I don't actually think the previous error code was right either).
- Restored a few unit tests in `NewResourceBundleTest` that had been hanging with endless loops previously.
- Added a Java version of a unit test I'd previously added only on the C++ side. 
