### PR TITLE
ICU-21707 Fix LocaleBuilder if default locale has BCP47 extension tags

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -118,6 +118,24 @@ jobs:
         CC: gcc
         CXX: g++
 #-------------------------------------------------------------------------
+- job: ICU4C_Clang_Ubuntu_2004_LANG
+  displayName: 'C: Linux Clang (Ubuntu 20.04) - LANG has extension tags'
+  timeoutInMinutes: 30
+  pool:
+    vmImage: 'ubuntu-20.04'
+  steps:
+    - checkout: self
+      lfs: true
+      fetchDepth: 10
+    - script: |
+        cd icu4c/source && ./runConfigureICU Linux && make -j2 check
+      displayName: 'Build and Test'
+      env:
+        CC: clang
+        CXX: clang++
+        LANG: "en_US@calendar=gregorian;hours=h12"
+
+#-------------------------------------------------------------------------
 # VS 2019 Builds
 #-------------------------------------------------------------------------
 - job: ICU4C_MSVC_x64_Release_Distrelease

--- a/icu4c/source/common/localebuilder.cpp
+++ b/icu4c/source/common/localebuilder.cpp
@@ -228,7 +228,7 @@ LocaleBuilder& LocaleBuilder::setExtension(char key, StringPiece value)
         return *this;
     }
     if (extensions_ == nullptr) {
-        extensions_ = new Locale();
+        extensions_ = Locale::getRoot().clone();
         if (extensions_ == nullptr) {
             status_ = U_MEMORY_ALLOCATION_ERROR;
             return *this;
@@ -259,11 +259,11 @@ LocaleBuilder& LocaleBuilder::setUnicodeLocaleKeyword(
       return *this;
     }
     if (extensions_ == nullptr) {
-        extensions_ = new Locale();
-    }
-    if (extensions_ == nullptr) {
-        status_ = U_MEMORY_ALLOCATION_ERROR;
-        return *this;
+        extensions_ = Locale::getRoot().clone();
+        if (extensions_ == nullptr) {
+            status_ = U_MEMORY_ALLOCATION_ERROR;
+            return *this;
+        }
     }
     extensions_->setUnicodeKeywordValue(key, type, status_);
     return *this;
@@ -280,7 +280,7 @@ LocaleBuilder& LocaleBuilder::addUnicodeLocaleAttribute(
         return *this;
     }
     if (extensions_ == nullptr) {
-        extensions_ = new Locale();
+        extensions_ = Locale::getRoot().clone();
         if (extensions_ == nullptr) {
             status_ = U_MEMORY_ALLOCATION_ERROR;
             return *this;
@@ -415,7 +415,7 @@ void LocaleBuilder::copyExtensionsFrom(const Locale& src, UErrorCode& errorCode)
         return;
     }
     if (extensions_ == nullptr) {
-        extensions_ = new Locale();
+        extensions_ = Locale::getRoot().clone();
         if (extensions_ == nullptr) {
             status_ = U_MEMORY_ALLOCATION_ERROR;
             return;

--- a/icu4c/source/test/intltest/localebuildertest.cpp
+++ b/icu4c/source/test/intltest/localebuildertest.cpp
@@ -25,6 +25,7 @@ void LocaleBuilderTest::runIndexedTest( int32_t index, UBool exec, const char* &
     TESTCASE_AUTO(TestAddUnicodeLocaleAttributeIllFormed);
     TESTCASE_AUTO(TestLocaleBuilder);
     TESTCASE_AUTO(TestLocaleBuilderBasic);
+    TESTCASE_AUTO(TestLocaleBuilderBasicWithExtensionsOnDefaultLocale);
     TESTCASE_AUTO(TestPosixCases);
     TESTCASE_AUTO(TestSetExtensionOthers);
     TESTCASE_AUTO(TestSetExtensionPU);
@@ -361,6 +362,25 @@ void LocaleBuilderTest::TestLocaleBuilderBasic() {
     bld.setRegion("");
     Verify(bld, "zh",
            "setRegion('') got Error: %s\n");
+}
+
+void LocaleBuilderTest::TestLocaleBuilderBasicWithExtensionsOnDefaultLocale() {
+    // Change the default locale to one with extension tags.
+    UErrorCode status = U_ZERO_ERROR;
+    Locale originalDefault;
+    Locale::setDefault(Locale::createFromName("en-US-u-hc-h12"), status);
+    if (U_FAILURE(status)) {
+        errln("ERROR: Could not change the default locale");
+        return;
+    }
+
+    // Invoke the basic test now that the default locale has been changed.
+    TestLocaleBuilderBasic();
+
+    Locale::setDefault(originalDefault, status);
+    if (U_FAILURE(status)) {
+        errln("ERROR: Could not restore the default locale");
+    }
 }
 
 void LocaleBuilderTest::TestSetLanguageWellFormed() {

--- a/icu4c/source/test/intltest/localebuildertest.h
+++ b/icu4c/source/test/intltest/localebuildertest.h
@@ -20,6 +20,7 @@ class LocaleBuilderTest: public IntlTest {
     void TestAddUnicodeLocaleAttributeIllFormed(void);
     void TestLocaleBuilder(void);
     void TestLocaleBuilderBasic(void);
+    void TestLocaleBuilderBasicWithExtensionsOnDefaultLocale(void);
     void TestPosixCases(void);
     void TestSetExtensionOthers(void);
     void TestSetExtensionPU(void);


### PR DESCRIPTION
The `LocaleBuilder` class assumes that ICU's default locale will never have any BCP47 extension tags on it.

The issue is that it uses a `Locale` object internally to store/track any extensions/keywords, but it creates this by calling `new Locale()`, assuming that the default locale will never have any pre-existing extensions/keywords on it.

This change modifies the `LocaleBuilder` class so that when creating the internal `Locale` object it will clear any pre-existing keywords by calling `uloc_getBaseName` (which removes any keywords from the name).

It adds a new test case which changes the default locale, then runs the `TestLocaleBuilderBasic` test (which previously would have failed).

This change also adds a new CI build bot that has the `LANG` environment variable set to `en_US@calendar=gregorian;hours=h12` in order to test with the default locale containing extension tags on ICU first start-up.

I used the [newly added](https://github.com/unicode-org/icu/pull/1762) `PreflightingLocaleIDBuffer` helper class for this, but could use something else as well if preferred.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21707
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
