### PR TITLE
ICU-20178 Initial checkin of Tibetan Calendar

### DIFF
--- a/icu4c/source/i18n/calendar.cpp
+++ b/icu4c/source/i18n/calendar.cpp
@@ -2,7 +2,7 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 /*
 *******************************************************************************
-* Copyright (C) 1997-2016, International Business Machines Corporation and    *
+* Copyright (C) 1997-2021, International Business Machines Corporation and    *
 * others. All Rights Reserved.                                                *
 *******************************************************************************
 *
@@ -40,6 +40,7 @@
 #include "gregoimp.h"
 #include "buddhcal.h"
 #include "taiwncal.h"
+#include "tibetancal.h"
 #include "japancal.h"
 #include "islamcal.h"
 #include "hebrwcal.h"
@@ -175,6 +176,8 @@ static const char * const gCalTypes[] = {
     "islamic-umalqura",
     "islamic-tbla",
     "islamic-rgsa",
+    "tibetan",
+    "tibetan-tsurphu",
     NULL
 };
 
@@ -198,7 +201,9 @@ typedef enum ECalType {
     CALTYPE_DANGI,
     CALTYPE_ISLAMIC_UMALQURA,
     CALTYPE_ISLAMIC_TBLA,
-    CALTYPE_ISLAMIC_RGSA
+    CALTYPE_ISLAMIC_RGSA,
+    CALTYPE_TIBETAN,
+    CALTYPE_TIBETAN_TSURPHU
 } ECalType;
 
 U_NAMESPACE_BEGIN
@@ -391,6 +396,12 @@ static Calendar *createStandardCalendar(ECalType calType, const Locale &loc, UEr
             break;
         case CALTYPE_DANGI:
             cal.adoptInsteadAndCheckErrorCode(new DangiCalendar(loc, status), status);
+            break;
+        case CALTYPE_TIBETAN:
+            cal.adoptInsteadAndCheckErrorCode(new TibetanCalendar(loc, status, TibetanCalendar::PHUGPA), status);
+            break;
+        case CALTYPE_TIBETAN_TSURPHU:
+            cal.adoptInsteadAndCheckErrorCode(new TibetanCalendar(loc, status, TibetanCalendar::TSURPHU), status);
             break;
         default:
             status = U_UNSUPPORTED_ERROR;
@@ -1301,6 +1312,9 @@ int32_t Calendar::getRelatedYear(UErrorCode &status) const
             year -=5492; break;
         case CALTYPE_DANGI:
             year -= 2333; break;
+        case CALTYPE_TIBETAN:
+        case CALTYPE_TIBETAN_TSURPHU:
+            year -= 126; break;
         case CALTYPE_ISLAMIC_CIVIL:
         case CALTYPE_ISLAMIC:
         case CALTYPE_ISLAMIC_UMALQURA:
@@ -1361,6 +1375,9 @@ void Calendar::setRelatedYear(int32_t year)
             year +=5492; break;
         case CALTYPE_DANGI:
             year += 2333; break;
+        case CALTYPE_TIBETAN:
+        case CALTYPE_TIBETAN_TSURPHU:
+            year += 126; break;
         case CALTYPE_ISLAMIC_CIVIL:
         case CALTYPE_ISLAMIC:
         case CALTYPE_ISLAMIC_UMALQURA:

--- a/icu4c/source/i18n/i18n.vcxproj
+++ b/icu4c/source/i18n/i18n.vcxproj
@@ -240,6 +240,7 @@
     <ClCompile Include="smpdtfst.cpp" />
     <ClCompile Include="standardplural.cpp" />
     <ClCompile Include="taiwncal.cpp" />
+    <ClCompile Include="tibetancal.cpp" />
     <ClCompile Include="timezone.cpp" />
     <ClCompile Include="tmunit.cpp" />
     <ClCompile Include="tmutamt.cpp" />
@@ -404,6 +405,7 @@
     <ClInclude Include="smpdtfst.h" />
     <ClInclude Include="standardplural.h" />
     <ClInclude Include="taiwncal.h" />
+    <ClInclude Include="tibetancal.h" />
     <ClInclude Include="umsg_imp.h" />
     <ClInclude Include="utf16collationiterator.h" />
     <ClInclude Include="utf8collationiterator.h" />

--- a/icu4c/source/i18n/i18n.vcxproj.filters
+++ b/icu4c/source/i18n/i18n.vcxproj.filters
@@ -282,6 +282,9 @@
     <ClCompile Include="taiwncal.cpp">
       <Filter>formatting</Filter>
     </ClCompile>
+    <ClCompile Include="tibetancal.cpp">
+      <Filter>formatting</Filter>
+    </ClCompile>
     <ClCompile Include="timezone.cpp">
       <Filter>formatting</Filter>
     </ClCompile>
@@ -1020,6 +1023,9 @@
       <Filter>formatting</Filter>
     </ClInclude>
     <ClInclude Include="taiwncal.h">
+      <Filter>formatting</Filter>
+    </ClInclude>
+    <ClInclude Include="tibetancal.h">
       <Filter>formatting</Filter>
     </ClInclude>
     <ClInclude Include="umsg_imp.h">

--- a/icu4c/source/i18n/sources.txt
+++ b/icu4c/source/i18n/sources.txt
@@ -178,6 +178,7 @@ strmatch.cpp
 strrepl.cpp
 stsearch.cpp
 taiwncal.cpp
+tibetancal.cpp
 timezone.cpp
 titletrn.cpp
 tmunit.cpp

--- a/icu4c/source/i18n/tibetancal.cpp
+++ b/icu4c/source/i18n/tibetancal.cpp
@@ -1,0 +1,538 @@
+// © 2016 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+/*
+ * Copyright (C) 2003-2021, International Business Machines Corporation
+ * and others. All Rights Reserved.
+ ******************************************************************************
+ *
+ * File TIBETANCAL.CPP
+ *****************************************************************************
+ */
+
+#include "tibetancal.h"
+#include <stdlib.h>
+#if !UCONFIG_NO_FORMATTING
+
+#include "umutex.h"
+#include <float.h>
+#include "gregoimp.h" // Math
+#include "uhash.h"
+
+// Debugging
+#ifdef U_DEBUG_TIBETANCAL
+#include <stdio.h>
+#include <stdarg.h>
+
+#endif
+
+U_NAMESPACE_BEGIN
+
+// Implementation of the TibetanCalendar class
+
+//-------------------------------------------------------------------------
+// Constructors...
+//-------------------------------------------------------------------------
+
+
+TibetanCalendar* TibetanCalendar::clone() const {
+  return new TibetanCalendar(*this);
+}
+
+TibetanCalendar::TibetanCalendar(const Locale& aLocale, UErrorCode& success)
+  :   Calendar(TimeZone::forLocaleOrDefault(aLocale), aLocale, success)
+{
+  setTimeInMillis(getNow(), success); // Call this again now that the vtable is set up properly.
+}
+
+TibetanCalendar::TibetanCalendar(const TibetanCalendar& other) : Calendar(other) {
+}
+
+TibetanCalendar::~TibetanCalendar()
+{
+}
+
+/**
+ * return the calendar type, "tibetan" or "tibetan-tsurphu".
+ *
+ * @return calendar type
+ * @internal
+ */
+const char *TibetanCalendar::getType() const { 
+   const char *sType = NULL;
+
+   switch (cType) {
+    case PHUGPA:
+      sType = 'tibetan';
+      break;
+    case TSURPHU:
+      sType = 'tibetan-tsurphu';
+      break;
+    default:
+      UPRV_UNREACHABLE; // out of range
+   }
+   return sType;
+}
+
+
+/**
+ * Sets Tibetan calendar calculation type used by this instance.
+ *
+ * @param type    The calendar calculation type, <code>PHUGPA</code> to use the phugpa
+ *                calendar, <code>TSURPHU</code> to use the tsurphu calendar.
+ * @internal
+ */
+void TibetanCalendar::setCalculationType(ECalculationType type, UErrorCode &status)
+{
+    if (cType != type) {
+        // The fields of the calendar will become invalid, because the calendar
+        // rules are different
+        UDate m = getTimeInMillis(status);
+        cType = type;
+        clear();
+        setTimeInMillis(m, status);
+    }
+}
+
+
+/**
+* Returns <code>true</code> if this object is using the phugpa
+* calendar, or <code>false</code> if using the tsurphu calendar.
+*/
+UBool TibetanCalendar::isPhugpa() {
+    return (cType == PHUGPA);
+}
+
+
+
+//-------------------------------------------------------------------------
+// Assorted calculation utilities
+//-------------------------------------------------------------------------
+
+// fixed tables
+int32_t SUN_TAB[] = {0, 6, 10, 11};
+int32_t MOON_TAB[] = {0, 5, 10, 15, 19, 22, 24, 25};
+
+// mean date
+double PHUGPA_M0 = 2015501 + 4783.0/5656;
+double TSURPHU_M0 = 2353745 + 1795153 / 7635600;
+double M1 = 167025.0/5656;
+double M2 = M1/30;
+
+// mean sun
+double PHUGPA_S0 = 743.0/804;
+double TSURPHU_S0 = -5983/108540;
+double S1 = 65.0/804;
+double S2 = S1/30;
+
+// anomaly moon
+double PHUGPA_A0 = 475.0/3528;
+double TSURPHU_A0 = 207 / 392;;
+double A1 = 253.0/3528;
+double A2 = 1.0/28;
+
+int32_t PHUGPA_YEAR0 = 806;
+int32_t PHUGPA_MONTH0 = 3;
+int32_t PHUGPA_BETA_STAR = 61;
+double PHUGPA_ALPHA = 1 + 827.0/1005;
+
+int32_t TSURPHU_YEAR0 = 1732;
+int32_t TSURPHU_MONTH0 = 3;
+int32_t TSURPHU_BETA_STAR = 59;
+double TSURPHU_ALPHA = 2 + 1052/9045;
+
+/**
+ * Return the moonTab by using the table for the given integer value. 
+ * @param moonTab An integer number
+ */
+int32_t TibetanCalendar::moonTab(int32_t moonTab) const {
+    moonTab = (moonTab % 28 + 28) % 28;
+    if(moonTab <= 7){
+        return MOON_TAB[moonTab];
+    }else if(moonTab <= 14){
+        return MOON_TAB[14 - moonTab];
+    }else if(moonTab <= 21){
+        return -MOON_TAB[moonTab - 14];
+    }else{
+        return -MOON_TAB[28 - moonTab];
+    }
+}
+
+
+/**
+ * Return the sunTab by using the table for the given integer value. 
+ * @param sunTab An integer number
+ */
+int32_t TibetanCalendar::sunTab(int32_t sunTab) const {
+    sunTab = (sunTab % 12 +12) % 12;
+    if(sunTab <= 3){
+        return SUN_TAB[sunTab];
+    }else if(sunTab <= 6){
+        return SUN_TAB[6 - sunTab];
+    }else if(sunTab <= 9){
+        return -SUN_TAB[sunTab - 6];
+    }else{
+        return -SUN_TAB[12 - sunTab];
+    }
+}
+
+
+/**
+ * Return the julian date at the end of the lunar day (similar to the month count since the beginning of the epoch, but for days)
+ * It is calculated by first calculating a simpler mean date corresponding to the linear mean motion of the moon and then adjusting 
+ * it by the equations of the sun and moon, which are determined by the anomalies of the sun and moon together with tables.
+ * @param day the tibetan day
+ * @param monthCount month count since the begining of epoch
+ */
+int32_t TibetanCalendar::trueDate(int32_t day, int32_t monthCount) const {
+
+    double meanDate =  monthCount*M1 + day*M2 + (isPhugpa()?PHUGPA_M0:TSURPHU_M0);
+    double moonAnomaly = 28.0*(monthCount*A1 + day*A2 + (isPhugpa()?PHUGPA_A0:TSURPHU_A0));
+    int32_t mu = moonTab((int)ceil(moonAnomaly)); 
+    int32_t md = moonTab((int)floor(moonAnomaly));
+    double moonEqu = (md + (moonAnomaly - floor(moonAnomaly))*(mu - md))/60.0;
+    double sunAnomaly = 12.0*(monthCount*S1 + day*S2 + (isPhugpa()?PHUGPA_S0:TSURPHU_S0) - 1.0/4);
+    int32_t su = sunTab((int)ceil(sunAnomaly));
+    int32_t sd = sunTab((int)floor(sunAnomaly));
+    double sunEqu = (sd +(sunAnomaly - floor(sunAnomaly))*(su - sd))/60.0;
+
+    return (int)floor(meanDate + moonEqu - sunEqu);
+}
+
+
+/**
+ * Return the month count(based on the epoch) from the given Tibetan year, month number and leap month indicator.
+ * @param month the month number
+ * @param is_leap_month flag indicating whether or not the given month is leap month
+ */
+int32_t TibetanCalendar::toMonthCount(int32_t eyear, int32_t month, int32_t is_leap_month) {
+
+    return floor((12*(eyear-127-(isPhugpa()?PHUGPA_YEAR0:TSURPHU_YEAR0)) + month - (isPhugpa()?PHUGPA_ALPHA:TSURPHU_ALPHA) - (1.0-12.0*S1)*is_leap_month)/(12.0*S1));
+}
+
+
+/**
+ * Return the modulo of the number if(num % mod != 0) else is return mod.
+ * @param num the number to be divided
+ * @param mod the number to be divided with
+ */
+int32_t TibetanCalendar::amod(int32_t num, int32_t mod) {
+
+    if((num % mod) == 0) return mod;
+    return (num % mod + mod) % mod;
+}
+
+
+//-------------------------------------------------------------------------
+// Minimum / Maximum access functions
+//-------------------------------------------------------------------------
+
+
+static const int32_t LIMITS[UCAL_FIELD_COUNT][4] = {
+    // Minimum  Greatest     Least    Maximum
+    //           Minimum   Maximum
+    {        1,        1,    83333,    83333}, // ERA 
+    {        1,        1,       60,       60}, // YEAR
+    {        0,        0,       11,       11}, // MONTH
+    {        1,        1,       50,       55}, // WEEK_OF_YEAR
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // WEEK_OF_MONTH
+    {        1,        1,       29,       30}, // DAY_OF_MONTH
+    {        1,        1,      354,      384}, // DAY_OF_YEAR
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // DAY_OF_WEEK
+    {       -1,       -1,        5,        5}, // DAY_OF_WEEK_IN_MONTH
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // AM_PM
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // HOUR
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // HOUR_OF_DAY
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // MINUTE
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // SECOND
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // MILLISECOND
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // ZONE_OFFSET
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // DST_OFFSET
+    { -5000000, -5000000,  5000000,  5000000}, // YEAR_WOY
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // DOW_LOCAL
+    { -5000000, -5000000,  5000000,  5000000}, // EXTENDED_YEAR
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // JULIAN_DAY
+    {/*N/A*/-1,/*N/A*/-1,/*N/A*/-1,/*N/A*/-1}, // MILLISECONDS_IN_DAY
+    {        0,        0,        1,        1}, // IS_LEAP_MONTH
+};
+
+
+/**
+ * Override Calendar method to return the number of days in the given
+ * extended year and month.
+ *
+ * <p>Note: This method also reads the IS_LEAP_MONTH field to determine
+ * whether or not the given month is a leap month.
+ * @stable ICU 2.8
+ */
+int32_t TibetanCalendar::handleGetMonthLength(int32_t eyear, int32_t month) const {
+    int32_t is_leap_month = (month>=(1<<6) ? 1 : 0);
+    int32_t trueMonth = (is_leap_month ? (month-(1<<6)) : month);
+    int32_t monthCount = toMonthCount(eyear, trueMonth, is_leap_month);
+
+    int32_t thisStart = trueDate(30,monthCount-1);
+    int32_t nextStart = trueDate(30,monthCount);
+
+    return nextStart - thisStart;
+}
+
+
+/**
+ * Return JD of start of given month/year.
+ * @internal
+ */
+ int32_t TibetanCalendar::handleComputeMonthStart(int32_t eyear, int32_t month, UBool useMonth) const {
+     UErrorCode status = U_ZERO_ERROR;
+ 
+     int32_t is_leap_month = (month>=(1<<6) ? 1 : 0);
+     int32_t trueMonth = (is_leap_month ? (month-(1<<6)) : month);
+     int32_t monthCount = toMonthCount(eyear, trueDate, is_leap_month);
+ 
+     return (int)(trueDate(30, monthCount-1));
+ }
+
+
+/**
+ * Override Calendar to handle leap months and leap days properly.
+ */
+void TibetanCalendar::add(UCalendarDateFields field, int32_t amount, UErrorCode& status) {
+    switch (field) {
+    case UCAL_MONTH:
+        int32_t month = internalGet(UCAL_MONTH);
+        int32_t is_leap_month = (month>=(1<<6) ? 1 : 0);
+        int32_t trueMonth = (is_leap_month ? (month-(1<<6)) : month);
+        int32_t monthCount = toMonthCount(eyear, trueMonth, is_leap_month);     
+        newMonthCount = monthCount + amount;
+        int32_t julianDay = trueDate(internalGet(UCAL_DAY_OF_MONTH),newMonthCount);
+        handleComputeFields(julianDay, status); 
+        break;
+    case UCAL_DAY_OF_MONTH:
+        int32_t julianDay = internalGet(UCAL_JULIAN_DAY);
+        int32_t newJulianDay = julianDay + amount;
+        handleComputeFields(newJulianDay, status);
+        break;
+    default:
+        Calendar::add(field, amount, status);
+        break;
+    }
+}
+
+
+/**
+ * Override Calendar to handle leap months and leap days properly.
+ */
+void TibetanCalendar::add(EDateFields field, int32_t amount, UErrorCode& status) {
+    add((UCalendarDateFields)field, amount, status);
+}
+
+
+/**
+ * Override Calendar to handle leap months and leap days properly.
+ */
+void TibetanCalendar::roll(UCalendarDateFields field, int32_t amount, UErrorCode& status) {
+    switch (field) {
+    case UCAL_MONTH:
+        int32_t month = internalGet(UCAL_MONTH);
+        int32_t is_leap_month = (month>=(1<<6) ? 1 : 0);
+        int32_t trueMonth = (is_leap_month ? (month-(1<<6)) : month);
+        int32_t monthCount = toMonthCount(eyear, trueMonth, is_leap_month);     
+        newMonthCount = monthCount + amount;
+        int32_t julianDay = trueDate(internalGet(UCAL_DAY_OF_MONTH),newMonthCount);
+        handleComputeFields(julianDay, status); 
+        break;
+    case UCAL_DAY_OF_MONTH:
+        int32_t julianDay = internalGet(UCAL_JULIAN_DAY);
+        int32_t newJulianDay = julianDay + amount;
+        handleComputeFields(newJulianDay, status);
+        break;
+    default:
+        Calendar::add(field, amount, status);
+        break;
+    }
+}
+
+
+/**
+ * Override Calendar to handle leap months and leap days properly.
+ */
+void TibetanCalendar::roll(EDateFields field, int32_t amount, UErrorCode& status) {
+    roll((UCalendarDateFields)field, amount, status);
+}
+
+
+/**
+  * Subclasses may override this method to compute several fields
+  * specific to each calendar system.  These are:
+  *
+  * <ul><li>ERA
+  * <li>YEAR
+  * <li>MONTH
+  * <li>DAY_OF_MONTH
+  * <li>DAY_OF_YEAR
+  * <li>EXTENDED_YEAR</ul>
+  *
+  * <p>The GregorianCalendar implementation implements
+  * a calendar with the specified Julian/Gregorian cutover date.
+  * @internal
+  */
+void TibetanCalendar::handleComputeFields(int32_t julianDay, UErrorCode &status) {
+    int32_t gyear = getGregorianYear();
+    int32_t dn1 = 1 + 30*toMonthCount(gyear + 126, 1, 1);
+    int32_t dn2 = 1 + 30*toMonthCount(gyear + 128, 1, 1);
+
+    int32_t jd1 = trueDate(amod(dn1, 30), floor((dn1 - 1)/30));
+    int32_t jd2 = trueDate(amod(dn2, 30), floor((dn2 - 1)/30));
+
+    while (dn1 < dn2 - 1  && jd1 < jd2 - 1){
+        int32_t ndn = (dn1 + dn2)>>1;
+        int32_t njd = trueDate(amod(ndn, 30), floor((ndn - 1)/30));
+
+        if(njd < julianDay){
+            dn1 = ndn;
+            jd1 = njd;
+        } else {
+            dn2 = ndn;
+            jd2 = njd;
+        }
+    }
+
+    if(jd1 == julianDay){
+        jd2 = jd1;
+        dn2 = dn1;
+    }
+    int32_t monthCount = (dn2-1)/30;
+    int32_t x = ceil(12*S1*monthCount + (isPhugpa()?PHUGPA_ALPHA:TSURPHU_ALPHA));
+
+    int32_t tmonth = amod(x, 12);
+    int32_t tyear = (x - tmonth)/12 + (isPhugpa()?PHUGPA_YEAR0?TSURPHU_YEAR0) + 127;
+    bool is_leap_month = (ceil(12*S1*(monthCount + 1) + (isPhugpa()?PHUGPA_ALPHA:TSURPHU_ALPHA)) == x);
+    int32_t tday = amod(dn2, 30);
+    bool is_leap_day = (jd2 > julianDay);
+    int32_t dayOfYear = julianDay - trueDate(30, toMonthCount(tyear - 1, 12, 0));
+
+    int32_t cycleNumber = ceil((tyear-1153.0)/60.0);
+    int32_t yearNumber = amod(tyear-133,60);
+    
+    if(is_leap_day){
+        tday += (1<<6);
+    }
+
+    if(is_leap_month){
+        tmonth += (1<<6);
+    }
+
+    internalSet(UCAL_ERA, cycleNumber);
+    internalSet(UCAL_YEAR, yearNumber);
+    internalSet(UCAL_EXTENDED_YEAR, tyear);
+    internalSet(UCAL_MONTH, tmonth);
+    internalSet(UCAL_DAY_OF_MONTH, tday);
+    internalSet(UCAL_DAY_OF_YEAR, dayOfYear);
+    internalSet(UCAL_JULIAN_DAY,julianDay);
+
+}
+
+
+/**
+ * Implement abstract Calendar method to return the extended year
+ * defined by the current fields.  This will use either the ERA and
+ * YEAR field as the cycle and year-of-cycle, or the EXTENDED_YEAR
+ * field as the continuous year count, depending on which is newer.
+ */
+ int32_t TibetanCalendar::handleGetExtendedYear() {
+    int32_t year;
+    if (newestStamp(UCAL_ERA, UCAL_YEAR, kUnset) <= fStamp[UCAL_EXTENDED_YEAR]) {
+        year = internalGet(UCAL_EXTENDED_YEAR, 1); // Default to year 1
+    } else {
+        int32_t cycle = internalGet(UCAL_ERA, 1) - 1; // 0-based cycle
+        // adjust to the instance specific epoch
+        year = cycle * 60 + internalGet(UCAL_YEAR, 1) - (fEpochYear - (isPhugpa()?PHUGPA_YEAR0?TSURPHU_YEAR0) );
+    }
+    return year;
+ }
+
+
+/**
+ * @internal
+ */
+ int32_t TibetanCalendar::handleGetLimit(UCalendarDateFields field, ELimitType limitType) const {
+     return LIMITS[field][limitType];
+ }
+
+
+UBool
+TibetanCalendar::inDaylightTime(UErrorCode& status) const
+{
+    // copied from GregorianCalendar
+    if (U_FAILURE(status) || !getTimeZone().useDaylightTime()) {
+        return FALSE;
+    }
+
+    // Force an update of the state of the Calendar.
+    ((TibetanCalendar*)this)->complete(status); // cast away const
+
+    return (UBool)(U_SUCCESS(status) ? (internalGet(UCAL_DST_OFFSET) != 0) : FALSE);
+}
+
+
+/**
+ * The system maintains a static default century start date and Year.  They are
+ * initialized the first time they are used.  Once the system default century date
+ * and year are set, they do not change.
+ */
+static UDate           gSystemDefaultCenturyStart       = DBL_MIN;
+static int32_t         gSystemDefaultCenturyStartYear   = -1;
+static icu::UInitOnce  gSystemDefaultCenturyInit        = U_INITONCE_INITIALIZER;
+
+
+UBool TibetanCalendar::haveDefaultCentury() const
+{
+    return TRUE;
+}
+
+
+static void U_CALLCONV initializeSystemDefaultCentury()
+{
+    // initialize systemDefaultCentury and systemDefaultCenturyYear based
+    // on the current time.  They'll be set to 80 years before
+    // the current time.
+    UErrorCode status = U_ZERO_ERROR;
+
+    if(isPhugpa()){
+        TibetanCalendar calendar ( Locale ( "@calendar=tibetan" ), status);
+    } else {
+        TibetanCalendar calendar ( Locale ( "@calendar=tibetan-tsurphu" ), status);       
+    }
+    if ( U_SUCCESS ( status ) ) {
+        calendar.setTime ( Calendar::getNow(), status );
+        calendar.add ( UCAL_YEAR, -80, status );
+
+        UDate    newStart = calendar.getTime ( status );
+        int32_t  newYear  = calendar.get ( UCAL_YEAR, status );
+
+        gSystemDefaultCenturyStart = newStart;
+        gSystemDefaultCenturyStartYear = newYear;
+    }
+    // We have no recourse upon failure.
+}
+
+
+UDate TibetanCalendar::defaultCenturyStart() const
+{
+    // lazy-evaluate systemDefaultCenturyStart
+    umtx_initOnce(gSystemDefaultCenturyInit, &initializeSystemDefaultCentury);
+    return gSystemDefaultCenturyStart;
+}
+
+
+int32_t TibetanCalendar::defaultCenturyStartYear() const
+{
+    // lazy-evaluate systemDefaultCenturyStartYear
+    umtx_initOnce(gSystemDefaultCenturyInit, &initializeSystemDefaultCentury);
+    return    gSystemDefaultCenturyStartYear;
+}
+
+
+UOBJECT_DEFINE_RTTI_IMPLEMENTATION(TibetanCalendar)
+
+U_NAMESPACE_END
+
+#endif

--- a/icu4c/source/i18n/tibetancal.h
+++ b/icu4c/source/i18n/tibetancal.h
@@ -1,0 +1,313 @@
+// © 2016 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+/*
+ *****************************************************************************
+ * Copyright (C) 2003-2021, International Business Machines Corporation
+ * and others. All Rights Reserved.
+ *****************************************************************************
+ *
+ * File TIBETANCAL.H
+ *****************************************************************************
+ */
+
+#ifndef TIBETANCAL_H
+#define TIBETANCAL_H
+
+#include "unicode/utypes.h"
+
+#if !UCONFIG_NO_FORMATTING
+
+#include "unicode/calendar.h"
+
+U_NAMESPACE_BEGIN
+
+/**
+*  Concrete class which provides the Tibetan calendar.
+*
+*
+*
+*
+*
+*
+*
+*/
+
+
+class U_I18N_API TibetanCalendar : public Calendar {
+public:
+  /**
+   * Useful constants for TibetanCalendar.
+   * @internal
+   */
+
+
+  /**
+   * Calendar type - phugpa or tsurphu
+   * @internal 
+   */
+  enum ECalculationType {
+    PHUGPA,
+    TSURPHU
+  };
+
+  //-------------------------------------------------------------------------
+  // Constructors...
+  //-------------------------------------------------------------------------
+
+  /**
+   * Constructs an TibetanCalendar based on the current time in the default time zone
+   * with the given locale.
+   *
+   * @param aLocale  The given locale.
+   * @param success  Indicates the status of TibetanCalendar object construction.
+   *                 Returns U_ZERO_ERROR if constructed successfully.
+   * @param type     The Tibetan calendar calculation type. The default vaue is PHUGPA.
+   * @internal
+   */
+  TibetanCalendar(const Locale& aLocale, UErrorCode &success, ECalculationType type = PHUGPA);
+
+
+  /**
+   * Copy Constructor
+   * @internal
+   */
+  TibetanCalendar(const TibetanCalendar& other);
+
+
+  /**
+   * Destructor.
+   * @internal
+   */
+  virtual ~TibetanCalendar();
+
+
+  /**
+   * Sets Tibetan calendar calculation type used by this instance.
+   *
+   * @param type    The calendar calculation type, <code>PHUGPA</code> to use the phugpa
+   *                calendar, <code>TSURPHU</code> to use the tsurphu calendar.
+   * @internal
+   */
+  void setCalculationType(ECalculationType type, UErrorCode &status);
+
+
+  /**
+   * Returns <code>true</code> if this object is using the phugpa
+   * calendar, or <code>false</code> if using the tsurphu calendar.
+   * @internal
+   */
+  UBool isPhugpa();
+
+
+  // clone
+  virtual TibetanCalendar* clone() const;
+
+
+
+  /**
+   * return the calendar type, "tibetan-phugpa" or "tibetan-tsurphu".
+   *
+   * @return calendar type
+   * @internal
+   */
+  virtual const char * getType() const;
+
+
+private:
+
+  //-------------------------------------------------------------------------
+  // Internal data....
+  //-------------------------------------------------------------------------
+
+/**
+ * Return the moonTab by using the table for the given integer value. 
+ * @param moonTab An integer number
+ */
+int32_t moonTab(int32_t moonTab) const;
+
+
+/**
+ * Return the sunTab by using the table for the given integer value. 
+ * @param sunTab An integer number
+ */
+int32_t sunTab(int32_t sunTab) const;
+
+
+/**
+ * Return the modulo of the number if(num % mod != 0) else is return mod.
+ * @param num the number to be divided
+ * @param mod the number to be divided with
+ */
+int32_t amod(int32_t num, int32_t mod) const;
+
+
+/**
+ * Return the month count(based on the epoch) from the given Tibetan year, month number and leap month indicator.
+ * @param month the month number
+ * @param is_leap_month flag indicating whether or not the given month is leap month
+ */
+int32_t toMonthCount(int32_t eyear, int32_t month, int32_t is_leap_month) const;
+
+
+/**
+ * Return the julian date at the end of the lunar day (similar to the month count since the beginning of the epoch, but for days)
+ * It is calculated by first calculating a simpler mean date corresponding to the linear mean motion of the moon and then adjusting 
+ * it by the equations of the sun and moon, which are determined by the anomalies of the sun and moon together with tables.
+ * @param day the tibetan day
+ * @param monthCount month count since the begining of epoch
+ */
+int32_t trueDate(int32_t day, int32_t monthCount) const;
+
+
+
+public:
+
+  /**
+   * (Overrides Calendar) UDate Arithmetic function. Adds the specified (signed) amount
+   * of time to the given time field, based on the calendar's rules.  For more
+   * information, see the documentation for Calendar::add().
+   *
+   * @param field   The time field.
+   * @param amount  The amount of date or time to be added to the field.
+   * @param status  Output param set to success/failure code on exit. If any value
+   *                previously set in the time field is invalid, this will be set to
+   *                an error status.
+   */
+  virtual void add(UCalendarDateFields field, int32_t amount, UErrorCode& status);
+    
+
+  /**
+   * @deprecated ICU 2.6 use UCalendarDateFields instead of EDateFields
+   */
+  virtual void add(EDateFields field, int32_t amount, UErrorCode& status)
+
+
+  /**
+   * (Overrides Calendar) Rolls up or down by the given amount in the specified field.
+   * For more information, see the documentation for Calendar::roll().
+   *
+   * @param field   The time field.
+   * @param amount  Indicates amount to roll.
+   * @param status  Output param set to success/failure code on exit. If any value
+   *                previously set in the time field is invalid, this will be set to
+   *                an error status.
+   * @internal
+   */
+  virtual void roll(UCalendarDateFields field, int32_t amount, UErrorCode& status);
+
+
+  /**
+   * @deprecated ICU 2.6. Use roll(UCalendarDateFields field, int32_t amount, UErrorCode& status) instead.
+`  */
+  virtual void roll(EDateFields field, int32_t amount, UErrorCode& status);
+
+
+  //----------------------------------------------------------------------
+  // Calendar framework
+  //----------------------------------------------------------------------
+
+private:
+    TibetanCalendar(); // default constructor not implemented
+
+protected:
+
+
+  /**
+   * Return the length (in days) of the given month.
+   * @param eyear the extended year
+   * @param month the month number
+   * @param return the number of days in the given month
+   * @internal
+   */
+  virtual int32_t handleGetMonthLength(int32_t eyear, int32_t month);
+
+
+  /**
+   * Return the Julian day number of day before the first day of the
+   * given month in the given extended year.  Subclasses should override
+   * this method to implement their calendar system.
+   * @param eyear the extended year
+   * @param month the month number, or 0 if useMonth is false
+   * @param useMonth if false, compute the day before the first day of
+   * the given year, otherwise, compute the day before the first day of
+   * the given month
+   * @param return the Julian day number of the day before the first
+   * day of the given month and year
+   * @internal
+   */
+  virtual int32_t handleComputeMonthStart(int32_t eyear, int32_t month,
+                                                   UBool useMonth) const;
+
+
+  /**
+    * Subclasses may override this method to compute several fields
+    * specific to each calendar system.  These are:
+    *
+    * <ul><li>ERA
+    * <li>YEAR
+    * <li>MONTH
+    * <li>DAY_OF_MONTH
+    * <li>DAY_OF_YEAR
+    * <li>EXTENDED_YEAR</ul>
+    *
+    * <p>The GregorianCalendar implementation implements
+    * a calendar with the specified Julian/Gregorian cutover date.
+    * @internal
+    */
+  virtual void handleComputeFields(int32_t julianDay, UErrorCode &status);
+
+
+  /**
+   * Calculate the limit for a specified type of limit and field
+   * @internal
+   */
+  virtual int32_t handleGetLimit(UCalendarDateFields field, ELimitType limitType) const;
+
+
+
+  /**
+   * Return the extended year defined by the current fields.
+   * @internal
+   */
+  virtual int32_t handleGetExtendedYear();
+
+
+  /**
+   * (Overrides Calendar) Return true if the current date for this Calendar is in
+   * Daylight Savings Time. Recognizes DST_OFFSET, if it is set.
+   *
+   * @param status Fill-in parameter which receives the status of this operation.
+   * @return   True if the current date for this Calendar is in Daylight Savings Time,
+   *           false, otherwise.
+   * @internal
+   */
+  virtual UBool inDaylightTime(UErrorCode& status) const;
+
+
+  /**
+   * Returns true because the Tibetan Calendar does have a default century
+   * @internal
+   */
+  virtual UBool haveDefaultCentury() const;
+
+
+  /**
+   * Returns the date of the start of the default century
+   * @return start of century - in milliseconds since epoch, 1970
+   * @internal
+   */
+  virtual UDate defaultCenturyStart() const;
+
+
+  /**
+   * Returns the year in which the default century begins
+   * @internal
+   */
+  virtual int32_t defaultCenturyStartYear() const;
+
+};
+
+U_NAMESPACE_END
+
+#endif
+#endif

--- a/icu4c/source/test/intltest/calcasts.cpp
+++ b/icu4c/source/test/intltest/calcasts.cpp
@@ -2,7 +2,7 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 /********************************************************************
  * COPYRIGHT: 
- * Copyright (c) 2003-2013, International Business Machines Corporation 
+ * Copyright (c) 2003-2021, International Business Machines Corporation 
  * and others. All Rights Reserved.
  ********************************************************************
  * Calendar Case Test is a type of CalendarTest which compares the 
@@ -19,6 +19,7 @@
 #include "indiancal.h"
 #include "coptccal.h"
 #include "ethpccal.h"
+#include "tibetancal.h"
 #include "unicode/datefmt.h"
 
 #define CASE(id,test) case id: name = #test; if (exec) { logln(#test "---"); logln((UnicodeString)""); test(); } break
@@ -33,6 +34,7 @@ void CalendarCaseTest::runIndexedTest( int32_t index, UBool exec, const char* &n
     CASE(2,Indian);
     CASE(3,Coptic);
     CASE(4,Ethiopic);
+    CASE(5,Tibetan);
     default: name = ""; break;
     }
 }
@@ -499,5 +501,81 @@ void CalendarCaseTest::Ethiopic() {
     delete c;
 }
 
+void CalendarCaseTest::Tibetan() {
+
+    //Testing Phugpa calculations 
+
+    static const TestCase tests1[] = {
+
+    // A huge list of test cases to make sure that computeTime and computeFields
+    // work properly for a wide range of data in the Tibetan calendar.
+    //
+    // Julian Day   Era Year     Month         Day  WkDay Hour Min Sec
+       {2458166.5,  0,  2145,         1,        1,  FRI,   0,  0,  0}, // Gregorian: 16/02/2018 - not a leap month - not a leap day - Losar
+       {2432758.5,  0,  2075,         6,       19,  SUN,   0,  0,  0}, // Gregorian: 25/07/1948 - not a leap month - not a leap day - Shakyamuni Buddha Day New Moon
+       {2361501.5,  1,  1880,         5,       84,  WED,   0,  0,  0}, // Gregorian: 20/06/1753 - not a leap month - leap day
+       {1740676.5,  0,   180,         9,       16,  MON,   0,  0,  0}, // Gregorian: 15/09/0053 - not a leap month - not a leap day
+       {1807769.5,  0,   364,         5,       15,  SAT,   0,  0,  0}, // Gregorian: 27/05/0237 - not a leap month - not a leap day
+       {1849958.5,  0,   479,        12,        5,  SAT,   0,  0,  0}, // Gregorian: 29/11/0352 - not a leap month - not a leap day
+       {1896793.5,  1,   608,         2,       69,  THU,   0,  0,  0}, // Gregorian: 20/02/0481 - not a leap month - leap day
+       {1919639.5,  0,   670,         8,       24,  TUE,   0,  0,  0}, // Gregorian: 10/09/0543 - not a leap month - not a leap day
+       {1952574.5,  0,   760,        11,        2,  TUE,   0,  0,  0}, // Gregorian: 12/11/0633 - not a leap month - not a leap day
+       {1975739.5,  0,   824,         4,       15,  THU,   0,  0,  0}, // Gregorian: 15/04/0697 - not a leap month - not a leap day - Amitabha Buddha Day Full Moon
+
+       {1995560.5,  0,   878,        71,       22,  MON,   0,  0,  0}, // Gregorian: 23/07/0751 - leap month - not a leap day
+       {1995583.5,  0,   878,         7,       15,  WED,   0,  0,  0}, // Gregorian: 15/08/0751 - not a leap month - not a leap day - Amitabha Buddha Day Full Moon
+       {2013762.5,  0,   928,         5,        3,  WED,   0,  0,  0}, // Gregorian: 23/05/0801 - not a leap month - not a leap day
+       {2041047.5,  0,  1003,        66,        1,  TUE,   0,  0,  0}, // Gregorian: 04/02/0876 - leap month - not a leap day
+       {2053145.5,  0,  1036,         2,       21,  THU,   0,  0,  0}, // Gregorian: 21/03/0909 - not a leap month - not a leap day
+       {2085852.5,  0,  1125,         9,        9,  SUN,   0,  0,  0}, // Gregorian: 07/10/0998 - not a leap month - not a leap day
+       {2095540.5,  0,  1152,         3,       11,  SUN,   0,  0,  0}, // Gregorian: 17/04/1025 - not a leap month - not a leap day
+       {2150153.5,  0,  1301,         9,       87,  SAT,   0,  0,  0}, // Gregorian: 26/10/1174 - not a leap month - leap day
+       {2176923.5,  0,  1375,         1,        7,  MON,   0,  0,  0}, // Gregorian: 10/02/1248 - not a leap month - not a leap day
+       {2225643.5,  0,  1508,         6,        2,  MON,   0,  0,  0}, // Gregorian: 02/07/1381 - not a leap month - not a leap day
+
+       {2247877.5,  0,  1569,         3,       29,  WED,   0,  0,  0}, // Gregorian: 18/05/1442 - not a leap month - not a leap day - Dharmapala Day
+       {2304268.5,  0,  1723,         8,       17,  TUE,   0,  0,  0}, // Gregorian: 08/10/1596 - not a leap month - not a leap day
+       {2327497.5,  0,  1787,         4,        5,  FRI,   0,  0,  0}, // Gregorian: 14/05/1660 - not a leap month - not a leap day
+       {2372681.5,  0,  1910,        12,        8,  THU,   0,  0,  0}, // Gregorian: 29/01/1784 - not a leap month - not a leap day - Medicine Buddha & Tara Day
+       {2401910.5,  0,  1991,         1,        1,  MON,   0,  0,  0}, // Gregorian: 08/02/1864 - not a leap month - not a leap day - Losar
+       {2436066.5,  0,  2084,         6,       20,  THU,   0,  0,  0}, // Gregorian: 15/08/1957 - not a leap month - not a leap day
+       {2473029.5,  0,  2185,         9,       11,  SUN,   0,  0,  0}, // Gregorian: 27/10/2058 - not a leap month - not a leap day 
+       {2496850.5,  0,  2250,        11,       30,  SUN,   0,  0,  0}, // Gregorian: 16/01/2124 - not a leap month - not a leap day - Shakyamuni Buddha Day New Moon
+       {2524704.5,  0,  2327,         3,        7,  MON,   0,  0,  0}, // Gregorian: 21/04/2200 - not a leap month - not a leap day
+       {2567015.5,  0,  2442,        12,       30,  THU,   0,  0,  0}, // Gregorian: 24/02/2316 - not a leap month - not a leap day - Shakyamuni Buddha Day New Moon
+       { -1,-1,-1,-1,-1,-1,-1,-1,-1 }
+    };
+
+    UErrorCode status = U_ZERO_ERROR;
+    Calendar *c = Calendar::createInstance("bo_IN@calendar=tibetan", status);
+    if (failure(status, "Calendar::createInstance", TRUE)) return;
+    c->setLenient(TRUE);
+    doTestCases(tests1, c);
+    delete c;
+
+
+    //Testing Tsurphu calculations 
+
+    static const TestCase tests2[] = {
+
+    // A huge list of test cases to make sure that computeTime and computeFields
+    // work properly for a wide range of data in the Tibetan calendar.
+    //
+    // Julian Day   Era Year     Month         Day  WkDay Hour Min Sec
+       {2451581.5,  0,  2127,         1,        1,  SUN,   0,  0,  0}, // Gregorian: 06/02/2000 - not a leap month - not a leap day - Losar
+       {2453089.5,  1,  2131,         2,       68,  WED,   0,  0,  0}, // Gregorian: 24/03/2004 - not a leap month - leap day
+       {2451998.5,  0,  2128,         2,        4,  THU,   0,  0,  0}, // Gregorian: 29/03/2001 - not a leap month - not a leap day     
+       {-1,-1,-1,-1,-1,-1,-1,-1,-1}
+    };
+
+    status = U_ZERO_ERROR;
+    c = Calendar::createInstance("bo_IN@calendar=tibetan-tsurphu", status);
+    if (failure(status, "Calendar::createInstance", TRUE)) return;
+    c->setLenient(TRUE);
+    doTestCases(tests2, c);
+
+    delete c;
+
+}
 
 #endif

--- a/icu4c/source/test/intltest/calcasts.h
+++ b/icu4c/source/test/intltest/calcasts.h
@@ -2,7 +2,7 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 /********************************************************************
  * COPYRIGHT: 
- * Copyright (c) 2003-2008, International Business Machines Corporation 
+ * Copyright (c) 2003-2021, International Business Machines Corporation 
  * and others. All Rights Reserved.
  ********************************************************************
  * Calendar Case Test is a type of CalendarTest which compares the 
@@ -61,6 +61,7 @@ class CalendarCaseTest: public CalendarTest {
   void Indian();
   void Coptic();
   void Ethiopic();
+  void Tibetan();
 };
 
 #endif

--- a/icu4c/source/test/intltest/callimts.cpp
+++ b/icu4c/source/test/intltest/callimts.cpp
@@ -2,7 +2,7 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 /***********************************************************************
  * COPYRIGHT: 
- * Copyright (c) 1997-2015, International Business Machines Corporation
+ * Copyright (c) 1997-2021, International Business Machines Corporation
  * and others. All Rights Reserved.
  ***********************************************************************/
 
@@ -170,7 +170,9 @@ TestCase TestCases[] = {
         {"indian",          FALSE,      DEFAULT_START, DEFAULT_END},
         {"coptic",          FALSE,      DEFAULT_START, DEFAULT_END},
         {"ethiopic",        FALSE,      DEFAULT_START, DEFAULT_END},
-        {"ethiopic-amete-alem", FALSE,  DEFAULT_START, DEFAULT_END}
+        {"ethiopic-amete-alem", FALSE,  DEFAULT_START, DEFAULT_END},
+        {"tibetan",         FALSE,      DEFAULT_START, DEFAULT_END},
+        {"tibetan-tsurphu", FALSE,      DEFAULT_START, DEFAULT_END}
 };
     
 struct {

--- a/icu4c/source/test/intltest/incaltst.cpp
+++ b/icu4c/source/test/intltest/incaltst.cpp
@@ -2,7 +2,7 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 /***********************************************************************
  * COPYRIGHT: 
- * Copyright (c) 1997-2014, International Business Machines Corporation
+ * Copyright (c) 1997-2021, International Business Machines Corporation
  * and others. All Rights Reserved.
  ***********************************************************************/
 
@@ -105,6 +105,8 @@ void IntlCalendarTest::runIndexedTest( int32_t index, UBool exec, const char* &n
     TESTCASE_AUTO(TestConsistencyIslamicUmalqura);
     TESTCASE_AUTO(TestConsistencyPersian);
     TESTCASE_AUTO(TestConsistencyJapanese);
+    TESTCASE_AUTO(TestConsistencyTibetan);
+    TESTCASE_AUTO(TestConsistencyTibetanTsurphu);
     TESTCASE_AUTO_END;
 }
 
@@ -985,6 +987,12 @@ void IntlCalendarTest::TestConsistencyJapanese() {
 }
 void IntlCalendarTest::TestConsistencyEthiopicAmeteAlem() {
     checkConsistency("en@calendar=ethiopic-amete-alem");
+}
+void IntlCalendarTest::TestConsistencyTibetan() {
+    checkConsistency("en@calendar=tibetan");
+}
+void IntlCalendarTest::TestConsistencyTibetanTsurphu() {
+    checkConsistency("en@calendar=tibetan-tsurphu");
 }
 void IntlCalendarTest::checkConsistency(const char* locale) {
     // Check 2.5 years in quick mode and 8000 years in exhaustive mode.

--- a/icu4c/source/test/intltest/incaltst.h
+++ b/icu4c/source/test/intltest/incaltst.h
@@ -2,7 +2,7 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 /********************************************************************
  * COPYRIGHT: 
- * Copyright (c) 1997-2007, International Business Machines Corporation and
+ * Copyright (c) 1997-2021, International Business Machines Corporation and
  * others. All Rights Reserved.
  ********************************************************************/
 
@@ -60,6 +60,8 @@ public:
     void TestConsistencyIslamicUmalqura(void);
     void TestConsistencyPersian(void);
     void TestConsistencyJapanese(void);
+    void TestConsistencyTibetan(void);
+    void TestConsistencyTibetanTsurphu(void);
 
  protected:
     // Test a Gregorian-Like calendar


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

This PR attempts to add support for the Tibetan calendar (Phagpha & Tsurphu) in ICU4C. 

The Tibetan calendar is a lunisolar calendar and the typical sequence of days of the month in a lunisolar calendar is not a simple sequence of numbers, but instead it has leap days as well as omitted days. A major challenge was to deal with leap days because the current calendar class of ICU4C does not have a leap day field. I've used a +64 encoding for storing leap day and leap month info that do not require any additional calendar field.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-20178
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
