### PR TITLE
ICU-21460 Changed the ULocale initializers to allow locale IDs that use BCP47 syntax, but with _ as a field delimiter.

### DIFF
--- a/icu4c/source/test/cintltst/capitst.c
+++ b/icu4c/source/test/cintltst/capitst.c
@@ -90,6 +90,7 @@ void addCollAPITest(TestNode** root)
     addTest(root, &TestBengaliSortKey, "tscoll/capitst/TestBengaliSortKey");
     addTest(root, &TestGetKeywordValuesForLocale, "tscoll/capitst/TestGetKeywordValuesForLocale");
     addTest(root, &TestStrcollNull, "tscoll/capitst/TestStrcollNull");
+    addTest(root, &TestLocaleIDWithUnderscoreAndExtension, "tscoll/capitst/TestLocaleIDWithUnderscoreAndExtension");
 }
 
 void TestGetSetAttr(void) {
@@ -2563,6 +2564,20 @@ static void TestStrcollNull(void) {
     }
 
     ucol_close(coll);
+}
+
+static void TestLocaleIDWithUnderscoreAndExtension(void) {
+    UErrorCode err = U_ZERO_ERROR;
+    UCollator* c1 = ucol_open("en-US-u-kn-true", &err);
+    UCollator* c2 = ucol_open("en_US-u-kn-true", &err);
+    
+    if (assertSuccess("Failed to create collators", &err)) {
+        assertTrue("Comparison using \"normal\" collator failed", !ucol_greater(c1, u"2", -1, u"10", -1));
+        assertTrue("Comparison using \"bad\" collator failed", !ucol_greater(c2, u"2", -1, u"10", -1));
+    }
+    
+    ucol_close(c1);
+    ucol_close(c2);
 }
 
 #endif /* #if !UCONFIG_NO_COLLATION */

--- a/icu4c/source/test/cintltst/capitst.h
+++ b/icu4c/source/test/cintltst/capitst.h
@@ -136,6 +136,11 @@
      * test strcoll with null arg
      */
     static void TestStrcollNull(void);
+ 
+    /**
+     * Simple test for ICU-21460.  The issue affects all components, but was originally reported against collation.
+     */
+    static void TestLocaleIDWithUnderscoreAndExtension(void);
 
 #endif /* #if !UCONFIG_NO_COLLATION */
 

--- a/icu4c/source/test/cintltst/cloctst.c
+++ b/icu4c/source/test/cintltst/cloctst.c
@@ -3723,13 +3723,13 @@ const char* const basic_maximize_data[][2] = {
     ""
   }, {
      "de_u_co_phonebk",
-     "de_Latn_DE_U_CO_PHONEBK"
+     "de_Latn_DE@collation=phonebook"
   }, {
      "de_Latn_u_co_phonebk",
-     "de_Latn_DE_U_CO_PHONEBK"
+      "de_Latn_DE@collation=phonebook"
   }, {
      "de_Latn_DE_u_co_phonebk",
-     "de_Latn_DE_U_CO_PHONEBK"
+      "de_Latn_DE@collation=phonebook"
   }, {
     "_Arab@em=emoji",
     "ar_Arab_EG@em=emoji"
@@ -6377,7 +6377,7 @@ static const struct {
     {"hant-cmn-cn", "hant", 4},
     {"zh-cmn-TW", "cmn_TW", FULL_LENGTH},
     {"zh-x_t-ab", "zh", 2},
-    {"zh-hans-cn-u-ca-x_t-u", "zh_Hans_CN@calendar=yes",  15},
+    {"zh-hans-cn-u-ca-x_t-u", "zh_Hans_CN@calendar=yes", 15},
     /* #20140 dupe keys in U-extension */
     {"zh-u-ca-chinese-ca-gregory", "zh@calendar=chinese", FULL_LENGTH},
     {"zh-u-ca-gregory-co-pinyin-ca-chinese", "zh@calendar=gregorian;collation=pinyin", FULL_LENGTH},

--- a/icu4c/source/test/intltest/loctest.cpp
+++ b/icu4c/source/test/intltest/loctest.cpp
@@ -4805,7 +4805,7 @@ void LocaleTest::TestCanonicalization(void)
         { "x-piglatin_ML.MBE", "x-piglatin_ML.MBE", "x-piglatin_ML" },
         { "i-cherokee_US.utf7", "i-cherokee_US.utf7", "i-cherokee_US" },
         { "x-filfli_MT_FILFLA.gb-18030", "x-filfli_MT_FILFLA.gb-18030", "x-filfli_MT_FILFLA" },
-        { "no-no-ny.utf8@B", "no_NO_NY.utf8@B", "no_NO_B_NY" /* not: "nn_NO" [alan ICU3.0] */ }, /* @ ignored unless variant is empty */
+        { "no-no-ny.utf8@B", "no_NO_NY.utf8@B", "no_NO@b=ny" /* not: "nn_NO" [alan ICU3.0] */ }, /* @ ignored unless variant is empty */
 
         /* fleshing out canonicalization */
         /* trim space and sort keywords, ';' is separator so not present at end in canonical form */

--- a/icu4j/main/classes/core/src/com/ibm/icu/util/ULocale.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/util/ULocale.java
@@ -1131,10 +1131,13 @@ public final class ULocale implements Serializable, Comparable<ULocale> {
      * @stable ICU 3.0
      */
     public static String getName(String localeID){
-        String tmpLocaleID;
+        String tmpLocaleID = localeID;
         // Convert BCP47 id if necessary
         if (localeID != null && !localeID.contains("@") && getShortestSubtagLength(localeID) == 1) {
-            tmpLocaleID = forLanguageTag(localeID).getName();
+            if (localeID.indexOf('_') >= 0 && localeID.charAt(1) != '_' && localeID.charAt(1) != '-') {
+                tmpLocaleID = localeID.replace('_', '-');
+            }
+            tmpLocaleID = forLanguageTag(tmpLocaleID).getName();
             if (tmpLocaleID.length() == 0) {
                 tmpLocaleID = localeID;
             }

--- a/icu4j/main/tests/collate/src/com/ibm/icu/dev/test/collator/CollationAPITest.java
+++ b/icu4j/main/tests/collate/src/com/ibm/icu/dev/test/collator/CollationAPITest.java
@@ -1702,4 +1702,17 @@ public class CollationAPITest extends TestFmwk {
             errln("unexpected exception for tailoring many characters at the end of symbols: " + e);
         }
     }
+
+    @Test
+    public void TestBogusLocaleID() {
+        try {
+            Collator c1 = Collator.getInstance(new ULocale("en-US-u-kn-true"));
+            Collator c2 = Collator.getInstance(new ULocale("en_US-u-kn-true"));
+
+            assertTrue("Comparison using \"normal\" collator failed", c1.compare("2", "10") < 0);
+            assertTrue("Comparison using \"bad\" collator failed", c2.compare("2", "10") < 0);
+        } catch (Exception e) {
+            errln("Exception creating collators: " + e);
+        }
+    }
 }


### PR DESCRIPTION
…core characters as field delimiters.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21460
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

This seemed fairly straightforward when I agreed to take on this bug, but was a little less so in practice.  The basic idea is that even though the `_` character is illegal in BCP47 language tags, because we support both the BCP47 syntax and the old-style locale-ID syntax (and a hybrid of the two), we'll still see locale IDs that use BCP47 syntax but with underscores between some of the fields.  So I just changed the BCP47 parser so that it'd accept either `-` or `_` as a field delimiter.

This works fine and solves the original symptom reported in JIRA, but I ended up having to change the expected results in a few existing unit tests.  I **think** the new results are okay, but I'm not absolutely certain I'm not having undesirable side effects.

On the Java side, there was an additional problem, where just changing the parser to accept `_` as a field delimiter resulted in "`x-klingon`" getting interpreted as "`@x=klingon`" (my change on the C side didn't have this problem).  I put in a workaround for this (because there didn't seem to be a good way to treat only `-` as a valid delimiter in some places and both `-` and `_` as valid in other places since they're all using the same token iterator), but it's kind of kludgey and I'm not sure it's the best solution to this problem.  Advice welcome.