### PR TITLE
ICU-21663 UnicodeSetIterator: make protected members private

### DIFF
--- a/icu4c/source/common/unicode/usetiter.h
+++ b/icu4c/source/common/unicode/usetiter.h
@@ -33,9 +33,7 @@ class UnicodeString;
  * code points or ranges have been returned, it returns the
  * multicharacter strings of the UnicodeSet, if any.
  *
- * This class is not intended to be subclassed.  Consider any fields
- *  or methods declared as "protected" to be private.  The use of
- *  protected in this class is an artifact of history.
+ * This class is not intended for public subclassing.
  *
  * <p>To iterate over code points and strings, use a loop like this:
  * <pre>
@@ -66,22 +64,17 @@ class UnicodeString;
  * @author M. Davis
  * @stable ICU 2.4
  */
-class U_COMMON_API UnicodeSetIterator : public UObject {
-
- protected:
-
+class U_COMMON_API UnicodeSetIterator U_FINAL : public UObject {
     /**
      * Value of <tt>codepoint</tt> if the iterator points to a string.
      * If <tt>codepoint == IS_STRING</tt>, then examine
      * <tt>string</tt> for the current iteration result.
-     * @stable ICU 2.4
      */
     enum { IS_STRING = -1 };
 
     /**
      * Current code point, or the special value <tt>IS_STRING</tt>, if
      * the iterator points to a string.
-     * @stable ICU 2.4
      */
     UChar32 codepoint;
 
@@ -92,7 +85,6 @@ class U_COMMON_API UnicodeSetIterator : public UObject {
      * iterating over code points using <tt>next()</tt>, or if
      * <tt>codepoint == IS_STRING</tt>, then the value of
      * <tt>codepointEnd</tt> is undefined.
-     * @stable ICU 2.4
      */
     UChar32 codepointEnd;
 
@@ -100,7 +92,6 @@ class U_COMMON_API UnicodeSetIterator : public UObject {
      * If <tt>codepoint == IS_STRING</tt>, then <tt>string</tt> points
      * to the current string.  If <tt>codepoint != IS_STRING</tt>, the
      * value of <tt>string</tt> is undefined.
-     * @stable ICU 2.4
      */
     const UnicodeString* string;
 
@@ -268,42 +259,32 @@ class U_COMMON_API UnicodeSetIterator : public UObject {
 
     // ======================= PRIVATES ===========================
 
- protected:
+private:
 
     // endElement and nextElements are really UChar32's, but we keep
     // them as signed int32_t's so we can do comparisons with
     // endElement set to -1.  Leave them as int32_t's.
     /** The set
-     * @stable ICU 2.4
      */
     const UnicodeSet* set;
     /** End range
-     * @stable ICU 2.4
      */
     int32_t endRange;
     /** Range
-     * @stable ICU 2.4
      */
     int32_t range;
     /** End element
-     * @stable ICU 2.4
      */
     int32_t endElement;
     /** Next element
-     * @stable ICU 2.4
      */
     int32_t nextElement;
-    //UBool abbreviated;
     /** Next string
-     * @stable ICU 2.4
      */
     int32_t nextString;
     /** String count
-     * @stable ICU 2.4
      */
     int32_t stringCount;
-
- private:
 
     /**
      *  Points to the string to use when the caller asks for a
@@ -311,23 +292,17 @@ class U_COMMON_API UnicodeSetIterator : public UObject {
      */
     UnicodeString *cpString;
 
- protected:
-
     /** Copy constructor. Disallowed.
-     * @stable ICU 2.4
      */
-    UnicodeSetIterator(const UnicodeSetIterator&); // disallow
+    UnicodeSetIterator(const UnicodeSetIterator&) = delete;
 
     /** Assignment operator. Disallowed.
-     * @stable ICU 2.4
      */
-    UnicodeSetIterator& operator=(const UnicodeSetIterator&); // disallow
+    UnicodeSetIterator& operator=(const UnicodeSetIterator&) = delete;
 
     /** Load range
-     * @stable ICU 2.4
      */
-    virtual void loadRange(int32_t range);
-
+    void loadRange(int32_t range);
 };
 
 inline UBool UnicodeSetIterator::isString() const {

--- a/icu4j/main/classes/core/src/com/ibm/icu/text/UnicodeSetIterator.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/UnicodeSetIterator.java
@@ -16,6 +16,8 @@ import java.util.Iterator;
  * code points or ranges have been returned, it returns the
  * multicharacter strings of the UnicodeSet, if any.
  *
+ * <p>This class is not intended for public subclassing.
+ *
  * <p>To iterate over code points and multicharacter strings,
  * use a loop like this:
  * <pre>
@@ -45,7 +47,7 @@ import java.util.Iterator;
  * @see UnicodeSet#strings()
  * @see UnicodeSet#iterator()
  */
-public class UnicodeSetIterator {
+public final class UnicodeSetIterator {
 
     /**
      * Value of <tt>codepoint</tt> if the iterator points to a string.
@@ -53,7 +55,7 @@ public class UnicodeSetIterator {
      * <tt>string</tt> for the current iteration result.
      * @stable ICU 2.0
      */
-    public static int IS_STRING = -1;
+    public static final int IS_STRING = -1;
 
     /**
      * Current code point, or the special value <tt>IS_STRING</tt>, if


### PR DESCRIPTION
As proposed:
- mark class UnicodeSetIterator as final in both Java and C++
- remove (make private) the protected `@stable` C++ UnicodeSetIterator members

Note that the class docs already said
> This class is not intended to be subclassed.
> Consider any fields or methods declared as "protected" to be private.
> The use of protected in this class is an artifact of history.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21663
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
