### PR TITLE
ICU-20973 Use standard keywords true & false to initialize type bool.

### DIFF
--- a/icu4c/source/common/bytestriebuilder.cpp
+++ b/icu4c/source/common/bytestriebuilder.cpp
@@ -346,10 +346,10 @@ BytesTrieBuilder::BTLinearMatchNode::BTLinearMatchNode(const char *bytes, int32_
 bool
 BytesTrieBuilder::BTLinearMatchNode::operator==(const Node &other) const {
     if(this==&other) {
-        return TRUE;
+        return true;
     }
     if(!LinearMatchNode::operator==(other)) {
-        return FALSE;
+        return false;
     }
     const BTLinearMatchNode &o=(const BTLinearMatchNode &)other;
     return 0==uprv_memcmp(s, o.s, length);

--- a/icu4c/source/common/messagepattern.cpp
+++ b/icu4c/source/common/messagepattern.cpp
@@ -312,7 +312,7 @@ MessagePattern::clear() {
 bool
 MessagePattern::operator==(const MessagePattern &other) const {
     if(this==&other) {
-        return TRUE;
+        return true;
     }
     return
         aposMode==other.aposMode &&
@@ -390,7 +390,7 @@ MessagePattern::getPluralOffset(int32_t pluralStart) const {
 bool
 MessagePattern::Part::operator==(const Part &other) const {
     if(this==&other) {
-        return TRUE;
+        return true;
     }
     return
         type==other.type &&

--- a/icu4c/source/common/rbbi.cpp
+++ b/icu4c/source/common/rbbi.cpp
@@ -372,10 +372,10 @@ RuleBasedBreakIterator::clone() const {
 bool
 RuleBasedBreakIterator::operator==(const BreakIterator& that) const {
     if (typeid(*this) != typeid(that)) {
-        return FALSE;
+        return false;
     }
     if (this == &that) {
-        return TRUE;
+        return true;
     }
 
     // The base class BreakIterator carries no state that participates in equality,
@@ -388,21 +388,21 @@ RuleBasedBreakIterator::operator==(const BreakIterator& that) const {
         // The two break iterators are operating on different text,
         //   or have a different iteration position.
         //   Note that fText's position is always the same as the break iterator's position.
-        return FALSE;
+        return false;
     }
 
     if (!(fPosition == that2.fPosition &&
             fRuleStatusIndex == that2.fRuleStatusIndex &&
             fDone == that2.fDone)) {
-        return FALSE;
+        return false;
     }
 
     if (that2.fData == fData ||
         (fData != NULL && that2.fData != NULL && *that2.fData == *fData)) {
             // The two break iterators are using the same rules.
-            return TRUE;
+            return true;
         }
-    return FALSE;
+    return false;
 }
 
 /**

--- a/icu4c/source/common/rbbidata.cpp
+++ b/icu4c/source/common/rbbidata.cpp
@@ -172,15 +172,15 @@ RBBIDataWrapper::~RBBIDataWrapper() {
 //-----------------------------------------------------------------------------
 bool RBBIDataWrapper::operator ==(const RBBIDataWrapper &other) const {
     if (fHeader == other.fHeader) {
-        return TRUE;
+        return true;
     }
     if (fHeader->fLength != other.fHeader->fLength) {
-        return FALSE;
+        return false;
     }
     if (uprv_memcmp(fHeader, other.fHeader, fHeader->fLength) == 0) {
-        return TRUE;
+        return true;
     }
-    return FALSE;
+    return false;
 }
 
 int32_t  RBBIDataWrapper::hashCode() {

--- a/icu4c/source/common/schriter.cpp
+++ b/icu4c/source/common/schriter.cpp
@@ -82,7 +82,7 @@ StringCharacterIterator::operator=(const StringCharacterIterator& that) {
 bool
 StringCharacterIterator::operator==(const ForwardCharacterIterator& that) const {
     if (this == &that) {
-        return TRUE;
+        return true;
     }
 
     // do not call UCharCharacterIterator::operator==()
@@ -90,7 +90,7 @@ StringCharacterIterator::operator==(const ForwardCharacterIterator& that) const 
     // while we compare UnicodeString objects
 
     if (typeid(*this) != typeid(that)) {
-        return FALSE;
+        return false;
     }
 
     StringCharacterIterator&    realThat = (StringCharacterIterator&)that;

--- a/icu4c/source/common/stringtriebuilder.cpp
+++ b/icu4c/source/common/stringtriebuilder.cpp
@@ -399,10 +399,10 @@ StringTrieBuilder::Node::markRightEdgesFirst(int32_t edgeNumber) {
 bool
 StringTrieBuilder::FinalValueNode::operator==(const Node &other) const {
     if(this==&other) {
-        return TRUE;
+        return true;
     }
     if(!Node::operator==(other)) {
-        return FALSE;
+        return false;
     }
     const FinalValueNode &o=(const FinalValueNode &)other;
     return value==o.value;
@@ -416,10 +416,10 @@ StringTrieBuilder::FinalValueNode::write(StringTrieBuilder &builder) {
 bool
 StringTrieBuilder::ValueNode::operator==(const Node &other) const {
     if(this==&other) {
-        return TRUE;
+        return true;
     }
     if(!Node::operator==(other)) {
-        return FALSE;
+        return false;
     }
     const ValueNode &o=(const ValueNode &)other;
     return hasValue==o.hasValue && (!hasValue || value==o.value);
@@ -428,10 +428,10 @@ StringTrieBuilder::ValueNode::operator==(const Node &other) const {
 bool
 StringTrieBuilder::IntermediateValueNode::operator==(const Node &other) const {
     if(this==&other) {
-        return TRUE;
+        return true;
     }
     if(!ValueNode::operator==(other)) {
-        return FALSE;
+        return false;
     }
     const IntermediateValueNode &o=(const IntermediateValueNode &)other;
     return next==o.next;
@@ -454,10 +454,10 @@ StringTrieBuilder::IntermediateValueNode::write(StringTrieBuilder &builder) {
 bool
 StringTrieBuilder::LinearMatchNode::operator==(const Node &other) const {
     if(this==&other) {
-        return TRUE;
+        return true;
     }
     if(!ValueNode::operator==(other)) {
-        return FALSE;
+        return false;
     }
     const LinearMatchNode &o=(const LinearMatchNode &)other;
     return length==o.length && next==o.next;
@@ -474,18 +474,18 @@ StringTrieBuilder::LinearMatchNode::markRightEdgesFirst(int32_t edgeNumber) {
 bool
 StringTrieBuilder::ListBranchNode::operator==(const Node &other) const {
     if(this==&other) {
-        return TRUE;
+        return true;
     }
     if(!Node::operator==(other)) {
-        return FALSE;
+        return false;
     }
     const ListBranchNode &o=(const ListBranchNode &)other;
     for(int32_t i=0; i<length; ++i) {
         if(units[i]!=o.units[i] || values[i]!=o.values[i] || equal[i]!=o.equal[i]) {
-            return FALSE;
+            return false;
         }
     }
-    return TRUE;
+    return true;
 }
 
 int32_t
@@ -553,10 +553,10 @@ StringTrieBuilder::ListBranchNode::write(StringTrieBuilder &builder) {
 bool
 StringTrieBuilder::SplitBranchNode::operator==(const Node &other) const {
     if(this==&other) {
-        return TRUE;
+        return true;
     }
     if(!Node::operator==(other)) {
-        return FALSE;
+        return false;
     }
     const SplitBranchNode &o=(const SplitBranchNode &)other;
     return unit==o.unit && lessThan==o.lessThan && greaterOrEqual==o.greaterOrEqual;
@@ -587,10 +587,10 @@ StringTrieBuilder::SplitBranchNode::write(StringTrieBuilder &builder) {
 bool
 StringTrieBuilder::BranchHeadNode::operator==(const Node &other) const {
     if(this==&other) {
-        return TRUE;
+        return true;
     }
     if(!ValueNode::operator==(other)) {
-        return FALSE;
+        return false;
     }
     const BranchHeadNode &o=(const BranchHeadNode &)other;
     return length==o.length && next==o.next;

--- a/icu4c/source/common/ucharstriebuilder.cpp
+++ b/icu4c/source/common/ucharstriebuilder.cpp
@@ -293,10 +293,10 @@ UCharsTrieBuilder::UCTLinearMatchNode::UCTLinearMatchNode(const UChar *units, in
 bool
 UCharsTrieBuilder::UCTLinearMatchNode::operator==(const Node &other) const {
     if(this==&other) {
-        return TRUE;
+        return true;
     }
     if(!LinearMatchNode::operator==(other)) {
-        return FALSE;
+        return false;
     }
     const UCTLinearMatchNode &o=(const UCTLinearMatchNode &)other;
     return 0==u_memcmp(s, o.s, length);

--- a/icu4c/source/common/uchriter.cpp
+++ b/icu4c/source/common/uchriter.cpp
@@ -69,10 +69,10 @@ UCharCharacterIterator::~UCharCharacterIterator() {
 bool
 UCharCharacterIterator::operator==(const ForwardCharacterIterator& that) const {
     if (this == &that) {
-        return TRUE;
+        return true;
     }
     if (typeid(*this) != typeid(that)) {
-        return FALSE;
+        return false;
     }
 
     UCharCharacterIterator&    realThat = (UCharCharacterIterator&)that;

--- a/icu4c/source/common/uniset.cpp
+++ b/icu4c/source/common/uniset.cpp
@@ -279,13 +279,13 @@ UnicodeSet *UnicodeSet::cloneAsThawed() const {
  * @return <tt>true</tt> if the specified set is equal to this set.
  */
 bool UnicodeSet::operator==(const UnicodeSet& o) const {
-    if (len != o.len) return FALSE;
+    if (len != o.len) return false;
     for (int32_t i = 0; i < len; ++i) {
-        if (list[i] != o.list[i]) return FALSE;
+        if (list[i] != o.list[i]) return false;
     }
-    if (hasStrings() != o.hasStrings()) { return FALSE; }
-    if (hasStrings() && *strings != *o.strings) return FALSE;
-    return TRUE;
+    if (hasStrings() != o.hasStrings()) { return false; }
+    if (hasStrings() && *strings != *o.strings) return false;
+    return true;
 }
 
 /**

--- a/icu4c/source/common/ustr_titlecase_brkiter.cpp
+++ b/icu4c/source/common/ustr_titlecase_brkiter.cpp
@@ -73,7 +73,7 @@ private:
 UOBJECT_DEFINE_RTTI_IMPLEMENTATION(WholeStringBreakIterator)
 
 WholeStringBreakIterator::~WholeStringBreakIterator() {}
-bool WholeStringBreakIterator::operator==(const BreakIterator&) const { return FALSE; }
+bool WholeStringBreakIterator::operator==(const BreakIterator&) const { return false; }
 WholeStringBreakIterator *WholeStringBreakIterator::clone() const { return nullptr; }
 
 CharacterIterator &WholeStringBreakIterator::getText() const {

--- a/icu4c/source/common/uvector.cpp
+++ b/icu4c/source/common/uvector.cpp
@@ -112,16 +112,16 @@ void UVector::assign(const UVector& other, UElementAssigner *assign, UErrorCode 
 // This only does something sensible if this object has a non-null comparer
 bool UVector::operator==(const UVector& other) {
     int32_t i;
-    if (count != other.count) return FALSE;
+    if (count != other.count) return false;
     if (comparer != NULL) {
         // Compare using this object's comparer
         for (i=0; i<count; ++i) {
             if (!(*comparer)(elements[i], other.elements[i])) {
-                return FALSE;
+                return false;
             }
         }
     }
-    return TRUE;
+    return true;
 }
 
 void UVector::addElementX(void* obj, UErrorCode &status) {

--- a/icu4c/source/common/uvectr32.cpp
+++ b/icu4c/source/common/uvectr32.cpp
@@ -85,13 +85,13 @@ void UVector32::assign(const UVector32& other, UErrorCode &ec) {
 
 bool UVector32::operator==(const UVector32& other) {
     int32_t i;
-    if (count != other.count) return FALSE;
+    if (count != other.count) return false;
     for (i=0; i<count; ++i) {
         if (elements[i] != other.elements[i]) {
-            return FALSE;
+            return false;
         }
     }
-    return TRUE;
+    return true;
 }
 
 

--- a/icu4c/source/common/uvectr64.cpp
+++ b/icu4c/source/common/uvectr64.cpp
@@ -82,13 +82,13 @@ void UVector64::assign(const UVector64& other, UErrorCode &ec) {
 
 bool UVector64::operator==(const UVector64& other) {
     int32_t i;
-    if (count != other.count) return FALSE;
+    if (count != other.count) return false;
     for (i=0; i<count; ++i) {
         if (elements[i] != other.elements[i]) {
-            return FALSE;
+            return false;
         }
     }
-    return TRUE;
+    return true;
 }
 
 

--- a/icu4c/source/i18n/alphaindex.cpp
+++ b/icu4c/source/i18n/alphaindex.cpp
@@ -800,12 +800,12 @@ UnicodeString AlphabeticIndex::separated(const UnicodeString &item) {
 
 
 bool AlphabeticIndex::operator==(const AlphabeticIndex& /* other */) const {
-    return FALSE;
+    return false;
 }
 
 
 bool AlphabeticIndex::operator!=(const AlphabeticIndex& /* other */) const {
-    return FALSE;
+    return false;
 }
 
 

--- a/icu4c/source/i18n/choicfmt.cpp
+++ b/icu4c/source/i18n/choicfmt.cpp
@@ -135,8 +135,8 @@ ChoiceFormat::ChoiceFormat(const UnicodeString& newPattern,
 bool
 ChoiceFormat::operator==(const Format& that) const
 {
-    if (this == &that) return TRUE;
-    if (!NumberFormat::operator==(that)) return FALSE;
+    if (this == &that) return true;
+    if (!NumberFormat::operator==(that)) return false;
     ChoiceFormat& thatAlias = (ChoiceFormat&)that;
     return msgPattern == thatAlias.msgPattern;
 }

--- a/icu4c/source/i18n/coleitr.cpp
+++ b/icu4c/source/i18n/coleitr.cpp
@@ -147,7 +147,7 @@ bool CollationElementIterator::operator==(
                                     const CollationElementIterator& that) const
 {
     if (this == &that) {
-        return TRUE;
+        return true;
     }
 
     return

--- a/icu4c/source/i18n/collationiterator.cpp
+++ b/icu4c/source/i18n/collationiterator.cpp
@@ -180,12 +180,12 @@ CollationIterator::operator==(const CollationIterator &other) const {
             cesIndex == other.cesIndex &&
             numCpFwd == other.numCpFwd &&
             isNumeric == other.isNumeric)) {
-        return FALSE;
+        return false;
     }
     for(int32_t i = 0; i < ceBuffer.length; ++i) {
-        if(ceBuffer.get(i) != other.ceBuffer.get(i)) { return FALSE; }
+        if(ceBuffer.get(i) != other.ceBuffer.get(i)) { return false; }
     }
-    return TRUE;
+    return true;
 }
 
 void

--- a/icu4c/source/i18n/collationsettings.cpp
+++ b/icu4c/source/i18n/collationsettings.cpp
@@ -50,13 +50,13 @@ CollationSettings::~CollationSettings() {
 
 bool
 CollationSettings::operator==(const CollationSettings &other) const {
-    if(options != other.options) { return FALSE; }
-    if((options & ALTERNATE_MASK) != 0 && variableTop != other.variableTop) { return FALSE; }
-    if(reorderCodesLength != other.reorderCodesLength) { return FALSE; }
+    if(options != other.options) { return false; }
+    if((options & ALTERNATE_MASK) != 0 && variableTop != other.variableTop) { return false; }
+    if(reorderCodesLength != other.reorderCodesLength) { return false; }
     for(int32_t i = 0; i < reorderCodesLength; ++i) {
-        if(reorderCodes[i] != other.reorderCodes[i]) { return FALSE; }
+        if(reorderCodes[i] != other.reorderCodes[i]) { return false; }
     }
-    return TRUE;
+    return true;
 }
 
 int32_t

--- a/icu4c/source/i18n/dcfmtsym.cpp
+++ b/icu4c/source/i18n/dcfmtsym.cpp
@@ -179,25 +179,25 @@ bool
 DecimalFormatSymbols::operator==(const DecimalFormatSymbols& that) const
 {
     if (this == &that) {
-        return TRUE;
+        return true;
     }
     if (fIsCustomCurrencySymbol != that.fIsCustomCurrencySymbol) { 
-        return FALSE; 
+        return false;
     } 
     if (fIsCustomIntlCurrencySymbol != that.fIsCustomIntlCurrencySymbol) { 
-        return FALSE; 
+        return false;
     } 
     for(int32_t i = 0; i < (int32_t)kFormatSymbolCount; ++i) {
         if(fSymbols[(ENumberFormatSymbol)i] != that.fSymbols[(ENumberFormatSymbol)i]) {
-            return FALSE;
+            return false;
         }
     }
     for(int32_t i = 0; i < (int32_t)UNUM_CURRENCY_SPACING_COUNT; ++i) {
         if(currencySpcBeforeSym[i] != that.currencySpcBeforeSym[i]) {
-            return FALSE;
+            return false;
         }
         if(currencySpcAfterSym[i] != that.currencySpcAfterSym[i]) {
-            return FALSE;
+            return false;
         }
     }
     // No need to check fCodePointZero since it is based on fSymbols

--- a/icu4c/source/i18n/dtfmtsym.cpp
+++ b/icu4c/source/i18n/dtfmtsym.cpp
@@ -544,7 +544,7 @@ DateFormatSymbols::operator==(const DateFormatSymbols& other) const
 {
     // First do cheap comparisons
     if (this == &other) {
-        return TRUE;
+        return true;
     }
     if (fErasCount == other.fErasCount &&
         fEraNamesCount == other.fEraNamesCount &&
@@ -625,22 +625,22 @@ DateFormatSymbols::operator==(const DateFormatSymbols& other) const
             // Compare the contents of fZoneStrings
             if (fZoneStrings == NULL && other.fZoneStrings == NULL) {
                 if (fZSFLocale == other.fZSFLocale) {
-                    return TRUE;
+                    return true;
                 }
             } else if (fZoneStrings != NULL && other.fZoneStrings != NULL) {
                 if (fZoneStringsRowCount == other.fZoneStringsRowCount
                     && fZoneStringsColCount == other.fZoneStringsColCount) {
-                    UBool cmpres = TRUE;
+                    bool cmpres = true;
                     for (int32_t i = 0; (i < fZoneStringsRowCount) && cmpres; i++) {
                         cmpres = arrayCompare(fZoneStrings[i], other.fZoneStrings[i], fZoneStringsColCount);
                     }
                     return cmpres;
                 }
             }
-            return FALSE;
+            return false;
         }
     }
-    return FALSE;
+    return false;
 }
 
 //------------------------------------------------------

--- a/icu4c/source/i18n/dtitvfmt.cpp
+++ b/icu4c/source/i18n/dtitvfmt.cpp
@@ -231,35 +231,35 @@ DateIntervalFormat::clone() const {
 
 bool
 DateIntervalFormat::operator==(const Format& other) const {
-    if (typeid(*this) != typeid(other)) {return FALSE;}
+    if (typeid(*this) != typeid(other)) {return false;}
     const DateIntervalFormat* fmt = (DateIntervalFormat*)&other;
-    if (this == fmt) {return TRUE;}
-    if (!Format::operator==(other)) {return FALSE;}
-    if ((fInfo != fmt->fInfo) && (fInfo == nullptr || fmt->fInfo == nullptr)) {return FALSE;}
-    if (fInfo && fmt->fInfo && (*fInfo != *fmt->fInfo )) {return FALSE;}
+    if (this == fmt) {return true;}
+    if (!Format::operator==(other)) {return false;}
+    if ((fInfo != fmt->fInfo) && (fInfo == nullptr || fmt->fInfo == nullptr)) {return false;}
+    if (fInfo && fmt->fInfo && (*fInfo != *fmt->fInfo )) {return false;}
     {
         Mutex lock(&gFormatterMutex);
-        if (fDateFormat != fmt->fDateFormat && (fDateFormat == nullptr || fmt->fDateFormat == nullptr)) {return FALSE;}
-        if (fDateFormat && fmt->fDateFormat && (*fDateFormat != *fmt->fDateFormat)) {return FALSE;}
+        if (fDateFormat != fmt->fDateFormat && (fDateFormat == nullptr || fmt->fDateFormat == nullptr)) {return false;}
+        if (fDateFormat && fmt->fDateFormat && (*fDateFormat != *fmt->fDateFormat)) {return false;}
     }
     // note: fFromCalendar and fToCalendar hold no persistent state, and therefore do not participate in operator ==.
     //       fDateFormat has the primary calendar for the DateIntervalFormat.
-    if (fSkeleton != fmt->fSkeleton) {return FALSE;}
-    if (fDatePattern != fmt->fDatePattern && (fDatePattern == nullptr || fmt->fDatePattern == nullptr)) {return FALSE;}
-    if (fDatePattern && fmt->fDatePattern && (*fDatePattern != *fmt->fDatePattern)) {return FALSE;}
-    if (fTimePattern != fmt->fTimePattern && (fTimePattern == nullptr || fmt->fTimePattern == nullptr)) {return FALSE;}
-    if (fTimePattern && fmt->fTimePattern && (*fTimePattern != *fmt->fTimePattern)) {return FALSE;}
-    if (fDateTimeFormat != fmt->fDateTimeFormat && (fDateTimeFormat == nullptr || fmt->fDateTimeFormat == nullptr)) {return FALSE;}
-    if (fDateTimeFormat && fmt->fDateTimeFormat && (*fDateTimeFormat != *fmt->fDateTimeFormat)) {return FALSE;}
-    if (fLocale != fmt->fLocale) {return FALSE;}
+    if (fSkeleton != fmt->fSkeleton) {return false;}
+    if (fDatePattern != fmt->fDatePattern && (fDatePattern == nullptr || fmt->fDatePattern == nullptr)) {return false;}
+    if (fDatePattern && fmt->fDatePattern && (*fDatePattern != *fmt->fDatePattern)) {return false;}
+    if (fTimePattern != fmt->fTimePattern && (fTimePattern == nullptr || fmt->fTimePattern == nullptr)) {return false;}
+    if (fTimePattern && fmt->fTimePattern && (*fTimePattern != *fmt->fTimePattern)) {return false;}
+    if (fDateTimeFormat != fmt->fDateTimeFormat && (fDateTimeFormat == nullptr || fmt->fDateTimeFormat == nullptr)) {return false;}
+    if (fDateTimeFormat && fmt->fDateTimeFormat && (*fDateTimeFormat != *fmt->fDateTimeFormat)) {return false;}
+    if (fLocale != fmt->fLocale) {return false;}
 
     for (int32_t i = 0; i< DateIntervalInfo::kIPI_MAX_INDEX; ++i ) {
-        if (fIntervalPatterns[i].firstPart != fmt->fIntervalPatterns[i].firstPart) {return FALSE;}
-        if (fIntervalPatterns[i].secondPart != fmt->fIntervalPatterns[i].secondPart ) {return FALSE;}
-        if (fIntervalPatterns[i].laterDateFirst != fmt->fIntervalPatterns[i].laterDateFirst) {return FALSE;}
+        if (fIntervalPatterns[i].firstPart != fmt->fIntervalPatterns[i].firstPart) {return false;}
+        if (fIntervalPatterns[i].secondPart != fmt->fIntervalPatterns[i].secondPart ) {return false;}
+        if (fIntervalPatterns[i].laterDateFirst != fmt->fIntervalPatterns[i].laterDateFirst) {return false;}
     }
-    if (fCapitalizationContext != fmt->fCapitalizationContext) {return FALSE;}
-    return TRUE;
+    if (fCapitalizationContext != fmt->fCapitalizationContext) {return false;}
+    return true;
 }
 
 

--- a/icu4c/source/i18n/dtitvinf.cpp
+++ b/icu4c/source/i18n/dtitvinf.cpp
@@ -167,11 +167,11 @@ DateIntervalInfo::~DateIntervalInfo() {
 
 bool
 DateIntervalInfo::operator==(const DateIntervalInfo& other) const {
-    UBool equal = (
+    bool equal = (
       fFallbackIntervalPattern == other.fFallbackIntervalPattern &&
       fFirstDateInPtnIsLaterDate == other.fFirstDateInPtnIsLaterDate );
 
-    if ( equal == TRUE ) {
+    if ( equal ) {
         equal = fIntervalPatterns->equals(*(other.fIntervalPatterns));
     }
 

--- a/icu4c/source/i18n/dtptngen.cpp
+++ b/icu4c/source/i18n/dtptngen.cpp
@@ -427,24 +427,24 @@ DateTimePatternGenerator::operator=(const DateTimePatternGenerator& other) {
 bool
 DateTimePatternGenerator::operator==(const DateTimePatternGenerator& other) const {
     if (this == &other) {
-        return TRUE;
+        return true;
     }
     if ((pLocale==other.pLocale) && (patternMap->equals(*other.patternMap)) &&
         (dateTimeFormat==other.dateTimeFormat) && (decimal==other.decimal)) {
         for ( int32_t i=0 ; i<UDATPG_FIELD_COUNT; ++i ) {
             if (appendItemFormats[i] != other.appendItemFormats[i]) {
-                return FALSE;
+                return false;
             }
             for (int32_t j=0; j< UDATPG_WIDTH_COUNT; ++j ) {
                 if (fieldDisplayNames[i][j] != other.fieldDisplayNames[i][j]) {
-                    return FALSE;
+                    return false;
                 }
             }
         }
-        return TRUE;
+        return true;
     }
     else {
-        return FALSE;
+        return false;
     }
 }
 

--- a/icu4c/source/i18n/fmtable.cpp
+++ b/icu4c/source/i18n/fmtable.cpp
@@ -280,13 +280,13 @@ Formattable::operator==(const Formattable& that) const
 {
     int32_t i;
 
-    if (this == &that) return TRUE;
+    if (this == &that) return true;
 
-    // Returns FALSE if the data types are different.
-    if (fType != that.fType) return FALSE;
+    // Returns false if the data types are different.
+    if (fType != that.fType) return false;
 
     // Compares the actual data values.
-    UBool equal = TRUE;
+    bool equal = true;
     switch (fType) {
     case kDate:
         equal = (fValue.fDate == that.fValue.fDate);
@@ -303,20 +303,20 @@ Formattable::operator==(const Formattable& that) const
         break;
     case kArray:
         if (fValue.fArrayAndCount.fCount != that.fValue.fArrayAndCount.fCount) {
-            equal = FALSE;
+            equal = false;
             break;
         }
         // Checks each element for equality.
         for (i=0; i<fValue.fArrayAndCount.fCount; ++i) {
             if (fValue.fArrayAndCount.fArray[i] != that.fValue.fArrayAndCount.fArray[i]) {
-                equal = FALSE;
+                equal = false;
                 break;
             }
         }
         break;
     case kObject:
         if (fValue.fObject == NULL || that.fValue.fObject == NULL) {
-            equal = FALSE;
+            equal = false;
         } else {
             equal = objectEquals(fValue.fObject, that.fValue.fObject);
         }

--- a/icu4c/source/i18n/fpositer.cpp
+++ b/icu4c/source/i18n/fpositer.cpp
@@ -47,15 +47,15 @@ FieldPositionIterator::FieldPositionIterator(const FieldPositionIterator &rhs)
 
 bool FieldPositionIterator::operator==(const FieldPositionIterator &rhs) const {
   if (&rhs == this) {
-    return TRUE;
+    return true;
   }
   if (pos != rhs.pos) {
-    return FALSE;
+    return false;
   }
   if (!data) {
     return rhs.data == NULL;
   }
-  return rhs.data ? data->operator==(*rhs.data) : FALSE;
+  return rhs.data ? data->operator==(*rhs.data) : false;
 }
 
 void FieldPositionIterator::setData(UVector32 *adopt, UErrorCode& status) {

--- a/icu4c/source/i18n/measfmt.cpp
+++ b/icu4c/source/i18n/measfmt.cpp
@@ -429,10 +429,10 @@ MeasureFormat::~MeasureFormat() {
 
 bool MeasureFormat::operator==(const Format &other) const {
     if (this == &other) { // Same object, equal
-        return TRUE;
+        return true;
     }
     if (!Format::operator==(other)) {
-        return FALSE;
+        return false;
     }
     const MeasureFormat &rhs = static_cast<const MeasureFormat &>(other);
 
@@ -441,7 +441,7 @@ bool MeasureFormat::operator==(const Format &other) const {
 
     // differing widths aren't equivalent
     if (fWidth != rhs.fWidth) {
-        return FALSE;
+        return false;
     }
     // Width the same check locales.
     // We don't need to check locales if both objects have same cache.
@@ -451,10 +451,10 @@ bool MeasureFormat::operator==(const Format &other) const {
         const char *rhsLocaleId = rhs.getLocaleID(status);
         if (U_FAILURE(status)) {
             // On failure, assume not equal
-            return FALSE;
+            return false;
         }
         if (uprv_strcmp(localeId, rhsLocaleId) != 0) {
-            return FALSE;
+            return false;
         }
     }
     // Locales same, check NumberFormat if shared data differs.

--- a/icu4c/source/i18n/measunit.cpp
+++ b/icu4c/source/i18n/measunit.cpp
@@ -2198,10 +2198,10 @@ const char *MeasureUnit::getIdentifier() const {
 
 bool MeasureUnit::operator==(const UObject& other) const {
     if (this == &other) {  // Same object, equal
-        return TRUE;
+        return true;
     }
     if (typeid(*this) != typeid(other)) { // Different types, not equal
-        return FALSE;
+        return false;
     }
     const MeasureUnit &rhs = static_cast<const MeasureUnit&>(other);
     return uprv_strcmp(getIdentifier(), rhs.getIdentifier()) == 0;

--- a/icu4c/source/i18n/measure.cpp
+++ b/icu4c/source/i18n/measure.cpp
@@ -62,10 +62,10 @@ Measure::~Measure() {
 
 bool Measure::operator==(const UObject& other) const {
     if (this == &other) {  // Same object, equal
-        return TRUE;
+        return true;
     }
     if (typeid(*this) != typeid(other)) { // Different types, not equal
-        return FALSE;
+        return false;
     }
     const Measure &m = static_cast<const Measure&>(other);
     return number == m.number &&

--- a/icu4c/source/i18n/msgfmt.cpp
+++ b/icu4c/source/i18n/msgfmt.cpp
@@ -392,7 +392,7 @@ MessageFormat::operator=(const MessageFormat& that)
 bool
 MessageFormat::operator==(const Format& rhs) const
 {
-    if (this == &rhs) return TRUE;
+    if (this == &rhs) return true;
 
     MessageFormat& that = (MessageFormat&)rhs;
 
@@ -400,37 +400,37 @@ MessageFormat::operator==(const Format& rhs) const
     if (!Format::operator==(rhs) ||
         msgPattern != that.msgPattern ||
         fLocale != that.fLocale) {
-        return FALSE;
+        return false;
     }
 
     // Compare hashtables.
     if ((customFormatArgStarts == NULL) != (that.customFormatArgStarts == NULL)) {
-        return FALSE;
+        return false;
     }
     if (customFormatArgStarts == NULL) {
-        return TRUE;
+        return true;
     }
 
     UErrorCode ec = U_ZERO_ERROR;
     const int32_t count = uhash_count(customFormatArgStarts);
     const int32_t rhs_count = uhash_count(that.customFormatArgStarts);
     if (count != rhs_count) {
-        return FALSE;
+        return false;
     }
     int32_t idx = 0, rhs_idx = 0, pos = UHASH_FIRST, rhs_pos = UHASH_FIRST;
     for (; idx < count && rhs_idx < rhs_count && U_SUCCESS(ec); ++idx, ++rhs_idx) {
         const UHashElement* cur = uhash_nextElement(customFormatArgStarts, &pos);
         const UHashElement* rhs_cur = uhash_nextElement(that.customFormatArgStarts, &rhs_pos);
         if (cur->key.integer != rhs_cur->key.integer) {
-            return FALSE;
+            return false;
         }
         const Format* format = (const Format*)uhash_iget(cachedFormatters, cur->key.integer);
         const Format* rhs_format = (const Format*)uhash_iget(that.cachedFormatters, rhs_cur->key.integer);
         if (*format != *rhs_format) {
-            return FALSE;
+            return false;
         }
     }
-    return TRUE;
+    return true;
 }
 
 // -------------------------------------
@@ -1870,7 +1870,7 @@ UBool MessageFormat::equalFormats(const void* left, const void* right) {
 
 
 bool MessageFormat::DummyFormat::operator==(const Format&) const {
-    return TRUE;
+    return true;
 }
 
 MessageFormat::DummyFormat* MessageFormat::DummyFormat::clone() const {

--- a/icu4c/source/i18n/nfrs.cpp
+++ b/icu4c/source/i18n/nfrs.cpp
@@ -354,19 +354,19 @@ NFRuleSet::operator==(const NFRuleSet& rhs) const
         // ...then compare the non-numerical rule lists...
         for (int i = 0; i < NON_NUMERICAL_RULE_LENGTH; i++) {
             if (!util_equalRules(nonNumericalRules[i], rhs.nonNumericalRules[i])) {
-                return FALSE;
+                return false;
             }
         }
 
         // ...then compare the rule lists...
         for (uint32_t i = 0; i < rules.size(); ++i) {
             if (*rules[i] != *rhs.rules[i]) {
-                return FALSE;
+                return false;
             }
         }
-        return TRUE;
+        return true;
     }
-    return FALSE;
+    return false;
 }
 
 void

--- a/icu4c/source/i18n/plurfmt.cpp
+++ b/icu4c/source/i18n/plurfmt.cpp
@@ -384,10 +384,10 @@ PluralFormat::operator=(const PluralFormat& other) {
 bool
 PluralFormat::operator==(const Format& other) const {
     if (this == &other) {
-        return TRUE;
+        return true;
     }
     if (!Format::operator==(other)) {
-        return FALSE;
+        return false;
     }
     const PluralFormat& o = (const PluralFormat&)other;
     return

--- a/icu4c/source/i18n/plurrule.cpp
+++ b/icu4c/source/i18n/plurrule.cpp
@@ -561,34 +561,34 @@ PluralRules::operator==(const PluralRules& other) const  {
     UErrorCode status= U_ZERO_ERROR;
 
     if ( this == &other ) {
-        return TRUE;
+        return true;
     }
     LocalPointer<StringEnumeration> myKeywordList(getKeywords(status));
     LocalPointer<StringEnumeration> otherKeywordList(other.getKeywords(status));
     if (U_FAILURE(status)) {
-        return FALSE;
+        return false;
     }
 
     if (myKeywordList->count(status)!=otherKeywordList->count(status)) {
-        return FALSE;
+        return false;
     }
     myKeywordList->reset(status);
     while ((ptrKeyword=myKeywordList->snext(status))!=nullptr) {
         if (!other.isKeyword(*ptrKeyword)) {
-            return FALSE;
+            return false;
         }
     }
     otherKeywordList->reset(status);
     while ((ptrKeyword=otherKeywordList->snext(status))!=nullptr) {
         if (!this->isKeyword(*ptrKeyword)) {
-            return FALSE;
+            return false;
         }
     }
     if (U_FAILURE(status)) {
-        return FALSE;
+        return false;
     }
 
-    return TRUE;
+    return true;
 }
 
 

--- a/icu4c/source/i18n/rbnf.cpp
+++ b/icu4c/source/i18n/rbnf.cpp
@@ -135,14 +135,14 @@ bool
 LocalizationInfo::operator==(const LocalizationInfo* rhs) const {
     if (rhs) {
         if (this == rhs) {
-            return TRUE;
+            return true;
         }
         
         int32_t rsc = getNumberOfRuleSets();
         if (rsc == rhs->getNumberOfRuleSets()) {
             for (int i = 0; i < rsc; ++i) {
                 if (!streq(getRuleSetName(i), rhs->getRuleSetName(i))) {
-                    return FALSE;
+                    return false;
                 }
             }
             int32_t dlc = getNumberOfDisplayLocales();
@@ -152,19 +152,19 @@ LocalizationInfo::operator==(const LocalizationInfo* rhs) const {
                     int32_t ix = rhs->indexForLocale(locale);
                     // if no locale, ix is -1, getLocaleName returns null, so streq returns false
                     if (!streq(locale, rhs->getLocaleName(ix))) {
-                        return FALSE;
+                        return false;
                     }
                     for (int j = 0; j < rsc; ++j) {
                         if (!streq(getDisplayName(i, j), rhs->getDisplayName(ix, j))) {
-                            return FALSE;
+                            return false;
                         }
                     }
                 }
-                return TRUE;
+                return true;
             }
         }
     }
-    return FALSE;
+    return false;
 }
 
 int32_t
@@ -940,7 +940,7 @@ bool
 RuleBasedNumberFormat::operator==(const Format& other) const
 {
     if (this == &other) {
-        return TRUE;
+        return true;
     }
 
     if (typeid(*this) == typeid(other)) {
@@ -953,7 +953,7 @@ RuleBasedNumberFormat::operator==(const Format& other) const
             (localizations == NULL 
                 ? rhs.localizations == NULL 
                 : (rhs.localizations == NULL 
-                    ? FALSE
+                    ? false
                     : *localizations == rhs.localizations))) {
 
             NFRuleSet** p = fRuleSets;
@@ -961,7 +961,7 @@ RuleBasedNumberFormat::operator==(const Format& other) const
             if (p == NULL) {
                 return q == NULL;
             } else if (q == NULL) {
-                return FALSE;
+                return false;
             }
             while (*p && *q && (**p == **q)) {
                 ++p;
@@ -971,7 +971,7 @@ RuleBasedNumberFormat::operator==(const Format& other) const
         }
     }
 
-    return FALSE;
+    return false;
 }
 
 UnicodeString

--- a/icu4c/source/i18n/rbtz.cpp
+++ b/icu4c/source/i18n/rbtz.cpp
@@ -91,21 +91,20 @@ RuleBasedTimeZone::operator=(const RuleBasedTimeZone& right) {
 bool
 RuleBasedTimeZone::operator==(const TimeZone& that) const {
     if (this == &that) {
-        return TRUE;
+        return true;
     }
-    if (typeid(*this) != typeid(that)
-        || BasicTimeZone::operator==(that) == FALSE) {
-        return FALSE;
+    if (typeid(*this) != typeid(that) || !BasicTimeZone::operator==(that)) {
+        return false;
     }
     RuleBasedTimeZone *rbtz = (RuleBasedTimeZone*)&that;
     if (*fInitialRule != *(rbtz->fInitialRule)) {
-        return FALSE;
+        return false;
     }
     if (compareRules(fHistoricRules, rbtz->fHistoricRules)
         && compareRules(fFinalRules, rbtz->fFinalRules)) {
-        return TRUE;
+        return true;
     }
-    return FALSE;
+    return false;
 }
 
 bool

--- a/icu4c/source/i18n/reldtfmt.cpp
+++ b/icu4c/source/i18n/reldtfmt.cpp
@@ -146,7 +146,7 @@ bool RelativeDateFormat::operator==(const Format& other) const {
                 fTimePattern==that->fTimePattern   &&
                 fLocale==that->fLocale );
     }
-    return FALSE;
+    return false;
 }
 
 static const UChar APOSTROPHE = (UChar)0x0027;

--- a/icu4c/source/i18n/repattrn.cpp
+++ b/icu4c/source/i18n/repattrn.cpp
@@ -297,7 +297,7 @@ bool    RegexPattern::operator ==(const RegexPattern &other) const {
             return *(this->fPatternString) == *(other.fPatternString);
         } else if (this->fPattern == NULL) {
             if (other.fPattern == NULL) {
-                return TRUE;
+                return true;
             }
         } else if (other.fPattern != NULL) {
             UTEXT_SETNATIVEINDEX(this->fPattern, 0);
@@ -305,7 +305,7 @@ bool    RegexPattern::operator ==(const RegexPattern &other) const {
             return utext_equals(this->fPattern, other.fPattern);
         }
     }
-    return FALSE;
+    return false;
 }
 
 //---------------------------------------------------------------------

--- a/icu4c/source/i18n/rulebasedcollator.cpp
+++ b/icu4c/source/i18n/rulebasedcollator.cpp
@@ -241,19 +241,19 @@ UOBJECT_DEFINE_RTTI_IMPLEMENTATION(RuleBasedCollator)
 
 bool
 RuleBasedCollator::operator==(const Collator& other) const {
-    if(this == &other) { return TRUE; }
-    if(!Collator::operator==(other)) { return FALSE; }
+    if(this == &other) { return true; }
+    if(!Collator::operator==(other)) { return false; }
     const RuleBasedCollator &o = static_cast<const RuleBasedCollator &>(other);
-    if(*settings != *o.settings) { return FALSE; }
-    if(data == o.data) { return TRUE; }
+    if(*settings != *o.settings) { return false; }
+    if(data == o.data) { return true; }
     UBool thisIsRoot = data->base == NULL;
     UBool otherIsRoot = o.data->base == NULL;
     U_ASSERT(!thisIsRoot || !otherIsRoot);  // otherwise their data pointers should be ==
-    if(thisIsRoot != otherIsRoot) { return FALSE; }
+    if(thisIsRoot != otherIsRoot) { return false; }
     if((thisIsRoot || !tailoring->rules.isEmpty()) &&
             (otherIsRoot || !o.tailoring->rules.isEmpty())) {
         // Shortcut: If both collators have valid rule strings, then compare those.
-        if(tailoring->rules == o.tailoring->rules) { return TRUE; }
+        if(tailoring->rules == o.tailoring->rules) { return true; }
     }
     // Different rule strings can result in the same or equivalent tailoring.
     // The rule strings are optional in ICU resource bundles, although included by default.
@@ -261,14 +261,14 @@ RuleBasedCollator::operator==(const Collator& other) const {
     UErrorCode errorCode = U_ZERO_ERROR;
     LocalPointer<UnicodeSet> thisTailored(getTailoredSet(errorCode));
     LocalPointer<UnicodeSet> otherTailored(o.getTailoredSet(errorCode));
-    if(U_FAILURE(errorCode)) { return FALSE; }
-    if(*thisTailored != *otherTailored) { return FALSE; }
+    if(U_FAILURE(errorCode)) { return false; }
+    if(*thisTailored != *otherTailored) { return false; }
     // For completeness, we should compare all of the mappings;
     // or we should create a list of strings, sort it with one collator,
     // and check if both collators compare adjacent strings the same
     // (order & strength, down to quaternary); or similar.
     // Testing equality of collators seems unusual.
-    return TRUE;
+    return true;
 }
 
 int32_t

--- a/icu4c/source/i18n/scriptset.cpp
+++ b/icu4c/source/i18n/scriptset.cpp
@@ -47,10 +47,10 @@ ScriptSet & ScriptSet::operator =(const ScriptSet &other) {
 bool ScriptSet::operator == (const ScriptSet &other) const {
     for (uint32_t i=0; i<UPRV_LENGTHOF(bits); i++) {
         if (bits[i] != other.bits[i]) {
-            return FALSE;
+            return false;
         }
     }
-    return TRUE;
+    return true;
 }
 
 UBool ScriptSet::test(UScriptCode script, UErrorCode &status) const {

--- a/icu4c/source/i18n/search.cpp
+++ b/icu4c/source/i18n/search.cpp
@@ -181,7 +181,7 @@ const UnicodeString & SearchIterator::getText(void) const
 bool SearchIterator::operator==(const SearchIterator &that) const
 {
     if (this == &that) {
-        return TRUE;
+        return true;
     }
     return (m_breakiterator_            == that.m_breakiterator_ &&
             m_search_->isCanonicalMatch == that.m_search_->isCanonicalMatch &&

--- a/icu4c/source/i18n/selfmt.cpp
+++ b/icu4c/source/i18n/selfmt.cpp
@@ -167,10 +167,10 @@ SelectFormat::operator=(const SelectFormat& other) {
 bool
 SelectFormat::operator==(const Format& other) const {
     if (this == &other) {
-        return TRUE;
+        return true;
     }
     if (!Format::operator==(other)) {
-        return FALSE;
+        return false;
     }
     const SelectFormat& o = (const SelectFormat&)other;
     return msgPattern == o.msgPattern;

--- a/icu4c/source/i18n/smpdtfmt.cpp
+++ b/icu4c/source/i18n/smpdtfmt.cpp
@@ -673,7 +673,7 @@ SimpleDateFormat::operator==(const Format& other) const
                 fHaveDefaultCentury  == that->fHaveDefaultCentury &&
                 fDefaultCenturyStart == that->fDefaultCenturyStart);
     }
-    return FALSE;
+    return false;
 }
 
 //----------------------------------------------------------------------

--- a/icu4c/source/i18n/stsearch.cpp
+++ b/icu4c/source/i18n/stsearch.cpp
@@ -208,14 +208,14 @@ StringSearch & StringSearch::operator=(const StringSearch &that)
 bool StringSearch::operator==(const SearchIterator &that) const
 {
     if (this == &that) {
-        return TRUE;
+        return true;
     }
     if (SearchIterator::operator ==(that)) {
         StringSearch &thatsrch = (StringSearch &)that;
         return (this->m_pattern_ == thatsrch.m_pattern_ &&
                 this->m_strsrch_->collator == thatsrch.m_strsrch_->collator);
     }
-    return FALSE;
+    return false;
 }
 
 // public get and set methods ----------------------------------------

--- a/icu4c/source/i18n/tzfmt.cpp
+++ b/icu4c/source/i18n/tzfmt.cpp
@@ -486,7 +486,7 @@ bool
 TimeZoneFormat::operator==(const Format& other) const {
     TimeZoneFormat* tzfmt = (TimeZoneFormat*)&other;
 
-    UBool isEqual =
+    bool isEqual =
             fLocale == tzfmt->fLocale
             && fGMTPattern == tzfmt->fGMTPattern
             && fGMTZeroFormat == tzfmt->fGMTZeroFormat

--- a/icu4c/source/i18n/tznames.cpp
+++ b/icu4c/source/i18n/tznames.cpp
@@ -222,7 +222,7 @@ TimeZoneNamesDelegate::~TimeZoneNamesDelegate() {
 bool
 TimeZoneNamesDelegate::operator==(const TimeZoneNames& other) const {
     if (this == &other) {
-        return TRUE;
+        return true;
     }
     // Just compare if the other object also use the same
     // cache entry
@@ -230,7 +230,7 @@ TimeZoneNamesDelegate::operator==(const TimeZoneNames& other) const {
     if (rhs) {
         return fTZnamesCacheEntry == rhs->fTZnamesCacheEntry;
     }
-    return FALSE;
+    return false;
 }
 
 TimeZoneNamesDelegate*

--- a/icu4c/source/i18n/tznames_impl.cpp
+++ b/icu4c/source/i18n/tznames_impl.cpp
@@ -1107,10 +1107,10 @@ TimeZoneNamesImpl::cleanup() {
 bool
 TimeZoneNamesImpl::operator==(const TimeZoneNames& other) const {
     if (this == &other) {
-        return TRUE;
+        return true;
     }
     // No implementation for now
-    return FALSE;
+    return false;
 }
 
 TimeZoneNamesImpl*
@@ -2159,10 +2159,10 @@ TZDBTimeZoneNames::~TZDBTimeZoneNames() {
 bool
 TZDBTimeZoneNames::operator==(const TimeZoneNames& other) const {
     if (this == &other) {
-        return TRUE;
+        return true;
     }
     // No implementation for now
-    return FALSE;
+    return false;
 }
 
 TZDBTimeZoneNames*

--- a/icu4c/source/i18n/tzrule.cpp
+++ b/icu4c/source/i18n/tzrule.cpp
@@ -229,10 +229,10 @@ AnnualTimeZoneRule::operator=(const AnnualTimeZoneRule& right) {
 bool
 AnnualTimeZoneRule::operator==(const TimeZoneRule& that) const {
     if (this == &that) {
-        return TRUE;
+        return true;
     }
     if (typeid(*this) != typeid(that)) {
-        return FALSE;
+        return false;
     }
     AnnualTimeZoneRule *atzr = (AnnualTimeZoneRule*)&that;
     return (*fDateTimeRule == *(atzr->fDateTimeRule) &&
@@ -448,21 +448,21 @@ TimeArrayTimeZoneRule::operator=(const TimeArrayTimeZoneRule& right) {
 bool
 TimeArrayTimeZoneRule::operator==(const TimeZoneRule& that) const {
     if (this == &that) {
-        return TRUE;
+        return true;
     }
-    if (typeid(*this) != typeid(that) || TimeZoneRule::operator==(that) == FALSE) {
-        return FALSE;
+    if (typeid(*this) != typeid(that) || !TimeZoneRule::operator==(that)) {
+        return false;
     }
     TimeArrayTimeZoneRule *tatzr = (TimeArrayTimeZoneRule*)&that;
     if (fTimeRuleType != tatzr->fTimeRuleType ||
         fNumStartTimes != tatzr->fNumStartTimes) {
-        return FALSE;
+        return false;
     }
     // Compare start times
-    UBool res = TRUE;
+    bool res = true;
     for (int32_t i = 0; i < fNumStartTimes; i++) {
         if (fStartTimes[i] != tatzr->fStartTimes[i]) {
-            res = FALSE;
+            res = false;
             break;
         }
     }

--- a/icu4c/source/i18n/tztrans.cpp
+++ b/icu4c/source/i18n/tztrans.cpp
@@ -66,22 +66,22 @@ TimeZoneTransition::operator=(const TimeZoneTransition& right) {
 bool
 TimeZoneTransition::operator==(const TimeZoneTransition& that) const {
     if (this == &that) {
-        return TRUE;
+        return true;
     }
     if (typeid(*this) != typeid(that)) {
-        return FALSE;
+        return false;
     }
     if (fTime != that.fTime) {
-        return FALSE;
+        return false;
     }
     if ((fFrom == NULL && that.fFrom == NULL)
         || (fFrom != NULL && that.fFrom != NULL && *fFrom == *(that.fFrom))) {
         if ((fTo == NULL && that.fTo == NULL)
             || (fTo != NULL && that.fTo != NULL && *fTo == *(that.fTo))) {
-            return TRUE;
+            return true;
         }
     }
-    return FALSE;
+    return false;
 }
 
 bool

--- a/icu4c/source/i18n/utf16collationiterator.cpp
+++ b/icu4c/source/i18n/utf16collationiterator.cpp
@@ -39,7 +39,7 @@ UTF16CollationIterator::~UTF16CollationIterator() {}
 
 bool
 UTF16CollationIterator::operator==(const CollationIterator &other) const {
-    if(!CollationIterator::operator==(other)) { return FALSE; }
+    if(!CollationIterator::operator==(other)) { return false; }
     const UTF16CollationIterator &o = static_cast<const UTF16CollationIterator &>(other);
     // Compare the iterator state but not the text: Assume that the caller does that.
     return (pos - start) == (o.pos - o.start);
@@ -174,11 +174,11 @@ FCDUTF16CollationIterator::~FCDUTF16CollationIterator() {}
 bool
 FCDUTF16CollationIterator::operator==(const CollationIterator &other) const {
     // Skip the UTF16CollationIterator and call its parent.
-    if(!CollationIterator::operator==(other)) { return FALSE; }
+    if(!CollationIterator::operator==(other)) { return false; }
     const FCDUTF16CollationIterator &o = static_cast<const FCDUTF16CollationIterator &>(other);
     // Compare the iterator state but not the text: Assume that the caller does that.
-    if(checkDir != o.checkDir) { return FALSE; }
-    if(checkDir == 0 && (start == segmentStart) != (o.start == o.segmentStart)) { return FALSE; }
+    if(checkDir != o.checkDir) { return false; }
+    if(checkDir == 0 && (start == segmentStart) != (o.start == o.segmentStart)) { return false; }
     if(checkDir != 0 || start == segmentStart) {
         return (pos - rawStart) == (o.pos - o.rawStart);
     } else {

--- a/icu4c/source/i18n/vtzone.cpp
+++ b/icu4c/source/i18n/vtzone.cpp
@@ -1050,10 +1050,10 @@ VTimeZone::operator=(const VTimeZone& right) {
 bool
 VTimeZone::operator==(const TimeZone& that) const {
     if (this == &that) {
-        return TRUE;
+        return true;
     }
     if (typeid(*this) != typeid(that) || !BasicTimeZone::operator==(that)) {
-        return FALSE;
+        return false;
     }
     VTimeZone *vtz = (VTimeZone*)&that;
     if (*tz == *(vtz->tz)
@@ -1061,9 +1061,9 @@ VTimeZone::operator==(const TimeZone& that) const {
         && lastmod == vtz->lastmod
         /* && olsonzid = that.olsonzid */
         /* && icutzver = that.icutzver */) {
-        return TRUE;
+        return true;
     }
-    return FALSE;
+    return false;
 }
 
 bool

--- a/icu4c/source/test/intltest/apicoll.cpp
+++ b/icu4c/source/test/intltest/apicoll.cpp
@@ -2058,8 +2058,8 @@ inline bool TestCollator::operator==(const Collator& other) const {
     return this == &other;
 
     // Normally, subclasses should do something like the following:
-    //    if (this == &other) { return TRUE; }
-    //    if (!Collator::operator==(other)) { return FALSE; }  // not the same class
+    //    if (this == &other) { return true; }
+    //    if (!Collator::operator==(other)) { return false; }  // not the same class
     //
     //    const TestCollator &o = (const TestCollator&)other;
     //    (compare this vs. o's subclass fields)

--- a/icu4c/source/test/intltest/srchtest.cpp
+++ b/icu4c/source/test/intltest/srchtest.cpp
@@ -2350,7 +2350,7 @@ SearchIterator * TestSearch::safeClone() const
 bool TestSearch::operator!=(const TestSearch &that) const
 {
     if (SearchIterator::operator !=(that)) {
-        return FALSE;
+        return false;
     }
     return m_offset_ != that.m_offset_ || m_pattern_ != that.m_pattern_;
 }


### PR DESCRIPTION
Now when all equality operators return standard bool (commit 633438f),
it no longer makes any sense to use the ICU4C constants TRUE & FALSE
or local variables of type UBool for their return value.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-20973
- [x] Required: The PR title must be prefixed with a JIRA Issue number.
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number.
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
