### PR TITLE
ICU-21130 Update cpp14 to cpp17 in CI builds

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -82,7 +82,7 @@ jobs:
         CXX: clang++
 #-------------------------------------------------------------------------
 - job: ICU4C_Clang_Cpp14_Debug_Ubuntu_1804
-  displayName: 'C: Linux Clang C++14 Debug (Ubuntu 18.04)'
+  displayName: 'C: Linux Clang C++17 Debug (Ubuntu 18.04)'
   timeoutInMinutes: 30
   pool:
     vmImage: 'ubuntu-18.04'
@@ -96,8 +96,8 @@ jobs:
         sudo apt remove libgcc-11-dev gcc-11
       displayName: Remove GCC 11 (work-around)
     - script: |
-        export CXXFLAGS="-std=c++14 -Winvalid-constexpr" && cd icu4c/source && ./runConfigureICU --enable-debug --disable-release Linux && make -j2 check
-      displayName: 'Build and Test C++14'
+        export CXXFLAGS="-std=c++17 -Winvalid-constexpr" && cd icu4c/source && ./runConfigureICU --enable-debug --disable-release Linux && make -j2 check
+      displayName: 'Build and Test C++17'
       env:
         CC: clang
         CXX: clang++
@@ -129,8 +129,8 @@ jobs:
       fetchDepth: 10
     - script: |
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-        sudo apt-get update
-        sudo apt-get install gcc-11 g++-11
+        sudo apt update
+        sudo apt install gcc-11 g++-11
       displayName: 'Install GCC-11'
     - script: |
         cd icu4c/source && ./runConfigureICU Linux && make -j2 check


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21130
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable


Updating build that uses C++14 to C++17
`export CXXFLAGS="-std=c++17 -Winvalid-constexpr" && cd icu4c/source && ./runConfigureICU --enable-debug --disable-release Linux && make -j2 check`

this is the new command that runs in the build. Notice the -std=c++17 instead of c++14 :) 