### PR TITLE
ICU-21617 Remove work around of uninstalling GCC11 in CI build

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -90,11 +90,6 @@ jobs:
     - checkout: self
       lfs: true
       fetchDepth: 10
-    # This is to work-around issue: https://github.com/actions/virtual-environments/issues/3376
-    # Once the Ubuntu 18.04 build bot image is fixed, we can remove this work-around.
-    - script: |
-        sudo apt remove libgcc-11-dev gcc-11
-      displayName: Remove GCC 11 (work-around)
     - script: |
         export CXXFLAGS="-std=c++17 -Winvalid-constexpr" && cd icu4c/source && ./runConfigureICU --enable-debug --disable-release Linux && make -j2 check
       displayName: 'Build and Test C++17'


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21617
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable


Since Ubuntu 18.04 rolled back to gcc++10 (https://github.com/LandSandBoat/server/pull/272) We can remove the workaround we had of uninstalling gcc+11 to avoid build failures
