### PR TITLE
ICU-21710 Additional clean up after removing BOYER_MOORE code from usearch.cpp

### DIFF
--- a/icu4c/source/i18n/usrchimp.h
+++ b/icu4c/source/i18n/usrchimp.h
@@ -127,7 +127,6 @@ private:
 U_NAMESPACE_END
 
 #define INITIAL_ARRAY_SIZE_       256
-#define MAX_TABLE_SIZE_           257
 
 struct USearch {
     // required since collation element iterator does not have a getText API
@@ -160,9 +159,6 @@ struct UPattern {
           int64_t             pcesBuffer[INITIAL_ARRAY_SIZE_];
           UBool               hasPrefixAccents;
           UBool               hasSuffixAccents;
-          int16_t             defaultShiftSize;
-          int16_t             shift[MAX_TABLE_SIZE_];
-          int16_t             backShift[MAX_TABLE_SIZE_];
 };
 
 struct UStringSearch {
@@ -182,8 +178,6 @@ struct UStringSearch {
            uint32_t            ceMask;
            uint32_t            variableTop;
            UBool               toShift;
-           UChar               canonicalPrefixAccents[INITIAL_ARRAY_SIZE_];
-           UChar               canonicalSuffixAccents[INITIAL_ARRAY_SIZE_];
 };
 
 /**

--- a/icu4c/source/test/cintltst/usrchtst.c
+++ b/icu4c/source/test/cintltst/usrchtst.c
@@ -302,7 +302,7 @@ static void TestInitialization(void)
 {
           UErrorCode      status = U_ZERO_ERROR;
           UChar           pattern[512];
-    const UChar           text[] = {0x61, 0x62, 0x63, 0x64, 0x65, 0x66};
+    const UChar           text[] = u"abcdef";
     int32_t i = 0;
     UStringSearch  *result;
 
@@ -332,6 +332,15 @@ static void TestInitialization(void)
         log_err("Error opening search %s\n", u_errorName(status));
     }
     usearch_close(result);
+
+    /* testing that a pattern with all ignoreables doesn't fail initialization with an error */
+    UChar patternIgnoreables[] = u"\u200b"; // Zero Width Space
+    result = usearch_openFromCollator(patternIgnoreables, 1, text, 3, EN_US_, NULL, &status);
+    if (U_FAILURE(status)) {
+        log_err("Error opening search %s\n", u_errorName(status));
+    }
+    usearch_close(result);
+
     close();
 }
 


### PR DESCRIPTION
This PR is a follow-up to PR #1800 (which removed BOYER_MOORE dead code from usearch.cpp).

This PR contains additional clean-up. 

Thanks to Andy for pointing out on the other PR that `initialize` and `setShiftTable` were still setting up Boyer-Moore related data. It turns out that we can we can completely remove the shift tables and related fields from the data structs, as well as remove the `setShiftTable` method.

The creation of `UStringSearch` objects should be slightly faster now, as we no longer waste time computing the unused shift tables (which hashed the pattern collation elements).

The `sizeof(UStringSearch)` is decreased from 5240 bytes to 3192 bytes (on x64), so this should help to reduce memory for applications that create many string search objects.

Also added a test case for a pattern with only ignoreable CEs. The comments on `initialize` said: "*If pattern has no non-ignorable ce, we return a illegal argument error*". However, it actually does not set illegal argument error.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21710
- [x] Required: The PR title must be prefixed with a JIRA Issue number. 
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number.
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
