### PR TITLE
ICU-21740 Output source code line when an error occurs when building with MSVC.

### DIFF
--- a/icu4c/source/allinone/Build.Windows.PlatformToolset.props
+++ b/icu4c/source/allinone/Build.Windows.PlatformToolset.props
@@ -56,4 +56,11 @@
     <!-- For example: MSBuild complains that the common project creates "icuuc62.dll" rather than "common.dll". However, this is intentional. -->
     <MSBuildWarningsAsMessages>MSB8012</MSBuildWarningsAsMessages>
   </PropertyGroup>
+  
+  <!-- This enables outputting the source code line when an error occurs (to make it easier to see what/where the issue is). -->
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <DiagnosticsFormat>Caret</DiagnosticsFormat>
+    </ClCompile>
+  </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
I have often wished that MSVC would output the line in question (similar to GCC/Clang) when it hits an error when compiling.
It turns out that MSVC (somewhat recently) added a new config option which will do just that.
This PR enables the setting for all projects when building ICU4C with MSVC.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21740
- [x] Required: The PR title must be prefixed with a JIRA Issue number.
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. 
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
