### PR TITLE
ICU-21747 Upgrade WarningsAsErrors build bot to Clang-13 on Ubuntu 20.04

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -45,21 +45,28 @@ jobs:
         cd icu4c/source/test/cintltst && LANG=C.UTF-8 LD_LIBRARY_PATH=../../lib:../../tools/ctestfw ./cintltst /tsutil/cloctst/TestCDefaultLocale
       displayName: 'Test C.UTF-8 Default locale'
 #-------------------------------------------------------------------------
-- job: ICU4C_Clang_Ubuntu_1804_WarningsAsErrors
-  displayName: 'C: Linux Clang WarningsAsErrors (Ubuntu 18.04)'
+- job: ICU4C_Clang13_Ubuntu_2004_WarningsAsErrors
+  displayName: 'C: Linux Clang-13 WarningsAsErrors (Ubuntu 20.04)'
   timeoutInMinutes: 30
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-20.04'
   steps:
     - checkout: self
       lfs: true
       fetchDepth: 10
+    # Install Clang-13 from https://apt.llvm.org/
+    - script: |
+        curl -Ls https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo apt-add-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main'
+        sudo apt update
+        sudo apt install -qy clang-13 lld-13 libc++-13-dev libc++abi-13-dev
+      displayName: 'Install Clang-13'
     - script: |
         export CPPFLAGS="-Werror -Wall -Wextra -Wextra-semi -Wundef -Wnon-virtual-dtor" && cd icu4c/source && ./runConfigureICU Linux && make -j2 tests
       displayName: 'Build only (WarningsAsErrors)'
       env:
-        CC: clang
-        CXX: clang++
+        CC: clang-13
+        CXX: clang++-13
 #-------------------------------------------------------------------------
 - job: ICU4C_Clang_Ubuntu_DataFilter_1804
   displayName: 'C: Linux Clang DataFilter (Ubuntu 18.04)'

--- a/icu4c/source/test/intltest/rbbitst.cpp
+++ b/icu4c/source/test/intltest/rbbitst.cpp
@@ -4014,6 +4014,7 @@ void RBBITest::RunMonkey(BreakIterator *bi, RBBIMonkeyKind &mk, const char *name
                 errln("breakPos > testText.length()");
             }
             expectedBreaks[breakPos] = 1;
+            expectedCount++;
             U_ASSERT(expectedCount<testText.length());
         }
 

--- a/icu4c/source/tools/genrb/wrtxml.cpp
+++ b/icu4c/source/tools/genrb/wrtxml.cpp
@@ -924,8 +924,6 @@ bin_write_xml(BinaryResource *res, const char* id, const char* /*language*/, UEr
 static void
 table_write_xml(TableResource *res, const char* id, const char* language, UBool isTopLevel, UErrorCode *status) {
 
-    uint32_t  i         = 0;
-
     struct SResource *current = NULL;
     char* sid = NULL;
 
@@ -940,7 +938,6 @@ table_write_xml(TableResource *res, const char* id, const char* language, UBool 
     }
 
     current = res->fFirst;
-    i = 0;
 
     while (current != NULL) {
         res_write_xml(current, sid, language, FALSE, status);
@@ -949,7 +946,6 @@ table_write_xml(TableResource *res, const char* id, const char* language, UBool 
             return;
         }
 
-        i += 1;
         current = current->fNext;
     }
 


### PR DESCRIPTION
In order to add `-Wsuggest-override` to the WarningsAsErrors build bot (see PR #1842), we'll need to first upgrade to a newer version of the Clang compiler.

However, updating to a newer version of the compiler also means that it is now better at spotting issues in the code -- so this PR also includes some fixes as well in order to build cleaning with WarningsAsErrors on Clang-13.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21747
- [x] Required: The PR title must be prefixed with a JIRA Issue number. 
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. 
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
