### PR TITLE
ICU-21747 Add check to ICU4J RBBI Monkey test for expectedBreakCount

### DIFF
--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/rbbi/RBBIMonkeyTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/rbbi/RBBIMonkeyTest.java
@@ -553,6 +553,8 @@ public class RBBIMonkeyTest extends TestFmwk {
             fRuleForPosition = new int[fString.length()+1];
             f2ndRuleForPos   = new int[fString.length()+1];
 
+            int expectedBreakCount = 0;
+
             // Apply reference rules to find the expected breaks.
 
             fExpectedBreaks[0] = true;       // Force an expected break before the start of the text.
@@ -619,6 +621,7 @@ public class RBBIMonkeyTest extends TestFmwk {
                 if (hasBreak) {
                     int breakPos = strIdx + BreakGroupStart(matchingRule.fRuleMatcher);
                     fExpectedBreaks[breakPos] = true;
+                    expectedBreakCount++;
                     // System.out.printf("recording break at %d\n", breakPos);
                     // For the next iteration, pick up applying rules immediately after the break,
                     // which may differ from end of the match. The matching rule may have included
@@ -638,6 +641,10 @@ public class RBBIMonkeyTest extends TestFmwk {
                     strIdx = updatedStrIdx;
                     initialMatch = false;
                 }
+            }
+            if (expectedBreakCount >= fString.length()) {
+                throw new IllegalArgumentException(String.format("expectedBreakCount (%d) should be less than the test string length (%d).",
+                        expectedBreakCount, fString.length()));
             }
         };
 


### PR DESCRIPTION
This is a follow-up from PR #1844.

The ICU4C RBBI Monkey test code had a check to ensure that the number of breaks was less than the test string length.
The ICU4J test code didn't have this check at all. -- This PR adds the check to the Java test code as well.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21747
- [x] Required: The PR title must be prefixed with a JIRA Issue number. 
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number.
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
