### PR TITLE
ICU-21662 Improve UVector error handling.

### DIFF
--- a/icu4c/source/common/brkeng.cpp
+++ b/icu4c/source/common/brkeng.cpp
@@ -135,14 +135,13 @@ ICULanguageBreakFactory::getEngineFor(UChar32 c) {
     static UMutex gBreakEngineMutex;
     Mutex m(&gBreakEngineMutex);
 
-    if (fEngines == NULL) {
-        UStack  *engines = new UStack(_deleteEngine, NULL, status);
-        if (U_FAILURE(status) || engines == NULL) {
+    if (fEngines == nullptr) {
+        LocalPointer<UStack>  engines(new UStack(_deleteEngine, nullptr, status), status);
+        if (U_FAILURE(status) ) {
             // Note: no way to return error code to caller.
-            delete engines;
-            return NULL;
+            return nullptr;
         }
-        fEngines = engines;
+        fEngines = engines.orphan();
     } else {
         int32_t i = fEngines->size();
         while (--i >= 0) {
@@ -155,10 +154,10 @@ ICULanguageBreakFactory::getEngineFor(UChar32 c) {
     
     // We didn't find an engine. Create one.
     lbe = loadEngineFor(c);
-    if (lbe != NULL) {
+    if (lbe != nullptr) {
         fEngines->push((void *)lbe, status);
     }
-    return lbe;
+    return U_SUCCESS(status) ? lbe : nullptr;
 }
 
 const LanguageBreakEngine *

--- a/icu4c/source/common/rbbinode.cpp
+++ b/icu4c/source/common/rbbinode.cpp
@@ -266,8 +266,9 @@ void   RBBINode::findNodes(UVector *dest, RBBINode::NodeType kind, UErrorCode &s
     if (U_FAILURE(status)) {
         return;
     }
+    U_ASSERT(!dest->hasDeleter());
     if (fType == kind) {
-        dest->addElementX(this, status);
+        dest->addElement(this, status);
     }
     if (fLeftChild != NULL) {
         fLeftChild->findNodes(dest, kind, status);

--- a/icu4c/source/common/rbbiscan.cpp
+++ b/icu4c/source/common/rbbiscan.cpp
@@ -775,7 +775,7 @@ void RBBIRuleScanner::findSetFor(const UnicodeString &s, RBBINode *node, Unicode
     //
     // Add the new uset node to the list of all uset nodes.
     //
-    fRB->fUSetNodes->addElementX(usetNode, *fRB->fStatus);
+    fRB->fUSetNodes->addElement(usetNode, *fRB->fStatus);
 
 
     //

--- a/icu4c/source/common/rbbisetb.cpp
+++ b/icu4c/source/common/rbbisetb.cpp
@@ -172,7 +172,7 @@ void RBBISetBuilder::buildRanges() {
             // The current rlRange is now entirely within the UnicodeSet range.
             // Add this unicode set to the list of sets for this rlRange
             if (rlRange->fIncludesSets->indexOf(usetNode) == -1) {
-                rlRange->fIncludesSets->addElementX(usetNode, *fStatus);
+                rlRange->fIncludesSets->addElement(usetNode, *fStatus);
                 if (U_FAILURE(*fStatus)) {
                     return;
                 }
@@ -600,7 +600,7 @@ RangeDescriptor::RangeDescriptor(const RangeDescriptor &other, UErrorCode &statu
     }
 
     for (int32_t i=0; i<other.fIncludesSets->size(); i++) {
-        this->fIncludesSets->addElementX(other.fIncludesSets->elementAt(i), status);
+        this->fIncludesSets->addElement(other.fIncludesSets->elementAt(i), status);
     }
 }
 

--- a/icu4c/source/common/uvector.h
+++ b/icu4c/source/common/uvector.h
@@ -351,8 +351,13 @@ public:
     int32_t popi(void);
     
     inline void* push(void* obj, UErrorCode &status) {
-        addElementX(obj, status);
-        return obj;
+        if (hasDeleter()) {
+            adoptElement(obj, status);
+            return (U_SUCCESS(status)) ? obj : nullptr;
+        } else {
+            addElement(obj, status);
+            return obj;
+        }
     }
 
     inline int32_t push(int32_t i, UErrorCode &status) {

--- a/icu4c/source/i18n/regexcmp.cpp
+++ b/icu4c/source/i18n/regexcmp.cpp
@@ -1656,13 +1656,16 @@ UBool RegexCompile::doParseActions(int32_t action)
         }
 
     case doSetBegin:
-        fixLiterals(FALSE);
-        fSetStack.push(new UnicodeSet(), *fStatus);
-        fSetOpStack.push(setStart, *fStatus);
-        if ((fModeFlags & UREGEX_CASE_INSENSITIVE) != 0) {
-            fSetOpStack.push(setCaseClose, *fStatus);
+        {
+            fixLiterals(FALSE);
+            LocalPointer<UnicodeSet> lpSet(new UnicodeSet(), *fStatus);
+            fSetStack.push(lpSet.orphan(), *fStatus);
+            fSetOpStack.push(setStart, *fStatus);
+            if ((fModeFlags & UREGEX_CASE_INSENSITIVE) != 0) {
+                fSetOpStack.push(setCaseClose, *fStatus);
+            }
+            break;
         }
-        break;
 
     case doSetBeginDifference1:
         //  We have scanned something like [[abc]-[
@@ -2427,7 +2430,7 @@ void        RegexCompile::compileSet(UnicodeSet *theSet)
             //  Put it into the compiled pattern as a set.
             theSet->freeze();
             int32_t setNumber = fRXPat->fSets->size();
-            fRXPat->fSets->addElementX(theSet, *fStatus);
+            fRXPat->fSets->addElement(theSet, *fStatus);
             appendOp(URX_SETREF, setNumber);
         }
     }
@@ -4649,7 +4652,8 @@ void RegexCompile::setEval(int32_t nextOp) {
 void RegexCompile::setPushOp(int32_t op) {
     setEval(op);
     fSetOpStack.push(op, *fStatus);
-    fSetStack.push(new UnicodeSet(), *fStatus);
+    LocalPointer<UnicodeSet> lpSet(new UnicodeSet(), *fStatus);
+    fSetStack.push(lpSet.orphan(), *fStatus);
 }
 
 U_NAMESPACE_END

--- a/icu4c/source/i18n/repattrn.cpp
+++ b/icu4c/source/i18n/repattrn.cpp
@@ -131,7 +131,7 @@ RegexPattern &RegexPattern::operator = (const RegexPattern &other) {
             fDeferredStatus = U_MEMORY_ALLOCATION_ERROR;
             break;
         }
-        fSets->addElementX(newSet, fDeferredStatus);
+        fSets->addElement(newSet, fDeferredStatus);
         fSets8[i] = other.fSets8[i];
     }
 

--- a/icu4c/source/test/intltest/rbbimonkeytest.cpp
+++ b/icu4c/source/test/intltest/rbbimonkeytest.cpp
@@ -225,7 +225,7 @@ void BreakRules::addRule(const UnicodeString &name, const UnicodeString &definit
     }
 
     // Put this new rule into the vector of all Rules.
-    fBreakRules.addElementX(thisRule.orphan(), status);
+    fBreakRules.adoptElement(thisRule.orphan(), status);
 }
 
 
@@ -359,7 +359,7 @@ void BreakRules::compileRules(UCHARBUF *rules, UErrorCode &status) {
         if (*ccName == UnicodeString("dictionary")) {
             fDictionarySet = *set;
         } else {
-            fCharClassList->addElementX(cclass, status);
+            fCharClassList->addElement(cclass, status);
         }
     }
 
@@ -367,7 +367,7 @@ void BreakRules::compileRules(UCHARBUF *rules, UErrorCode &status) {
         // fprintf(stderr, "have an other set.\n");
         UnicodeString pattern;
         CharClass *cclass = addCharClass(UnicodeString("__Others"), otherSet.toPattern(pattern), status);
-        fCharClassList->addElementX(cclass, status);
+        fCharClassList->addElement(cclass, status);
     }
 }
 
@@ -962,7 +962,7 @@ void RBBIMonkeyTest::testMonkey() {
             break;
         }
         test->startTest();
-        startedTests.addElementX(test.orphan(), status);
+        startedTests.addElement(test.orphan(), status);
         if (U_FAILURE(status)) {
             errln("%s:%d: error %s while starting test %s.", __FILE__, __LINE__, u_errorName(status), tests[i]);
             break;

--- a/icu4c/source/test/intltest/rbbitst.cpp
+++ b/icu4c/source/test/intltest/rbbitst.cpp
@@ -1646,21 +1646,21 @@ RBBICharMonkey::RBBICharMonkey() {
     fSets             = new UVector(status);
 
     // Important: Keep class names the same as the class contents.
-    fSets->addElementX(fCRLFSet, status); classNames.push_back("CRLF");
-    fSets->addElementX(fControlSet, status); classNames.push_back("Control");
-    fSets->addElementX(fExtendSet, status); classNames.push_back("Extended");
-    fSets->addElementX(fRegionalIndicatorSet, status); classNames.push_back("RegionalIndicator");
+    fSets->addElement(fCRLFSet, status); classNames.push_back("CRLF");
+    fSets->addElement(fControlSet, status); classNames.push_back("Control");
+    fSets->addElement(fExtendSet, status); classNames.push_back("Extended");
+    fSets->addElement(fRegionalIndicatorSet, status); classNames.push_back("RegionalIndicator");
     if (!fPrependSet->isEmpty()) {
-        fSets->addElementX(fPrependSet, status); classNames.push_back("Prepend");
+        fSets->addElement(fPrependSet, status); classNames.push_back("Prepend");
     }
-    fSets->addElementX(fSpacingSet, status); classNames.push_back("Spacing");
-    fSets->addElementX(fHangulSet, status); classNames.push_back("Hangul");
-    fSets->addElementX(fZWJSet, status); classNames.push_back("ZWJ");
-    fSets->addElementX(fExtendedPictSet, status); classNames.push_back("ExtendedPict");
-    fSets->addElementX(fViramaSet, status); classNames.push_back("Virama");
-    fSets->addElementX(fLinkingConsonantSet, status); classNames.push_back("LinkingConsonant");
-    fSets->addElementX(fExtCccZwjSet, status); classNames.push_back("ExtCcccZwj");
-    fSets->addElementX(fAnySet, status); classNames.push_back("Any");
+    fSets->addElement(fSpacingSet, status); classNames.push_back("Spacing");
+    fSets->addElement(fHangulSet, status); classNames.push_back("Hangul");
+    fSets->addElement(fZWJSet, status); classNames.push_back("ZWJ");
+    fSets->addElement(fExtendedPictSet, status); classNames.push_back("ExtendedPict");
+    fSets->addElement(fViramaSet, status); classNames.push_back("Virama");
+    fSets->addElement(fLinkingConsonantSet, status); classNames.push_back("LinkingConsonant");
+    fSets->addElement(fExtCccZwjSet, status); classNames.push_back("ExtCcccZwj");
+    fSets->addElement(fAnySet, status); classNames.push_back("Any");
 
     if (U_FAILURE(status)) {
         deferredStatus = status;
@@ -1964,31 +1964,31 @@ RBBIWordMonkey::RBBIWordMonkey()
     fOtherSet->removeAll(*fDictionarySet);
 
     // Add classes and their names
-    fSets->addElementX(fCRSet, status); classNames.push_back("CR");
-    fSets->addElementX(fLFSet, status); classNames.push_back("LF");
-    fSets->addElementX(fNewlineSet, status); classNames.push_back("Newline");
-    fSets->addElementX(fRegionalIndicatorSet, status); classNames.push_back("RegionalIndicator");
-    fSets->addElementX(fHebrew_LetterSet, status); classNames.push_back("Hebrew");
-    fSets->addElementX(fALetterSet, status); classNames.push_back("ALetter");
-    fSets->addElementX(fSingle_QuoteSet, status); classNames.push_back("Single Quote");
-    fSets->addElementX(fDouble_QuoteSet, status); classNames.push_back("Double Quote");
+    fSets->addElement(fCRSet, status); classNames.push_back("CR");
+    fSets->addElement(fLFSet, status); classNames.push_back("LF");
+    fSets->addElement(fNewlineSet, status); classNames.push_back("Newline");
+    fSets->addElement(fRegionalIndicatorSet, status); classNames.push_back("RegionalIndicator");
+    fSets->addElement(fHebrew_LetterSet, status); classNames.push_back("Hebrew");
+    fSets->addElement(fALetterSet, status); classNames.push_back("ALetter");
+    fSets->addElement(fSingle_QuoteSet, status); classNames.push_back("Single Quote");
+    fSets->addElement(fDouble_QuoteSet, status); classNames.push_back("Double Quote");
     // Omit Katakana from fSets, which omits Katakana characters
     // from the test data. They are all in the dictionary set,
     // which this (old, to be retired) monkey test cannot handle.
     //fSets->addElement(fKatakanaSet, status);
 
-    fSets->addElementX(fMidLetterSet, status); classNames.push_back("MidLetter");
-    fSets->addElementX(fMidNumLetSet, status); classNames.push_back("MidNumLet");
-    fSets->addElementX(fMidNumSet, status); classNames.push_back("MidNum");
-    fSets->addElementX(fNumericSet, status); classNames.push_back("Numeric");
-    fSets->addElementX(fFormatSet, status); classNames.push_back("Format");
-    fSets->addElementX(fExtendSet, status); classNames.push_back("Extend");
-    fSets->addElementX(fOtherSet, status); classNames.push_back("Other");
-    fSets->addElementX(fExtendNumLetSet, status); classNames.push_back("ExtendNumLet");
-    fSets->addElementX(fWSegSpaceSet, status); classNames.push_back("WSegSpace");
+    fSets->addElement(fMidLetterSet, status); classNames.push_back("MidLetter");
+    fSets->addElement(fMidNumLetSet, status); classNames.push_back("MidNumLet");
+    fSets->addElement(fMidNumSet, status); classNames.push_back("MidNum");
+    fSets->addElement(fNumericSet, status); classNames.push_back("Numeric");
+    fSets->addElement(fFormatSet, status); classNames.push_back("Format");
+    fSets->addElement(fExtendSet, status); classNames.push_back("Extend");
+    fSets->addElement(fOtherSet, status); classNames.push_back("Other");
+    fSets->addElement(fExtendNumLetSet, status); classNames.push_back("ExtendNumLet");
+    fSets->addElement(fWSegSpaceSet, status); classNames.push_back("WSegSpace");
 
-    fSets->addElementX(fZWJSet, status); classNames.push_back("ZWJ");
-    fSets->addElementX(fExtendedPictSet, status); classNames.push_back("ExtendedPict");
+    fSets->addElement(fZWJSet, status); classNames.push_back("ZWJ");
+    fSets->addElement(fExtendedPictSet, status); classNames.push_back("ExtendedPict");
 
     if (U_FAILURE(status)) {
         deferredStatus = status;
@@ -2304,19 +2304,19 @@ RBBISentMonkey::RBBISentMonkey()
     fOtherSet->removeAll(*fCloseSet);
     fOtherSet->removeAll(*fExtendSet);
 
-    fSets->addElementX(fSepSet, status); classNames.push_back("Sep");
-    fSets->addElementX(fFormatSet, status); classNames.push_back("Format");
-    fSets->addElementX(fSpSet, status); classNames.push_back("Sp");
-    fSets->addElementX(fLowerSet, status); classNames.push_back("Lower");
-    fSets->addElementX(fUpperSet, status); classNames.push_back("Upper");
-    fSets->addElementX(fOLetterSet, status); classNames.push_back("OLetter");
-    fSets->addElementX(fNumericSet, status); classNames.push_back("Numeric");
-    fSets->addElementX(fATermSet, status); classNames.push_back("ATerm");
-    fSets->addElementX(fSContinueSet, status); classNames.push_back("SContinue");
-    fSets->addElementX(fSTermSet, status); classNames.push_back("STerm");
-    fSets->addElementX(fCloseSet, status); classNames.push_back("Close");
-    fSets->addElementX(fOtherSet, status); classNames.push_back("Other");
-    fSets->addElementX(fExtendSet, status); classNames.push_back("Extend");
+    fSets->addElement(fSepSet, status); classNames.push_back("Sep");
+    fSets->addElement(fFormatSet, status); classNames.push_back("Format");
+    fSets->addElement(fSpSet, status); classNames.push_back("Sp");
+    fSets->addElement(fLowerSet, status); classNames.push_back("Lower");
+    fSets->addElement(fUpperSet, status); classNames.push_back("Upper");
+    fSets->addElement(fOLetterSet, status); classNames.push_back("OLetter");
+    fSets->addElement(fNumericSet, status); classNames.push_back("Numeric");
+    fSets->addElement(fATermSet, status); classNames.push_back("ATerm");
+    fSets->addElement(fSContinueSet, status); classNames.push_back("SContinue");
+    fSets->addElement(fSTermSet, status); classNames.push_back("STerm");
+    fSets->addElement(fCloseSet, status); classNames.push_back("Close");
+    fSets->addElement(fOtherSet, status); classNames.push_back("Other");
+    fSets->addElement(fExtendSet, status); classNames.push_back("Extend");
 
     if (U_FAILURE(status)) {
         deferredStatus = status;
@@ -2707,50 +2707,50 @@ RBBILineMonkey::RBBILineMonkey() :
     fHH->add(u'\u2010');   // Hyphen, '‐'
 
     // Sets and names.
-    fSets->addElementX(fBK, status); classNames.push_back("fBK");
-    fSets->addElementX(fCR, status); classNames.push_back("fCR");
-    fSets->addElementX(fLF, status); classNames.push_back("fLF");
-    fSets->addElementX(fCM, status); classNames.push_back("fCM");
-    fSets->addElementX(fNL, status); classNames.push_back("fNL");
-    fSets->addElementX(fWJ, status); classNames.push_back("fWJ");
-    fSets->addElementX(fZW, status); classNames.push_back("fZW");
-    fSets->addElementX(fGL, status); classNames.push_back("fGL");
-    fSets->addElementX(fCB, status); classNames.push_back("fCB");
-    fSets->addElementX(fSP, status); classNames.push_back("fSP");
-    fSets->addElementX(fB2, status); classNames.push_back("fB2");
-    fSets->addElementX(fBA, status); classNames.push_back("fBA");
-    fSets->addElementX(fBB, status); classNames.push_back("fBB");
-    fSets->addElementX(fHY, status); classNames.push_back("fHY");
-    fSets->addElementX(fH2, status); classNames.push_back("fH2");
-    fSets->addElementX(fH3, status); classNames.push_back("fH3");
-    fSets->addElementX(fCL, status); classNames.push_back("fCL");
-    fSets->addElementX(fCP, status); classNames.push_back("fCP");
-    fSets->addElementX(fEX, status); classNames.push_back("fEX");
-    fSets->addElementX(fIN, status); classNames.push_back("fIN");
-    fSets->addElementX(fJL, status); classNames.push_back("fJL");
-    fSets->addElementX(fJT, status); classNames.push_back("fJT");
-    fSets->addElementX(fJV, status); classNames.push_back("fJV");
-    fSets->addElementX(fNS, status); classNames.push_back("fNS");
-    fSets->addElementX(fOP, status); classNames.push_back("fOP");
-    fSets->addElementX(fQU, status); classNames.push_back("fQU");
-    fSets->addElementX(fIS, status); classNames.push_back("fIS");
-    fSets->addElementX(fNU, status); classNames.push_back("fNU");
-    fSets->addElementX(fPO, status); classNames.push_back("fPO");
-    fSets->addElementX(fPR, status); classNames.push_back("fPR");
-    fSets->addElementX(fSY, status); classNames.push_back("fSY");
-    fSets->addElementX(fAI, status); classNames.push_back("fAI");
-    fSets->addElementX(fAL, status); classNames.push_back("fAL");
-    fSets->addElementX(fHL, status); classNames.push_back("fHL");
-    fSets->addElementX(fID, status); classNames.push_back("fID");
-    fSets->addElementX(fRI, status); classNames.push_back("fRI");
-    fSets->addElementX(fSG, status); classNames.push_back("fSG");
-    fSets->addElementX(fEB, status); classNames.push_back("fEB");
-    fSets->addElementX(fEM, status); classNames.push_back("fEM");
-    fSets->addElementX(fZWJ, status); classNames.push_back("fZWJ");
+    fSets->addElement(fBK, status); classNames.push_back("fBK");
+    fSets->addElement(fCR, status); classNames.push_back("fCR");
+    fSets->addElement(fLF, status); classNames.push_back("fLF");
+    fSets->addElement(fCM, status); classNames.push_back("fCM");
+    fSets->addElement(fNL, status); classNames.push_back("fNL");
+    fSets->addElement(fWJ, status); classNames.push_back("fWJ");
+    fSets->addElement(fZW, status); classNames.push_back("fZW");
+    fSets->addElement(fGL, status); classNames.push_back("fGL");
+    fSets->addElement(fCB, status); classNames.push_back("fCB");
+    fSets->addElement(fSP, status); classNames.push_back("fSP");
+    fSets->addElement(fB2, status); classNames.push_back("fB2");
+    fSets->addElement(fBA, status); classNames.push_back("fBA");
+    fSets->addElement(fBB, status); classNames.push_back("fBB");
+    fSets->addElement(fHY, status); classNames.push_back("fHY");
+    fSets->addElement(fH2, status); classNames.push_back("fH2");
+    fSets->addElement(fH3, status); classNames.push_back("fH3");
+    fSets->addElement(fCL, status); classNames.push_back("fCL");
+    fSets->addElement(fCP, status); classNames.push_back("fCP");
+    fSets->addElement(fEX, status); classNames.push_back("fEX");
+    fSets->addElement(fIN, status); classNames.push_back("fIN");
+    fSets->addElement(fJL, status); classNames.push_back("fJL");
+    fSets->addElement(fJT, status); classNames.push_back("fJT");
+    fSets->addElement(fJV, status); classNames.push_back("fJV");
+    fSets->addElement(fNS, status); classNames.push_back("fNS");
+    fSets->addElement(fOP, status); classNames.push_back("fOP");
+    fSets->addElement(fQU, status); classNames.push_back("fQU");
+    fSets->addElement(fIS, status); classNames.push_back("fIS");
+    fSets->addElement(fNU, status); classNames.push_back("fNU");
+    fSets->addElement(fPO, status); classNames.push_back("fPO");
+    fSets->addElement(fPR, status); classNames.push_back("fPR");
+    fSets->addElement(fSY, status); classNames.push_back("fSY");
+    fSets->addElement(fAI, status); classNames.push_back("fAI");
+    fSets->addElement(fAL, status); classNames.push_back("fAL");
+    fSets->addElement(fHL, status); classNames.push_back("fHL");
+    fSets->addElement(fID, status); classNames.push_back("fID");
+    fSets->addElement(fRI, status); classNames.push_back("fRI");
+    fSets->addElement(fSG, status); classNames.push_back("fSG");
+    fSets->addElement(fEB, status); classNames.push_back("fEB");
+    fSets->addElement(fEM, status); classNames.push_back("fEM");
+    fSets->addElement(fZWJ, status); classNames.push_back("fZWJ");
     // TODO: fOP30 & fCP30 overlap with plain fOP. Probably OK, but fOP/CP chars will be over-represented.
-    fSets->addElementX(fOP30, status); classNames.push_back("fOP30");
-    fSets->addElementX(fCP30, status); classNames.push_back("fCP30");
-    fSets->addElementX(fExtPictUnassigned, status); classNames.push_back("fExtPictUnassigned");
+    fSets->addElement(fOP30, status); classNames.push_back("fOP30");
+    fSets->addElement(fCP30, status); classNames.push_back("fCP30");
+    fSets->addElement(fExtPictUnassigned, status); classNames.push_back("fExtPictUnassigned");
 
     const char *rules =
             "((\\p{Line_Break=PR}|\\p{Line_Break=PO})(\\p{Line_Break=CM}|\\u200d)*)?"

--- a/icu4c/source/tools/toolutil/xmlparser.cpp
+++ b/icu4c/source/tools/toolutil/xmlparser.cpp
@@ -391,7 +391,7 @@ UXMLParser::parse(const UnicodeString &src, UErrorCode &status) {
             // Nested Element Start
             if (mXMLElemStart.lookingAt(fPos, status)) {
                 UXMLElement *t = createElement(mXMLElemStart, status);
-                el->fChildren.addElementX(t, status);
+                el->fChildren.addElement(t, status);
                 t->fParent = el;
                 fElementStack.push(el, status);
                 el = t;
@@ -407,7 +407,7 @@ UXMLParser::parse(const UnicodeString &src, UErrorCode &status) {
                     // This chunk of text contains something other than just
                     //  white space. Make a child node for it.
                     replaceCharRefs(s, status);
-                    el->fChildren.addElementX(s.clone(), status);
+                    el->fChildren.addElement(s.clone(), status);
                 }
                 mXMLSP.reset(src);    // The matchers need to stay set to the main input string.
                 continue;
@@ -445,7 +445,7 @@ UXMLParser::parse(const UnicodeString &src, UErrorCode &status) {
             // Empty Element.  Stored as a child of the current element, but not stacked.
             if (mXMLElemEmpty.lookingAt(fPos, status)) {
                 UXMLElement *t = createElement(mXMLElemEmpty, status);
-                el->fChildren.addElementX(t, status);
+                el->fChildren.addElement(t, status);
                 continue;
             }
 
@@ -521,8 +521,8 @@ UXMLParser::createElement(RegexMatcher  &mEl, UErrorCode &status) {
         replaceCharRefs(attValue, status);
 
         // Save the attribute name and value in our document structure.
-        el->fAttNames.addElementX((void *)intern(attName, status), status);
-        el->fAttValues.addElementX(attValue.clone(), status);
+        el->fAttNames.addElement((void *)intern(attName, status), status);
+        el->fAttValues.addElement(attValue.clone(), status);
         pos = mAttrValue.end(2, status);
     }
     fPos = mEl.end(0, status);


### PR DESCRIPTION
This is the next installment of UVector error handling cleanup. It includes:

- Revise UStack to follow the conventions of UVector, to leave the stack
  unmodified when there is an incoming error code. And, for stacks with a
  deleter function, to delete the incoming object if it cannot be
  succesfully pushed.

 - Review all useage of UStack in ICU; adjust call sites as needed.

 - Review all uses of UVector::addElementX() in the implementation of
   - Regular Expressions
   - Break Iteration
   - toolutil/xmlparser
   
   changing to the updated functions, and adjusting call sites as needed.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21662
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
