### PR TITLE
ICU-20870 If locale/lang name lookup fails, canonicalize lang and try again

### DIFF
--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/ULocaleTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/ULocaleTest.java
@@ -1189,22 +1189,22 @@ public class ULocaleTest extends TestFmwk {
                 new Item("da", NM_DIA, CAP_BEG, LEN_FU, SUB_SU, "en_GB", "Britisk engelsk"),
                 new Item("da", NM_DIA, CAP_UIL, LEN_FU, SUB_SU, "en_GB", "Britisk engelsk"),
                 new Item("da", NM_DIA, CAP_STA, LEN_FU, SUB_SU, "en_GB", "britisk engelsk"),
-                new Item("es", NM_STD, CAP_MID, LEN_FU, SUB_SU, "en", "ingl\u00E9s"),
-                new Item("es", NM_STD, CAP_BEG, LEN_FU, SUB_SU, "en", "Ingl\u00E9s"),
-                new Item("es", NM_STD, CAP_UIL, LEN_FU, SUB_SU, "en", "Ingl\u00E9s"),
-                new Item("es", NM_STD, CAP_STA, LEN_FU, SUB_SU, "en", "Ingl\u00E9s"),
-                new Item("es", NM_STD, CAP_MID, LEN_FU, SUB_SU, "en_GB", "ingl\u00E9s (Reino Unido)"),
-                new Item("es", NM_STD, CAP_BEG, LEN_FU, SUB_SU, "en_GB", "Ingl\u00E9s (Reino Unido)"),
-                new Item("es", NM_STD, CAP_UIL, LEN_FU, SUB_SU, "en_GB", "Ingl\u00E9s (Reino Unido)"),
-                new Item("es", NM_STD, CAP_STA, LEN_FU, SUB_SU, "en_GB", "Ingl\u00E9s (Reino Unido)"),
-                new Item("es", NM_STD, CAP_MID, LEN_SH, SUB_SU, "en_GB", "ingl\u00E9s (RU)"),
-                new Item("es", NM_STD, CAP_BEG, LEN_SH, SUB_SU, "en_GB", "Ingl\u00E9s (RU)"),
-                new Item("es", NM_STD, CAP_UIL, LEN_SH, SUB_SU, "en_GB", "Ingl\u00E9s (RU)"),
-                new Item("es", NM_STD, CAP_STA, LEN_SH, SUB_SU, "en_GB", "Ingl\u00E9s (RU)"),
-                new Item("es", NM_DIA, CAP_MID, LEN_FU, SUB_SU, "en_GB", "ingl\u00E9s brit\u00E1nico"),
-                new Item("es", NM_DIA, CAP_BEG, LEN_FU, SUB_SU, "en_GB", "Ingl\u00E9s brit\u00E1nico"),
-                new Item("es", NM_DIA, CAP_UIL, LEN_FU, SUB_SU, "en_GB", "Ingl\u00E9s brit\u00E1nico"),
-                new Item("es", NM_DIA, CAP_STA, LEN_FU, SUB_SU, "en_GB", "Ingl\u00E9s brit\u00E1nico"),
+                new Item("es", NM_STD, CAP_MID, LEN_FU, SUB_SU, "en", "inglés"),
+                new Item("es", NM_STD, CAP_BEG, LEN_FU, SUB_SU, "en", "Inglés"),
+                new Item("es", NM_STD, CAP_UIL, LEN_FU, SUB_SU, "en", "Inglés"),
+                new Item("es", NM_STD, CAP_STA, LEN_FU, SUB_SU, "en", "Inglés"),
+                new Item("es", NM_STD, CAP_MID, LEN_FU, SUB_SU, "en_GB", "inglés (Reino Unido)"),
+                new Item("es", NM_STD, CAP_BEG, LEN_FU, SUB_SU, "en_GB", "Inglés (Reino Unido)"),
+                new Item("es", NM_STD, CAP_UIL, LEN_FU, SUB_SU, "en_GB", "Inglés (Reino Unido)"),
+                new Item("es", NM_STD, CAP_STA, LEN_FU, SUB_SU, "en_GB", "Inglés (Reino Unido)"),
+                new Item("es", NM_STD, CAP_MID, LEN_SH, SUB_SU, "en_GB", "inglés (RU)"),
+                new Item("es", NM_STD, CAP_BEG, LEN_SH, SUB_SU, "en_GB", "Inglés (RU)"),
+                new Item("es", NM_STD, CAP_UIL, LEN_SH, SUB_SU, "en_GB", "Inglés (RU)"),
+                new Item("es", NM_STD, CAP_STA, LEN_SH, SUB_SU, "en_GB", "Inglés (RU)"),
+                new Item("es", NM_DIA, CAP_MID, LEN_FU, SUB_SU, "en_GB", "inglés británico"),
+                new Item("es", NM_DIA, CAP_BEG, LEN_FU, SUB_SU, "en_GB", "Inglés británico"),
+                new Item("es", NM_DIA, CAP_UIL, LEN_FU, SUB_SU, "en_GB", "Inglés británico"),
+                new Item("es", NM_DIA, CAP_STA, LEN_FU, SUB_SU, "en_GB", "Inglés británico"),
                 new Item("ru", NM_STD, CAP_MID, LEN_FU, SUB_SU, "uz_Latn", "\u0443\u0437\u0431\u0435\u043A\u0441\u043A\u0438\u0439 (\u043B\u0430\u0442\u0438\u043D\u0438\u0446\u0430)"),
                 new Item("ru", NM_STD, CAP_BEG, LEN_FU, SUB_SU, "uz_Latn", "\u0423\u0437\u0431\u0435\u043A\u0441\u043A\u0438\u0439 (\u043B\u0430\u0442\u0438\u043D\u0438\u0446\u0430)"),
                 new Item("ru", NM_STD, CAP_UIL, LEN_FU, SUB_SU, "uz_Latn", "\u0423\u0437\u0431\u0435\u043A\u0441\u043A\u0438\u0439 (\u043B\u0430\u0442\u0438\u043D\u0438\u0446\u0430)"),
@@ -1214,6 +1214,26 @@ public class ULocaleTest extends TestFmwk {
                 new Item("en", NM_STD, CAP_MID, LEN_SH, SUB_SU, "ur@numbers=arabext", "Urdu (X Arabic-Indic Digits)"),
                 new Item("af", NM_STD, CAP_NON, LEN_FU, SUB_NO, "aa", "Afar"),
                 new Item("cs", NM_STD, CAP_NON, LEN_FU, SUB_NO, "vai", "vai"),
+                // https://unicode-org.atlassian.net/browse/ICU-20870:
+                new Item("en", NM_STD, CAP_MID, LEN_FU, SUB_SU, "fa_AF",  "Persian (Afghanistan)" ),
+                new Item("en", NM_STD, CAP_MID, LEN_FU, SUB_SU, "prs",    "Dari" ),
+                new Item("en", NM_STD, CAP_MID, LEN_FU, SUB_SU, "prs_AF", "Dari (Afghanistan)" ),
+                new Item("en", NM_STD, CAP_MID, LEN_FU, SUB_SU, "prs_TJ", "Dari (Tajikistan)" ),
+                new Item("en", NM_DIA, CAP_MID, LEN_FU, SUB_SU, "fa_AF",  "Dari" ),
+                new Item("en", NM_DIA, CAP_MID, LEN_FU, SUB_SU, "prs",    "Dari" ),
+                new Item("en", NM_DIA, CAP_MID, LEN_FU, SUB_SU, "prs_AF", "Dari (Afghanistan)" ),
+                new Item("en", NM_DIA, CAP_MID, LEN_FU, SUB_SU, "prs_TJ", "Dari (Tajikistan)" ),
+                // https://unicode-org.atlassian.net/browse/ICU-21742:
+                new Item("en", NM_STD, CAP_MID, LEN_FU, SUB_SU, "ji",     "Yiddish" ),
+                new Item("en", NM_STD, CAP_MID, LEN_FU, SUB_SU, "ji_US",  "Yiddish (United States)" ),
+                new Item("yi", NM_STD, CAP_MID, LEN_FU, SUB_SU, "ji",     "ייִדיש" ),
+                new Item("yi", NM_STD, CAP_MID, LEN_FU, SUB_SU, "ji_US",  "ייִדיש (פֿאַראייניגטע שטאַטן)" ),
+                 // https://unicode-org.atlassian.net/browse/ICU-11563:
+                new Item("en", NM_STD, CAP_MID, LEN_FU, SUB_SU, "mo",     "Romanian" ),
+                new Item("en", NM_STD, CAP_MID, LEN_FU, SUB_SU, "mo_MD",  "Romanian (Moldova)" ),
+                new Item("en", NM_DIA, CAP_MID, LEN_FU, SUB_SU, "mo",     "Romanian" ),
+                new Item("ro", NM_STD, CAP_MID, LEN_FU, SUB_SU, "mo",     "română" ),
+                new Item("ro", NM_STD, CAP_MID, LEN_FU, SUB_SU, "mo_MD",  "română (Republica Moldova)" ),
             };
             for (Item item: items) {
                 ULocale locale = new ULocale(item.displayLocale);
@@ -1227,14 +1247,44 @@ public class ULocaleTest extends TestFmwk {
                 DisplayContext substituteHandling = ldn.getContext(DisplayContext.Type.SUBSTITUTE_HANDLING);
                 if (dialectHandling != item.dialectHandling || capitalization != item.capitalization || nameLength != item.nameLength || substituteHandling != item.substituteHandling) {
                     errln("FAIL: displayLoc: " + item.displayLocale + ", dialectNam?: " + item.dialectHandling +
-                            ", capitalize: " + item.capitalization + ", nameLen: " + item.nameLength + ", substituteHandling: " + item.substituteHandling + ", locToName: " + item.localeToBeNamed +
-                            ", => read back dialectNam?: " + dialectHandling + ", capitalize: " + capitalization + ", nameLen: " + nameLength + ", substituteHandling: " + substituteHandling);
+                            ", capitalize: " + item.capitalization + ", nameLen: " + item.nameLength +
+                            ", substituteHandling: " + item.substituteHandling + ", locToName: " + item.localeToBeNamed +
+                            ", => read back dialectNam?: " + dialectHandling + ", capitalize: " + capitalization +
+                            ", nameLen: " + nameLength + ", substituteHandling: " + substituteHandling);
                 } else {
+                    boolean checkULocaleDisplay = (dialectHandling==NM_STD && capitalization==CAP_MID && nameLength==LEN_FU && substituteHandling==SUB_SU);
+                    boolean checkJustLanguage = item.localeToBeNamed.matches("[a-z]{2,3}");
                     String result = ldn.localeDisplayName(item.localeToBeNamed);
                     if (!(item.result == null && result == null) && !(result != null && result.equals(item.result))) {
                         errln("FAIL: displayLoc: " + item.displayLocale + ", dialectNam?: " + item.dialectHandling +
-                                ", capitalize: " + item.capitalization + ", nameLen: " + item.nameLength + ", substituteHandling: " + item.substituteHandling + ", locToName: " + item.localeToBeNamed +
-                                ", => expected result: " + item.result + ", got: " + result);
+                                ", capitalize: " + item.capitalization + ", nameLen: " + item.nameLength +
+                                ", substituteHandling: " + item.substituteHandling + "; locToName: " + item.localeToBeNamed +
+                                ", => expected result: " + item.result + ", got LDN name: " + result);
+                    }
+                    if (checkULocaleDisplay) {
+                        result = ULocale.getDisplayName(item.localeToBeNamed, locale);
+                        if (!(item.result == null && result == null) && !(result != null && result.equals(item.result))) {
+                            errln("FAIL: displayLoc: " + item.displayLocale +
+                                    ", dialectNam: std, capitalize: mid, nameLen: full, substitute: yes; locToName: " + item.localeToBeNamed +
+                                    ", => expected result: " + item.result + ", got ULoc name: " + result);
+                        }
+                    }
+                    if (checkJustLanguage) {
+                        result = ldn.languageDisplayName(item.localeToBeNamed);
+                        if (!(item.result == null && result == null) && !(result != null && result.equals(item.result))) {
+                            errln("FAIL: displayLoc: " + item.displayLocale + ", dialectNam?: " + item.dialectHandling +
+                                    ", capitalize: " + item.capitalization + ", nameLen: " + item.nameLength +
+                                    ", substituteHandling: " + item.substituteHandling + "; locToName: " + item.localeToBeNamed +
+                                    ", => expected result: " + item.result + ", got LDN lang: " + result);
+                        }
+                        if (checkULocaleDisplay) {
+                            result = ULocale.getDisplayLanguage(item.localeToBeNamed, locale);
+                            if (!(item.result == null && result == null) && !(result != null && result.equals(item.result))) {
+                                errln("FAIL: displayLoc: " + item.displayLocale +
+                                        ", dialectNam: std, capitalize: mid, nameLen: full, substitute: yes; locToName: " + item.localeToBeNamed +
+                                        ", => expected result: " + item.result + ", got ULoc lang: " + result);
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-20870
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

If display name lookup fails for a language code, or for the language-code portion of a locale ID with other elements, then try canonicalizing the language code and looking it up again. This is per the updated locale display name algorithm in the CLDR spec: https://www.unicode.org/reports/tr35/tr35-general.html#locale_display_name_algorithm (added per https://unicode-org.atlassian.net/browse/CLDR-14490)

I think this fixes at least a couple of other tickets (linked to the CLDR ticket for this)