### PR TITLE
ICU-21662 UVector Error Handling in Regex

### DIFF
--- a/icu4c/source/common/ustack.cpp
+++ b/icu4c/source/common/ustack.cpp
@@ -37,10 +37,9 @@ UStack::~UStack() {}
 
 void* UStack::pop(void) {
     int32_t n = size() - 1;
-    void* result = 0;
+    void* result = nullptr;
     if (n >= 0) {
-        result = elementAt(n);
-        removeElementAt(n);
+        result = orphanElementAt(n);
     }
     return result;
 }

--- a/icu4c/source/common/uvector.h
+++ b/icu4c/source/common/uvector.h
@@ -346,6 +346,11 @@ public:
 
     inline int32_t peeki(void) const {return lastElementi();}
     
+    /**
+     * Pop and return an element from the stack.
+     * For stacks with a deleter function, the caller takes ownership
+     * of the popped element.
+     */
     void* pop(void);
     
     int32_t popi(void);


### PR DESCRIPTION
Clean up some oversights from commit 0ec329c. This was triggered by fuzz testing finding
a memory leak with the original commit, see https://oss-fuzz.com/testcase-detail/4656781834452992

I was unable to replicate the fuzzing failure, but reviewing the nearby code showed
some likely problems.

In this commit,
- Fix UStack::pop() to not delete the popped element when a deleter function is present.
  This was a bug, but because there were no stacks with deleters, was not causing trouble.

- Change RegexCompile::compileSet() to delete the set if it cannot be added to the internal
  vector of sets. I suspect this is the cause of the fuzzing leak - 0ec329c changed the
  behavior of UVector in the presence of errors.

- Changed RegexCompile::fSetStack to use an object deleter function. This fixes the
  leak checking at the points new elements are pushed onto this stack.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21662
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
