### PR TITLE
ICU-21749 Fix stack-use-after-scope bug in uloc

### DIFF
--- a/icu4c/source/test/cintltst/cloctst.c
+++ b/icu4c/source/test/cintltst/cloctst.c
@@ -243,6 +243,7 @@ void addLocaleTest(TestNode** root)
     TESTCASE(TestKeywordSet);
     TESTCASE(TestKeywordSetError);
     TESTCASE(TestDisplayKeywords);
+    TESTCASE(TestCanonicalization21749StackUseAfterScope);
     TESTCASE(TestDisplayKeywordValues);
     TESTCASE(TestGetBaseName);
 #if !UCONFIG_NO_FILE_IO
@@ -2491,6 +2492,19 @@ static void TestCanonicalizationBuffer(void)
     if (uprv_strncmp(name, buffer, len) != 0) {
         log_err("FAIL: uloc_canonicalize(%s) => \"%.*s\", expected \"%s\"\n",
                 name, reslen, buffer, name);
+        return;
+    }
+}
+
+static void TestCanonicalization21749StackUseAfterScope(void)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    char buffer[256];
+    const char* input = "- _";
+    uloc_canonicalize(input, buffer, -1, &status);
+    if (U_SUCCESS(status)) {
+        log_err("FAIL: uloc_canonicalize(%s) => %s, expected U_FAILURE()\n",
+                input, u_errorName(status));
         return;
     }
 }

--- a/icu4c/source/test/cintltst/cloctst.h
+++ b/icu4c/source/test/cintltst/cloctst.h
@@ -88,6 +88,7 @@ static void TestGetAvailableLocalesByType(void);
 
  static void TestCanonicalization(void);
  static void TestCanonicalizationBuffer(void);
+static  void TestCanonicalization21749StackUseAfterScope(void);
 
  static void TestDisplayKeywords(void);
 


### PR DESCRIPTION
Change the _ConvertBCP47 function to return the new string
instead of modify the pointer of the first arg to make such behavior
obvious. Add a new pointer arg in the end to get the length instead.
Move the stack allocated memory to the right scope.

The bug is caused by https://github.com/unicode-org/icu/pull/1795 rich landed 10 days ago

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21749
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
