### PR TITLE
ICU-11891 make UnicodeSet.toPattern() well-formed & round-trip

### DIFF
--- a/icu4c/source/common/unicode/uniset.h
+++ b/icu4c/source/common/unicode/uniset.h
@@ -1597,6 +1597,9 @@ private:
 
     static void _appendToPat(UnicodeString& buf, UChar32 c, UBool escapeUnprintable);
 
+    static void _appendToPat(UnicodeString &result, UChar32 start, UChar32 end,
+                             UBool escapeUnprintable);
+
     //----------------------------------------------------------------
     // Implementation: Fundamental operators
     //----------------------------------------------------------------

--- a/icu4c/source/common/util.cpp
+++ b/icu4c/source/common/util.cpp
@@ -65,38 +65,52 @@ UnicodeString& ICU_Utility::appendNumber(UnicodeString& result, int32_t n,
     return result;
 }
 
-/**
- * Return true if the character is NOT printable ASCII.
- */
 UBool ICU_Utility::isUnprintable(UChar32 c) {
     return !(c >= 0x20 && c <= 0x7E);
 }
 
-/**
- * Escape unprintable characters using \uxxxx notation for U+0000 to
- * U+FFFF and \Uxxxxxxxx for U+10000 and above.  If the character is
- * printable ASCII, then do nothing and return FALSE.  Otherwise,
- * append the escaped notation and return TRUE.
- */
+UBool ICU_Utility::shouldAlwaysBeEscaped(UChar32 c) {
+    if (c < 0x20) {
+        return true;  // C0 control codes
+    } else if (c <= 0x7e) {
+        return false;  // printable ASCII
+    } else if (c <= 0x9f) {
+        return true;  // C1 control codes
+    } else if (c < 0xd800) {
+        return false;  // most of the BMP
+    } else if (c <= 0xdfff || (0xfdd0 <= c && c <= 0xfdef) || (c & 0xfffe) == 0xfffe) {
+        return true;  // surrogate or noncharacter code points
+    } else if (c <= 0x10ffff) {
+        return false;  // all else
+    } else {
+        return true;  // not a code point
+    }
+}
+
 UBool ICU_Utility::escapeUnprintable(UnicodeString& result, UChar32 c) {
     if (isUnprintable(c)) {
-        result.append(BACKSLASH);
-        if (c & ~0xFFFF) {
-            result.append(UPPER_U);
-            result.append(DIGITS[0xF&(c>>28)]);
-            result.append(DIGITS[0xF&(c>>24)]);
-            result.append(DIGITS[0xF&(c>>20)]);
-            result.append(DIGITS[0xF&(c>>16)]);
-        } else {
-            result.append(LOWER_U);
-        }
-        result.append(DIGITS[0xF&(c>>12)]);
-        result.append(DIGITS[0xF&(c>>8)]);
-        result.append(DIGITS[0xF&(c>>4)]);
-        result.append(DIGITS[0xF&c]);
-        return TRUE;
+        escape(result, c);
+        return true;
     }
-    return FALSE;
+    return false;
+}
+
+UnicodeString &ICU_Utility::escape(UnicodeString& result, UChar32 c) {
+    result.append(BACKSLASH);
+    if (c & ~0xFFFF) {
+        result.append(UPPER_U);
+        result.append(DIGITS[0xF&(c>>28)]);
+        result.append(DIGITS[0xF&(c>>24)]);
+        result.append(DIGITS[0xF&(c>>20)]);
+        result.append(DIGITS[0xF&(c>>16)]);
+    } else {
+        result.append(LOWER_U);
+    }
+    result.append(DIGITS[0xF&(c>>12)]);
+    result.append(DIGITS[0xF&(c>>8)]);
+    result.append(DIGITS[0xF&(c>>4)]);
+    result.append(DIGITS[0xF&c]);
+    return result;
 }
 
 /**

--- a/icu4c/source/common/util.h
+++ b/icu4c/source/common/util.h
@@ -55,19 +55,29 @@ class U_COMMON_API ICU_Utility /* not : public UObject because all methods are s
 
     /**
      * Return true if the character is NOT printable ASCII.
-     *
-     * This method should really be in UnicodeString (or similar).  For
-     * now, we implement it here and share it with friend classes.
+     * The tab, newline and linefeed characters are considered unprintable.
      */
     static UBool isUnprintable(UChar32 c);
 
     /**
-     * Escape unprintable characters using \uxxxx notation for U+0000 to
+     * @return true for control codes and for surrogate and noncharacter code points
+     */
+    static UBool shouldAlwaysBeEscaped(UChar32 c);
+
+    /**
+     * Escapes one unprintable code point using \uxxxx notation for U+0000 to
      * U+FFFF and \Uxxxxxxxx for U+10000 and above.  If the character is
      * printable ASCII, then do nothing and return false.  Otherwise,
      * append the escaped notation and return true.
      */
     static UBool escapeUnprintable(UnicodeString& result, UChar32 c);
+
+    /**
+     * Escapes one code point using \uxxxx notation
+     * for U+0000 to U+FFFF and \Uxxxxxxxx for U+10000 and above.
+     * @return result
+     */
+    static UnicodeString &escape(UnicodeString& result, UChar32 c);
 
     /**
      * Returns the index of a character, ignoring quoted text.

--- a/icu4c/source/test/intltest/usettest.h
+++ b/icu4c/source/test/intltest/usettest.h
@@ -91,7 +91,7 @@ private:
 
     void TestStringSpan();
 
-    void TestUCAUnsafeBackwards();
+    void TestPatternWithSurrogates();
     void TestIntOverflow();
     void TestUnusedCcc();
     void TestDeepPattern();

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/Utility.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/Utility.java
@@ -1536,34 +1536,65 @@ public final class Utility {
     }
 
     /**
-     * Escape unprintable characters using <backslash>uxxxx notation
+     * @return true for control codes and for surrogate and noncharacter code points
+     */
+    public static boolean shouldAlwaysBeEscaped(int c) {
+        if (c < 0x20) {
+            return true;  // C0 control codes
+        } else if (c <= 0x7e) {
+            return false;  // printable ASCII
+        } else if (c <= 0x9f) {
+            return true;  // C1 control codes
+        } else if (c < 0xd800) {
+            return false;  // most of the BMP
+        } else if (c <= 0xdfff || (0xfdd0 <= c && c <= 0xfdef) || (c & 0xfffe) == 0xfffe) {
+            return true;  // surrogate or noncharacter code points
+        } else if (c <= 0x10ffff) {
+            return false;  // all else
+        } else {
+            return true;  // not a code point
+        }
+    }
+
+    /**
+     * Escapes one unprintable code point using <backslash>uxxxx notation
      * for U+0000 to U+FFFF and <backslash>Uxxxxxxxx for U+10000 and
      * above.  If the character is printable ASCII, then do nothing
      * and return FALSE.  Otherwise, append the escaped notation and
      * return TRUE.
      */
     public static <T extends Appendable> boolean escapeUnprintable(T result, int c) {
+        if (isUnprintable(c)) {
+            escape(result, c);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Escapes one code point using <backslash>uxxxx notation
+     * for U+0000 to U+FFFF and <backslash>Uxxxxxxxx for U+10000 and above.
+     * @return result
+     */
+    public static <T extends Appendable> T escape(T result, int c) {
         try {
-            if (isUnprintable(c)) {
-                result.append('\\');
-                if ((c & ~0xFFFF) != 0) {
-                    result.append('U');
-                    result.append(DIGITS[0xF&(c>>28)]);
-                    result.append(DIGITS[0xF&(c>>24)]);
-                    result.append(DIGITS[0xF&(c>>20)]);
-                    result.append(DIGITS[0xF&(c>>16)]);
-                } else {
-                    result.append('u');
-                }
-                result.append(DIGITS[0xF&(c>>12)]);
-                result.append(DIGITS[0xF&(c>>8)]);
-                result.append(DIGITS[0xF&(c>>4)]);
-                result.append(DIGITS[0xF&c]);
-                return true;
+            result.append('\\');
+            if ((c & ~0xFFFF) != 0) {
+                result.append('U');
+                result.append(DIGITS[0xF&(c>>28)]);
+                result.append(DIGITS[0xF&(c>>24)]);
+                result.append(DIGITS[0xF&(c>>20)]);
+                result.append(DIGITS[0xF&(c>>16)]);
+            } else {
+                result.append('u');
             }
-            return false;
+            result.append(DIGITS[0xF&(c>>12)]);
+            result.append(DIGITS[0xF&(c>>8)]);
+            result.append(DIGITS[0xF&(c>>4)]);
+            result.append(DIGITS[0xF&c]);
+            return result;
         } catch (IOException e) {
-            throw new IllegalIcuArgumentException(e);
+            throw new ICUUncheckedIOException(e);
         }
     }
 

--- a/icu4j/main/tests/translit/src/com/ibm/icu/dev/test/translit/RegexUtilitiesTest.java
+++ b/icu4j/main/tests/translit/src/com/ibm/icu/dev/test/translit/RegexUtilitiesTest.java
@@ -79,8 +79,13 @@ public class RegexUtilitiesTest extends TestFmwk {
                 errln(e.getMessage());
                 continue;
             }
-            final String expected = "[" + s + "]";
-            assertEquals("Doubled character works" + hex.transform(s), expected, pattern);
+            String expected = "[" + s + "]";  // Try this first for faster testing.
+            boolean ok = pattern.equals(expected);
+            if (!ok) {
+                expected = new UnicodeSet(expected).toPattern(false);
+                ok = pattern.equals(expected);
+            }
+            assertTrue("Doubled character works " + hex.transform(s), ok);
 
             // verify that we can create a regex pattern and use as expected
             String shouldNotMatch = UTF16.valueOf((cp + 1) % 0x110000);


### PR DESCRIPTION
UnicodeSet.toPattern() changes:
- Always escape surrogate code points, so that the pattern string is well-formed UTF-16.
  - For good measure (and after checking with the ICU team), toPattern() now also always escapes control codes (gc=Cc) and noncharacter code points, which could otherwise trip up consumers of the pattern string.
- When a range a-b has exactly the two code points a and b, then it is normally written without the dash (just ab). However, when these are the last lead surrogate and the first trail surrogate (U+DBFF and U+DC00), we do need to write the dash (a-b) so that the two do not combine into a surrogate pair.
- When a range a-f is followed by a range q-x, f is a lead surrogate, and q is a trail surrogate, then we have to do *something* so that f and q do not combine into a surrogate pair.
  - Merely escaping the surrogate code points is not sufficient, because the unescaping in applyPattern() (just like in the Java lexer) combines a pair of lead+trail surrogates into a supplementary code point *even when one or both are escaped*.
  - Mark suggested writing a space, but toPattern() has never added spaces before.
  - Instead, I am changing the order in which the ranges are written. (The order of elements in a set or its pattern is irrelevant.)
  - All ranges ending with a lead surrogate are postponed to after those that start with a trail surrogate.
  - If there is a range that starts with a lead surrogate and ends with a trail surrogate, it could be written immediately, or it could be postponed. Postponing it is easier to implement (and the code easier to understand).
- I moved the code for writing a range into a helper function, since there are now more places in the logic that write various ranges. (And this code got extended by the additional ab check mentioned above.)
- The toPattern() implementation used to have two code paths for whether the pattern was to be written with the actual ranges vs. as the complement of the not-contained ranges.
  - Keeping it that way would have required duplicating the new logic for avoiding surrogate pairs, with some confusing range iteration because the complement path used (getRangeEnd(previous)+1, getRangeStart(current)-1) pairs.
  - I changed the iteration to read directly from the inversion list. This by itself is less readable, but by reading (start, limit) pairs starting from index 1 instead of from index 0 we automatically get the complement of the ranges. Otherwise the logic is exactly the same.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-11891
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
