### PR TITLE
ICU-21545 fix Unicode properties Bazel build

### DIFF
--- a/icu4c/source/tools/toolutil/BUILD
+++ b/icu4c/source/tools/toolutil/BUILD
@@ -54,7 +54,11 @@ cc_library(
     local_defines = [
         "U_TOOLUTIL_IMPLEMENTATION",
     ],
-    deps = ["//icu4c/source/common:platform"],
+    deps = [
+        "//icu4c/source/common:bytestream",
+        "//icu4c/source/common:platform",
+        "//icu4c/source/common:uniset_core",
+    ],
 )
 
 cc_library(

--- a/icu4c/source/tools/toolutil/writesrc.cpp
+++ b/icu4c/source/tools/toolutil/writesrc.cpp
@@ -32,6 +32,12 @@
 #include "writesrc.h"
 #include "util.h"
 
+U_NAMESPACE_BEGIN
+
+ValueNameGetter::~ValueNameGetter() {}
+
+U_NAMESPACE_END
+
 U_NAMESPACE_USE
 
 static FILE *
@@ -401,7 +407,7 @@ U_CAPI void U_EXPORT2
 usrc_writeUCPMap(
         FILE *f,
         const UCPMap *pMap,
-        UProperty uproperty,
+        icu::ValueNameGetter *valueNameGetter,
         UTargetSyntax syntax) {
     // ccode is not yet supported
     U_ASSERT(syntax == UPRV_TARGET_SYNTAX_TOML);
@@ -413,9 +419,9 @@ usrc_writeUCPMap(
     fprintf(f, "# Code points `a` through `b` have value `v`, corresponding to `name`.\n");
     fprintf(f, "ranges = [\n");
     while ((end = ucpmap_getRange(pMap, start, UCPMAP_RANGE_NORMAL, 0, nullptr, nullptr, &value)) >= 0) {
-        if (uproperty != UCHAR_INVALID_CODE) {
-            const char* short_name = u_getPropertyValueName(uproperty, value, U_SHORT_PROPERTY_NAME);
-            fprintf(f, "  {a=0x%x, b=0x%x, v=%u, name=\"%s\"},\n", start, end, value, short_name);
+        if (valueNameGetter != nullptr) {
+            const char *name = valueNameGetter->getName(value);
+            fprintf(f, "  {a=0x%x, b=0x%x, v=%u, name=\"%s\"},\n", start, end, value, name);
         } else {
             fprintf(f, "  {a=0x%x, b=0x%x, v=%u},\n", start, end, value);
         }

--- a/icu4c/source/tools/toolutil/writesrc.h
+++ b/icu4c/source/tools/toolutil/writesrc.h
@@ -143,18 +143,32 @@ usrc_writeUnicodeSet(
     const USet *pSet,
     UTargetSyntax syntax);
 
+#ifdef __cplusplus
+
+U_NAMESPACE_BEGIN
+
+class U_TOOLUTIL_API ValueNameGetter {
+public:
+    virtual ~ValueNameGetter();
+    virtual const char *getName(uint32_t value) = 0;
+};
+
+U_NAMESPACE_END
+
 /**
  * Writes the UCPMap ranges list.
  *
- * The "uproperty" argument is optional; ignored if UCHAR_INVALID_CODE. If present, it will be used
- * to look up the property value name strings.
+ * The "valueNameGetter" argument is optional; ignored if nullptr.
+ * If present, it will be used to look up value name strings.
  */
 U_CAPI void U_EXPORT2
 usrc_writeUCPMap(
     FILE *f,
     const UCPMap *pMap,
-    UProperty uproperty,
+    icu::ValueNameGetter *valueNameGetter,
     UTargetSyntax syntax);
+
+#endif  // __cplusplus
 
 /**
  * Writes the contents of an array of mostly invariant characters.


### PR DESCRIPTION
1. Add Bazel dependencies for toolutil:writesrc corresponding to changes in PR #1741
2. Change writesrc to not depend on common:propname because tools early in the Unicode build process need writesrc before propname_data.h has been generated.
3. Instead, make usrc_writeUCPMap() more generic: Pull the fetching of value names into an abstract interface, and move the u_getPropertyValueName() into the icuexportdata tool code.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21545
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
