### PR TITLE
ICU-21581 check non-stable API macros (mostly U_HIDE_INTERNAL_API)

### DIFF
--- a/icu4c/source/common/unicode/uloc.h
+++ b/icu4c/source/common/unicode/uloc.h
@@ -841,7 +841,7 @@ typedef enum ULocAvailableType {
    * @internal
    */
   ULOC_AVAILABLE_COUNT
-#endif
+#endif  /* U_HIDE_INTERNAL_API */
 } ULocAvailableType;
 
 /**

--- a/icu4c/source/i18n/unicode/alphaindex.h
+++ b/icu4c/source/i18n/unicode/alphaindex.h
@@ -647,7 +647,7 @@ public:
 private:
      /**
       * No Copy constructor.
-      * @internal
+      * @internal (private)
       */
      AlphabeticIndex(const AlphabeticIndex &other);
 
@@ -658,13 +658,13 @@ private:
 
     /**
      * No Equality operators.
-     * @internal
+     * @internal (private)
      */
      virtual bool operator==(const AlphabeticIndex& other) const;
 
     /**
      * Inequality operator.
-     * @internal
+     * @internal (private)
      */
      virtual bool operator!=(const AlphabeticIndex& other) const;
 
@@ -723,7 +723,7 @@ private:
     /**
      * Holds all user records before they are distributed into buckets.
      * Type of contents is (Record *)
-     * @internal
+     * @internal (private)
      */
     UVector  *inputList_;
 

--- a/icu4c/source/i18n/unicode/dcfmtsym.h
+++ b/icu4c/source/i18n/unicode/dcfmtsym.h
@@ -174,7 +174,7 @@ public:
          * @internal
          */
         kApproximatelySignSymbol,
-#endif
+#endif  /* U_HIDE_INTERNAL_API */
         /** count symbol constants */
         kFormatSymbolCount = kExponentMultiplicationSymbol + 2
     };

--- a/icu4c/source/i18n/unicode/measunit.h
+++ b/icu4c/source/i18n/unicode/measunit.h
@@ -107,12 +107,14 @@ typedef enum UMeasurePrefix {
      */
     UMEASURE_PREFIX_YOTTA = UMEASURE_PREFIX_ONE + 24,
 
+#ifndef U_HIDE_INTERNAL_API
     /**
      * ICU use only.
      * Used to determine the set of base-10 SI prefixes.
      * @internal
      */
     UMEASURE_PREFIX_INTERNAL_MAX_SI = UMEASURE_PREFIX_YOTTA,
+#endif  /* U_HIDE_INTERNAL_API */
 
     /**
      * SI prefix: zetta, 10^21.

--- a/icu4c/source/i18n/unicode/numberrangeformatter.h
+++ b/icu4c/source/i18n/unicode/numberrangeformatter.h
@@ -648,7 +648,7 @@ class U_I18N_API FormattedNumberRange : public UMemory, public FormattedValue {
      */
     FormattedNumberRange()
         : fData(nullptr), fErrorCode(U_INVALID_STATE_ERROR) {}
-#endif
+#endif  /* U_HIDE_DRAFT_API */
 
     /**
      * Copying not supported; use move constructor instead.

--- a/icu4c/source/i18n/unicode/unumberrangeformatter.h
+++ b/icu4c/source/i18n/unicode/unumberrangeformatter.h
@@ -193,7 +193,7 @@ typedef enum UNumberRangeIdentityResult {
      * @internal
      */
     UNUM_IDENTITY_RESULT_COUNT
-#endif
+#endif  /* U_HIDE_INTERNAL_API */
 
 } UNumberRangeIdentityResult;
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21581
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

This was for the BRS task to check the non-stable API macros (mostly U_HIDE_INTERNAL_API, since the others are now checked automatically). I only needed to add one actual U_HIDE_INTERNAL_API conditional; the rest of this was adding "private" comments to things marked @internal that are already private, and adding #endif comments indicating what conditional is being ended.