### PR TITLE
ICU-21770 suppress compiler warning from priority

### DIFF
--- a/icu4c/source/i18n/number_skeletons.cpp
+++ b/icu4c/source/i18n/number_skeletons.cpp
@@ -1344,7 +1344,7 @@ bool blueprint_helpers::parseFracSigOption(const StringSegment& segment, MacroPr
         // @, @@, @@@
         maxSig = minSig;
     }
-    UNumberRoundingPriority priority;
+    UNumberRoundingPriority priority = UNUM_ROUNDING_PRIORITY_RELAXED;
     if (offset < segment.length()) {
         if (maxSig == -1) {
             // The wildcard character is not allowed with the priority annotation


### PR DESCRIPTION
Currently the following compiler warning is generated when using gcc
11.2.1:
```console
number_skeletons.cpp: In function ‘bool icu_70::number::impl::blueprint_helpers::parseFracSigOption(const icu_70::StringSegment&, icu_70::number::impl::MacroProps&, UErrorCode&)’:
number_skeletons.cpp:1383:58: warning: ‘priority’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 1383 |     macros.precision = oldPrecision.withSignificantDigits(minSig, maxSig, priority);
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
```
This commit initializes priority to UNUM_ROUNDING_PRIORITY_RELAXED to
avoid this warning.


##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21770
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
