### PR TITLE
ICU-21768 u_snprintf improperly counts buffer size

### DIFF
--- a/icu4c/source/io/sprintf.cpp
+++ b/icu4c/source/io/sprintf.cpp
@@ -41,6 +41,12 @@ u_sprintf_write(void        *context,
                 int32_t     count)
 {
     u_localized_print_string *output = (u_localized_print_string *)context;
+
+    /* just calculating buffer size */
+    if (output->str == 0) {
+        return count;
+    }
+
     int32_t size = ufmt_min(count, output->available);
 
     u_strncpy(output->str + (output->len - output->available), str, size);
@@ -57,6 +63,12 @@ u_sprintf_pad_and_justify(void                        *context,
     u_localized_print_string *output = (u_localized_print_string *)context;
     int32_t written = 0;
     int32_t lengthOfResult = resultLen;
+
+    /* just calculating buffer size */
+    if (output->str == 0 &&
+        info->fWidth != -1 && resultLen < info->fWidth) {
+        return info->fWidth;
+    }
 
     resultLen = ufmt_min(resultLen, output->available);
 

--- a/icu4c/source/test/iotest/strtst.c
+++ b/icu4c/source/test/iotest/strtst.c
@@ -315,9 +315,10 @@ static void TestLocalizedString(void) {
 #if !UCONFIG_NO_FORMATTING
 #define Test_u_snprintf(limit, format, value, expectedSize, expectedStr) UPRV_BLOCK_MACRO_BEGIN { \
     u_uastrncpy(testStr, "xxxxxxxxxxxxxx", UPRV_LENGTHOF(testStr));\
-    size = u_snprintf(testStr, limit, format, value);\
+    size = u_snprintf(0, 0, format, value);\
+    written = u_snprintf(testStr, limit, format, value);\
     u_austrncpy(cTestResult, testStr, UPRV_LENGTHOF(cTestResult));\
-    if (size != expectedSize || strcmp(cTestResult, expectedStr) != 0) {\
+    if (size != written || size != expectedSize || strcmp(cTestResult, expectedStr) != 0) {\
         log_err("Unexpected formatting. size=%d expectedSize=%d cTestResult=%s expectedStr=%s\n",\
             size, expectedSize, cTestResult, expectedStr);\
     }\
@@ -332,7 +333,7 @@ static void TestSnprintf(void) {
 #if !UCONFIG_NO_FORMATTING
     UChar testStr[256];
     char cTestResult[256];
-    int32_t size;
+    int32_t size, written;
 
     Test_u_snprintf(0, "%d", 123, 3, "xxxxxxxxxxxxxx");
     Test_u_snprintf(2, "%d", 123, 3, "12xxxxxxxxxxxx");


### PR DESCRIPTION
ICU-21768 Fixed (u_snprintf improperly counts the required buffer size).
Modified TestSnprintf in iotest to test the null buffer case.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21768
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
