### PR TITLE
ICU-21780 suppress stringop-trunction warnings

### DIFF
--- a/icu4c/source/common/ucurr.cpp
+++ b/icu4c/source/common/ucurr.cpp
@@ -382,10 +382,12 @@ struct CReg : public icu::UMemory {
         if (len > (int32_t)(sizeof(id)-1)) {
             len = (sizeof(id)-1);
         }
+#if defined(__clang__) || U_GCC_MAJOR_MINOR >= 1100
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
         uprv_strncpy(id, _id, len);
 #pragma GCC diagnostic pop
+#endif
         id[len] = 0;
         u_memcpy(iso, _iso, ISO_CURRENCY_CODE_LENGTH);
         iso[ISO_CURRENCY_CODE_LENGTH] = 0;

--- a/icu4c/source/common/ucurr.cpp
+++ b/icu4c/source/common/ucurr.cpp
@@ -382,7 +382,10 @@ struct CReg : public icu::UMemory {
         if (len > (int32_t)(sizeof(id)-1)) {
             len = (sizeof(id)-1);
         }
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
         uprv_strncpy(id, _id, len);
+#pragma GCC diagnostic pop
         id[len] = 0;
         u_memcpy(iso, _iso, ISO_CURRENCY_CODE_LENGTH);
         iso[ISO_CURRENCY_CODE_LENGTH] = 0;

--- a/icu4c/source/common/uloc_tag.cpp
+++ b/icu4c/source/common/uloc_tag.cpp
@@ -2124,7 +2124,10 @@ ultag_parse(const char* tag, int32_t tagLen, int32_t* parsedLen, UErrorCode* sta
                 if (*redundantTagEnd  == '\0' || *redundantTagEnd == SEP) {
                     const char* preferredTag = REDUNDANT[i + 1];
                     size_t preferredTagLen = uprv_strlen(preferredTag);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
                     uprv_strncpy(t->buf, preferredTag, preferredTagLen);
+#pragma GCC diagnostic pop
                     if (*redundantTagEnd == SEP) {
                         uprv_memmove(tagBuf + preferredTagLen,
                                      redundantTagEnd,

--- a/icu4c/source/common/uloc_tag.cpp
+++ b/icu4c/source/common/uloc_tag.cpp
@@ -2124,10 +2124,12 @@ ultag_parse(const char* tag, int32_t tagLen, int32_t* parsedLen, UErrorCode* sta
                 if (*redundantTagEnd  == '\0' || *redundantTagEnd == SEP) {
                     const char* preferredTag = REDUNDANT[i + 1];
                     size_t preferredTagLen = uprv_strlen(preferredTag);
+#if defined(__clang__) || U_GCC_MAJOR_MINOR >= 1100
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
                     uprv_strncpy(t->buf, preferredTag, preferredTagLen);
 #pragma GCC diagnostic pop
+#endif
                     if (*redundantTagEnd == SEP) {
                         uprv_memmove(tagBuf + preferredTagLen,
                                      redundantTagEnd,

--- a/icu4c/source/i18n/calendar.cpp
+++ b/icu4c/source/i18n/calendar.cpp
@@ -841,10 +841,12 @@ Calendar::operator=(const Calendar &right)
         fWeekendCeaseMillis      = right.fWeekendCeaseMillis;
         fNextStamp               = right.fNextStamp;
         uprv_strncpy(validLocale, right.validLocale, sizeof(validLocale));
+#if defined(__clang__) || U_GCC_MAJOR_MINOR >= 1100
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
         uprv_strncpy(actualLocale, right.actualLocale, sizeof(actualLocale));
 #pragma GCC diagnostic pop
+#endif
         validLocale[sizeof(validLocale)-1] = 0;
         actualLocale[sizeof(validLocale)-1] = 0;
     }

--- a/icu4c/source/i18n/calendar.cpp
+++ b/icu4c/source/i18n/calendar.cpp
@@ -841,7 +841,10 @@ Calendar::operator=(const Calendar &right)
         fWeekendCeaseMillis      = right.fWeekendCeaseMillis;
         fNextStamp               = right.fNextStamp;
         uprv_strncpy(validLocale, right.validLocale, sizeof(validLocale));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
         uprv_strncpy(actualLocale, right.actualLocale, sizeof(actualLocale));
+#pragma GCC diagnostic pop
         validLocale[sizeof(validLocale)-1] = 0;
         actualLocale[sizeof(validLocale)-1] = 0;
     }

--- a/icu4c/source/tools/ctestfw/ctest.c
+++ b/icu4c/source/tools/ctestfw/ctest.c
@@ -180,7 +180,10 @@ static TestNode *createTestNode(const char* name, int32_t nameLen)
     newNode->sibling = NULL;
     newNode->child = NULL;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
     strncpy( newNode->name, name, nameLen );
+#pragma GCC diagnostic pop
     newNode->name[nameLen] = 0;
 
     return  newNode;

--- a/icu4c/source/tools/ctestfw/ctest.c
+++ b/icu4c/source/tools/ctestfw/ctest.c
@@ -180,10 +180,12 @@ static TestNode *createTestNode(const char* name, int32_t nameLen)
     newNode->sibling = NULL;
     newNode->child = NULL;
 
+#if defined(__clang__) || U_GCC_MAJOR_MINOR >= 1100
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
     strncpy( newNode->name, name, nameLen );
 #pragma GCC diagnostic pop
+#endif
     newNode->name[nameLen] = 0;
 
     return  newNode;


### PR DESCRIPTION
Currently there are a few stringop-truncation warning generated with
gcc 11.2.1, for example:
```console
In file included from ucurr.cpp:25:
In constructor ‘CReg::CReg(const UChar*, const char*)’,
    inlined from ‘static const void* CReg::reg(const UChar*,
                                               const char*,
                                               UErrorCode*)’
    at ucurr.cpp:397:41,
    inlined from ‘const void* ucurr_register_70(const UChar*,
                                                const char*,
                                                UErrorCode*)’
    at ucurr.cpp:469:25:
cstring.h:43:70: warning:
‘char* strncpy(char*, const char*, size_t)’ output truncated before
terminating nul copying as many bytes from a string as its length
[-Wstringop-truncation]
   43 | #define uprv_strncpy(dst, src, size)
            U_STANDARD_CPP_NAMESPACE strncpy(dst, src, size)
ucurr.cpp:387:9: note: in expansion of macro ‘uprv_strncpy’
  387 |         uprv_strncpy(id, _id, len);
      |         ^~~~~~~~~~~~
ucurr.cpp: In function ‘const void* ucurr_register_70(const UChar*,
                                                      const char*,
                                                      UErrorCode*)’:
cstring.h:37:57: note: length computed here
   37 | #define uprv_strlen(str) U_STANDARD_CPP_NAMESPACE strlen(str)
ucurr.cpp:381:32: note: in expansion of macro ‘uprv_strlen’
  381 |         int32_t len = (int32_t)uprv_strlen(_id);
      |                                ^~~~~~~~~~~
```
This commit adds a GCC ignore for this warnings.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21780
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
