### PR TITLE
ICU-21781 suppress Wstringop-overflow in decNumber

### DIFF
--- a/icu4c/source/i18n/decNumber.cpp
+++ b/icu4c/source/i18n/decNumber.cpp
@@ -1414,6 +1414,7 @@ U_CAPI decNumber * U_EXPORT2 uprv_decNumberLogB(decNumber *res, const decNumber 
 #if defined(__clang__) || U_GCC_MAJOR_MINOR >= 406
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif
 U_CAPI decNumber * U_EXPORT2 uprv_decNumberLog10(decNumber *res, const decNumber *rhs,
                           decContext *set) {
@@ -2829,6 +2830,7 @@ U_CAPI decNumber * U_EXPORT2 uprv_decNumberShift(decNumber *res, const decNumber
 #if defined(__clang__) || U_GCC_MAJOR_MINOR >= 406
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif
 U_CAPI decNumber * U_EXPORT2 uprv_decNumberSquareRoot(decNumber *res, const decNumber *rhs,
                                 decContext *set) {
@@ -5626,6 +5628,7 @@ static const uShort LNnn[90]={9016,  8652,  8316,  8008,  7724,  7456,  7208,
 #if defined(__clang__) || U_GCC_MAJOR_MINOR >= 406
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif
 decNumber * decLnOp(decNumber *res, const decNumber *rhs,
                     decContext *set, uInt *status) {


### PR DESCRIPTION
Currently there are a few compiler warnings generated when using GCC
11.2.1:
```console
decNumber.cpp: In function ‘decNumber* uprv_decNumberSquareRoot_70(
    decNumber*, const decNumber*, decContext*)’:
decNumber.cpp:2976:31: warning:
 writing 1 byte into a region of size 0 [-Wstringop-overflow=]
 2976 |         t->lsu[0]=9; t->lsu[1]=5; t->lsu[2]=2;
      |                      ~~~~~~~~~^~
In file included from decNumber.cpp:184:
decNumber.h:89:19: note:
 at offset 1 into destination object ‘decNumber::lsu’ of size 1
   89 |     decNumberUnit lsu[DECNUMUNITS];
      |                   ^~~
```
There is an ignore for array-bounds warnings in this file which was
added in Commit 38f7c0625c3a49208cc573720deaafcd2843c381 ("ICU-8954
add pragma to slience clang/gcc 4.6 about array bound error"). This
commit add an ignore for stringop-overflow to suppress this warning.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21781
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
