### PR TITLE
ICU-21781 suppress Wreturn-local-addr in formattedvalue

### DIFF
--- a/icu4c/source/i18n/formattedvalue.cpp
+++ b/icu4c/source/i18n/formattedvalue.cpp
@@ -193,6 +193,9 @@ ucfpos_close(UConstrainedFieldPosition* ptr) {
 }
 
 
+#if defined(__clang__) || U_GCC_MAJOR_MINOR >= 1100
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wreturn-local-addr"
 U_CAPI const UChar* U_EXPORT2
 ufmtval_getString(
         const UFormattedValue* ufmtval,
@@ -211,6 +214,8 @@ ufmtval_getString(
     }
     return readOnlyAlias.getBuffer();
 }
+#pragma GCC diagnostic pop
+#endif
 
 
 U_CAPI UBool U_EXPORT2


### PR DESCRIPTION
This commit attempts to suppress the following warning when using GCC
11.2.1:
```console
In function ‘const UChar* icu_70::ufmtval_getString_70(
    const UFormattedValue*, int32_t*, UErrorCode*)’:
cc1plus: warning:
function may return address of local variable [-Wreturn-local-addr]
formattedvalue.cpp:207:19: note: declared here
207 |     UnicodeString readOnlyAlias = impl->fFormattedValue->
    |                   ^~~~~~~~~~~~~   toTempString(*ec);
```
This does not actually allow the warning to be ignored and I believe
the following issue has been opened in GCC for this:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=93644
But adding this ignore would allow for this warning to be ignored when a
fix for this is included in GCC.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21781
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
