### PR TITLE
ICU-21776 integrate CLDR release-40-beta3 to ICU maint/maint-70

### DIFF
--- a/icu4c/source/data/misc/timezoneTypes.txt
+++ b/icu4c/source/data/misc/timezoneTypes.txt
@@ -93,6 +93,7 @@ timezoneTypes:table(nofallback){
             "Mexico:BajaSur"{"America/Mazatlan"}
             "Mexico:General"{"America/Mexico_City"}
             "Pacific:Chuuk"{"Pacific/Truk"}
+            "Pacific:Kanton"{"Pacific/Enderbury"}
             "Pacific:Pohnpei"{"Pacific/Ponape"}
             "Pacific:Samoa"{"Pacific/Pago_Pago"}
             "Pacific:Yap"{"Pacific/Truk"}

--- a/icu4j/main/shared/data/icudata.jar
+++ b/icu4j/main/shared/data/icudata.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:708c473591db665d3f9b9aa321219885a86b5106e26ece98d2cf0a1aa816cffd
-size 13627094
+oid sha256:44951f88294c06e433a3b61238d9bb5f59ba01f091fcfb8fe4966f98f0748ef7
+size 13627084

--- a/icu4j/main/shared/data/icutzdata.jar
+++ b/icu4j/main/shared/data/icutzdata.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2c6618e94cf3c02a34113555937eb6c4417c867bc9f9cb03783dd2daef08e591
-size 96370
+oid sha256:534d810701908227007cfdbd3134ff9dcf87bb7e9372cf0f513d5c365fe1836e
+size 96378

--- a/icu4j/main/shared/data/testdata.jar
+++ b/icu4j/main/shared/data/testdata.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0888b8ed722fcd5bace2a0f3ce6fb2463bdd9686d97ee0b56effd3672b652fd4
-size 829042
+oid sha256:cf33f21346eea88c0282a4960f19f27e475554449f52ef4f25889e2b8a34a1c0
+size 826063


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21776
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

Integrate CLDR release-40-beta3 (tagged last week) into ICU maint/maint-70; no other data chnages have come into CLDR maint/maint-40 since then. 

This just adds the Pacific/Kanton timezone alias.