### PR TITLE
ICU-21800 Fix ARM64 search path for Windows

### DIFF
--- a/icu4c/source/data/makedata.mak
+++ b/icu4c/source/data/makedata.mak
@@ -142,13 +142,20 @@ TESTDATABLD=$(ICUP)\source\test\testdata\out\build
 ICUTOOLS=$(ICUP)\source\tools
 !MESSAGE ICU tools path is $(ICUTOOLS)
 
+NATIVE_ARM=
+!IF "$(PROCESSOR_ARCHITECTURE)" == "ARM64" || "$(PROCESSOR_ARCHITEW6432)" == "ARM64"
+NATIVE_ARM=ARM64
+!ELSE IF "$(PROCESSOR_ARCHITECTURE)" == "ARM" || "$(PROCESSOR_ARCHITEW6432)" == "ARM"
+NATIVE_ARM=ARM
+!ENDIF
+
 #   ARM_CROSS_BUILD
 #       In order to support cross-compiling for ARM/ARM64 using the x64 tools
 #       we need to know if we're building the ARM/ARM64 data DLL, otherwise
 #       the existence of the x64 bits will cause us to think we are already done.
 #    Note: This is only for the "regular" builds, the UWP builds have a separate project file entirely.
 ARM_CROSS_BUILD=
-!IF "$(UWP)" == ""
+!IF "$(UWP)" == "" && "$(NATIVE_ARM)" == ""
 !IF "$(CFG)" == "ARM\Release" || "$(CFG)" == "ARM\Debug"
 ARM_CROSS_BUILD=ARM
 ARM_CROSSBUILD_TS=$(ICUTMP)\$(ARM_CROSS_BUILD).timestamp
@@ -185,6 +192,18 @@ CFGTOOLS=x64\Debug
 !IF "$(CFG)" == "x86\Release" || "$(CFG)" == "x86\Debug"
 PATH = $(ICUP)\bin;$(PATH)
 ICUPBIN=$(ICUP)\bin
+# Use these path whether or not it's UWP build.
+!ELSE IF "$(NATIVE_ARM)" != ""
+!IF "$(CFG)" == "ARM\Release" || "$(CFG)" == "ARM\Debug"
+PATH = $(ICUP)\binARM;$(PATH)
+ICUPBIN=$(ICUP)\binARM
+!ELSE IF "$(CFG)" == "ARM64\Release" || "$(CFG)" == "ARM64\Debug"
+PATH = $(ICUP)\binARM64;$(PATH)
+ICUPBIN=$(ICUP)\binARM64
+!ELSE
+!ERROR Cross-build from ARM to x86 is not supported!
+!ENDIF
+# Build x86_64 or cross-build ARM
 !ELSE
 PATH = $(ICUP)\bin64;$(PATH)
 ICUPBIN=$(ICUP)\bin64

--- a/icu4c/source/extra/uconv/makedata.mak
+++ b/icu4c/source/extra/uconv/makedata.mak
@@ -51,14 +51,31 @@ PKGMODE=static
 ICD=$(ICUDATA)^\
 DATA_PATH=$(ICUP)\data^\
 
+NATIVE_ARM=
+!IF "$(PROCESSOR_ARCHITECTURE)" == "ARM64" || "$(PROCESSOR_ARCHITEW6432)" == "ARM64"
+NATIVE_ARM=ARM64
+!ELSE IF "$(PROCESSOR_ARCHITECTURE)" == "ARM" || "$(PROCESSOR_ARCHITEW6432)" == "ARM"
+NATIVE_ARM=ARM
+!ENDIF
+
 # Use the x64 tools for building ARM and ARM64.
 # Note: This is similar to the TOOLS CFG PATH in source\data\makedata.mak
+!IF "$(NATIVE_ARM)" == ""
 !IF "$(CFG)" == "x64\Release" || "$(CFG)" == "x64\Debug" || "$(CFG)" == "ARM\Release" || "$(CFG)" == "ARM\Debug" || "$(CFG)" == "ARM64\Release"  || "$(CFG)" == "ARM64\Debug"
 ICUTOOLS=$(ICUP)\bin64
 PATH = $(ICUP)\bin64;$(PATH)
 !ELSE
 ICUTOOLS=$(ICUP)\bin
 PATH = $(ICUP)\bin;$(PATH)
+!ENDIF
+!ELSE
+!IF "$(CFG)" == "ARM\Release" || "$(CFG)" == "ARM\Debug"
+ICUTOOLS=$(ICUP)\binARM
+PATH = $(ICUP)\binARM;$(PATH)
+!ELSE
+ICUTOOLS=$(ICUP)\binARM64
+PATH = $(ICUP)\binARM64;$(PATH)
+!ENDIF
 !ENDIF
 
 # If building ARM/ARM, then we need to pass the arch as an argument.

--- a/icu4c/source/test/intltest/windttst.cpp
+++ b/icu4c/source/test/intltest/windttst.cpp
@@ -156,7 +156,7 @@ void Win32DateTimeTest::testLocales(DateFormatTest *log)
         wdLength = GetDateFormatW(lcidRecords[i].lcid, DATE_LONGDATE, &winNow, NULL, wdBuffer, UPRV_LENGTHOF(wdBuffer));
         wtLength = GetTimeFormatW(lcidRecords[i].lcid, 0, &winNow, NULL, wtBuffer, UPRV_LENGTHOF(wtBuffer));
 
-        if (uprv_strchr(localeID, '@') > 0) {
+        if (uprv_strchr(localeID, '@')) {
             uprv_strcat(localeID, ";");
         } else {
             uprv_strcat(localeID, "@");

--- a/icu4c/source/test/intltest/winnmtst.cpp
+++ b/icu4c/source/test/intltest/winnmtst.cpp
@@ -303,7 +303,7 @@ void Win32NumberTest::testLocales(NumberFormatTest *log)
 
         strcpy(localeID, lcidRecords[i].localeID);
 
-        if (strchr(localeID, '@') > 0) {
+        if (strchr(localeID, '@')) {
             strcat(localeID, ";");
         } else {
             strcat(localeID, "@");


### PR DESCRIPTION
The PR is for native build on ARM/ARM64 architecture.

Also fixed the compilation error of `icu4c/source/test/intltest/windttst.cpp` and `icu4c/source/test/intltest/winnmtst.cpp`.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21800
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
