### PR TITLE
ICU-21803 Fix Windows build break on MSYS2 with GCC 11

### DIFF
--- a/icu4c/source/test/intltest/windttst.cpp
+++ b/icu4c/source/test/intltest/windttst.cpp
@@ -156,7 +156,7 @@ void Win32DateTimeTest::testLocales(DateFormatTest *log)
         wdLength = GetDateFormatW(lcidRecords[i].lcid, DATE_LONGDATE, &winNow, NULL, wdBuffer, UPRV_LENGTHOF(wdBuffer));
         wtLength = GetTimeFormatW(lcidRecords[i].lcid, 0, &winNow, NULL, wtBuffer, UPRV_LENGTHOF(wtBuffer));
 
-        if (uprv_strchr(localeID, '@') > 0) {
+        if (uprv_strchr(localeID, '@')) {
             uprv_strcat(localeID, ";");
         } else {
             uprv_strcat(localeID, "@");

--- a/icu4c/source/test/intltest/winnmtst.cpp
+++ b/icu4c/source/test/intltest/winnmtst.cpp
@@ -303,7 +303,7 @@ void Win32NumberTest::testLocales(NumberFormatTest *log)
 
         strcpy(localeID, lcidRecords[i].localeID);
 
-        if (strchr(localeID, '@') > 0) {
+        if (strchr(localeID, '@')) {
             strcat(localeID, ";");
         } else {
             strcat(localeID, "@");


### PR DESCRIPTION
Cherry-picked from the `maint/maint-70` branch into `main`. See PR https://github.com/unicode-org/icu/pull/1911

I'm cherry-picking this change into `main` now, instead of waiting for the larger merge of the maintenance branch into `main` later in order to unblock PRs in the meantime (since this causes build failures).
(FYI for @sffc in case this causes merge conflicts later on... sorry about it).

*From the original PR description:*
The default compiler for MSYS2 was updated to use GCC 11 instead of GCC 10.
(from `mingw-w64-x86_64-gcc-10.3.0-5` to `mingw-w64-x86_64-gcc-11.2.0`)

This causes a new fatal error in the Windows test code.

(Thanks to @JackyYin, who had a fix for this included as part of the changes in PR #1907.)

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21803
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
