### PR TITLE
ICU-21778 UnicodeString::clone error handling fix

### DIFF
--- a/icu4c/source/common/unistr.cpp
+++ b/icu4c/source/common/unistr.cpp
@@ -334,7 +334,8 @@ Replaceable::clone() const {
 // UnicodeString overrides clone() with a real implementation
 UnicodeString *
 UnicodeString::clone() const {
-  return new UnicodeString(*this);
+  LocalPointer<UnicodeString> clonedString(new UnicodeString(*this));
+  return clonedString.isValid() && !clonedString->isBogus() ? clonedString.orphan() : nullptr;
 }
 
 //========================================

--- a/icu4c/source/test/intltest/ustrtest.cpp
+++ b/icu4c/source/test/intltest/ustrtest.cpp
@@ -1653,6 +1653,16 @@ UnicodeStringTest::TestBogus() {
     if(test1>=test2 || !(test2>test1) || test1.compare(test2)>=0 || !(test2.compare(test1)>0)) {
         errln("bogus<empty failed");
     }
+
+    // test that copy constructor of bogus is bogus & clone of bogus is nullptr
+    {
+        test3.setToBogus();
+        UnicodeString test3Copy(test3);
+        UnicodeString *test3Clone = test3.clone();
+        assertTrue(WHERE, test3.isBogus());
+        assertTrue(WHERE, test3Copy.isBogus());
+        assertTrue(WHERE, test3Clone == nullptr);
+    }
 }
 
 // StringEnumeration ------------------------------------------------------- ***


### PR DESCRIPTION
Change UnicodeString::clone() to return a nullptr if the underlying copy
constructor produces a bogus string. This can happen if the copy constructor
encounters a memory allocation failure in allocating the copy's internal string
buffer, or if the string being copied was already bogus.

The change is consistent with other ICU clone functions, which are generally
defined to return nullptr in case of errors.


##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21778
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
