### PR TITLE
ICU-21820 ucase_toFullXyz() reset output pointer

### DIFF
--- a/icu4c/source/common/ucase.cpp
+++ b/icu4c/source/common/ucase.cpp
@@ -1064,6 +1064,8 @@ ucase_toFullLower(UChar32 c,
     // The sign of the result has meaning, input must be non-negative so that it can be returned as is.
     U_ASSERT(c >= 0);
     UChar32 result=c;
+    // Reset the output pointer in case it was uninitialized.
+    *pString=nullptr;
     uint16_t props=UTRIE2_GET16(&ucase_props_singleton.trie, c);
     if(!UCASE_HAS_EXCEPTION(props)) {
         if(UCASE_IS_UPPER_OR_TITLE(props)) {
@@ -1148,7 +1150,6 @@ ucase_toFullLower(UChar32 c,
                     0307; ; 0307; 0307; tr After_I; # COMBINING DOT ABOVE
                     0307; ; 0307; 0307; az After_I; # COMBINING DOT ABOVE
                  */
-                *pString=nullptr;
                 return 0; /* remove the dot (continue without output) */
             } else if(loc==UCASE_LOC_TURKISH && c==0x49 && !isFollowedByDotAbove(iter, context)) {
                 /*
@@ -1215,6 +1216,8 @@ toUpperOrTitle(UChar32 c,
     // The sign of the result has meaning, input must be non-negative so that it can be returned as is.
     U_ASSERT(c >= 0);
     UChar32 result=c;
+    // Reset the output pointer in case it was uninitialized.
+    *pString=nullptr;
     uint16_t props=UTRIE2_GET16(&ucase_props_singleton.trie, c);
     if(!UCASE_HAS_EXCEPTION(props)) {
         if(UCASE_GET_TYPE(props)==UCASE_LOWER) {
@@ -1252,7 +1255,6 @@ toUpperOrTitle(UChar32 c,
 
                     0307; 0307; ; ; lt After_Soft_Dotted; # COMBINING DOT ABOVE
                  */
-                *pString=nullptr;
                 return 0; /* remove the dot (continue without output) */
             } else if(c==0x0587) {
                 // See ICU-13416:
@@ -1449,6 +1451,8 @@ ucase_toFullFolding(UChar32 c,
     // The sign of the result has meaning, input must be non-negative so that it can be returned as is.
     U_ASSERT(c >= 0);
     UChar32 result=c;
+    // Reset the output pointer in case it was uninitialized.
+    *pString=nullptr;
     uint16_t props=UTRIE2_GET16(&ucase_props_singleton.trie, c);
     if(!UCASE_HAS_EXCEPTION(props)) {
         if(UCASE_IS_UPPER_OR_TITLE(props)) {


### PR DESCRIPTION
I decided to basically take Vitaly's suggested fix to always reset the output pointer in each function implementation. This makes them behave like returning a (pointer, length) value pair.

I did look at the alternative of resetting the output pointer at each call site. That might save a smidgen of time if we also move the pointer declarations outside of their string-case-mapping loops but seems more errorprone.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21820
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
