### PR TITLE
ICU-21838 Migrate Azure pipelines win2016 images to win2019. Update Mac OSX to 10.15

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -384,13 +384,13 @@ jobs:
         filename: icu4c/source/allinone/icucheck.bat
         arguments: 'x64 Release'
 #-------------------------------------------------------------------------
-# VS 2017 Builds
+# VS2019 using the VS2017 toolset builds
 #-------------------------------------------------------------------------
 - job: ICU4C_MSVC_x64_Release_VS2017
   displayName: 'C: MSVC 64-bit Release (VS 2017)'
   timeoutInMinutes: 30
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
     demands: 
       - msbuild
       - visualstudio
@@ -405,6 +405,7 @@ jobs:
         solution: icu4c/source/allinone/allinone.sln
         platform: x64
         configuration: Release
+        msbuildArgs: /p:DefaultPlatformToolset=v141
     - task: BatchScript@1
       displayName: 'Run Tests (icucheck.bat)'
       inputs:
@@ -415,7 +416,7 @@ jobs:
   displayName: 'C: MSVC 32-bit Debug (VS 2017)'
   timeoutInMinutes: 60
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
     demands: 
       - msbuild
       - visualstudio
@@ -430,6 +431,7 @@ jobs:
         solution: icu4c/source/allinone/allinone.sln
         platform: Win32
         configuration: Debug
+        msbuildArgs: /p:DefaultPlatformToolset=v141
     - task: BatchScript@1
       displayName: 'Run Tests (icucheck.bat)'
       inputs:
@@ -468,7 +470,7 @@ jobs:
   displayName: 'C: MSYS2 GCC x86_64 Release'
   timeoutInMinutes: 45
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
     demands:
       - Cmd
   steps:
@@ -500,10 +502,10 @@ jobs:
       displayName: 'run icuinfo'
 #-------------------------------------------------------------------------
 - job: ICU4C_Clang_MacOSX_WarningsAsErrors
-  displayName: 'C: macOSX Clang WarningsAsErrors (Mojave 10.14)'
+  displayName: 'C: macOSX Clang WarningsAsErrors (Catalina 10.15)'
   timeoutInMinutes: 30
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   steps:
     - checkout: self
       lfs: true


### PR DESCRIPTION
We need to migrate the Azure CI builds off the `vs2017-win2016` and `macOS-10.14` images, as they are being removed due to support ending soon. (Dec. 10th 2021 for macOS)

From: https://github.com/actions/virtual-environments/issues/4312

> *Breaking changes*
> Windows 2016 hosted runners will be removed from GitHub actions and Azure DevOps.
> 
> *The motivation for the changes*
> Windows Server 2016 Active support ends on 11 Jan 2022 and Windows Server 2022 VM image is going out of beta later this year.
> As part of our ongoing efforts to keep GitHub and Azure Devops hosted runners updated and secure, the Windows 2016 virtual environment will be removed from GitHub Actions and Azure DevOps.

From: https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/

> The macOS-10.14 environment is deprecated and will be removed on December 10, 2021.

We have 3 build lines using the `vs2017-win2016` image in the CI builds.

- C: MSVC 64-bit Release (VS 2017)
- C: MSVC 32-bit Debug (VS 2017)
- C: MSYS2 GCC x86_64 Release

For the first two, we can move to a newer image but set the `p:DefaultPlatformToolset` to still compile with VS2017 build tools, so we aren't losing any coverage for VS2017.

For the 3rd one, we can move it over to a newer image without issue.

For the MacOSX build, we can update to `macOS-10.15`.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21838
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
