### PR TITLE
ICU-21763 UVector cleanup, remove old funcs.

### DIFF
--- a/icu4c/source/common/uvector.cpp
+++ b/icu4c/source/common/uvector.cpp
@@ -99,14 +99,6 @@ bool UVector::operator==(const UVector& other) const {
     return true;
 }
 
-// TODO: delete this function once all call sites have been migrated to the
-//       new addElement().
-void UVector::addElementX(void* obj, UErrorCode &status) {
-    if (ensureCapacityX(count + 1, status)) {
-        elements[count++].pointer = obj;
-    }
-}
-
 void UVector::addElement(void* obj, UErrorCode &status) {
     U_ASSERT(deleter == nullptr);
     if (ensureCapacity(count + 1, status)) {
@@ -331,38 +323,6 @@ int32_t UVector::indexOf(UElement key, int32_t startIndex, int8_t hint) const {
     return -1;
 }
 
-UBool UVector::ensureCapacityX(int32_t minimumCapacity, UErrorCode &status) {
-    if (minimumCapacity < 0) {
-        status = U_ILLEGAL_ARGUMENT_ERROR;
-        return FALSE;
-	}
-    if (capacity < minimumCapacity) {
-        if (capacity > (INT32_MAX - 1) / 2) {        	// integer overflow check
-        	status = U_ILLEGAL_ARGUMENT_ERROR;
-        	return FALSE;
-        }
-        int32_t newCap = capacity * 2;
-        if (newCap < minimumCapacity) {
-            newCap = minimumCapacity;
-        }
-        if (newCap > (int32_t)(INT32_MAX / sizeof(UElement))) {	// integer overflow check
-        	// We keep the original memory contents on bad minimumCapacity.
-        	status = U_ILLEGAL_ARGUMENT_ERROR;
-        	return FALSE;
-        }
-        UElement* newElems = (UElement *)uprv_realloc(elements, sizeof(UElement)*newCap);
-        if (newElems == nullptr) {
-            // We keep the original contents on the memory failure on realloc or bad minimumCapacity.
-            status = U_MEMORY_ALLOCATION_ERROR;
-            return FALSE;
-        }
-        elements = newElems;
-        capacity = newCap;
-    }
-    return TRUE;
-}
-
-
 UBool UVector::ensureCapacity(int32_t minimumCapacity, UErrorCode &status) {
     if (U_FAILURE(status)) {
         return false;
@@ -370,7 +330,7 @@ UBool UVector::ensureCapacity(int32_t minimumCapacity, UErrorCode &status) {
     if (minimumCapacity < 0) {
         status = U_ILLEGAL_ARGUMENT_ERROR;
         return false;
-	}
+    }
     if (capacity < minimumCapacity) {
         if (capacity > (INT32_MAX - 1) / 2) {        	// integer overflow check
             status = U_ILLEGAL_ARGUMENT_ERROR;
@@ -396,6 +356,7 @@ UBool UVector::ensureCapacity(int32_t minimumCapacity, UErrorCode &status) {
     }
     return true;
 }
+
 /**
  * Change the size of this vector as follows: If newSize is smaller,
  * then truncate the array, possibly deleting held elements for i >=

--- a/icu4c/source/common/uvector.h
+++ b/icu4c/source/common/uvector.h
@@ -123,12 +123,6 @@ public:
     // java.util.Vector API
     //------------------------------------------------------------
 
-    /*
-     * Old version of addElement, with non-standard error handling.
-     * Will be removed once all uses have been switched to the new addElement().
-     */
-    void addElementX(void* obj, UErrorCode &status);
-
     /**
      * Add an element at the end of the vector.
      * For use only with vectors that do not adopt their elements, which is to say,
@@ -196,12 +190,6 @@ public:
     inline int32_t size(void) const {return count;}
 
     inline UBool isEmpty(void) const {return count == 0;}
-
-    /*
-     * Old version of ensureCapacity, with non-standard error handling.
-     * Will be removed once all uses have been switched to the new ensureCapacity().
-     */
-    UBool ensureCapacityX(int32_t minimumCapacity, UErrorCode &status);
 
     UBool ensureCapacity(int32_t minimumCapacity, UErrorCode &status);
 


### PR DESCRIPTION
Remove the functions UVector::addElementX() and UVector::ensureCapacityX() that
were temporarily added to aid in the cleaning up of UVector's out-of-memory
error handling.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21763
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
