### PR TITLE
ICU-21353 Implement DateTimePatternGenerator use of correct datetime pattern; includes new API

### DIFF
--- a/icu4c/source/i18n/udatpg.cpp
+++ b/icu4c/source/i18n/udatpg.cpp
@@ -210,12 +210,47 @@ udatpg_setDateTimeFormat(const UDateTimePatternGenerator *dtpg,
 U_CAPI const UChar * U_EXPORT2
 udatpg_getDateTimeFormat(const UDateTimePatternGenerator *dtpg,
                          int32_t *pLength) {
-    const UnicodeString &result=((const DateTimePatternGenerator *)dtpg)->getDateTimeFormat();
-    if(pLength!=NULL) {
+    UErrorCode status = U_ZERO_ERROR;
+    return udatpg_getDateTimeFormatForStyle(dtpg, UDAT_MEDIUM, pLength, &status);
+}
+
+U_CAPI void U_EXPORT2
+udatpg_setDateTimeFormatForStyle(UDateTimePatternGenerator *udtpg,
+                        UDateFormatStyle style,
+                        const UChar *dateTimeFormat, int32_t length,
+                        UErrorCode *pErrorCode) {
+    if (U_FAILURE(*pErrorCode)) {
+        return;
+    } else if (dateTimeFormat==nullptr) {
+        *pErrorCode = U_ILLEGAL_ARGUMENT_ERROR;
+        return;
+    }
+    DateTimePatternGenerator *dtpg = reinterpret_cast<DateTimePatternGenerator *>(udtpg);
+    UnicodeString dtFormatString((UBool)(length<0), dateTimeFormat, length);
+    dtpg->setDateTimeFormat(style, dtFormatString, *pErrorCode);
+}
+
+U_CAPI const UChar* U_EXPORT2
+udatpg_getDateTimeFormatForStyle(const UDateTimePatternGenerator *udtpg,
+                        UDateFormatStyle style, int32_t *pLength,
+                        UErrorCode *pErrorCode) {
+    static const UChar emptyString[] = { (UChar)0 };
+    if (U_FAILURE(*pErrorCode)) {
+        if (pLength !=nullptr) {
+            *pLength = 0;
+        }
+        return emptyString;
+    }
+    const DateTimePatternGenerator *dtpg = reinterpret_cast<const DateTimePatternGenerator *>(udtpg);
+    const UnicodeString &result = dtpg->getDateTimeFormat(style, *pErrorCode);
+    if (pLength != nullptr) {
         *pLength=result.length();
     }
+    // Note: The UnicodeString for the dateTimeFormat string in the DateTimePatternGenerator
+    // was NUL-terminated what it was set, to avoid doing it here which could re-allocate
+    // the buffe and affect and cont references to the string or its buffer.
     return result.getBuffer();
-}
+ }
 
 U_CAPI void U_EXPORT2
 udatpg_setDecimal(UDateTimePatternGenerator *dtpg,

--- a/icu4c/source/i18n/unicode/dtptngen.h
+++ b/icu4c/source/i18n/unicode/dtptngen.h
@@ -311,6 +311,11 @@ public:
      * for those two skeletons, so the result is put together with this pattern,
      * resulting in "d-MMM h:mm".
      *
+     * There are four DateTimeFormats in a DateTimePatternGenerator object,
+     * corresponding to date styles UDAT_FULL..UDAT_SHORT. This method sets
+     * all of them to the specified pattern. To set them individually, see
+     * setDateTimeFormat(UDateFormatStyle style, ...).
+     *
      * @param dateTimeFormat
      *            message format pattern, here {1} will be replaced by the date
      *            pattern and {0} will be replaced by the time pattern.
@@ -320,10 +325,65 @@ public:
 
     /**
      * Getter corresponding to setDateTimeFormat.
+     *
+     * There are four DateTimeFormats in a DateTimePatternGenerator object,
+     * corresponding to date styles UDAT_FULL..UDAT_SHORT. This method gets
+     * the style for UDAT_MEDIUM (the default). To get them individually, see
+     * getDateTimeFormat(UDateFormatStyle style).
+     *
      * @return DateTimeFormat.
      * @stable ICU 3.8
      */
     const UnicodeString& getDateTimeFormat() const;
+
+#if !UCONFIG_NO_FORMATTING
+#ifndef U_HIDE_DRAFT_API
+    /**
+     * dateTimeFormats are message patterns used to compose combinations of date
+     * and time patterns. There are four length styles, corresponding to the
+     * inferred style of the date pattern; these are UDateFormatStyle values:
+     *  - UDAT_FULL (for date pattern with weekday and long month), else
+     *  - UDAT_LONG (for a date pattern with long month), else
+     *  - UDAT_MEDIUM (for a date pattern with abbreviated month), else
+     *  - UDAT_SHORT (for any other date pattern).
+     * For details on dateTimeFormats, see
+     * https://www.unicode.org/reports/tr35/tr35-dates.html#dateTimeFormats.
+     * The default pattern in the root locale for all styles is "{1} {0}".
+     *
+     * @param style
+     *              one of DateFormat.FULL..DateFormat.SHORT. Error if out of range.
+     * @param dateTimeFormat
+     *              the new dateTimeFormat to set for the the specified style
+     * @param status
+     *              in/out parameter; if no failure status is already set,
+     *              it will be set according to result of the function (e.g.
+     *              U_ILLEGAL_ARGUMENT_ERROR for style out of range).
+     * @draft ICU 71
+     */
+    void setDateTimeFormat(UDateFormatStyle style, const UnicodeString& dateTimeFormat,
+                            UErrorCode& status);
+
+    /**
+     * Getter corresponding to setDateTimeFormat.
+     *
+     * @param style
+     *              one of UDAT_FULL..UDAT_SHORT. Error if out of range.
+     * @param status
+     *              in/out parameter; if no failure status is already set,
+     *              it will be set according to result of the function (e.g.
+     *              U_ILLEGAL_ARGUMENT_ERROR for style out of range).
+     * @return
+     *              the current dateTimeFormat for the the specified style, or
+     *              empty string in case of error. The UnicodeString reference,
+     *              or the contents of the string, may no longer be valid if
+     *              setDateTimeFormat is called, or the DateTimePatternGenerator
+     *              object is deleted.
+     * @draft ICU 71
+     */
+    const UnicodeString& getDateTimeFormat(UDateFormatStyle style,
+                            UErrorCode& status) const;
+#endif /* U_HIDE_DRAFT_API */
+#endif /* #if !UCONFIG_NO_FORMATTING */
 
     /**
      * Return the best pattern matching the input skeleton. It is guaranteed to
@@ -556,7 +616,7 @@ private:
     UnicodeString appendItemFormats[UDATPG_FIELD_COUNT];
     // TODO(ticket:13619): [3] -> UDATPG_WIDTH_COUNT
     UnicodeString fieldDisplayNames[UDATPG_FIELD_COUNT][3];
-    UnicodeString dateTimeFormat;
+    UnicodeString dateTimeFormat[4];
     UnicodeString decimal;
     DateTimeMatcher *skipMatcher;
     Hashtable *fAvailableFormatKeyHash;

--- a/icu4c/source/i18n/unicode/udatpg.h
+++ b/icu4c/source/i18n/unicode/udatpg.h
@@ -492,6 +492,11 @@ udatpg_getFieldDisplayName(const UDateTimePatternGenerator *dtpg,
  * for those two skeletons, so the result is put together with this pattern,
  * resulting in "d-MMM h:mm".
  *
+ * There are four DateTimeFormats in a UDateTimePatternGenerator object,
+ * corresponding to date styles UDAT_FULL..UDAT_SHORT. This method sets
+ * all of them to the specified pattern. To set them individually, see
+ * udatpg_setDateTimeFormatForStyle.
+ *
  * @param dtpg a pointer to UDateTimePatternGenerator.
  * @param dtFormat
  *            message format pattern, here {1} will be replaced by the date
@@ -505,6 +510,12 @@ udatpg_setDateTimeFormat(const UDateTimePatternGenerator *dtpg,
 
 /**
  * Getter corresponding to setDateTimeFormat.
+ *
+ * There are four DateTimeFormats in a UDateTimePatternGenerator object,
+ * corresponding to date styles UDAT_FULL..UDAT_SHORT. This method gets
+ * the style for UDAT_MEDIUM (the default). To get them individually, see
+ * udatpg_getDateTimeFormatForStyle.
+ *
  * @param dtpg   a pointer to UDateTimePatternGenerator.
  * @param pLength A pointer that will receive the length of the format
  * @return dateTimeFormat.
@@ -513,6 +524,70 @@ udatpg_setDateTimeFormat(const UDateTimePatternGenerator *dtpg,
 U_CAPI const UChar * U_EXPORT2
 udatpg_getDateTimeFormat(const UDateTimePatternGenerator *dtpg,
                          int32_t *pLength);
+
+#if !UCONFIG_NO_FORMATTING
+#ifndef U_HIDE_DRAFT_API
+/**
+ * dateTimeFormats are message patterns used to compose combinations of date
+ * and time patterns. There are four length styles, corresponding to the
+ * inferred style of the date pattern; these are UDateFormatStyle values:
+ *  - UDAT_FULL (for date pattern with weekday and long month), else
+ *  - UDAT_LONG (for a date pattern with long month), else
+ *  - UDAT_MEDIUM (for a date pattern with abbreviated month), else
+ *  - UDAT_SHORT (for any other date pattern).
+ * For details on dateTimeFormats, see
+ * https://www.unicode.org/reports/tr35/tr35-dates.html#dateTimeFormats.
+ * The default pattern in the root locale for all styles is "{1} {0}".
+ *
+ * @param udtpg
+ *              a pointer to the UDateTimePatternGenerator
+ * @param style
+ *              one of UDAT_FULL..UDAT_SHORT. Error if out of range.
+ * @param dateTimeFormat
+ *              the new dateTimeFormat to set for the the specified style
+ * @param length
+ *              the length of dateTimeFormat, or -1 if unknown and pattern
+ *              is null-terminated
+ * @param pErrorCode
+ *              a pointer to the UErrorCode (in/out parameter); if no failure
+ *              status is already set, it will be set according to result of the
+ *              function (e.g. U_ILLEGAL_ARGUMENT_ERROR for style out of range).
+ * @draft ICU 71
+ */
+U_CAPI void U_EXPORT2
+udatpg_setDateTimeFormatForStyle(UDateTimePatternGenerator *udtpg,
+                        UDateFormatStyle style,
+                        const UChar *dateTimeFormat, int32_t length,
+                        UErrorCode *pErrorCode);
+
+/**
+ * Getter corresponding to udatpg_setDateTimeFormatForStyle.
+ *
+ * @param udtpg
+ *              a pointer to the UDateTimePatternGenerator
+ * @param style
+ *              one of UDAT_FULL..UDAT_SHORT. Error if out of range.
+ * @param pLength
+ *              a pointer that will receive the length of the format. May be NULL
+ *              if length is not desired.
+ * @param pErrorCode
+ *              a pointer to the UErrorCode (in/out parameter); if no failure
+ *              status is already set, it will be set according to result of the
+ *              function (e.g. U_ILLEGAL_ARGUMENT_ERROR for style out of range).
+ * @return
+ *              pointer to the current dateTimeFormat (0 terminated) for the specified
+ *              style, or empty string in case of error. The pointer and its contents
+ *              may no longer be valid if udatpg_setDateTimeFormat is called, or
+ *              udatpg_setDateTimeFormatForStyle for the same style is called, or the
+ *              UDateTimePatternGenerator object is closed.
+ * @draft ICU 71
+ */
+U_CAPI const UChar* U_EXPORT2
+udatpg_getDateTimeFormatForStyle(const UDateTimePatternGenerator *udtpg,
+                        UDateFormatStyle style, int32_t *pLength,
+                        UErrorCode *pErrorCode);
+#endif /* U_HIDE_DRAFT_API */
+#endif /* #if !UCONFIG_NO_FORMATTING */
 
 /**
  * The decimal value is used in formatting fractions of seconds. If the

--- a/icu4c/source/test/cintltst/cdateintervalformattest.c
+++ b/icu4c/source/test/cintltst/cdateintervalformattest.c
@@ -368,23 +368,23 @@ static void TestFormatToResult() {
 
     {
         const char* message = "Field position test 1";
-        const UChar* expectedString = u"27. September 2010, 15:00 – 2. März 2011, 18:30";
+        const UChar* expectedString = u"27. September 2010 um 15:00 – 2. März 2011 um 18:30";
         udtitvfmt_formatToResult(fmt, Date201009270800, Date201103021030, fdi, &ec);
         assertSuccess("Formatting", &ec);
         static const UFieldPositionWithCategory expectedFieldPositions[] = {
             // category, field, begin index, end index
-            {UFIELD_CATEGORY_DATE_INTERVAL_SPAN, 0, 0, 25},
+            {UFIELD_CATEGORY_DATE_INTERVAL_SPAN, 0, 0, 27},
             {UFIELD_CATEGORY_DATE, UDAT_DATE_FIELD, 0, 2},
             {UFIELD_CATEGORY_DATE, UDAT_MONTH_FIELD, 4, 13},
             {UFIELD_CATEGORY_DATE, UDAT_YEAR_FIELD, 14, 18},
-            {UFIELD_CATEGORY_DATE, UDAT_HOUR_OF_DAY0_FIELD, 20, 22},
-            {UFIELD_CATEGORY_DATE, UDAT_MINUTE_FIELD, 23, 25},
-            {UFIELD_CATEGORY_DATE_INTERVAL_SPAN, 1, 28, 47},
-            {UFIELD_CATEGORY_DATE, UDAT_DATE_FIELD, 28, 29},
-            {UFIELD_CATEGORY_DATE, UDAT_MONTH_FIELD, 31, 35},
-            {UFIELD_CATEGORY_DATE, UDAT_YEAR_FIELD, 36, 40},
-            {UFIELD_CATEGORY_DATE, UDAT_HOUR_OF_DAY0_FIELD, 42, 44},
-            {UFIELD_CATEGORY_DATE, UDAT_MINUTE_FIELD, 45, 47}};
+            {UFIELD_CATEGORY_DATE, UDAT_HOUR_OF_DAY0_FIELD, 22, 24},
+            {UFIELD_CATEGORY_DATE, UDAT_MINUTE_FIELD, 25, 27},
+            {UFIELD_CATEGORY_DATE_INTERVAL_SPAN, 1, 30, 51},
+            {UFIELD_CATEGORY_DATE, UDAT_DATE_FIELD, 30, 31},
+            {UFIELD_CATEGORY_DATE, UDAT_MONTH_FIELD, 33, 37},
+            {UFIELD_CATEGORY_DATE, UDAT_YEAR_FIELD, 38, 42},
+            {UFIELD_CATEGORY_DATE, UDAT_HOUR_OF_DAY0_FIELD, 46, 48},
+            {UFIELD_CATEGORY_DATE, UDAT_MINUTE_FIELD, 49, 51}};
         checkMixedFormattedValue(
             message,
             udtitvfmt_resultAsValue(fdi, &ec),
@@ -438,23 +438,23 @@ static void TestFormatCalendarToResult() {
 
     {
         const char* message = "Field position test 1";
-        const UChar* expectedString = u"27. September 2010, 15:00 – 2. März 2011, 18:30";
+        const UChar* expectedString = u"27. September 2010 um 15:00 – 2. März 2011 um 18:30";
         udtitvfmt_formatCalendarToResult(fmt, ucal1, ucal2, fdi, &ec);
         assertSuccess("Formatting", &ec);
         static const UFieldPositionWithCategory expectedFieldPositions[] = {
             // category, field, begin index, end index
-            {UFIELD_CATEGORY_DATE_INTERVAL_SPAN, 0, 0, 25},
+            {UFIELD_CATEGORY_DATE_INTERVAL_SPAN, 0, 0, 27},
             {UFIELD_CATEGORY_DATE, UDAT_DATE_FIELD, 0, 2},
             {UFIELD_CATEGORY_DATE, UDAT_MONTH_FIELD, 4, 13},
             {UFIELD_CATEGORY_DATE, UDAT_YEAR_FIELD, 14, 18},
-            {UFIELD_CATEGORY_DATE, UDAT_HOUR_OF_DAY0_FIELD, 20, 22},
-            {UFIELD_CATEGORY_DATE, UDAT_MINUTE_FIELD, 23, 25},
-            {UFIELD_CATEGORY_DATE_INTERVAL_SPAN, 1, 28, 47},
-            {UFIELD_CATEGORY_DATE, UDAT_DATE_FIELD, 28, 29},
-            {UFIELD_CATEGORY_DATE, UDAT_MONTH_FIELD, 31, 35},
-            {UFIELD_CATEGORY_DATE, UDAT_YEAR_FIELD, 36, 40},
-            {UFIELD_CATEGORY_DATE, UDAT_HOUR_OF_DAY0_FIELD, 42, 44},
-            {UFIELD_CATEGORY_DATE, UDAT_MINUTE_FIELD, 45, 47}};
+            {UFIELD_CATEGORY_DATE, UDAT_HOUR_OF_DAY0_FIELD, 22, 24},
+            {UFIELD_CATEGORY_DATE, UDAT_MINUTE_FIELD, 25, 27},
+            {UFIELD_CATEGORY_DATE_INTERVAL_SPAN, 1, 30, 51},
+            {UFIELD_CATEGORY_DATE, UDAT_DATE_FIELD, 30, 31},
+            {UFIELD_CATEGORY_DATE, UDAT_MONTH_FIELD, 33, 37},
+            {UFIELD_CATEGORY_DATE, UDAT_YEAR_FIELD, 38, 42},
+            {UFIELD_CATEGORY_DATE, UDAT_HOUR_OF_DAY0_FIELD, 46, 48},
+            {UFIELD_CATEGORY_DATE, UDAT_MINUTE_FIELD, 49, 51}};
         checkMixedFormattedValue(
             message,
             udtitvfmt_resultAsValue(fdi, &ec),
@@ -493,23 +493,23 @@ static void TestFormatCalendarToResult() {
         ucal_setMillis(ucal5, Date158210160000, &ec);
         //                                        1         2         3         4
         //                              012345678901234567890123456789012345678901234567890
-        const UChar* expectedString = u"4. Oktober 1582, 00:00 – 16. Oktober 1582, 00:00";
+        const UChar* expectedString = u"4. Oktober 1582 um 00:00 – 16. Oktober 1582 um 00:00";
         udtitvfmt_formatCalendarToResult(fmt, ucal4, ucal5, fdi, &ec);
         assertSuccess("Formatting", &ec);
         static const UFieldPositionWithCategory expectedFieldPositions[] = {
             // category, field, begin index, end index
-            {UFIELD_CATEGORY_DATE_INTERVAL_SPAN, 0, 0, 22},
+            {UFIELD_CATEGORY_DATE_INTERVAL_SPAN, 0, 0, 24},
             {UFIELD_CATEGORY_DATE, UDAT_DATE_FIELD, 0, 1},
             {UFIELD_CATEGORY_DATE, UDAT_MONTH_FIELD, 3, 10},
             {UFIELD_CATEGORY_DATE, UDAT_YEAR_FIELD, 11, 15},
-            {UFIELD_CATEGORY_DATE, UDAT_HOUR_OF_DAY0_FIELD, 17, 19},
-            {UFIELD_CATEGORY_DATE, UDAT_MINUTE_FIELD, 20, 22},
-            {UFIELD_CATEGORY_DATE_INTERVAL_SPAN, 1, 25, 48},
-            {UFIELD_CATEGORY_DATE, UDAT_DATE_FIELD, 25, 27},
-            {UFIELD_CATEGORY_DATE, UDAT_MONTH_FIELD, 29, 36},
-            {UFIELD_CATEGORY_DATE, UDAT_YEAR_FIELD, 37, 41},
-            {UFIELD_CATEGORY_DATE, UDAT_HOUR_OF_DAY0_FIELD, 43, 45},
-            {UFIELD_CATEGORY_DATE, UDAT_MINUTE_FIELD, 46, 48}};
+            {UFIELD_CATEGORY_DATE, UDAT_HOUR_OF_DAY0_FIELD, 19, 21},
+            {UFIELD_CATEGORY_DATE, UDAT_MINUTE_FIELD, 22, 24},
+            {UFIELD_CATEGORY_DATE_INTERVAL_SPAN, 1, 27, 52},
+            {UFIELD_CATEGORY_DATE, UDAT_DATE_FIELD, 27, 29},
+            {UFIELD_CATEGORY_DATE, UDAT_MONTH_FIELD, 31, 38},
+            {UFIELD_CATEGORY_DATE, UDAT_YEAR_FIELD, 39, 43},
+            {UFIELD_CATEGORY_DATE, UDAT_HOUR_OF_DAY0_FIELD, 47, 49},
+            {UFIELD_CATEGORY_DATE, UDAT_MINUTE_FIELD, 50, 52}};
         checkMixedFormattedValue(
             message,
             udtitvfmt_resultAsValue(fdi, &ec),
@@ -527,23 +527,23 @@ static void TestFormatCalendarToResult() {
         const char* message = "Field position test 4";
         //                                        1         2         3         4
         //                              012345678901234567890123456789012345678901234567890
-        const UChar* expectedString = u"14. Oktober 1582, 00:00 – 16. Oktober 1582, 00:00";
+        const UChar* expectedString = u"14. Oktober 1582 um 00:00 – 16. Oktober 1582 um 00:00";
         udtitvfmt_formatCalendarToResult(fmt, ucal4, ucal5, fdi, &ec);
         assertSuccess("Formatting", &ec);
         static const UFieldPositionWithCategory expectedFieldPositions[] = {
             // category, field, begin index, end index
-            {UFIELD_CATEGORY_DATE_INTERVAL_SPAN, 0, 0, 23},
+            {UFIELD_CATEGORY_DATE_INTERVAL_SPAN, 0, 0, 25},
             {UFIELD_CATEGORY_DATE, UDAT_DATE_FIELD, 0, 2},
             {UFIELD_CATEGORY_DATE, UDAT_MONTH_FIELD, 4, 11},
             {UFIELD_CATEGORY_DATE, UDAT_YEAR_FIELD, 12, 16},
-            {UFIELD_CATEGORY_DATE, UDAT_HOUR_OF_DAY0_FIELD, 18, 20},
-            {UFIELD_CATEGORY_DATE, UDAT_MINUTE_FIELD, 21, 23},
-            {UFIELD_CATEGORY_DATE_INTERVAL_SPAN, 1, 26, 49},
-            {UFIELD_CATEGORY_DATE, UDAT_DATE_FIELD, 26, 28},
-            {UFIELD_CATEGORY_DATE, UDAT_MONTH_FIELD, 30, 37},
-            {UFIELD_CATEGORY_DATE, UDAT_YEAR_FIELD, 38, 42},
-            {UFIELD_CATEGORY_DATE, UDAT_HOUR_OF_DAY0_FIELD, 44, 46},
-            {UFIELD_CATEGORY_DATE, UDAT_MINUTE_FIELD, 47, 49}};
+            {UFIELD_CATEGORY_DATE, UDAT_HOUR_OF_DAY0_FIELD, 20, 22},
+            {UFIELD_CATEGORY_DATE, UDAT_MINUTE_FIELD, 23, 25},
+            {UFIELD_CATEGORY_DATE_INTERVAL_SPAN, 1, 28, 53},
+            {UFIELD_CATEGORY_DATE, UDAT_DATE_FIELD, 28, 30},
+            {UFIELD_CATEGORY_DATE, UDAT_MONTH_FIELD, 32, 39},
+            {UFIELD_CATEGORY_DATE, UDAT_YEAR_FIELD, 40, 44},
+            {UFIELD_CATEGORY_DATE, UDAT_HOUR_OF_DAY0_FIELD, 48, 50},
+            {UFIELD_CATEGORY_DATE, UDAT_MINUTE_FIELD, 51, 53}};
         checkMixedFormattedValue(
             message,
             udtitvfmt_resultAsValue(fdi, &ec),

--- a/icu4c/source/test/intltest/dtfmttst.cpp
+++ b/icu4c/source/test/intltest/dtfmttst.cpp
@@ -190,7 +190,7 @@ void DateFormatTest::TestPatterns() {
         {UDAT_ABBR_UTC_TZ, "ZZZZ", "en", "ZZZZ"},
 
         {UDAT_YEAR_NUM_MONTH_DAY UDAT_ABBR_UTC_TZ, "yMdZZZZ", "en", "M/d/y, ZZZZ"},
-        {UDAT_MONTH_DAY UDAT_LOCATION_TZ, "MMMMdVVVV", "en", "MMMM d, VVVV"}
+        {UDAT_MONTH_DAY UDAT_LOCATION_TZ, "MMMMdVVVV", "en", "MMMM d 'at' VVVV"}
     };
 
     IcuTestErrorCode errorCode(*this, "TestPatterns()");

--- a/icu4c/source/test/intltest/dtptngts.h
+++ b/icu4c/source/test/intltest/dtptngts.h
@@ -13,6 +13,8 @@
 
 #if !UCONFIG_NO_FORMATTING
 
+#include "unicode/dtptngen.h"
+#include "unicode/ustring.h"
 #include "intltest.h"
 
 /**
@@ -38,6 +40,14 @@ private:
     void testGetDefaultHourCycle_OnEmptyInstance();
     void test_jConsistencyOddLocales();
     void testBestPattern();
+    void testDateTimePatterns();
+
+    enum { kNumDateTimePatterns = 4 };
+    typedef struct {
+        const char* localeID;
+        const UnicodeString expectPat[kNumDateTimePatterns];
+    } DTPLocaleAndResults;
+    void doDTPatternTest(DateTimePatternGenerator* dtpg, UnicodeString* skeletons, DTPLocaleAndResults* localeAndResultsPtr);
 };
 
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/test/intltest/tmsgfmt.cpp
+++ b/icu4c/source/test/intltest/tmsgfmt.cpp
@@ -2051,7 +2051,7 @@ void TestMessageFormat::TestMessageFormatDateSkeleton() {
     UDate date = LocaleTest::date(2021-1900, UCAL_NOVEMBER, 23, 16, 42, 55);
 
     doTheRealDateTimeSkeletonTesting(date, u"{0,date,::MMMMd}", "en", u"November 23", status);
-    doTheRealDateTimeSkeletonTesting(date, u"{0,date,::yMMMMdjm}", "en", u"November 23, 2021, 4:42 PM", status);
+    doTheRealDateTimeSkeletonTesting(date, u"{0,date,::yMMMMdjm}", "en", u"November 23, 2021 at 4:42 PM", status);
     doTheRealDateTimeSkeletonTesting(date, u"{0,date,   ::   yMMMMd   }", "en", u"November 23, 2021", status);
     doTheRealDateTimeSkeletonTesting(date, u"{0,date,::yMMMMd}", "fr", u"23 novembre 2021", status);
     doTheRealDateTimeSkeletonTesting(date, u"Expiration: {0,date,::yMMM}!", "en", u"Expiration: Nov 2021!", status);
@@ -2065,7 +2065,7 @@ void TestMessageFormat::TestMessageFormatTimeSkeleton() {
     UDate date = LocaleTest::date(2021-1900, UCAL_NOVEMBER, 23, 16, 42, 55);
 
     doTheRealDateTimeSkeletonTesting(date, u"{0,time,::MMMMd}", "en", u"November 23", status);
-    doTheRealDateTimeSkeletonTesting(date, u"{0,time,::yMMMMdjm}", "en", u"November 23, 2021, 4:42 PM", status);
+    doTheRealDateTimeSkeletonTesting(date, u"{0,time,::yMMMMdjm}", "en", u"November 23, 2021 at 4:42 PM", status);
     doTheRealDateTimeSkeletonTesting(date, u"{0,time,   ::   yMMMMd   }", "en", u"November 23, 2021", status);
     doTheRealDateTimeSkeletonTesting(date, u"{0,time,::yMMMMd}", "fr", u"23 novembre 2021", status);
     doTheRealDateTimeSkeletonTesting(date, u"Expiration: {0,time,::yMMM}!", "en", u"Expiration: Nov 2021!", status);

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/DateFormatTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/DateFormatTest.java
@@ -132,7 +132,7 @@ public class DateFormatTest extends TestFmwk {
                 {}, // marker for starting combinations
 
                 {DateFormat.YEAR_NUM_MONTH_DAY + DateFormat.ABBR_UTC_TZ, "yMdZZZZ", "en", "M/d/y, ZZZZ"},
-                {DateFormat.MONTH_DAY + DateFormat.LOCATION_TZ, "MMMMdVVVV", "en", "MMMM d, VVVV"},
+                {DateFormat.MONTH_DAY + DateFormat.LOCATION_TZ, "MMMMdVVVV", "en", "MMMM d 'at' VVVV"},
         };
         Date testDate = new Date(2012-1900, 6, 1, 14, 58, 59); // just for verbose log
 

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/TestMessageFormat.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/TestMessageFormat.java
@@ -2140,7 +2140,7 @@ public class TestMessageFormat extends TestFmwk {
         Date date = new GregorianCalendar(2021, Calendar.NOVEMBER, 23, 16, 42, 55).getTime();
 
         doTheRealDateTimeSkeletonTesting(date, "{0,date,::MMMMd}", ULocale.ENGLISH, "November 23");
-        doTheRealDateTimeSkeletonTesting(date, "{0,date,::yMMMMdjm}", ULocale.ENGLISH, "November 23, 2021, 4:42 PM");
+        doTheRealDateTimeSkeletonTesting(date, "{0,date,::yMMMMdjm}", ULocale.ENGLISH, "November 23, 2021 at 4:42 PM");
         doTheRealDateTimeSkeletonTesting(date, "{0,date,   ::   yMMMMd   }", ULocale.ENGLISH, "November 23, 2021");
         doTheRealDateTimeSkeletonTesting(date, "{0,date,::yMMMMd}", ULocale.FRENCH, "23 novembre 2021");
         doTheRealDateTimeSkeletonTesting(date, "Expiration: {0,date,::yMMM}!", ULocale.ENGLISH, "Expiration: Nov 2021!");
@@ -2152,7 +2152,7 @@ public class TestMessageFormat extends TestFmwk {
         Date date = new GregorianCalendar(2021, Calendar.NOVEMBER, 23, 16, 42, 55).getTime();
 
         doTheRealDateTimeSkeletonTesting(date, "{0,time,::MMMMd}", ULocale.ENGLISH, "November 23");
-        doTheRealDateTimeSkeletonTesting(date, "{0,time,::yMMMMdjm}", ULocale.ENGLISH, "November 23, 2021, 4:42 PM");
+        doTheRealDateTimeSkeletonTesting(date, "{0,time,::yMMMMdjm}", ULocale.ENGLISH, "November 23, 2021 at 4:42 PM");
         doTheRealDateTimeSkeletonTesting(date, "{0,time,   ::   yMMMMd   }", ULocale.ENGLISH, "November 23, 2021");
         doTheRealDateTimeSkeletonTesting(date, "{0,time,::yMMMMd}", ULocale.FRENCH, "23 novembre 2021");
         doTheRealDateTimeSkeletonTesting(date, "Expiration: {0,time,::yMMM}!", ULocale.ENGLISH, "Expiration: Nov 2021!");


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21353
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable

Implement support for DateTimePatternGenerator choosing the correct date-time combining pattern when formatting a combination for date and time, per[ CLDR spec](https://www.unicode.org/reports/tr35/tr35-dates.html#Missing_Skeleton_Fields). Java, C++ and C all had API to get and set the single "default" pattern previously used for this purpose, so this adds new API to set and get each of the 4 patterns. These were approved in ICU TC on 2022-01-12 with amendments, and the current version of this PR has been updated to reflect the approved getter/setter API. Removing draft status.