### PR TITLE
ICU-21896 Use double base in pow()

### DIFF
--- a/icu4c/source/i18n/plurrule.cpp
+++ b/icu4c/source/i18n/plurrule.cpp
@@ -1618,7 +1618,7 @@ FixedDecimal::FixedDecimal(double n, int32_t v, int64_t f, int32_t e) {
     init(n, v, f, e);
     // check values. TODO make into unit test.
     //            
-    //            long visiblePower = (int) Math.pow(10, v);
+    //            long visiblePower = (int) Math.pow(10.0, v);
     //            if (decimalDigits > visiblePower) {
     //                throw new IllegalArgumentException();
     //            }
@@ -1871,7 +1871,7 @@ void FixedDecimal::adjustForMinFractionDigits(int32_t minFractionDigits) {
 
 double FixedDecimal::getPluralOperand(PluralOperand operand) const {
     switch(operand) {
-        case PLURAL_OPERAND_N: return (exponent == 0 ? source : source * pow(10, exponent));
+        case PLURAL_OPERAND_N: return (exponent == 0 ? source : source * pow(10.0, exponent));
         case PLURAL_OPERAND_I: return (double) longValue();
         case PLURAL_OPERAND_F: return static_cast<double>(decimalDigits);
         case PLURAL_OPERAND_T: return static_cast<double>(decimalDigitsWithoutTrailingZeros);
@@ -1922,14 +1922,14 @@ UnicodeString FixedDecimal::toString() const {
 }
 
 double FixedDecimal::doubleValue() const {
-    return (isNegative ? -source : source) * pow(10, exponent);
+    return (isNegative ? -source : source) * pow(10.0, exponent);
 }
 
 int64_t FixedDecimal::longValue() const {
     if (exponent == 0) {
         return intValue;
     } else {
-        return (long) (pow(10, exponent) * intValue);
+        return (long) (pow(10.0, exponent) * intValue);
     }
 }
 


### PR DESCRIPTION
gcc 5.5 on Solaris refuses to recognise pow(int, int32_t)

(I would reword the commit message, but I need some hints)

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21896
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
<!--
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
-->

Potentially related to #1875.