### PR TITLE
ICU-21900 MeasureUnit update; just marks mg-ofGlucose-perDeciliter as stable

### DIFF
--- a/icu4c/source/i18n/unicode/measunit.h
+++ b/icu4c/source/i18n/unicode/measunit.h
@@ -989,23 +989,21 @@ class U_I18N_API MeasureUnit: public UObject {
      */
     static MeasureUnit getKarat();
 
-#ifndef U_HIDE_DRAFT_API
     /**
      * Returns by pointer, unit of concentr: milligram-ofglucose-per-deciliter.
      * Caller owns returned value and must free it.
      * Also see {@link #getMilligramOfglucosePerDeciliter()}.
      * @param status ICU error code.
-     * @draft ICU 69
+     * @stable ICU 69
      */
     static MeasureUnit *createMilligramOfglucosePerDeciliter(UErrorCode &status);
 
     /**
      * Returns by value, unit of concentr: milligram-ofglucose-per-deciliter.
      * Also see {@link #createMilligramOfglucosePerDeciliter()}.
-     * @draft ICU 69
+     * @stable ICU 69
      */
     static MeasureUnit getMilligramOfglucosePerDeciliter();
-#endif /* U_HIDE_DRAFT_API */
 
     /**
      * Returns by pointer, unit of concentr: milligram-per-deciliter.

--- a/icu4c/source/test/intltest/measfmttest.cpp
+++ b/icu4c/source/test/intltest/measfmttest.cpp
@@ -2683,7 +2683,7 @@ void MeasureFormatTest::TestCompatible69() {
     assertSuccess("", status);
 }
 
-void MeasureFormatTest::TestCompatible70() {
+void MeasureFormatTest::TestCompatible70() { // TestCompatible71 would be identical
     UErrorCode status = U_ZERO_ERROR;
     LocalPointer<MeasureUnit> measureUnit;
     MeasureUnit measureUnitValue;
@@ -3063,6 +3063,9 @@ void MeasureFormatTest::TestCompatible70() {
     measureUnitValue = MeasureUnit::getTeaspoon();
     assertSuccess("", status);
 }
+
+// TestCompatible71 would be identical to TestCompatible70,
+// no need to add it
 
 void MeasureFormatTest::TestBasic() {
     UErrorCode status = U_ZERO_ERROR;

--- a/icu4j/main/classes/core/src/com/ibm/icu/util/MeasureUnit.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/util/MeasureUnit.java
@@ -1007,7 +1007,7 @@ public class MeasureUnit implements Serializable {
 
     /**
      * Constant for unit of concentr: milligram-ofglucose-per-deciliter
-     * @draft ICU 69
+     * @stable ICU 69
      */
     public static final MeasureUnit MILLIGRAM_OFGLUCOSE_PER_DECILITER = MeasureUnit.internalGetInstance("concentr", "milligram-ofglucose-per-deciliter");
 

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/MeasureUnitTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/MeasureUnitTest.java
@@ -85,7 +85,7 @@ public class MeasureUnitTest extends TestFmwk {
         }
     }
 
-    private static final String[] DRAFT_VERSIONS = {"68", "69"};
+    private static final String[] DRAFT_VERSIONS = {"70", "71"};
 
     private static final HashSet<String> DRAFT_VERSION_SET = new HashSet<>();
 
@@ -322,12 +322,12 @@ public class MeasureUnitTest extends TestFmwk {
         // various generateXXX calls go here, see
         // docs/processes/release/tasks/updating-measure-unit.md
         // use this test to run each of the ollowing in succession
-        //generateConstants("70"); // for MeasureUnit.java, update generated MeasureUnit constants
-        //generateBackwardCompatibilityTest("70"); // for MeasureUnitTest.java, create TestCompatible70
-        //generateCXXHConstants("70"); // for measunit.h, update generated createXXX methods
+        //generateConstants("71"); // for MeasureUnit.java, update generated MeasureUnit constants
+        //generateBackwardCompatibilityTest("71"); // for MeasureUnitTest.java, create TestCompatible70
+        //generateCXXHConstants("71"); // for measunit.h, update generated createXXX methods
         //generateCXXConstants(); // for measunit.cpp, update generated code
-        //generateCXXBackwardCompatibilityTest("70"); // for measfmttest.cpp, create TestCompatible70
-        //updateJAVAVersions("70"); // for MeasureUnitTest.java, JAVA_VERSIONS
+        //generateCXXBackwardCompatibilityTest("71"); // for measfmttest.cpp, create TestCompatible70
+        //updateJAVAVersions("71"); // for MeasureUnitTest.java, JAVA_VERSIONS
     }
 
     @Test
@@ -2084,7 +2084,7 @@ public class MeasureUnitTest extends TestFmwk {
     }
 
     @Test
-    public void TestCompatible70() {
+    public void TestCompatible70() { // TestCompatible71 would be identical
         MeasureUnit[] units = {
                 MeasureUnit.G_FORCE,
                 MeasureUnit.METER_PER_SECOND_SQUARED,
@@ -2276,6 +2276,9 @@ public class MeasureUnitTest extends TestFmwk {
         };
         assertEquals("",  187, units.length);
     }
+
+    // TestCompatible71 would be identical to TestCompatible70,
+    // no need to add it
 
     @Test
     public void TestExamplesInDocs() {


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21900
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

Ran the process in [Updating MeasureUnit with new CLDR data](https://unicode-org.github.io/icu/processes/release/tasks/updating-measure-unit.html#update-measureunitjava). Since there were no new measurement units in CLDR 41, this just updates the list of which ICU versions should be draft, which in turn results in the measurement unit functions associated with milligram-ofglucose-per-deciliter moving from @draft to @stable (this process for measurement units always precedes the normal ICU API promotion step).
