### PR TITLE
ICU-21843 Modifies performance tests and test framework in preparation of

### DIFF
--- a/icu4c/source/test/perf/Makefile.in
+++ b/icu4c/source/test/perf/Makefile.in
@@ -22,7 +22,7 @@ subdir = test/perf
 ## Files to remove for 'make clean'
 CLEANFILES = *~
 
-SUBDIRS = collationperf collperf collperf2 charperf dicttrieperf localecanperf normperf ubrkperf unisetperf usetperf ustrperf utfperf utrie2perf DateFmtPerf howExpensiveIs
+SUBDIRS = collationperf collperf collperf2 charperf dicttrieperf localecanperf normperf strsrchperf ubrkperf unisetperf usetperf ustrperf utfperf utrie2perf DateFmtPerf howExpensiveIs
 
 # Subdirs that support 'xperf'
 XSUBDIRS = DateFmtPerf
@@ -38,10 +38,7 @@ check check-recursive check-local xperf xperf-recursive
 
 ## List of standard targets
 everything: all-recursive all-local
-all:
-ifneq ($(RECURSIVE),YES)
-	@echo simply use \`make\' \(or \`make everything\'\) to do all
-endif
+all: everything
 
 install: install-recursive install-local
 clean: clean-recursive clean-local

--- a/icu4c/source/test/perf/charperf/charperf.cpp
+++ b/icu4c/source/test/perf/charperf/charperf.cpp
@@ -81,7 +81,6 @@ CharPerformanceTest::CharPerformanceTest(int32_t argc, const char *argv[],
     else {
         MAX_ = 0xffff;
     }
-    printf("MAX_ size will be 0x%x\n", MAX_);
     if (options[MIN_OPTION_].doesOccur) {
         MIN_ = atoi(options[MIN_OPTION_].value);
     }

--- a/icu4c/source/test/perf/ustrperf/Makefile.in
+++ b/icu4c/source/test/perf/ustrperf/Makefile.in
@@ -20,7 +20,7 @@ subdir = test/perf/ustrperf
 CLEANFILES = *~ $(DEPS)
 
 ## Target information
-TARGET = stringperf
+TARGET = ustrperf
 
 CPPFLAGS += -I$(top_srcdir)/common -I$(top_srcdir)/tools/toolutil -I$(top_srcdir)/tools/ctestfw
 LIBS = $(LIBCTESTFW) $(LIBICUI18N) $(LIBICUUC) $(LIBICUTOOLUTIL) $(DEFAULT_LIBS) $(LIB_M)

--- a/icu4c/source/test/perf/ustrperf/stringperf.h
+++ b/icu4c/source/test/perf/ustrperf/stringperf.h
@@ -444,7 +444,6 @@ inline void catenate(const UChar* src,int32_t srcLen, UnicodeString s0)
 
     utimer_getTime(&mystop);
     double mytime = utimer_getDeltaSeconds(&mystart,&mystop);
-    printf("\nmytime=%f \n", mytime);
 
     *catICU += uCatenate_STR;
 }
@@ -533,7 +532,6 @@ inline void StdLibCatenate(const wchar_t* src,int32_t srcLen, stlstring s0)
 
     utimer_getTime(&mystop);
     double mytime = utimer_getDeltaSeconds(&mystart,&mystop);
-    printf("\nmytime=%f \n", mytime);
 
 }
 

--- a/icu4c/source/tools/ctestfw/uperf.cpp
+++ b/icu4c/source/tools/ctestfw/uperf.cpp
@@ -390,7 +390,7 @@ UBool UPerfTest::runTestLoop( char* testname, char* par )
                         loops = failsafe;
                         failsafe *= 10;
                     } else {
-                        //System.out.println("# " + meth.getName() + " x " + loops + " = " + t);                            
+                        //System.out.println("# " + meth.getName() + " x " + loops + " = " + t);
                         loops = (int)((double)n / t * loops + 0.5);
                         if (loops == 0) {
                             fprintf(stderr,"Unable to converge on desired duration");
@@ -412,15 +412,13 @@ UBool UPerfTest::runTestLoop( char* testname, char* par )
             long events = -1;
 
             for(int32_t ps =0; ps < passes; ps++){
-                fprintf(stdout,"= %s begin " ,name);
                 if(verbose==TRUE){
+                    fprintf(stdout,"= %s begin " ,name);
                     if(iterations > 0) {
                         fprintf(stdout, "%i\n", (int)loops);
                     } else {
                         fprintf(stdout, "%i\n", (int)n);
                     }
-                } else {
-                    fprintf(stdout, "\n");
                 }
                 t = testFunction->time(loops, &status);
                 if(U_FAILURE(status)){
@@ -438,12 +436,6 @@ UBool UPerfTest::runTestLoop( char* testname, char* par )
                         fprintf(stdout, "= %s end: %f loops: %i operations: %li \n", name, t, (int)loops, ops);
                     }else{
                         fprintf(stdout, "= %s end: %f loops: %i operations: %li events: %li\n", name, t, (int)loops, ops, events);
-                    }
-                }else{
-                    if(events == -1){
-                        fprintf(stdout,"= %s end %f %i %li\n", name, t, (int)loops, ops);
-                    }else{
-                        fprintf(stdout,"= %s end %f %i %li %li\n", name, t, (int)loops, ops, events);
                     }
                 }
             }
@@ -464,6 +456,12 @@ UBool UPerfTest::runTestLoop( char* testname, char* par )
                     fprintf(stdout, "_= %s min: %.4g loops: %i min/op: %.4g ns min/event: %.4g ns\n",
                             name, min_t, (int)loops, (min_t*1E9)/(loops*ops), (min_t*1E9)/(loops*events));
                 }
+            }
+            else if(U_SUCCESS(status)) {
+                // Print results in ndjson format for GHA Benchmark to process.
+                fprintf(stdout,
+                        "{\"biggerIsBetter\":false,\"name\":\"%s\",\"unit\":\"ns/iter\",\"value\":%.4f}\n",
+                        name, (min_t*1E9)/(loops*ops));
             }
             delete testFunction;
         }


### PR DESCRIPTION
adding performance tests to ICU CI.
test/perf/Makefile.in:
    adds strsrchperf to list of subdirs.
    changes target 'all' to compile everything in the standard way.

test/perf/ustrperf/Makefile.in: changes target executable from stringperf to
  ustrperf (i.e. name of directory) to allow uniform handling with other
  perf tests in GHA CI rules.

tools/ctestfw/uperf.cpp: changes output to ndjson format for processing with
  GHA Benchmark. Keep the previous output, which gets processed by the Perl
  scripts, when executed in 'verbose' mode. Backward compatibility,
  in case someone still wants to use the Perl scripts for the time being.
  May get cleaned up later.

Also remove a few non-essential output lines that would interfere with
GHA Benchmark.


<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21843
- [ ] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
