### PR TITLE
ICU-21832 Remove unsafe double-checked lock in ICUNotifier

### DIFF
--- a/icu4c/source/common/servnotf.cpp
+++ b/icu4c/source/common/servnotf.cpp
@@ -106,13 +106,11 @@ ICUNotifier::removeListener(const EventListener *l, UErrorCode& status)
 void 
 ICUNotifier::notifyChanged(void) 
 {
+    Mutex lmx(&notifyLock);
     if (listeners != NULL) {
-        Mutex lmx(&notifyLock);
-        if (listeners != NULL) {
-            for (int i = 0, e = listeners->size(); i < e; ++i) {
-                EventListener* el = (EventListener*)listeners->elementAt(i);
-                notifyListener(*el);
-            }
+        for (int i = 0, e = listeners->size(); i < e; ++i) {
+            EventListener* el = (EventListener*)listeners->elementAt(i);
+            notifyListener(*el);
         }
     }
 }


### PR DESCRIPTION
ICUNotifier::notifyChanged() was using the thread-unsafe double-checked lock
idiom. Replace it with use of the mutex only.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21832
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
