### PR TITLE
ICU-21918 Updated expected useDaylightTime() value for MIT (Asia/Apia).

### DIFF
--- a/icu4c/source/test/intltest/tztest.cpp
+++ b/icu4c/source/test/intltest/tztest.cpp
@@ -906,7 +906,7 @@ void TimeZoneTest::TestShortZoneIDs()
         {"AET", 600, TRUE},   // ICU Link - Australia/Sydney
         {"SST", 660, FALSE},  // ICU Link - Pacific/Guadalcanal
         {"NST", 720, TRUE},   // ICU Link - Pacific/Auckland
-        {"MIT", 780, TRUE},   // ICU Link - Pacific/Apia
+        {"MIT", 780, FALSE},  // ICU Link - Pacific/Apia
 
         {"Etc/Unknown", 0, FALSE},  // CLDR
 

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/timezone/TimeZoneTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/timezone/TimeZoneTest.java
@@ -172,7 +172,7 @@ public class TimeZoneTest extends TestFmwk
             new ZoneDescriptor("AET", 600, true),   // ICU Link - Australia/Sydney
             new ZoneDescriptor("SST", 660, false),  // ICU Link - Pacific/Guadalcanal
             new ZoneDescriptor("NST", 720, true),   // ICU Link - Pacific/Auckland
-            new ZoneDescriptor("MIT", 780, true),   // ICU Link - Pacific/Apia
+            new ZoneDescriptor("MIT", 780, false),  // ICU Link - Pacific/Apia
 
             new ZoneDescriptor("Etc/Unknown", 0, false),    // CLDR
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21918
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
