### PR TITLE
ICU-21900 Adjusts performance alert threshold to 150%, i.e. the alert…

### DIFF
--- a/.github/workflows/icu_merge_ci.yml
+++ b/.github/workflows/icu_merge_ci.yml
@@ -99,7 +99,7 @@ jobs:
           tool: 'ndjson'
           output-file-path: icu4c/source/test/perf/results/${{ matrix.perf }}/output.txt
           # Tentative setting.
-          alert-threshold: '100%'
+          alert-threshold: '150%'
           fail-on-alert: true
           gh-pages-branch: perfdata
           benchmark-data-dir-path: perf/results/${{ matrix.perf }}
@@ -169,7 +169,7 @@ jobs:
           tool: 'ndjson'
           output-file-path: icu4c/source/test/perf/results/${{ matrix.perf }}/${{ matrix.data }}/output.txt
           # Tentative setting.
-          alert-threshold: '100%'
+          alert-threshold: '150%'
           fail-on-alert: true
           gh-pages-branch: perfdata
           benchmark-data-dir-path: perf/results/${{ matrix.perf }}/${{ matrix.data }}


### PR DESCRIPTION
… only is

triggered if the current measured execution time is 50% higher than the previous
time.
The current setting of 100% means that even a 1% increase from previous time
triggers the alert already.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [ ] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21900
- [ ] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
