### PR TITLE
ICU-21839 Add ICU4J test that ISO8601 inherits patterns/symbols from Gregorian

### DIFF
--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/DateTimeGeneratorTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/DateTimeGeneratorTest.java
@@ -2004,4 +2004,30 @@ public class DateTimeGeneratorTest extends TestFmwk {
             }
         }
     }
+
+    // Test for ICU-21839: Make sure ISO8601 patterns/symbols are inherited from Gregorian
+    @Test
+    public void testISO8601() {
+        String[] localeIDs = {
+            "de-AT-u-ca-iso8601",
+            "de-CH-u-ca-iso8601",
+        };
+        String skeleton = "jms";
+
+        for (String localeID : localeIDs) {
+            ULocale uloc = ULocale.forLanguageTag(localeID);
+
+            DateTimePatternGenerator dtpg = DateTimePatternGenerator.getInstance(uloc);
+            String pattern = dtpg.getBestPattern(skeleton);
+            if (pattern.contains("├") || pattern.contains("Minute")) {
+                errln("ERROR: locale " + localeID + ", skeleton " + skeleton + ", bad pattern: " + pattern);
+            }
+
+            DateFormat df = DateFormat.getTimeInstance(DateFormat.MEDIUM, uloc);
+            String format = df.format(new Date());
+            if (format.contains("├") || format.contains("Minute")) {
+                errln("ERROR: locale " + localeID + ", MEDIUM, bad format: " + format);
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21839
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

Add ICU4J test to verify that the problem reported in ICU-21839 no longer occurs (probably because of Rich Gillam fixes for sideways inheritance; and the reported problem only occurred in ICU4J).