### PR TITLE
ICU-21755 commit checker: add support for COMMIT_METADATA.md file

### DIFF
--- a/tools/commit-checker/Pipfile
+++ b/tools/commit-checker/Pipfile
@@ -1,5 +1,5 @@
 # Copyright (C) 2018 and later: Unicode, Inc. and others.
-# License & terms of use: http://www.unicode.org/copyright.html 
+# License & terms of use: http://www.unicode.org/copyright.html
 # Author: shane@unicode.org
 
 [[source]]
@@ -15,3 +15,4 @@ gitpython = "*"
 jira = "*"
 
 [dev-packages]
+pytest = "*"

--- a/tools/commit-checker/TEST_COMMIT_METADATA.md
+++ b/tools/commit-checker/TEST_COMMIT_METADATA.md
@@ -1,0 +1,25 @@
+# - Commit Metadata
+
+### Copyright (C) 2022 and later: Unicode, Inc. and others.
+### License & terms of use: http://www.unicode.org/copyright.html
+### All lines starting with one hash (#) are significant
+### All lines starting with a dash (-) are significant.
+###
+### The following list of commits is parsed by the ICU/CLDR commit checker.
+### It has the following structure:
+### `- <commit> <bug id or hyphen> <message>`
+
+- 00decafbad CLDR-0000 Bad commit message
+- 50257a7a3eba7bbed634961a2aa74e77b12810bf - Early commit, no bug id
+- 283dc84d81cfc47fb15cd664fce4b0151d070ea6 - Early commit, no bug id
+- 02198373a591a15b804127acddd32582ec985b7e CLDR-15852 v42 merge commit
+
+
+### The following are items to skip for a certain CLDR version
+### Format: `# SKIP v00` followed by a list of commits to skip for that version
+
+# SKIP v41
+
+- 56ca5d5 CLDR-14877 split ticket
+
+

--- a/tools/commit-checker/commit_metadata.py
+++ b/tools/commit-checker/commit_metadata.py
@@ -1,0 +1,83 @@
+# Copyright (C) 2022 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
+# Author: srloomis@unicode.org
+
+from re import compile
+from typing import Tuple
+import typing
+
+commit_line = compile('^\s*-\s+([0-9a-f]+)\s+([^\s]+)\s+(.*)$') # '- <sha> <hypen-or-ticketid> <message>'
+verb_line = compile('^\s*#\s+([A-Z]+)\s+(.*)$') # '# ACTION any other content…'
+
+class CommitMetadata():
+    def __init__(self, metadata_file=None) -> None:
+        skipset = {}
+        fixset = []  # sha, id, message
+        current_skip = None
+        if metadata_file:
+            with open(metadata_file, 'r') as f:
+                for line in f.readlines():
+                    line = line.strip()
+                    m = commit_line.match(line)
+                    if m:
+                        sha = m.group(1)
+                        id = m.group(2)
+                        message = m.group(3)
+                        fixset.append((sha, id, message))
+                        if current_skip:
+                            skipset[current_skip].append((sha, id, message))
+                        continue
+                    m = verb_line.match(line)
+                    if m:
+                        action = m.group(1)
+                        content = m.group(2)
+                        # for now we only support SKIP
+                        assert action == "SKIP", "Unknown action %s in %s (expected 'SKIP')" % (action, line)
+                        current_skip = content
+                        assert content not in skipset, "Error: two sections like %s" % line
+                        skipset[content] = []  # initialize this
+                        continue
+        self.fixset = fixset
+        self.skipset = skipset
+        pass
+
+    def get_commit_info(self, commit, skip=None) -> typing.Tuple[str, str, str]:
+        """Return an override line given a commit
+
+        Args:
+            commit (str): hash or short hash of a commit
+            skip (str): If set, a version to skip such as 'v41' (this will match a section - SKIP v41)
+
+        Returns:
+            sha (str): original sha from line
+            id (str): ticket id or hash
+            message (str): override message
+        """
+        if skip:
+            if not skip in self.skipset:
+                return None
+            return CommitMetadata.match_list(commit, self.skipset[skip])
+        else:
+            return CommitMetadata.match_list(commit, self.fixset)
+
+    @staticmethod
+    def match_list(commit, l) -> any:
+        """Find the first match in a list of commits
+
+        Args:
+            commit (str): short or long commit string
+            l (list): list of tuples, where item 0 is the commit
+
+        Returns:
+            any: matching list member, or None
+        """
+        for i in l:
+            if CommitMetadata.match_commit(commit, i[0]):
+                return i
+        return None
+
+    @staticmethod
+    def match_commit(h1, h2) -> bool:
+        """return true if the prefix of the hashes are the same"""
+        comm = min(len(h1), len(h2))
+        return h1[0:comm] == h2[0:comm]

--- a/tools/commit-checker/test_commit_metadata.py
+++ b/tools/commit-checker/test_commit_metadata.py
@@ -1,0 +1,65 @@
+# Copyright (C) 2022 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
+# Author: srloomis@unicode.org
+
+from commit_metadata import CommitMetadata
+
+def test_hash():
+    assert CommitMetadata.match_commit("512a679aba", "512a679aba22e144a4443df5f8f304e4f8b39054")
+    assert CommitMetadata.match_commit("512a679aba", "512a679aba")
+    assert CommitMetadata.match_commit("512a679aba22e144a4443df5f8f304e4f8b39054", "512a679aba22e144a4443df5f8f304e4f8b39054")
+    assert not CommitMetadata.match_commit("512a679aba", "16aae80199")
+    assert not CommitMetadata.match_commit("512a679aba22e144a4443df5f8f304e4f8b39054", "16aae80199")
+
+def test_matchcommit():
+    assert CommitMetadata.match_list("512a679aba", [("00decafbad", 44), ("512a679aba", 99)]) == ("512a679aba", 99)
+    assert CommitMetadata.match_list("512a679aba22e144a4443df5f8f304e4f8b39054", [("00decafbad", 44), ("512a679aba", 99)]) == ("512a679aba", 99)
+    assert CommitMetadata.match_list("512a679aba", [("00decafbad", 44), ("512a679aba22e144a4443df5f8f304e4f8b39054", 99)]) == ("512a679aba22e144a4443df5f8f304e4f8b39054", 99)
+    assert not CommitMetadata.match_list("16aae80199", [("00decafbad", 44), ("512a679aba", 99)])
+    assert not CommitMetadata.match_list("16aae80199", [("00decafbad", 44), ("512a679aba22e144a4443df5f8f304e4f8b39054", 99)])
+
+def test_read():
+    m = CommitMetadata(metadata_file="./TEST_COMMIT_METADATA.md")
+    assert m
+
+    assert not m.get_commit_info('00000000')  # not in list
+    assert m.get_commit_info('00decafbad')
+    assert m.get_commit_info('00decafbad')[1].startswith('CLDR-0000')
+    assert m.get_commit_info('56ca5d5')
+    assert m.get_commit_info('56ca5d5')[1].startswith('CLDR-14877')
+    # short or long, same
+    assert m.get_commit_info('56ca5d5') == m.get_commit_info('56ca5d563cf57990a7598f570cb9be51956cb9de')
+
+    # skip list
+    assert m.get_commit_info('56ca5d5', skip='v41')
+    assert not m.get_commit_info('56ca5d5', skip='v42')
+    assert m.get_commit_info('56ca5d563cf57990a7598f570cb9be51956cb9de', skip='v41')
+    assert not m.get_commit_info('56ca5d563cf57990a7598f570cb9be51956cb9de', skip='v42')
+    assert not m.get_commit_info('00decafbad', 'v41')
+
+def test_null_read():
+    m = CommitMetadata(metadata_file=None)
+    assert m
+
+    # function with no info
+    assert not m.get_commit_info('00000000')  # not in list
+    assert not m.get_commit_info('00decafbad')
+    assert not m.get_commit_info('56ca5d5')
+    assert not m.get_commit_info('56ca5d5', skip='v41')
+    assert not m.get_commit_info('56ca5d5', skip='v42')
+
+def test_parse_42():
+    m = CommitMetadata(metadata_file="./TEST_COMMIT_METADATA.md")
+    assert m
+
+    # no skip
+    info = m.get_commit_info('02198373a591a15b804127acddd32582ec985b7e')
+    assert info
+    assert info[0] == '02198373a591a15b804127acddd32582ec985b7e'
+    assert info[1] == 'CLDR-15852'
+    assert info[2] == 'v42 merge commit'
+
+    # skip
+    info = m.get_commit_info('02198373a591a15b804127acddd32582ec985b7e', skip='v42')
+    # not found because it isn't in SKIP v42
+    assert not info


### PR DESCRIPTION
ICU-21755

- new option, --commit-metadata= with path to metadata file
- new option, --fix-version=41 (used for SKIP sections)
- scaffolding for 'bad commits' list
- new module CommitMetadata with unit tests
- sample file format TEST_COMMIT_METADATA.md
- such commits are skipped
- refactored the commit skipping part (formerly used for cherry pick skips)
- add a report section for skipped commits
- add a cache for JIRA queries (for dev use): --cache-for-dev "/tmp/cldr-commit-cache"
- add an 'excluded commits' section at the bottom


See https://github.com/unicode-org/cldr/pull/1790 for an example of use and output reports.