### PR TITLE
ICU-21824 make the Unicode license match exactly

### DIFF
--- a/icu4c/LICENSE
+++ b/icu4c/LICENSE
@@ -1,4 +1,17 @@
-COPYRIGHT AND PERMISSION NOTICE (ICU 58 and later)
+UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE
+
+See Terms of Use <https://www.unicode.org/copyright.html>
+for definitions of Unicode Inc.’s Data Files and Software.
+
+NOTICE TO USER: Carefully read the following legal agreement.
+BY DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING UNICODE INC.'S
+DATA FILES ("DATA FILES"), AND/OR SOFTWARE ("SOFTWARE"),
+YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT.
+IF YOU DO NOT AGREE, DO NOT DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE
+THE DATA FILES OR SOFTWARE.
+
+COPYRIGHT AND PERMISSION NOTICE
 
 Copyright © 1991-2022 Unicode, Inc. All rights reserved.
 Distributed under the Terms of Use in https://www.unicode.org/copyright.html.

--- a/icu4j/main/shared/licenses/LICENSE
+++ b/icu4j/main/shared/licenses/LICENSE
@@ -1,4 +1,17 @@
-COPYRIGHT AND PERMISSION NOTICE (ICU 58 and later)
+UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE
+
+See Terms of Use <https://www.unicode.org/copyright.html>
+for definitions of Unicode Inc.’s Data Files and Software.
+
+NOTICE TO USER: Carefully read the following legal agreement.
+BY DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING UNICODE INC.'S
+DATA FILES ("DATA FILES"), AND/OR SOFTWARE ("SOFTWARE"),
+YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT.
+IF YOU DO NOT AGREE, DO NOT DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE
+THE DATA FILES OR SOFTWARE.
+
+COPYRIGHT AND PERMISSION NOTICE
 
 Copyright © 1991-2022 Unicode, Inc. All rights reserved.
 Distributed under the Terms of Use in https://www.unicode.org/copyright.html.

--- a/tools/unicodetools/license.html
+++ b/tools/unicodetools/license.html
@@ -1,34 +1,18 @@
 <html>
 
 <head>
-<title>ICU4J license - ICU4J 1.3.1 and later</title>
+<title>ICU License - moved to LICENSE</title>
 </head>
 
 <body BGCOLOR="#ffffff">
-<h2>ICU4J license - ICU4J 1.3.1 and later</h2>
+<h2>ICU License - moved to LICENSE</h2>
 
-<p>COPYRIGHT AND PERMISSION NOTICE</p>
+<p>The ICU license is now in plain text format, see
+<a href="https://github.com/unicode-org/icu/blob/main/icu4j/main/shared/licenses/LICENSE">LICENSE</a>.
+Update links and software appropriately.</p>
 
-<p>
-Copyright (c) 1995-2002 International Business Machines Corporation and others
-</p>
-<p>
-All rights reserved.
-</p>
-<p>
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, and/or sell copies of the Software, and to permit persons
-to whom the Software is furnished to do so, provided that the above copyright notice(s) and this permission notice appear in all copies of the Software and that both the above copyright notice(s) and this permission notice appear in supporting documentation.
-</p>
-<p>
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-</p>
-<p>
-Except as contained in this notice, the name of a copyright holder shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Software without prior written authorization of the copyright holder.
-</p>
+<i>© 2016 and later: Unicode, Inc. and others. License &amp; terms of use: http://www.unicode.org/copyright.html</i>
+<!-- i>Copyright (c) 1995-2016 International Business Machines Corporation and others</i -->
 
-<hr>
-<small>
-All trademarks and registered trademarks mentioned herein are the property of their respective owners.
-</small>
 </body>
 </html>


### PR DESCRIPTION
The ICU copy of the Unicode license was missing some lines that are
considered part of the license text.

See https://github.com/unicode-org/template-repo/blob/main/LICENSE
and https://www.unicode.org/license.txt

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21824
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
