### PR TITLE
ICU-21944 Sync recent uloc_getLanguage/Countries updates to ICU4J; add "mo" mapping for C

### DIFF
--- a/icu4c/source/common/uloc.cpp
+++ b/icu4c/source/common/uloc.cpp
@@ -186,10 +186,10 @@ NULL
 };
 
 static const char* const DEPRECATED_LANGUAGES[]={
-    "in", "iw", "ji", "jw", NULL, NULL
+    "in", "iw", "ji", "jw", "mo", NULL, NULL
 };
 static const char* const REPLACEMENT_LANGUAGES[]={
-    "id", "he", "yi", "jv", NULL, NULL
+    "id", "he", "yi", "jv", "ro", NULL, NULL
 };
 
 /**

--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/LocaleIDs.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/LocaleIDs.java
@@ -136,6 +136,7 @@ public class LocaleIDs {
      */
     /* tables updated per http://lcweb.loc.gov/standards/iso639-2/
        to include the revisions up to 2001/7/27 *CWB*/
+    /* Subsequent hand addition of selected languages */
     /* The 3 character codes are the terminology codes like RFC 3066.
        This is compatible with prior ICU codes */
     /* "in" "iw" "ji" "jw" & "sh" have been withdrawn but are still in
@@ -147,183 +148,181 @@ public class LocaleIDs {
     /* This list MUST be in sorted order, and MUST contain the two-letter codes
     if one exists otherwise use the three letter code */
     private static final String[] _languages = {
-        "aa",  "ab",  "ace", "ach", "ada", "ady", "ae",  "af",  
-        "afa", "afh", "agq", "ain", "ak",  "akk", "ale", "alg", 
-        "alt", "am",  "an",  "ang", "anp", "apa", "ar",  "arc", 
-        "arn", "arp", "ars", "art", "arw", "as",  "asa", "ast",
-        "ath", "aus", "av",  "awa", "ay",  "az",  
-        "ba",  "bad", "bai", "bal", "ban", "bas", "bat", "bax", 
-        "bbj", "be",  "bej", "bem", "ber", "bez", "bfd", "bg",  
-        "bh",  "bho", "bi",  "bik", "bin", "bkm", "bla", "bm",  
-        "bn",  "bnt", "bo",  "br",  "bra", "brx", "bs",  "bss", 
-        "btk", "bua", "bug", "bum", "byn", "byv", 
-        "ca",  "cad", "cai", "car", "cau", "cay", "cch", "ce",  
-        "ceb", "cel", "cgg", "ch",  "chb", "chg", "chk", "chm", 
-        "chn", "cho", "chp", "chr", "chy", "ckb", "cmc", "co",  
-        "cop", "cpe", "cpf", "cpp", "cr",  "crh", "crp", "cs",  
-        "csb", "cu",  "cus", "cv",  "cy",  
-        "da",  "dak", "dar", "dav", "day", "de",  "del", "den", 
-        "dgr", "din", "dje", "doi", "dra", "dsb", "dua", "dum", 
-        "dv",  "dyo", "dyu", "dz",  "dzg", 
-        "ebu", "ee",  "efi", "egy", "eka", "el",  "elx", "en",  
-        "enm", "eo",  "es",  "et",  "eu",  "ewo", 
-        "fa",  "fan", "fat", "ff",  "fi",  "fil", "fiu", "fj",  
-        "fo",  "fon", "fr",  "frm", "fro", "frr", "frs", "fur", 
-        "fy",  
-        "ga",  "gaa", "gay", "gba", "gd",  "gem", "gez", "gil", 
-        "gl",  "gmh", "gn",  "goh", "gon", "gor", "got", "grb", 
-        "grc", "gsw", "gu",  "guz", "gv",  "gwi", 
-        "ha",  "hai", "haw", "he",  "hi",  "hil", "him", "hit", 
-        "hmn", "ho",  "hr",  "hsb", "ht",  "hu",  "hup", "hy",  
-        "hz",  
-        "ia",  "iba", "ibb", "id",  "ie",  "ig",  "ii",  "ijo", 
-        "ik",  "ilo", "inc", "ine", "inh", "io",  "ira", "iro", 
-        "is",  "it",  "iu",  
-        "ja",  "jbo", "jgo", "jmc", "jpr", "jrb", "jv",  
-        "ka",  "kaa", "kab", "kac", "kaj", "kam", "kar", "kaw", 
-        "kbd", "kbl", "kcg", "kde", "kea", "kfo", "kg",  "kha", 
-        "khi", "kho", "khq", "ki",  "kj",  "kk",  "kkj", "kl",  
-        "kln", "km",  "kmb", "kn",  "ko",  "kok", "kos", "kpe", 
-        "kr",  "krc", "krl", "kro", "kru", "ks",  "ksb", "ksf", 
-        "ksh", "ku",  "kum", "kut", "kv",  "kw",  "ky",  
-        "la",  "lad", "lag", "lah", "lam", "lb",  "lez", "lg",  
-        "li",  "lkt", "ln",  "lo",  "lol", "loz", "lt",  "lu",  
-        "lua", "lui", "lun", "luo", "lus", "luy", "lv",  
-        "mad", "maf", "mag", "mai", "mak", "man", "map", "mas", 
-        "mde", "mdf", "mdr", "men", "mer", "mfe", "mg",  "mga", 
-        "mgh", "mgo", "mh",  "mi",  "mic", "min", "mis", "mk",  
-        "mkh", "ml",  "mn",  "mnc", "mni", "mno", "mo",  "moh", 
-        "mos", "mr",  "ms",  "mt",  "mua", "mul", "mun", "mus", 
-        "mwl", "mwr", "my",  "mye", "myn", "myv", 
-        "na",  "nah", "nai", "nap", "naq", "nb",  "nd",  "nds", 
-        "ne",  "new", "ng",  "nia", "nic", "niu", "nl",  "nmg", 
-        "nn",  "nnh", "no",  "nog", "non", "nqo", "nr",  "nso", 
-        "nub", "nus", "nv",  "nwc", "ny",  "nym", "nyn", "nyo", 
-        "nzi", 
-        "oc",  "oj",  "om",  "or",  "os",  "osa", "ota", "oto", 
-        "pa",  "paa", "pag", "pal", "pam", "pap", "pau", "peo", 
-        "phi", "phn", "pi",  "pl",  "pon", "pra", "pro", "ps",  
-        "pt",  
-        "qu",  
-        "raj", "rap", "rar", "rm",  "rn",  "ro",  "roa", "rof", 
-        "rom", "ru",  "rup", "rw",  "rwk", 
-        "sa",  "sad", "sah", "sai", "sal", "sam", "saq", "sas", 
-        "sat", "sba", "sbp", "sc",  "scn", "sco", "sd",  "se",  
-        "see", "seh", "sel", "sem", "ses", "sg",  "sga", "sgn", 
-        "shi", "shn", "shu", "si",  "sid", "sio", "sit", 
-        "sk",  "sl",  "sla", "sm",  "sma", "smi", "smj", "smn", 
-        "sms", "sn",  "snk", "so",  "sog", "son", "sq",  "sr",  
-        "srn", "srr", "ss",  "ssa", "ssy", "st",  "su",  "suk", 
-        "sus", "sux", "sv",  "sw",  "swb", "swc", "syc", "syr", 
-        "ta",  "tai", "te",  "tem", "teo", "ter", "tet", "tg",  
-        "th",  "ti",  "tig", "tiv", "tk",  "tkl", "tl",  "tlh", 
-        "tli", "tmh", "tn",  "to",  "tog", "tpi", "tr",  "trv", 
-        "ts",  "tsi", "tt",  "tum", "tup", "tut", "tvl", "tw",  
-        "twq", "ty",  "tyv", "tzm", 
-        "udm", "ug",  "uga", "uk",  "umb", "und", "ur",  "uz",  
-        "vai", "ve",  "vi",  "vo",  "vot", "vun", 
-        "wa",  "wae", "wak", "wal", "war", "was", "wen", "wo",  
-        "xal", "xh",  "xog", 
-        "yao", "yap", "yav", "ybb", "yi",  "yo",  "ypk", "yue", 
-        "za",  "zap", "zbl", "zen", "zh",  "znd", "zu",  "zun", 
+        "aa",  "ab",  "ace", "ach", "ada", "ady", "ae",  "aeb",
+        "af",  "afh", "agq", "ain", "ak",  "akk", "akz", "ale",
+        "aln", "alt", "am",  "an",  "ang", "anp", "ar",  "arc",
+        "arn", "aro", "arp", "arq", "ars", "arw", "ary", "arz", "as",
+        "asa", "ase", "ast", "av",  "avk", "awa", "ay",  "az",
+        "ba",  "bal", "ban", "bar", "bas", "bax", "bbc", "bbj",
+        "be",  "bej", "bem", "bew", "bez", "bfd", "bfq", "bg",
+        "bgn", "bho", "bi",  "bik", "bin", "bjn", "bkm", "bla",
+        "bm",  "bn",  "bo",  "bpy", "bqi", "br",  "bra", "brh",
+        "brx", "bs",  "bss", "bua", "bug", "bum", "byn", "byv",
+        "ca",  "cad", "car", "cay", "cch", "ccp", "ce",  "ceb", "cgg",
+        "ch",  "chb", "chg", "chk", "chm", "chn", "cho", "chp",
+        "chr", "chy", "ckb", "co",  "cop", "cps", "cr",  "crh",
+        "cs",  "csb", "cu",  "cv",  "cy",
+        "da",  "dak", "dar", "dav", "day", "de",  "del", "den",
+        "dgr", "din", "dje", "doi", "dra", "dsb", "dua", "dum",
+        "dv",  "dyo", "dyu", "dz",  "dzg",
+        "ebu", "ee",  "efi", "egy", "eka", "el",  "elx", "en",
+        "enm", "eo",  "es",  "et",  "eu",  "ewo",
+        "fa",  "fan", "fat", "ff",  "fi",  "fil", "fiu", "fj",
+        "fo",  "fon", "fr",  "frm", "fro", "frr", "frs", "fur",
+        "fy",
+        "ga",  "gaa", "gay", "gba", "gd",  "gem", "gez", "gil",
+        "gl",  "gmh", "gn",  "goh", "gon", "gor", "got", "grb",
+        "grc", "gsw", "gu",  "guz", "gv",  "gwi",
+        "ha",  "hai", "haw", "he",  "hi",  "hil", "him", "hit",
+        "hmn", "ho",  "hr",  "hsb", "ht",  "hu",  "hup", "hy",
+        "hz",
+        "ia",  "iba", "ibb", "id",  "ie",  "ig",  "ii",  "ijo",
+        "ik",  "ilo", "inc", "ine", "inh", "io",  "ira", "iro",
+        "is",  "it",  "iu",
+        "ja",  "jbo", "jgo", "jmc", "jpr", "jrb", "jv",
+        "ka",  "kaa", "kab", "kac", "kaj", "kam", "kar", "kaw",
+        "kbd", "kbl", "kcg", "kde", "kea", "kfo", "kg",  "kha",
+        "khi", "kho", "khq", "ki",  "kj",  "kk",  "kkj", "kl",
+        "kln", "km",  "kmb", "kn",  "ko",  "kok", "kos", "kpe",
+        "kr",  "krc", "krl", "kro", "kru", "ks",  "ksb", "ksf",
+        "ksh", "ku",  "kum", "kut", "kv",  "kw",  "ky",
+        "la",  "lad", "lag", "lah", "lam", "lb",  "lez", "lg",
+        "li",  "lkt", "ln",  "lo",  "lol", "loz", "lt",  "lu",
+        "lua", "lui", "lun", "luo", "lus", "luy", "lv",
+        "mad", "maf", "mag", "mai", "mak", "man", "map", "mas",
+        "mde", "mdf", "mdr", "men", "mer", "mfe", "mg",  "mga",
+        "mgh", "mgo", "mh",  "mi",  "mic", "min", "mis", "mk",
+        "mkh", "ml",  "mn",  "mnc", "mni", "mno", "moh",
+        "mos", "mr",  "ms",  "mt",  "mua", "mul", "mun", "mus",
+        "mwl", "mwr", "my",  "mye", "myn", "myv",
+        "na",  "nah", "nai", "nap", "naq", "nb",  "nd",  "nds",
+        "ne",  "new", "ng",  "nia", "nic", "niu", "nl",  "nmg",
+        "nn",  "nnh", "no",  "nog", "non", "nqo", "nr",  "nso",
+        "nub", "nus", "nv",  "nwc", "ny",  "nym", "nyn", "nyo",
+        "nzi",
+        "oc",  "oj",  "om",  "or",  "os",  "osa", "ota", "oto",
+        "pa",  "paa", "pag", "pal", "pam", "pap", "pau", "peo",
+        "phi", "phn", "pi",  "pl",  "pon", "pra", "pro", "ps",
+        "pt",
+        "qu",
+        "raj", "rap", "rar", "rm",  "rn",  "ro",  "roa", "rof",
+        "rom", "ru",  "rup", "rw",  "rwk",
+        "sa",  "sad", "sah", "sai", "sal", "sam", "saq", "sas",
+        "sat", "sba", "sbp", "sc",  "scn", "sco", "sd",  "se",
+        "see", "seh", "sel", "sem", "ses", "sg",  "sga", "sgn",
+        "shi", "shn", "shu", "si",  "sid", "sio", "sit",
+        "sk",  "sl",  "sla", "sm",  "sma", "smi", "smj", "smn",
+        "sms", "sn",  "snk", "so",  "sog", "son", "sq",  "sr",
+        "srn", "srr", "ss",  "ssa", "ssy", "st",  "su",  "suk",
+        "sus", "sux", "sv",  "sw",  "swb", "syc", "syr",
+        "ta",  "tai", "te",  "tem", "teo", "ter", "tet", "tg",
+        "th",  "ti",  "tig", "tiv", "tk",  "tkl", "tlh",
+        "tli", "tmh", "tn",  "to",  "tog", "tpi", "tr",  "trv",
+        "ts",  "tsi", "tt",  "tum", "tup", "tut", "tvl", "tw",
+        "twq", "ty",  "tyv", "tzm",
+        "udm", "ug",  "uga", "uk",  "umb", "und", "ur",  "uz",
+        "vai", "ve",  "vi",  "vo",  "vot", "vun",
+        "wa",  "wae", "wak", "wal", "war", "was", "wen", "wo",
+        "xal", "xh",  "xog",
+        "yao", "yap", "yav", "ybb", "yi",  "yo",  "ypk", "yue",
+        "za",  "zap", "zbl", "zen", "zh",  "znd", "zu",  "zun",
         "zxx", "zza" };
-        
+
     private static final String[] _replacementLanguages = {
-        "id", "he", "yi", "jv", "sr", /* replacement language codes */
+        "id", "he", "yi", "jv", "ro", "sr", /* replacement language codes */
     };
-    
+
     private static final String[] _obsoleteLanguages = {
-        "in", "iw", "ji", "jw", "sh", /* obsolete language codes */
+        "in", "iw", "ji", "jw", "mo", "sh", /* obsolete language codes */
     };
-    
+
     /* This list MUST contain a three-letter code for every two-letter code in the
     list above, and they MUST ne in the same order (i.e., the same language must
     be in the same place in both lists)! */
     private static final String[] _languages3 = {
-        "aar", "abk", "ace", "ach", "ada", "ady", "ave", "afr", 
-        "afa", "afh", "agq", "ain", "aka", "akk", "ale", "alg", 
-        "alt", "amh", "arg", "ang", "anp", "apa", "ara", "arc", 
-        "arn", "arp", "ars", "art", "arw", "asm", "asa", "ast",
-        "ath", "aus", "ava", "awa", "aym", "aze", 
-        "bak", "bad", "bai", "bal", "ban", "bas", "bat", "bax", 
-        "bbj", "bel", "bej", "bem", "ber", "bez", "bfd", "bul", 
-        "bih", "bho", "bis", "bik", "bin", "bkm", "bla", "bam", 
-        "ben", "bnt", "bod", "bre", "bra", "brx", "bos", "bss", 
-        "btk", "bua", "bug", "bum", "byn", "byv", 
-        "cat", "cad", "cai", "car", "cau", "cay", "cch", "che", 
-        "ceb", "cel", "cgg", "cha", "chb", "chg", "chk", "chm", 
-        "chn", "cho", "chp", "chr", "chy", "ckb", "cmc", "cos", 
-        "cop", "cpe", "cpf", "cpp", "cre", "crh", "crp", "ces", 
-        "csb", "chu", "cus", "chv", "cym", 
-        "dan", "dak", "dar", "dav", "day", "deu", "del", "den", 
-        "dgr", "din", "dje", "doi", "dra", "dsb", "dua", "dum", 
-        "div", "dyo", "dyu", "dzo", "dzg", 
-        "ebu", "ewe", "efi", "egy", "eka", "ell", "elx", "eng", 
-        "enm", "epo", "spa", "est", "eus", "ewo", 
-        "fas", "fan", "fat", "ful", "fin", "fil", "fiu", "fij", 
-        "fao", "fon", "fra", "frm", "fro", "frr", "frs", "fur", 
-        "fry", 
-        "gle", "gaa", "gay", "gba", "gla", "gem", "gez", "gil", 
-        "glg", "gmh", "grn", "goh", "gon", "gor", "got", "grb", 
-        "grc", "gsw", "guj", "guz", "glv", "gwi", 
-        "hau", "hai", "haw", "heb", "hin", "hil", "him", "hit", 
-        "hmn", "hmo", "hrv", "hsb", "hat", "hun", "hup", "hye", 
-        "her", 
-        "ina", "iba", "ibb", "ind", "ile", "ibo", "iii", "ijo", 
-        "ipk", "ilo", "inc", "ine", "inh", "ido", "ira", "iro", 
-        "isl", "ita", "iku", 
-        "jpn", "jbo", "jgo", "jmc", "jpr", "jrb", "jav", 
-        "kat", "kaa", "kab", "kac", "kaj", "kam", "kar", "kaw", 
-        "kbd", "kbl", "kcg", "kde", "kea", "kfo", "kon", "kha", 
-        "khi", "kho", "khq", "kik", "kua", "kaz", "kkj", "kal", 
-        "kln", "khm", "kmb", "kan", "kor", "kok", "kos", "kpe", 
-        "kau", "krc", "krl", "kro", "kru", "kas", "ksb", "ksf", 
-        "ksh", "kur", "kum", "kut", "kom", "cor", "kir", 
-        "lat", "lad", "lag", "lah", "lam", "ltz", "lez", "lug", 
-        "lim", "lkt", "lin", "lao", "lol", "loz", "lit", "lub", 
-        "lua", "lui", "lun", "luo", "lus", "luy", "lav", 
-        "mad", "maf", "mag", "mai", "mak", "man", "map", "mas", 
-        "mde", "mdf", "mdr", "men", "mer", "mfe", "mlg", "mga", 
-        "mgh", "mgo", "mah", "mri", "mic", "min", "mis", "mkd", 
-        "mkh", "mal", "mon", "mnc", "mni", "mno", "mol", "moh", 
-        "mos", "mar", "msa", "mlt", "mua", "mul", "mun", "mus", 
-        "mwl", "mwr", "mya", "mye", "myn", "myv", 
-        "nau", "nah", "nai", "nap", "naq", "nob", "nde", "nds", 
-        "nep", "new", "ndo", "nia", "nic", "niu", "nld", "nmg", 
-        "nno", "nnh", "nor", "nog", "non", "nqo", "nbl", "nso", 
-        "nub", "nus", "nav", "nwc", "nya", "nym", "nyn", "nyo", 
-        "nzi", 
-        "oci", "oji", "orm", "ori", "oss", "osa", "ota", "oto", 
-        "pan", "paa", "pag", "pal", "pam", "pap", "pau", "peo", 
-        "phi", "phn", "pli", "pol", "pon", "pra", "pro", "pus", 
-        "por", 
-        "que", 
-        "raj", "rap", "rar", "roh", "run", "ron", "roa", "rof", 
-        "rom", "rus", "rup", "kin", "rwk", 
-        "san", "sad", "sah", "sai", "sal", "sam", "saq", "sas", 
-        "sat", "sba", "sbp", "srd", "scn", "sco", "snd", "sme", 
-        "see", "seh", "sel", "sem", "ses", "sag", "sga", "sgn", 
-        "shi", "shn", "shu", "sin", "sid", "sio", "sit", 
-        "slk", "slv", "sla", "smo", "sma", "smi", "smj", "smn", 
-        "sms", "sna", "snk", "som", "sog", "son", "sqi", "srp", 
-        "srn", "srr", "ssw", "ssa", "ssy", "sot", "sun", "suk", 
-        "sus", "sux", "swe", "swa", "swb", "swc", "syc", "syr", 
-        "tam", "tai", "tel", "tem", "teo", "ter", "tet", "tgk", 
-        "tha", "tir", "tig", "tiv", "tuk", "tkl", "tgl", "tlh", 
-        "tli", "tmh", "tsn", "ton", "tog", "tpi", "tur", "trv", 
-        "tso", "tsi", "tat", "tum", "tup", "tut", "tvl", "twi", 
-        "twq", "tah", "tyv", "tzm", 
-        "udm", "uig", "uga", "ukr", "umb", "und", "urd", "uzb", 
-        "vai", "ven", "vie", "vol", "vot", "vun", 
-        "wln", "wae", "wak", "wal", "war", "was", "wen", "wol", 
-        "xal", "xho", "xog", 
-        "yao", "yap", "yav", "ybb", "yid", "yor", "ypk", "yue", 
-        "zha", "zap", "zbl", "zen", "zho", "znd", "zul", "zun", 
+        "aar", "abk", "ace", "ach", "ada", "ady", "ave", "aeb",
+        "afr", "afh", "agq", "ain", "aka", "akk", "akz", "ale",
+        "aln", "alt", "amh", "arg", "ang", "anp", "ara", "arc",
+        "arn", "aro", "arp", "arq", "ars", "arw", "ary", "arz", "asm",
+        "asa", "ase", "ast", "ava", "avk", "awa", "aym", "aze",
+        "bak", "bal", "ban", "bar", "bas", "bax", "bbc", "bbj",
+        "bel", "bej", "bem", "bew", "bez", "bfd", "bfq", "bul",
+        "bgn", "bho", "bis", "bik", "bin", "bjn", "bkm", "bla",
+        "bam", "ben", "bod", "bpy", "bqi", "bre", "bra", "brh",
+        "brx", "bos", "bss", "bua", "bug", "bum", "byn", "byv",
+        "cat", "cad", "car", "cay", "cch", "ccp", "che", "ceb", "cgg",
+        "cha", "chb", "chg", "chk", "chm", "chn", "cho", "chp",
+        "chr", "chy", "ckb", "cos", "cop", "cps", "cre", "crh",
+        "ces", "csb", "chu", "chv", "cym",
+        "dan", "dak", "dar", "dav", "day", "deu", "del", "den",
+        "dgr", "din", "dje", "doi", "dra", "dsb", "dua", "dum",
+        "div", "dyo", "dyu", "dzo", "dzg",
+        "ebu", "ewe", "efi", "egy", "eka", "ell", "elx", "eng",
+        "enm", "epo", "spa", "est", "eus", "ewo",
+        "fas", "fan", "fat", "ful", "fin", "fil", "fiu", "fij",
+        "fao", "fon", "fra", "frm", "fro", "frr", "frs", "fur",
+        "fry",
+        "gle", "gaa", "gay", "gba", "gla", "gem", "gez", "gil",
+        "glg", "gmh", "grn", "goh", "gon", "gor", "got", "grb",
+        "grc", "gsw", "guj", "guz", "glv", "gwi",
+        "hau", "hai", "haw", "heb", "hin", "hil", "him", "hit",
+        "hmn", "hmo", "hrv", "hsb", "hat", "hun", "hup", "hye",
+        "her",
+        "ina", "iba", "ibb", "ind", "ile", "ibo", "iii", "ijo",
+        "ipk", "ilo", "inc", "ine", "inh", "ido", "ira", "iro",
+        "isl", "ita", "iku",
+        "jpn", "jbo", "jgo", "jmc", "jpr", "jrb", "jav",
+        "kat", "kaa", "kab", "kac", "kaj", "kam", "kar", "kaw",
+        "kbd", "kbl", "kcg", "kde", "kea", "kfo", "kon", "kha",
+        "khi", "kho", "khq", "kik", "kua", "kaz", "kkj", "kal",
+        "kln", "khm", "kmb", "kan", "kor", "kok", "kos", "kpe",
+        "kau", "krc", "krl", "kro", "kru", "kas", "ksb", "ksf",
+        "ksh", "kur", "kum", "kut", "kom", "cor", "kir",
+        "lat", "lad", "lag", "lah", "lam", "ltz", "lez", "lug",
+        "lim", "lkt", "lin", "lao", "lol", "loz", "lit", "lub",
+        "lua", "lui", "lun", "luo", "lus", "luy", "lav",
+        "mad", "maf", "mag", "mai", "mak", "man", "map", "mas",
+        "mde", "mdf", "mdr", "men", "mer", "mfe", "mlg", "mga",
+        "mgh", "mgo", "mah", "mri", "mic", "min", "mis", "mkd",
+        "mkh", "mal", "mon", "mnc", "mni", "mno", "moh",
+        "mos", "mar", "msa", "mlt", "mua", "mul", "mun", "mus",
+        "mwl", "mwr", "mya", "mye", "myn", "myv",
+        "nau", "nah", "nai", "nap", "naq", "nob", "nde", "nds",
+        "nep", "new", "ndo", "nia", "nic", "niu", "nld", "nmg",
+        "nno", "nnh", "nor", "nog", "non", "nqo", "nbl", "nso",
+        "nub", "nus", "nav", "nwc", "nya", "nym", "nyn", "nyo",
+        "nzi",
+        "oci", "oji", "orm", "ori", "oss", "osa", "ota", "oto",
+        "pan", "paa", "pag", "pal", "pam", "pap", "pau", "peo",
+        "phi", "phn", "pli", "pol", "pon", "pra", "pro", "pus",
+        "por",
+        "que",
+        "raj", "rap", "rar", "roh", "run", "ron", "roa", "rof",
+        "rom", "rus", "rup", "kin", "rwk",
+        "san", "sad", "sah", "sai", "sal", "sam", "saq", "sas",
+        "sat", "sba", "sbp", "srd", "scn", "sco", "snd", "sme",
+        "see", "seh", "sel", "sem", "ses", "sag", "sga", "sgn",
+        "shi", "shn", "shu", "sin", "sid", "sio", "sit",
+        "slk", "slv", "sla", "smo", "sma", "smi", "smj", "smn",
+        "sms", "sna", "snk", "som", "sog", "son", "sqi", "srp",
+        "srn", "srr", "ssw", "ssa", "ssy", "sot", "sun", "suk",
+        "sus", "sux", "swe", "swa", "swb", "syc", "syr",
+        "tam", "tai", "tel", "tem", "teo", "ter", "tet", "tgk",
+        "tha", "tir", "tig", "tiv", "tuk", "tkl", "tlh",
+        "tli", "tmh", "tsn", "ton", "tog", "tpi", "tur", "trv",
+        "tso", "tsi", "tat", "tum", "tup", "tut", "tvl", "twi",
+        "twq", "tah", "tyv", "tzm",
+        "udm", "uig", "uga", "ukr", "umb", "und", "urd", "uzb",
+        "vai", "ven", "vie", "vol", "vot", "vun",
+        "wln", "wae", "wak", "wal", "war", "was", "wen", "wol",
+        "xal", "xho", "xog",
+        "yao", "yap", "yav", "ybb", "yid", "yor", "ypk", "yue",
+        "zha", "zap", "zbl", "zen", "zho", "znd", "zul", "zun",
         "zxx", "zza" };
 
     private static final String[] _obsoleteLanguages3 = {
-        /* "in",  "iw",  "ji",  "jw",  "sh", */
-        "ind", "heb", "yid", "jaw", "srp",
+        /* "in",  "iw",  "ji",  "jw",  "mo",  "sh", */
+        "ind", "heb", "yid", "jaw", "ron", "srp"
     };
 
     /* ZR(ZAR) is now CD(COD) and FX(FXX) is PS(PSE) as per
@@ -342,13 +341,13 @@ public class LocaleIDs {
         "BJ",  "BL",  "BM",  "BN",  "BO",  "BQ",  "BR",  "BS",  "BT",  "BV",
         "BW",  "BY",  "BZ",  "CA",  "CC",  "CD",  "CF",  "CG",
         "CH",  "CI",  "CK",  "CL",  "CM",  "CN",  "CO",  "CR",
-        "CU",  "CV",  "CW",  "CX",  "CY",  "CZ",  "DE",  "DJ",  "DK",
-        "DM",  "DO",  "DZ",  "EC",  "EE",  "EG",  "EH",  "ER",
+        "CU",  "CV",  "CW",  "CX",  "CY",  "CZ",  "DE",  "DG",  "DJ",  "DK",
+        "DM",  "DO",  "DZ",  "EA",  "EC",  "EE",  "EG",  "EH",  "ER",
         "ES",  "ET",  "FI",  "FJ",  "FK",  "FM",  "FO",  "FR",
         "GA",  "GB",  "GD",  "GE",  "GF",  "GG",  "GH",  "GI",  "GL",
         "GM",  "GN",  "GP",  "GQ",  "GR",  "GS",  "GT",  "GU",
         "GW",  "GY",  "HK",  "HM",  "HN",  "HR",  "HT",  "HU",
-        "ID",  "IE",  "IL",  "IM",  "IN",  "IO",  "IQ",  "IR",  "IS",
+        "IC",  "ID",  "IE",  "IL",  "IM",  "IN",  "IO",  "IQ",  "IR",  "IS",
         "IT",  "JE",  "JM",  "JO",  "JP",  "KE",  "KG",  "KH",  "KI",
         "KM",  "KN",  "KP",  "KR",  "KW",  "KY",  "KZ",  "LA",
         "LB",  "LC",  "LI",  "LK",  "LR",  "LS",  "LT",  "LU",
@@ -365,22 +364,22 @@ public class LocaleIDs {
         "TK",  "TL",  "TM",  "TN",  "TO",  "TR",  "TT",  "TV",
         "TW",  "TZ",  "UA",  "UG",  "UM",  "US",  "UY",  "UZ",
         "VA",  "VC",  "VE",  "VG",  "VI",  "VN",  "VU",  "WF",
-        "WS",  "YE",  "YT",  "ZA",  "ZM",  "ZW" };
-    
+        "WS",  "XK",  "YE",  "YT",  "ZA",  "ZM",  "ZW" };
+
     private static final String[] _deprecatedCountries = {
         "AN", "BU", "CS", "DD", "DY", "FX", "HV", "NH", "RH", "SU", "TP", "UK", "VD", "YD", "YU", "ZR" /* deprecated country list */
     };
-    
+
     private static final String[] _replacementCountries = {
     /*  "AN", "BU", "CS", "DD", "DY", "FX", "HV", "NH", "RH", "SU", "TP", "UK", "VD", "YD", "YU", "ZR" */
-        "CW", "MM", "RS", "DE", "BJ", "FR", "BF", "VU", "ZW", "RU", "TL", "GB", "VN", "YE", "RS", "CD"  /* replacement country codes */      
+        "CW", "MM", "RS", "DE", "BJ", "FR", "BF", "VU", "ZW", "RU", "TL", "GB", "VN", "YE", "RS", "CD"  /* replacement country codes */
     };
-    
+
     /* this table is used for three letter codes */
     private static final String[] _obsoleteCountries = {
         "AN",  "BU", "CS", "FX", "RO", "SU", "TP", "YD", "YU", "ZR",   /* obsolete country codes */
     };
-    
+
     /* This list MUST contain a three-letter code for every two-letter code in
     the above list, and they MUST be listed in the same order! */
     private static final String[] _countries3 = {
@@ -396,10 +395,10 @@ public class LocaleIDs {
         "BWA", "BLR", "BLZ", "CAN", "CCK", "COD", "CAF", "COG",
     /*  "CH",  "CI",  "CK",  "CL",  "CM",  "CN",  "CO",  "CR",     */
         "CHE", "CIV", "COK", "CHL", "CMR", "CHN", "COL", "CRI",
-    /*  "CU",  "CV",  "CW",  "CX",  "CY",  "CZ",  "DE",  "DJ",  "DK",     */
-        "CUB", "CPV", "CUW", "CXR", "CYP", "CZE", "DEU", "DJI", "DNK",
-    /*  "DM",  "DO",  "DZ",  "EC",  "EE",  "EG",  "EH",  "ER",     */
-        "DMA", "DOM", "DZA", "ECU", "EST", "EGY", "ESH", "ERI",
+    /*  "CU",  "CV",  "CW",  "CX",  "CY",  "CZ",  "DE",  "DG",  "DJ",  "DK",     */
+        "CUB", "CPV", "CUW", "CXR", "CYP", "CZE", "DEU", "DGA", "DJI", "DNK",
+    /*  "DM",  "DO",  "DZ",  "EA",  "EC",  "EE",  "EG",  "EH",  "ER",     */
+        "DMA", "DOM", "DZA", "XEA", "ECU", "EST", "EGY", "ESH", "ERI",
     /*  "ES",  "ET",  "FI",  "FJ",  "FK",  "FM",  "FO",  "FR",     */
         "ESP", "ETH", "FIN", "FJI", "FLK", "FSM", "FRO", "FRA",
     /*  "GA",  "GB",  "GD",  "GE",  "GF",  "GG",  "GH",  "GI",  "GL",     */
@@ -408,8 +407,8 @@ public class LocaleIDs {
         "GMB", "GIN", "GLP", "GNQ", "GRC", "SGS", "GTM", "GUM",
     /*  "GW",  "GY",  "HK",  "HM",  "HN",  "HR",  "HT",  "HU",     */
         "GNB", "GUY", "HKG", "HMD", "HND", "HRV", "HTI", "HUN",
-    /*  "ID",  "IE",  "IL",  "IM",  "IN",  "IO",  "IQ",  "IR",  "IS" */
-        "IDN", "IRL", "ISR", "IMN", "IND", "IOT", "IRQ", "IRN", "ISL",
+    /*  "IC",  "ID",  "IE",  "IL",  "IM",  "IN",  "IO",  "IQ",  "IR",  "IS" */
+        "XIC", "IDN", "IRL", "ISR", "IMN", "IND", "IOT", "IRQ", "IRN", "ISL",
     /*  "IT",  "JE",  "JM",  "JO",  "JP",  "KE",  "KG",  "KH",  "KI",     */
         "ITA", "JEY", "JAM", "JOR", "JPN", "KEN", "KGZ", "KHM", "KIR",
     /*  "KM",  "KN",  "KP",  "KR",  "KW",  "KY",  "KZ",  "LA",     */
@@ -442,9 +441,9 @@ public class LocaleIDs {
         "TWN", "TZA", "UKR", "UGA", "UMI", "USA", "URY", "UZB",
     /*  "VA",  "VC",  "VE",  "VG",  "VI",  "VN",  "VU",  "WF",     */
         "VAT", "VCT", "VEN", "VGB", "VIR", "VNM", "VUT", "WLF",
-    /*  "WS",  "YE",  "YT",  "ZA",  "ZM",  "ZW",          */
-        "WSM", "YEM", "MYT", "ZAF", "ZMB", "ZWE" };
-    
+    /*  "WS",  "XK",  "YE",  "YT",  "ZA",  "ZM",  "ZW",          */
+        "WSM", "XKK", "YEM", "MYT", "ZAF", "ZMB", "ZWE" };
+
     private static final String[] _obsoleteCountries3 = {
     /*  "AN",  "BU",  "CS",  "FX",  "RO",  "SU",  "TP",  "YD",  "YU",  "ZR" */
         "ANT", "BUR", "SCG", "FXX", "ROM", "SUN", "TMP", "YMD", "YUG", "ZAR",

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/ULocaleTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/util/ULocaleTest.java
@@ -822,6 +822,20 @@ public class ULocaleTest extends TestFmwk {
                 { "ji", "yid", "ji", "", "" },
                 { "jw", "jaw", "jw", "", "" },
                 { "sh", "srp", "sh", "", "" },
+                { "mo", "ron", "mo", "", "" },
+                // and some non-obsolete ones
+                { "az", "aze", "az", "", "" },
+                { "cy", "cym", "cy", "", "" },
+                { "hz", "her", "hz", "", "" },
+                { "ky", "kir", "ky", "", "" },
+                { "na", "nau", "na", "", "" },
+                { "sa", "san", "sa", "", "" },
+                { "ts", "tso", "ts", "", "" },
+                { "zu", "zul", "zu", "", "" },
+                { "zz_DG", "", "zz", "DGA", "DG" },
+                { "zz_IC", "", "zz", "XIC", "IC" },
+                { "zz_XK", "", "zz", "XKK", "XK" },
+                // terminator
                 { "", "", "", "", "" }
         };
 

--- a/icu4j/main/tests/localespi/src/com/ibm/icu/dev/test/localespi/LocaleNameTest.java
+++ b/icu4j/main/tests/localespi/src/com/ibm/icu/dev/test/localespi/LocaleNameTest.java
@@ -285,7 +285,7 @@ public class LocaleNameTest extends TestFmwk {
             {"he", "heb"},
             {"iw", "heb"},
             {"ro", "ron"},
-            {"mo", "mol"},
+            {"mo", "ron"},
         };
         for (String[] cas : cases) {
             ULocale loc = new ULocale(cas[0]);


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21944
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable

Sync some recent ICU4C updates (for uloc_getISOLanguages, uloc_getISOCountries) in ICU-21341 and ICU-21942  to ICU4J LocaleIDs (getISOLanguages, getISOCountries, getISO3Language, getISO3Country) which is used by ULocale. Also add missing "mo" → "ro" mapping in C and sync that over too. Finally, sync some of the 2015 updates to the C language code list over to J (language code adds and removes; in this PR only did the 2015 updates for language codes beginning with a through c, the rest will be for another ticket).
