### PR TITLE
ICU-21900 check non-stable API macros, move class boilerplate out of conditionals

### DIFF
--- a/icu4c/source/i18n/unicode/numberformatter.h
+++ b/icu4c/source/i18n/unicode/numberformatter.h
@@ -1202,30 +1202,31 @@ class U_I18N_API Scale : public UMemory {
 
 namespace impl {
 
-// Do not enclose entire StringProp with #ifndef U_HIDE_INTERNAL_API, needed for a protected field
+// Do not enclose entire StringProp with #ifndef U_HIDE_INTERNAL_API, needed for a protected field.
+// And do not enclose its class boilerplate within #ifndef U_HIDE_INTERNAL_API.
 /**
  * Manages NumberFormatterSettings::usage()'s char* instance on the heap.
  * @internal
  */
 class U_I18N_API StringProp : public UMemory {
 
-#ifndef U_HIDE_INTERNAL_API
-
   public:
+    /** @internal */
+    ~StringProp();
+
     /** @internal */
     StringProp(const StringProp &other);
 
     /** @internal */
     StringProp &operator=(const StringProp &other);
 
+#ifndef U_HIDE_INTERNAL_API
+
     /** @internal */
     StringProp(StringProp &&src) U_NOEXCEPT;
 
     /** @internal */
     StringProp &operator=(StringProp &&src) U_NOEXCEPT;
-
-    /** @internal */
-    ~StringProp();
 
     /** @internal */
     int16_t length() const {


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21900
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

Just one change from checking non-stable API macros: In internal StringProp class (which is not completely within #ifndef U_HIDE_INTERNAL_API), move the #ifndef U_HIDE_INTERNAL_API that is present to not include class boilerplate.