### PR TITLE
ICU-21972 Use a shared props file for the ICU Major Version number in VS build projects

### DIFF
--- a/docs/processes/release/tasks/versions.md
+++ b/docs/processes/release/tasks/versions.md
@@ -73,15 +73,13 @@ Edit icuver.txt directly.
 
 1.  The instructions for updating the version number are in
     [icu4c/source/common/unicode/uvernum.h](https://github.com/unicode-org/icu/blob/main/icu4c/source/common/unicode/uvernum.h).
-2.  [icu4c/source/stubdata/stubdata.vcxproj](https://github.com/unicode-org/icu/blob/main/icu4c/source/stubdata/stubdata.vcxproj)
-    and
-    [icu4c/source/data/makedata.mak](https://github.com/unicode-org/icu/blob/main/icu4c/source/data/makedata.mak)
-    may also need to updated with the correct version for icudt.
-3.  After uvernum.h is updated, the Windows project files should be updated by
-    running the UNIX makefile target '**update-windows-makefiles**' in
-    icu/source.
-    *   You will need to rerun "./configure" first though before you can run the
-        command "make update-windows-makefiles".
+2.  [icu4c/source/data/makedata.mak](https://github.com/unicode-org/icu/blob/main/icu4c/source/data/makedata.mak)
+    also needs to be updated with the correct version for `U_ICUDATA_NAME` (icudt).
+3.  After `uvernum.h` is updated, the file [Build.Windows.IcuVersion.props](https://github.com/unicode-org/icu/blob/main/icu4c/source/allinone/Build.Windows.IcuVersion.props) should be updated.
+    This can be done by hand, or by running the UNIX makefile target '**update-windows-makefiles**'
+    in `icu4c/source`.
+    *   You will need to rerun "`./configure`" first though before you can run the
+        command "`make update-windows-makefiles`".
     *   Note: You can use MSYS+MinGW to run the UNIX makefile on Windows
         platforms as well.
 4.  As well, the ICU4C "configure" script should be updated so that it reflects

--- a/icu4c/source/Makefile.in
+++ b/icu4c/source/Makefile.in
@@ -371,7 +371,7 @@ icu4j-data-install icu4j-data: all tests
 
 # For updating Windows makefiles
 
-WINDOWS_UPDATEFILES=$(srcdir)/data/makedata.mak $(shell find $(srcdir) -name '*.vcproj' -o -name '*.vcxproj')
+WINDOWS_UPDATEFILES=$(srcdir)/data/makedata.mak $(srcdir)/allinone/Build.Windows.IcuVersion.props
 
 WINDOWS_UPDATEFILES_SED=config/windows-update.sed
 

--- a/icu4c/source/allinone/Build.Windows.IcuVersion.props
+++ b/icu4c/source/allinone/Build.Windows.IcuVersion.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2016 and later: Unicode, Inc. and others. License & terms of use: http://www.unicode.org/copyright.html -->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- This file is used to set the ICU Major Version number, which is used as a suffix on various file names in other Visual Studio projects. -->
+  <PropertyGroup>
+    <IcuMajorVersion>71</IcuMajorVersion>
+  </PropertyGroup>
+</Project>

--- a/icu4c/source/allinone/Build.Windows.ProjectConfiguration.props
+++ b/icu4c/source/allinone/Build.Windows.ProjectConfiguration.props
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (C) 2016 and later: Unicode, Inc. and others. License & terms of use: http://www.unicode.org/copyright.html -->
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- This file is used to set default configuration options for all non-UWP Visual Studio projects. -->
+  <!-- The following import will set the ICU Major Version number. -->
+  <Import Project="Build.Windows.IcuVersion.props" />
   <!-- These are the default project configurations for building. -->
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">

--- a/icu4c/source/allinone/Build.Windows.UWP.ProjectConfiguration.props
+++ b/icu4c/source/allinone/Build.Windows.UWP.ProjectConfiguration.props
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (C) 2016 and later: Unicode, Inc. and others. License & terms of use: http://www.unicode.org/copyright.html -->
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- The following import will set the ICU Major Version number. -->
+  <Import Project="Build.Windows.IcuVersion.props" />
   <!-- This file is used to set common configuration options for all *_uwp projects. -->
   <PropertyGroup>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>

--- a/icu4c/source/common/common.vcxproj
+++ b/icu4c/source/common/common.vcxproj
@@ -58,7 +58,7 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <OutputFile>..\..\$(IcuBinOutputDir)\icuuc71d.dll</OutputFile>
+      <OutputFile>..\..\$(IcuBinOutputDir)\icuuc$(IcuMajorVersion)d.dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuucd.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuucd.lib</ImportLibrary>
     </Link>
@@ -70,7 +70,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
     </ClCompile>
     <Link>
-      <OutputFile>..\..\$(IcuBinOutputDir)\icuuc71.dll</OutputFile>
+      <OutputFile>..\..\$(IcuBinOutputDir)\icuuc$(IcuMajorVersion).dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuuc.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuuc.lib</ImportLibrary>
     </Link>

--- a/icu4c/source/common/common_uwp.vcxproj
+++ b/icu4c/source/common/common_uwp.vcxproj
@@ -125,7 +125,7 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <AdditionalDependencies>vccorlib.lib;msvcrt.lib;vcruntime.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>..\..\$(IcuBinOutputDir)\icuuc71.dll</OutputFile>
+      <OutputFile>..\..\$(IcuBinOutputDir)\icuuc$(IcuMajorVersion).dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuuc.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuuc.lib</ImportLibrary>
     </Link>
@@ -148,7 +148,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>vccorlibd.lib;msvcrtd.lib;vcruntimed.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>..\..\$(IcuBinOutputDir)\icuuc71d.dll</OutputFile>
+      <OutputFile>..\..\$(IcuBinOutputDir)\icuuc$(IcuMajorVersion)d.dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuucd.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuucd.lib</ImportLibrary>
     </Link>

--- a/icu4c/source/common/unicode/uvernum.h
+++ b/icu4c/source/common/unicode/uvernum.h
@@ -31,19 +31,12 @@
   *                    renaming macro, and copyright
   *
   * The following files need to be updated as well, which can be done
-  *  by running the UNIX makefile target 'update-windows-makefiles' in icu/source.
+  *  by running the UNIX makefile target 'update-windows-makefiles' in icu4c/source.
   *
-  *
-  * source/common/common_uwp.vcxproj
-  * source/common/common.vcxproj - update 'Output file name' on the link tab so
-  *                   that it contains the new major/minor combination
-  * source/i18n/i18n.vcxproj - same as for the common.vcxproj
-  * source/i18n/i18n_uwp.vcxproj - same as for the common_uwp.vcxproj
-  * source/layoutex/layoutex.vcproj - same
-  * source/stubdata/stubdata.vcproj - same as for the common.vcxproj
-  * source/io/io.vcproj - same as for the common.vcxproj
+  * source/allinone/Build.Windows.IcuVersion.props - Update the IcuMajorVersion
   * source/data/makedata.mak - change U_ICUDATA_NAME so that it contains
-  *                            the new major/minor combination and the Unicode version.
+  *                            the new major/minor combination, and UNICODE_VERSION
+  *                            for the Unicode version.
   */
 
 #ifndef UVERNUM_H

--- a/icu4c/source/config/windows-update.sed.in
+++ b/icu4c/source/config/windows-update.sed.in
@@ -4,5 +4,4 @@
 # sed script for updating windows .mak and .vcproj files
 s%^U_ICUDATA_NAME=.*%U_ICUDATA_NAME=icudt@LIB_VERSION_MAJOR@%
 s%^UNICODE_VERSION=.*%UNICODE_VERSION=@UNICODE_VERSION@%
-s%\(icu[a-zA-Z]*\)[0-9][0-9]\(d\.dll\)%\1@LIB_VERSION_MAJOR@\2%g
-s%\(icu[a-zA-Z]*\)[0-9][0-9]\(\.dll\)%\1@LIB_VERSION_MAJOR@\2%g
+s%\(<IcuMajorVersion>\)[0-9][0-9]%\1@LIB_VERSION_MAJOR@%g

--- a/icu4c/source/i18n/i18n.vcxproj
+++ b/icu4c/source/i18n/i18n.vcxproj
@@ -60,7 +60,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>icuucd.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>..\..\$(IcuBinOutputDir)\icuin71d.dll</OutputFile>
+      <OutputFile>..\..\$(IcuBinOutputDir)\icuin$(IcuMajorVersion)d.dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuind.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuind.lib</ImportLibrary>
     </Link>
@@ -73,7 +73,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>icuuc.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>..\..\$(IcuBinOutputDir)\icuin71.dll</OutputFile>
+      <OutputFile>..\..\$(IcuBinOutputDir)\icuin$(IcuMajorVersion).dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuin.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuin.lib</ImportLibrary>
     </Link>

--- a/icu4c/source/i18n/i18n_uwp.vcxproj
+++ b/icu4c/source/i18n/i18n_uwp.vcxproj
@@ -186,7 +186,7 @@
       <ProgramDataBaseFileName>.\x86\ReleaseUWP/</ProgramDataBaseFileName>
     </ClCompile>
     <Link>
-      <OutputFile>..\..\bin32uwp\icuin71.dll</OutputFile>
+      <OutputFile>..\..\bin32uwp\icuin$(IcuMajorVersion).dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\lib32uwp\icuin.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\lib32uwp\icuin.lib</ImportLibrary>
       <AdditionalDependencies>..\..\lib32uwp\icuuc.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -203,7 +203,7 @@
       <ProgramDataBaseFileName>.\x86\DebugUWP/</ProgramDataBaseFileName>
     </ClCompile>
     <Link>
-      <OutputFile>..\..\bin32uwp\icuin71d.dll</OutputFile>
+      <OutputFile>..\..\bin32uwp\icuin$(IcuMajorVersion)d.dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\lib32uwp\icuind.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\lib32uwp\icuind.lib</ImportLibrary>
       <AdditionalDependencies>..\..\lib32uwp\icuucd.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -220,7 +220,7 @@
       <ProgramDataBaseFileName>.\x64\ReleaseUWP/</ProgramDataBaseFileName>
     </ClCompile>
     <Link>
-      <OutputFile>..\..\bin64uwp\icuin71.dll</OutputFile>
+      <OutputFile>..\..\bin64uwp\icuin$(IcuMajorVersion).dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\lib64uwp\icuin.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\lib64uwp\icuin.lib</ImportLibrary>
       <AdditionalDependencies>..\..\lib64uwp\icuuc.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -237,7 +237,7 @@
       <ProgramDataBaseFileName>.\x64\DebugUWP/</ProgramDataBaseFileName>
     </ClCompile>
     <Link>
-      <OutputFile>..\..\bin64uwp\icuin71d.dll</OutputFile>
+      <OutputFile>..\..\bin64uwp\icuin$(IcuMajorVersion)d.dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\lib64uwp\icuind.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\lib64uwp\icuind.lib</ImportLibrary>
       <AdditionalDependencies>..\..\lib64uwp\icuucd.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -254,7 +254,7 @@
       <ProgramDataBaseFileName>.\ARM\ReleaseUWP/</ProgramDataBaseFileName>
     </ClCompile>
     <Link>
-      <OutputFile>..\..\binARMuwp\icuin71.dll</OutputFile>
+      <OutputFile>..\..\binARMuwp\icuin$(IcuMajorVersion).dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\libARMuwp\icuin.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\libARMuwp\icuin.lib</ImportLibrary>
       <AdditionalDependencies>..\..\libARMuwp\icuuc.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -271,7 +271,7 @@
       <ProgramDataBaseFileName>.\ARM\DebugUWP/</ProgramDataBaseFileName>
     </ClCompile>
     <Link>
-      <OutputFile>..\..\binARMuwp\icuin71d.dll</OutputFile>
+      <OutputFile>..\..\binARMuwp\icuin$(IcuMajorVersion)d.dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\libARMuwp\icuind.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\libARMuwp\icuind.lib</ImportLibrary>
       <AdditionalDependencies>..\..\libARMuwp\icuucd.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -288,7 +288,7 @@
       <ProgramDataBaseFileName>.\ARM64\ReleaseUWP/</ProgramDataBaseFileName>
     </ClCompile>
     <Link>
-      <OutputFile>..\..\binARM64uwp\icuin71.dll</OutputFile>
+      <OutputFile>..\..\binARM64uwp\icuin$(IcuMajorVersion).dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\libARM64uwp\icuin.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\libARM64uwp\icuin.lib</ImportLibrary>
       <AdditionalDependencies>..\..\libARM64uwp\icuuc.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -305,7 +305,7 @@
       <ProgramDataBaseFileName>.\ARM64\DebugUWP/</ProgramDataBaseFileName>
     </ClCompile>
     <Link>
-      <OutputFile>..\..\binARM64uwp\icuin71d.dll</OutputFile>
+      <OutputFile>..\..\binARM64uwp\icuin$(IcuMajorVersion)d.dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\libARM64uwp\icuind.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\libARM64uwp\icuind.lib</ImportLibrary>
       <AdditionalDependencies>..\..\libARM64uwp\icuucd.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/icu4c/source/io/io.vcxproj
+++ b/icu4c/source/io/io.vcxproj
@@ -60,7 +60,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <OutputFile>..\..\$(IcuBinOutputDir)\icuio71d.dll</OutputFile>
+      <OutputFile>..\..\$(IcuBinOutputDir)\icuio$(IcuMajorVersion)d.dll</OutputFile>
       <ProgramDatabaseFile>..\..\$(IcuLibOutputDir)\icuiod.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuiod.lib</ImportLibrary>
       <AdditionalDependencies>icuucd.lib;icuind.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -73,7 +73,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
     </ClCompile>
     <Link>
-      <OutputFile>..\..\$(IcuBinOutputDir)\icuio71.dll</OutputFile>
+      <OutputFile>..\..\$(IcuBinOutputDir)\icuio$(IcuMajorVersion).dll</OutputFile>
       <ProgramDatabaseFile>..\..\$(IcuLibOutputDir)\icuio.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuio.lib</ImportLibrary>
       <AdditionalDependencies>icuuc.lib;icuin.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/icu4c/source/layoutex/layoutex.vcxproj
+++ b/icu4c/source/layoutex/layoutex.vcxproj
@@ -54,7 +54,7 @@
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
-      <OutputFile>..\..\bin\iculx71.dll</OutputFile>
+      <OutputFile>..\..\bin\iculx$(IcuMajorVersion).dll</OutputFile>
       <AdditionalDependencies>icuuc.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>.\..\..\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\..\..\lib\iculx.pdb</ProgramDatabaseFile>
@@ -79,7 +79,7 @@
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
-      <OutputFile>..\..\bin\iculx71d.dll</OutputFile>
+      <OutputFile>..\..\bin\iculx$(IcuMajorVersion)d.dll</OutputFile>
       <AdditionalDependencies>icuucd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>.\..\..\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -104,7 +104,7 @@
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
-      <OutputFile>..\..\bin64\iculx71.dll</OutputFile>
+      <OutputFile>..\..\bin64\iculx$(IcuMajorVersion).dll</OutputFile>
       <AdditionalDependencies>icuuc.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>.\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>.\..\..\lib64\iculx.pdb</ProgramDatabaseFile>
@@ -127,7 +127,7 @@
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
-      <OutputFile>..\..\bin64\iculx71d.dll</OutputFile>
+      <OutputFile>..\..\bin64\iculx$(IcuMajorVersion)d.dll</OutputFile>
       <AdditionalDependencies>icuucd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>.\..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/icu4c/source/stubdata/stubdata.vcxproj
+++ b/icu4c/source/stubdata/stubdata.vcxproj
@@ -56,7 +56,7 @@
       <SetChecksum>true</SetChecksum>
       <TurnOffAssemblyGeneration>true</TurnOffAssemblyGeneration>
       <!-- Note: stubdata is somewhat odd in that it doesn't suffix the Debug output DLL/LIB with a "d" like common/i18n/etc. -->
-      <OutputFile>..\..\$(IcuBinOutputDir)\icudt71.dll</OutputFile>
+      <OutputFile>..\..\$(IcuBinOutputDir)\icudt$(IcuMajorVersion).dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icudt.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\$(IcuLibOutputDir)\icudt.lib</ImportLibrary>
     </Link>

--- a/icu4c/source/tools/ctestfw/ctestfw.vcxproj
+++ b/icu4c/source/tools/ctestfw/ctestfw.vcxproj
@@ -53,7 +53,7 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <OutputFile>..\..\..\$(IcuBinOutputDir)\icutest71d.exe</OutputFile>
+      <OutputFile>..\..\..\$(IcuBinOutputDir)\icutest$(IcuMajorVersion)d.exe</OutputFile>
       <ProgramDatabaseFile>.\..\..\..\$(IcuLibOutputDir)\icutestd.pdb</ProgramDatabaseFile>
       <ImportLibrary>.\..\..\..\$(IcuLibOutputDir)\icutestd.lib</ImportLibrary>
       <AdditionalDependencies>icuucd.lib;icutud.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -66,7 +66,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
     </ClCompile>
     <Link>
-      <OutputFile>..\..\..\$(IcuBinOutputDir)\icutest71.exe</OutputFile>
+      <OutputFile>..\..\..\$(IcuBinOutputDir)\icutest$(IcuMajorVersion).exe</OutputFile>
       <ProgramDatabaseFile>.\..\..\..\$(IcuLibOutputDir)\icutest.pdb</ProgramDatabaseFile>
       <ImportLibrary>.\..\..\..\$(IcuLibOutputDir)\icutest.lib</ImportLibrary>
       <AdditionalDependencies>icuuc.lib;icutu.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/icu4c/source/tools/toolutil/toolutil.vcxproj
+++ b/icu4c/source/tools/toolutil/toolutil.vcxproj
@@ -74,7 +74,7 @@
       <TypeLibraryName>.\..\..\..\lib\icutu.tlb</TypeLibraryName>
     </Midl>
     <Link>
-      <OutputFile>..\..\..\bin\icutu71.dll</OutputFile>
+      <OutputFile>..\..\..\bin\icutu$(IcuMajorVersion).dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\..\lib\icutu.pdb</ProgramDatabaseFile>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
@@ -86,7 +86,7 @@
       <TypeLibraryName>.\..\..\..\lib\icutud.tlb</TypeLibraryName>
     </Midl>
     <Link>
-      <OutputFile>..\..\..\bin\icutu71d.dll</OutputFile>
+      <OutputFile>..\..\..\bin\icutu$(IcuMajorVersion)d.dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\..\lib\icutud.pdb</ProgramDatabaseFile>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
@@ -113,7 +113,7 @@
       <WholeProgramOptimization>true</WholeProgramOptimization>
     </ClCompile>
     <Link>
-      <OutputFile>..\..\..\bin64\icutu71.dll</OutputFile>
+      <OutputFile>..\..\..\bin64\icutu$(IcuMajorVersion).dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\..\lib64\icutu.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\..\lib64\icutu.lib</ImportLibrary>
     </Link>
@@ -123,7 +123,7 @@
       <TypeLibraryName>.\..\..\..\lib64\icutud.tlb</TypeLibraryName>
     </Midl>
     <Link>
-      <OutputFile>..\..\..\bin64\icutu71d.dll</OutputFile>
+      <OutputFile>..\..\..\bin64\icutu$(IcuMajorVersion)d.dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\..\lib64\icutud.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\..\lib64\icutud.lib</ImportLibrary>
     </Link>
@@ -144,7 +144,7 @@
       <TypeLibraryName>..\..\..\libARM\icutu.tlb</TypeLibraryName>
     </Midl>
     <Link>
-      <OutputFile>..\..\..\binARM\icutu71.dll</OutputFile>
+      <OutputFile>..\..\..\binARM\icutu$(IcuMajorVersion).dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\..\libARM\icutu.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\..\libARM\icutu.lib</ImportLibrary>
     </Link>
@@ -157,7 +157,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <OutputFile>..\..\..\binARM\icutu71d.dll</OutputFile>
+      <OutputFile>..\..\..\binARM\icutu$(IcuMajorVersion)d.dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\..\libARM\icutud.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\..\libARM\icutud.lib</ImportLibrary>
     </Link>
@@ -178,7 +178,7 @@
       <TypeLibraryName>.\..\..\..\libARM64\icutu.tlb</TypeLibraryName>
     </Midl>
     <Link>
-      <OutputFile>..\..\..\binARM64\icutu71.dll</OutputFile>
+      <OutputFile>..\..\..\binARM64\icutu$(IcuMajorVersion).dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\..\libARM64\icutu.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\..\libARM64\icutu.lib</ImportLibrary>
     </Link>
@@ -191,7 +191,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <OutputFile>..\..\..\binARM64\icutu71d.dll</OutputFile>
+      <OutputFile>..\..\..\binARM64\icutu$(IcuMajorVersion)d.dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\..\libARM64\icutud.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\..\libARM64\icutud.lib</ImportLibrary>
     </Link>


### PR DESCRIPTION
By using a shared `.props` file with the ICU Major Version number, we can reduce the number of places that need to be edited in the Windows Visual Studio project files.
This means that there will be less churn when we do an ICU version update. With this change, we'll have 8 fewer files to edit.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21972
- [x] Required: The PR title must be prefixed with a JIRA Issue number.
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number.
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
