### PR TITLE
ICU-20715 Fix fuzzing problem in CollationDataBuilder.

### DIFF
--- a/icu4c/source/i18n/collationbuilder.cpp
+++ b/icu4c/source/i18n/collationbuilder.cpp
@@ -308,12 +308,14 @@ CollationBuilder::addReset(int32_t strength, const UnicodeString &str,
             return;
         }
         cesLength = dataBuilder->getCEs(nfdString, ces, 0, errorCode);
+        if (U_FAILURE(errorCode)) {
+            // NOTE: as of right now (3/25/22), the only error getCEs() returns is INPUT_TOO_LONG_ERROR
+            parserErrorReason = "exhausted maximum CONTRACTION_TAG value";
+            return;
+        }
         if(cesLength > Collation::MAX_EXPANSION_LENGTH) {
             errorCode = U_ILLEGAL_ARGUMENT_ERROR;
             parserErrorReason = "reset position maps to too many collation elements (more than 31)";
-            return;
-        } else if (errorCode == U_INPUT_TOO_LONG_ERROR) {
-            parserErrorReason = "exhausted maximum CONTRACTION_TAG value";
             return;
         }
     }
@@ -738,13 +740,15 @@ CollationBuilder::addRelation(int32_t strength, const UnicodeString &prefix,
             return;
         }
         cesLength = dataBuilder->getCEs(nfdExtension, ces, cesLength, errorCode);
+        if (U_FAILURE(errorCode)) {
+            // NOTE: as of right now (3/25/22), the only error getCEs() returns is INPUT_TOO_LONG_ERROR
+            parserErrorReason = "exhausted maximum CONTRACTION_TAG value";
+            return;
+        }
         if(cesLength > Collation::MAX_EXPANSION_LENGTH) {
             errorCode = U_ILLEGAL_ARGUMENT_ERROR;
             parserErrorReason =
                 "extension string adds too many collation elements (more than 31 total)";
-            return;
-        } else if (errorCode == U_INPUT_TOO_LONG_ERROR) {
-            parserErrorReason = "exhausted maximum CONTRACTION_TAG value";
             return;
         }
     }
@@ -1189,11 +1193,12 @@ CollationBuilder::addTailComposites(const UnicodeString &nfdPrefix, const Unicod
             continue;
         }
         int32_t newCEsLength = dataBuilder->getCEs(nfdPrefix, newNFDString, newCEs, 0, errorCode);
+        if (U_FAILURE(errorCode)) {
+            return;
+        }
         if(newCEsLength > Collation::MAX_EXPANSION_LENGTH) {
             // Ignore mappings that we cannot store.
             continue;
-        } else if (U_FAILURE(errorCode)) {
-            return;
         }
         // Note: It is possible that the newCEs do not make use of the mapping
         // for which we are adding the tail composites, in which case we might be adding

--- a/icu4c/source/i18n/collationdatabuilder.cpp
+++ b/icu4c/source/i18n/collationdatabuilder.cpp
@@ -290,10 +290,10 @@ CollationDataBuilder::CollationDataBuilder(UErrorCode &errorCode)
           base(NULL), baseSettings(NULL),
           trie(NULL),
           ce32s(errorCode), ce64s(errorCode), conditionalCE32s(errorCode),
-          modified(FALSE),
           lastContextIndex(0),
           lastContextCE32(0),
           lastContextWasSuffix(false),
+          modified(FALSE),
           fastLatinEnabled(FALSE), fastLatinBuilder(NULL),
           collIter(NULL) {
     // Reserve the first CE32 for U+0000.

--- a/icu4c/source/i18n/collationdatabuilder.cpp
+++ b/icu4c/source/i18n/collationdatabuilder.cpp
@@ -292,10 +292,10 @@ CollationDataBuilder::CollationDataBuilder(UErrorCode &errorCode)
           ce32s(errorCode), ce64s(errorCode), conditionalCE32s(errorCode),
           modified(FALSE),
           fastLatinEnabled(FALSE), fastLatinBuilder(NULL),
-          collIter(NULL),
           lastContextIndex(0),
           lastContextCE32(0),
-          lastContextWasSuffix(false) {
+          lastContextWasSuffix(false),
+          collIter(NULL) {
     // Reserve the first CE32 for U+0000.
     ce32s.addElement(0, errorCode);
     conditionalCE32s.setDeleter(uprv_deleteConditionalCE32);

--- a/icu4c/source/i18n/collationdatabuilder.cpp
+++ b/icu4c/source/i18n/collationdatabuilder.cpp
@@ -292,7 +292,10 @@ CollationDataBuilder::CollationDataBuilder(UErrorCode &errorCode)
           ce32s(errorCode), ce64s(errorCode), conditionalCE32s(errorCode),
           modified(FALSE),
           fastLatinEnabled(FALSE), fastLatinBuilder(NULL),
-          collIter(NULL) {
+          collIter(NULL),
+          lastContextIndex(0),
+          lastContextCE32(0),
+          lastContextWasSuffix(false) {
     // Reserve the first CE32 for U+0000.
     ce32s.addElement(0, errorCode);
     conditionalCE32s.setDeleter(uprv_deleteConditionalCE32);

--- a/icu4c/source/i18n/collationdatabuilder.cpp
+++ b/icu4c/source/i18n/collationdatabuilder.cpp
@@ -291,10 +291,10 @@ CollationDataBuilder::CollationDataBuilder(UErrorCode &errorCode)
           trie(NULL),
           ce32s(errorCode), ce64s(errorCode), conditionalCE32s(errorCode),
           modified(FALSE),
-          fastLatinEnabled(FALSE), fastLatinBuilder(NULL),
           lastContextIndex(0),
           lastContextCE32(0),
           lastContextWasSuffix(false),
+          fastLatinEnabled(FALSE), fastLatinBuilder(NULL),
           collIter(NULL) {
     // Reserve the first CE32 for U+0000.
     ce32s.addElement(0, errorCode);

--- a/icu4c/source/i18n/collationdatabuilder.h
+++ b/icu4c/source/i18n/collationdatabuilder.h
@@ -162,9 +162,9 @@ public:
      *
      * @return incremented cesLength
      */
-    int32_t getCEs(const UnicodeString &s, int64_t ces[], int32_t cesLength);
+    int32_t getCEs(const UnicodeString &s, int64_t ces[], int32_t cesLength, UErrorCode& errorCode);
     int32_t getCEs(const UnicodeString &prefix, const UnicodeString &s,
-                   int64_t ces[], int32_t cesLength);
+                   int64_t ces[], int32_t cesLength, UErrorCode& errorCode);
 
 protected:
     friend class CopyHelper;
@@ -214,11 +214,11 @@ protected:
     void buildContexts(UErrorCode &errorCode);
     uint32_t buildContext(ConditionalCE32 *head, UErrorCode &errorCode);
     int32_t addContextTrie(uint32_t defaultCE32, UCharsTrieBuilder &trieBuilder,
-                           UErrorCode &errorCode);
+                           UBool isSuffix, UErrorCode &errorCode);
 
     void buildFastLatinTable(CollationData &data, UErrorCode &errorCode);
 
-    int32_t getCEs(const UnicodeString &s, int32_t start, int64_t ces[], int32_t cesLength);
+    int32_t getCEs(const UnicodeString &s, int32_t start, int64_t ces[], int32_t cesLength, UErrorCode& errorCode);
 
     static UChar32 jamoCpFromIndex(int32_t i) {
         // 0 <= i < CollationData::JAMO_CE32S_LENGTH = 19 + 21 + 27
@@ -244,6 +244,9 @@ protected:
     UnicodeSet contextChars;
     // Serialized UCharsTrie structures for finalized contexts.
     UnicodeString contexts;
+    int32_t lastContextIndex;
+    uint32_t lastContextCE32;
+    UBool lastContextWasSuffix;
     UnicodeSet unsafeBackwardSet;
     UBool modified;
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-20715
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

Long explanation of what was wrong and how this fix addresses it:

The fuzzer was passing random garbage to the RuleBasedCollator constructor as a collation rule string.  If you try to parse the string as a set of collation rules, you wind up with a couple of very big contraction strings, each with a very large number of canonical-equivalent strings, and many also with before context.  Even though the crash (or ASAN failure) is in UCharsTrie, both UCharsTrie and its builder are working fine.  The problem is in the data structure that contains them.

The collator organizes all of its various before-context and after-context strings into a series of UCharsTrie structures, which are concatenated together and stored in a single UnicodeString (for simplicity).  We'll call this the "contexts array."  The collation element values that use these tries incorporate their absolute indexes into the contexts array.  For the final collator, this isn't a problem, but while the builder is building the collator, it puts lots of pressure on its contexts array.  Every time it encounters a new rule (or variant of an existing rule, as you get when expanding canonical equivalents) that has a context trie, it creates a new context trie and appends it to the end of the contexts array.  If the new context means updating an existing context trie, a new version of that trie is generated and appended to the end of the contexts array, effectively leaking the old version.

If the length of the contexts array exceeds Collation::MAX_INDEX, instead of bailing out and reporting an error, we were just clearing out the contexts array and re-adding the new trie to the now-empty contexts array.  In many cases, this would be fine, because everything in it was dead anyway, but in some cases (such as the fuzzing test), we'd have collation element values in other data structures that pointed to tries in the old contexts array and weren't rebuilt after that array was emptied.  The collation key would be pointing to a position in the contexts array that was either off the end or (in the fuzzing failure) no longer the root node of a UCharsTrie.  We'd try to traverse it as if it WERE the root note, and we'd run off the end of the array and either crash or trigger an ASAN failure.

So the fix was to change things so that if we exceeded Collation::MAX_INDEX, we'd dump out and report an error.  This involved adding "errorCode" parameters to a number of functions in the call chain that didn't already have them, so that the error could propagate back up to the RuleBasedCollator constructor.

Unfortunately, while this fix did solve the fuzzing problem (now we just dump out with an error, as we should), it caused genrb to fail (with the new error) while building the Japanese collation rules.  We were getting away with this before because everything in the contexts array at the point where it was cleared WAS dead and could be safely discarded.

An ideal solution to that problem would be to replace the builder's contexts array with some other type of structure that would let us throw out old tries when they get updated, or to rebuild the whole contexts array whenever one of the tries gets updated.  But both of these solutions would require us to use different collation element values that didn't depend on the physical location of the trie in the contexts array, or to update all the existing collation element values any time we regenerated the contexts array.  This was way too big a change for me to want to attempt without a lot of help from somebody who understands this code better than I do.

What I did instead was to add code that would check if the new trie being added to the contexts array is an update of the last trie that was added.  If so, we just overwrite the old version of the trie and reuse its collation-element value.  This saves a lot of space if you're repeatedly updating the same trie, which is what the Japanese rule set is actually doing, but it doesn't do much for you if there are multiple tries in the contexts array and they get updated in random order (or two get updated in alternating order, which happens if a rule has both before context AND a contraction).  It's enough to get the Japanese collator building, though, so I'm going with it and leaving a more comprehensive solution for later.

One more note about the fix: I'm detecting whether I'm updating the trie at the end of the contexts array by checking its defaultCE32 value.  This doesn't completely work, though-- if a rule has both before context and contractions, you get two different tries with the same defaultCE32 value: One for the before context (prefix) and a different one for the contraction information (suffixes).  I got around this by adding a flag that lets me differentiate between the two cases, but this is inelegant.

I didn't add a regression test for this fix because reusing the fuzzer test would give us a test that'd either crash or only show an error if you were using ASAN.  Explicitly running the fuzzer test using Frank's instructions above does show that the problem is fixed.

This is a C++-only fix.  I checked the Java code, and it DOES throw an exception in this situation, so it didn't have the same problem (and it was okay there because the Java code isn't used to build our collation data files).
