### PR TITLE
ICU-21965 fix utilities.jar module name

### DIFF
--- a/icu4j/build.xml
+++ b/icu4j/build.xml
@@ -1945,8 +1945,17 @@
         </javac>
 
         <mkdir dir="${cldr.util.out.dir}/lib"/>
+        <copy file="tools/build/manifest-utilities.stub" todir="${out.dir}">
+            <filterset>
+                <filter token="SPECVERSION" value="${jar.spec.version}"/>
+                <filter token="IMPLVERSION" value="${jar.impl.version}"/>
+                <filter token="COPYRIGHT" value="${jar.copyright.info}"/>
+                <filter token="EXECENV" value="${jar.exec.env}"/>
+            </filterset>
+        </copy>
         <jar jarfile="${cldr.util.out.dir}/lib/utilities.jar"
                 compress="true"
+                manifest="${out.dir}/manifest-utilities.stub"
                 basedir="${cldr.util.out.dir}/bin">
             <include name="com/ibm/icu/dev/util/*.class"/>
             <include name="com/ibm/icu/dev/tool/UOption*.class"/>

--- a/icu4j/tools/build/manifest-utilities.stub
+++ b/icu4j/tools/build/manifest-utilities.stub
@@ -1,0 +1,17 @@
+Manifest-Version: 1.0
+Specification-Title: International Components for Unicode for Java Utilities
+Specification-Version: @SPECVERSION@
+Specification-Vendor: Unicode, Inc.
+Implementation-Title: International Components for Unicode for Java Utilities
+Implementation-Version: @IMPLVERSION@
+Implementation-Vendor: Unicode, Inc.
+Implementation-Vendor-Id: org.unicode
+Bundle-ManifestVersion: 2
+Bundle-Name: ICU4JUtilities
+Bundle-Description: International Components for Unicode for Java Utilities
+Bundle-SymbolicName: com.ibm.icu.utilities
+Bundle-Version: @IMPLVERSION@
+Bundle-Vendor: Unicode, Inc.
+Bundle-Copyright: @COPYRIGHT@
+Bundle-RequiredExecutionEnvironment: @EXECENV@
+Automatic-Module-Name: com.ibm.icu.utilities


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-21965

com.ibm.icu.utilities - otherwise the automatic module name is unusable

this is on maint-71