### PR TITLE
ICU-21679 avoid escape of U+FFFF in a character literal

### DIFF
--- a/icu4c/source/test/intltest/usettest.cpp
+++ b/icu4c/source/test/intltest/usettest.cpp
@@ -279,7 +279,7 @@ UnicodeSetTest::TestPatterns(void) {
     // Throw in a test of complement
     set.complement();
     UnicodeString exp;
-    exp.append((UChar)0x0000).append("aeeoouu").append((UChar)(u'z'+1)).append(u'\uFFFF');
+    exp.append((UChar)0x0000).append("aeeoouu").append((UChar)(u'z'+1)).append((UChar)0xFFFF);
     expectPairs(set, exp);
 }
 


### PR DESCRIPTION
Workaround for a gcc 4.9 bug.
Nice for users who work on legacy platforms (RHEL5 and RHEL5_64), with gcc version 4.9.
This partially reverts one line of the changes in https://github.com/unicode-org/icu/pull/1522.
While working on that PR, I already had to change the escape of U+0000 back to the cast -- on the same line of test code.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21679
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
