### PR TITLE
ICU-21960 Add missing "const" to kAttributeKey

### DIFF
--- a/icu4c/source/common/localebuilder.cpp
+++ b/icu4c/source/common/localebuilder.cpp
@@ -15,7 +15,7 @@ U_NAMESPACE_BEGIN
 #define UPRV_ISDIGIT(c) (((c) >= '0') && ((c) <= '9'))
 #define UPRV_ISALPHANUM(c) (uprv_isASCIILetter(c) || UPRV_ISDIGIT(c) )
 
-const char* kAttributeKey = "attribute";
+constexpr const char* kAttributeKey = "attribute";
 
 static bool _isExtensionSubtags(char key, const char* s, int32_t len) {
     switch (uprv_tolower(key)) {


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-21960 minor warning fixes

This variable was flagged by a chromium check that looks for variables named like constants that end up in the `.data` ELF section (rather than in `.rodata`).