### PR TITLE
ICU-22010 Add early check for AX_CHECK_COMPILE_FLAG

### DIFF
--- a/icu4c/source/configure.ac
+++ b/icu4c/source/configure.ac
@@ -199,6 +199,8 @@ fi
 #AC_CHECK_PROG(AUTOCONF, autoconf, autoconf, true)
 #AC_CHECK_PROG(STRIP, strip, strip, true)
 
+m4_ifndef([AX_CHECK_COMPILE_FLAG], [AC_MSG_ERROR(['autoconf-archive' is missing])])
+
 # TODO(ICU-20301): Remove fallback to Python 2.
 AC_CHECK_PROGS(PYTHON, python3 "py -3" python "py")
 AC_SUBST(PYTHON)


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-22010

This helps to avoid misleading error message:

```
./source/configure: line 7981: syntax error near unexpected token 'newline'
./source/configure: line 7981: 'AX_CHECK_COMPILE_FLAG('
```

This is the original GitHub Issue: 
https://github.com/microsoft/vcpkg/issues/24361

