### PR TITLE
ICU-22016 utrie2.h need not include mutex.h

### DIFF
--- a/icu4c/source/common/utrie2.h
+++ b/icu4c/source/common/utrie2.h
@@ -591,8 +591,8 @@ U_CDECL_END
 
 #ifdef __cplusplus
 
+#include "unicode/uobject.h"
 #include "unicode/utf.h"
-#include "mutex.h"
 
 U_NAMESPACE_BEGIN
 

--- a/icu4c/source/i18n/uspoof_impl.h
+++ b/icu4c/source/i18n/uspoof_impl.h
@@ -28,6 +28,7 @@
 #ifdef __cplusplus
 
 #include "capi_helper.h"
+#include "umutex.h"
 
 U_NAMESPACE_BEGIN
 


### PR DESCRIPTION
... and adjust uspoof_impl.h which depended on utrie2.h for the indirect inclusion of umutex.h

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22016
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
