### PR TITLE
ICU-22017 Test cases showing the failing of NumberFormat::forSkeleton while there are numbering-system in skeleton

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -140,7 +140,7 @@ jobs:
       env:
         CC: gcc-11
         CXX: g++-11
-        CXXFLAGS: '-std=c++20 -fext-numeric-literals'
+        CXXFLAGS: '-std=c++20 -fext-numeric-literals -Werror'
 #-------------------------------------------------------------------------
 - job: ICU4C_Clang_Ubuntu_2004_LANG
   displayName: 'C: Linux Clang (Ubuntu 20.04) - LANG has extension tags'

--- a/icu4c/source/test/intltest/numbertest.h
+++ b/icu4c/source/test/intltest/numbertest.h
@@ -326,6 +326,7 @@ class NumberRangeFormatterTest : public IntlTestWithFieldPosition {
     void test21684_Performance();
     void test21358_SignPosition();
     void test21683_StateLeak();
+    void testCreateLNRFFromNumberingSystemInSkeleton();
 
     void runIndexedTest(int32_t index, UBool exec, const char *&name, char *par = 0) override;
 

--- a/icu4c/source/test/intltest/numbertest_range.cpp
+++ b/icu4c/source/test/intltest/numbertest_range.cpp
@@ -57,6 +57,7 @@ void NumberRangeFormatterTest::runIndexedTest(int32_t index, UBool exec, const c
         TESTCASE_AUTO(test21684_Performance);
         TESTCASE_AUTO(test21358_SignPosition);
         TESTCASE_AUTO(test21683_StateLeak);
+        TESTCASE_AUTO(testCreateLNRFFromNumberingSystemInSkeleton);
     TESTCASE_AUTO_END;
 }
 
@@ -1028,6 +1029,34 @@ void NumberRangeFormatterTest::test21358_SignPosition() {
             .numberFormatterBoth(NumberFormatter::forSkeleton(u"%", status));
         UnicodeString actual = lnrf.formatFormattableRange(2, -3, status).toString(status);
         assertEquals("Positive to negative percent", u"2% – -3%", actual);
+    }
+}
+
+void NumberRangeFormatterTest::testCreateLNRFFromNumberingSystemInSkeleton() {
+    IcuTestErrorCode status(*this, "testCreateLNRFFromNumberingSystemInSkeleton");
+    {
+        LocalizedNumberRangeFormatter lnrf = NumberRangeFormatter::withLocale("en")
+            .numberFormatterBoth(NumberFormatter::forSkeleton(
+                u".### rounding-mode-half-up", status));
+        UnicodeString actual = lnrf.formatFormattableRange(1, 234, status).toString(status);
+        assertEquals("default numbering system", u"1–234", actual);
+        status.errIfFailureAndReset("default numbering system");
+    }
+    {
+        LocalizedNumberRangeFormatter lnrf = NumberRangeFormatter::withLocale("th")
+            .numberFormatterBoth(NumberFormatter::forSkeleton(
+                u".### rounding-mode-half-up numbering-system/thai", status));
+        UnicodeString actual = lnrf.formatFormattableRange(1, 234, status).toString(status);
+        assertEquals("Thai numbering system", u"๑-๒๓๔", actual);
+        status.errIfFailureAndReset("thai numbering system");
+    }
+    {
+        LocalizedNumberRangeFormatter lnrf = NumberRangeFormatter::withLocale("en")
+            .numberFormatterBoth(NumberFormatter::forSkeleton(
+                u".### rounding-mode-half-up numbering-system/arab", status));
+        UnicodeString actual = lnrf.formatFormattableRange(1, 234, status).toString(status);
+        assertEquals("Arabic numbering system", u"١–٢٣٤", actual);
+        status.errIfFailureAndReset("arab numbering system");
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [ ] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
- [ ] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
