### PR TITLE
ICU-22023 Fix Calendar::get() return out of bound value and SimpleDateTime::format assert while TimeZone is "UTC" and value is -1e-9

### DIFF
--- a/icu4c/source/i18n/cecal.cpp
+++ b/icu4c/source/i18n/cecal.cpp
@@ -135,7 +135,7 @@ CECalendar::jdToCE(int32_t julianDay, int32_t jdEpochOffset, int32_t& year, int3
     int32_t c4; // number of 4 year cycle (1461 days)
     int32_t r4; // remainder of 4 year cycle, always positive
 
-    c4 = ClockMath::floorDivide(julianDay - jdEpochOffset, 1461, r4);
+    c4 = ClockMath::floorDivide(julianDay - jdEpochOffset, 1461, &r4);
 
     year = 4 * c4 + (r4/365 - r4/1460); // 4 * <number of 4year cycle> + <years within the last cycle>
 

--- a/icu4c/source/i18n/chnsecal.cpp
+++ b/icu4c/source/i18n/chnsecal.cpp
@@ -328,7 +328,7 @@ int32_t ChineseCalendar::handleComputeMonthStart(int32_t eyear, int32_t month, U
     // modify the extended year value accordingly.
     if (month < 0 || month > 11) {
         double m = month;
-        eyear += (int32_t)ClockMath::floorDivide(m, 12.0, m);
+        eyear += (int32_t)ClockMath::floorDivide(m, 12.0, &m);
         month = (int32_t)m;
     }
 
@@ -727,7 +727,7 @@ void ChineseCalendar::computeChineseFields(int32_t days, int32_t gyear, int32_t 
 
         // 0->0,60  1->1,1  60->1,60  61->2,1  etc.
         int32_t yearOfCycle;
-        int32_t cycle = ClockMath::floorDivide(cycle_year - 1, 60, yearOfCycle);
+        int32_t cycle = ClockMath::floorDivide(cycle_year - 1, 60, &yearOfCycle);
         internalSet(UCAL_ERA, cycle + 1);
         internalSet(UCAL_YEAR, yearOfCycle + 1);
 

--- a/icu4c/source/i18n/gregocal.cpp
+++ b/icu4c/source/i18n/gregocal.cpp
@@ -388,7 +388,7 @@ void GregorianCalendar::handleComputeFields(int32_t julianDay, UErrorCode& statu
         // The Julian epoch day (not the same as Julian Day)
         // is zero on Saturday December 30, 0 (Gregorian).
         int32_t julianEpochDay = julianDay - (kJan1_1JulianDay - 2);
-		eyear = (int32_t) ClockMath::floorDivide((4.0*julianEpochDay) + 1464.0, (int32_t) 1461, unusedRemainder);
+		eyear = (int32_t) ClockMath::floorDivide((4.0*julianEpochDay) + 1464.0, (int32_t) 1461, &unusedRemainder);
 
         // Compute the Julian calendar day number for January 1, eyear
         int32_t january1 = 365*(eyear-1) + ClockMath::floorDivide(eyear-1, (int32_t)4);
@@ -537,7 +537,7 @@ int32_t GregorianCalendar::handleComputeMonthStart(int32_t eyear, int32_t month,
     // If the month is out of range, adjust it into range, and
     // modify the extended year value accordingly.
     if (month < 0 || month > 11) {
-        eyear += ClockMath::floorDivide(month, 12, month);
+        eyear += ClockMath::floorDivide(month, 12, &month);
     }
 
     UBool isLeap = eyear%4 == 0;
@@ -580,7 +580,7 @@ int32_t GregorianCalendar::handleGetMonthLength(int32_t extendedYear, int32_t mo
     // If the month is out of range, adjust it into range, and
     // modify the extended year value accordingly.
     if (month < 0 || month > 11) {
-        extendedYear += ClockMath::floorDivide(month, 12, month);
+        extendedYear += ClockMath::floorDivide(month, 12, &month);
     }
 
     return isLeapYear(extendedYear) ? kLeapMonthLength[month] : kMonthLength[month];

--- a/icu4c/source/i18n/gregoimp.cpp
+++ b/icu4c/source/i18n/gregoimp.cpp
@@ -33,28 +33,33 @@ int64_t ClockMath::floorDivide(int64_t numerator, int64_t denominator) {
 }
 
 int32_t ClockMath::floorDivide(double numerator, int32_t denominator,
-                          int32_t& remainder) {
-    double quotient;
-    quotient = uprv_floor(numerator / denominator);
-    remainder = (int32_t) (numerator - (quotient * denominator));
+                          int32_t* remainder) {
+    // For an integer n and representable ⌊x/n⌋, ⌊RN(x/n)⌋=⌊x/n⌋, where RN is
+    // rounding to nearest.
+    double quotient = uprv_floor(numerator / denominator);
+    // For doubles x and n, where n is an integer and ⌊x+n⌋ < 2³¹, the
+    // expression `(int32_t) (x + n)` evaluated with rounding to nearest
+    // differs from ⌊x+n⌋ if 0 < ⌈x⌉−x ≪ x+n, as `x + n` is rounded up to
+    // n+⌈x⌉ = ⌊x+n⌋ + 1.  Rewriting it as ⌊x⌋+n makes the addition exact.
+    *remainder = (int32_t) (uprv_floor(numerator) - (quotient * denominator));
     return (int32_t) quotient;
 }
 
 double ClockMath::floorDivide(double dividend, double divisor,
-                         double& remainder) {
+                         double* remainder) {
     // Only designed to work for positive divisors
     U_ASSERT(divisor > 0);
     double quotient = floorDivide(dividend, divisor);
-    remainder = dividend - (quotient * divisor);
+    *remainder = dividend - (quotient * divisor);
     // N.B. For certain large dividends, on certain platforms, there
     // is a bug such that the quotient is off by one.  If you doubt
     // this to be true, set a breakpoint below and run cintltst.
-    if (remainder < 0 || remainder >= divisor) {
+    if (*remainder < 0 || *remainder >= divisor) {
         // E.g. 6.7317038241449352e+022 / 86400000.0 is wrong on my
         // machine (too high by one).  4.1792057231752762e+024 /
         // 86400000.0 is wrong the other way (too low).
         double q = quotient;
-        quotient += (remainder < 0) ? -1 : +1;
+        quotient += (*remainder < 0) ? -1 : +1;
         if (q == quotient) {
             // For quotients > ~2^53, we won't be able to add or
             // subtract one, since the LSB of the mantissa will be >
@@ -65,12 +70,12 @@ double ClockMath::floorDivide(double dividend, double divisor,
             // values give back an approximate answer rather than
             // crashing.  For example, UDate values above a ~10^25
             // might all have a time of midnight.
-            remainder = 0;
+            *remainder = 0;
         } else {
-            remainder = dividend - (quotient * divisor);
+            *remainder = dividend - (quotient * divisor);
         }
     }
-    U_ASSERT(0 <= remainder && remainder < divisor);
+    U_ASSERT(0 <= *remainder && *remainder < divisor);
     return quotient;
 }
 
@@ -106,10 +111,10 @@ void Grego::dayToFields(double day, int32_t& year, int32_t& month,
     // representation.  We use 400-year, 100-year, and 4-year cycles.
     // For example, the 4-year cycle has 4 years + 1 leap day; giving
     // 1461 == 365*4 + 1 days.
-    int32_t n400 = ClockMath::floorDivide(day, 146097, doy); // 400-year cycle length
-    int32_t n100 = ClockMath::floorDivide(doy, 36524, doy); // 100-year cycle length
-    int32_t n4   = ClockMath::floorDivide(doy, 1461, doy); // 4-year cycle length
-    int32_t n1   = ClockMath::floorDivide(doy, 365, doy);
+    int32_t n400 = ClockMath::floorDivide(day, 146097, &doy); // 400-year cycle length
+    int32_t n100 = ClockMath::floorDivide(doy, 36524, &doy); // 100-year cycle length
+    int32_t n4   = ClockMath::floorDivide(doy, 1461, &doy); // 4-year cycle length
+    int32_t n1   = ClockMath::floorDivide(doy, 365, &doy);
     year = 400*n400 + 100*n100 + 4*n4 + n1;
     if (n100 == 4 || n1 == 4) {
         doy = 365; // Dec 31 at end of 4- or 400-year cycle
@@ -137,14 +142,14 @@ void Grego::dayToFields(double day, int32_t& year, int32_t& month,
 void Grego::timeToFields(UDate time, int32_t& year, int32_t& month,
                         int32_t& dom, int32_t& dow, int32_t& doy, int32_t& mid) {
     double millisInDay;
-    double day = ClockMath::floorDivide((double)time, (double)U_MILLIS_PER_DAY, millisInDay);
+    double day = ClockMath::floorDivide((double)time, (double)U_MILLIS_PER_DAY, &millisInDay);
     mid = (int32_t)millisInDay;
     dayToFields(day, year, month, dom, dow, doy);
 }
 
 int32_t Grego::dayOfWeek(double day) {
     int32_t dow;
-    ClockMath::floorDivide(day + int{UCAL_THURSDAY}, 7, dow);
+    ClockMath::floorDivide(day + int{UCAL_THURSDAY}, 7, &dow);
     return (dow == 0) ? UCAL_SATURDAY : dow;
 }
 

--- a/icu4c/source/i18n/gregoimp.h
+++ b/icu4c/source/i18n/gregoimp.h
@@ -78,7 +78,7 @@ class ClockMath {
      * @return the floor of the quotient
      */
     static int32_t floorDivide(double numerator, int32_t denominator,
-                               int32_t& remainder);
+                               int32_t* remainder);
 
     /**
      * For a positive divisor, return the quotient and remainder
@@ -91,7 +91,7 @@ class ClockMath {
      * Calling with a divisor <= 0 is disallowed.
      */
     static double floorDivide(double dividend, double divisor,
-                              double& remainder);
+                              double* remainder);
 };
 
 // Useful millisecond constants

--- a/icu4c/source/i18n/indiancal.cpp
+++ b/icu4c/source/i18n/indiancal.cpp
@@ -110,7 +110,7 @@ static UBool isGregorianLeap(int32_t year)
  */
 int32_t IndianCalendar::handleGetMonthLength(int32_t eyear, int32_t month) const {
    if (month < 0 || month > 11) {
-      eyear += ClockMath::floorDivide(month, 12, month);
+      eyear += ClockMath::floorDivide(month, 12, &month);
    }
 
    if (isGregorianLeap(eyear + INDIAN_ERA_START) && month == 0) {
@@ -210,7 +210,7 @@ int32_t IndianCalendar::handleComputeMonthStart(int32_t eyear, int32_t month, UB
 
     // If the month is out of range, adjust it into range, and adjust the extended year accordingly
    if (month < 0 || month > 11) {
-      eyear += (int32_t)ClockMath::floorDivide(month, 12, month);
+      eyear += (int32_t)ClockMath::floorDivide(month, 12, &month);
    }
 
    if(month == 12){

--- a/icu4c/source/i18n/persncal.cpp
+++ b/icu4c/source/i18n/persncal.cpp
@@ -110,7 +110,7 @@ int32_t PersianCalendar::handleGetLimit(UCalendarDateFields field, ELimitType li
 UBool PersianCalendar::isLeapYear(int32_t year)
 {
     int32_t remainder;
-    ClockMath::floorDivide(25 * year + 11, 33, remainder);
+    ClockMath::floorDivide(25 * year + 11, 33, &remainder);
     return (remainder < 8);
 }
     
@@ -147,7 +147,7 @@ int32_t PersianCalendar::handleGetMonthLength(int32_t extendedYear, int32_t mont
     // If the month is out of range, adjust it into range, and
     // modify the extended year value accordingly.
     if (month < 0 || month > 11) {
-        extendedYear += ClockMath::floorDivide(month, 12, month);
+        extendedYear += ClockMath::floorDivide(month, 12, &month);
     }
 
     return isLeapYear(extendedYear) ? kPersianLeapMonthLength[month] : kPersianMonthLength[month];
@@ -169,7 +169,7 @@ int32_t PersianCalendar::handleComputeMonthStart(int32_t eyear, int32_t month, U
     // If the month is out of range, adjust it into range, and
     // modify the extended year value accordingly.
     if (month < 0 || month > 11) {
-        eyear += ClockMath::floorDivide(month, 12, month);
+        eyear += ClockMath::floorDivide(month, 12, &month);
     }
 
     int32_t julianDay = PERSIAN_EPOCH - 1 + 365 * (eyear - 1) + ClockMath::floorDivide(8 * eyear + 21, 33);

--- a/icu4c/source/i18n/simpletz.cpp
+++ b/icu4c/source/i18n/simpletz.cpp
@@ -518,9 +518,8 @@ SimpleTimeZone::getOffsetFromLocal(UDate date, UTimeZoneLocalOption nonExistingT
     }
 
     rawOffsetGMT = getRawOffset();
-    int32_t year, month, dom, dow;
-    double day = uprv_floor(date / U_MILLIS_PER_DAY);
-    int32_t millis = (int32_t) (date - day * U_MILLIS_PER_DAY);
+    int32_t year, month, dom, dow, millis;
+    int32_t day = ClockMath::floorDivide(date, U_MILLIS_PER_DAY, &millis);
 
     Grego::dayToFields(day, year, month, dom, dow);
 
@@ -549,8 +548,7 @@ SimpleTimeZone::getOffsetFromLocal(UDate date, UTimeZoneLocalOption nonExistingT
         }
     }
     if (recalc) {
-        day = uprv_floor(date / U_MILLIS_PER_DAY);
-        millis = (int32_t) (date - day * U_MILLIS_PER_DAY);
+        day = ClockMath::floorDivide(date, U_MILLIS_PER_DAY, &millis);
         Grego::dayToFields(day, year, month, dom, dow);
         savingsDST = getOffset(GregorianCalendar::AD, year, month, dom,
                           (uint8_t) dow, millis,

--- a/icu4c/source/i18n/timezone.cpp
+++ b/icu4c/source/i18n/timezone.cpp
@@ -729,9 +729,8 @@ void TimeZone::getOffset(UDate date, UBool local, int32_t& rawOffset,
     // (with 7 args) twice when local == true and DST is
     // detected in the initial call.
     for (int32_t pass=0; ; ++pass) {
-        int32_t year, month, dom, dow;
-        double day = uprv_floor(date / U_MILLIS_PER_DAY);
-        int32_t millis = (int32_t) (date - day * U_MILLIS_PER_DAY);
+        int32_t year, month, dom, dow, millis;
+        double day = ClockMath::floorDivide(date, U_MILLIS_PER_DAY, &millis);
 
         Grego::dayToFields(day, year, month, dom, dow);
 

--- a/icu4c/source/test/intltest/calregts.h
+++ b/icu4c/source/test/intltest/calregts.h
@@ -81,12 +81,14 @@ public:
     void TestPersianCalOverflow(void);
     void TestIslamicCalOverflow(void);
     void TestWeekOfYear13548(void);
+    void TestUTCWrongAMPM22023(void);
 
     void Test13745(void);
 
     void printdate(GregorianCalendar *cal, const char *string);
     void dowTest(UBool lenient) ;
 
+    void VerifyGetStayInBound(double test_value);
 
     static UDate getAssociatedDate(UDate d, UErrorCode& status);
     static UDate makeDate(int32_t y, int32_t m = 0, int32_t d = 0, int32_t hr = 0, int32_t min = 0, int32_t sec = 0);

--- a/icu4c/source/test/intltest/dtfmttst.cpp
+++ b/icu4c/source/test/intltest/dtfmttst.cpp
@@ -130,6 +130,7 @@ void DateFormatTest::runIndexedTest( int32_t index, UBool exec, const char* &nam
     TESTCASE_AUTO(TestParseRegression13744);
     TESTCASE_AUTO(TestAdoptCalendarLeak);
     TESTCASE_AUTO(Test20741_ABFields);
+    TESTCASE_AUTO(Test22023_UTCWithMinusZero);
 
     TESTCASE_AUTO_END;
 }
@@ -5724,6 +5725,22 @@ void DateFormatTest::Test20741_ABFields() {
             }
         }
     }
+}
+
+void DateFormatTest::Test22023_UTCWithMinusZero() {
+    IcuTestErrorCode status(*this, "Test22023_UTCWithMinusZero");
+    Locale locale("en");
+    SimpleDateFormat fmt("h a", locale, status);
+    ASSERT_OK(status);
+    fmt.adoptCalendar(Calendar::createInstance(
+        TimeZone::createTimeZone("UTC"), locale, status));
+    ASSERT_OK(status);
+    FieldPositionIterator fp_iter;
+    icu::UnicodeString formatted;
+    // very small negative value in double cause it to be -0
+    // internally and trigger the assertion and bug.
+    fmt.format(-1e-9, formatted, &fp_iter, status);
+    ASSERT_OK(status);
 }
 
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/test/intltest/dtfmttst.h
+++ b/icu4c/source/test/intltest/dtfmttst.h
@@ -266,6 +266,7 @@ public:
     void TestParseRegression13744();
     void TestAdoptCalendarLeak();
     void Test20741_ABFields();
+    void Test22023_UTCWithMinusZero();
 
 private:
     UBool showParse(DateFormat &format, const UnicodeString &formattedString);


### PR DESCRIPTION
This PR fix several issures related to Calendar::get() return value out of bound
defined by Calendar::getMinimum() and Calendar::getMaximum() while
the Date is a tiny negative value ( between 0 and -1e-9) and the TimeZone is
 "UTC". It also fix the issue while Calendar::get() return error under the same 
condition.

The issue is caused by a tiny value of x (0 .. -1e-9) and a huge value of y (> 1e8)
in the form of 
int32_t w = (int32_t)(x + y); while both x and y are double.
This produce a 1-off rounding error.
We fix it by change it by wrapping x with uprv_floor. This appeared in several places 
related to timezone code and we fix them all in this PR

We also add U_ASSERT to check the bound for most fields except fields of year which
has not real hard constrain of range.

We add two new test cases to demostrate the problem w/o the fix.
intltest format/DateFormatTest/Test22023_UTCWithMinusZero
intltest format/CalendarRegressionTest/TestUTCWrongAMPM22023

We also notice there are unit test to [test ZONE_OFFSET with 30 hours](https://github.com/unicode-org/icu/blob/369357aaa7ff13553ac9943de31d2e69f9313de4/icu4c/source/test/intltest/tzfmttst.cpp#L913) and [DST_OFFSET with -1 hour](https://github.com/unicode-org/icu/blob/369357aaa7ff13553ac9943de31d2e69f9313de4/icu4c/source/test/intltest/tzregts.cpp#L1230) so we change the limit to ensure it will not assert under those test condition since both thes two  bound should not impact the caller.

We also found in [time zone “Antarctica/Troll” the DST is 2 hours (7200s) ](https://github.com/unicode-org/icu/blob/main/icu4c/source/data/misc/zoneinfo64.txt#:~:text=Antarctica/Troll)  so we also change the maximum DST_OFFSET
from 1 hour to 2 hours. (see https://unicode-org.atlassian.net/browse/ICU-22031)
 
Also change the function signature of the three parameters floorDivision so the output parameter
is pointer instead of ref to make it clear from the calling code that value could be changed instead of
implicit side effect via reference passing.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22023
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
