### PR TITLE
ICU-22030 Modifies GHA CI performance testing so that existing files …

### DIFF
--- a/.github/workflows/icu_merge_ci.yml
+++ b/.github/workflows/icu_merge_ci.yml
@@ -197,3 +197,4 @@ jobs:
           external_repository: unicode-org/icu-perf
           publish_branch: main
           publish_dir: ./perf
+          keep_files: true


### PR DESCRIPTION
…in the

performance results publishing repository are no longer deleted when the test
results are forwarded. This concretely affects the README file in the icu-perf
repository, which got deleted with the first data transfer.

Restoring the README file in icu-perf will be a complementary PR.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [ ] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22030.
- [ ] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
