### PR TITLE
ICU-22041 Fix "Africa/Casablanca" show strange LONG displayName

### DIFF
--- a/icu4c/source/i18n/olsontz.cpp
+++ b/icu4c/source/i18n/olsontz.cpp
@@ -430,8 +430,7 @@ void OlsonTimeZone::setRawOffset(int32_t /*offsetMillis*/) {
 int32_t OlsonTimeZone::getRawOffset() const {
     UErrorCode ec = U_ZERO_ERROR;
     int32_t raw, dst;
-    getOffset((double) uprv_getUTCtime() * U_MILLIS_PER_SECOND,
-              FALSE, raw, dst, ec);
+    getOffset(uprv_getUTCtime(), FALSE, raw, dst, ec);
     return raw;
 }
 

--- a/icu4c/source/i18n/rbtz.cpp
+++ b/icu4c/source/i18n/rbtz.cpp
@@ -479,8 +479,7 @@ RuleBasedTimeZone::getRawOffset(void) const {
     // as of current time.
     UErrorCode status = U_ZERO_ERROR;
     int32_t raw, dst;
-    getOffset(uprv_getUTCtime() * U_MILLIS_PER_SECOND,
-        FALSE, raw, dst, status);
+    getOffset(uprv_getUTCtime(), FALSE, raw, dst, status);
     return raw;
 }
 
@@ -490,7 +489,7 @@ RuleBasedTimeZone::useDaylightTime(void) const {
     // daylight saving time is used as of now or
     // after the next transition.
     UErrorCode status = U_ZERO_ERROR;
-    UDate now = uprv_getUTCtime() * U_MILLIS_PER_SECOND;
+    UDate now = uprv_getUTCtime();
     int32_t raw, dst;
     getOffset(now, FALSE, raw, dst, status);
     if (dst != 0) {

--- a/icu4c/source/test/intltest/tztest.cpp
+++ b/icu4c/source/test/intltest/tztest.cpp
@@ -76,6 +76,8 @@ void TimeZoneTest::runIndexedTest( int32_t index, UBool exec, const char* &name,
     TESTCASE_AUTO(TestGetGMT);
     TESTCASE_AUTO(TestGetWindowsID);
     TESTCASE_AUTO(TestGetIDForWindowsID);
+    TESTCASE_AUTO(TestCasablancaNameAndOffset22041);
+    TESTCASE_AUTO(TestRawOffsetAndOffsetConsistency22041);
     TESTCASE_AUTO_END;
 }
 
@@ -2544,4 +2546,41 @@ void TimeZoneTest::TestGetIDForWindowsID(void) {
     }
 }
 
+void TimeZoneTest::TestCasablancaNameAndOffset22041(void) {
+    std::unique_ptr<TimeZone> zone(TimeZone::createTimeZone("Africa/Casablanca"));
+    UnicodeString standardName, summerName;
+    zone->getDisplayName(false, TimeZone::LONG, Locale::getEnglish(), standardName);
+    zone->getDisplayName(true, TimeZone::LONG, Locale::getEnglish(), summerName);
+    int32_t raw, dst;
+    UErrorCode status = U_ZERO_ERROR;
+    zone->getOffset(Calendar::getNow(), false, raw, dst, status);
+    assertEquals(u"TimeZone name for Africa/Casablanca should not contain '+02' since it is located in UTC, but got "
+                 + standardName, -1, standardName.indexOf("+02"));
+    assertEquals(u"TimeZone name for Africa/Casablanca should not contain '+02' since it is located in UTC, but got "
+                 + summerName, -1, summerName.indexOf("+02"));
+    assertEquals("getRawOffset() and the raw from getOffset(now, false, raw, dst, status) should not be different but got",
+                 zone->getRawOffset(), raw);
+}
+
+void TimeZoneTest::TestRawOffsetAndOffsetConsistency22041(void) {
+    UErrorCode status = U_ZERO_ERROR;
+    LocalPointer<StringEnumeration> s(TimeZone::createEnumeration(status));
+    if (U_FAILURE(status)) {
+        dataerrln("Unable to create TimeZone enumeration");
+        return;
+    }
+    const char* tz;
+    UDate now = Calendar::getNow();
+    while ((tz = s->next(nullptr, status)) != nullptr && U_SUCCESS(status)) {
+        std::unique_ptr<TimeZone> zone(TimeZone::createTimeZone(tz));
+        int32_t raw, dst;
+        zone->getOffset(now, false, raw, dst, status);
+        if (U_FAILURE(status)) {
+           errln("TimeZone '%s' getOffset() return error", tz);
+        }
+        assertEquals(u"TimeZone '" + UnicodeString(tz) +
+                     u"' getRawOffset() and the raw from getOffset(now, false, raw, dst, status) should not be different but got",
+                     zone->getRawOffset(), raw);
+    }
+}
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/test/intltest/tztest.h
+++ b/icu4c/source/test/intltest/tztest.h
@@ -103,6 +103,8 @@ public:
 
     void TestGetWindowsID(void);
     void TestGetIDForWindowsID(void);
+    void TestCasablancaNameAndOffset22041(void);
+    void TestRawOffsetAndOffsetConsistency22041(void);
 
     static const UDate INTERVAL;
 

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/timezone/TimeZoneTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/timezone/TimeZoneTest.java
@@ -2323,6 +2323,36 @@ public class TimeZoneTest extends TestFmwk
         assertFalse("Compare TimeZoneAdapter with TimeZone", icuChicagoWrapped.equals(icuChicago));
         assertTrue("Compare two TimeZoneAdapters", icuChicagoWrapped.equals(icuChicagoWrapped2));
     }
+
+    @Test
+    public void TestCasablancaNameAndOffset22041() {
+        String id = "Africa/Casablanca";
+        TimeZone zone = TimeZone.getTimeZone(id);
+        String standardName = zone.getDisplayName(false, TimeZone.LONG, Locale.ENGLISH);
+        String summerName = zone.getDisplayName(true, TimeZone.LONG, Locale.ENGLISH);
+        assertEquals("TimeZone name for Africa/Casablanca should not contain '+02' since it is located in UTC, but got "
+                     + standardName, -1, standardName.indexOf("+02"));
+        assertEquals("TimeZone name for Africa/Casablanca should not contain '+02' since it is located in UTC, but got "
+                     + summerName, -1, summerName.indexOf("+02"));
+        int[] offsets = new int[2]; // raw = offsets[0], dst = offsets[1]
+        zone.getOffset((new Date()).getTime(), false, offsets);
+        int raw = offsets[0];
+        assertEquals("getRawOffset() and the raw from getOffset(now, false, offset) should not be different but got",
+                     zone.getRawOffset(), raw);
+    }
+
+    @Test
+    public void TestRawOffsetAndOffsetConsistency22041() {
+        long now = (new Date()).getTime();
+        int[] offsets = new int[2]; // raw = offsets[0], dst = offsets[1]
+        for (String id : TimeZone.getAvailableIDs()) {
+            TimeZone zone = TimeZone.getTimeZone(id);
+            zone.getOffset((new Date()).getTime(), false, offsets);
+            int raw = offsets[0];
+            assertEquals("getRawOffset() and the raw from getOffset(now, false, offset) should not be different but got",
+                         zone.getRawOffset(), raw);
+        }
+    }
 }
 
 //eof


### PR DESCRIPTION
Fix incorrect raw offset and display name of "Africa/Casablanca" caused by 
extra `* U_MILLIS_PER_SECOND` before using return value of 
uprv_getUTCtime() which is already in ms per source/common/putilimp.h


Adding test to show the issue
The code is currently only printout in -v mode
Running (notice the -v parameter)
```
LD_LIBRARY_PATH=lib:stubdata:tools/ctestfw:../../lib:../../stubdata:../../tools/ctestfw:$LD_LIBRARY_PATH  ./intltest format/TimeZoneTest/TestCasablancaNameAndOffset22041 -v
```
get
```
-----------------------------------------------
 IntlTest (C++) Test Suite for                 
   International Components for Unicode 72.0.1
   Bits: 64, Byte order: Little endian, Chars: ASCII
-----------------------------------------------
 Options:                                       
   all (a)                  : Off
   Verbose (v)              : On
   No error messages (n)    : Off
   Exhaustive (e)           : Off
   Leaks (l)                : Off
   utf-8 (u)                : Off
   notime (T)               : Off
   noknownissues (K)        : Off
   Warn on missing data (w) : Off
   Write golden data (G)    : Off
   Threads                  : 12
-----------------------------------------------

=== Handling test: format/TimeZoneTest/TestCasablancaNameAndOffset22041: ===
   format {
   TestSuite Format---
   
      TimeZoneTest {
      TestSuite Format: 
      TimeZoneTest test---
      
         TestCasablancaNameAndOffset22041 {
         TestSuite TestTimeZone
         TestCasablancaNameAndOffset22041---
         
         Normal Name: GMT+01:00
         Summer Name: GMT+02:00
         getRawOffset() return 3600000
         
         getOffset(Calendar::getNow(), false, raw, dst, status) return raw=0 dst=3600000 status=0
         
         } OK:   TestCasablancaNameAndOffset22041 
      } OK:   TimeZoneTest 
   } OK:   format 

```

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22041
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
