### PR TITLE
ICU-21946 RBBI Break Cache Optimizations

### DIFF
--- a/icu4c/source/test/intltest/rbbitst.h
+++ b/icu4c/source/test/intltest/rbbitst.h
@@ -95,6 +95,7 @@ public:
     void TestBug13590();
     void TestLSTMThai();
     void TestLSTMBurmese();
+    void TestRandomAccess();
 
 #if U_ENABLE_TRACING
     void TestTraceCreateCharacter();


### PR DESCRIPTION
Adjust RuleBasedBreakIterator::BreakCache::populateNear() to retain
the cache contents in additional cases where they are still useful, resulting in
improved performance.

This change is related to PR #2039, which addressed the same problem. This one
retains the cache contents in more situations.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21946
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
