### PR TITLE
ICU-21957 improve logKnownIssue skip for FormattedStringBuilderTest::testInsertOverflow crash

### DIFF
--- a/icu4c/source/test/intltest/formatted_string_builder_test.cpp
+++ b/icu4c/source/test/intltest/formatted_string_builder_test.cpp
@@ -311,7 +311,7 @@ void FormattedStringBuilderTest::testCodePoints() {
 }
 
 void FormattedStringBuilderTest::testInsertOverflow() {
-    if (quick) return;
+    if (quick || logKnownIssue("22047", "FormattedStringBuilder with long length crashes in toUnicodeString in CI Linux tests")) return;
     
     // Setup the test fixture in sb, sb2, ustr.
     UErrorCode status = U_ZERO_ERROR;
@@ -330,17 +330,16 @@ void FormattedStringBuilderTest::testInsertOverflow() {
     infoln("# log: setup 2 done, sb2 len %d, status %s", sb2.length(), u_errorName(status));
     assertSuccess("Setup the second FormattedStringBuilder", status);
 
-    if (!logKnownIssue("22047", "FormattedStringBuilder with long length crashes in toUnicodeString in CI Linux tests")) {
-        // The following should set ustr to have length 1610612734, but is currently crashing
-        // in the CI test "C: Linux Clang Exhaustive Tests (Ubuntu 18.04)", though not
-        // crashing when running exhaustive tests locally on e.g. macOS 12.4 on Intel).
-        // Skipping this leaves ustr with length 1073741823.
-        ustr = sb2.toUnicodeString();
-    } else {
-        // Alternative approach which sets ustr to length 1073741871, still long
-        // enough to test the expected behavior for the remainder of the code here.
-        ustr.append(u"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",-1);
-    }
+    // The following should set ustr to have length 1610612734, but is currently crashing
+    // in the CI test "C: Linux Clang Exhaustive Tests (Ubuntu 18.04)", though not
+    // crashing when running exhaustive tests locally on e.g. macOS 12.4 on Intel).
+    // Hence the logKnownIssue skip above.
+    ustr = sb2.toUnicodeString();
+    // Note that trying the following alternative approach which sets ustr to length 1073741871
+    // (still long enough to test the expected behavior for the remainder of the code here)
+    // also crashed in "C: Linux Clang Exhaustive Tests (Ubuntu 18.04)":
+    // ustr.append(u"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",-1);
+
     // Complete setting up the test fixture in sb, sb2 and ustr.
     infoln("# log: setup 3 done, ustr len %d", ustr.length());
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21957
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable

The logKnownIssue skip that was added in PR #2103 to address the unrelated exhaustive test crash in FormattedStringBuilderTest::testInsertOverflow() did not quite skip the crash; the additional change in this PR does.
- See the bug about the problem being skipped with logKnownIssue: https://unicode-org.atlassian.net/browse/ICU-22047
- The crash may be related to the following change in FormattedStringBuilder per https://unicode-org.atlassian.net/browse/ICU-22005 (Integer overflow leading to OOB/CHECK in icu_71::FormattedStringBuilder::prepareForInsertHelper): PR #2070