### PR TITLE
ICU-22068 Cleanup inconsistent annotations between declarations and d…

### DIFF
--- a/icu4c/source/common/filteredbrk.cpp
+++ b/icu4c/source/common/filteredbrk.cpp
@@ -58,7 +58,7 @@ static int32_t U_CALLCONV compareUnicodeString(UElement t1, UElement t2) {
 /**
  * A UVector which implements a set of strings.
  */
-class U_COMMON_API UStringSet : public UVector {
+class UStringSet : public UVector {
  public:
   UStringSet(UErrorCode &status) : UVector(uprv_deleteUObject,
                                            uhash_compareUnicodeString,
@@ -482,7 +482,7 @@ SimpleFilteredSentenceBreakIterator::last(void) {
 /**
  * Concrete implementation of builder class.
  */
-class U_COMMON_API SimpleFilteredBreakIteratorBuilder : public FilteredBreakIteratorBuilder {
+class SimpleFilteredBreakIteratorBuilder : public FilteredBreakIteratorBuilder {
 public:
   virtual ~SimpleFilteredBreakIteratorBuilder();
   SimpleFilteredBreakIteratorBuilder(const Locale &fromLocale, UErrorCode &status);

--- a/icu4c/source/common/unicode/utf_old.h
+++ b/icu4c/source/common/unicode/utf_old.h
@@ -293,10 +293,10 @@ typedef int32_t UTextOffset;
 #ifdef U_UTF8_IMPL
 // No forward declaration if compiling utf_impl.cpp, which defines utf8_countTrailBytes.
 #elif defined(U_STATIC_IMPLEMENTATION) || defined(U_COMMON_IMPLEMENTATION)
-U_CFUNC const uint8_t utf8_countTrailBytes[];
+U_CAPI const uint8_t utf8_countTrailBytes[];
 #else
-U_CFUNC U_IMPORT const uint8_t utf8_countTrailBytes[];    /* U_IMPORT2? */ /*U_IMPORT*/
-#endif
+U_CFUNC U_IMPORT const uint8_t utf8_countTrailBytes[];
+#endif 
 
 /**
  * Count the trail bytes for a UTF-8 lead byte.

--- a/icu4c/source/common/unifiedcache.cpp
+++ b/icu4c/source/common/unifiedcache.cpp
@@ -45,20 +45,20 @@ U_CDECL_END
 
 U_NAMESPACE_BEGIN
 
-U_CAPI int32_t U_EXPORT2
+int32_t U_EXPORT2
 ucache_hashKeys(const UHashTok key) {
     const CacheKeyBase *ckey = (const CacheKeyBase *) key.pointer;
     return ckey->hashCode();
 }
 
-U_CAPI UBool U_EXPORT2
+UBool U_EXPORT2
 ucache_compareKeys(const UHashTok key1, const UHashTok key2) {
     const CacheKeyBase *p1 = (const CacheKeyBase *) key1.pointer;
     const CacheKeyBase *p2 = (const CacheKeyBase *) key2.pointer;
     return *p1 == *p2;
 }
 
-U_CAPI void U_EXPORT2
+void U_EXPORT2
 ucache_deleteKey(void *obj) {
     CacheKeyBase *p = (CacheKeyBase *) obj;
     delete p;

--- a/icu4c/source/common/utf_impl.cpp
+++ b/icu4c/source/common/utf_impl.cpp
@@ -55,7 +55,7 @@
  * -finish:
  * (BSR: Bit Scan Reverse, scans for a 1-bit, starting from the MSB)
  */
-extern "C" U_EXPORT const uint8_t
+U_CAPI const uint8_t
 utf8_countTrailBytes[256]={
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/icu4c/source/i18n/collation.cpp
+++ b/icu4c/source/i18n/collation.cpp
@@ -20,15 +20,6 @@
 
 U_NAMESPACE_BEGIN
 
-// Some compilers don't care if constants are defined in the .cpp file.
-// MS Visual C++ does not like it, but gcc requires it. clang does not care.
-#ifndef _MSC_VER
-const uint8_t Collation::LEVEL_SEPARATOR_BYTE;
-const uint8_t Collation::MERGE_SEPARATOR_BYTE;
-const uint32_t Collation::ONLY_TERTIARY_MASK;
-const uint32_t Collation::CASE_AND_TERTIARY_MASK;
-#endif
-
 uint32_t
 Collation::incTwoBytePrimaryByOffset(uint32_t basePrimary, UBool isCompressible, int32_t offset) {
     // Extract the second byte, minus the minimum byte value,

--- a/icu4c/source/i18n/collationbuilder.cpp
+++ b/icu4c/source/i18n/collationbuilder.cpp
@@ -191,13 +191,6 @@ RuleBasedCollator::internalBuildTailoring(const UnicodeString &rules,
 
 // CollationBuilder implementation ----------------------------------------- ***
 
-// Some compilers don't care if constants are defined in the .cpp file.
-// MS Visual C++ does not like it, but gcc requires it. clang does not care.
-#ifndef _MSC_VER
-const int32_t CollationBuilder::HAS_BEFORE2;
-const int32_t CollationBuilder::HAS_BEFORE3;
-#endif
-
 CollationBuilder::CollationBuilder(const CollationTailoring *b, UBool icu4xMode, UErrorCode &errorCode)
         : nfd(*Normalizer2::getNFDInstance(errorCode)),
           fcd(*Normalizer2Factory::getFCDInstance(errorCode)),

--- a/icu4c/source/i18n/collationdatabuilder.cpp
+++ b/icu4c/source/i18n/collationdatabuilder.cpp
@@ -109,7 +109,7 @@ struct ConditionalCE32 : public UMemory {
 
 U_CDECL_BEGIN
 
-U_CAPI void U_CALLCONV
+void U_CALLCONV
 uprv_deleteConditionalCE32(void *obj) {
     delete static_cast<ConditionalCE32 *>(obj);
 }

--- a/icu4c/source/i18n/collationtailoring.h
+++ b/icu4c/source/i18n/collationtailoring.h
@@ -24,6 +24,8 @@
 #include "collationsettings.h"
 #include "uhash.h"
 #include "umutex.h"
+#include "unifiedcache.h"
+ 
 
 struct UDataMemory;
 struct UResourceBundle;
@@ -105,6 +107,10 @@ struct U_I18N_API CollationCacheEntry : public SharedObject {
     const CollationTailoring *tailoring;
 };
 
+template<> U_I18N_API
+const CollationCacheEntry *
+LocaleCacheKey<CollationCacheEntry>::createObject(const void *creationContext,
+                                                  UErrorCode &errorCode) const;
 U_NAMESPACE_END
 
 #endif  // !UCONFIG_NO_COLLATION

--- a/icu4c/source/i18n/datefmt.cpp
+++ b/icu4c/source/i18n/datefmt.cpp
@@ -46,7 +46,7 @@
 
 U_NAMESPACE_BEGIN
 
-class U_I18N_API DateFmtBestPattern : public SharedObject {
+class DateFmtBestPattern : public SharedObject {
 public:
     UnicodeString fPattern;
 
@@ -58,14 +58,14 @@ public:
 DateFmtBestPattern::~DateFmtBestPattern() {
 }
 
-template<> U_I18N_API
+template<> 
 const DateFmtBestPattern *LocaleCacheKey<DateFmtBestPattern>::createObject(
         const void * /*creationContext*/, UErrorCode &status) const {
     status = U_UNSUPPORTED_ERROR;
     return NULL;
 }
 
-class U_I18N_API DateFmtBestPatternKey : public LocaleCacheKey<DateFmtBestPattern> { 
+class DateFmtBestPatternKey : public LocaleCacheKey<DateFmtBestPattern> { 
 private:
     UnicodeString fSkeleton;
 protected:

--- a/icu4c/source/i18n/decContext.h
+++ b/icu4c/source/i18n/decContext.h
@@ -262,7 +262,6 @@
   U_CAPI decContext  * U_EXPORT2 uprv_decContextSetStatusFromStringQuiet(decContext *, const char *);
   U_CAPI decContext  * U_EXPORT2 uprv_decContextSetStatusQuiet(decContext *, uint32_t);
   U_CAPI const char  * U_EXPORT2 uprv_decContextStatusToString(const decContext *);
-  U_CAPI int32_t       U_EXPORT2 uprv_decContextTestEndian(uint8_t);
   U_CAPI uint32_t      U_EXPORT2 uprv_decContextTestSavedStatus(uint32_t, uint32_t);
   U_CAPI uint32_t      U_EXPORT2 uprv_decContextTestStatus(decContext *, uint32_t);
   U_CAPI decContext  * U_EXPORT2 uprv_decContextZeroStatus(decContext *);

--- a/icu4c/source/i18n/measfmt.cpp
+++ b/icu4c/source/i18n/measfmt.cpp
@@ -239,7 +239,7 @@ static NumericDateFormatters *loadNumericDateFormatters(
     return result;
 }
 
-template<> U_I18N_API
+template<> 
 const MeasureFormatCacheData *LocaleCacheKey<MeasureFormatCacheData>::createObject(
         const void * /*unused*/, UErrorCode &status) const {
     const char *localeId = fLoc.getName();

--- a/icu4c/source/i18n/reldatefmt.cpp
+++ b/icu4c/source/i18n/reldatefmt.cpp
@@ -701,7 +701,7 @@ static UBool getDateTimePattern(
     return getStringByIndex(topLevel.getAlias(), dateTimeFormatOffset, result, status);
 }
 
-template<> U_I18N_API
+template<> 
 const RelativeDateTimeCacheData *LocaleCacheKey<RelativeDateTimeCacheData>::createObject(const void * /*unused*/, UErrorCode &status) const {
     const char *localeId = fLoc.getName();
     LocalUResourceBundlePointer topLevel(ures_open(nullptr, localeId, &status));

--- a/icu4c/source/i18n/scriptset.h
+++ b/icu4c/source/i18n/scriptset.h
@@ -83,4 +83,7 @@ uhash_hashScriptSet(const UElement key);
 U_CAPI void U_EXPORT2
 uhash_deleteScriptSet(void *obj);
 
-#endif // __SCRIPTSET_H__
+U_CAPI UBool U_EXPORT2
+uhash_equalsScriptSet(const UElement key1, const UElement key2);
+
+#endif // __SCRIPTSET_H_

--- a/icu4c/source/i18n/sharedcalendar.h
+++ b/icu4c/source/i18n/sharedcalendar.h
@@ -13,6 +13,7 @@
 
 #include "unicode/utypes.h"
 #include "sharedobject.h"
+#include "unifiedcache.h"
 
 U_NAMESPACE_BEGIN
 
@@ -30,6 +31,11 @@ private:
     SharedCalendar(const SharedCalendar &) = delete;
     SharedCalendar &operator=(const SharedCalendar &) = delete;
 };
+
+template<> U_I18N_API
+const SharedCalendar *LocaleCacheKey<SharedCalendar>::createObject(
+        const void * /*unusedCreationContext*/, UErrorCode &status) const;
+
 
 U_NAMESPACE_END
 

--- a/icu4c/source/i18n/shareddateformatsymbols.h
+++ b/icu4c/source/i18n/shareddateformatsymbols.h
@@ -17,6 +17,7 @@
 
 #include "sharedobject.h"
 #include "unicode/dtfmtsym.h"
+#include "unifiedcache.h"
 
 U_NAMESPACE_BEGIN
 
@@ -33,6 +34,11 @@ private:
     SharedDateFormatSymbols(const SharedDateFormatSymbols &) = delete;
     SharedDateFormatSymbols &operator=(const SharedDateFormatSymbols &) = delete;
 };
+
+template<> U_I18N_API
+const SharedDateFormatSymbols *
+        LocaleCacheKey<SharedDateFormatSymbols>::createObject(
+            const void * /*unusedContext*/, UErrorCode &status) const;
 
 U_NAMESPACE_END
 

--- a/icu4c/source/i18n/sharednumberformat.h
+++ b/icu4c/source/i18n/sharednumberformat.h
@@ -13,6 +13,7 @@
 
 #include "unicode/utypes.h"
 #include "sharedobject.h"
+#include "unifiedcache.h"
 
 U_NAMESPACE_BEGIN
 
@@ -30,6 +31,10 @@ private:
     SharedNumberFormat(const SharedNumberFormat &) = delete;
     SharedNumberFormat &operator=(const SharedNumberFormat &) = delete;
 };
+
+template<> U_I18N_API
+const SharedNumberFormat *LocaleCacheKey<SharedNumberFormat>::createObject(
+        const void * /*unused*/, UErrorCode &status) const;
 
 U_NAMESPACE_END
 

--- a/icu4c/source/i18n/sharedpluralrules.h
+++ b/icu4c/source/i18n/sharedpluralrules.h
@@ -13,6 +13,7 @@
 
 #include "unicode/utypes.h"
 #include "sharedobject.h"
+#include "unifiedcache.h"
 
 U_NAMESPACE_BEGIN
 
@@ -29,6 +30,10 @@ private:
     SharedPluralRules(const SharedPluralRules &) = delete;
     SharedPluralRules &operator=(const SharedPluralRules &) =delete;
 };
+
+template<> U_I18N_API
+const SharedPluralRules *LocaleCacheKey<SharedPluralRules>::createObject(
+        const void * /*unused*/, UErrorCode &status) const;
 
 U_NAMESPACE_END
 

--- a/icu4c/source/stubdata/BUILD.bazel
+++ b/icu4c/source/stubdata/BUILD.bazel
@@ -16,6 +16,7 @@ package(
 cc_library(
     name = "stubdata",
     srcs = ["stubdata.cpp"],
+    hdrs = ["stubdata.h"],
     deps = ["//icu4c/source/common:headers"],
     local_defines = [
         "U_COMMON_IMPLEMENTATION",

--- a/icu4c/source/stubdata/stubdata.cpp
+++ b/icu4c/source/stubdata/stubdata.cpp
@@ -19,26 +19,8 @@
 *   for running the data building tools.
 *
 */
-#include "unicode/utypes.h"
-#include "unicode/udata.h"
-#include "unicode/uversion.h"
 
-
-typedef struct {
-    uint16_t headerSize;
-    uint8_t magic1, magic2;
-    UDataInfo info;
-    char padding[8];
-    uint32_t count, reserved;
-    /*
-    const struct {
-    const char *const name; 
-    const void *const data;
-    } toc[1];
-    */
-   int   fakeNameAndData[4];       /* TODO:  Change this header type from */
-                                   /*        pointerTOC to OffsetTOC.     */
-} ICU_Data_Header;
+#include "stubdata.h"
 
 extern "C" U_EXPORT const ICU_Data_Header U_ICUDATA_ENTRY_POINT = {
     32,          /* headerSize */

--- a/icu4c/source/stubdata/stubdata.h
+++ b/icu4c/source/stubdata/stubdata.h
@@ -1,0 +1,52 @@
+// © 2016 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+/******************************************************************************
+*
+*   Copyright (C) 2001, International Business Machines
+*   Corporation and others.  All Rights Reserved.
+*
+*******************************************************************************
+*   file name:  stubdata.h
+*
+*   This header file is intended to be internal and only included in the 
+*   accompanying implementation file. This file declares a single entry
+*   point for visibility of tools like TAPI.
+*
+*   Define initialized data that will build into a valid, but empty
+*   ICU data library.  Used to bootstrap the ICU build, which has these
+*   dependencies:
+*       ICU Common library depends on ICU data
+*       ICU data requires data building tools.
+*       ICU data building tools require the ICU common library.
+*
+*   The stub data library (for which this file is the source) is sufficient
+*   for running the data building tools.
+*
+*/
+
+#ifndef __STUBDATA_H__
+#define __STUBDATA_H__
+
+#include "unicode/utypes.h"
+#include "unicode/udata.h"
+#include "unicode/uversion.h"
+
+typedef struct {
+    uint16_t headerSize;
+    uint8_t magic1, magic2;
+    UDataInfo info;
+    char padding[8];
+    uint32_t count, reserved;
+    /*
+    const struct {
+    const char *const name;
+    const void *const data;
+    } toc[1];
+    */
+   int   fakeNameAndData[4];       /* TODO:  Change this header type from */
+                                   /*        pointerTOC to OffsetTOC.     */
+} ICU_Data_Header;
+
+extern "C" U_EXPORT const ICU_Data_Header U_ICUDATA_ENTRY_POINT;
+
+#endif /* __STUBDATA_H__ */


### PR DESCRIPTION
…efinitions

This cleans up inconsistent annotations between declared APIs in headers
vs defined implementations in cpp's. This better ensures the API's
referenceable in headers represent what is exposed and defined in the
ultimate binary library's symbol table.

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22068
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable (current regression tests should suffice) 
- [ ] API docs and/or User Guide docs changed or added, if applicable
