### PR TITLE
ICU-22086 Add ibm-clang_r/ibm-clang++_r to runConfigureICU

### DIFF
--- a/icu4c/source/runConfigureICU
+++ b/icu4c/source/runConfigureICU
@@ -38,6 +38,7 @@ The following names can be supplied as the argument for platform:
 
     AIX                 Use the IBM XL xlclang/xlclang compilers on AIX
     AIX/GCC             Use the GNU gcc/g++ compilers on AIX
+    AIX/OpenXL          Use the IBM Open XL ibm-clang_r/ibm-clang++_r compilers on AIX
     Cygwin              Use the GNU gcc/g++ compilers on Cygwin
     Cygwin/MSVC         Use the Microsoft Visual C++ compiler on Cygwin
     Cygwin/MSVC2005     Use the Microsoft Visual C++ 2005 compiler on Cygwin
@@ -154,6 +155,20 @@ case $platform in
         DEBUG_CFLAGS='-g -O0'
         DEBUG_CXXFLAGS='-g -O0'
         ;;
+    AIX/OpenXL)
+        THE_OS=AIX
+        THE_COMP="ibm-clang_r"
+        CC=`which ibm-clang_r`; export CC
+        if [ ! -x $CC ]; then
+           echo "ERROR: ibm-clang_r was not found, please check the PATH to make sure it is correct."; exit 1
+        fi
+        CXX=`which ibm-clang++_r`; export CXX
+        if [ ! -x $CXX ]; then
+           echo "ERROR: ibm-clang++_r was not found, please check the PATH to make sure it is correct."; exit 1
+        fi
+        RELEASE_CFLAGS="-O3"
+        RELEASE_CXXFLAGS="-O3"
+	;;
     Solaris)
         THE_OS=SOLARIS
         THE_COMP="Sun's CC"


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

Currently `runConfigureICU` supports the `xlclang` and `xlclang++` compilers from IBM XL C/C++ 16.1.0. The latest major release is IBM Open XL C/C++ 17.1.0 and has renamed the compilers to `ibm-clang_r` and `ibm-clang++_r`, both of which are now effectively pure `clang`/`clang++` variants which no longer support any of the old -q options.

This PR adds support for using these compilers to `runConfigureICU`.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22086
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
