### PR TITLE
ICU-21939 Fix bogus "conflicting fields" error in DateIntervalFormat.

### DIFF
--- a/icu4c/source/test/intltest/dtifmtts.cpp
+++ b/icu4c/source/test/intltest/dtifmtts.cpp
@@ -65,6 +65,7 @@ void DateIntervalFormatTest::runIndexedTest( int32_t index, UBool exec, const ch
     TESTCASE_AUTO(testTicket21222GregorianEraDiff);
     TESTCASE_AUTO(testTicket21222ROCEraDiff);
     TESTCASE_AUTO(testTicket21222JapaneseEraDiff);
+    TESTCASE_AUTO(testTicket21939);
     TESTCASE_AUTO_END;
 }
 
@@ -2370,6 +2371,18 @@ void DateIntervalFormatTest::testTicket21222JapaneseEraDiff() {
                  u"H31/3/2 午前6時～R1/5/4 午前6時",
                  formatted.toString(status));
     verifyCategoryAndField(formatted, expectedCategory, expectedField, status);
+}
+
+void DateIntervalFormatTest::testTicket21939() {
+    IcuTestErrorCode err(*this, "testTicket21939");
+    LocalPointer<DateIntervalFormat> dif(DateIntervalFormat::createInstance(u"rMdhm", Locale::forLanguageTag("en-u-ca-chinese", err), err));
+    
+    if (assertSuccess("Error creating DateIntervalFormat", err)) {
+        const DateFormat* df = dif->getDateFormat();
+        const SimpleDateFormat* sdf = dynamic_cast<const SimpleDateFormat*>(df);
+        UnicodeString pattern;
+        assertEquals("Wrong pattern", u"M/d/r, h:mm\u202Fa", sdf->toPattern(pattern));
+    }
 }
 
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/test/intltest/dtifmtts.h
+++ b/icu4c/source/test/intltest/dtifmtts.h
@@ -88,6 +88,8 @@ public:
     void testTicket21222GregorianEraDiff();
     void testTicket21222ROCEraDiff();
     void testTicket21222JapaneseEraDiff();
+    
+    void testTicket21939();
 
 private:
     /**

--- a/icu4j/main/classes/core/src/com/ibm/icu/text/DateTimePatternGenerator.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/DateTimePatternGenerator.java
@@ -2804,8 +2804,8 @@ public class DateTimePatternGenerator implements Freezable<DateTimePatternGenera
                     char ch1 = original.getFieldChar(field);
                     char ch2 = value.charAt(0);
                     if ( allowDuplicateFields ||
-                            (ch1 == 'r' && ch2 == 'U') ||
-                            (ch1 == 'U' && ch2 == 'r') ) {
+                            (ch1 == 'r' && (ch2 == 'U' || ch2 == 'y')) ||
+                            ((ch1 == 'U' || ch1 == 'y') && ch2 == 'r') ) {
                         continue;
                     }
                     throw new IllegalArgumentException("Conflicting fields:\t"

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/DateIntervalFormatTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/DateIntervalFormatTest.java
@@ -2481,4 +2481,14 @@ public class DateIntervalFormatTest extends TestFmwk {
                      formatted.toString());
         verifyFields(formatted, expectedFields);
     }
+    
+    @Test
+    public void testTicket21939() {
+        // the test here is just to check that this particular skeleton doesn't
+        // lead to an IllegalArgumentException
+        DateIntervalFormat dif = DateIntervalFormat.getInstance("rMdhm", ULocale.forLanguageTag("en-u-ca-chinese"));
+        DateFormat df = dif.getDateFormat();
+        SimpleDateFormat sdf = (SimpleDateFormat)df;
+        assertEquals("Wrong date format", "M/d/r, h:mm\u202Fa", sdf.toPattern());
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21939
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
