### PR TITLE
ICU-22075 Reduces concurrency of encoding converter performance tests…

### DIFF
--- a/.github/workflows/icu_merge_ci.yml
+++ b/.github/workflows/icu_merge_ci.yml
@@ -440,74 +440,30 @@ jobs:
       matrix:
         source_text: [arabic, english, french, greek, hebrew, hindi, japanese, korean, s-chinese]
         perf: [TestCharsetDecoderICU, TestCharsetEncoderICU]
-        test_enc: [UTF-8]
         include:
+          - test_enc: UTF-8
           - test_enc: csisolatinarabic
             source_text: arabic
-            perf: TestCharsetDecoderICU
-          - test_enc: csisolatinarabic
-            source_text: arabic
-            perf: TestCharsetEncoderICU
           - test_enc: csisolatin1
             source_text: french
-            perf: TestCharsetDecoderICU
-          - test_enc: csisolatin1
-            source_text: french
-            perf: TestCharsetEncoderICU
           - test_enc: csisolatingreek
             source_text: greek
-            perf: TestCharsetDecoderICU
-          - test_enc: csisolatingreek
-            source_text: greek
-            perf: TestCharsetEncoderICU
           - test_enc: csisolatinhebrew
             source_text: hebrew
-            perf: TestCharsetDecoderICU
-          - test_enc: csisolatinhebrew
-            source_text: hebrew
-            perf: TestCharsetEncoderICU
           - test_enc: EUC-JP
             source_text: japanese
-            perf: TestCharsetDecoderICU
-          - test_enc: EUC-JP
-            source_text: japanese
-            perf: TestCharsetEncoderICU
           - test_enc: csiso2022jp
             source_text: japanese
-            perf: TestCharsetDecoderICU
-          - test_enc: csiso2022jp
-            source_text: japanese
-            perf: TestCharsetEncoderICU
           - test_enc: csiso2022kr
             source_text: korean
-            perf: TestCharsetDecoderICU
-          - test_enc: csiso2022kr
-            source_text: korean
-            perf: TestCharsetEncoderICU
           - test_enc: EUC-CN
             source_text: s-chinese
-            perf: TestCharsetDecoderICU
-          - test_enc: EUC-CN
-            source_text: s-chinese
-            perf: TestCharsetEncoderICU
           - test_enc: UTF-16BE
             source_text: french
-            perf: TestCharsetDecoderICU
-          - test_enc: UTF-16BE
-            source_text: french
-            perf: TestCharsetEncoderICU
           - test_enc: UTF-16LE
             source_text: french
-            perf: TestCharsetDecoderICU
-          - test_enc: UTF-16LE
-            source_text: french
-            perf: TestCharsetEncoderICU
           - test_enc: US-ASCII
             source_text: english
-            perf: TestCharsetDecoderICU
-          - test_enc: US-ASCII
-            source_text: english
-            perf: TestCharsetEncoderICU
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
… from

40 tests to 18 by removing tests for UTF-8 --> UTF-8 conversions for different
languages. The encoding conversion test is the main culprit for data
uploading conflicts.
Simplified the test matrix in general.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [ ] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22075
- [ ] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
