### PR TITLE
ICU-22109 icu-config hardcodes build paths unnecessarily

### DIFF
--- a/icu4c/source/Makefile.in
+++ b/icu4c/source/Makefile.in
@@ -337,7 +337,7 @@ $(top_builddir)/config/icu-config: $(top_builddir)/Makefile $(top_srcdir)/config
 	chmod u+w $@
 	@echo "# Following from icu/icu4c/source/config/Makefile.inc" >> $@
 	LC_ALL=C $(SED) -f $(top_srcdir)/config/make2sh.sed < $(top_builddir)/config/Makefile.inc | grep -v '#M#' | uniq >> $@
-	@echo "# Following from @platform_make_fragment@" >> $@
+	@echo "# Following from @platform_make_fragment_name@" >> $@
 	LC_ALL=C $(SED) -f $(top_srcdir)/config/make2sh.sed < @platform_make_fragment@ | grep -v '#M#' | uniq >> $@
 	cat $(top_srcdir)/config/icu-config-bottom >> $@
 	chmod u-w $@


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-22109

The makefile hardcodes paths to the build directory into icu-config. It doesn’t
need to do this and it unnecessarily breaks build reproducibility. This patch
makes a simple change to avoid this.

Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
