### PR TITLE
ICU-22117 Replace uprv_strncpy() by uprv_memcpy()

### DIFF
--- a/icu4c/source/common/uloc_tag.cpp
+++ b/icu4c/source/common/uloc_tag.cpp
@@ -2124,7 +2124,7 @@ ultag_parse(const char* tag, int32_t tagLen, int32_t* parsedLen, UErrorCode* sta
                 if (*redundantTagEnd  == '\0' || *redundantTagEnd == SEP) {
                     const char* preferredTag = REDUNDANT[i + 1];
                     size_t preferredTagLen = uprv_strlen(preferredTag);
-                    uprv_strncpy(t->buf, preferredTag, preferredTagLen);
+                    uprv_memcpy(t->buf, preferredTag, preferredTagLen);
                     if (*redundantTagEnd == SEP) {
                         uprv_memmove(tagBuf + preferredTagLen,
                                      redundantTagEnd,


### PR DESCRIPTION
This fixes a warning on gcc 9.4.0, which is triggered because the third argument to `strncpy()` depends on the length of the second argument (but should actually indicate the buffer size). Replacing by `memcpy()` seems harmless because a null terminator is appended further below, and the buffer is sized to be "large enough" elsewhere.

See https://github.com/duckdb/duckdb/issues/4391 for details.

Fixing the warning is important for us, because the checks in the duckdb repository treat all warnings as errors.

Happy to file JIRA issues and to tick the checklist boxes if needed.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22117
- [x] Required: The PR title must be prefixed with a JIRA Issue number.
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number.
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
