### PR TITLE
ICU-21959 add the uemoji feature to ICU Data Build Tool chapter

### DIFF
--- a/docs/userguide/icu_data/buildtool.md
+++ b/docs/userguide/icu_data/buildtool.md
@@ -233,6 +233,7 @@ summarizes the ICU data files and their corresponding features and categories:
 | StringPrep | `"stringprep"` | sprep/\*.txt | 193 KiB |
 | Time Zones | `"misc"` <br/> `"zone_tree"` <br/> `"zone_supplemental"` | misc/metaZones.txt <br/> misc/timezoneTypes.txt <br/> misc/windowsZones.txt <br/> misc/zoneinfo64.txt <br/> zone/\*.txt <br/> zone/tzdbNames.txt | 41 KiB <br/> 20 KiB <br/> 22 KiB <br/> 151 KiB <br/> **2.7 MiB** <br/> 4.8 KiB |
 | Transliteration | `"translit"` | translit/\*.txt | 685 KiB |
+| Unicode Emoji<br/>Properties | `"uemoji"` | in/uemoji.icu | 13 KiB |
 | Unicode Character <br/> Names | `"unames"` | in/unames.icu | 269 KiB |
 | Unicode Text Layout | `"ulayout"` | in/ulayout.icu | 14 KiB |
 | Units | `"unit_tree"` | unit/\*.txt | **1.7 MiB** |


### PR DESCRIPTION
The uemoji.icu data file and the uemoji build tool feature were added in ICU 70 ICU-21652 https://github.com/unicode-org/icu/pull/1848

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21959
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
