### PR TITLE
ICU-20512 ICU4J: just add test of parse with empty curr symbol, code already works as desired

### DIFF
--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/NumberFormatTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/format/NumberFormatTest.java
@@ -6966,4 +6966,94 @@ public class NumberFormatTest extends TestFmwk {
             assertEquals("Via applyPattern: field position end", 3, fp.getEndIndex());
         }
     }
+
+    @Test
+    public void TestParseWithEmptyCurr() {
+        DecimalFormat df = (DecimalFormat)NumberFormat.getInstance(new ULocale("en_US"), NumberFormat.CURRENCYSTYLE);
+        DecimalFormatSymbols dfs = df.getDecimalFormatSymbols();
+        dfs.setCurrencySymbol("");
+        df.setDecimalFormatSymbols(dfs);
+ 
+        String textToParse = "3";    
+        ParsePosition ppos = new ParsePosition(0);
+
+        Number num = df.parse(textToParse, ppos);
+        if (ppos.getIndex() != 1 || num.doubleValue() != 3.0) {
+            errln("parse with empty curr symbol, expect pos 1, value 3.0; get "
+                                + ppos.getIndex() + ", " + num.doubleValue());
+        }
+
+        ppos.setIndex(0);
+        CurrencyAmount currAmt = df.parseCurrency(textToParse, ppos);
+        if (currAmt != null) {
+            errln("parseCurrency with empty curr symbol, expect null but succeeds");
+        }
+
+        //                        "¤#,##0.00" "¤ #,##0.00" "#,##0.00 ¤" "#,##,##0.00¤"
+        final String[] locales = {"en_US",    "nb_NO",     "cs_CZ",     "bn_BD"};
+        for (String locale: locales) {
+            df = (DecimalFormat)NumberFormat.getInstance(new ULocale(locale), NumberFormat.CURRENCYSTYLE);
+            dfs = df.getDecimalFormatSymbols();
+            dfs.setCurrencySymbol("");
+            df.setDecimalFormatSymbols(dfs);
+
+            final double posValToUse = 37.0;
+            final double negValToUse = -3.0;
+
+            textToParse = df.format(posValToUse);
+            int expectParseLen = textToParse.length();
+            if (textToParse.endsWith("\u00A0") || textToParse.endsWith("\u202F")) { // NBSP, NNBSP
+                expectParseLen--;
+            }
+            ppos.setIndex(0);
+            num = df.parse(textToParse, ppos);
+            if (ppos.getIndex() != expectParseLen || num.doubleValue() != posValToUse) {
+                errln("locale " + locale + ", parse with empty curr symbol, expect pos, value "
+                                + expectParseLen + ", " + posValToUse + ";  get "
+                                + ppos.getIndex() + ", " + num.doubleValue());
+            }
+
+            textToParse = df.format(negValToUse);
+            expectParseLen = textToParse.length();
+            if (textToParse.endsWith("\u00A0") || textToParse.endsWith("\u202F")) { // NBSP, NNBSP
+                expectParseLen--;
+            }
+            ppos.setIndex(0);
+            num = df.parse(textToParse, ppos);
+            if (ppos.getIndex() != expectParseLen || num.doubleValue() != negValToUse) {
+                errln("locale " + locale + ", parse with empty curr symbol, expect pos, value "
+                                + expectParseLen + ", " + negValToUse + ";  get "
+                                + ppos.getIndex() + ", " + num.doubleValue());
+            }
+
+            df.applyPattern("#,##0.00¤");
+
+            textToParse = df.format(posValToUse);
+            expectParseLen = textToParse.length();
+            if (textToParse.endsWith("\u00A0") || textToParse.endsWith("\u202F")) { // NBSP, NNBSP
+                expectParseLen--;
+            }
+            ppos.setIndex(0);
+            num = df.parse(textToParse, ppos);
+            if (ppos.getIndex() != expectParseLen || num.doubleValue() != posValToUse) {
+                errln("locale " + locale + "with \"#,##0.00¤\", parse with empty curr symbol, expect pos, value "
+                                + expectParseLen + ", " + posValToUse + ";  get "
+                                + ppos.getIndex() + ", " + num.doubleValue());
+            }
+
+            textToParse = df.format(negValToUse);
+            expectParseLen = textToParse.length();
+            if (textToParse.endsWith("\u00A0") || textToParse.endsWith("\u202F")) { // NBSP, NNBSP
+                expectParseLen--;
+            }
+            ppos.setIndex(0);
+            num = df.parse(textToParse, ppos);
+            if (ppos.getIndex() != expectParseLen || num.doubleValue() != negValToUse) {
+                errln("locale " + locale + "with \"#,##0.00¤\", parse with empty curr symbol, expect pos, value "
+                                + expectParseLen + ", " + negValToUse + ";  get "
+                                + ppos.getIndex() + ", " + num.doubleValue());
+            }
+
+        }
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-20512
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

In ICU4J, just add a test of parsing with empty currency symbol (corresponds to ICU4C test in #2187), code already behaves as desired per ICU-20512