### PR TITLE
ICU-22124 Update the MessageFormat v2 links to the main branch

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/message2/MessageFormatter.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/message2/MessageFormatter.java
@@ -30,7 +30,7 @@ import java.util.Map;
  * is hosted on <a target="github" href="https://github.com/unicode-org/message-format-wg">GitHub</a>.</p>
  *
  * <p>The current specification for the syntax and data model can be found
- * <a target="github" href="https://github.com/unicode-org/message-format-wg/blob/develop/spec/syntax.md">here</a>.</p>
+ * <a target="github" href="https://github.com/unicode-org/message-format-wg/blob/main/spec/syntax.md">here</a>.</p>
  *
  * <p>This tech preview implements enough of the {@code MessageFormat} functions to be useful,
  * but the final set of functions and the parameters accepted by those functions is not yet finalized.</p>

--- a/icu4j/main/classes/core/src/com/ibm/icu/message2/Mf2DataModel.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/message2/Mf2DataModel.java
@@ -16,9 +16,9 @@ import java.util.StringJoiner;
  * This maps closely to the official specification.
  * Since it is not final, we will not add javadoc everywhere.
  *
- * <p>See <a target="github" href="https://github.com/unicode-org/message-format-wg/blob/develop/spec/syntax.md">the
+ * <p>See <a target="github" href="https://github.com/unicode-org/message-format-wg/blob/main/spec/syntax.md">the
  * description of the syntax with examples and use cases</a> and the corresponding
- * <a target="github" href="https://github.com/unicode-org/message-format-wg/blob/develop/spec/message.ebnf">EBNF</a>.</p>
+ * <a target="github" href="https://github.com/unicode-org/message-format-wg/blob/main/spec/message.ebnf">EBNF</a>.</p>
  *
  * @internal ICU 72 technology preview
  * @deprecated This API is for ICU internal use only.

--- a/icu4j/main/classes/core/src/com/ibm/icu/message2/package.html
+++ b/icu4j/main/classes/core/src/com/ibm/icu/message2/package.html
@@ -9,7 +9,7 @@
 <body bgcolor="white">
 
 <p>Tech Preview implementation of the
-<a href="https://github.com/unicode-org/message-format-wg/blob/develop/spec/syntax.md">MessageFormat v2 specification</a>.</p>
+<a href="https://github.com/unicode-org/message-format-wg/blob/main/spec/syntax.md">MessageFormat v2 specification</a>.</p>
 
 </body>
 </html>

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/message2/Mf2FeaturesTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/message2/Mf2FeaturesTest.java
@@ -20,7 +20,7 @@ import com.ibm.icu.util.CurrencyAmount;
  * Trying to show off most of the features in one place.
  *
  * <p>It covers the examples in the
- * <a href="https://github.com/unicode-org/message-format-wg/blob/develop/spec/syntax.md">spec document</a>,
+ * <a href="https://github.com/unicode-org/message-format-wg/blob/main/spec/syntax.md">spec document</a>,
  * except for the custom formatters ones, which are too verbose and were moved to separate test classes.</p>
  * </p>
  */


### PR DESCRIPTION
The GitHub links need to change from:
   https://github.com/unicode-org/message-format-wg/blob/develop/spec/
to
   https://github.com/unicode-org/message-format-wg/blob/main/spec/

It is not a disaster if it does not happen, we will make sure we don’t delete the branch, so the links will stay valid. But it looks a bit more professional.

See https://unicode-org.atlassian.net/browse/ICU-22124

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22124
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [X] API docs and/or User Guide docs changed or added, if applicable
