### PR TITLE
ICU-22124 Tag the default constructor of OrderedMap as internal/deprecated

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/message2/Mf2DataModel.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/message2/Mf2DataModel.java
@@ -664,6 +664,17 @@ public class Mf2DataModel {
     @Deprecated
     public static class OrderedMap<K, V> extends LinkedHashMap<K, V> {
         private static final long serialVersionUID = -7049361727790825496L;
+
+        /**
+         * {@inheritDoc}
+         *
+         * @internal ICU 72 technology preview
+         * @deprecated This API is for ICU internal use only.
+         */
+        @Deprecated
+        public OrderedMap() {
+            super();
+        }
     }
 
     private final OrderedMap<String, Expression> localVariables;


### PR DESCRIPTION
ICU-22124 Tag the default constructor of OrderedMap as internal/deprecated

Fix for apireport, see https://github.com/unicode-org/icu/pull/2193

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [X] API docs and/or User Guide docs changed or added, if applicable
