### PR TITLE
ICU-22081 Fix table in PersonNameFormatter Javadoc.

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/text/PersonNameFormatter.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/PersonNameFormatter.java
@@ -14,13 +14,56 @@ import com.ibm.icu.impl.personname.PersonNameFormatterImpl;
  *
  * The Length, Usage, and Formality options can be used to get a wide variety of results.  In English, they would
  * produce results along these lines:
- *
- * |        | REFERRING             | REFERRING    | ADDRESSING | ADDRESSING | MONOGRAM | MONOGRAM |
- * |        | FORMAL                | INFORMAL     | FORMAL     | INFORMAL   | FORMAL   | INFORMAL |
- * |--------|-----------------------|--------------|------------|------------|----------|----------|
- * | LONG   | James Earl Carter Jr. | Jimmy Carter | Mr. Carter | Jimmy      | JEC      | JC       |
- * | MEDIUM | James E. Carter Jr.   | Jimmy Carter | Mr. Carter | Jimmy      | C        | J        |
- * | SHORT  | J. E. Carter          | Jimmy Carter | Mr. Carter | Jimmy      | C        | J        |
+ * <table border="1">
+ *     <tr>
+ *         <th rowspan="2">
+ *         </th>
+ *         <th colspan="2">
+ *             REFERRING
+ *         </th>
+ *         <th colspan="2">
+ *             ADDRESSING
+ *         </th>
+ *         <th colspan="2">
+ *             MONOGRAM
+ *         </th>
+ *     </tr>
+ *     <tr>
+ *         <th>FORMAL</th>
+ *         <th>INFORMAL</th>
+ *         <th>FORMAL</th>
+ *         <th>INFORMAL</th>
+ *         <th>FORMAL</th>
+ *         <th>INFORMAL</th>
+ *     </tr>
+ *     <tr>
+ *         <th>LONG</th>
+ *         <td>James Earl Carter Jr.</td>
+ *         <td>Jimmy Carter</td>
+ *         <td>Mr. Carter</td>
+ *         <td>Jimmy</td>
+ *         <td>JEC</td>
+ *         <td>JC</td>
+ *     </tr>
+ *     <tr>
+ *         <th>MEDIUM</th>
+ *         <td>James E. Carter Jr.</td>
+ *         <td>Jimmy Carter</td>
+ *         <td>Mr. Carter</td>
+ *         <td>Jimmy</td>
+ *         <td>C</td>
+ *         <td>J</td>
+ *     </tr>
+ *     <tr>
+ *         <th>SHORT</th>
+ *         <td>J. E. Carter</td>
+ *         <td>Jimmy Carter</td>
+ *         <td>Mr. Carter</td>
+ *         <td>Jimmy</td>
+ *         <td>C</td>
+ *         <td>J</td>
+ *     </tr>
+ * </table>
  *
  * @internal ICU 72 technology preview
  * @deprecated This API is for technology preview only.


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22081
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable

Turns out Javadoc doesn't support tables in Markdown format (which I should have known), so I'm sacrificing readability in the source file for readability of the actual generated code by using literal HTML.