### PR TITLE
ICU-21959 fix file-level doxygen issues

### DIFF
--- a/icu4c/source/common/unicode/ubiditransform.h
+++ b/icu4c/source/common/unicode/ubiditransform.h
@@ -28,7 +28,7 @@
 
 /**
  * \file
- * \brief Bidi Transformations
+ * \brief C API: Bidi Transformations
  */
 
 /**

--- a/icu4c/source/common/unicode/ucnv_cb.h
+++ b/icu4c/source/common/unicode/ucnv_cb.h
@@ -15,8 +15,8 @@
  */
 
 /**
- * \file 
- * \brief C UConverter functions to aid the writers of callbacks
+ * \file
+ * \brief C API: UConverter functions to aid the writers of callbacks
  *
  * <h2> Callback API for UConverter </h2>
  * 

--- a/icu4c/source/common/unicode/ucnv_err.h
+++ b/icu4c/source/common/unicode/ucnv_err.h
@@ -12,7 +12,7 @@
 
 /**
  * \file
- * \brief C UConverter predefined error callbacks
+ * \brief C API: UConverter predefined error callbacks
  *
  *  <h2>Error Behaviour Functions</h2>
  *  Defines some error behaviour functions called by ucnv_{from,to}Unicode

--- a/icu4c/source/common/unicode/ucnvsel.h
+++ b/icu4c/source/common/unicode/ucnvsel.h
@@ -36,6 +36,7 @@
 
 /**
  * \file
+ * \brief C API: Encoding/charset encoding selector
  *
  * A converter selector is built with a set of encoding/charset names
  * and given an input string returns the set of names of the

--- a/icu4c/source/common/unicode/ucpmap.h
+++ b/icu4c/source/common/unicode/ucpmap.h
@@ -13,8 +13,7 @@ U_CDECL_BEGIN
 
 /**
  * \file
- *
- * This file defines an abstract map from Unicode code points to integer values.
+ * \brief C API: This file defines an abstract map from Unicode code points to integer values.
  *
  * @see UCPMap
  * @see UCPTrie

--- a/icu4c/source/common/unicode/ucptrie.h
+++ b/icu4c/source/common/unicode/ucptrie.h
@@ -19,8 +19,7 @@ U_CDECL_BEGIN
 
 /**
  * \file
- *
- * This file defines an immutable Unicode code point trie.
+ * \brief C API: This file defines an immutable Unicode code point trie.
  *
  * @see UCPTrie
  * @see UMutableCPTrie

--- a/icu4c/source/common/unicode/uloc.h
+++ b/icu4c/source/common/unicode/uloc.h
@@ -26,9 +26,9 @@
 #include "unicode/utypes.h"
 #include "unicode/uenum.h"
 
-/**    
+/**
  * \file
- * \brief  C API: Locale 
+ * \brief C API: Locale ID functionality similar to C++ class Locale
  *
  * <h2> ULoc C API for Locale </h2>
  * A <code>Locale</code> represents a specific geographical, political,

--- a/icu4c/source/common/unicode/umisc.h
+++ b/icu4c/source/common/unicode/umisc.h
@@ -21,9 +21,9 @@
 
 /**
  * \file
- * \brief  C API:misc definitions 
+ * \brief C API: Miscellaneous definitions
  *
- *  This file contains miscellaneous definitions for the C APIs. 
+ *  This file contains miscellaneous definitions for the C APIs.
  */
 
 U_CDECL_BEGIN

--- a/icu4c/source/common/unicode/umutablecptrie.h
+++ b/icu4c/source/common/unicode/umutablecptrie.h
@@ -21,8 +21,7 @@ U_CDECL_BEGIN
 
 /**
  * \file
- *
- * This file defines a mutable Unicode code point trie.
+ * \brief C API: This file defines a mutable Unicode code point trie.
  *
  * @see UCPTrie
  * @see UMutableCPTrie

--- a/icu4c/source/i18n/unicode/displayoptions.h
+++ b/icu4c/source/i18n/unicode/displayoptions.h
@@ -10,6 +10,13 @@
 
 #if !UCONFIG_NO_FORMATTING
 
+/**
+ * \file
+ * \brief C++ API: Display options class
+ *
+ * This class is designed as a more modern version of the UDisplayContext mechanism.
+ */
+
 #include "unicode/udisplayoptions.h"
 #include "unicode/uversion.h"
 

--- a/icu4c/source/i18n/unicode/regex.h
+++ b/icu4c/source/i18n/unicode/regex.h
@@ -22,7 +22,7 @@
 
 /**
  * \file
- * \brief  C++ API:  Regular Expressions
+ * \brief C++ API: Regular Expressions
  *
  * The ICU API for processing regular expressions consists of two classes,
  *  `RegexPattern` and `RegexMatcher`.

--- a/icu4c/source/i18n/unicode/udisplayoptions.h
+++ b/icu4c/source/i18n/unicode/udisplayoptions.h
@@ -8,6 +8,14 @@
 
 #if !UCONFIG_NO_FORMATTING
 
+/**
+ * \file
+ * \brief C API: Display options (enum types, values, helper functions)
+ *
+ * These display options are designed to be used in class DisplayOptions
+ * as a more modern version of the UDisplayContext mechanism.
+ */
+
 #include "unicode/uversion.h"
 
 #ifndef U_HIDE_DRAFT_API
@@ -111,8 +119,9 @@ U_CAPI const char * U_EXPORT2
 udispopt_getPluralCategoryIdentifier(UDisplayOptionsPluralCategory pluralCategory);
 
 /**
- * @param keyword for example "few" or "other"
- * @return the plural category corresponding to the keyword, or `UDISPOPT_PLURAL_CATEGORY_UNDEFINED`
+ * @param identifier for example "few" or "other"
+ * @return the plural category corresponding to the identifier (plural keyword),
+ *         or `UDISPOPT_PLURAL_CATEGORY_UNDEFINED`
  *
  * @draft ICU 72
  */

--- a/icu4c/source/i18n/unicode/unumberformatter.h
+++ b/icu4c/source/i18n/unicode/unumberformatter.h
@@ -16,7 +16,7 @@
 
 /**
  * \file
- * \brief C-compatible API for localized number formatting; not recommended for C++.
+ * \brief C API: Localized number formatting; not recommended for C++.
  *
  * This is the C-compatible version of the NumberFormatter API introduced in ICU 60. C++ users should
  * include unicode/numberformatter.h and use the proper C++ APIs.

--- a/icu4c/source/i18n/unicode/unumberrangeformatter.h
+++ b/icu4c/source/i18n/unicode/unumberrangeformatter.h
@@ -17,7 +17,7 @@
 
 /**
  * \file
- * \brief C-compatible API for localized number range formatting.
+ * \brief C API: Localized number range formatting
  *
  * This is the C-compatible version of the NumberRangeFormatter API. C++ users
  * should include unicode/numberrangeformatter.h and use the proper C++ APIs.

--- a/icu4c/source/i18n/unicode/uspoof.h
+++ b/icu4c/source/i18n/unicode/uspoof.h
@@ -35,7 +35,7 @@
 
 /**
  * \file
- * \brief Unicode Security and Spoofing Detection, C API.
+ * \brief C API: Unicode Security and Spoofing Detection
  *
  * <p>
  * This class, based on <a href="http://unicode.org/reports/tr36">Unicode Technical Report #36</a> and


### PR DESCRIPTION
While looking at the ICU 72rc [API docs](https://unicode-org.github.io/icu-docs/) I noticed that some old and new files did not look right in the file listing, and the files from ICU-21935 (display options) didn't show up at all in some places where they should. Once I added the `\file` tag to the display options headers, I had to fix a minor parameter name mismatch.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21959
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
