### PR TITLE
ICU-21180 BreakIterator, change all NULL to nulptr

### DIFF
--- a/icu4c/source/common/brkeng.cpp
+++ b/icu4c/source/common/brkeng.cpp
@@ -130,7 +130,7 @@ U_NAMESPACE_BEGIN
 
 const LanguageBreakEngine *
 ICULanguageBreakFactory::getEngineFor(UChar32 c) {
-    const LanguageBreakEngine *lbe = NULL;
+    const LanguageBreakEngine *lbe = nullptr;
     UErrorCode  status = U_ZERO_ERROR;
 
     static UMutex gBreakEngineMutex;
@@ -147,7 +147,7 @@ ICULanguageBreakFactory::getEngineFor(UChar32 c) {
         int32_t i = fEngines->size();
         while (--i >= 0) {
             lbe = (const LanguageBreakEngine *)(fEngines->elementAt(i));
-            if (lbe != NULL && lbe->handles(c)) {
+            if (lbe != nullptr && lbe->handles(c)) {
                 return lbe;
             }
         }
@@ -185,7 +185,7 @@ ICULanguageBreakFactory::loadEngineFor(UChar32 c) {
         }
         status = U_ZERO_ERROR;  // fallback to dictionary based
         DictionaryMatcher *m = loadDictionaryMatcherFor(code);
-        if (m != NULL) {
+        if (m != nullptr) {
             switch(code) {
             case USCRIPT_THAI:
                 engine = new ThaiBreakEngine(m, status);
@@ -230,17 +230,17 @@ ICULanguageBreakFactory::loadEngineFor(UChar32 c) {
             default:
                 break;
             }
-            if (engine == NULL) {
+            if (engine == nullptr) {
                 delete m;
             }
             else if (U_FAILURE(status)) {
                 delete engine;
-                engine = NULL;
+                engine = nullptr;
             }
             return engine;
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 DictionaryMatcher *
@@ -254,12 +254,12 @@ ICULanguageBreakFactory::loadDictionaryMatcherFor(UScriptCode script) {
         ures_getStringByKeyWithFallback(b, uscript_getShortName(script), &dictnlength, &status);
     if (U_FAILURE(status)) {
         ures_close(b);
-        return NULL;
+        return nullptr;
     }
     CharString dictnbuf;
     CharString ext;
     const UChar *extStart = u_memrchr(dictfname, 0x002e, dictnlength);  // last dot
-    if (extStart != NULL) {
+    if (extStart != nullptr) {
         int32_t len = (int32_t)(extStart - dictfname);
         ext.appendInvariantChars(UnicodeString(false, extStart + 1, dictnlength - len - 1), status);
         dictnlength = len;
@@ -274,7 +274,7 @@ ICULanguageBreakFactory::loadDictionaryMatcherFor(UScriptCode script) {
         const int32_t *indexes = (const int32_t *)data;
         const int32_t offset = indexes[DictionaryData::IX_STRING_TRIE_OFFSET];
         const int32_t trieType = indexes[DictionaryData::IX_TRIE_TYPE] & DictionaryData::TRIE_TYPE_MASK;
-        DictionaryMatcher *m = NULL;
+        DictionaryMatcher *m = nullptr;
         if (trieType == DictionaryData::TRIE_TYPE_BYTES) {
             const int32_t transform = indexes[DictionaryData::IX_TRANSFORM];
             const char *characters = (const char *)(data + offset);
@@ -284,19 +284,19 @@ ICULanguageBreakFactory::loadDictionaryMatcherFor(UScriptCode script) {
             const UChar *characters = (const UChar *)(data + offset);
             m = new UCharsDictionaryMatcher(characters, file);
         }
-        if (m == NULL) {
+        if (m == nullptr) {
             // no matcher exists to take ownership - either we are an invalid 
             // type or memory allocation failed
             udata_close(file);
         }
         return m;
-    } else if (dictfname != NULL) {
+    } else if (dictfname != nullptr) {
         // we don't have a dictionary matcher.
-        // returning NULL here will cause us to fail to find a dictionary break engine, as expected
+        // returning nullptr here will cause us to fail to find a dictionary break engine, as expected
         status = U_ZERO_ERROR;
-        return NULL;
+        return nullptr;
     }
-    return NULL;
+    return nullptr;
 }
 
 U_NAMESPACE_END

--- a/icu4c/source/common/brkeng.h
+++ b/icu4c/source/common/brkeng.h
@@ -266,7 +266,7 @@ protected:
    * <p>Create a DictionaryMatcher for the specified script and break type.</p>
    * @param script An ISO 15924 script code that identifies the dictionary to be
    * created.
-   * @return A DictionaryMatcher with the desired characteristics, or NULL.
+   * @return A DictionaryMatcher with the desired characteristics, or nullptr.
    */
   virtual DictionaryMatcher *loadDictionaryMatcherFor(UScriptCode script);
 };

--- a/icu4c/source/common/brkiter.cpp
+++ b/icu4c/source/common/brkiter.cpp
@@ -60,15 +60,15 @@ BreakIterator::buildInstance(const Locale& loc, const char *type, UErrorCode &st
     char ext[4]={'\0'};
     CharString actualLocale;
     int32_t size;
-    const UChar* brkfname = NULL;
+    const UChar* brkfname = nullptr;
     UResourceBundle brkRulesStack;
     UResourceBundle brkNameStack;
     UResourceBundle *brkRules = &brkRulesStack;
     UResourceBundle *brkName  = &brkNameStack;
-    RuleBasedBreakIterator *result = NULL;
+    RuleBasedBreakIterator *result = nullptr;
 
     if (U_FAILURE(status))
-        return NULL;
+        return nullptr;
 
     ures_initStackObject(brkRules);
     ures_initStackObject(brkName);
@@ -97,7 +97,7 @@ BreakIterator::buildInstance(const Locale& loc, const char *type, UErrorCode &st
 
             UChar* extStart=u_strchr(brkfname, 0x002e);
             int len = 0;
-            if(extStart!=NULL){
+            if (extStart != nullptr){
                 len = (int)(extStart-brkfname);
                 u_UCharsToChars(extStart+1, ext, sizeof(ext)); // nul terminates the buff
                 u_UCharsToChars(brkfname, fnbuff, len);
@@ -112,14 +112,14 @@ BreakIterator::buildInstance(const Locale& loc, const char *type, UErrorCode &st
     UDataMemory* file = udata_open(U_ICUDATA_BRKITR, ext, fnbuff, &status);
     if (U_FAILURE(status)) {
         ures_close(b);
-        return NULL;
+        return nullptr;
     }
 
     // Create a RuleBasedBreakIterator
-    result = new RuleBasedBreakIterator(file, uprv_strstr(type, "phrase") != NULL, status);
+    result = new RuleBasedBreakIterator(file, uprv_strstr(type, "phrase") != nullptr, status);
 
     // If there is a result, set the valid locale and actual locale, and the kind
-    if (U_SUCCESS(status) && result != NULL) {
+    if (U_SUCCESS(status) && result != nullptr) {
         U_LOCALE_BASED(locBased, *(BreakIterator*)result);
         locBased.setLocaleIDs(ures_getLocaleByType(b, ULOC_VALID_LOCALE, &status), 
                               actualLocale.data());
@@ -127,12 +127,12 @@ BreakIterator::buildInstance(const Locale& loc, const char *type, UErrorCode &st
 
     ures_close(b);
 
-    if (U_FAILURE(status) && result != NULL) {  // Sometimes redundant check, but simple
+    if (U_FAILURE(status) && result != nullptr) {  // Sometimes redundant check, but simple
         delete result;
-        return NULL;
+        return nullptr;
     }
 
-    if (result == NULL) {
+    if (result == nullptr) {
         udata_close(file);
         if (U_SUCCESS(status)) {
             status = U_MEMORY_ALLOCATION_ERROR;
@@ -280,7 +280,7 @@ ICUBreakIteratorService::~ICUBreakIteratorService() {}
 U_NAMESPACE_END
 
 static icu::UInitOnce gInitOnceBrkiter {};
-static icu::ICULocaleService* gService = NULL;
+static icu::ICULocaleService* gService = nullptr;
 
 
 
@@ -292,7 +292,7 @@ static UBool U_CALLCONV breakiterator_cleanup(void) {
 #if !UCONFIG_NO_SERVICE
     if (gService) {
         delete gService;
-        gService = NULL;
+        gService = nullptr;
     }
     gInitOnceBrkiter.reset();
 #endif
@@ -320,7 +320,7 @@ getService(void)
 static inline UBool
 hasService(void)
 {
-    return !gInitOnceBrkiter.isReset() && getService() != NULL;
+    return !gInitOnceBrkiter.isReset() && getService() != nullptr;
 }
 
 // -------------------------------------
@@ -329,9 +329,9 @@ URegistryKey U_EXPORT2
 BreakIterator::registerInstance(BreakIterator* toAdopt, const Locale& locale, UBreakIteratorType kind, UErrorCode& status)
 {
     ICULocaleService *service = getService();
-    if (service == NULL) {
+    if (service == nullptr) {
         status = U_MEMORY_ALLOCATION_ERROR;
-        return NULL;
+        return nullptr;
     }
     return service->registerInstance(toAdopt, locale, kind, status);
 }
@@ -356,8 +356,8 @@ StringEnumeration* U_EXPORT2
 BreakIterator::getAvailableLocales(void)
 {
     ICULocaleService *service = getService();
-    if (service == NULL) {
-        return NULL;
+    if (service == nullptr) {
+        return nullptr;
     }
     return service->getAvailableLocales();
 }
@@ -369,7 +369,7 @@ BreakIterator*
 BreakIterator::createInstance(const Locale& loc, int32_t kind, UErrorCode& status)
 {
     if (U_FAILURE(status)) {
-        return NULL;
+        return nullptr;
     }
 
 #if !UCONFIG_NO_SERVICE
@@ -386,7 +386,7 @@ BreakIterator::createInstance(const Locale& loc, int32_t kind, UErrorCode& statu
         // handleDefault calls), so we don't touch it.  YES, A COMMENT
         // THIS LONG is a sign of bad code -- so the action item is to
         // revisit this in ICU 3.0 and clean it up/fix it/remove it.
-        if (U_SUCCESS(status) && (result != NULL) && *actualLoc.getName() != 0) {
+        if (U_SUCCESS(status) && (result != nullptr) && *actualLoc.getName() != 0) {
             U_LOCALE_BASED(locBased, *result);
             locBased.setLocaleIDs(actualLoc.getName(), actualLoc.getName());
         }
@@ -407,10 +407,10 @@ BreakIterator::makeInstance(const Locale& loc, int32_t kind, UErrorCode& status)
 {
 
     if (U_FAILURE(status)) {
-        return NULL;
+        return nullptr;
     }
 
-    BreakIterator *result = NULL;
+    BreakIterator *result = nullptr;
     switch (kind) {
     case UBRK_CHARACTER:
         {
@@ -485,7 +485,7 @@ BreakIterator::makeInstance(const Locale& loc, int32_t kind, UErrorCode& status)
     }
 
     if (U_FAILURE(status)) {
-        return NULL;
+        return nullptr;
     }
 
     return result;

--- a/icu4c/source/common/dictbe.cpp
+++ b/icu4c/source/common/dictbe.cpp
@@ -140,7 +140,7 @@ int32_t PossibleWord::candidates( UText *text, DictionaryMatcher *dict, int32_t 
     int32_t start = (int32_t)utext_getNativeIndex(text);
     if (start != offset) {
         offset = start;
-        count = dict->matches(text, rangeEnd-start, UPRV_LENGTHOF(cuLengths), cuLengths, cpLengths, NULL, &prefix);
+        count = dict->matches(text, rangeEnd-start, UPRV_LENGTHOF(cuLengths), cuLengths, cpLengths, nullptr, &prefix);
         // Dictionary leaves text after longest prefix, not longest word. Back up.
         if (count <= 0) {
             utext_setNativeIndex(text, start);
@@ -1135,7 +1135,7 @@ CjkBreakEngine::divideUpDictionaryRange( UText *inText,
     UnicodeString inString;
 
     // inputMap[inStringIndex] = corresponding native index from UText inText.
-    // If NULL then mapping is 1:1
+    // If nullptr then mapping is 1:1
     LocalPointer<UVector32>     inputMap;
 
     // if UText has the input string as one contiguous UTF-16 chunk
@@ -1292,9 +1292,9 @@ CjkBreakEngine::divideUpDictionaryRange( UText *inText,
         int32_t count;
         utext_setNativeIndex(&fu, ix);
         count = fDictionary->matches(&fu, maxWordSize, numCodePts,
-                             NULL, lengths.getBuffer(), values.getBuffer(), NULL);
+                             nullptr, lengths.getBuffer(), values.getBuffer(), nullptr);
                              // Note: lengths is filled with code point lengths
-                             //       The NULL parameter is the ignored code unit lengths.
+                             //       The nullptr parameter is the ignored code unit lengths.
 
         // if there are no single character matches found in the dictionary 
         // starting with this character, treat character as a 1-character word 

--- a/icu4c/source/common/filteredbrk.cpp
+++ b/icu4c/source/common/filteredbrk.cpp
@@ -102,7 +102,7 @@ class UStringSet : public UVector {
   inline UBool add(const UnicodeString& str, UErrorCode &status) {
     if(U_FAILURE(status)) return false;
     UnicodeString *t = new UnicodeString(str);
-    if(t==NULL) {
+    if(t==nullptr) {
       status = U_MEMORY_ALLOCATION_ERROR; return false;
     }
     return adopt(t, status);
@@ -191,7 +191,7 @@ public:
     return clone();
   }
   virtual SimpleFilteredSentenceBreakIterator* clone() const override { return new SimpleFilteredSentenceBreakIterator(*this); }
-  virtual UClassID getDynamicClassID(void) const override { return NULL; }
+  virtual UClassID getDynamicClassID(void) const override { return nullptr; }
   virtual bool operator==(const BreakIterator& o) const override { if(this==&o) return true; return false; }
 
   /* -- text modifying -- */
@@ -516,7 +516,7 @@ SimpleFilteredBreakIteratorBuilder::SimpleFilteredBreakIteratorBuilder(const Loc
 #endif
       return;  // leaves the builder empty, if you try to use it.
     }
-    LocalUResourceBundlePointer exceptions(ures_getByKeyWithFallback(b.getAlias(), "exceptions", NULL, &subStatus));
+    LocalUResourceBundlePointer exceptions(ures_getByKeyWithFallback(b.getAlias(), "exceptions", nullptr, &subStatus));
     if (U_FAILURE(subStatus) || (subStatus == U_USING_DEFAULT_WARNING) ) {    
       status = subStatus; // copy the failing status 
 #if FB_DEBUG
@@ -524,7 +524,7 @@ SimpleFilteredBreakIteratorBuilder::SimpleFilteredBreakIteratorBuilder(const Loc
 #endif
       return;  // leaves the builder empty, if you try to use it.
     }
-    LocalUResourceBundlePointer breaks(ures_getByKeyWithFallback(exceptions.getAlias(), "SentenceBreak", NULL, &subStatus));
+    LocalUResourceBundlePointer breaks(ures_getByKeyWithFallback(exceptions.getAlias(), "SentenceBreak", nullptr, &subStatus));
 
 #if FB_DEBUG
     {
@@ -590,7 +590,7 @@ SimpleFilteredBreakIteratorBuilder::build(BreakIterator* adoptBreakIterator, UEr
   LocalPointer<UCharsTrieBuilder> builder(new UCharsTrieBuilder(status), status);
   LocalPointer<UCharsTrieBuilder> builder2(new UCharsTrieBuilder(status), status);
   if(U_FAILURE(status)) {
-    return NULL;
+    return nullptr;
   }
 
   int32_t revCount = 0;
@@ -620,7 +620,7 @@ SimpleFilteredBreakIteratorBuilder::build(BreakIterator* adoptBreakIterator, UEr
     } else {
       FB_TRACE("build",abbr,false,i);
       status = U_MEMORY_ALLOCATION_ERROR;
-      return NULL;
+      return nullptr;
     }
     partials[n] = 0; // default: not partial
     n++;
@@ -682,21 +682,21 @@ SimpleFilteredBreakIteratorBuilder::build(BreakIterator* adoptBreakIterator, UEr
       ////if(debug2) u_printf("SUPPRESS- not Added(%d):  /%S/ status=%s\n",partials[i], ustrs[i].getTerminatedBuffer(), u_errorName(status));
     }
   }
-  FB_TRACE("AbbrCount",NULL,false, subCount);
+  FB_TRACE("AbbrCount",nullptr,false, subCount);
 
   if(revCount>0) {
     backwardsTrie.adoptInstead(builder->build(USTRINGTRIE_BUILD_FAST, status));
     if(U_FAILURE(status)) {
-      FB_TRACE(u_errorName(status),NULL,false, -1);
-      return NULL;
+      FB_TRACE(u_errorName(status),nullptr,false, -1);
+      return nullptr;
     }
   }
 
   if(fwdCount>0) {
     forwardsPartialTrie.adoptInstead(builder2->build(USTRINGTRIE_BUILD_FAST, status));
     if(U_FAILURE(status)) {
-      FB_TRACE(u_errorName(status),NULL,false, -1);
-      return NULL;
+      FB_TRACE(u_errorName(status),nullptr,false, -1);
+      return nullptr;
     }
   }
 
@@ -714,9 +714,9 @@ FilteredBreakIteratorBuilder::~FilteredBreakIteratorBuilder() {
 
 FilteredBreakIteratorBuilder *
 FilteredBreakIteratorBuilder::createInstance(const Locale& where, UErrorCode& status) {
-  if(U_FAILURE(status)) return NULL;
+  if(U_FAILURE(status)) return nullptr;
   LocalPointer<FilteredBreakIteratorBuilder> ret(new SimpleFilteredBreakIteratorBuilder(where, status), status);
-  return (U_SUCCESS(status))? ret.orphan(): NULL;
+  return (U_SUCCESS(status))? ret.orphan(): nullptr;
 }
 
 FilteredBreakIteratorBuilder *
@@ -726,9 +726,9 @@ FilteredBreakIteratorBuilder::createInstance(UErrorCode &status) {
 
 FilteredBreakIteratorBuilder *
 FilteredBreakIteratorBuilder::createEmptyInstance(UErrorCode& status) {
-  if(U_FAILURE(status)) return NULL;
+  if(U_FAILURE(status)) return nullptr;
   LocalPointer<FilteredBreakIteratorBuilder> ret(new SimpleFilteredBreakIteratorBuilder(status), status);
-  return (U_SUCCESS(status))? ret.orphan(): NULL;
+  return (U_SUCCESS(status))? ret.orphan(): nullptr;
 }
 
 U_NAMESPACE_END

--- a/icu4c/source/common/rbbi.cpp
+++ b/icu4c/source/common/rbbi.cpp
@@ -108,7 +108,7 @@ RuleBasedBreakIterator::RuleBasedBreakIterator(const uint8_t *compiledRules,
     if (U_FAILURE(status)) {
         return;
     }
-    if (compiledRules == NULL || ruleLength < sizeof(RBBIDataHeader)) {
+    if (compiledRules == nullptr || ruleLength < sizeof(RBBIDataHeader)) {
         status = U_ILLEGAL_ARGUMENT_ERROR;
         return;
     }
@@ -261,9 +261,9 @@ RuleBasedBreakIterator::operator=(const RuleBasedBreakIterator& that) {
     }
     BreakIterator::operator=(that);
 
-    if (fLanguageBreakEngines != NULL) {
+    if (fLanguageBreakEngines != nullptr) {
         delete fLanguageBreakEngines;
-        fLanguageBreakEngines = NULL;   // Just rebuild for now
+        fLanguageBreakEngines = nullptr;   // Just rebuild for now
     }
     // TODO: clone fLanguageBreakEngines from "that"
     UErrorCode status = U_ZERO_ERROR;
@@ -274,22 +274,22 @@ RuleBasedBreakIterator::operator=(const RuleBasedBreakIterator& that) {
     }
     fCharIter = &fSCharIter;
 
-    if (that.fCharIter != NULL && that.fCharIter != &that.fSCharIter) {
+    if (that.fCharIter != nullptr && that.fCharIter != &that.fSCharIter) {
         // This is a little bit tricky - it will initially appear that
         //  this->fCharIter is adopted, even if that->fCharIter was
         //  not adopted.  That's ok.
         fCharIter = that.fCharIter->clone();
     }
     fSCharIter = that.fSCharIter;
-    if (fCharIter == NULL) {
+    if (fCharIter == nullptr) {
         fCharIter = &fSCharIter;
     }
 
-    if (fData != NULL) {
+    if (fData != nullptr) {
         fData->removeReference();
-        fData = NULL;
+        fData = nullptr;
     }
-    if (that.fData != NULL) {
+    if (that.fData != nullptr) {
         fData = that.fData->addReference();
     }
 
@@ -346,10 +346,10 @@ void RuleBasedBreakIterator::init(UErrorCode &status) {
         return;
     }
 
-    utext_openUChars(&fText, NULL, 0, &status);
+    utext_openUChars(&fText, nullptr, 0, &status);
     fDictionaryCache = new DictionaryCache(this, status);
     fBreakCache      = new BreakCache(this, status);
-    if (U_SUCCESS(status) && (fDictionaryCache == NULL || fBreakCache == NULL)) {
+    if (U_SUCCESS(status) && (fDictionaryCache == nullptr || fBreakCache == nullptr)) {
         status = U_MEMORY_ALLOCATION_ERROR;
     }
 
@@ -412,7 +412,7 @@ RuleBasedBreakIterator::operator==(const BreakIterator& that) const {
     }
 
     if (that2.fData == fData ||
-        (fData != NULL && that2.fData != NULL && *that2.fData == *fData)) {
+        (fData != nullptr && that2.fData != nullptr && *that2.fData == *fData)) {
             // The two break iterators are using the same rules.
             return true;
         }
@@ -426,7 +426,7 @@ RuleBasedBreakIterator::operator==(const BreakIterator& that) const {
 int32_t
 RuleBasedBreakIterator::hashCode(void) const {
     int32_t   hash = 0;
-    if (fData != NULL) {
+    if (fData != nullptr) {
         hash = fData->hashCode();
     }
     return hash;
@@ -494,10 +494,10 @@ RuleBasedBreakIterator::adoptText(CharacterIterator* newText) {
     UErrorCode status = U_ZERO_ERROR;
     fBreakCache->reset();
     fDictionaryCache->reset();
-    if (newText==NULL || newText->startIndex() != 0) {
+    if (newText==nullptr || newText->startIndex() != 0) {
         // startIndex !=0 wants to be an error, but there's no way to report it.
         // Make the iterator text be an empty string.
-        utext_openUChars(&fText, NULL, 0, &status);
+        utext_openUChars(&fText, nullptr, 0, &status);
     } else {
         utext_openCharacterIterator(&fText, newText, &status);
     }
@@ -542,7 +542,7 @@ RuleBasedBreakIterator &RuleBasedBreakIterator::refreshInputText(UText *input, U
     if (U_FAILURE(status)) {
         return *this;
     }
-    if (input == NULL) {
+    if (input == nullptr) {
         status = U_ILLEGAL_ARGUMENT_ERROR;
         return *this;
     }
@@ -1009,7 +1009,7 @@ int32_t RuleBasedBreakIterator::handleSafePrevious(int32_t fromPosition) {
     #endif
 
     // if we're already at the start of the text, return DONE.
-    if (fData == NULL || UTEXT_GETNATIVEINDEX(&fText)==0) {
+    if (fData == nullptr || UTEXT_GETNATIVEINDEX(&fText)==0) {
         return BreakIterator::DONE;
     }
 
@@ -1117,10 +1117,10 @@ int32_t RuleBasedBreakIterator::getRuleStatusVec(
 //
 //-------------------------------------------------------------------------------
 const uint8_t  *RuleBasedBreakIterator::getBinaryRules(uint32_t &length) {
-    const uint8_t  *retPtr = NULL;
+    const uint8_t  *retPtr = nullptr;
     length = 0;
 
-    if (fData != NULL) {
+    if (fData != nullptr) {
         retPtr = (const uint8_t *)fData->fHeader;
         length = fData->fHeader->fLength;
     }
@@ -1131,16 +1131,16 @@ const uint8_t  *RuleBasedBreakIterator::getBinaryRules(uint32_t &length) {
 RuleBasedBreakIterator *RuleBasedBreakIterator::createBufferClone(
         void * /*stackBuffer*/, int32_t &bufferSize, UErrorCode &status) {
     if (U_FAILURE(status)){
-        return NULL;
+        return nullptr;
     }
 
     if (bufferSize == 0) {
         bufferSize = 1;  // preflighting for deprecated functionality
-        return NULL;
+        return nullptr;
     }
 
     BreakIterator *clonedBI = clone();
-    if (clonedBI == NULL) {
+    if (clonedBI == nullptr) {
         status = U_MEMORY_ALLOCATION_ERROR;
     } else {
         status = U_SAFECLONE_ALLOCATED_WARNING;
@@ -1185,14 +1185,14 @@ static void U_CALLCONV rbbiInit() {
 
 static void U_CALLCONV initLanguageFactories() {
     UErrorCode status = U_ZERO_ERROR;
-    U_ASSERT(gLanguageBreakFactories == NULL);
-    gLanguageBreakFactories = new UStack(_deleteFactory, NULL, status);
-    if (gLanguageBreakFactories != NULL && U_SUCCESS(status)) {
+    U_ASSERT(gLanguageBreakFactories == nullptr);
+    gLanguageBreakFactories = new UStack(_deleteFactory, nullptr, status);
+    if (gLanguageBreakFactories != nullptr && U_SUCCESS(status)) {
         ICULanguageBreakFactory *builtIn = new ICULanguageBreakFactory(status);
         gLanguageBreakFactories->push(builtIn, status);
 #ifdef U_LOCAL_SERVICE_HOOK
         LanguageBreakFactory *extra = (LanguageBreakFactory *)uprv_svc_hook("languageBreakFactory", &status);
-        if (extra != NULL) {
+        if (extra != nullptr) {
             gLanguageBreakFactories->push(extra, status);
         }
 #endif
@@ -1205,16 +1205,16 @@ static const LanguageBreakEngine*
 getLanguageBreakEngineFromFactory(UChar32 c)
 {
     umtx_initOnce(gLanguageBreakFactoriesInitOnce, &initLanguageFactories);
-    if (gLanguageBreakFactories == NULL) {
-        return NULL;
+    if (gLanguageBreakFactories == nullptr) {
+        return nullptr;
     }
 
     int32_t i = gLanguageBreakFactories->size();
-    const LanguageBreakEngine *lbe = NULL;
+    const LanguageBreakEngine *lbe = nullptr;
     while (--i >= 0) {
         LanguageBreakFactory *factory = (LanguageBreakFactory *)(gLanguageBreakFactories->elementAt(i));
         lbe = factory->getEngineFor(c);
-        if (lbe != NULL) {
+        if (lbe != nullptr) {
             break;
         }
     }
@@ -1230,15 +1230,15 @@ getLanguageBreakEngineFromFactory(UChar32 c)
 //-------------------------------------------------------------------------------
 const LanguageBreakEngine *
 RuleBasedBreakIterator::getLanguageBreakEngine(UChar32 c) {
-    const LanguageBreakEngine *lbe = NULL;
+    const LanguageBreakEngine *lbe = nullptr;
     UErrorCode status = U_ZERO_ERROR;
 
-    if (fLanguageBreakEngines == NULL) {
+    if (fLanguageBreakEngines == nullptr) {
         fLanguageBreakEngines = new UStack(status);
-        if (fLanguageBreakEngines == NULL || U_FAILURE(status)) {
+        if (fLanguageBreakEngines == nullptr || U_FAILURE(status)) {
             delete fLanguageBreakEngines;
             fLanguageBreakEngines = 0;
-            return NULL;
+            return nullptr;
         }
     }
 
@@ -1255,7 +1255,7 @@ RuleBasedBreakIterator::getLanguageBreakEngine(UChar32 c) {
     lbe = getLanguageBreakEngineFromFactory(c);
 
     // If we got one, use it and push it on our stack.
-    if (lbe != NULL) {
+    if (lbe != nullptr) {
         fLanguageBreakEngines->push((void *)lbe, status);
         // Even if we can't remember it, we can keep looking it up, so
         // return it even if the push fails.
@@ -1264,9 +1264,9 @@ RuleBasedBreakIterator::getLanguageBreakEngine(UChar32 c) {
 
     // No engine is forthcoming for this character. Add it to the
     // reject set. Create the reject break engine if needed.
-    if (fUnhandledBreakEngine == NULL) {
+    if (fUnhandledBreakEngine == nullptr) {
         fUnhandledBreakEngine = new UnhandledEngine(status);
-        if (U_SUCCESS(status) && fUnhandledBreakEngine == NULL) {
+        if (U_SUCCESS(status) && fUnhandledBreakEngine == nullptr) {
             status = U_MEMORY_ALLOCATION_ERROR;
             return nullptr;
         }
@@ -1278,7 +1278,7 @@ RuleBasedBreakIterator::getLanguageBreakEngine(UChar32 c) {
         if (U_FAILURE(status)) {
             delete fUnhandledBreakEngine;
             fUnhandledBreakEngine = 0;
-            return NULL;
+            return nullptr;
         }
     }
 
@@ -1303,7 +1303,7 @@ void RuleBasedBreakIterator::dumpTables() {
 
 const UnicodeString&
 RuleBasedBreakIterator::getRules() const {
-    if (fData != NULL) {
+    if (fData != nullptr) {
         return fData->getRuleSourceString();
     } else {
         umtx_initOnce(gRBBIInitOnce, &rbbiInit);

--- a/icu4c/source/common/rbbi_cache.cpp
+++ b/icu4c/source/common/rbbi_cache.cpp
@@ -162,7 +162,7 @@ void RuleBasedBreakIterator::DictionaryCache::populateDictionary(int32_t startPo
 
         // Ask the language object if there are any breaks. It will add them to the cache and
         // leave the text pointer on the other side of its range, ready to search for the next one.
-        if (lbe != NULL) {
+        if (lbe != nullptr) {
             foundBreakCount += lbe->findBreaks(text, rangeStart, rangeEnd, fBreaks, fBI->fIsPhraseBreaking, status);
         }
 

--- a/icu4c/source/common/rbbidata.cpp
+++ b/icu4c/source/common/rbbidata.cpp
@@ -78,13 +78,13 @@ UBool RBBIDataWrapper::isDataVersionAcceptable(const UVersionInfo version) {
 //
 //-----------------------------------------------------------------------------
 void RBBIDataWrapper::init0() {
-    fHeader = NULL;
-    fForwardTable = NULL;
-    fReverseTable = NULL;
-    fRuleSource   = NULL;
-    fRuleStatusTable = NULL;
-    fTrie         = NULL;
-    fUDataMem     = NULL;
+    fHeader = nullptr;
+    fForwardTable = nullptr;
+    fReverseTable = nullptr;
+    fRuleSource   = nullptr;
+    fRuleStatusTable = nullptr;
+    fTrie         = nullptr;
+    fUDataMem     = nullptr;
     fRefCount     = 0;
     fDontFreeData = true;
 }
@@ -246,7 +246,7 @@ void  RBBIDataWrapper::printTable(const char *heading, const RBBIStateTable *tab
     }
     RBBIDebugPrintf("\n");
 
-    if (table == NULL) {
+    if (table == nullptr) {
         RBBIDebugPrintf("         N U L L   T A B L E\n\n");
         return;
     }
@@ -305,10 +305,10 @@ U_CAPI int32_t U_EXPORT2
 ubrk_swap(const UDataSwapper *ds, const void *inData, int32_t length, void *outData,
            UErrorCode *status) {
 
-    if (status == NULL || U_FAILURE(*status)) {
+    if (status == nullptr || U_FAILURE(*status)) {
         return 0;
     }
-    if(ds==NULL || inData==NULL || length<-1 || (length>0 && outData==NULL)) {
+    if(ds==nullptr || inData==nullptr || length<-1 || (length>0 && outData==nullptr)) {
         *status=U_ILLEGAL_ARGUMENT_ERROR;
         return 0;
     }

--- a/icu4c/source/common/rbbinode.cpp
+++ b/icu4c/source/common/rbbinode.cpp
@@ -52,10 +52,10 @@ RBBINode::RBBINode(NodeType t) : UMemory() {
     fSerialNum    = ++gLastSerial;
 #endif
     fType         = t;
-    fParent       = NULL;
-    fLeftChild    = NULL;
-    fRightChild   = NULL;
-    fInputSet     = NULL;
+    fParent       = nullptr;
+    fLeftChild    = nullptr;
+    fRightChild   = nullptr;
+    fInputSet     = nullptr;
     fFirstPos     = 0;
     fLastPos      = 0;
     fNullable     = false;
@@ -82,9 +82,9 @@ RBBINode::RBBINode(const RBBINode &other) : UMemory(other) {
     fSerialNum   = ++gLastSerial;
 #endif
     fType        = other.fType;
-    fParent      = NULL;
-    fLeftChild   = NULL;
-    fRightChild  = NULL;
+    fParent      = nullptr;
+    fLeftChild   = nullptr;
+    fRightChild  = nullptr;
     fInputSet    = other.fInputSet;
     fPrecedence  = other.fPrecedence;
     fText        = other.fText;
@@ -113,7 +113,7 @@ RBBINode::RBBINode(const RBBINode &other) : UMemory(other) {
 RBBINode::~RBBINode() {
     // printf("deleting node %8x   serial %4d\n", this, this->fSerialNum);
     delete fInputSet;
-    fInputSet = NULL;
+    fInputSet = nullptr;
 
     switch (this->fType) {
     case varRef:
@@ -124,9 +124,9 @@ RBBINode::~RBBINode() {
 
     default:
         delete        fLeftChild;
-        fLeftChild =   NULL;
+        fLeftChild =   nullptr;
         delete        fRightChild;
-        fRightChild = NULL;
+        fRightChild = nullptr;
     }
 
 
@@ -158,12 +158,12 @@ RBBINode *RBBINode::cloneTree() {
     } else {
         n = new RBBINode(*this);
         // Check for null pointer.
-        if (n != NULL) {
-            if (fLeftChild != NULL) {
+        if (n != nullptr) {
+            if (fLeftChild != nullptr) {
                 n->fLeftChild          = fLeftChild->cloneTree();
                 n->fLeftChild->fParent = n;
             }
-            if (fRightChild != NULL) {
+            if (fRightChild != nullptr) {
                 n->fRightChild          = fRightChild->cloneTree();
                 n->fRightChild->fParent = n;
             }
@@ -195,7 +195,7 @@ RBBINode *RBBINode::cloneTree() {
 RBBINode *RBBINode::flattenVariables() {
     if (fType == varRef) {
         RBBINode *retNode  = fLeftChild->cloneTree();
-        if (retNode != NULL) {
+        if (retNode != nullptr) {
             retNode->fRuleRoot = this->fRuleRoot;
             retNode->fChainIn  = this->fChainIn;
         }
@@ -203,11 +203,11 @@ RBBINode *RBBINode::flattenVariables() {
         return retNode;
     }
 
-    if (fLeftChild != NULL) {
+    if (fLeftChild != nullptr) {
         fLeftChild = fLeftChild->flattenVariables();
         fLeftChild->fParent  = this;
     }
-    if (fRightChild != NULL) {
+    if (fRightChild != nullptr) {
         fRightChild = fRightChild->flattenVariables();
         fRightChild->fParent = this;
     }
@@ -226,7 +226,7 @@ RBBINode *RBBINode::flattenVariables() {
 void RBBINode::flattenSets() {
     U_ASSERT(fType != setRef);
 
-    if (fLeftChild != NULL) {
+    if (fLeftChild != nullptr) {
         if (fLeftChild->fType==setRef) {
             RBBINode *setRefNode = fLeftChild;
             RBBINode *usetNode   = setRefNode->fLeftChild;
@@ -239,7 +239,7 @@ void RBBINode::flattenSets() {
         }
     }
 
-    if (fRightChild != NULL) {
+    if (fRightChild != nullptr) {
         if (fRightChild->fType==setRef) {
             RBBINode *setRefNode = fRightChild;
             RBBINode *usetNode   = setRefNode->fLeftChild;
@@ -270,10 +270,10 @@ void   RBBINode::findNodes(UVector *dest, RBBINode::NodeType kind, UErrorCode &s
     if (fType == kind) {
         dest->addElement(this, status);
     }
-    if (fLeftChild != NULL) {
+    if (fLeftChild != nullptr) {
         fLeftChild->findNodes(dest, kind, status);
     }
-    if (fRightChild != NULL) {
+    if (fRightChild != nullptr) {
         fRightChild->findNodes(dest, kind, status);
     }
 }
@@ -287,7 +287,7 @@ void   RBBINode::findNodes(UVector *dest, RBBINode::NodeType kind, UErrorCode &s
 #ifdef RBBI_DEBUG
 
 static int32_t serial(const RBBINode *node) {
-    return (node == NULL? -1 : node->fSerialNum);
+    return (node == nullptr? -1 : node->fSerialNum);
 }
 
 
@@ -311,7 +311,7 @@ void RBBINode::printNode(const RBBINode *node) {
                 "opLParen"
     };
 
-    if (node==NULL) {
+    if (node==nullptr) {
         RBBIDebugPrintf("%10p", (void *)node);
     } else {
         RBBIDebugPrintf("%10p %5d %12s %c%c  %5d       %5d     %5d       %6d     %d ",
@@ -350,15 +350,15 @@ void RBBINode::printTree(const RBBINode *node, UBool printHeading) {
         printNodeHeader();
     }
     printNode(node);
-    if (node != NULL) {
+    if (node != nullptr) {
         // Only dump the definition under a variable reference if asked to.
         // Unconditionally dump children of all other node types.
         if (node->fType != varRef) {
-            if (node->fLeftChild != NULL) {
+            if (node->fLeftChild != nullptr) {
                 printTree(node->fLeftChild, false);
             }
             
-            if (node->fRightChild != NULL) {
+            if (node->fRightChild != nullptr) {
                 printTree(node->fRightChild, false);
             }
         }

--- a/icu4c/source/common/rbbirb.cpp
+++ b/icu4c/source/common/rbbirb.cpp
@@ -52,26 +52,26 @@ RBBIRuleBuilder::RBBIRuleBuilder(const UnicodeString   &rules,
 {
     fStatus = &status; // status is checked below
     fParseError = parseErr;
-    fDebugEnv   = NULL;
+    fDebugEnv   = nullptr;
 #ifdef RBBI_DEBUG
     fDebugEnv   = getenv("U_RBBIDEBUG");
 #endif
 
 
-    fForwardTree        = NULL;
-    fReverseTree        = NULL;
-    fSafeFwdTree        = NULL;
-    fSafeRevTree        = NULL;
+    fForwardTree        = nullptr;
+    fReverseTree        = nullptr;
+    fSafeFwdTree        = nullptr;
+    fSafeRevTree        = nullptr;
     fDefaultTree        = &fForwardTree;
-    fForwardTable       = NULL;
-    fRuleStatusVals     = NULL;
+    fForwardTable       = nullptr;
+    fRuleStatusVals     = nullptr;
     fChainRules         = false;
     fLBCMNoChain        = false;
     fLookAheadHardBreak = false;
-    fUSetNodes          = NULL;
-    fRuleStatusVals     = NULL;
-    fScanner            = NULL;
-    fSetBuilder         = NULL;
+    fUSetNodes          = nullptr;
+    fRuleStatusVals     = nullptr;
+    fScanner            = nullptr;
+    fSetBuilder         = nullptr;
     if (parseErr) {
         uprv_memset(parseErr, 0, sizeof(UParseError));
     }
@@ -104,7 +104,7 @@ RBBIRuleBuilder::~RBBIRuleBuilder() {
     int        i;
     for (i=0; ; i++) {
         RBBINode *n = (RBBINode *)fUSetNodes->elementAt(i);
-        if (n==NULL) {
+        if (n==nullptr) {
             break;
         }
         delete n;
@@ -138,7 +138,7 @@ RBBIDataHeader *RBBIRuleBuilder::flattenData() {
     int32_t    i;
 
     if (U_FAILURE(*fStatus)) {
-        return NULL;
+        return nullptr;
     }
 
     // Remove whitespace from the rules to make it smaller.
@@ -183,9 +183,9 @@ RBBIDataHeader *RBBIRuleBuilder::flattenData() {
 #endif
 
     RBBIDataHeader  *data     = (RBBIDataHeader *)uprv_malloc(totalSize);
-    if (data == NULL) {
+    if (data == nullptr) {
         *fStatus = U_MEMORY_ALLOCATION_ERROR;
-        return NULL;
+        return nullptr;
     }
     uprv_memset(data, 0, totalSize);
 
@@ -226,7 +226,7 @@ RBBIDataHeader *RBBIRuleBuilder::flattenData() {
                        fStrippedRules.getBuffer(), fStrippedRules.length(),
                        0xfffd, nullptr, fStatus);
     if (U_FAILURE(*fStatus)) {
-        return NULL;
+        return nullptr;
     }
 
     return data;
@@ -250,7 +250,7 @@ RBBIRuleBuilder::createRuleBasedBreakIterator( const UnicodeString    &rules,
     //
     RBBIRuleBuilder  builder(rules, parseError, status);
     if (U_FAILURE(status)) { // status checked here bcos build below doesn't
-        return NULL;
+        return nullptr;
     }
 
     RBBIDataHeader *data = builder.build(status);
@@ -267,9 +267,9 @@ RBBIRuleBuilder::createRuleBasedBreakIterator( const UnicodeString    &rules,
     RuleBasedBreakIterator *This = new RuleBasedBreakIterator(data, status);
     if (U_FAILURE(status)) {
         delete This;
-        This = NULL;
+        This = nullptr;
     } 
-    else if(This == NULL) { // test for NULL
+    else if(This == nullptr) { // test for nullptr
         status = U_MEMORY_ALLOCATION_ERROR;
     }
     return This;
@@ -328,7 +328,7 @@ RBBIDataHeader *RBBIRuleBuilder::build(UErrorCode &status) {
     //   Package up the compiled data into a memory image
     //      in the run-time format.
     //
-    RBBIDataHeader *data = flattenData(); // returns NULL if error
+    RBBIDataHeader *data = flattenData(); // returns nullptr if error
     if (U_FAILURE(status)) {
         return nullptr;
     }

--- a/icu4c/source/common/rbbiscan.cpp
+++ b/icu4c/source/common/rbbiscan.cpp
@@ -97,18 +97,18 @@ RBBIRuleScanner::RBBIRuleScanner(RBBIRuleBuilder *rb)
     fCharNum            = 0;
     fLastChar           = 0;
     
-    fStateTable         = NULL;
+    fStateTable         = nullptr;
     fStack[0]           = 0;
     fStackPtr           = 0;
-    fNodeStack[0]       = NULL;
+    fNodeStack[0]       = nullptr;
     fNodeStackPtr       = 0;
 
     fReverseRule        = false;
     fLookAheadRule      = false;
     fNoChainInRule      = false;
 
-    fSymbolTable        = NULL;
-    fSetTable           = NULL;
+    fSymbolTable        = nullptr;
+    fSetTable           = nullptr;
     fRuleNum            = 0;
     fOptionStart        = 0;
 
@@ -146,11 +146,11 @@ RBBIRuleScanner::RBBIRuleScanner(RBBIRuleBuilder *rb)
     }
 
     fSymbolTable = new RBBISymbolTable(this, rb->fRules, *rb->fStatus);
-    if (fSymbolTable == NULL) {
+    if (fSymbolTable == nullptr) {
         *rb->fStatus = U_MEMORY_ALLOCATION_ERROR;
         return;
     }
-    fSetTable    = uhash_open(uhash_hashUnicodeString, uhash_compareUnicodeString, NULL, rb->fStatus);
+    fSetTable    = uhash_open(uhash_hashUnicodeString, uhash_compareUnicodeString, nullptr, rb->fStatus);
     if (U_FAILURE(*rb->fStatus)) {
         return;
     }
@@ -166,9 +166,9 @@ RBBIRuleScanner::RBBIRuleScanner(RBBIRuleBuilder *rb)
 //------------------------------------------------------------------------------
 RBBIRuleScanner::~RBBIRuleScanner() {
     delete fSymbolTable;
-    if (fSetTable != NULL) {
+    if (fSetTable != nullptr) {
          uhash_close(fSetTable);
-         fSetTable = NULL;
+         fSetTable = nullptr;
 
     }
 
@@ -199,7 +199,7 @@ RBBIRuleScanner::~RBBIRuleScanner() {
 //------------------------------------------------------------------------------
 UBool RBBIRuleScanner::doParseActions(int32_t action)
 {
-    RBBINode *n       = NULL;
+    RBBINode *n       = nullptr;
 
     UBool   returnVal = true;
 
@@ -374,7 +374,7 @@ UBool RBBIRuleScanner::doParseActions(int32_t action)
         //
         RBBINode **destRules = (fReverseRule? &fRB->fSafeRevTree : fRB->fDefaultTree);
 
-        if (*destRules != NULL) {
+        if (*destRules != nullptr) {
             // This is not the first rule encountered.
             // OR previous stuff  (from *destRules)
             // with the current rule expression (on the Node Stack)
@@ -583,7 +583,7 @@ UBool RBBIRuleScanner::doParseActions(int32_t action)
 
     case doEndVariableName:
         n = fNodeStack[fNodeStackPtr];
-        if (n==NULL || n->fType != RBBINode::varRef) {
+        if (n==nullptr || n->fType != RBBINode::varRef) {
             error(U_BRK_INTERNAL_ERROR);
             break;
         }
@@ -598,7 +598,7 @@ UBool RBBIRuleScanner::doParseActions(int32_t action)
 
     case doCheckVarDef:
         n = fNodeStack[fNodeStackPtr];
-        if (n->fLeftChild == NULL) {
+        if (n->fLeftChild == nullptr) {
             error(U_BRK_UNDEFINED_VARIABLE);
             returnVal = false;
         }
@@ -737,7 +737,7 @@ void RBBIRuleScanner::findSetFor(const UnicodeString &s, RBBINode *node, Unicode
     // If so, just use the cached set in the new node.
     //   delete any set provided by the caller, since we own it.
     el = (RBBISetTableEl *)uhash_get(fSetTable, &s);
-    if (el != NULL) {
+    if (el != nullptr) {
         delete setToAdopt;
         node->fLeftChild = el->val;
         U_ASSERT(node->fLeftChild->fType == RBBINode::uset);
@@ -747,7 +747,7 @@ void RBBIRuleScanner::findSetFor(const UnicodeString &s, RBBINode *node, Unicode
     // Haven't seen this set before.
     // If the caller didn't provide us with a prebuilt set,
     //   create a new UnicodeSet now.
-    if (setToAdopt == NULL) {
+    if (setToAdopt == nullptr) {
         if (s.compare(kAny, -1) == 0) {
             setToAdopt = new UnicodeSet(0x000000, 0x10ffff);
         } else {
@@ -762,7 +762,7 @@ void RBBIRuleScanner::findSetFor(const UnicodeString &s, RBBINode *node, Unicode
     // This new uset node becomes the child of the caller's setReference node.
     //
     RBBINode *usetNode    = new RBBINode(RBBINode::uset);
-    if (usetNode == NULL) {
+    if (usetNode == nullptr) {
         error(U_MEMORY_ALLOCATION_ERROR);
         return;
     }
@@ -783,14 +783,14 @@ void RBBIRuleScanner::findSetFor(const UnicodeString &s, RBBINode *node, Unicode
     //
     el      = (RBBISetTableEl *)uprv_malloc(sizeof(RBBISetTableEl));
     UnicodeString *tkey = new UnicodeString(s);
-    if (tkey == NULL || el == NULL || setToAdopt == NULL) {
+    if (tkey == nullptr || el == nullptr || setToAdopt == nullptr) {
         // Delete to avoid memory leak
         delete tkey;
-        tkey = NULL;
+        tkey = nullptr;
         uprv_free(el);
-        el = NULL;
+        el = nullptr;
         delete setToAdopt;
-        setToAdopt = NULL;
+        setToAdopt = nullptr;
 
         error(U_MEMORY_ALLOCATION_ERROR);
         return;
@@ -1119,7 +1119,7 @@ void RBBIRuleScanner::parse() {
     
     // If there are no forward rules set an error.
     //
-    if (fRB->fForwardTree == NULL) {
+    if (fRB->fForwardTree == nullptr) {
         error(U_BRK_RULE_SYNTAX);
         return;
     }
@@ -1169,16 +1169,16 @@ void RBBIRuleScanner::printNodeStack(const char *title) {
 //------------------------------------------------------------------------------
 RBBINode  *RBBIRuleScanner::pushNewNode(RBBINode::NodeType  t) {
     if (U_FAILURE(*fRB->fStatus)) {
-        return NULL;
+        return nullptr;
     }
     if (fNodeStackPtr >= kStackSize - 1) {
         error(U_BRK_RULE_SYNTAX);
         RBBIDebugPuts("RBBIRuleScanner::pushNewNode - stack overflow.");
-        return NULL;
+        return nullptr;
     }
     fNodeStackPtr++;
     fNodeStack[fNodeStackPtr] = new RBBINode(t);
-    if (fNodeStack[fNodeStackPtr] == NULL) {
+    if (fNodeStack[fNodeStackPtr] == nullptr) {
         *fRB->fStatus = U_MEMORY_ALLOCATION_ERROR;
     }
     return fNodeStack[fNodeStackPtr];
@@ -1214,7 +1214,7 @@ void RBBIRuleScanner::scanSet() {
     startPos = fScanIndex;
     UErrorCode localStatus = U_ZERO_ERROR;
     uset = new UnicodeSet();
-    if (uset == NULL) {
+    if (uset == nullptr) {
         localStatus = U_MEMORY_ALLOCATION_ERROR;
     } else {
         uset->applyPatternIgnoreSpace(fRB->fRules, pos, fSymbolTable, localStatus);
@@ -1232,7 +1232,7 @@ void RBBIRuleScanner::scanSet() {
 
     // Verify that the set contains at least one code point.
     //
-    U_ASSERT(uset!=NULL);
+    U_ASSERT(uset!=nullptr);
     if (uset->isEmpty()) {
         // This set is empty.
         //  Make it an error, because it almost certainly is not what the user wanted.

--- a/icu4c/source/common/rbbiscan.h
+++ b/icu4c/source/common/rbbiscan.h
@@ -86,7 +86,7 @@ private:
     void        error(UErrorCode e);                   // error reporting convenience function.
     void        fixOpStack(RBBINode::OpPrecedence p);
                                                        //   a character.
-    void        findSetFor(const UnicodeString &s, RBBINode *node, UnicodeSet *setToAdopt = NULL);
+    void        findSetFor(const UnicodeString &s, RBBINode *node, UnicodeSet *setToAdopt = nullptr);
 
     UChar32     nextCharLL();
 #ifdef RBBI_DEBUG

--- a/icu4c/source/common/rbbisetb.cpp
+++ b/icu4c/source/common/rbbisetb.cpp
@@ -74,7 +74,7 @@ RBBISetBuilder::~RBBISetBuilder()
     RangeDescriptor   *nextRangeDesc;
 
     // Walk through & delete the linked list of RangeDescriptors
-    for (nextRangeDesc = fRangeList; nextRangeDesc!=NULL;) {
+    for (nextRangeDesc = fRangeList; nextRangeDesc!=nullptr;) {
         RangeDescriptor *r = nextRangeDesc;
         nextRangeDesc      = r->fNext;
         delete r;
@@ -104,7 +104,7 @@ void RBBISetBuilder::buildRanges() {
     //  that is in no sets.
     //
     fRangeList                = new RangeDescriptor(*fStatus); // will check for status here
-    if (fRangeList == NULL) {
+    if (fRangeList == nullptr) {
         *fStatus = U_MEMORY_ALLOCATION_ERROR;
         return;
     }
@@ -121,7 +121,7 @@ void RBBISetBuilder::buildRanges() {
     int  ni;
     for (ni=0; ; ni++) {        // Loop over each of the UnicodeSets encountered in the input rules
         usetNode = (RBBINode *)this->fRB->fUSetNodes->elementAt(ni);
-        if (usetNode==NULL) {
+        if (usetNode==nullptr) {
             break;
         }
 
@@ -252,7 +252,7 @@ void RBBISetBuilder::buildRanges() {
     UnicodeString bofString(u"bof");
     for (ni=0; ; ni++) {        // Loop over each of the UnicodeSets encountered in the input rules
         usetNode = (RBBINode *)this->fRB->fUSetNodes->elementAt(ni);
-        if (usetNode==NULL) {
+        if (usetNode==nullptr) {
             break;
         }
         UnicodeSet      *inputSet = usetNode->fInputSet;
@@ -376,12 +376,12 @@ void  RBBISetBuilder::addValToSets(UVector *sets, uint32_t val) {
 
 void  RBBISetBuilder::addValToSet(RBBINode *usetNode, uint32_t val) {
     RBBINode *leafNode = new RBBINode(RBBINode::leafChar);
-    if (leafNode == NULL) {
+    if (leafNode == nullptr) {
         *fStatus = U_MEMORY_ALLOCATION_ERROR;
         return;
     }
     leafNode->fVal = (unsigned short)val;
-    if (usetNode->fLeftChild == NULL) {
+    if (usetNode->fLeftChild == nullptr) {
         usetNode->fLeftChild = leafNode;
         leafNode->fParent    = usetNode;
     } else {
@@ -389,7 +389,7 @@ void  RBBISetBuilder::addValToSet(RBBINode *usetNode, uint32_t val) {
         // Set up an OR node, with the previous stuff as the left child
         //   and the new value as the right child.
         RBBINode *orNode = new RBBINode(RBBINode::opOr);
-        if (orNode == NULL) {
+        if (orNode == nullptr) {
             *fStatus = U_MEMORY_ALLOCATION_ERROR;
             return;
         }
@@ -507,9 +507,9 @@ void RBBISetBuilder::printRangeGroups() {
                 RBBINode       *usetNode    = (RBBINode *)rlRange->fIncludesSets->elementAt(i);
                 UnicodeString   setName = UNICODE_STRING("anon", 4);
                 RBBINode       *setRef = usetNode->fParent;
-                if (setRef != NULL) {
+                if (setRef != nullptr) {
                     RBBINode *varRef = setRef->fParent;
-                    if (varRef != NULL  &&  varRef->fType == RBBINode::varRef) {
+                    if (varRef != nullptr  &&  varRef->fType == RBBINode::varRef) {
                         setName = varRef->fText;
                     }
                 }
@@ -551,16 +551,16 @@ void RBBISetBuilder::printSets() {
         UnicodeString    setName;
 
         usetNode = (RBBINode *)fRB->fUSetNodes->elementAt(i);
-        if (usetNode == NULL) {
+        if (usetNode == nullptr) {
             break;
         }
 
         RBBIDebugPrintf("%3d    ", i);
         setName = UNICODE_STRING("anonymous", 9);
         setRef = usetNode->fParent;
-        if (setRef != NULL) {
+        if (setRef != nullptr) {
             varRef = setRef->fParent;
-            if (varRef != NULL  &&  varRef->fType == RBBINode::varRef) {
+            if (varRef != nullptr  &&  varRef->fType == RBBINode::varRef) {
                 setName = varRef->fText;
             }
         }
@@ -568,7 +568,7 @@ void RBBISetBuilder::printSets() {
         RBBIDebugPrintf("   ");
         RBBI_DEBUG_printUnicodeString(usetNode->fText);
         RBBIDebugPrintf("\n");
-        if (usetNode->fLeftChild != NULL) {
+        if (usetNode->fLeftChild != nullptr) {
             RBBINode::printTree(usetNode->fLeftChild, true);
         }
     }

--- a/icu4c/source/common/rbbistbl.cpp
+++ b/icu4c/source/common/rbbistbl.cpp
@@ -43,10 +43,10 @@ U_NAMESPACE_BEGIN
 RBBISymbolTable::RBBISymbolTable(RBBIRuleScanner *rs, const UnicodeString &rules, UErrorCode &status)
     :fRules(rules), fRuleScanner(rs), ffffString(UChar(0xffff))
 {
-    fHashTable       = NULL;
-    fCachedSetLookup = NULL;
+    fHashTable       = nullptr;
+    fCachedSetLookup = nullptr;
     
-    fHashTable = uhash_open(uhash_hashUnicodeString, uhash_compareUnicodeString, NULL, &status);
+    fHashTable = uhash_open(uhash_hashUnicodeString, uhash_compareUnicodeString, nullptr, &status);
     // uhash_open checks status
     if (U_FAILURE(status)) {
         return;
@@ -79,8 +79,8 @@ const UnicodeString  *RBBISymbolTable::lookup(const UnicodeString& s) const
     RBBISymbolTable       *This = (RBBISymbolTable *)this;   // cast off const
 
     el = (RBBISymbolTableEntry *)uhash_get(fHashTable, &s);
-    if (el == NULL) {
-        return NULL;
+    if (el == nullptr) {
+        return nullptr;
     }
 
     varRefNode = el->val;
@@ -98,7 +98,7 @@ const UnicodeString  *RBBISymbolTable::lookup(const UnicodeString& s) const
         // The variable refers to something other than just a set.
         // return the original source string for the expression
         retString = &exprNode->fText;
-        This->fCachedSetLookup = NULL;
+        This->fCachedSetLookup = nullptr;
     }
     return retString;
 }
@@ -118,7 +118,7 @@ const UnicodeString  *RBBISymbolTable::lookup(const UnicodeString& s) const
 //    and we just need to remember what set to return between these two calls.
 const UnicodeFunctor *RBBISymbolTable::lookupMatcher(UChar32 ch) const
 {
-    UnicodeSet *retVal = NULL;
+    UnicodeSet *retVal = nullptr;
     RBBISymbolTable *This = (RBBISymbolTable *)this;   // cast off const
     if (ch == 0xffff) {
         retVal = fCachedSetLookup;
@@ -163,15 +163,15 @@ UnicodeString   RBBISymbolTable::parseReference(const UnicodeString& text,
 //
 // RBBISymbolTable::lookupNode      Given a key (a variable name), return the
 //                                  corresponding RBBI Node.  If there is no entry
-//                                  in the table for this name, return NULL.
+//                                  in the table for this name, return nullptr.
 //
 RBBINode       *RBBISymbolTable::lookupNode(const UnicodeString &key) const{
 
-    RBBINode             *retNode = NULL;
+    RBBINode             *retNode = nullptr;
     RBBISymbolTableEntry *el;
 
     el = (RBBISymbolTableEntry *)uhash_get(fHashTable, &key);
-    if (el != NULL) {
+    if (el != nullptr) {
         retNode = el->val;
     }
     return retNode;
@@ -191,13 +191,13 @@ void            RBBISymbolTable::addEntry  (const UnicodeString &key, RBBINode *
         return;
     }
     e = (RBBISymbolTableEntry *)uhash_get(fHashTable, &key);
-    if (e != NULL) {
+    if (e != nullptr) {
         err = U_BRK_VARIABLE_REDFINITION;
         return;
     }
 
     e = new RBBISymbolTableEntry;
-    if (e == NULL) {
+    if (e == nullptr) {
         err = U_MEMORY_ALLOCATION_ERROR;
         return;
     }
@@ -207,7 +207,7 @@ void            RBBISymbolTable::addEntry  (const UnicodeString &key, RBBINode *
 }
 
 
-RBBISymbolTableEntry::RBBISymbolTableEntry() : UMemory(), key(), val(NULL) {}
+RBBISymbolTableEntry::RBBISymbolTableEntry() : UMemory(), key(), val(nullptr) {}
 
 RBBISymbolTableEntry::~RBBISymbolTableEntry() {
     // The "val" of a symbol table entry is a variable reference node.
@@ -215,7 +215,7 @@ RBBISymbolTableEntry::~RBBISymbolTableEntry() {
     // Unlike other node types, children of variable reference nodes are not
     //    automatically recursively deleted.  We do it manually here.
     delete val->fLeftChild;
-    val->fLeftChild = NULL;
+    val->fLeftChild = nullptr;
 
     delete  val;
 
@@ -233,10 +233,10 @@ void RBBISymbolTable::rbbiSymtablePrint() const {
            "-------------------------------------------------------------------\n");
 
     int32_t pos = UHASH_FIRST;
-    const UHashElement  *e   = NULL;
+    const UHashElement  *e   = nullptr;
     for (;;) {
         e = uhash_nextElement(fHashTable,  &pos);
-        if (e == NULL ) {
+        if (e == nullptr ) {
             break;
         }
         RBBISymbolTableEntry  *s   = (RBBISymbolTableEntry *)e->value.pointer;
@@ -249,7 +249,7 @@ void RBBISymbolTable::rbbiSymtablePrint() const {
     pos = -1;
     for (;;) {
         e = uhash_nextElement(fHashTable,  &pos);
-        if (e == NULL ) {
+        if (e == nullptr ) {
             break;
         }
         RBBISymbolTableEntry  *s   = (RBBISymbolTableEntry *)e->value.pointer;

--- a/icu4c/source/common/rbbitblb.cpp
+++ b/icu4c/source/common/rbbitblb.cpp
@@ -73,7 +73,7 @@ void  RBBITableBuilder::buildForwardTable() {
 
     // If there were no rules, just return.  This situation can easily arise
     //   for the reverse rules.
-    if (fTree==NULL) {
+    if (fTree==nullptr) {
         return;
     }
 
@@ -99,7 +99,7 @@ void  RBBITableBuilder::buildForwardTable() {
         RBBINode *bofTop    = new RBBINode(RBBINode::opCat);
         RBBINode *bofLeaf   = new RBBINode(RBBINode::leafChar);
         // Delete and exit if memory allocation failed.
-        if (bofTop == NULL || bofLeaf == NULL) {
+        if (bofTop == nullptr || bofLeaf == nullptr) {
             *fStatus = U_MEMORY_ALLOCATION_ERROR;
             delete bofTop;
             delete bofLeaf;
@@ -119,7 +119,7 @@ void  RBBITableBuilder::buildForwardTable() {
     //
     RBBINode *cn = new RBBINode(RBBINode::opCat);
     // Exit if memory allocation failed.
-    if (cn == NULL) {
+    if (cn == nullptr) {
         *fStatus = U_MEMORY_ALLOCATION_ERROR;
         return;
     }
@@ -127,7 +127,7 @@ void  RBBITableBuilder::buildForwardTable() {
     fTree->fParent = cn;
     RBBINode *endMarkerNode = cn->fRightChild = new RBBINode(RBBINode::endMark);
     // Delete and exit if memory allocation failed.
-    if (cn->fRightChild == NULL) {
+    if (cn->fRightChild == nullptr) {
         *fStatus = U_MEMORY_ALLOCATION_ERROR;
         delete cn;
         return;
@@ -203,7 +203,7 @@ void  RBBITableBuilder::buildForwardTable() {
 //
 //-----------------------------------------------------------------------------
 void RBBITableBuilder::calcNullable(RBBINode *n) {
-    if (n == NULL) {
+    if (n == nullptr) {
         return;
     }
     if (n->fType == RBBINode::setRef ||
@@ -250,7 +250,7 @@ void RBBITableBuilder::calcNullable(RBBINode *n) {
 //
 //-----------------------------------------------------------------------------
 void RBBITableBuilder::calcFirstPos(RBBINode *n) {
-    if (n == NULL) {
+    if (n == nullptr) {
         return;
     }
     if (n->fType == RBBINode::leafChar  ||
@@ -296,7 +296,7 @@ void RBBITableBuilder::calcFirstPos(RBBINode *n) {
 //
 //-----------------------------------------------------------------------------
 void RBBITableBuilder::calcLastPos(RBBINode *n) {
-    if (n == NULL) {
+    if (n == nullptr) {
         return;
     }
     if (n->fType == RBBINode::leafChar  ||
@@ -342,7 +342,7 @@ void RBBITableBuilder::calcLastPos(RBBINode *n) {
 //
 //-----------------------------------------------------------------------------
 void RBBITableBuilder::calcFollowPos(RBBINode *n) {
-    if (n == NULL ||
+    if (n == nullptr ||
         n->fType == RBBINode::leafChar ||
         n->fType == RBBINode::endMark) {
         return;
@@ -387,7 +387,7 @@ void RBBITableBuilder::calcFollowPos(RBBINode *n) {
 //
 //-----------------------------------------------------------------------------
 void RBBITableBuilder::addRuleRootNodes(UVector *dest, RBBINode *node) {
-    if (node == NULL || U_FAILURE(*fStatus)) {
+    if (node == nullptr || U_FAILURE(*fStatus)) {
         return;
     }
     U_ASSERT(!dest->hasDeleter());
@@ -567,21 +567,21 @@ void RBBITableBuilder::buildStateTable() {
         return;
     }
     RBBIStateDescriptor *failState;
-    // Set it to NULL to avoid uninitialized warning
-    RBBIStateDescriptor *initialState = NULL; 
+    // Set it to nullptr to avoid uninitialized warning
+    RBBIStateDescriptor *initialState = nullptr;
     //
     // Add a dummy state 0 - the stop state.  Not from Aho.
     int      lastInputSymbol = fRB->fSetBuilder->getNumCharCategories() - 1;
     failState = new RBBIStateDescriptor(lastInputSymbol, fStatus);
-    if (failState == NULL) {
+    if (failState == nullptr) {
         *fStatus = U_MEMORY_ALLOCATION_ERROR;
         goto ExitBuildSTdeleteall;
     }
     failState->fPositions = new UVector(*fStatus);
-    if (failState->fPositions == NULL) {
+    if (failState->fPositions == nullptr) {
         *fStatus = U_MEMORY_ALLOCATION_ERROR;
     }
-    if (failState->fPositions == NULL || U_FAILURE(*fStatus)) {
+    if (failState->fPositions == nullptr || U_FAILURE(*fStatus)) {
         goto ExitBuildSTdeleteall;
     }
     fDStates->addElement(failState, *fStatus);
@@ -592,14 +592,14 @@ void RBBITableBuilder::buildStateTable() {
     // initially, the only unmarked state in Dstates is firstpos(root),
     //       where toot is the root of the syntax tree for (r)#;
     initialState = new RBBIStateDescriptor(lastInputSymbol, fStatus);
-    if (initialState == NULL) {
+    if (initialState == nullptr) {
         *fStatus = U_MEMORY_ALLOCATION_ERROR;
     }
     if (U_FAILURE(*fStatus)) {
         goto ExitBuildSTdeleteall;
     }
     initialState->fPositions = new UVector(*fStatus);
-    if (initialState->fPositions == NULL) {
+    if (initialState->fPositions == nullptr) {
         *fStatus = U_MEMORY_ALLOCATION_ERROR;
     }
     if (U_FAILURE(*fStatus)) {
@@ -613,7 +613,7 @@ void RBBITableBuilder::buildStateTable() {
 
     // while there is an unmarked state T in Dstates do begin
     for (;;) {
-        RBBIStateDescriptor *T = NULL;
+        RBBIStateDescriptor *T = nullptr;
         int32_t              tx;
         for (tx=1; tx<fDStates->size(); tx++) {
             RBBIStateDescriptor *temp;
@@ -623,7 +623,7 @@ void RBBITableBuilder::buildStateTable() {
                 break;
             }
         }
-        if (T == NULL) {
+        if (T == nullptr) {
             break;
         }
 
@@ -636,15 +636,15 @@ void RBBITableBuilder::buildStateTable() {
             // let U be the set of positions that are in followpos(p)
             //    for some position p in T
             //    such that the symbol at position p is a;
-            UVector    *U = NULL;
+            UVector    *U = nullptr;
             RBBINode   *p;
             int32_t     px;
             for (px=0; px<T->fPositions->size(); px++) {
                 p = (RBBINode *)T->fPositions->elementAt(px);
                 if ((p->fType == RBBINode::leafChar) &&  (p->fVal == a)) {
-                    if (U == NULL) {
+                    if (U == nullptr) {
                         U = new UVector(*fStatus);
-                        if (U == NULL) {
+                        if (U == nullptr) {
                         	*fStatus = U_MEMORY_ALLOCATION_ERROR;
                         	goto ExitBuildSTdeleteall;
                         }
@@ -656,7 +656,7 @@ void RBBITableBuilder::buildStateTable() {
             // if U is not empty and not in DStates then
             int32_t  ux = 0;
             UBool    UinDstates = false;
-            if (U != NULL) {
+            if (U != nullptr) {
                 U_ASSERT(U->size() > 0);
                 int  ix;
                 for (ix=0; ix<fDStates->size(); ix++) {
@@ -675,7 +675,7 @@ void RBBITableBuilder::buildStateTable() {
                 if (!UinDstates)
                 {
                     RBBIStateDescriptor *newState = new RBBIStateDescriptor(lastInputSymbol, fStatus);
-                    if (newState == NULL) {
+                    if (newState == nullptr) {
                     	*fStatus = U_MEMORY_ALLOCATION_ERROR;
                     }
                     if (U_FAILURE(*fStatus)) {
@@ -942,7 +942,7 @@ void  RBBITableBuilder::mergeRuleStatusVals() {
     for (n=0; n<fDStates->size(); n++) {
         RBBIStateDescriptor *sd = (RBBIStateDescriptor *)fDStates->elementAt(n);
         UVector *thisStatesTagValues = sd->fTagVals;
-        if (thisStatesTagValues == NULL) {
+        if (thisStatesTagValues == nullptr) {
             // No tag values are explicitly associated with this state.
             //   Set the default tag value.
             sd->fTagsIdx = 0;
@@ -1012,10 +1012,10 @@ void  RBBITableBuilder::mergeRuleStatusVals() {
 void RBBITableBuilder::sortedAdd(UVector **vector, int32_t val) {
     int32_t i;
 
-    if (*vector == NULL) {
+    if (*vector == nullptr) {
         *vector = new UVector(*fStatus);
     }
-    if (*vector == NULL || U_FAILURE(*fStatus)) {
+    if (*vector == nullptr || U_FAILURE(*fStatus)) {
         return;
     }
     UVector *vec = *vector;
@@ -1053,7 +1053,7 @@ void RBBITableBuilder::setAdd(UVector *dest, UVector *source) {
     void **destLim, **sourceLim;
 
     if (destOriginalSize > destArray.getCapacity()) {
-        if (destArray.resize(destOriginalSize) == NULL) {
+        if (destArray.resize(destOriginalSize) == nullptr) {
             return;
         }
     }
@@ -1061,7 +1061,7 @@ void RBBITableBuilder::setAdd(UVector *dest, UVector *source) {
     destLim = destPtr + destOriginalSize;  // destArray.getArrayLimit()?
 
     if (sourceSize > sourceArray.getCapacity()) {
-        if (sourceArray.resize(sourceSize) == NULL) {
+        if (sourceArray.resize(sourceSize) == nullptr) {
             return;
         }
     }
@@ -1125,7 +1125,7 @@ UBool RBBITableBuilder::setEquals(UVector *a, UVector *b) {
 //-----------------------------------------------------------------------------
 #ifdef RBBI_DEBUG
 void RBBITableBuilder::printPosSets(RBBINode *n) {
-    if (n==NULL) {
+    if (n==nullptr) {
         return;
     }
     printf("\n");
@@ -1339,7 +1339,7 @@ int32_t  RBBITableBuilder::getTableSize() const {
     int32_t    numCols;
     int32_t    rowSize;
 
-    if (fTree == NULL) {
+    if (fTree == nullptr) {
         return 0;
     }
 
@@ -1373,7 +1373,7 @@ void RBBITableBuilder::exportTable(void *where) {
     uint32_t           state;
     int                col;
 
-    if (U_FAILURE(*fStatus) || fTree == NULL) {
+    if (U_FAILURE(*fStatus) || fTree == nullptr) {
         return;
     }
 
@@ -1651,7 +1651,7 @@ void RBBITableBuilder::printSet(UVector *s) {
     int32_t  i;
     for (i=0; i<s->size(); i++) {
         const RBBINode *v = static_cast<const RBBINode *>(s->elementAt(i));
-        RBBIDebugPrintf("%5d", v==NULL? -1 : v->fSerialNum);
+        RBBIDebugPrintf("%5d", v==nullptr? -1 : v->fSerialNum);
     }
     RBBIDebugPrintf("\n");
 }
@@ -1777,15 +1777,15 @@ RBBIStateDescriptor::RBBIStateDescriptor(int lastInputSymbol, UErrorCode *fStatu
     fAccepting = 0;
     fLookAhead = 0;
     fTagsIdx   = 0;
-    fTagVals   = NULL;
-    fPositions = NULL;
-    fDtran     = NULL;
+    fTagVals   = nullptr;
+    fPositions = nullptr;
+    fDtran     = nullptr;
 
     fDtran     = new UVector32(lastInputSymbol+1, *fStatus);
     if (U_FAILURE(*fStatus)) {
         return;
     }
-    if (fDtran == NULL) {
+    if (fDtran == nullptr) {
         *fStatus = U_MEMORY_ALLOCATION_ERROR;
         return;
     }
@@ -1800,9 +1800,9 @@ RBBIStateDescriptor::~RBBIStateDescriptor() {
     delete       fPositions;
     delete       fDtran;
     delete       fTagVals;
-    fPositions = NULL;
-    fDtran     = NULL;
-    fTagVals   = NULL;
+    fPositions = nullptr;
+    fDtran     = nullptr;
+    fTagVals   = nullptr;
 }
 
 U_NAMESPACE_END

--- a/icu4c/source/common/rbbitblb.h
+++ b/icu4c/source/common/rbbitblb.h
@@ -156,7 +156,7 @@ private:
 public:
 #ifdef RBBI_DEBUG
     void     printSet(UVector *s);
-    void     printPosSets(RBBINode *n /* = NULL*/);
+    void     printPosSets(RBBINode *n /* = nullptr */);
     void     printStates();
     void     printRuleStatusTable();
     void     printReverseTable();

--- a/icu4c/source/common/ubrk.cpp
+++ b/icu4c/source/common/ubrk.cpp
@@ -79,7 +79,7 @@ ubrk_open(UBreakIteratorType type,
 
 
   UBreakIterator *uBI = (UBreakIterator *)result;
-  if (text != NULL) {
+  if (text != nullptr) {
       ubrk_setText(uBI, text, textLength, status);
   }
   return uBI;
@@ -101,7 +101,7 @@ ubrk_openRules(  const UChar        *rules,
                        UParseError  *parseErr,
                        UErrorCode   *status)  {
 
-    if (status == NULL || U_FAILURE(*status)){
+    if (status == nullptr || U_FAILURE(*status)){
         return 0;
     }
 
@@ -113,7 +113,7 @@ ubrk_openRules(  const UChar        *rules,
     }
 
     UBreakIterator *uBI = (UBreakIterator *)result;
-    if (text != NULL) {
+    if (text != nullptr) {
         ubrk_setText(uBI, text, textLength, status);
     }
     return uBI;
@@ -126,18 +126,18 @@ ubrk_openBinaryRules(const uint8_t *binaryRules, int32_t rulesLength,
                      UErrorCode *   status)
 {
     if (U_FAILURE(*status)) {
-        return NULL;
+        return nullptr;
     }
     if (rulesLength < 0) {
         *status = U_ILLEGAL_ARGUMENT_ERROR;
-        return NULL;
+        return nullptr;
     }
     LocalPointer<RuleBasedBreakIterator> lpRBBI(new RuleBasedBreakIterator(binaryRules, rulesLength, *status), *status);
     if (U_FAILURE(*status)) {
-        return NULL;
+        return nullptr;
     }
     UBreakIterator *uBI = reinterpret_cast<UBreakIterator *>(lpRBBI.orphan());
-    if (text != NULL) {
+    if (text != nullptr) {
         ubrk_setText(uBI, text, textLength, status);
     }
     return uBI;
@@ -151,24 +151,24 @@ ubrk_safeClone(
           int32_t *pBufferSize,
           UErrorCode *status)
 {
-    if (status == NULL || U_FAILURE(*status)){
-        return NULL;
+    if (status == nullptr || U_FAILURE(*status)){
+        return nullptr;
     }
-    if (bi == NULL) {
+    if (bi == nullptr) {
        *status = U_ILLEGAL_ARGUMENT_ERROR;
-        return NULL;
+        return nullptr;
     }
-    if (pBufferSize != NULL) {
+    if (pBufferSize != nullptr) {
         int32_t inputSize = *pBufferSize;
         *pBufferSize = 1;
         if (inputSize == 0) {
-            return NULL;  // preflighting for deprecated functionality
+            return nullptr;  // preflighting for deprecated functionality
         }
     }
     BreakIterator *newBI = ((BreakIterator *)bi)->clone();
-    if (newBI == NULL) {
+    if (newBI == nullptr) {
         *status = U_MEMORY_ALLOCATION_ERROR;
-    } else if (pBufferSize != NULL) {
+    } else if (pBufferSize != nullptr) {
         *status = U_SAFECLONE_ALLOCATED_WARNING;
     }
     return (UBreakIterator *)newBI;
@@ -304,11 +304,11 @@ ubrk_getLocaleByType(const UBreakIterator *bi,
                      ULocDataLocaleType type,
                      UErrorCode* status)
 {
-    if (bi == NULL) {
+    if (bi == nullptr) {
         if (U_SUCCESS(*status)) {
             *status = U_ILLEGAL_ARGUMENT_ERROR;
         }
-        return NULL;
+        return nullptr;
     }
     return ((BreakIterator*)bi)->getLocaleID(type, *status);
 }
@@ -331,12 +331,12 @@ ubrk_getBinaryRules(UBreakIterator *bi,
     if (U_FAILURE(*status)) {
         return 0;
     }
-    if ((binaryRules == NULL && rulesCapacity > 0) || rulesCapacity < 0) {
+    if ((binaryRules == nullptr && rulesCapacity > 0) || rulesCapacity < 0) {
         *status = U_ILLEGAL_ARGUMENT_ERROR;
         return 0;
     }
     RuleBasedBreakIterator* rbbi;
-    if ((rbbi = dynamic_cast<RuleBasedBreakIterator*>(reinterpret_cast<BreakIterator*>(bi))) == NULL) {
+    if ((rbbi = dynamic_cast<RuleBasedBreakIterator*>(reinterpret_cast<BreakIterator*>(bi))) == nullptr) {
         *status = U_ILLEGAL_ARGUMENT_ERROR;
         return 0;
     }
@@ -346,7 +346,7 @@ ubrk_getBinaryRules(UBreakIterator *bi,
         *status = U_INDEX_OUTOFBOUNDS_ERROR;
         return 0;
     }
-    if (binaryRules != NULL) { // if not preflighting
+    if (binaryRules != nullptr) { // if not preflighting
         // Here we know rulesLength <= INT32_MAX and rulesCapacity >= 0, can cast safely
         if ((int32_t)rulesLength > rulesCapacity) {
             *status = U_BUFFER_OVERFLOW_ERROR;

--- a/icu4c/source/test/intltest/rbbiapts.cpp
+++ b/icu4c/source/test/intltest/rbbiapts.cpp
@@ -330,7 +330,7 @@ void RBBIAPITest::TestGetSetAdoptText()
     //                012345678901
 
     status.reset();
-    LocalUTextPointer ut(utext_openUTF8(NULL, s1, -1, status));
+    LocalUTextPointer ut(utext_openUTF8(nullptr, s1, -1, status));
     wordIter1->setText(ut.getAlias(), status);
     TEST_ASSERT_SUCCESS(status);
 
@@ -347,7 +347,7 @@ void RBBIAPITest::TestGetSetAdoptText()
     TEST_ASSERT(pos==UBRK_DONE);
 
     status.reset();
-    LocalUTextPointer ut2(utext_openUTF8(NULL, s2, -1, status));
+    LocalUTextPointer ut2(utext_openUTF8(nullptr, s2, -1, status));
     TEST_ASSERT_SUCCESS(status);
     wordIter1->setText(ut2.getAlias(), status);
     TEST_ASSERT_SUCCESS(status);
@@ -372,7 +372,7 @@ void RBBIAPITest::TestGetSetAdoptText()
 
     status.reset();
     UnicodeString sEmpty;
-    LocalUTextPointer gut2(utext_openUnicodeString(NULL, &sEmpty, status));
+    LocalUTextPointer gut2(utext_openUnicodeString(nullptr, &sEmpty, status));
     wordIter1->getUText(gut2.getAlias(), status);
     TEST_ASSERT_SUCCESS(status);
     status.reset();
@@ -386,42 +386,42 @@ void RBBIAPITest::TestIteration()
 
     UErrorCode status=U_ZERO_ERROR;
     RuleBasedBreakIterator* bi  = (RuleBasedBreakIterator*)RuleBasedBreakIterator::createCharacterInstance(Locale::getDefault(), status);
-    if (U_FAILURE(status) || bi == NULL)  {
+    if (U_FAILURE(status) || bi == nullptr)  {
         errcheckln(status, "Failure creating character break iterator.  Status = %s", u_errorName(status));
     }
     delete bi;
 
     status=U_ZERO_ERROR;
     bi  = (RuleBasedBreakIterator*)RuleBasedBreakIterator::createWordInstance(Locale::getDefault(), status);
-    if (U_FAILURE(status) || bi == NULL)  {
+    if (U_FAILURE(status) || bi == nullptr)  {
         errcheckln(status, "Failure creating Word break iterator.  Status = %s", u_errorName(status));
     }
     delete bi;
 
     status=U_ZERO_ERROR;
     bi  = (RuleBasedBreakIterator*)RuleBasedBreakIterator::createLineInstance(Locale::getDefault(), status);
-    if (U_FAILURE(status) || bi == NULL)  {
+    if (U_FAILURE(status) || bi == nullptr)  {
         errcheckln(status, "Failure creating Line break iterator.  Status = %s", u_errorName(status));
     }
     delete bi;
 
     status=U_ZERO_ERROR;
     bi  = (RuleBasedBreakIterator*)RuleBasedBreakIterator::createSentenceInstance(Locale::getDefault(), status);
-    if (U_FAILURE(status) || bi == NULL)  {
+    if (U_FAILURE(status) || bi == nullptr)  {
         errcheckln(status, "Failure creating Sentence break iterator.  Status = %s", u_errorName(status));
     }
     delete bi;
 
     status=U_ZERO_ERROR;
     bi  = (RuleBasedBreakIterator*)RuleBasedBreakIterator::createTitleInstance(Locale::getDefault(), status);
-    if (U_FAILURE(status) || bi == NULL)  {
+    if (U_FAILURE(status) || bi == nullptr)  {
         errcheckln(status, "Failure creating Title break iterator.  Status = %s", u_errorName(status));
     }
     delete bi;
 
     status=U_ZERO_ERROR;
     bi  = (RuleBasedBreakIterator*)RuleBasedBreakIterator::createCharacterInstance(Locale::getDefault(), status);
-    if (U_FAILURE(status) || bi == NULL)  {
+    if (U_FAILURE(status) || bi == nullptr)  {
         errcheckln(status, "Failure creating character break iterator.  Status = %s", u_errorName(status));
         return;   // Skip the rest of these tests.
     }
@@ -1078,8 +1078,8 @@ void RBBIAPITest::TestGetBinaryRules() {
         return;
     }
     RuleBasedBreakIterator *rbbi = dynamic_cast<RuleBasedBreakIterator *>(bi.getAlias());
-    if (rbbi == NULL) {
-        dataerrln("FAIL: RuleBasedBreakIterator is NULL");
+    if (rbbi == nullptr) {
+        dataerrln("FAIL: RuleBasedBreakIterator is nullptr");
         return;
     }
 
@@ -1096,7 +1096,7 @@ void RBBIAPITest::TestGetBinaryRules() {
     uint32_t ruleLength;
     const uint8_t *binRules = rbbi->getBinaryRules(ruleLength);
     TEST_ASSERT(ruleLength > 0);
-    TEST_ASSERT(binRules != NULL);
+    TEST_ASSERT(binRules != nullptr);
 
     // Clone the binary rules, and create a break iterator from that.
     // The break iterator does not adopt the rules; we must delete when we are finished with the iterator.

--- a/icu4c/source/test/intltest/rbbitst.cpp
+++ b/icu4c/source/test/intltest/rbbitst.cpp
@@ -168,7 +168,7 @@ void RBBITest::runIndexedTest( int32_t index, UBool exec, const char* &name, cha
 //--------------------------------------------------------------------------------------
 
 RBBITest::RBBITest() {
-    fTestParams = NULL;
+    fTestParams = nullptr;
 }
 
 
@@ -216,8 +216,8 @@ static void printStringBreaks(UText *tstr, int expected[], int expectedCount) {
 
 static void printStringBreaks(const UnicodeString &ustr, int expected[], int expectedCount) {
    UErrorCode status = U_ZERO_ERROR;
-   UText *tstr = NULL;
-   tstr = utext_openConstUnicodeString(NULL, &ustr, &status);
+   UText *tstr = nullptr;
+   tstr = utext_openConstUnicodeString(nullptr, &ustr, &status);
    if (U_FAILURE(status)) {
        printf("printStringBreaks, utext_openConstUnicodeString() returns %s\n", u_errorName(status));
        return;
@@ -236,7 +236,7 @@ void RBBITest::TestBug3818() {
     UnicodeString  thaiStr(thaiWordData);
 
     BreakIterator* bi = BreakIterator::createWordInstance(Locale("th"), status);
-    if (U_FAILURE(status) || bi == NULL) {
+    if (U_FAILURE(status) || bi == nullptr) {
         errcheckln(status, "Fail at file %s, line %d, status = %s", __FILE__, __LINE__, u_errorName(status));
         return;
     }
@@ -365,8 +365,8 @@ void RBBITest::TestBug5775() {
         return;
     }
 // Check for status first for better handling of no data errors.
-    TEST_ASSERT(bi != NULL);
-    if (bi == NULL) {
+    TEST_ASSERT(bi != nullptr);
+    if (bi == nullptr) {
         return;
     }
 
@@ -405,11 +405,11 @@ struct TestParams {
     CharString       utf8String;           // UTF-8 form of text to break.
 
     TestParams(UErrorCode &status) : dataToBreak() {
-        bi               = NULL;
+        bi               = nullptr;
         expectedBreaks   = new UVector32(status);
         srcLine          = new UVector32(status);
         srcCol           = new UVector32(status);
-        textToBreak      = NULL;
+        textToBreak      = nullptr;
         textMap          = new UVector32(status);
     }
 
@@ -438,9 +438,9 @@ static void CharStringAppend(CharString &dest, const UnicodeString &src, UErrorC
         return;
     }
     int32_t utf8Length;
-    u_strToUTF8WithSub(NULL, 0, &utf8Length,            // Output Buffer, NULL for preflight.
+    u_strToUTF8WithSub(nullptr, 0, &utf8Length,         // Output Buffer, nullptr for preflight.
                        src.getBuffer(), src.length(),   // UTF-16 data
-                       0xfffd, NULL,                    // Substitution char, number of subs.
+                       0xfffd, nullptr,                 // Substitution char, number of subs.
                        &status);
     if (U_FAILURE(status) && status != U_BUFFER_OVERFLOW_ERROR) {
         return;
@@ -448,9 +448,9 @@ static void CharStringAppend(CharString &dest, const UnicodeString &src, UErrorC
     status = U_ZERO_ERROR;
     int32_t capacity;
     char *buffer = dest.getAppendBuffer(utf8Length, utf8Length, capacity, status);
-    u_strToUTF8WithSub(buffer, utf8Length, NULL,
+    u_strToUTF8WithSub(buffer, utf8Length, nullptr,
                        src.getBuffer(), src.length(),
-                       0xfffd, NULL, &status);
+                       0xfffd, nullptr, &status);
     dest.append(buffer, utf8Length, status);
 }
 
@@ -554,7 +554,7 @@ void RBBITest::executeTest(TestParams *t, UErrorCode &status) {
         return;
     }
 
-    if (t->bi == NULL) {
+    if (t->bi == nullptr) {
         return;
     }
 
@@ -1296,7 +1296,7 @@ void RBBITest::runUnicodeTestData(const char *fileName, RuleBasedBreakIterator *
     //
     const char *testDataDirectory = IntlTest::getSourceTestData(status);
     char testFileName[1000];
-    if (testDataDirectory == NULL || strlen(testDataDirectory) >= sizeof(testFileName)) {
+    if (testDataDirectory == nullptr || strlen(testDataDirectory) >= sizeof(testFileName)) {
         dataerrln("Can't open test data.  Path too long.");
         return;
     }
@@ -1309,9 +1309,9 @@ void RBBITest::runUnicodeTestData(const char *fileName, RuleBasedBreakIterator *
     UChar *testFile = ReadAndConvertFile(testFileName, len, "UTF-8", status);
     if (status != U_FILE_ACCESS_ERROR) {
         TEST_ASSERT_SUCCESS(status);
-        TEST_ASSERT(testFile != NULL);
+        TEST_ASSERT(testFile != nullptr);
     }
-    if (U_FAILURE(status) || testFile == NULL) {
+    if (U_FAILURE(status) || testFile == nullptr) {
         return; /* something went wrong, error already output */
     }
     UnicodeString testFileAsString(true, testFile, len);
@@ -1365,7 +1365,7 @@ void RBBITest::runUnicodeTestData(const char *fileName, RuleBasedBreakIterator *
             if (length<=8) {
                 char buf[10];
                 hexNumber.extract (0, length, buf, sizeof(buf), US_INV);
-                UChar32 c = (UChar32)strtol(buf, NULL, 16);
+                UChar32 c = (UChar32)strtol(buf, nullptr, 16);
                 if (c<=0x10ffff) {
                     testString.append(c);
                 } else {
@@ -1621,7 +1621,7 @@ private:
 RBBICharMonkey::RBBICharMonkey() {
     UErrorCode  status = U_ZERO_ERROR;
 
-    fText = NULL;
+    fText = nullptr;
 
     fCRLFSet    = new UnicodeSet(UNICODE_STRING_SIMPLE("[\\r\\n]"), status);
     fControlSet = new UnicodeSet(UNICODE_STRING_SIMPLE("[[\\p{Grapheme_Cluster_Break = Control}]]"), status);
@@ -2645,11 +2645,11 @@ private:
 
 RBBILineMonkey::RBBILineMonkey() :
     RBBIMonkeyKind(),
-    fSets(NULL),
+    fSets(nullptr),
 
-    fCharBI(NULL),
-    fText(NULL),
-    fNumberMatcher(NULL)
+    fCharBI(nullptr),
+    fText(nullptr),
+    fNumberMatcher(nullptr)
 
 {
     if (U_FAILURE(deferredStatus)) {
@@ -3409,7 +3409,7 @@ static int32_t  getIntParam(UnicodeString name, UnicodeString &params, int32_t d
             paramLength = (int32_t)(sizeof(valString)-2);
         }
         params.extract(m.start(1, status), paramLength, valString, sizeof(valString));
-        val = strtol(valString, NULL, 10);
+        val = strtol(valString, nullptr, 10);
 
         // Delete this parameter from the params string.
         m.reset();
@@ -3857,7 +3857,7 @@ void RBBITest::TestMonkey() {
             // Each option is stripped out of the option string as it is processed.
             // All options have been checked.  The option string should have been completely emptied..
             char buf[100];
-            p.extract(buf, sizeof(buf), NULL, status);
+            p.extract(buf, sizeof(buf), nullptr, status);
             buf[sizeof(buf)-1] = 0;
             errln("Unrecognized or extra parameter:  %s\n", buf);
             return;
@@ -3974,7 +3974,7 @@ void RBBITest::RunMonkey(BreakIterator *bi, RBBIMonkeyKind &mk, const char *name
     // Verify that the character classes all have at least one member.
     for (i=0; i<numCharClasses; i++) {
         UnicodeSet *s = (UnicodeSet *)chClasses->elementAt(i);
-        if (s == NULL || s->size() == 0) {
+        if (s == nullptr || s->size() == 0) {
             errln("Character Class #%d is null or of zero size.", i);
             return;
         }
@@ -4037,7 +4037,7 @@ void RBBITest::RunMonkey(BreakIterator *bi, RBBIMonkeyKind &mk, const char *name
         memset(forwardBreaks, 0, sizeof(forwardBreaks));
         if (useUText) {
             UErrorCode status = U_ZERO_ERROR;
-            UText *testUText = utext_openReplaceable(NULL, &testText, &status);
+            UText *testUText = utext_openReplaceable(nullptr, &testText, &status);
             // testUText = utext_openUnicodeString(testUText, &testText, &status);
             bi->setText(testUText, status);
             TEST_ASSERT_SUCCESS(status);
@@ -4122,8 +4122,8 @@ void RBBITest::RunMonkey(BreakIterator *bi, RBBIMonkeyKind &mk, const char *name
 
         // Compare the expected and actual results.
         for (i=0; i<=testText.length(); i++) {
-            const char *errorType = NULL;
-            const char* currentBreakData = NULL;
+            const char *errorType = nullptr;
+            const char* currentBreakData = nullptr;
             if  (forwardBreaks[i] != expectedBreaks[i]) {
                 errorType = "next()";
                 currentBreakData = forwardBreaks;
@@ -4141,7 +4141,7 @@ void RBBITest::RunMonkey(BreakIterator *bi, RBBIMonkeyKind &mk, const char *name
                 currentBreakData = precedingBreaks;
             }
 
-            if (errorType != NULL) {
+            if (errorType != nullptr) {
                 // Format a range of the test text that includes the failure as
                 //  a data item that can be included in the rbbi test data file.
 
@@ -4372,7 +4372,7 @@ void RBBITest::TestBug12918() {
     // This test triggers an assertion failure in dictbe.cpp
     const UChar *crasherString = u"\u3325\u4a16";
     UErrorCode status = U_ZERO_ERROR;
-    UBreakIterator* iter = ubrk_open(UBRK_WORD, NULL, crasherString, -1, &status);
+    UBreakIterator* iter = ubrk_open(UBRK_WORD, nullptr, crasherString, -1, &status);
     if (U_FAILURE(status)) {
         dataerrln("%s:%d status = %s", __FILE__, __LINE__, u_errorName(status));
         return;
@@ -4426,7 +4426,7 @@ void RBBITest::TestEmoji() {
 
     int    len;
     UChar *testFile = ReadAndConvertFile(testFileName.data(), len, "UTF-8", status);
-    if (U_FAILURE(status) || testFile == NULL) {
+    if (U_FAILURE(status) || testFile == nullptr) {
         errln("%s:%s %s while opening emoji-test.txt", __FILE__, __LINE__, u_errorName(status));
         return;
     }
@@ -4459,7 +4459,7 @@ void RBBITest::TestEmoji() {
             }
             CharString hex8;
             hex8.appendInvariantChars(hex, status);
-            UChar32 c = (UChar32)strtol(hex8.data(), NULL, 16);
+            UChar32 c = (UChar32)strtol(hex8.data(), nullptr, 16);
             if (c<=0x10ffff) {
                 testString.append(c);
             } else {


### PR DESCRIPTION
In the C++ break iterator code, change all use of NULL to nullptr. This is in preparation for follow-on PRs to improve out-of-memory error handling in Break Iterators, keeping use of nullptr consistent between old and new or updated code.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21180
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
