### PR TITLE
ICU-22191 writesrc.cpp: fix cinttypes header

### DIFF
--- a/icu4c/source/tools/toolutil/writesrc.cpp
+++ b/icu4c/source/tools/toolutil/writesrc.cpp
@@ -19,8 +19,8 @@
 */
 
 #include <stdio.h>
-#include <inttypes.h>
 #include <time.h>
+#include <cinttypes>
 #include "unicode/utypes.h"
 #include "unicode/putil.h"
 #include "unicode/ucptrie.h"


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

Fixes build failure on macOS with GCC.
`<cinttypes>` should be used instead of `<inttypes.h>`: https://en.cppreference.com/w/cpp/header/cinttypes

P. S. Using <inttypes.h> requires defining `__STDC_FORMAT_MACROS`: https://opensource.apple.com/source/gcc/gcc-926.1/inttypes.h.auto.html – but it is not defined, which results in build failure.
Alternative would be adding something like:
```
#if defined __APPLE__
#define __STDC_FORMAT_MACROS
#endif
```
before problematic header.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22191
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
