### PR TITLE
ICU-22204 toolutil: Fix crash when trying to generate MinGW assembly

### DIFF
--- a/icu4c/source/tools/toolutil/pkg_genc.cpp
+++ b/icu4c/source/tools/toolutil/pkg_genc.cpp
@@ -315,12 +315,11 @@ writeAssemblyCode(
             exit(U_ILLEGAL_ARGUMENT_ERROR);
         }
         uprv_strcpy(outFilePath, buffer.chars);
-    }
-
 #if defined (WINDOWS_WITH_GNUC) && U_PLATFORM != U_PF_CYGWIN
-    /* Need to fix the file separator character when using MinGW. */
-    swapFileSepChar(outFilePath, U_FILE_SEP_CHAR, '/');
+        /* Need to fix the file separator character when using MinGW. */
+        swapFileSepChar(outFilePath, U_FILE_SEP_CHAR, '/');
 #endif
+    }
 
     if(optEntryPoint != NULL) {
         uprv_strcpy(entry, optEntryPoint);
@@ -433,6 +432,10 @@ writeCCode(
             exit(U_ILLEGAL_ARGUMENT_ERROR);
         }
         uprv_strcpy(outFilePath, buffer);
+#if defined (WINDOWS_WITH_GNUC) && U_PLATFORM != U_PF_CYGWIN
+        /* Need to fix the file separator character when using MinGW. */
+        swapFileSepChar(outFilePath, U_FILE_SEP_CHAR, '/');
+#endif
     }
 
     out=T_FileStream_open(buffer, "w");


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

👋

This is the associated PR to fix bug [ICU-22204](https://unicode-org.atlassian.net/browse/ICU-22204).

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22204
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
