### PR TITLE
ICU-22211 macOS PPC should use `.p2align 4` instead `.balign 16` 

### DIFF
--- a/icu4c/source/acinclude.m4
+++ b/icu4c/source/acinclude.m4
@@ -77,6 +77,7 @@ x86_64-*-cygwin)
 *-*ibm-openedition*|*-*-os390*)	icu_cv_host_frag=mh-os390 ;;
 *-*-os400*)	icu_cv_host_frag=mh-os400 ;;
 *-apple-rhapsody*)	icu_cv_host_frag=mh-darwin ;;
+powerpc*-apple-darwin*)	icu_cv_host_frag=mh-darwin-ppc ;;
 *-apple-darwin*)	icu_cv_host_frag=mh-darwin ;;
 *-*-beos)       icu_cv_host_frag=mh-beos ;; 
 *-*-haiku)      icu_cv_host_frag=mh-haiku ;; 

--- a/icu4c/source/config/mh-darwin-ppc
+++ b/icu4c/source/config/mh-darwin-ppc
@@ -1,0 +1,85 @@
+## -*-makefile-*-
+## Copyright (C) 2016 and later: Unicode, Inc. and others.
+## License & terms of use: http://www.unicode.org/copyright.html
+## Darwin-specific setup (Darwin is the Mac OS X developer preview, successor
+## to Rhapsody, aka Mac OS X Server)
+## Copyright (c) 1999-2012 International Business Machines Corporation and
+## others. All Rights Reserved.
+
+## Flags for position independent code
+SHAREDLIBCFLAGS = -dynamic
+SHAREDLIBCXXFLAGS = -dynamic
+SHAREDLIBCPPFLAGS =
+
+# Do not export internal methods by default
+LIBCFLAGS += -fvisibility=hidden
+LIBCXXFLAGS += -fvisibility=hidden
+
+# Pad out the paths to the maximum possible length
+LD_FLAGS += -headerpad_max_install_names
+
+# We do not need to see the stderr message that the archive was made.
+ARFLAGS += -c
+
+## Commands to compile
+COMPILE.c=	$(CC) $(DEFS) $(CPPFLAGS) $(CFLAGS) -fno-common -c
+COMPILE.cc=	$(CXX) $(DEFS) $(CPPFLAGS) $(CXXFLAGS) -fno-common -c
+
+## Commands to make a shared library
+SHLIB.c=	$(CC) -dynamiclib -dynamic $(CFLAGS) $(LDFLAGS) $(LD_SOOPTIONS)
+SHLIB.cc=	$(CXX) -dynamiclib -dynamic $(CXXFLAGS) $(LDFLAGS) $(LD_SOOPTIONS)
+
+## Compiler switches to embed a library name and version information
+ifeq ($(ENABLE_RPATH),YES)
+LD_SONAME = -Wl,-compatibility_version -Wl,$(SO_TARGET_VERSION_MAJOR) -Wl,-current_version -Wl,$(SO_TARGET_VERSION) -install_name $(libdir)/$(notdir $(MIDDLE_SO_TARGET))
+else
+LD_SONAME = -Wl,-compatibility_version -Wl,$(SO_TARGET_VERSION_MAJOR) -Wl,-current_version -Wl,$(SO_TARGET_VERSION) -install_name $(notdir $(MIDDLE_SO_TARGET)) $(PKGDATA_TRAILING_SPACE)
+endif
+
+## Compiler switch to embed a runtime search path
+LD_RPATH=
+LD_RPATH_PRE= -Wl,-rpath,
+
+## Environment variable to set a runtime search path
+LDLIBRARYPATH_ENVVAR = DYLD_LIBRARY_PATH
+
+GENCCODE_ASSEMBLY=-a gcc-darwin-ppc
+
+## Shared object suffix
+SO=		dylib
+## Non-shared intermediate object suffix
+STATIC_O = ao
+
+## Override Versioned target for a shared library.
+FINAL_SO_TARGET=  $(basename $(SO_TARGET)).$(SO_TARGET_VERSION).$(SO)
+MIDDLE_SO_TARGET= $(basename $(SO_TARGET)).$(SO_TARGET_VERSION_MAJOR).$(SO)
+
+## Compilation and dependency rules
+%.$(STATIC_O): $(srcdir)/%.c
+	$(call SILENT_COMPILE,$(strip $(COMPILE.c) $(STATICCPPFLAGS) $(STATICCFLAGS)) -MMD -MT "$*.d $*.o $*.$(STATIC_O)" -o $@ $<)
+%.o: $(srcdir)/%.c
+	$(call SILENT_COMPILE,$(strip $(COMPILE.c) $(DYNAMICCPPFLAGS) $(DYNAMICCFLAGS)) -MMD -MT "$*.d $*.o $*.$(STATIC_O)" -o $@ $<)
+
+%.$(STATIC_O): $(srcdir)/%.cpp
+	$(call SILENT_COMPILE,$(strip $(COMPILE.cc) $(STATICCPPFLAGS) $(STATICCXXFLAGS)) -MMD -MT "$*.d $*.o $*.$(STATIC_O)" -o $@ $<)
+%.o: $(srcdir)/%.cpp
+	$(call SILENT_COMPILE,$(strip $(COMPILE.cc) $(DYNAMICCPPFLAGS) $(DYNAMICCXXFLAGS)) -MMD -MT "$*.d $*.o $*.$(STATIC_O)" -o $@ $<)
+
+## Versioned libraries rules
+
+%.$(SO_TARGET_VERSION_MAJOR).$(SO): %.$(SO_TARGET_VERSION).$(SO)
+	$(RM) $@ && ln -s ${<F} $@
+%.$(SO): %.$(SO_TARGET_VERSION_MAJOR).$(SO)
+	$(RM) $@ && ln -s ${*F}.$(SO_TARGET_VERSION).$(SO) $@
+
+# tzcode option
+TZORIG_EXTRA_CFLAGS=-DSTD_INSPIRED
+
+# genren opts
+GENREN_PL_OPTS=-x Mach-O -n '-g' -p '| c++filt'
+
+## Remove shared library 's'
+STATIC_PREFIX_WHEN_USED = 
+STATIC_PREFIX = 
+
+## End Darwin-specific setup

--- a/icu4c/source/tools/toolutil/pkg_genc.cpp
+++ b/icu4c/source/tools/toolutil/pkg_genc.cpp
@@ -158,6 +158,22 @@ static const struct AssemblyType {
 
         ".long ","",HEX_0X
     },
+    /* macOS PPC should use `.p2align 4` instead `.balign 16` because is
+     * unknown pseudo ops for such legacy system*/
+    {"gcc-darwin-ppc",
+        /*"\t.section __TEXT,__text,regular,pure_instructions\n"
+        "\t.section __TEXT,__picsymbolstub1,symbol_stubs,pure_instructions,32\n"*/
+        ".globl _%s\n"
+        "#ifdef U_HIDE_DATA_SYMBOL\n"
+        "\t.private_extern _%s\n"
+        "#endif\n"
+        "\t.data\n"
+        "\t.const\n"
+        "\t.p2align 4\n"
+        "_%s:\n\n",
+
+        ".long ","",HEX_0X
+    },
     {"gcc-cygwin",
         ".globl _%s\n"
         "\t.section .rodata\n"


### PR DESCRIPTION
An attempt to build ICU on old macOS with PowerPC leads to an issue:
```
./out/tmp/icudt72b_dat.S:7:Unknown pseudo-op: .balign
./out/tmp/icudt72b_dat.S:7:Rest of line ignored. 1st junk character valued 49 (1).
```

Why? Because `as` is too old.

Anyway, switc to `.p2align 4` fix a build and allows to pass all tests.

See: https://trac.macports.org/ticket/66258

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22211
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
