### PR TITLE
ICU-9749 Move explicit instantiation definition, add declaration

### DIFF
--- a/icu4c/source/i18n/number_decimalquantity.cpp
+++ b/icu4c/source/i18n/number_decimalquantity.cpp
@@ -29,6 +29,13 @@ using namespace icu::number::impl;
 using icu::double_conversion::DoubleToStringConverter;
 using icu::double_conversion::StringToDoubleConverter;
 
+U_NAMESPACE_BEGIN
+
+// This explicit template instantiation is used in class DecNum; see number_decnum.h.
+template class U_I18N_API MaybeStackHeaderAndArray<decNumber, char, DECNUM_INITIAL_CAPACITY>;
+
+U_NAMESPACE_END
+
 namespace {
 
 int8_t NEGATIVE_FLAG = 1;

--- a/icu4c/source/i18n/number_decnum.h
+++ b/icu4c/source/i18n/number_decnum.h
@@ -15,11 +15,11 @@ U_NAMESPACE_BEGIN
 
 #define DECNUM_INITIAL_CAPACITY 34
 
-// Export an explicit template instantiation of the MaybeStackHeaderAndArray that is used as a data member of DecNum.
-// When building DLLs for Windows this is required even though no direct access to the MaybeStackHeaderAndArray leaks out of the i18n library.
-// (See digitlst.h, pluralaffix.h, datefmt.h, and others for similar examples.)
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API MaybeStackHeaderAndArray<decNumber, char, DECNUM_INITIAL_CAPACITY>;
+// An explicit template instantiation of MaybeStackHeaderAndArray that is
+// used as a data member below is defined in number_decimalquantity.cpp.
+// (MSVC treats imports/exports of explicit instantiations differently.)
+#ifndef _MSC_VER
+extern template class MaybeStackHeaderAndArray<decNumber, char, DECNUM_INITIAL_CAPACITY>;
 #endif
 
 namespace number {


### PR DESCRIPTION
Moves the definition of an explicit template instantiation from the header number_decnum.h into the .cpp file number_decimalquantity.cpp, and adds a declaration of the instantiation to the header instead.

Removes old guard macros for specific platforms. The new construction is portable C++11.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-9749
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
