### PR TITLE
ICU-22193 fix some CI test failures

### DIFF
--- a/icu4c/source/common/unicode/icuplug.h
+++ b/icu4c/source/common/unicode/icuplug.h
@@ -187,8 +187,12 @@ typedef enum {
 
 /**
  * Entrypoint for an ICU plugin.
- * @param plug the UPlugData handle. 
- * @param status the plugin's extended status code.
+ * @param plug the UPlugData handle.
+ * @param reason the reason code for the entrypoint's call.
+ * @param status Standard ICU error code. Its input value must
+ *               pass the U_SUCCESS() test, or else the function returns
+ *               immediately. Check for U_FAILURE() on output or use with
+ *               function chaining. (See User Guide for details.)
  * @return A valid plugin must return UPLUG_TOKEN
  * @internal ICU 4.4 Technology Preview
  */

--- a/icu4c/source/common/unicode/uclean.h
+++ b/icu4c/source/common/unicode/uclean.h
@@ -114,7 +114,8 @@ typedef void *U_CALLCONV UMemAllocFn(const void *context, size_t size);
 /**
   *  Pointer type for a user supplied memory re-allocation function.
   *  @param context user supplied value, obtained from u_setMemoryFunctions().
-  *  @param size    The number of bytes to be allocated
+  *  @param mem     Pointer to the memory block to be resized.
+  *  @param size    The new size for the block.
   *  @return        Pointer to the newly allocated memory, or NULL if the allocation failed.
   *  @stable ICU 2.8
   *  @system
@@ -124,8 +125,7 @@ typedef void *U_CALLCONV UMemReallocFn(const void *context, void *mem, size_t si
   *  Pointer type for a user supplied memory free  function.  Behavior should be
   *  similar the standard C library free().
   *  @param context user supplied value, obtained from u_setMemoryFunctions().
-  *  @param mem     Pointer to the memory block to be resized
-  *  @param size    The new size for the block
+  *  @param mem     Pointer to the memory block to be freed.
   *  @return        Pointer to the resized memory block, or NULL if the resizing failed.
   *  @stable ICU 2.8
   *  @system

--- a/icu4c/source/test/depstest/dependencies.txt
+++ b/icu4c/source/test/depstest/dependencies.txt
@@ -48,6 +48,9 @@ group: std_mutex
     std::condition_variable::~condition_variable()
     std::condition_variable_any::condition_variable_any()
     std::condition_variable_any::~condition_variable_any()
+    pthread_once
+    pthread_mutex_lock
+    pthread_mutex_unlock
 
 group: ubsan
     # UBSan=UndefinedBehaviorSanitizer, clang -fsanitize=bounds


### PR DESCRIPTION
Fixing some CI test failures that I noticed on other pending PRs.
- API doc warnings about parameters in function typedefs
- dependency checker: mutex/init-once code calling pthread_* functions

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22193
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
