### PR TITLE
ICU-22193 Use Ubuntu 20.04 for jobs failing in migration to 22.04

### DIFF
--- a/.github/workflows/icu_ci.yml
+++ b/.github/workflows/icu_ci.yml
@@ -172,7 +172,7 @@ jobs:
   # (FORCE guards make this tool pass but won't compile to working code.
   # See the testtagsguards.sh script for details.)
   clang-release-build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 
@@ -261,7 +261,7 @@ jobs:
 
   # Run ICU4C tests with stubdata.
   run-with-stubdata:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 
@@ -402,7 +402,7 @@ jobs:
 
   # Build Unicode update tools
   unicode-update-tools:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - uses: bazelbuild/setup-bazelisk@v1


### PR DESCRIPTION
Github has been rolling out their migration of their Github Actions CI runner VM from Ubuntu 20.04 to 22.04:
https://github.com/actions/runner-images/issues/6399

The announcement issue says that if we encounter problems, pin the failing jobs to the old Ubuntu version and file an issue on the runner VM repository.

Based on a [test in my personal fork](https://github.com/echeran/icu/actions/runs/3690618526/jobs/6247821953), reverting to the old version of Ubuntu does allow the jobs to pass.

This PR is to pin the failing jobs to the old Ubuntu version (20.04).

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22193
- [X] Required: The PR title must be prefixed with a JIRA Issue number.
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
