### PR TITLE
ICU-22242 Test to show incorrect calculation of 1890

### DIFF
--- a/icu4c/source/test/intltest/caltest.h
+++ b/icu4c/source/test/intltest/caltest.h
@@ -286,6 +286,7 @@ public: // package
         int32_t dst_offset, int32_t year_woy, int32_t dow_local, int32_t extended_year,
         int32_t julian_day, int32_t milliseconds_in_day, int32_t is_leap_month);
 
+    void TestChineseCalendarMonthInSpecialYear(void);
     void TestGregorianCalendarInTemporalLeapYear(void);
     void TestChineseCalendarInTemporalLeapYear(void);
     void TestDangiCalendarInTemporalLeapYear(void);


### PR DESCRIPTION
This PR add test cases for some tricky year (M11L and incorrect M12L) in 1890 and 2033.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22242
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
