### PR TITLE
ICU-22193 Make clang-release-build-and-test work with ubuntu-latest.

### DIFF
--- a/.github/workflows/icu_ci.yml
+++ b/.github/workflows/icu_ci.yml
@@ -220,7 +220,7 @@ jobs:
   # (FORCE guards make this tool pass but won't compile to working code.
   # See the testtagsguards.sh script for details.)
   clang-release-build-and-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 

--- a/icu4c/source/test/hdrtst/testtagsguards.sh
+++ b/icu4c/source/test/hdrtst/testtagsguards.sh
@@ -45,7 +45,7 @@ for file in source/common/unicode/*.h source/i18n/unicode/*.h source/io/unicode/
     GUARD=DEPRECATED
     echo "    @$TAG"
     $CXX $INCL -C -E -DU_HIDE_${GUARD}_API=1 -DU_FORCE_HIDE_${GUARD}_API=1 $DEF -o $TMPDIR/ht-$base-$TAG.i $TMPDIR/ht-$base.cpp
-    if grep "@$TAG" -C 5 $TMPDIR/ht-$base-$TAG.i; then
+    if grep "@$TAG\b.*\bICU\b" -C 5 $TMPDIR/ht-$base-$TAG.i; then
         echo "*** error: @$TAG not hidden in $TMPDIR/ht-$base-$TAG.i"
         exit 1
     fi


### PR DESCRIPTION
Contemporary implementations of the C++ standard library also use the `@deprecated` annotation in its header files and these then get included by the preprocessor when preprocessing the ICU header files, like this:

```
  /// @deprecated Non-standard. Use `is_null_pointer` instead.
```

In order to work as expected, testtagsguards.sh must therefore be updated to ignore `@deprecated` annotations unless they're for ICU.

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22193
- [X] Required: The PR title must be prefixed with a JIRA Issue number.
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number.
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
