### PR TITLE
ICU-12811 Make CI jobs for Maven run serially

### DIFF
--- a/.github/workflows/icu_ci.yml
+++ b/.github/workflows/icu_ci.yml
@@ -63,6 +63,10 @@ jobs:
   java8-icu4j-test-maven:
     name: Run unit tests with Maven using JDK 8
     runs-on: ubuntu-latest
+    # Make this unit test target job depend on a later phase target job to prevent race condition when
+    # trying to persist the Maven cache to the Github cache, knowing that artifacts needed for
+    # the later phase `verify` are a superset of the artifacts needed for the earlier phase `test`.
+    needs: java8-icu4j-verify-maven
     steps:
       - name: Checkout and setup
         uses: actions/checkout@v2


### PR DESCRIPTION
There are 2 CI jobs that run a Maven command at the root.  The jobs are configured to persist any downloaded Maven artifact dependencies, and cache them (save them at the end of the job, load the cache at the beginning of the next instantiation).

We want the cache to work properly to make the jobs more resilient in case of ephemeral network connections, etc., like what happened in this [recent workflow run](https://github.com/unicode-org/icu/actions/runs/3700019863/jobs/6268025244#logs).

But because these jobs run in parallel, there is probably a race condition.  One job invokes a target (`verify`) that is later phase in the Maven lifecycle than the other job's target phase (`test`). This means the first jobs required set of dependencies is a superset of the other.

We could have a separate cache for each job, or we could have the job that needs fewer dependencies always execute after the other, and then the latter job can reuse the former job's cache.  This PR takes the latter approach.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-12811
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
