### PR TITLE
ICU-12811 Add CI workflow to retain caches that are flaky/costly to init

### DIFF
--- a/.github/workflows/cache_retain.yml
+++ b/.github/workflows/cache_retain.yml
@@ -1,0 +1,48 @@
+# Copyright (C) 2023 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
+#
+# This workflow is designed to keep specific caches on the main
+# branch from getting evicted according to the Github Actions policy
+# (currently in 2023: 7 days) in cases where the cost to construct
+# the cache is high, especially in cases where there is flakiness
+# (ex: network loss / throttling when downloading artifacts) involved in
+# constructing the cache.
+#
+# Preventing a cache from eviction using this workflow requires that:
+#  - the cache is not too big that it starves other caches 
+#    from using the shared cache quota for the repository
+#  - the cache key is specific enough to avoid cache collisions, according
+#    to good cache key design
+#  - the cache key is not overly specific to cause unnecessary cache misses
+#    (resulting in duplicate caches values, thereby wasting space), according
+#    to good cache key design
+#  - For more details, see: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
+
+name: Retain Specific Caches
+
+on:
+  schedule:
+    # Because the Github Actions cache eviction policy is every 7 days,
+    # this cron schedule is set to run every 6 days to ensure retention
+    - cron: '0 12 0/6 * *'
+
+jobs:
+  retain-maven-cache:
+    name: Run all tests with Maven
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout and setup
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+      - name: Checkout lfs objects
+        run: git lfs pull
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: maven
+      - name: Run Maven unit & integration tests
+        run: |
+          cd icu4j/maven-build;
+          mvn --batch-mode verify


### PR DESCRIPTION
This PR is adding a workflow to ensure that certain CI caches are not evicted when they are flaky/costly to create.

The motivating reason is that [PRs can have spurious build failures](https://github.com/unicode-org/icu/actions/runs/3896922654/jobs/6654020248) because the Maven build job cannot download all of the dependency artifacts due to flakiness. The job needs to be re-run in that case until all of the dependency artifacts can be successfully downloaded. This happens when the cache does not exist, which can happen because the cache  is evicted automatically after 7 days of inactivity.

Note: Although ICU4J only has a few test dependencies, the Maven build uses plugins that are implemented with code that have many transitive dependencies. 

By ensuring that the cache exists on the upstream default branch (`main`), the CI invocations for PRs will be able to reuse the cache from the default branch and load from it during the first run for that PR. This will help insulate contributors from job failures due to the flakiness.

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-12811
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
