### PR TITLE
ICU-12811 Fix CI cache retain workflow's cron schedule string

### DIFF
--- a/.github/workflows/cache_retain.yml
+++ b/.github/workflows/cache_retain.yml
@@ -24,7 +24,7 @@ on:
   schedule:
     # Because the Github Actions cache eviction policy is every 7 days,
     # this cron schedule is set to run every 6 days to ensure retention
-    - cron: '0 12 0/6 * *'
+    - cron: '0 12 */6 * *'
 
 jobs:
   retain-maven-cache:


### PR DESCRIPTION
Fixes the cron schedule string, which turned out to be incorrectly formatted.

I've [tested this fix in my personal fork](https://github.com/echeran/icu/actions/runs/3914831364/workflow#L33) repo, and the workflow parser seems happy with it.

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-12811
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
