### PR TITLE
ICU-22233 Fix CI cache name for Bazel build

### DIFF
--- a/.github/workflows/icu_ci.yml
+++ b/.github/workflows/icu_ci.yml
@@ -490,11 +490,15 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: bazelbuild/setup-bazelisk@v1
+    - name: Get CI Linux runner VM version
+      id: linux-version
+      run: |
+        echo "LINUX_VERSION=$(grep -F VERSION_ID /etc/os-release | cut -d'"' -f2)" >> $GITHUB_OUTPUT
     - name: Mount bazel cache
       uses: actions/cache@v2
       with:
         path: "~/.cache/bazel"
-        key: ${{ runner.os }}-bazel
+        key: bazel-${{ runner.os }}-${{ steps.linux-version.outputs.LINUX_VERSION }}
 
     - name: Generate the data
       run: |


### PR DESCRIPTION
After looking at the list of [caches in the upstream repo](https://github.com/unicode-org/icu/actions/caches), I realized that the CI Bazel job's cache key wasn't as specific as intended. 

The cache key should include the version of Ubuntu. It was the version bump of Ubuntu from 20.04 to 22.04 that corresponded to the library version differences that led to the original compilation errors in the ticket.

However, the Github Actions predefined variable `${{ runner.os }}` only returns the value `Linux`, and there is no other predefined variable that provides the [runner VM name that includes the version number](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners).

This PR creates a workaround using info available in Ubuntu 16+ systems to get the version number in order to create an appropriately specific cache key.

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22233
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
