### PR TITLE
icu4c: preserve configure arguments

### DIFF
--- a/icu4c/source/runConfigureICU
+++ b/icu4c/source/runConfigureICU
@@ -447,7 +447,7 @@ export LDFLAGS
 echo "export CPP=$CPP CC=$CC CXX=$CXX CPPFLAGS=$CPPFLAGS CFLAGS=$CFLAGS CXXFLAGS=$CXXFLAGS LDFLAGS=$LDFLAGS MAKE=$MAKE"
 echo "Running ./configure $OPTS $@ for $THE_OS using $THE_COMP compiler"
 echo
-if $configure $OPTS $@
+if $configure $OPTS "$@"
 then
 	echo
 	echo If the result of the above commands looks okay to you, go to the directory


### PR DESCRIPTION
Please feel free to consider this a bug report and fix it yourself if you feel like. I'm just trying to keep OpenWrt downstream patches to the minimum, so sending it here for your consideration, I'm not sure I'll be able to properly create a corresponding Jira issue etc.

We want to avoid word splitting on the configure arguments during substitution.

A problem was exposed by using CC="ccache mips-openwrt-linux-musl-gcc" (that is, cross-compiling for MIPS OpenWrt with ccache enabled), it failed to build without this change.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [ ] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
- [ ] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
