### PR TITLE
Remove some legacy things from the locale fallback file

### DIFF
--- a/icu4c/source/data/curr/LOCALE_DEPS.json
+++ b/icu4c/source/data/curr/LOCALE_DEPS.json
@@ -22,7 +22,6 @@
         "mni_IN": "mni_Beng_IN",
         "mo": "ro",
         "no_NO": "no",
-        "no_NO_NY": "nn_NO",
         "pa_IN": "pa_Guru_IN",
         "pa_PK": "pa_Arab_PK",
         "sat_IN": "sat_Olck_IN",

--- a/icu4c/source/data/curr/nn_NO.txt
+++ b/icu4c/source/data/curr/nn_NO.txt
@@ -1,9 +1,0 @@
-﻿// © 2016 and later: Unicode, Inc. and others.
-// License & terms of use: http://www.unicode.org/copyright.html
-// Generated using tools/cldr/cldr-to-icu/build-icu-data.xml
-/**
- * generated alias target
- */
-nn_NO{
-    ___{""}
-}

--- a/icu4c/source/data/curr/no_NO_NY.txt
+++ b/icu4c/source/data/curr/no_NO_NY.txt
@@ -1,6 +1,0 @@
-﻿// © 2016 and later: Unicode, Inc. and others.
-// License & terms of use: http://www.unicode.org/copyright.html
-// Generated using tools/cldr/cldr-to-icu/build-icu-data.xml
-no_NO_NY{
-    "%%ALIAS"{"nn_NO"}
-}

--- a/icu4c/source/data/lang/LOCALE_DEPS.json
+++ b/icu4c/source/data/lang/LOCALE_DEPS.json
@@ -22,7 +22,6 @@
         "mni_IN": "mni_Beng_IN",
         "mo": "ro",
         "no_NO": "no",
-        "no_NO_NY": "nn_NO",
         "pa_IN": "pa_Guru_IN",
         "pa_PK": "pa_Arab_PK",
         "sat_IN": "sat_Olck_IN",

--- a/icu4c/source/data/lang/nn_NO.txt
+++ b/icu4c/source/data/lang/nn_NO.txt
@@ -1,9 +1,0 @@
-﻿// © 2016 and later: Unicode, Inc. and others.
-// License & terms of use: http://www.unicode.org/copyright.html
-// Generated using tools/cldr/cldr-to-icu/build-icu-data.xml
-/**
- * generated alias target
- */
-nn_NO{
-    ___{""}
-}

--- a/icu4c/source/data/lang/no_NO_NY.txt
+++ b/icu4c/source/data/lang/no_NO_NY.txt
@@ -1,6 +1,0 @@
-﻿// © 2016 and later: Unicode, Inc. and others.
-// License & terms of use: http://www.unicode.org/copyright.html
-// Generated using tools/cldr/cldr-to-icu/build-icu-data.xml
-no_NO_NY{
-    "%%ALIAS"{"nn_NO"}
-}

--- a/icu4c/source/data/locales/LOCALE_DEPS.json
+++ b/icu4c/source/data/locales/LOCALE_DEPS.json
@@ -22,7 +22,6 @@
         "mni_IN": "mni_Beng_IN",
         "mo": "ro",
         "no_NO": "no",
-        "no_NO_NY": "nn_NO",
         "pa_IN": "pa_Guru_IN",
         "pa_PK": "pa_Arab_PK",
         "sat_IN": "sat_Olck_IN",

--- a/icu4c/source/data/locales/no_NO_NY.txt
+++ b/icu4c/source/data/locales/no_NO_NY.txt
@@ -1,6 +1,0 @@
-﻿// © 2016 and later: Unicode, Inc. and others.
-// License & terms of use: http://www.unicode.org/copyright.html
-// Generated using tools/cldr/cldr-to-icu/build-icu-data.xml
-no_NO_NY{
-    "%%ALIAS"{"nn_NO"}
-}

--- a/icu4c/source/data/rbnf/LOCALE_DEPS.json
+++ b/icu4c/source/data/rbnf/LOCALE_DEPS.json
@@ -10,7 +10,6 @@
         "iw": "he",
         "sh": "sr_Latn",
         "zh_HK": "zh_Hant_HK",
-        "zh_Hant_HK": "yue",
         "zh_MO": "zh_Hant_MO",
         "zh_TW": "zh_Hant_TW"
     },

--- a/icu4c/source/data/rbnf/zh_Hant_HK.txt
+++ b/icu4c/source/data/rbnf/zh_Hant_HK.txt
@@ -2,5 +2,4 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 // Generated using tools/cldr/cldr-to-icu/build-icu-data.xml
 zh_Hant_HK{
-    "%%ALIAS"{"yue"}
 }

--- a/icu4c/source/data/region/LOCALE_DEPS.json
+++ b/icu4c/source/data/region/LOCALE_DEPS.json
@@ -22,7 +22,6 @@
         "mni_IN": "mni_Beng_IN",
         "mo": "ro",
         "no_NO": "no",
-        "no_NO_NY": "nn_NO",
         "pa_IN": "pa_Guru_IN",
         "pa_PK": "pa_Arab_PK",
         "sat_IN": "sat_Olck_IN",

--- a/icu4c/source/data/region/nn_NO.txt
+++ b/icu4c/source/data/region/nn_NO.txt
@@ -1,9 +1,0 @@
-﻿// © 2016 and later: Unicode, Inc. and others.
-// License & terms of use: http://www.unicode.org/copyright.html
-// Generated using tools/cldr/cldr-to-icu/build-icu-data.xml
-/**
- * generated alias target
- */
-nn_NO{
-    ___{""}
-}

--- a/icu4c/source/data/region/no_NO_NY.txt
+++ b/icu4c/source/data/region/no_NO_NY.txt
@@ -1,6 +1,0 @@
-﻿// © 2016 and later: Unicode, Inc. and others.
-// License & terms of use: http://www.unicode.org/copyright.html
-// Generated using tools/cldr/cldr-to-icu/build-icu-data.xml
-no_NO_NY{
-    "%%ALIAS"{"nn_NO"}
-}

--- a/icu4c/source/data/unit/LOCALE_DEPS.json
+++ b/icu4c/source/data/unit/LOCALE_DEPS.json
@@ -22,7 +22,6 @@
         "mni_IN": "mni_Beng_IN",
         "mo": "ro",
         "no_NO": "no",
-        "no_NO_NY": "nn_NO",
         "pa_IN": "pa_Guru_IN",
         "pa_PK": "pa_Arab_PK",
         "sat_IN": "sat_Olck_IN",

--- a/icu4c/source/data/unit/nn_NO.txt
+++ b/icu4c/source/data/unit/nn_NO.txt
@@ -1,9 +1,0 @@
-﻿// © 2016 and later: Unicode, Inc. and others.
-// License & terms of use: http://www.unicode.org/copyright.html
-// Generated using tools/cldr/cldr-to-icu/build-icu-data.xml
-/**
- * generated alias target
- */
-nn_NO{
-    ___{""}
-}

--- a/icu4c/source/data/unit/no_NO_NY.txt
+++ b/icu4c/source/data/unit/no_NO_NY.txt
@@ -1,6 +1,0 @@
-﻿// © 2016 and later: Unicode, Inc. and others.
-// License & terms of use: http://www.unicode.org/copyright.html
-// Generated using tools/cldr/cldr-to-icu/build-icu-data.xml
-no_NO_NY{
-    "%%ALIAS"{"nn_NO"}
-}

--- a/icu4c/source/data/zone/LOCALE_DEPS.json
+++ b/icu4c/source/data/zone/LOCALE_DEPS.json
@@ -22,7 +22,6 @@
         "mni_IN": "mni_Beng_IN",
         "mo": "ro",
         "no_NO": "no",
-        "no_NO_NY": "nn_NO",
         "pa_IN": "pa_Guru_IN",
         "pa_PK": "pa_Arab_PK",
         "sat_IN": "sat_Olck_IN",

--- a/icu4c/source/data/zone/nn_NO.txt
+++ b/icu4c/source/data/zone/nn_NO.txt
@@ -1,9 +1,0 @@
-﻿// © 2016 and later: Unicode, Inc. and others.
-// License & terms of use: http://www.unicode.org/copyright.html
-// Generated using tools/cldr/cldr-to-icu/build-icu-data.xml
-/**
- * generated alias target
- */
-nn_NO{
-    ___{""}
-}

--- a/icu4c/source/data/zone/no_NO_NY.txt
+++ b/icu4c/source/data/zone/no_NO_NY.txt
@@ -1,6 +1,0 @@
-﻿// © 2016 and later: Unicode, Inc. and others.
-// License & terms of use: http://www.unicode.org/copyright.html
-// Generated using tools/cldr/cldr-to-icu/build-icu-data.xml
-no_NO_NY{
-    "%%ALIAS"{"nn_NO"}
-}

--- a/tools/cldr/cldr-to-icu/build-icu-data.xml
+++ b/tools/cldr/cldr-to-icu/build-icu-data.xml
@@ -219,7 +219,7 @@
                 mt, mua, my, mzn
 
                 // N
-                naq, nb, nd, ne, nl, nmg, nn, nnh, no, no_NO, no_NO_NY, nus, nyn
+                naq, nb, nd, ne, nl, nmg, nn, nnh, no, no_NO, nus, nyn
 
                 // O
                 om, or, os
@@ -327,13 +327,6 @@
             </directory>
 
             <directory dir="rbnf">
-                <!-- It is not at all clear why this is being done. It's certainly not exactly the
-                     same as above, since (a) the alias is reversed (b) "zh_Hant" does exist, with
-                     different data than "yue", so this alias is not just rewriting the base
-                     language. -->
-                <!-- TODO: Find out and document this properly. -->
-                <forcedAlias source="zh_Hant_HK" target="yue"/>
-
                 <localeIds>
                     root,
 
@@ -372,9 +365,6 @@
                  generate an alias in order to affect "sideways inheritance" for spoken languages,
                  and at some stage it should probably be supported properly in the CLDR data. -->
             <forcedAlias source="ars" target="ar_SA"/>
-
-            <!-- A legacy global alias (note that "no_NO_NY" is not even structurally valid). -->
-            <forcedAlias source="no_NO_NY" target="nn_NO"/>
 
             <!-- This one is a bit silly, it is just to generate a stub for no_NO, which is
                  not in CLDR. If we do not do this, then including it in localeIds will generate


### PR DESCRIPTION
Part of [CLDR-16253](https://unicode-org.atlassian.net/browse/CLDR-16253)

In an effort to migrate the ICU-specific aliases upstream to CLDR (https://github.com/unicode-org/cldr/pull/2664), I wanted to remove some aliases that were labeled legacy or similar in ICU. I don't entirely know the impact of this change so would appreciate a review from that angle.

##### Checklist

- [ ] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
- [ ] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
