### PR TITLE
ICU-22262 Automate environment test

### DIFF
--- a/.github/workflows/icu_envtest.yml
+++ b/.github/workflows/icu_envtest.yml
@@ -1,0 +1,136 @@
+# Copyright (C) 2023 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
+#
+# GitHub Action configuration script for ICU environment test tasks.
+#
+
+name: GHA EnvTest
+
+on:
+  workflow_dispatch:
+    # To trigger the Env Test workflow manually, follow the instructions in
+    # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
+
+  schedule:
+    # This cron schedule is set to run 10:23 UTC every SAT
+    - cron: '23 10 * * SAT'
+
+jobs:
+  #=================================================================
+  # locale env tests.
+  env-test-locale:
+    runs-on: ubuntu-latest
+    strategy:
+      # "fail-fast: false" let other jobs keep running even if the test break in some locales.
+      fail-fast: false
+      matrix:
+        # Since we have total 500+ locales to run on three set of test, we create
+        # many jobs to test concurrently.
+        # shard is used to bucket the lines from the locale list into jobs.
+        # Currently we run testing of 30 locales per shard, and we have total 17 shards.
+        # 17x30 = 510 > 502 (the number of locales in 'locale -a').
+        tests_per_shard: [30]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+    steps:
+      - name: Install all locales by apt-get
+        run: |
+          sudo apt-get update -y;
+          sudo apt-get install -y locales-all;
+      - name: Show installed locales post apt-get
+        run: |
+          locale -a;
+      - name: Checkout and setup
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          cd icu4c/source/;
+          ./runConfigureICU Linux;
+          make -j10 tests;
+      - name: Test different locales as LC_ALL
+        run: |
+          echo "This job run the environment test of the following Locales";
+          begin=$(( ${{matrix.shard}} * ${{matrix.tests_per_shard}} + 1));
+          end=$(( (${{matrix.shard}}+1) * ${{matrix.tests_per_shard}} ));
+          sedarg=${begin},${end}p;
+          locale -a |sed -n ${sedarg};
+
+          cd icu4c/source/test;
+          for loc in `locale -a |sed -n ${sedarg}`;
+          do
+              echo "============================================";
+              echo "Start Tests under LC_ALL=$loc locale";
+              for test_dir in iotest cintltst intltest
+              do
+                  cd $test_dir;
+                  LC_ALL=$loc make check;
+                  cd ..;
+              done
+
+              echo "Complete Tests under LC_ALL=$loc locale";
+              echo "============================================";
+          done
+
+          echo "This job completed the test of the following Locales";
+          locale -a |sed -n ${sedarg};
+
+  #=================================================================
+  # tz env tests.
+  env-test-tz:
+    runs-on: ubuntu-latest
+    strategy:
+      # "fail-fast: false" let other jobs keep running even if the test break in some timezones.
+      fail-fast: false
+      matrix:
+        # Since we have total 600+ timezones to run on three set of test, we create
+        # many jobs to test concurrently.
+        # shard is used to bucket the lines from the timezone list into jobs.
+        # Currently we run testing of 30 timezones per shard, and we have total 21 shards.
+        # 21x30 = 630 > 604 (the number of known timezones).
+        tests_per_shard: [30]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+    steps:
+      - name: Install all locales by apt-get
+        run: |
+          sudo apt-get update -y;
+          sudo apt-get install -y tzdata;
+      - name: Show all the TimeZones
+        run: |
+          echo "Total number of TimeZone is "
+          find /usr/share/zoneinfo/ -type f,l|egrep -v "/(right|posix)/"|egrep -v "\.tab"|wc -l;
+          find /usr/share/zoneinfo/ -type f,l|egrep -v "/(right|posix)/"|egrep -v "\.tab"|cut -d '/' -f5-50;
+      - name: Checkout and setup
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          cd icu4c/source/;
+          ./runConfigureICU Linux;
+          make -j10 tests;
+      - name: Test different locales as TZ
+        run: |
+          echo "This job run the environment test of the following TimeZones";
+          begin=$(( ${{matrix.shard}} * ${{matrix.tests_per_shard}} + 1));
+          end=$(( (${{matrix.shard}}+1) * ${{matrix.tests_per_shard}} ));
+          sedarg=${begin},${end}p;
+          find /usr/share/zoneinfo/ -type f,l|egrep -v "/(right|posix)/"|egrep -v "\.tab"|sed -n ${sedarg}|cut -d '/' -f5-50;
+
+          cd icu4c/source/test;
+          for tz in `find /usr/share/zoneinfo/ -type f,l|egrep -v "/(right|posix)/"|egrep -v "\.tab"|sed -n ${sedarg}|cut -d '/' -f5-50`;
+
+          do
+              echo "============================================";
+              echo "Start Tests under TZ=$tz TimeZone";
+              for test_dir in iotest cintltst intltest
+              do
+                  cd $test_dir;
+                  TZ=$tz make check;
+                  cd ..;
+              done
+
+              echo "Complete Tests under TZ=$tz TimeZone";
+              echo "============================================";
+          done
+
+          echo "This job completed the test of the following TimeZones";
+          find /usr/share/zoneinfo/ -type f,l|egrep -v "/(right|posix)/"|egrep -v "\.tab"|sed -n ${sedarg}|cut -d '/' -f5-50;
+
+  #=================================================================

--- a/icu4c/source/test/cintltst/cdtrgtst.c
+++ b/icu4c/source/test/cintltst/cdtrgtst.c
@@ -26,8 +26,10 @@
 #include "unicode/uloc.h"
 #include "unicode/udat.h"
 #include "unicode/ucal.h"
+#include "unicode/uchar.h"
 #include "unicode/unum.h"
 #include "unicode/ustring.h"
+#include "unicode/utf16.h"
 #include "cintltst.h"
 #include "cdtrgtst.h"
 #include "cmemory.h"
@@ -190,8 +192,12 @@ void Test4056591()
             log_err("myFormatit failed!\n");
         }
         else if(u_strcmp(gotdate, expdate) !=0){
-            log_err("set2DigitYearStart broken for %s \n  got: %s, expected: %s\n", austrdup(s),
-                austrdup(gotdate), austrdup(expdate) );
+            if (strcmp("gregorian", ucal_getType(udat_getCalendar(def), &status)) == 0) {
+                // Only report error if the calendar is gregorian because the
+                // expectation is only for gregorian.
+                log_err("set2DigitYearStart broken for %s \n  got: %s, expected: %s\n", austrdup(s),
+                    austrdup(gotdate), austrdup(expdate) );
+            }
         }
     }
     
@@ -241,6 +247,30 @@ void Test4059917()
     free(myDate);
 }
 
+UBool EqualIgnoreNumberingSystem(UChar* a, UChar* b);
+// This function return true if the sting contains the same value or the
+// numerical values are the same if we ignore the numbering system.
+UBool EqualIgnoreNumberingSystem(UChar* a, UChar* b) {
+    // len1 and len2 may not be the same if one of them are numeric outside BMP.
+    int32_t len1 = u_strlen(a);
+    int32_t len2 = u_strlen(b);
+    UChar32 ch1, ch2;
+    int32_t idx1, idx2;
+    idx1=idx2=0;
+    // U16_NEXT will increment idx1 and idx2 inside the loop.
+    while (idx1 < len1 && idx2 < len2) {
+        U16_NEXT(a, idx1, len1, ch1);
+        U16_NEXT(b, idx2, len2, ch2);
+        if (ch1 != ch2) {
+            int32_t digit1 = u_charDigitValue(ch1);
+            int32_t digit2 = u_charDigitValue(ch2);
+            if (digit1 < 0 || digit1 != digit2) { return false; }
+        }
+    }
+    // only return true if both reach end of the string.
+    return idx1 == len1 && idx2 == len2;
+}
+
 void aux917( UDateFormat *fmt, UChar* str) 
 {    
     int32_t resultlength, resultlengthneeded;
@@ -266,7 +296,14 @@ void aux917( UDateFormat *fmt, UChar* str)
     status = U_ZERO_ERROR;
     formatted = myFormatit(fmt, d1);
     if( u_strcmp(formatted,str)!=0) {
-        log_err("Fail: Want %s Got: %s\n", austrdup(str),  austrdup(formatted) );
+        // We may get non-ASCII result back for some locale such as ne_NP
+        // which use numbering systems other than latn
+        if (strcmp("gregorian", ucal_getType(udat_getCalendar(fmt), &status)) != 0) {
+          log_verbose("Skipping Test4059917 when the default date time format is not using gregorian calendar.");
+
+        } else if (!EqualIgnoreNumberingSystem(formatted,str)) {
+          log_err("Fail: Want %s Got: %s\n", austrdup(str),  austrdup(formatted) );
+        }
     }
     free(pat);
 }

--- a/icu4c/source/test/cintltst/cloctst.c
+++ b/icu4c/source/test/cintltst/cloctst.c
@@ -7219,6 +7219,10 @@ static void TestCDefaultLocale() {
       log_verbose("Skipping TestCDefaultLocale test, as the LANG variable is not set.");
       return;
     }
+    if (getenv("LC_ALL") != NULL) {
+      log_verbose("Skipping TestCDefaultLocale test, as the LC_ALL variable is set.");
+      return;
+    }
     if ((strcmp(env_var, "C") == 0 || strcmp(env_var, "C.UTF-8") == 0) && strcmp(defaultLocale, "en_US_POSIX") != 0) {
       log_err("The default locale for LANG=%s should be en_US_POSIX, not %s\n", env_var, defaultLocale);
     }

--- a/icu4c/source/test/intltest/itercoll.cpp
+++ b/icu4c/source/test/intltest/itercoll.cpp
@@ -488,22 +488,23 @@ void CollationIteratorTest::TestAssignment()
     CollationElementIterator *iter4 
                         = coll->createCollationElementIterator(source);
     CollationElementIterator iter5(*iter4);
+    int32_t order4, order5;
     if (*iter4 != iter5) {
         errln("collation iterator assignment does not produce the same elements");
     }
-    iter4->next(status);
+    order4 = iter4->next(status);
     if (U_FAILURE(status) || *iter4 == iter5) {
         errln("collation iterator not equal");
     }
-    iter5.next(status);
+    order5 = iter5.next(status);
     if (U_FAILURE(status) || *iter4 != iter5) {
         errln("collation iterator equal");
     }
-    iter4->next(status);
+    order4 = iter4->next(status);
     if (U_FAILURE(status) || *iter4 == iter5) {
         errln("collation iterator not equal");
     }
-    iter5.next(status);
+    order5 = iter5.next(status);
     if (U_FAILURE(status) || *iter4 != iter5) {
         errln("collation iterator equal");
     }
@@ -511,21 +512,24 @@ void CollationIteratorTest::TestAssignment()
     if (*iter4 != iter6) {
         errln("collation iterator equal");
     }
-    iter4->next(status);
+    order4 = iter4->next(status);
     if (U_FAILURE(status) || *iter4 == iter5) {
         errln("collation iterator not equal");
     }
-    iter5.next(status);
+    order5 = iter5.next(status);
     if (U_FAILURE(status) || *iter4 != iter5) {
         errln("collation iterator equal");
     }
-    iter4->next(status);
-    if (U_FAILURE(status) || *iter4 == iter5) {
-        errln("collation iterator not equal");
-    }
-    iter5.next(status);
-    if (U_FAILURE(status) || *iter4 != iter5) {
-        errln("collation iterator equal");
+    if (!(order4 == CollationElementIterator::NULLORDER &&
+          order5 == CollationElementIterator::NULLORDER)) {
+        order4 = iter4->next(status);
+        if (U_FAILURE(status) || *iter4 == iter5) {
+            errln("collation iterator not equal");
+        }
+        order5 = iter5.next(status);
+        if (U_FAILURE(status) || *iter4 != iter5) {
+            errln("collation iterator equal");
+        }
     }
     delete iter1;
     delete iter4;

--- a/icu4c/source/test/intltest/loctest.cpp
+++ b/icu4c/source/test/intltest/loctest.cpp
@@ -1407,13 +1407,15 @@ LocaleTest::Test4139940()
     // o double acute (\u0151) IS.
     char16_t ocf = 0x00f4;
     char16_t oda = 0x0151;
+
     if (str.indexOf(oda) < 0 || str.indexOf(ocf) >= 0) {
-      /* If the default locale is "th" this test will fail because of the buddhist calendar. */
-      if (strcmp(Locale::getDefault().getLanguage(), "th") != 0) {
+      /* If the default calendar of the default locale is not "gregorian" this test will fail. */
+      LocalPointer<Calendar> defaultCalendar(Calendar::createInstance(status));
+      if (strcmp(defaultCalendar->getType(), "gregorian") == 0) {
         errln("Fail: Monday in Hungarian is wrong - oda's index is %d and ocf's is %d",
               str.indexOf(oda), str.indexOf(ocf));
       } else {
-        logln(UnicodeString("An error is produce in buddhist calendar."));
+        logln(UnicodeString("An error is produce in non Gregorian calendar."));
       }
       logln(UnicodeString("String is: ") + str );
     }

--- a/icu4c/source/test/intltest/tztest.cpp
+++ b/icu4c/source/test/intltest/tztest.cpp
@@ -147,7 +147,17 @@ TimeZoneTest::TestGenericAPI()
 
     /* Host time zone's offset should match the offset returned by uprv_timezone() */
     if (hostZoneRawOffset != tzoffset * (-1000)) {
-        errln("FAIL: detectHostTimeZone()'s raw offset != host timezone's offset");
+        UnicodeString id;
+        hostZone->getID(id);
+        // Known issues in ICU-22274 we have issues in time zone
+        // Africa/Casablanca Europe/Dublin America/Godthab America/Nuuk
+        if (id == u"Africa/Casablanca" || id == u"Europe/Dublin" ||
+            id == u"America/Godthab" || id == u"America/Nuuk" ||
+            id == u"Africa/El_Aaiun") {
+          logKnownIssue( "ICU-22274", "detectHostTimeZone()'s raw offset != host timezone's offset in TimeZone " + id);
+        } else {
+          errln("FAIL: detectHostTimeZone()'s raw offset != host timezone's offset");
+        }
     }
     delete hostZone;
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22262
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable


Configure 17+21 = 38 jobs to run icu tests under
500+ locales with LC_ALL= environment variable, and
600+ timezone with TZ= environment variable.

Fix broken tests discovered:
1. Ignore error in cintltst/cdtrgtst.c if the calendar of the default
   locale is not "gregorian" because the expectation is reasonable
   for 'gregorian' calendar only.
2. Consider the string are the same if the numerical value of the digit
   are the same for tests inside cintltst/cdtrgtst.c.
3. Skip the TestCDefaultLocale() error in cintltst/cloctst.c
   if LC_ALL env is set.
4. Fix the test which incorrectly assume the string iteration is not end
   (under "wo" locale") and avoid incorrect expectation in TestAssignment()
   of intltest/itercoll.cpp (see [ICU-22273](https://unicode-org.atlassian.net/browse/ICU-22273) )
5. Skip Test4139940() error in intltest/loctest.cpp
   if the calendar is not "gregorian".
6. Log known issue [ICU-22274](https://unicode-org.atlassian.net/browse/ICU-22274) for failure of detectHostTimeZone()'s raw offset
   != host timezone's offset while the default TimeZones is one of the
   following troublesome TimeZones:
   "Africa/Casablanca", "Europe/Dublin", "America/Godthab", "America/Nuuk",
   or "Africa/El_Aaiun".

Following
https://unicode-org.github.io/icu/processes/release/tasks/integration.html#run-the-environment-tests

[ICU-22273]: https://unicode-org.atlassian.net/browse/ICU-22273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ