### PR TITLE
ICU-22266 update OS version to 22.04 from 18.04

### DIFF
--- a/.ci-builds/.azure-exhaustive-tests.yml
+++ b/.ci-builds/.azure-exhaustive-tests.yml
@@ -30,11 +30,11 @@ trigger:
 jobs:
 #-------------------------------------------------------------------------
 # Note: The exhaustive tests can take more than 1 hour to complete.
-- job: ICU4J_OpenJDK_Ubuntu_1804
-  displayName: 'J: Linux OpenJDK (Ubuntu 18.04)'
+- job: ICU4J_OpenJDK_Ubuntu_2204
+  displayName: 'J: Linux OpenJDK (Ubuntu 22.04)'
   timeoutInMinutes: 120
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-22.04'
     demands: ant
   steps:
     - checkout: self
@@ -52,11 +52,11 @@ jobs:
       timeoutInMinutes: 2
 #-------------------------------------------------------------------------
 # Note: The exhaustive tests can take more than 1 hour to complete.
-- job: ICU4C_Clang_Exhaustive_Ubuntu_1804
-  displayName: 'C: Linux Clang Exhaustive Tests (Ubuntu 18.04)'
+- job: ICU4C_Clang_Exhaustive_Ubuntu_2204
+  displayName: 'C: Linux Clang Exhaustive Tests (Ubuntu 22.04)'
   timeoutInMinutes: 120
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-22.04'
   steps:
     - checkout: self
       lfs: true
@@ -73,10 +73,10 @@ jobs:
 #-------------------------------------------------------------------------
 # Based on https://unicode-org.github.io/icu/processes/release/tasks/integration.html#test-icu4j-with-only-little-endian-icu4c-data
 - job: ICU4J_with_only_little_endian_ICU4C_data
-  displayName: 'CJ: ICU4J Linux Clang Tests little-endian ICU4C data (Ubuntu 18.04)'
+  displayName: 'CJ: ICU4J Linux Clang Tests little-endian ICU4C data (Ubuntu 22.04)'
   timeoutInMinutes: 50
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-22.04'
     demands: ant
   steps:
     - checkout: self

--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -2,11 +2,11 @@
 
 jobs:
 #-------------------------------------------------------------------------
-- job: ICU4J_OpenJDK_Ubuntu_1804
-  displayName: 'J: Linux OpenJDK (Ubuntu 18.04)'
+- job: ICU4J_OpenJDK_Ubuntu_2204
+  displayName: 'J: Linux OpenJDK (Ubuntu 22.04)'
   timeoutInMinutes: 20
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-22.04'
     demands: ant
   steps:
     - checkout: self
@@ -23,11 +23,11 @@ jobs:
       condition: failed() # only run if the build fails.
       displayName: 'List failures (if any)'
 #-------------------------------------------------------------------------
-- job: ICU4C_Clang_Ubuntu_1804
-  displayName: 'C: Linux Clang (Ubuntu 18.04)'
+- job: ICU4C_Clang_Ubuntu_2204
+  displayName: 'C: Linux Clang (Ubuntu 22.04)'
   timeoutInMinutes: 30
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-22.04'
   steps:
     - checkout: self
       lfs: true
@@ -45,11 +45,11 @@ jobs:
         cd icu4c/source/test/cintltst && LANG=C.UTF-8 LD_LIBRARY_PATH=../../lib:../../tools/ctestfw ./cintltst /tsutil/cloctst/TestCDefaultLocale
       displayName: 'Test C.UTF-8 Default locale'
 #-------------------------------------------------------------------------
-- job: ICU4C_Clang_Ubuntu_DataFilter_1804
-  displayName: 'C: Linux Clang DataFilter (Ubuntu 18.04)'
+- job: ICU4C_Clang_Ubuntu_DataFilter_2204
+  displayName: 'C: Linux Clang DataFilter (Ubuntu 22.04)'
   timeoutInMinutes: 30
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-22.04'
   steps:
     - checkout: self
       lfs: true
@@ -65,11 +65,11 @@ jobs:
         CC: clang
         CXX: clang++
 #-------------------------------------------------------------------------
-- job: ICU4C_Clang_Cpp14_Debug_Ubuntu_1804
-  displayName: 'C: Linux Clang C++17 Debug (Ubuntu 18.04)'
+- job: ICU4C_Clang_Cpp14_Debug_Ubuntu_2204
+  displayName: 'C: Linux Clang C++17 Debug (Ubuntu 22.04)'
   timeoutInMinutes: 30
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-22.04'
   steps:
     - checkout: self
       lfs: true
@@ -612,11 +612,11 @@ jobs:
         CC: gcc
         CXX: g++
 #-------------------------------------------------------------------------
-- job: ICU4C_icuexportdata_Ubuntu_1804
+- job: ICU4C_icuexportdata_Ubuntu_2204
   displayName: 'C: Create Artifacts from icuexportdata'
   timeoutInMinutes: 30
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-22.04'
   steps:
     - checkout: self
       lfs: true

--- a/.ci-builds/.azure-valgrind.yml
+++ b/.ci-builds/.azure-valgrind.yml
@@ -28,19 +28,19 @@ pr:
 
 jobs:
 #-------------------------------------------------------------------------
-- job: ICU4C_Clang_Valgrind_Ubuntu_1804
-  displayName: 'C: Linux Clang Valgrind (Ubuntu 18.04)'
+- job: ICU4C_Clang_Valgrind_Ubuntu_2004
+  displayName: 'C: Linux Clang Valgrind (Ubuntu 20.04)'
   timeoutInMinutes: 75
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-20.04'
   steps:
     - checkout: self
       lfs: true
       fetchDepth: 10
     - script: |
         set -ex
-        sudo apt -y update
-        sudo apt install -y valgrind
+        sudo apt-get -y update
+        sudo apt-get install -y valgrind
       displayName: 'Install valgrind'
       timeoutInMinutes: 5
     - script: |


### PR DESCRIPTION
Update configuration in main/.ci-builds from the deprecated 18.04 to the newest 22.04. The Valgrind build somehow is not working under 22.04, so I keep it in 20.04 for now.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22266
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
