### PR TITLE
ICU-22262 fine tune env tests

### DIFF
--- a/.github/workflows/icu_envtest.yml
+++ b/.github/workflows/icu_envtest.yml
@@ -27,10 +27,10 @@ jobs:
         # Since we have total 500+ locales to run on three set of test, we create
         # many jobs to test concurrently.
         # shard is used to bucket the lines from the locale list into jobs.
-        # Currently we run testing of 30 locales per shard, and we have total 17 shards.
-        # 17x30 = 510 > 502 (the number of locales in 'locale -a').
-        tests_per_shard: [30]
-        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+        # Currently we run testing of 30 locales per shard, and we have total 26 shards.
+        # 26x20 = 520 > 502 (the number of locales in 'locale -a').
+        tests_per_shard: [20]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 13, 24, 25]
     steps:
       - name: Install all locales by apt-get
         run: |
@@ -84,10 +84,10 @@ jobs:
         # Since we have total 600+ timezones to run on three set of test, we create
         # many jobs to test concurrently.
         # shard is used to bucket the lines from the timezone list into jobs.
-        # Currently we run testing of 30 timezones per shard, and we have total 21 shards.
-        # 21x30 = 630 > 604 (the number of known timezones).
-        tests_per_shard: [30]
-        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+        # Currently we run testing of 30 timezones per shard, and we have total 31 shards.
+        # 31x20 = 620 > 604 (the number of known timezones).
+        tests_per_shard: [20]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
     steps:
       - name: Install all locales by apt-get
         run: |


### PR DESCRIPTION
After the landing of , the manual trigger of the Env Test on 
https://github.com/unicode-org/icu/actions/runs/4189068447
show it took 64 minus to run. 

Reduce the # of tests per job from 30 to 20 to speed up the run. Currently, with 30 tests per job each run for about 35-40 mins and took a total 70 mins to run. Reduce to 20 should make it faster.  Now use 26 + 31 = 57 parallel jobs instead of 17+ 21 = 38 parallel jobs.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22262
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
