### PR TITLE
ICU-22270 Use hex discriminants for exported toml properties

### DIFF
--- a/icu4c/source/tools/icuexportdata/icuexportdata.cpp
+++ b/icu4c/source/tools/icuexportdata/icuexportdata.cpp
@@ -170,13 +170,18 @@ void dumpBinaryProperty(UProperty uproperty, FILE* f) {
 
 // If the value exists, dump an indented entry of the format
 // `"  {discr = <discriminant>, long = <longname>, short = <shortname>, aliases = [<aliases>]},"`
-void dumpValueEntry(UProperty uproperty, int v, FILE* f) {
+void dumpValueEntry(UProperty uproperty, int v, bool is_mask, FILE* f) {
     const char* fullValueName = u_getPropertyValueName(uproperty, v, U_LONG_PROPERTY_NAME);
     const char* shortValueName = u_getPropertyValueName(uproperty, v, U_SHORT_PROPERTY_NAME);
     if (!fullValueName) {
         return;
     }
-    fprintf(f, "  {discr = %i, long = \"%s\"", v, fullValueName);
+    if (is_mask) {
+        fprintf(f, "  {discr = 0x%X", v);
+    } else {
+        fprintf(f, "  {discr = %i", v);
+    }
+    fprintf(f, ", long = \"%s\"", fullValueName);
     if (shortValueName) {
         fprintf(f, ", short = \"%s\"", shortValueName);
     }
@@ -220,7 +225,7 @@ void dumpEnumeratedProperty(UProperty uproperty, FILE* f) {
 
     fprintf(f, "values = [\n");
     for (int v = minValue; v <= maxValue; v++) {
-        dumpValueEntry(uproperty, v, f);
+        dumpValueEntry(uproperty, v, false, f);
     }
     fprintf(f, "]\n");
 
@@ -251,7 +256,7 @@ void dumpEnumeratedProperty(UProperty uproperty, FILE* f) {
 // after the property in the listing
 void maybeDumpMaskValue(UProperty uproperty, uint32_t v, uint32_t mask, FILE* f) {
     if (U_MASK(v) < mask && U_MASK(v + 1) > mask)
-        dumpValueEntry(uproperty, mask, f);
+        dumpValueEntry(uproperty, mask, true, f);
 }
 
 void dumpGeneralCategoryMask(FILE* f) {
@@ -274,7 +279,7 @@ void dumpGeneralCategoryMask(FILE* f) {
 
     fprintf(f, "values = [\n");
     for (uint32_t v = minValue; v <= maxValue; v++) {
-        dumpValueEntry(uproperty, U_MASK(v), f);
+        dumpValueEntry(uproperty, U_MASK(v), true, f);
 
         // We want to dump these masks "in order", which means they
         // should come immediately after every property they contain


### PR DESCRIPTION
Followup from https://github.com/unicode-org/icu/pull/2339

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22270
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable