### PR TITLE
ICU-22298 Include <utility> in measunit.h

### DIFF
--- a/icu4c/source/i18n/unicode/measunit.h
+++ b/icu4c/source/i18n/unicode/measunit.h
@@ -19,6 +19,7 @@
 
 #if !UCONFIG_NO_FORMATTING
 
+#include <utility>
 #include "unicode/unistr.h"
 #include "unicode/localpointer.h"
 


### PR DESCRIPTION
measunit.h uses std::pair, std::make_pair, and std::move, all of which are declared in the <utility> header. This still compiles because many implementations of the C++ standard library have <utility> as a transitive dependency of other C++ standard library headers; however, these transitive includes are not guaranteed to exist and will not exist in some contexts (e.g. building against LLVM's libc++ with -fmodules).

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22298
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [X] API docs and/or User Guide docs changed or added, if applicable
