### PR TITLE
ICU-21833 remove pre-C++11 code; U_SIZEOF_UCHAR=2

### DIFF
--- a/icu4c/source/common/unicode/platform.h
+++ b/icu4c/source/common/unicode/platform.h
@@ -516,13 +516,6 @@
 #   define U_CPLUSPLUS_VERSION 1
 #endif
 
-#if (U_PLATFORM == U_PF_AIX || U_PLATFORM == U_PF_OS390) && defined(__cplusplus) &&(U_CPLUSPLUS_VERSION < 11)
-// add in std::nullptr_t
-namespace std {
-  typedef decltype(nullptr) nullptr_t;
-};
-#endif
-
 /**
  * \def U_NOEXCEPT
  * "noexcept" if supported, otherwise empty.
@@ -764,7 +757,7 @@ namespace std {
  * \def U_HAVE_CHAR16_T
  * Defines whether the char16_t type is available for UTF-16
  * and u"abc" UTF-16 string literals are supported.
- * This is a new standard type and standard string literal syntax in C++0x
+ * This is a new standard type and standard string literal syntax in C++11
  * but has been available in some compilers before.
  * @internal
  */
@@ -773,12 +766,6 @@ namespace std {
 #else
     /*
      * Notes:
-     * Visual Studio 2010 (_MSC_VER==1600) defines char16_t as a typedef
-     * and does not support u"abc" string literals.
-     * Visual Studio 2015 (_MSC_VER>=1900) and above adds support for
-     * both char16_t and u"abc" string literals.
-     * gcc 4.4 defines the __CHAR16_TYPE__ macro to a usable type but
-     * does not support u"abc" string literals.
      * C++11 and C11 require support for UTF-16 literals
      * TODO: Fix for plain C. Doesn't work on Mac.
      */

--- a/icu4c/source/common/unicode/umachine.h
+++ b/icu4c/source/common/unicode/umachine.h
@@ -326,7 +326,7 @@ typedef int8_t UBool;
 
 /* UChar and UChar32 definitions -------------------------------------------- */
 
-/** Number of bytes in a UChar. @stable ICU 2.0 */
+/** Number of bytes in a UChar (always 2). @stable ICU 2.0 */
 #define U_SIZEOF_UCHAR 2
 
 /**
@@ -334,11 +334,7 @@ typedef int8_t UBool;
  * If 1, then char16_t is a typedef and not a real type (yet)
  * @internal
  */
-#if (U_PLATFORM == U_PF_AIX) && defined(__cplusplus) &&(U_CPLUSPLUS_VERSION < 11)
-// for AIX, uchar.h needs to be included
-# include <uchar.h>
-# define U_CHAR16_IS_TYPEDEF 1
-#elif defined(_MSC_VER) && (_MSC_VER < 1900)
+#if defined(_MSC_VER) && (_MSC_VER < 1900)
 // Versions of Visual Studio/MSVC below 2015 do not support char16_t as a real type,
 // and instead use a typedef.  https://msdn.microsoft.com/library/bb531344.aspx
 # define U_CHAR16_IS_TYPEDEF 1
@@ -386,10 +382,10 @@ typedef int8_t UBool;
     typedef char16_t UChar;
 #elif defined(UCHAR_TYPE)
     typedef UCHAR_TYPE UChar;
-#elif (U_CPLUSPLUS_VERSION >= 11)
-    typedef char16_t UChar;
+#elif U_CPLUSPLUS_VERSION != 0
+    typedef char16_t UChar;  // C++
 #else
-    typedef uint16_t UChar;
+    typedef uint16_t UChar;  // C
 #endif
 
 /**

--- a/icu4c/source/common/unicode/ustring.h
+++ b/icu4c/source/common/unicode/ustring.h
@@ -931,12 +931,8 @@ u_memrchr32(const UChar *s, UChar32 c, int32_t count);
 #   define U_STRING_DECL(var, cs, length) static const UChar *var=(const UChar *)U_DECLARE_UTF16(cs)
     /**@stable ICU 2.0 */
 #   define U_STRING_INIT(var, cs, length)
-#elif U_SIZEOF_WCHAR_T==U_SIZEOF_UCHAR && (U_CHARSET_FAMILY==U_ASCII_FAMILY || (U_SIZEOF_UCHAR == 2 && defined(U_WCHAR_IS_UTF16)))
+#elif U_SIZEOF_WCHAR_T==U_SIZEOF_UCHAR && (U_CHARSET_FAMILY==U_ASCII_FAMILY || defined(U_WCHAR_IS_UTF16))
 #   define U_STRING_DECL(var, cs, length) static const UChar var[(length)+1]=L ## cs
-    /**@stable ICU 2.0 */
-#   define U_STRING_INIT(var, cs, length)
-#elif U_SIZEOF_UCHAR==1 && U_CHARSET_FAMILY==U_ASCII_FAMILY
-#   define U_STRING_DECL(var, cs, length) static const UChar var[(length)+1]=cs
     /**@stable ICU 2.0 */
 #   define U_STRING_INIT(var, cs, length)
 #else

--- a/icu4c/source/i18n/listformatter.cpp
+++ b/icu4c/source/i18n/listformatter.cpp
@@ -405,16 +405,9 @@ enum {
 
 struct ListFormatter::ListPatternsSink : public ResourceSink {
     UnicodeString two, start, middle, end;
-#if ((U_PLATFORM == U_PF_AIX) || (U_PLATFORM == U_PF_OS390)) && (U_CPLUSPLUS_VERSION < 11)
-    char aliasedStyle[kStyleLenMax+1];
-    ListPatternsSink() {
-      uprv_memset(aliasedStyle, 0, kStyleLenMax+1);
-    }
-#else
     char aliasedStyle[kStyleLenMax+1] = {0};
 
     ListPatternsSink() {}
-#endif
     virtual ~ListPatternsSink();
 
     void setAliasedStyle(UnicodeString alias) {

--- a/icu4c/source/tools/gennorm2/gennorm2.cpp
+++ b/icu4c/source/tools/gennorm2/gennorm2.cpp
@@ -238,11 +238,7 @@ void parseFile(std::ifstream &f, Normalizer2DataBuilder &builder) {
         if (lineString.empty()) {
             continue;  // skip empty lines.
         }
-#if (U_CPLUSPLUS_VERSION >= 11)
         char *line = &lineString.front();
-#else
-        char *line = &lineString.at(0);
-#endif
         char *comment=(char *)strchr(line, '#');
         if(comment!=nullptr) {
             *comment=0;


### PR DESCRIPTION
No need to keep testing for C++11 vs. earlier versions of C++.
We do need to keep testing for C vs. C++ in some cases.
U_CPLUSPLUS_VERSION is either 0 (for C) or at least 11 (for C++11).

No need to keep testing for U_SIZEOF_UCHAR==2, this value is fixed.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21833
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
