### PR TITLE
ICU-21833 replace U_NOEXCEPT with C++11 standard noexcept

### DIFF
--- a/icu4c/source/common/charstr.cpp
+++ b/icu4c/source/common/charstr.cpp
@@ -26,12 +26,12 @@
 
 U_NAMESPACE_BEGIN
 
-CharString::CharString(CharString&& src) U_NOEXCEPT
+CharString::CharString(CharString&& src) noexcept
         : buffer(std::move(src.buffer)), len(src.len) {
     src.len = 0;  // not strictly necessary because we make no guarantees on the source string
 }
 
-CharString& CharString::operator=(CharString&& src) U_NOEXCEPT {
+CharString& CharString::operator=(CharString&& src) noexcept {
     buffer = std::move(src.buffer);
     len = src.len;
     src.len = 0;  // not strictly necessary because we make no guarantees on the source string

--- a/icu4c/source/common/charstr.h
+++ b/icu4c/source/common/charstr.h
@@ -59,13 +59,13 @@ public:
      * Move constructor; might leave src in an undefined state.
      * This string will have the same contents and state that the source string had.
      */
-    CharString(CharString &&src) U_NOEXCEPT;
+    CharString(CharString &&src) noexcept;
     /**
      * Move assignment operator; might leave src in an undefined state.
      * This string will have the same contents and state that the source string had.
      * The behavior is undefined if *this and src are the same object.
      */
-    CharString &operator=(CharString &&src) U_NOEXCEPT;
+    CharString &operator=(CharString &&src) noexcept;
 
     /**
      * Replaces this string's contents with the other string's contents.

--- a/icu4c/source/common/charstrmap.h
+++ b/icu4c/source/common/charstrmap.h
@@ -26,7 +26,7 @@ public:
         map = uhash_openSize(uhash_hashChars, uhash_compareChars, uhash_compareChars,
                              size, &errorCode);
     }
-    CharStringMap(CharStringMap &&other) U_NOEXCEPT : map(other.map) {
+    CharStringMap(CharStringMap &&other) noexcept : map(other.map) {
         other.map = nullptr;
     }
     CharStringMap(const CharStringMap &other) = delete;
@@ -34,7 +34,7 @@ public:
         uhash_close(map);
     }
 
-    CharStringMap &operator=(CharStringMap &&other) U_NOEXCEPT {
+    CharStringMap &operator=(CharStringMap &&other) noexcept {
         map = other.map;
         other.map = nullptr;
         return *this;

--- a/icu4c/source/common/cmemory.h
+++ b/icu4c/source/common/cmemory.h
@@ -197,7 +197,7 @@ public:
      * Move constructor, leaves src with isNull().
      * @param src source smart pointer
      */
-    LocalMemory(LocalMemory<T> &&src) U_NOEXCEPT : LocalPointerBase<T>(src.ptr) {
+    LocalMemory(LocalMemory<T> &&src) noexcept : LocalPointerBase<T>(src.ptr) {
         src.ptr=nullptr;
     }
     /**
@@ -212,7 +212,7 @@ public:
      * @param src source smart pointer
      * @return *this
      */
-    LocalMemory<T> &operator=(LocalMemory<T> &&src) U_NOEXCEPT {
+    LocalMemory<T> &operator=(LocalMemory<T> &&src) noexcept {
         uprv_free(LocalPointerBase<T>::ptr);
         LocalPointerBase<T>::ptr=src.ptr;
         src.ptr=nullptr;
@@ -222,7 +222,7 @@ public:
      * Swap pointers.
      * @param other other smart pointer
      */
-    void swap(LocalMemory<T> &other) U_NOEXCEPT {
+    void swap(LocalMemory<T> &other) noexcept {
         T *temp=LocalPointerBase<T>::ptr;
         LocalPointerBase<T>::ptr=other.ptr;
         other.ptr=temp;
@@ -232,7 +232,7 @@ public:
      * @param p1 will get p2's pointer
      * @param p2 will get p1's pointer
      */
-    friend inline void swap(LocalMemory<T> &p1, LocalMemory<T> &p2) U_NOEXCEPT {
+    friend inline void swap(LocalMemory<T> &p1, LocalMemory<T> &p2) noexcept {
         p1.swap(p2);
     }
     /**
@@ -332,10 +332,10 @@ template<typename T, int32_t stackCapacity>
 class MaybeStackArray {
 public:
     // No heap allocation. Use only on the stack.
-    static void* U_EXPORT2 operator new(size_t) U_NOEXCEPT = delete;
-    static void* U_EXPORT2 operator new[](size_t) U_NOEXCEPT = delete;
+    static void* U_EXPORT2 operator new(size_t) noexcept = delete;
+    static void* U_EXPORT2 operator new[](size_t) noexcept = delete;
 #if U_HAVE_PLACEMENT_NEW
-    static void* U_EXPORT2 operator new(size_t, void*) U_NOEXCEPT = delete;
+    static void* U_EXPORT2 operator new(size_t, void*) noexcept = delete;
 #endif
 
     /**
@@ -364,11 +364,11 @@ public:
     /**
      * Move constructor: transfers ownership or copies the stack array.
      */
-    MaybeStackArray(MaybeStackArray<T, stackCapacity> &&src) U_NOEXCEPT;
+    MaybeStackArray(MaybeStackArray<T, stackCapacity> &&src) noexcept;
     /**
      * Move assignment: transfers ownership or copies the stack array.
      */
-    MaybeStackArray<T, stackCapacity> &operator=(MaybeStackArray<T, stackCapacity> &&src) U_NOEXCEPT;
+    MaybeStackArray<T, stackCapacity> &operator=(MaybeStackArray<T, stackCapacity> &&src) noexcept;
     /**
      * Returns the array capacity (number of T items).
      * @return array capacity
@@ -475,7 +475,7 @@ private:
 
 template<typename T, int32_t stackCapacity>
 icu::MaybeStackArray<T, stackCapacity>::MaybeStackArray(
-        MaybeStackArray <T, stackCapacity>&& src) U_NOEXCEPT
+        MaybeStackArray <T, stackCapacity>&& src) noexcept
         : ptr(src.ptr), capacity(src.capacity), needToRelease(src.needToRelease) {
     if (src.ptr == src.stackArray) {
         ptr = stackArray;
@@ -487,7 +487,7 @@ icu::MaybeStackArray<T, stackCapacity>::MaybeStackArray(
 
 template<typename T, int32_t stackCapacity>
 inline MaybeStackArray <T, stackCapacity>&
-MaybeStackArray<T, stackCapacity>::operator=(MaybeStackArray <T, stackCapacity>&& src) U_NOEXCEPT {
+MaybeStackArray<T, stackCapacity>::operator=(MaybeStackArray <T, stackCapacity>&& src) noexcept {
     releaseArray();  // in case this instance had its own memory allocated
     capacity = src.capacity;
     needToRelease = src.needToRelease;
@@ -568,10 +568,10 @@ template<typename H, typename T, int32_t stackCapacity>
 class MaybeStackHeaderAndArray {
 public:
     // No heap allocation. Use only on the stack.
-    static void* U_EXPORT2 operator new(size_t) U_NOEXCEPT = delete;
-    static void* U_EXPORT2 operator new[](size_t) U_NOEXCEPT = delete;
+    static void* U_EXPORT2 operator new(size_t) noexcept = delete;
+    static void* U_EXPORT2 operator new[](size_t) noexcept = delete;
 #if U_HAVE_PLACEMENT_NEW
-    static void* U_EXPORT2 operator new(size_t, void*) U_NOEXCEPT = delete;
+    static void* U_EXPORT2 operator new(size_t, void*) noexcept = delete;
 #endif
 
     /**
@@ -768,12 +768,12 @@ public:
     MemoryPool(const MemoryPool&) = delete;
     MemoryPool& operator=(const MemoryPool&) = delete;
 
-    MemoryPool(MemoryPool&& other) U_NOEXCEPT : fCount(other.fCount),
+    MemoryPool(MemoryPool&& other) noexcept : fCount(other.fCount),
                                                 fPool(std::move(other.fPool)) {
         other.fCount = 0;
     }
 
-    MemoryPool& operator=(MemoryPool&& other) U_NOEXCEPT {
+    MemoryPool& operator=(MemoryPool&& other) noexcept {
         // Since `this` may contain instances that need to be deleted, we can't
         // just throw them away and replace them with `other`. The normal way of
         // dealing with this in C++ is to swap `this` and `other`, rather than

--- a/icu4c/source/common/edits.cpp
+++ b/icu4c/source/common/edits.cpp
@@ -35,7 +35,7 @@ const int32_t LENGTH_IN_2TRAIL = 62;
 
 }  // namespace
 
-void Edits::releaseArray() U_NOEXCEPT {
+void Edits::releaseArray() noexcept {
     if (array != stackArray) {
         uprv_free(array);
     }
@@ -63,7 +63,7 @@ Edits &Edits::copyArray(const Edits &other) {
     return *this;
 }
 
-Edits &Edits::moveArray(Edits &src) U_NOEXCEPT {
+Edits &Edits::moveArray(Edits &src) noexcept {
     if (U_FAILURE(errorCode_)) {
         length = delta = numChanges = 0;
         return *this;
@@ -94,7 +94,7 @@ Edits &Edits::operator=(const Edits &other) {
     return copyArray(other);
 }
 
-Edits &Edits::operator=(Edits &&src) U_NOEXCEPT {
+Edits &Edits::operator=(Edits &&src) noexcept {
     length = src.length;
     delta = src.delta;
     numChanges = src.numChanges;
@@ -106,7 +106,7 @@ Edits::~Edits() {
     releaseArray();
 }
 
-void Edits::reset() U_NOEXCEPT {
+void Edits::reset() noexcept {
     length = delta = numChanges = 0;
     errorCode_ = U_ZERO_ERROR;
 }

--- a/icu4c/source/common/localematcher.cpp
+++ b/icu4c/source/common/localematcher.cpp
@@ -51,7 +51,7 @@ typedef enum ULocMatchLifetime ULocMatchLifetime;
 
 U_NAMESPACE_BEGIN
 
-LocaleMatcher::Result::Result(LocaleMatcher::Result &&src) U_NOEXCEPT :
+LocaleMatcher::Result::Result(LocaleMatcher::Result &&src) noexcept :
         desiredLocale(src.desiredLocale),
         supportedLocale(src.supportedLocale),
         desiredIndex(src.desiredIndex),
@@ -70,7 +70,7 @@ LocaleMatcher::Result::~Result() {
     }
 }
 
-LocaleMatcher::Result &LocaleMatcher::Result::operator=(LocaleMatcher::Result &&src) U_NOEXCEPT {
+LocaleMatcher::Result &LocaleMatcher::Result::operator=(LocaleMatcher::Result &&src) noexcept {
     this->~Result();
 
     desiredLocale = src.desiredLocale;
@@ -122,7 +122,7 @@ Locale LocaleMatcher::Result::makeResolvedLocale(UErrorCode &errorCode) const {
     return b.build(errorCode);
 }
 
-LocaleMatcher::Builder::Builder(LocaleMatcher::Builder &&src) U_NOEXCEPT :
+LocaleMatcher::Builder::Builder(LocaleMatcher::Builder &&src) noexcept :
         errorCode_(src.errorCode_),
         supportedLocales_(src.supportedLocales_),
         thresholdDistance_(src.thresholdDistance_),
@@ -142,7 +142,7 @@ LocaleMatcher::Builder::~Builder() {
     delete maxDistanceSupported_;
 }
 
-LocaleMatcher::Builder &LocaleMatcher::Builder::operator=(LocaleMatcher::Builder &&src) U_NOEXCEPT {
+LocaleMatcher::Builder &LocaleMatcher::Builder::operator=(LocaleMatcher::Builder &&src) noexcept {
     this->~Builder();
 
     errorCode_ = src.errorCode_;
@@ -483,7 +483,7 @@ LocaleMatcher::LocaleMatcher(const Builder &builder, UErrorCode &errorCode) :
     }
 }
 
-LocaleMatcher::LocaleMatcher(LocaleMatcher &&src) U_NOEXCEPT :
+LocaleMatcher::LocaleMatcher(LocaleMatcher &&src) noexcept :
         likelySubtags(src.likelySubtags),
         localeDistance(src.localeDistance),
         thresholdDistance(src.thresholdDistance),
@@ -520,7 +520,7 @@ LocaleMatcher::~LocaleMatcher() {
     delete ownedDefaultLocale;
 }
 
-LocaleMatcher &LocaleMatcher::operator=(LocaleMatcher &&src) U_NOEXCEPT {
+LocaleMatcher &LocaleMatcher::operator=(LocaleMatcher &&src) noexcept {
     this->~LocaleMatcher();
 
     thresholdDistance = src.thresholdDistance;

--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -407,7 +407,7 @@ Locale::Locale(const Locale &other)
     *this = other;
 }
 
-Locale::Locale(Locale&& other) U_NOEXCEPT
+Locale::Locale(Locale&& other) noexcept
     : UObject(other), fullName(fullNameBuffer), baseName(fullName) {
   *this = std::move(other);
 }
@@ -445,7 +445,7 @@ Locale& Locale::operator=(const Locale& other) {
     return *this;
 }
 
-Locale& Locale::operator=(Locale&& other) U_NOEXCEPT {
+Locale& Locale::operator=(Locale&& other) noexcept {
     if ((baseName != fullName) && (baseName != fullNameBuffer)) uprv_free(baseName);
     if (fullName != fullNameBuffer) uprv_free(fullName);
 

--- a/icu4c/source/common/lsr.cpp
+++ b/icu4c/source/common/lsr.cpp
@@ -31,7 +31,7 @@ LSR::LSR(char prefix, const char *lang, const char *scr, const char *r, int32_t 
     }
 }
 
-LSR::LSR(LSR &&other) U_NOEXCEPT :
+LSR::LSR(LSR &&other) noexcept :
         language(other.language), script(other.script), region(other.region), owned(other.owned),
         regionIndex(other.regionIndex), flags(other.flags),
         hashCode(other.hashCode) {
@@ -46,7 +46,7 @@ void LSR::deleteOwned() {
     uprv_free(owned);
 }
 
-LSR &LSR::operator=(LSR &&other) U_NOEXCEPT {
+LSR &LSR::operator=(LSR &&other) noexcept {
     this->~LSR();
     language = other.language;
     script = other.script;

--- a/icu4c/source/common/lsr.h
+++ b/icu4c/source/common/lsr.h
@@ -45,7 +45,7 @@ struct LSR final : public UMemory {
      */
     LSR(char prefix, const char *lang, const char *scr, const char *r, int32_t f,
         UErrorCode &errorCode);
-    LSR(LSR &&other) U_NOEXCEPT;
+    LSR(LSR &&other) noexcept;
     LSR(const LSR &other) = delete;
     inline ~LSR() {
         // Pure inline code for almost all instances.
@@ -54,7 +54,7 @@ struct LSR final : public UMemory {
         }
     }
 
-    LSR &operator=(LSR &&other) U_NOEXCEPT;
+    LSR &operator=(LSR &&other) noexcept;
     LSR &operator=(const LSR &other) = delete;
 
     /**

--- a/icu4c/source/common/ulocimp.h
+++ b/icu4c/source/common/ulocimp.h
@@ -333,10 +333,10 @@ public:
     int32_t requestedCapacity = ULOC_FULLNAME_CAPACITY;
 
     // No heap allocation. Use only on the stack.
-    static void* U_EXPORT2 operator new(size_t) U_NOEXCEPT = delete;
-    static void* U_EXPORT2 operator new[](size_t) U_NOEXCEPT = delete;
+    static void* U_EXPORT2 operator new(size_t) noexcept = delete;
+    static void* U_EXPORT2 operator new[](size_t) noexcept = delete;
 #if U_HAVE_PLACEMENT_NEW
-    static void* U_EXPORT2 operator new(size_t, void*) U_NOEXCEPT = delete;
+    static void* U_EXPORT2 operator new(size_t, void*) noexcept = delete;
 #endif
 
     PreflightingLocaleIDBuffer() {}

--- a/icu4c/source/common/unicode/edits.h
+++ b/icu4c/source/common/unicode/edits.h
@@ -103,7 +103,7 @@ public:
      * @param src source edits
      * @stable ICU 60
      */
-    Edits(Edits &&src) U_NOEXCEPT :
+    Edits(Edits &&src) noexcept :
             array(stackArray), capacity(STACK_CAPACITY), length(src.length),
             delta(src.delta), numChanges(src.numChanges),
             errorCode_(src.errorCode_) {
@@ -132,13 +132,13 @@ public:
      * @return *this
      * @stable ICU 60
      */
-    Edits &operator=(Edits &&src) U_NOEXCEPT;
+    Edits &operator=(Edits &&src) noexcept;
 
     /**
      * Resets the data but may not release memory.
      * @stable ICU 59
      */
-    void reset() U_NOEXCEPT;
+    void reset() noexcept;
 
     /**
      * Adds a no-change edit: a record for an unchanged segment of text.
@@ -504,9 +504,9 @@ public:
     Edits &mergeAndAppend(const Edits &ab, const Edits &bc, UErrorCode &errorCode);
 
 private:
-    void releaseArray() U_NOEXCEPT;
+    void releaseArray() noexcept;
     Edits &copyArray(const Edits &other);
-    Edits &moveArray(Edits &src) U_NOEXCEPT;
+    Edits &moveArray(Edits &src) noexcept;
 
     void setLastUnit(int32_t last) { array[length - 1] = (uint16_t)last; }
     int32_t lastUnit() const { return length > 0 ? array[length - 1] : 0xffff; }

--- a/icu4c/source/common/unicode/localematcher.h
+++ b/icu4c/source/common/unicode/localematcher.h
@@ -198,7 +198,7 @@ public:
          * @param src Result to move contents from.
          * @stable ICU 65
          */
-        Result(Result &&src) U_NOEXCEPT;
+        Result(Result &&src) noexcept;
 
         /**
          * Destructor.
@@ -214,7 +214,7 @@ public:
          * @param src Result to move contents from.
          * @stable ICU 65
          */
-        Result &operator=(Result &&src) U_NOEXCEPT;
+        Result &operator=(Result &&src) noexcept;
 
         /**
          * Returns the best-matching desired locale.
@@ -313,7 +313,7 @@ public:
          * @param src Builder to move contents from.
          * @stable ICU 65
          */
-        Builder(Builder &&src) U_NOEXCEPT;
+        Builder(Builder &&src) noexcept;
 
         /**
          * Destructor.
@@ -329,7 +329,7 @@ public:
          * @param src Builder to move contents from.
          * @stable ICU 65
          */
-        Builder &operator=(Builder &&src) U_NOEXCEPT;
+        Builder &operator=(Builder &&src) noexcept;
 
         /**
          * Parses an Accept-Language string
@@ -548,7 +548,7 @@ public:
      * @param src source matcher
      * @stable ICU 65
      */
-    LocaleMatcher(LocaleMatcher &&src) U_NOEXCEPT;
+    LocaleMatcher(LocaleMatcher &&src) noexcept;
 
     /**
      * Destructor.
@@ -564,7 +564,7 @@ public:
      * @return *this
      * @stable ICU 65
      */
-    LocaleMatcher &operator=(LocaleMatcher &&src) U_NOEXCEPT;
+    LocaleMatcher &operator=(LocaleMatcher &&src) noexcept;
 
     /**
      * Returns the supported locale which best matches the desired locale.

--- a/icu4c/source/common/unicode/localpointer.h
+++ b/icu4c/source/common/unicode/localpointer.h
@@ -221,7 +221,7 @@ public:
      * @param src source smart pointer
      * @stable ICU 56
      */
-    LocalPointer(LocalPointer<T> &&src) U_NOEXCEPT : LocalPointerBase<T>(src.ptr) {
+    LocalPointer(LocalPointer<T> &&src) noexcept : LocalPointerBase<T>(src.ptr) {
         src.ptr=nullptr;
     }
 
@@ -252,7 +252,7 @@ public:
      * @return *this
      * @stable ICU 56
      */
-    LocalPointer<T> &operator=(LocalPointer<T> &&src) U_NOEXCEPT {
+    LocalPointer<T> &operator=(LocalPointer<T> &&src) noexcept {
         delete LocalPointerBase<T>::ptr;
         LocalPointerBase<T>::ptr=src.ptr;
         src.ptr=nullptr;
@@ -267,7 +267,7 @@ public:
      * @return *this
      * @stable ICU 64
      */
-    LocalPointer<T> &operator=(std::unique_ptr<T> &&p) U_NOEXCEPT {
+    LocalPointer<T> &operator=(std::unique_ptr<T> &&p) noexcept {
         adoptInstead(p.release());
         return *this;
     }
@@ -277,7 +277,7 @@ public:
      * @param other other smart pointer
      * @stable ICU 56
      */
-    void swap(LocalPointer<T> &other) U_NOEXCEPT {
+    void swap(LocalPointer<T> &other) noexcept {
         T *temp=LocalPointerBase<T>::ptr;
         LocalPointerBase<T>::ptr=other.ptr;
         other.ptr=temp;
@@ -288,7 +288,7 @@ public:
      * @param p2 will get p1's pointer
      * @stable ICU 56
      */
-    friend inline void swap(LocalPointer<T> &p1, LocalPointer<T> &p2) U_NOEXCEPT {
+    friend inline void swap(LocalPointer<T> &p1, LocalPointer<T> &p2) noexcept {
         p1.swap(p2);
     }
     /**
@@ -396,7 +396,7 @@ public:
      * @param src source smart pointer
      * @stable ICU 56
      */
-    LocalArray(LocalArray<T> &&src) U_NOEXCEPT : LocalPointerBase<T>(src.ptr) {
+    LocalArray(LocalArray<T> &&src) noexcept : LocalPointerBase<T>(src.ptr) {
         src.ptr=nullptr;
     }
 
@@ -427,7 +427,7 @@ public:
      * @return *this
      * @stable ICU 56
      */
-    LocalArray<T> &operator=(LocalArray<T> &&src) U_NOEXCEPT {
+    LocalArray<T> &operator=(LocalArray<T> &&src) noexcept {
         delete[] LocalPointerBase<T>::ptr;
         LocalPointerBase<T>::ptr=src.ptr;
         src.ptr=nullptr;
@@ -442,7 +442,7 @@ public:
      * @return *this
      * @stable ICU 64
      */
-    LocalArray<T> &operator=(std::unique_ptr<T[]> &&p) U_NOEXCEPT {
+    LocalArray<T> &operator=(std::unique_ptr<T[]> &&p) noexcept {
         adoptInstead(p.release());
         return *this;
     }
@@ -452,7 +452,7 @@ public:
      * @param other other smart pointer
      * @stable ICU 56
      */
-    void swap(LocalArray<T> &other) U_NOEXCEPT {
+    void swap(LocalArray<T> &other) noexcept {
         T *temp=LocalPointerBase<T>::ptr;
         LocalPointerBase<T>::ptr=other.ptr;
         other.ptr=temp;
@@ -463,7 +463,7 @@ public:
      * @param p2 will get p1's pointer
      * @stable ICU 56
      */
-    friend inline void swap(LocalArray<T> &p1, LocalArray<T> &p2) U_NOEXCEPT {
+    friend inline void swap(LocalArray<T> &p1, LocalArray<T> &p2) noexcept {
         p1.swap(p2);
     }
     /**
@@ -553,7 +553,7 @@ public:
         using LocalPointerBase<Type>::operator*; \
         using LocalPointerBase<Type>::operator->; \
         explicit LocalPointerClassName(Type *p=nullptr) : LocalPointerBase<Type>(p) {} \
-        LocalPointerClassName(LocalPointerClassName &&src) U_NOEXCEPT \
+        LocalPointerClassName(LocalPointerClassName &&src) noexcept \
                 : LocalPointerBase<Type>(src.ptr) { \
             src.ptr=nullptr; \
         } \
@@ -561,7 +561,7 @@ public:
         explicit LocalPointerClassName(std::unique_ptr<Type, decltype(&closeFunction)> &&p) \
                 : LocalPointerBase<Type>(p.release()) {} \
         ~LocalPointerClassName() { if (ptr != nullptr) { closeFunction(ptr); } } \
-        LocalPointerClassName &operator=(LocalPointerClassName &&src) U_NOEXCEPT { \
+        LocalPointerClassName &operator=(LocalPointerClassName &&src) noexcept { \
             if (ptr != nullptr) { closeFunction(ptr); } \
             LocalPointerBase<Type>::ptr=src.ptr; \
             src.ptr=nullptr; \
@@ -572,12 +572,12 @@ public:
             adoptInstead(p.release()); \
             return *this; \
         } \
-        void swap(LocalPointerClassName &other) U_NOEXCEPT { \
+        void swap(LocalPointerClassName &other) noexcept { \
             Type *temp=LocalPointerBase<Type>::ptr; \
             LocalPointerBase<Type>::ptr=other.ptr; \
             other.ptr=temp; \
         } \
-        friend inline void swap(LocalPointerClassName &p1, LocalPointerClassName &p2) U_NOEXCEPT { \
+        friend inline void swap(LocalPointerClassName &p1, LocalPointerClassName &p2) noexcept { \
             p1.swap(p2); \
         } \
         void adoptInstead(Type *p) { \

--- a/icu4c/source/common/unicode/locid.h
+++ b/icu4c/source/common/unicode/locid.h
@@ -294,7 +294,7 @@ public:
      * @param other The Locale object being moved in.
      * @stable ICU 63
      */
-    Locale(Locale&& other) U_NOEXCEPT;
+    Locale(Locale&& other) noexcept;
 
     /**
      * Destructor
@@ -320,7 +320,7 @@ public:
      * @return      *this
      * @stable ICU 63
      */
-    Locale& operator=(Locale&& other) U_NOEXCEPT;
+    Locale& operator=(Locale&& other) noexcept;
 
     /**
      * Checks if two locale keys are the same.

--- a/icu4c/source/common/unicode/platform.h
+++ b/icu4c/source/common/unicode/platform.h
@@ -524,19 +524,6 @@ namespace std {
 #endif
 
 /**
- * \def U_NOEXCEPT
- * "noexcept" if supported, otherwise empty.
- * Some code, especially STL containers, uses move semantics of objects only
- * if the move constructor and the move operator are declared as not throwing exceptions.
- * @internal
- */
-#ifdef U_NOEXCEPT
-    /* Use the predefined value. */
-#else
-#   define U_NOEXCEPT noexcept
-#endif
-
-/**
  * \def U_FALLTHROUGH
  * Annotate intentional fall-through between switch labels.
  * http://clang.llvm.org/docs/AttributeReference.html#fallthrough-clang-fallthrough

--- a/icu4c/source/common/unicode/unistr.h
+++ b/icu4c/source/common/unicode/unistr.h
@@ -1906,14 +1906,14 @@ public:
    * @return *this
    * @stable ICU 56
    */
-  UnicodeString &operator=(UnicodeString &&src) U_NOEXCEPT;
+  UnicodeString &operator=(UnicodeString &&src) noexcept;
 
   /**
    * Swap strings.
    * @param other other string
    * @stable ICU 56
    */
-  void swap(UnicodeString &other) U_NOEXCEPT;
+  void swap(UnicodeString &other) noexcept;
 
   /**
    * Non-member UnicodeString swap function.
@@ -1922,7 +1922,7 @@ public:
    * @stable ICU 56
    */
   friend inline void U_EXPORT2
-  swap(UnicodeString &s1, UnicodeString &s2) U_NOEXCEPT {
+  swap(UnicodeString &s1, UnicodeString &s2) noexcept {
     s1.swap(s2);
   }
 
@@ -3306,7 +3306,7 @@ public:
    * @param src source string
    * @stable ICU 56
    */
-  UnicodeString(UnicodeString &&src) U_NOEXCEPT;
+  UnicodeString(UnicodeString &&src) noexcept;
 
   /**
    * 'Substring' constructor from tail of source string.
@@ -3618,7 +3618,7 @@ private:
   UnicodeString &copyFrom(const UnicodeString &src, UBool fastCopy=false);
 
   // Copies just the fields without memory management.
-  void copyFieldsFrom(UnicodeString &src, UBool setSrcToBogus) U_NOEXCEPT;
+  void copyFieldsFrom(UnicodeString &src, UBool setSrcToBogus) noexcept;
 
   // Pin start and limit to acceptable values.
   inline void pinIndex(int32_t& start) const;

--- a/icu4c/source/common/unicode/uobject.h
+++ b/icu4c/source/common/unicode/uobject.h
@@ -32,7 +32,7 @@
 
 /**
  * \def U_NO_THROW
- *         Since ICU 64, use U_NOEXCEPT instead.
+ *         Since ICU 64, use noexcept instead.
  *
  *         Previously, define this to define the throw() specification so
  *                 certain functions do not throw any exceptions
@@ -43,10 +43,10 @@
  *         constructor is still called, and if the constructor references member 
  *         data, (which it typically does), the result is a segmentation violation.
  *
- * @stable ICU 4.2. Since ICU 64, Use U_NOEXCEPT instead. See ICU-20422.
+ * @stable ICU 4.2. Since ICU 64, Use noexcept instead. See ICU-20422.
  */
 #ifndef U_NO_THROW
-#define U_NO_THROW U_NOEXCEPT
+#define U_NO_THROW noexcept
 #endif
 
 /*===========================================================================*/
@@ -131,14 +131,14 @@ public:
      * for ICU4C C++ classes
      * @stable ICU 2.4
      */
-    static void * U_EXPORT2 operator new(size_t size) U_NOEXCEPT;
+    static void * U_EXPORT2 operator new(size_t size) noexcept;
 
     /**
      * Override for ICU4C C++ memory management.
      * See new().
      * @stable ICU 2.4
      */
-    static void * U_EXPORT2 operator new[](size_t size) U_NOEXCEPT;
+    static void * U_EXPORT2 operator new[](size_t size) noexcept;
 
     /**
      * Override for ICU4C C++ memory management.
@@ -148,14 +148,14 @@ public:
      * for ICU4C C++ classes
      * @stable ICU 2.4
      */
-    static void U_EXPORT2 operator delete(void *p) U_NOEXCEPT;
+    static void U_EXPORT2 operator delete(void *p) noexcept;
 
     /**
      * Override for ICU4C C++ memory management.
      * See delete().
      * @stable ICU 2.4
      */
-    static void U_EXPORT2 operator delete[](void *p) U_NOEXCEPT;
+    static void U_EXPORT2 operator delete[](void *p) noexcept;
 
 #if U_HAVE_PLACEMENT_NEW
     /**
@@ -163,14 +163,14 @@ public:
      * See new().
      * @stable ICU 2.6
      */
-    static inline void * U_EXPORT2 operator new(size_t, void *ptr) U_NOEXCEPT { return ptr; }
+    static inline void * U_EXPORT2 operator new(size_t, void *ptr) noexcept { return ptr; }
 
     /**
      * Override for ICU4C C++ memory management for STL.
      * See delete().
      * @stable ICU 2.6
      */
-    static inline void U_EXPORT2 operator delete(void *, void *) U_NOEXCEPT {}
+    static inline void U_EXPORT2 operator delete(void *, void *) noexcept {}
 #endif /* U_HAVE_PLACEMENT_NEW */
 #if U_HAVE_DEBUG_LOCATION_NEW
     /**
@@ -180,7 +180,7 @@ public:
       * @param file   The file where the allocation was requested
       * @param line   The line where the allocation was requested 
       */ 
-    static void * U_EXPORT2 operator new(size_t size, const char* file, int line) U_NOEXCEPT;
+    static void * U_EXPORT2 operator new(size_t size, const char* file, int line) noexcept;
     /**
       * This method provides a matching delete for the MFC debug new
       * 
@@ -188,7 +188,7 @@ public:
       * @param file   The file where the allocation was requested
       * @param line   The line where the allocation was requested 
       */ 
-    static void U_EXPORT2 operator delete(void* p, const char* file, int line) U_NOEXCEPT;
+    static void U_EXPORT2 operator delete(void* p, const char* file, int line) noexcept;
 #endif /* U_HAVE_DEBUG_LOCATION_NEW */
 #endif /* U_OVERRIDE_CXX_ALLOCATION */
 

--- a/icu4c/source/common/unistr.cpp
+++ b/icu4c/source/common/unistr.cpp
@@ -308,7 +308,7 @@ UnicodeString::UnicodeString(const UnicodeString& that) {
   copyFrom(that);
 }
 
-UnicodeString::UnicodeString(UnicodeString &&src) U_NOEXCEPT {
+UnicodeString::UnicodeString(UnicodeString &&src) noexcept {
   copyFieldsFrom(src, true);
 }
 
@@ -572,7 +572,7 @@ UnicodeString::copyFrom(const UnicodeString &src, UBool fastCopy) {
   return *this;
 }
 
-UnicodeString &UnicodeString::operator=(UnicodeString &&src) U_NOEXCEPT {
+UnicodeString &UnicodeString::operator=(UnicodeString &&src) noexcept {
   // No explicit check for self move assignment, consistent with standard library.
   // Self move assignment causes no crash nor leak but might make the object bogus.
   releaseArray();
@@ -581,7 +581,7 @@ UnicodeString &UnicodeString::operator=(UnicodeString &&src) U_NOEXCEPT {
 }
 
 // Same as move assignment except without memory management.
-void UnicodeString::copyFieldsFrom(UnicodeString &src, UBool setSrcToBogus) U_NOEXCEPT {
+void UnicodeString::copyFieldsFrom(UnicodeString &src, UBool setSrcToBogus) noexcept {
   int16_t lengthAndFlags = fUnion.fFields.fLengthAndFlags = src.fUnion.fFields.fLengthAndFlags;
   if(lengthAndFlags & kUsingStackBuffer) {
     // Short string using the stack buffer, copy the contents.
@@ -607,7 +607,7 @@ void UnicodeString::copyFieldsFrom(UnicodeString &src, UBool setSrcToBogus) U_NO
   }
 }
 
-void UnicodeString::swap(UnicodeString &other) U_NOEXCEPT {
+void UnicodeString::swap(UnicodeString &other) noexcept {
   UnicodeString temp;  // Empty short string: Known not to need releaseArray().
   // Copy fields without resetting source values in between.
   temp.copyFieldsFrom(*this, false);

--- a/icu4c/source/common/uobject.cpp
+++ b/icu4c/source/common/uobject.cpp
@@ -58,32 +58,32 @@ U_NAMESPACE_BEGIN
  * and replace with uprv_malloc/uprv_free.
  */
 
-void * U_EXPORT2 UMemory::operator new(size_t size) U_NOEXCEPT {
+void * U_EXPORT2 UMemory::operator new(size_t size) noexcept {
     return uprv_malloc(size);
 }
 
-void U_EXPORT2 UMemory::operator delete(void *p) U_NOEXCEPT {
+void U_EXPORT2 UMemory::operator delete(void *p) noexcept {
     if(p!=nullptr) {
         uprv_free(p);
     }
 }
 
-void * U_EXPORT2 UMemory::operator new[](size_t size) U_NOEXCEPT {
+void * U_EXPORT2 UMemory::operator new[](size_t size) noexcept {
     return uprv_malloc(size);
 }
 
-void U_EXPORT2 UMemory::operator delete[](void *p) U_NOEXCEPT {
+void U_EXPORT2 UMemory::operator delete[](void *p) noexcept {
     if(p!=nullptr) {
         uprv_free(p);
     }
 }
 
 #if U_HAVE_DEBUG_LOCATION_NEW
-void * U_EXPORT2 UMemory::operator new(size_t size, const char* /*file*/, int /*line*/) U_NOEXCEPT {
+void * U_EXPORT2 UMemory::operator new(size_t size, const char* /*file*/, int /*line*/) noexcept {
     return UMemory::operator new(size);
 }
 
-void U_EXPORT2 UMemory::operator delete(void* p, const char* /*file*/, int /*line*/) U_NOEXCEPT {
+void U_EXPORT2 UMemory::operator delete(void* p, const char* /*file*/, int /*line*/) noexcept {
     UMemory::operator delete(p);
 }
 #endif /* U_HAVE_DEBUG_LOCATION_NEW */

--- a/icu4c/source/common/uresimp.h
+++ b/icu4c/source/common/uresimp.h
@@ -118,10 +118,10 @@ U_NAMESPACE_BEGIN
 class U_COMMON_API StackUResourceBundle {
 public:
     // No heap allocation. Use only on the stack.
-    static void* U_EXPORT2 operator new(size_t) U_NOEXCEPT = delete;
-    static void* U_EXPORT2 operator new[](size_t) U_NOEXCEPT = delete;
+    static void* U_EXPORT2 operator new(size_t) noexcept = delete;
+    static void* U_EXPORT2 operator new[](size_t) noexcept = delete;
 #if U_HAVE_PLACEMENT_NEW
-    static void* U_EXPORT2 operator new(size_t, void*) U_NOEXCEPT = delete;
+    static void* U_EXPORT2 operator new(size_t, void*) noexcept = delete;
 #endif
 
     StackUResourceBundle();

--- a/icu4c/source/i18n/formattedval_impl.h
+++ b/icu4c/source/i18n/formattedval_impl.h
@@ -222,7 +222,7 @@ struct UFormattedValueImpl : public UMemory, public UFormattedValueApiHelper {
 
 /** Implementation of the methods from U_FORMATTED_VALUE_SUBCLASS_AUTO. */
 #define UPRV_FORMATTED_VALUE_SUBCLASS_AUTO_IMPL(Name) \
-    Name::Name(Name&& src) U_NOEXCEPT \
+    Name::Name(Name&& src) noexcept \
             : fData(src.fData), fErrorCode(src.fErrorCode) { \
         src.fData = nullptr; \
         src.fErrorCode = U_INVALID_STATE_ERROR; \
@@ -231,7 +231,7 @@ struct UFormattedValueImpl : public UMemory, public UFormattedValueApiHelper {
         delete fData; \
         fData = nullptr; \
     } \
-    Name& Name::operator=(Name&& src) U_NOEXCEPT { \
+    Name& Name::operator=(Name&& src) noexcept { \
         delete fData; \
         fData = src.fData; \
         src.fData = nullptr; \

--- a/icu4c/source/i18n/fphdlimp.h
+++ b/icu4c/source/i18n/fphdlimp.h
@@ -74,10 +74,10 @@ class U_I18N_API FieldPositionIteratorHandler : public FieldPositionHandler {
   // to be destroyed before status goes out of scope.  Easiest thing is to
   // allocate us on the stack in the same (or narrower) scope as status has.
   // This attempts to encourage that by blocking heap allocation.
-  static void* U_EXPORT2 operator new(size_t) U_NOEXCEPT = delete;
-  static void* U_EXPORT2 operator new[](size_t) U_NOEXCEPT = delete;
+  static void* U_EXPORT2 operator new(size_t) noexcept = delete;
+  static void* U_EXPORT2 operator new[](size_t) noexcept = delete;
 #if U_HAVE_PLACEMENT_NEW
-  static void* U_EXPORT2 operator new(size_t, void*) U_NOEXCEPT = delete;
+  static void* U_EXPORT2 operator new(size_t, void*) noexcept = delete;
 #endif
 
  public:

--- a/icu4c/source/i18n/number_decimalquantity.cpp
+++ b/icu4c/source/i18n/number_decimalquantity.cpp
@@ -89,7 +89,7 @@ DecimalQuantity::DecimalQuantity(const DecimalQuantity &other) {
     *this = other;
 }
 
-DecimalQuantity::DecimalQuantity(DecimalQuantity&& src) U_NOEXCEPT {
+DecimalQuantity::DecimalQuantity(DecimalQuantity&& src) noexcept {
     *this = std::move(src);
 }
 
@@ -102,7 +102,7 @@ DecimalQuantity &DecimalQuantity::operator=(const DecimalQuantity &other) {
     return *this;
 }
 
-DecimalQuantity& DecimalQuantity::operator=(DecimalQuantity&& src) U_NOEXCEPT {
+DecimalQuantity& DecimalQuantity::operator=(DecimalQuantity&& src) noexcept {
     if (this == &src) {
         return *this;
     }

--- a/icu4c/source/i18n/number_decimalquantity.h
+++ b/icu4c/source/i18n/number_decimalquantity.h
@@ -36,7 +36,7 @@ class U_I18N_API DecimalQuantity : public IFixedDecimal, public UMemory {
     DecimalQuantity(const DecimalQuantity &other);
 
     /** Move constructor. */
-    DecimalQuantity(DecimalQuantity &&src) U_NOEXCEPT;
+    DecimalQuantity(DecimalQuantity &&src) noexcept;
 
     DecimalQuantity();
 
@@ -50,7 +50,7 @@ class U_I18N_API DecimalQuantity : public IFixedDecimal, public UMemory {
     DecimalQuantity &operator=(const DecimalQuantity &other);
 
     /** Move assignment */
-    DecimalQuantity &operator=(DecimalQuantity&& src) U_NOEXCEPT;
+    DecimalQuantity &operator=(DecimalQuantity&& src) noexcept;
 
     /**
      * Sets the minimum integer digits that this {@link DecimalQuantity} should generate.

--- a/icu4c/source/i18n/number_fluent.cpp
+++ b/icu4c/source/i18n/number_fluent.cpp
@@ -431,10 +431,10 @@ UnlocalizedNumberFormatter::UnlocalizedNumberFormatter(const NFS<UNF>& other)
 }
 
 // Make default copy constructor call the NumberFormatterSettings copy constructor.
-UnlocalizedNumberFormatter::UnlocalizedNumberFormatter(UNF&& src) U_NOEXCEPT
+UnlocalizedNumberFormatter::UnlocalizedNumberFormatter(UNF&& src) noexcept
         : UNF(static_cast<NFS<UNF>&&>(src)) {}
 
-UnlocalizedNumberFormatter::UnlocalizedNumberFormatter(NFS<UNF>&& src) U_NOEXCEPT
+UnlocalizedNumberFormatter::UnlocalizedNumberFormatter(NFS<UNF>&& src) noexcept
         : NFS<UNF>(std::move(src)) {
     // No additional fields to assign
 }
@@ -445,7 +445,7 @@ UnlocalizedNumberFormatter& UnlocalizedNumberFormatter::operator=(const UNF& oth
     return *this;
 }
 
-UnlocalizedNumberFormatter& UnlocalizedNumberFormatter::operator=(UNF&& src) U_NOEXCEPT {
+UnlocalizedNumberFormatter& UnlocalizedNumberFormatter::operator=(UNF&& src) noexcept {
     NFS<UNF>::operator=(static_cast<NFS<UNF>&&>(src));
     // No additional fields to assign
     return *this;
@@ -461,10 +461,10 @@ LocalizedNumberFormatter::LocalizedNumberFormatter(const NFS<LNF>& other)
     lnfCopyHelper(static_cast<const LNF&>(other), localStatus);
 }
 
-LocalizedNumberFormatter::LocalizedNumberFormatter(LocalizedNumberFormatter&& src) U_NOEXCEPT
+LocalizedNumberFormatter::LocalizedNumberFormatter(LocalizedNumberFormatter&& src) noexcept
         : LNF(static_cast<NFS<LNF>&&>(src)) {}
 
-LocalizedNumberFormatter::LocalizedNumberFormatter(NFS<LNF>&& src) U_NOEXCEPT
+LocalizedNumberFormatter::LocalizedNumberFormatter(NFS<LNF>&& src) noexcept
         : NFS<LNF>(std::move(src)) {
     lnfMoveHelper(std::move(static_cast<LNF&&>(src)));
 }
@@ -477,7 +477,7 @@ LocalizedNumberFormatter& LocalizedNumberFormatter::operator=(const LNF& other) 
     return *this;
 }
 
-LocalizedNumberFormatter& LocalizedNumberFormatter::operator=(LNF&& src) U_NOEXCEPT {
+LocalizedNumberFormatter& LocalizedNumberFormatter::operator=(LNF&& src) noexcept {
     NFS<LNF>::operator=(static_cast<NFS<LNF>&&>(src));
     lnfMoveHelper(std::move(src));
     return *this;

--- a/icu4c/source/i18n/number_modifiers.cpp
+++ b/icu4c/source/i18n/number_modifiers.cpp
@@ -69,7 +69,7 @@ AdoptingSignumModifierStore::~AdoptingSignumModifierStore()  {
 }
 
 AdoptingSignumModifierStore&
-AdoptingSignumModifierStore::operator=(AdoptingSignumModifierStore&& other) U_NOEXCEPT {
+AdoptingSignumModifierStore::operator=(AdoptingSignumModifierStore&& other) noexcept {
     for (size_t i=0; i<SIGNUM_COUNT; i++) {
         this->mods[i] = other.mods[i];
         other.mods[i] = nullptr;

--- a/icu4c/source/i18n/number_modifiers.h
+++ b/icu4c/source/i18n/number_modifiers.h
@@ -284,10 +284,10 @@ class U_I18N_API AdoptingSignumModifierStore : public UMemory {
     AdoptingSignumModifierStore& operator=(const AdoptingSignumModifierStore& other) = delete;
 
     // Moving is OK
-    AdoptingSignumModifierStore(AdoptingSignumModifierStore &&other) U_NOEXCEPT {
+    AdoptingSignumModifierStore(AdoptingSignumModifierStore &&other) noexcept {
         *this = std::move(other);
     }
-    AdoptingSignumModifierStore& operator=(AdoptingSignumModifierStore&& other) U_NOEXCEPT;
+    AdoptingSignumModifierStore& operator=(AdoptingSignumModifierStore&& other) noexcept;
 
     /** Take ownership of the Modifier and slot it in at the given Signum. */
     void adoptModifier(Signum signum, const Modifier* mod) {

--- a/icu4c/source/i18n/number_multiplier.cpp
+++ b/icu4c/source/i18n/number_multiplier.cpp
@@ -58,13 +58,13 @@ Scale& Scale::operator=(const Scale& other) {
     return *this;
 }
 
-Scale::Scale(Scale&& src) U_NOEXCEPT
+Scale::Scale(Scale&& src) noexcept
         : fMagnitude(src.fMagnitude), fArbitrary(src.fArbitrary), fError(src.fError) {
     // Take ownership away from src if necessary
     src.fArbitrary = nullptr;
 }
 
-Scale& Scale::operator=(Scale&& src) U_NOEXCEPT {
+Scale& Scale::operator=(Scale&& src) noexcept {
     fMagnitude = src.fMagnitude;
     if (fArbitrary != nullptr) {
         delete fArbitrary;

--- a/icu4c/source/i18n/number_patternstring.h
+++ b/icu4c/source/i18n/number_patternstring.h
@@ -83,7 +83,7 @@ struct U_I18N_API ParsedPatternInfo : public AffixPatternProvider, public UMemor
     ~ParsedPatternInfo() override = default;
 
     // Need to declare this explicitly because of the destructor
-    ParsedPatternInfo& operator=(ParsedPatternInfo&& src) U_NOEXCEPT = default;
+    ParsedPatternInfo& operator=(ParsedPatternInfo&& src) noexcept = default;
 
     static int32_t getLengthFromEndpoints(const Endpoints& endpoints);
 
@@ -115,7 +115,7 @@ struct U_I18N_API ParsedPatternInfo : public AffixPatternProvider, public UMemor
         explicit ParserState(const UnicodeString& _pattern)
                 : pattern(_pattern) {}
 
-        ParserState& operator=(ParserState&& src) U_NOEXCEPT {
+        ParserState& operator=(ParserState&& src) noexcept {
             // Leave pattern reference alone; it will continue to point to the same place in memory,
             // which gets overwritten by ParsedPatternInfo's implicit move assignment.
             offset = src.offset;

--- a/icu4c/source/i18n/number_symbolswrapper.cpp
+++ b/icu4c/source/i18n/number_symbolswrapper.cpp
@@ -16,7 +16,7 @@ SymbolsWrapper::SymbolsWrapper(const SymbolsWrapper &other) {
     doCopyFrom(other);
 }
 
-SymbolsWrapper::SymbolsWrapper(SymbolsWrapper &&src) U_NOEXCEPT {
+SymbolsWrapper::SymbolsWrapper(SymbolsWrapper &&src) noexcept {
     doMoveFrom(std::move(src));
 }
 
@@ -29,7 +29,7 @@ SymbolsWrapper &SymbolsWrapper::operator=(const SymbolsWrapper &other) {
     return *this;
 }
 
-SymbolsWrapper &SymbolsWrapper::operator=(SymbolsWrapper &&src) U_NOEXCEPT {
+SymbolsWrapper &SymbolsWrapper::operator=(SymbolsWrapper &&src) noexcept {
     if (this == &src) {
         return *this;
     }

--- a/icu4c/source/i18n/number_usageprefs.cpp
+++ b/icu4c/source/i18n/number_usageprefs.cpp
@@ -60,7 +60,7 @@ StringProp &StringProp::operator=(const StringProp &other) {
 }
 
 // Move constructor
-StringProp::StringProp(StringProp &&src) U_NOEXCEPT : fValue(src.fValue),
+StringProp::StringProp(StringProp &&src) noexcept : fValue(src.fValue),
                                                       fLength(src.fLength),
                                                       fError(src.fError) {
     // Take ownership away from src if necessary
@@ -68,7 +68,7 @@ StringProp::StringProp(StringProp &&src) U_NOEXCEPT : fValue(src.fValue),
 }
 
 // Move assignment operator
-StringProp &StringProp::operator=(StringProp &&src) U_NOEXCEPT {
+StringProp &StringProp::operator=(StringProp &&src) noexcept {
     if (this == &src) {
         return *this;
     }

--- a/icu4c/source/i18n/numrange_fluent.cpp
+++ b/icu4c/source/i18n/numrange_fluent.cpp
@@ -204,10 +204,10 @@ UnlocalizedNumberRangeFormatter::UnlocalizedNumberRangeFormatter(const NFS<UNF>&
 }
 
 // Make default copy constructor call the NumberRangeFormatterSettings copy constructor.
-UnlocalizedNumberRangeFormatter::UnlocalizedNumberRangeFormatter(UNF&& src) U_NOEXCEPT
+UnlocalizedNumberRangeFormatter::UnlocalizedNumberRangeFormatter(UNF&& src) noexcept
         : UNF(static_cast<NFS<UNF>&&>(src)) {}
 
-UnlocalizedNumberRangeFormatter::UnlocalizedNumberRangeFormatter(NFS<UNF>&& src) U_NOEXCEPT
+UnlocalizedNumberRangeFormatter::UnlocalizedNumberRangeFormatter(NFS<UNF>&& src) noexcept
         : NFS<UNF>(std::move(src)) {
     // No additional fields to assign
 }
@@ -218,7 +218,7 @@ UnlocalizedNumberRangeFormatter& UnlocalizedNumberRangeFormatter::operator=(cons
     return *this;
 }
 
-UnlocalizedNumberRangeFormatter& UnlocalizedNumberRangeFormatter::operator=(UNF&& src) U_NOEXCEPT {
+UnlocalizedNumberRangeFormatter& UnlocalizedNumberRangeFormatter::operator=(UNF&& src) noexcept {
     NFS<UNF>::operator=(static_cast<NFS<UNF>&&>(src));
     // No additional fields to assign
     return *this;
@@ -233,10 +233,10 @@ LocalizedNumberRangeFormatter::LocalizedNumberRangeFormatter(const NFS<LNF>& oth
     // No additional fields to assign
 }
 
-LocalizedNumberRangeFormatter::LocalizedNumberRangeFormatter(LocalizedNumberRangeFormatter&& src) U_NOEXCEPT
+LocalizedNumberRangeFormatter::LocalizedNumberRangeFormatter(LocalizedNumberRangeFormatter&& src) noexcept
         : LNF(static_cast<NFS<LNF>&&>(src)) {}
 
-LocalizedNumberRangeFormatter::LocalizedNumberRangeFormatter(NFS<LNF>&& src) U_NOEXCEPT
+LocalizedNumberRangeFormatter::LocalizedNumberRangeFormatter(NFS<LNF>&& src) noexcept
         : NFS<LNF>(std::move(src)) {
     // Steal the compiled formatter
     LNF&& _src = static_cast<LNF&&>(src);
@@ -252,7 +252,7 @@ LocalizedNumberRangeFormatter& LocalizedNumberRangeFormatter::operator=(const LN
     return *this;
 }
 
-LocalizedNumberRangeFormatter& LocalizedNumberRangeFormatter::operator=(LNF&& src) U_NOEXCEPT {
+LocalizedNumberRangeFormatter& LocalizedNumberRangeFormatter::operator=(LNF&& src) noexcept {
     NFS<LNF>::operator=(static_cast<NFS<LNF>&&>(src));
     // Steal the compiled formatter
     auto* stolen = src.fAtomicFormatter.exchange(nullptr);

--- a/icu4c/source/i18n/unicode/dtitvfmt.h
+++ b/icu4c/source/i18n/unicode/dtitvfmt.h
@@ -68,7 +68,7 @@ class U_I18N_API FormattedDateInterval : public UMemory, public FormattedValue {
      * Move constructor: Leaves the source FormattedDateInterval in an undefined state.
      * @stable ICU 64
      */
-    FormattedDateInterval(FormattedDateInterval&& src) U_NOEXCEPT;
+    FormattedDateInterval(FormattedDateInterval&& src) noexcept;
 
     /**
      * Destruct an instance of FormattedDateInterval.
@@ -86,7 +86,7 @@ class U_I18N_API FormattedDateInterval : public UMemory, public FormattedValue {
      * Move assignment: Leaves the source FormattedDateInterval in an undefined state.
      * @stable ICU 64
      */
-    FormattedDateInterval& operator=(FormattedDateInterval&& src) U_NOEXCEPT;
+    FormattedDateInterval& operator=(FormattedDateInterval&& src) noexcept;
 
     /** @copydoc FormattedValue::toString() */
     UnicodeString toString(UErrorCode& status) const override;

--- a/icu4c/source/i18n/unicode/formattednumber.h
+++ b/icu4c/source/i18n/unicode/formattednumber.h
@@ -58,7 +58,7 @@ class U_I18N_API FormattedNumber : public UMemory, public FormattedValue {
      * Move constructor: Leaves the source FormattedNumber in an undefined state.
      * @stable ICU 62
      */
-    FormattedNumber(FormattedNumber&& src) U_NOEXCEPT;
+    FormattedNumber(FormattedNumber&& src) noexcept;
 
     /**
      * Destruct an instance of FormattedNumber.
@@ -76,7 +76,7 @@ class U_I18N_API FormattedNumber : public UMemory, public FormattedValue {
      * Move assignment: Leaves the source FormattedNumber in an undefined state.
      * @stable ICU 62
      */
-    FormattedNumber& operator=(FormattedNumber&& src) U_NOEXCEPT;
+    FormattedNumber& operator=(FormattedNumber&& src) noexcept;
 
     // Copybrief: this method is older than the parent method
     /**

--- a/icu4c/source/i18n/unicode/listformatter.h
+++ b/icu4c/source/i18n/unicode/listformatter.h
@@ -95,7 +95,7 @@ class U_I18N_API FormattedList : public UMemory, public FormattedValue {
      * Move constructor: Leaves the source FormattedList in an undefined state.
      * @stable ICU 64
      */
-    FormattedList(FormattedList&& src) U_NOEXCEPT;
+    FormattedList(FormattedList&& src) noexcept;
 
     /**
      * Destruct an instance of FormattedList.
@@ -113,7 +113,7 @@ class U_I18N_API FormattedList : public UMemory, public FormattedValue {
      * Move assignment: Leaves the source FormattedList in an undefined state.
      * @stable ICU 64
      */
-    FormattedList& operator=(FormattedList&& src) U_NOEXCEPT;
+    FormattedList& operator=(FormattedList&& src) noexcept;
 
     /** @copydoc FormattedValue::toString() */
     UnicodeString toString(UErrorCode& status) const override;

--- a/icu4c/source/i18n/unicode/numberformatter.h
+++ b/icu4c/source/i18n/unicode/numberformatter.h
@@ -1146,10 +1146,10 @@ class U_I18N_API Scale : public UMemory {
     Scale& operator=(const Scale& other);
 
     /** @stable ICU 62 */
-    Scale(Scale&& src) U_NOEXCEPT;
+    Scale(Scale&& src) noexcept;
 
     /** @stable ICU 62 */
-    Scale& operator=(Scale&& src) U_NOEXCEPT;
+    Scale& operator=(Scale&& src) noexcept;
 
     /** @stable ICU 62 */
     ~Scale();
@@ -1225,10 +1225,10 @@ class U_I18N_API StringProp : public UMemory {
 #ifndef U_HIDE_INTERNAL_API
 
     /** @internal */
-    StringProp(StringProp &&src) U_NOEXCEPT;
+    StringProp(StringProp &&src) noexcept;
 
     /** @internal */
-    StringProp &operator=(StringProp &&src) U_NOEXCEPT;
+    StringProp &operator=(StringProp &&src) noexcept;
 
     /** @internal */
     int16_t length() const {
@@ -1289,10 +1289,10 @@ class U_I18N_API SymbolsWrapper : public UMemory {
     SymbolsWrapper &operator=(const SymbolsWrapper &other);
 
     /** @internal */
-    SymbolsWrapper(SymbolsWrapper&& src) U_NOEXCEPT;
+    SymbolsWrapper(SymbolsWrapper&& src) noexcept;
 
     /** @internal */
-    SymbolsWrapper &operator=(SymbolsWrapper&& src) U_NOEXCEPT;
+    SymbolsWrapper &operator=(SymbolsWrapper&& src) noexcept;
 
     /** @internal */
     ~SymbolsWrapper();
@@ -2475,7 +2475,7 @@ class U_I18N_API UnlocalizedNumberFormatter
      * The source UnlocalizedNumberFormatter will be left in a valid but undefined state.
      * @stable ICU 62
      */
-    UnlocalizedNumberFormatter(UnlocalizedNumberFormatter&& src) U_NOEXCEPT;
+    UnlocalizedNumberFormatter(UnlocalizedNumberFormatter&& src) noexcept;
 
     /**
      * Copy assignment operator.
@@ -2488,13 +2488,13 @@ class U_I18N_API UnlocalizedNumberFormatter
      * The source UnlocalizedNumberFormatter will be left in a valid but undefined state.
      * @stable ICU 62
      */
-    UnlocalizedNumberFormatter& operator=(UnlocalizedNumberFormatter&& src) U_NOEXCEPT;
+    UnlocalizedNumberFormatter& operator=(UnlocalizedNumberFormatter&& src) noexcept;
 
   private:
     explicit UnlocalizedNumberFormatter(const NumberFormatterSettings<UnlocalizedNumberFormatter>& other);
 
     explicit UnlocalizedNumberFormatter(
-            NumberFormatterSettings<UnlocalizedNumberFormatter>&& src) U_NOEXCEPT;
+            NumberFormatterSettings<UnlocalizedNumberFormatter>&& src) noexcept;
 
     // To give the fluent setters access to this class's constructor:
     friend class NumberFormatterSettings<UnlocalizedNumberFormatter>;
@@ -2621,7 +2621,7 @@ class U_I18N_API LocalizedNumberFormatter
      * The source LocalizedNumberFormatter will be left in a valid but undefined state.
      * @stable ICU 62
      */
-    LocalizedNumberFormatter(LocalizedNumberFormatter&& src) U_NOEXCEPT;
+    LocalizedNumberFormatter(LocalizedNumberFormatter&& src) noexcept;
 
     /**
      * Copy assignment operator.
@@ -2634,7 +2634,7 @@ class U_I18N_API LocalizedNumberFormatter
      * The source LocalizedNumberFormatter will be left in a valid but undefined state.
      * @stable ICU 62
      */
-    LocalizedNumberFormatter& operator=(LocalizedNumberFormatter&& src) U_NOEXCEPT;
+    LocalizedNumberFormatter& operator=(LocalizedNumberFormatter&& src) noexcept;
 
 #ifndef U_HIDE_INTERNAL_API
 
@@ -2672,7 +2672,7 @@ class U_I18N_API LocalizedNumberFormatter
 
     explicit LocalizedNumberFormatter(const NumberFormatterSettings<LocalizedNumberFormatter>& other);
 
-    explicit LocalizedNumberFormatter(NumberFormatterSettings<LocalizedNumberFormatter>&& src) U_NOEXCEPT;
+    explicit LocalizedNumberFormatter(NumberFormatterSettings<LocalizedNumberFormatter>&& src) noexcept;
 
     LocalizedNumberFormatter(const impl::MacroProps &macros, const Locale &locale);
 

--- a/icu4c/source/i18n/unicode/numberrangeformatter.h
+++ b/icu4c/source/i18n/unicode/numberrangeformatter.h
@@ -440,7 +440,7 @@ class U_I18N_API UnlocalizedNumberRangeFormatter
      * The source UnlocalizedNumberRangeFormatter will be left in a valid but undefined state.
      * @stable ICU 63
      */
-    UnlocalizedNumberRangeFormatter(UnlocalizedNumberRangeFormatter&& src) U_NOEXCEPT;
+    UnlocalizedNumberRangeFormatter(UnlocalizedNumberRangeFormatter&& src) noexcept;
 
     /**
      * Copy assignment operator.
@@ -453,14 +453,14 @@ class U_I18N_API UnlocalizedNumberRangeFormatter
      * The source UnlocalizedNumberRangeFormatter will be left in a valid but undefined state.
      * @stable ICU 63
      */
-    UnlocalizedNumberRangeFormatter& operator=(UnlocalizedNumberRangeFormatter&& src) U_NOEXCEPT;
+    UnlocalizedNumberRangeFormatter& operator=(UnlocalizedNumberRangeFormatter&& src) noexcept;
 
   private:
     explicit UnlocalizedNumberRangeFormatter(
             const NumberRangeFormatterSettings<UnlocalizedNumberRangeFormatter>& other);
 
     explicit UnlocalizedNumberRangeFormatter(
-            NumberRangeFormatterSettings<UnlocalizedNumberRangeFormatter>&& src) U_NOEXCEPT;
+            NumberRangeFormatterSettings<UnlocalizedNumberRangeFormatter>&& src) noexcept;
 
     // To give the fluent setters access to this class's constructor:
     friend class NumberRangeFormatterSettings<UnlocalizedNumberRangeFormatter>;
@@ -514,7 +514,7 @@ class U_I18N_API LocalizedNumberRangeFormatter
      * The source LocalizedNumberRangeFormatter will be left in a valid but undefined state.
      * @stable ICU 63
      */
-    LocalizedNumberRangeFormatter(LocalizedNumberRangeFormatter&& src) U_NOEXCEPT;
+    LocalizedNumberRangeFormatter(LocalizedNumberRangeFormatter&& src) noexcept;
 
     /**
      * Copy assignment operator.
@@ -527,7 +527,7 @@ class U_I18N_API LocalizedNumberRangeFormatter
      * The source LocalizedNumberRangeFormatter will be left in a valid but undefined state.
      * @stable ICU 63
      */
-    LocalizedNumberRangeFormatter& operator=(LocalizedNumberRangeFormatter&& src) U_NOEXCEPT;
+    LocalizedNumberRangeFormatter& operator=(LocalizedNumberRangeFormatter&& src) noexcept;
 
 #ifndef U_HIDE_INTERNAL_API
 
@@ -561,7 +561,7 @@ class U_I18N_API LocalizedNumberRangeFormatter
         const NumberRangeFormatterSettings<LocalizedNumberRangeFormatter>& other);
 
     explicit LocalizedNumberRangeFormatter(
-        NumberRangeFormatterSettings<LocalizedNumberRangeFormatter>&& src) U_NOEXCEPT;
+        NumberRangeFormatterSettings<LocalizedNumberRangeFormatter>&& src) noexcept;
 
     LocalizedNumberRangeFormatter(const impl::RangeMacroProps &macros, const Locale &locale);
 
@@ -668,14 +668,14 @@ class U_I18N_API FormattedNumberRange : public UMemory, public FormattedValue {
      * Leaves the source FormattedNumberRange in an undefined state.
      * @stable ICU 63
      */
-    FormattedNumberRange(FormattedNumberRange&& src) U_NOEXCEPT;
+    FormattedNumberRange(FormattedNumberRange&& src) noexcept;
 
     /**
      * Move assignment:
      * Leaves the source FormattedNumberRange in an undefined state.
      * @stable ICU 63
      */
-    FormattedNumberRange& operator=(FormattedNumberRange&& src) U_NOEXCEPT;
+    FormattedNumberRange& operator=(FormattedNumberRange&& src) noexcept;
 
     /**
      * Destruct an instance of FormattedNumberRange, cleaning up any memory it might own.

--- a/icu4c/source/i18n/unicode/reldatefmt.h
+++ b/icu4c/source/i18n/unicode/reldatefmt.h
@@ -283,7 +283,7 @@ class U_I18N_API FormattedRelativeDateTime : public UMemory, public FormattedVal
      * Move constructor: Leaves the source FormattedRelativeDateTime in an undefined state.
      * @stable ICU 64
      */
-    FormattedRelativeDateTime(FormattedRelativeDateTime&& src) U_NOEXCEPT;
+    FormattedRelativeDateTime(FormattedRelativeDateTime&& src) noexcept;
 
     /**
      * Destruct an instance of FormattedRelativeDateTime.
@@ -301,7 +301,7 @@ class U_I18N_API FormattedRelativeDateTime : public UMemory, public FormattedVal
      * Move assignment: Leaves the source FormattedRelativeDateTime in an undefined state.
      * @stable ICU 64
      */
-    FormattedRelativeDateTime& operator=(FormattedRelativeDateTime&& src) U_NOEXCEPT;
+    FormattedRelativeDateTime& operator=(FormattedRelativeDateTime&& src) noexcept;
 
     /** @copydoc FormattedValue::toString() */
     UnicodeString toString(UErrorCode& status) const override;

--- a/icu4c/source/i18n/unicode/simplenumberformatter.h
+++ b/icu4c/source/i18n/unicode/simplenumberformatter.h
@@ -139,7 +139,7 @@ class U_I18N_API SimpleNumber : public UMemory {
      *
      * @draft ICU 73
      */
-    SimpleNumber(SimpleNumber&& other) U_NOEXCEPT {
+    SimpleNumber(SimpleNumber&& other) noexcept {
         fData = other.fData;
         fSign = other.fSign;
         other.fData = nullptr;
@@ -150,7 +150,7 @@ class U_I18N_API SimpleNumber : public UMemory {
      *
      * @draft ICU 73
      */
-    SimpleNumber& operator=(SimpleNumber&& other) U_NOEXCEPT {
+    SimpleNumber& operator=(SimpleNumber&& other) noexcept {
         cleanup();
         fData = other.fData;
         fSign = other.fSign;
@@ -267,7 +267,7 @@ class U_I18N_API SimpleNumberFormatter : public UMemory {
      *
      * @draft ICU 73
      */
-    SimpleNumberFormatter(SimpleNumberFormatter&& other) U_NOEXCEPT {
+    SimpleNumberFormatter(SimpleNumberFormatter&& other) noexcept {
         fGroupingStrategy = other.fGroupingStrategy;
         fOwnedSymbols = other.fOwnedSymbols;
         fMicros = other.fMicros;
@@ -282,7 +282,7 @@ class U_I18N_API SimpleNumberFormatter : public UMemory {
      *
      * @draft ICU 73
      */
-    SimpleNumberFormatter& operator=(SimpleNumberFormatter&& other) U_NOEXCEPT {
+    SimpleNumberFormatter& operator=(SimpleNumberFormatter&& other) noexcept {
         cleanup();
         fGroupingStrategy = other.fGroupingStrategy;
         fOwnedSymbols = other.fOwnedSymbols;

--- a/tools/release/java/src/main/java/com/ibm/icu/dev/tools/docs/StableAPI.java
+++ b/tools/release/java/src/main/java/com/ibm/icu/dev/tools/docs/StableAPI.java
@@ -552,6 +552,7 @@ public class StableAPI {
                                       //  TODO: notify about this difference, separately
                 "[ ]*U_NOEXCEPT", "", // remove U_NOEXCEPT (this was fixed in Doxyfile, but fixing here so it is
                                       //  retroactive)
+                "[ ]*noexcept", "",
                 "[ ]*override", "",   // remove override
                 // Simplify possibly-covariant functions to void*
                 "^([^\\* ]+)\\*(.*)::(clone|safeClone|cloneAsThawed|freeze|createBufferClone)\\((.*)", "void*$2::$3($4",


### PR DESCRIPTION
We require C++11, so we no longer need a conditional definition of a U_NOEXCEPT macro.
(For review: This `@internal` definition was in icu4c/source/common/unicode/platform.h)

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21833
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
