### PR TITLE
ICU-22220 BRS 73rc adjust #ifndef U_HIDE_DRAFT_API for virtual methods, fix conditionalized enums

### DIFF
--- a/icu4c/source/i18n/unicode/calendar.h
+++ b/icu4c/source/i18n/unicode/calendar.h
@@ -1349,7 +1349,7 @@ public:
      */
     virtual UBool isWeekend(void) const;
 
-#ifndef U_HIDE_DRAFT_API
+#ifndef U_FORCE_HIDE_DRAFT_API
     /**
      * Returns true if the date is in a leap year. Recalculate the current time
      * field values if the time value has been changed by a call to * setTime().
@@ -1407,7 +1407,7 @@ public:
      */
     virtual void setTemporalMonthCode(const char* temporalMonth, UErrorCode& status);
 
-#endif /* U_HIDE_DRAFT_API */
+#endif  // U_FORCE_HIDE_DRAFT_API
 
 protected:
 
@@ -1549,6 +1549,7 @@ protected:
      * @internal
      */
     inline int32_t internalGet(UCalendarDateFields field) const {return fFields[field];}
+#endif  /* U_HIDE_INTERNAL_API */
 
     /**
      * Use this function instead of internalGet(UCAL_MONTH). The implementation
@@ -1573,8 +1574,6 @@ protected:
      * @internal
      */
     virtual int32_t internalGetMonth(int32_t defaultValue) const;
-
-#endif  /* U_HIDE_INTERNAL_API */
 
 #ifndef U_HIDE_DEPRECATED_API
     /**

--- a/icu4c/source/i18n/unicode/ucal.h
+++ b/icu4c/source/i18n/unicode/ucal.h
@@ -477,7 +477,8 @@ enum UCalendarDateFields {
      * @deprecated ICU 58 The numeric value may change over time, see ICU ticket #12420.
      */
 #ifdef U_HIDE_DRAFT_API
-    UCAL_FIELD_COUNT = UCAL_IS_LEAP_MONTH + 1,
+    // Must include all fields that will be in structs
+    UCAL_FIELD_COUNT = UCAL_IS_LEAP_MONTH + 2,
 #else  // U_HIDE_DRAFT_API (for UCAL_ORDINAL_MONTH)
     UCAL_FIELD_COUNT = UCAL_ORDINAL_MONTH + 1,
 #endif  // U_HIDE_DRAFT_API (for UCAL_ORDINAL_MONTH)

--- a/icu4c/source/i18n/unicode/unum.h
+++ b/icu4c/source/i18n/unicode/unum.h
@@ -362,11 +362,7 @@ typedef enum UNumberFormatFields {
      * One more than the highest normal UNumberFormatFields value.
      * @deprecated ICU 58 The numeric value may change over time, see ICU ticket #12420.
      */
-#ifndef U_HIDE_DRAFT_API
-    UNUM_FIELD_COUNT = UNUM_COMPACT_FIELD + 2
-#else  // U_HIDE_DRAFT_API (for UNUM_APPROXIMATELY_SIGN_FIELD)
-    UNUM_FIELD_COUNT = UNUM_COMPACT_FIELD + 1
-#endif  // U_HIDE_DRAFT_API (for UNUM_APPROXIMATELY_SIGN_FIELD)
+    UNUM_FIELD_COUNT
 #endif  /* U_HIDE_DEPRECATED_API */
 } UNumberFormatFields;
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22220
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

BRS task: Check non-stable API macros (U_HIDE_DRAFT_API and others)
- Some virtual methods were conditionalized with U_HIDE_DRAFT_API, that should not be done
- A couple of enum constants whose values are used to determine the size of structures had different values depending on U_HIDE_DRAFT_API; that should not happen, otherwise clients will use structs that do not match the implementation. 


