### PR TITLE
ICU-22194 Add CI job to generate Github Pages using Github Actions

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,0 +1,78 @@
+# Copyright (C) 2023 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
+#
+# Note: the workflow here is based on the Github Actions workflow used
+# by the Jekyll theme we are using:
+# https://github.com/just-the-docs/just-the-docs/blob/main/.github/workflows/deploy.yml
+#
+# The Jekyll theme (just-the-docs) configured its Github CI to manually run the Jekyll
+# build instead of relying on the default behavior from
+# https://github.com/actions/jekyll-build-pages . The default behavior of 
+# actions/jekyll-build-pages seems to be causing errors with this theme.
+
+name: Deploy User Guide
+
+on:
+  # Runs on pushes targeting the default branch and only if in the `docs/` directory
+  push:
+    branches: ["main"]
+    paths: ["docs/**"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7.4' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+        with:
+          generator_config_file: docs/_config.yml
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        run: |
+          cd docs  # root directory of markdown, also contains Jekyll configs, etc.
+          bundle install
+          # The baseurl arg is parsed from the `baseurl` field of _config.yml.
+          bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs/_site
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -11,15 +11,10 @@ source "https://rubygems.org"
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
 
-# gem "jekyll", "~> 3.8.7"
-
-# This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.5"
-# If you aren't using GitHub Pages, then uncomment out the line above that starts with
-# 'gem "jekyll"' and then comment out the line below that starts with 'gem "github-pages"'.
-# To upgrade, run `bundle update github-pages`.
-gem "github-pages", "~> 213", group: :jekyll_plugins
 gem "just-the-docs"
+
+gem "github-pages", "228", group: :jekyll_plugins
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
@@ -34,4 +29,3 @@ end
 
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
-

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -14,7 +14,7 @@ url: "https://unicode-org.github.io" # the base hostname & protocol for your sit
 twitter_username: unicode
 github_username:  unicode-org
 
-remote_theme: pmarsceill/just-the-docs
+theme: just-the-docs
 
 # GitHub uses its own markdown renderer called CommonMarkGhPages.
 #

--- a/docs/_sass/color_schemes/light.scss
+++ b/docs/_sass/color_schemes/light.scss
@@ -1,8 +1,0 @@
-// © 2020 and later: Unicode, Inc. and others.
-// License & terms of use: http://www.unicode.org/copyright.html
-
-// Increase the side bar width as some of the page titles don't fit in the default size.
-$nav-width: 284px;
-
-// Increase the main content area width as some tables assume a larger size.
-$content-width: 900px;


### PR DESCRIPTION
## Background

Our User Guide is published via the Github Pages feature. I noticed that updates to it have been [failing over the past 2 weeks](https://github.com/unicode-org/icu/actions/workflows/pages/pages-build-deployment).

When we set it up a couple of years ago, it was still a black box how Github would run its internal version of Jekyll to generate the static pages. Since then, the Github Actions CI framework has become popular, and it is now the [default place to generate and/or deploy Github Pages](https://github.blog/2022-08-10-github-pages-now-uses-actions-by-default/). Even the legacy mechanism is now represented as a Github Actions CI workflow, as the links above show and describe.

## Changes in this PR

This PR introduces a new CI workflow that supports the deployment of our Github Pages (User Guide).

If the new CI workflow succeeds as expected, then we should follow [these instructions](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow) to update the repo's Github settings for how to publish our Github Pages. Making that update will use the new CI workflow in favor of the currently broken legacy black box style of generating Github Pages.

Note: Figuring out the new workflow was very tricky because, on top of everything else, the Jekyll theme that we use will occasionally have conflicts with the versions of Jekyll-related dependencies that Github likes to use. It appears that the latest 0.4.1 and 0.4.2 versions of our Jekyll theme, which were released in early February, have a parser error that manifests when combined into our GH Pages Jekyll setup, and that is what caused our Github Pages to stop updating. Pinning the version of the theme to 0.4.0 gets it to work again.


##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22194
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
