### PR TITLE
ICU-22308 stubdata empty pointerTOC alignas(16)

### DIFF
--- a/icu4c/source/stubdata/stubdata.cpp
+++ b/icu4c/source/stubdata/stubdata.cpp
@@ -6,7 +6,7 @@
 *   Corporation and others.  All Rights Reserved.
 *
 *******************************************************************************
-*   file name:  stubdata.c
+*   file name:  stubdata.cpp
 *
 *   Define initialized data that will build into a valid, but empty
 *   ICU data library.  Used to bootstrap the ICU build, which has these
@@ -49,10 +49,8 @@ extern "C" U_EXPORT const ICU_Data_Header U_ICUDATA_ENTRY_POINT = {
     0,                  /* Reserved     */
     {                   /*  TOC structure */
 /*        {    */
-          0 , 0 , 0, 0  /* name and data entries.  Count says there are none,  */
+          0 , 0         /* name and data entries.  Count says there are none,  */
                         /*  but put one in just in case.                       */
 /*        }  */
     }
 };
-
-

--- a/icu4c/source/stubdata/stubdata.h
+++ b/icu4c/source/stubdata/stubdata.h
@@ -31,7 +31,7 @@
 #include "unicode/udata.h"
 #include "unicode/uversion.h"
 
-typedef struct {
+typedef struct alignas(16) {
     uint16_t headerSize;
     uint8_t magic1, magic2;
     UDataInfo info;
@@ -43,7 +43,7 @@ typedef struct {
     const void *const data;
     } toc[1];
     */
-   int   fakeNameAndData[4];       /* TODO:  Change this header type from */
+   uint64_t fakeNameAndData[2];    /* TODO:  Change this header type from */
                                    /*        pointerTOC to OffsetTOC.     */
 } ICU_Data_Header;
 


### PR DESCRIPTION
use C++11 `alignas(16)` for desired alignment of the empty stubdata pointerTOC

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22308
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
