### PR TITLE
ICU-21940 DateFormatSymbols::assignArray should handle null srcArray

### DIFF
--- a/icu4c/source/i18n/dtfmtsym.cpp
+++ b/icu4c/source/i18n/dtfmtsym.cpp
@@ -314,6 +314,14 @@ DateFormatSymbols::assignArray(UnicodeString*& dstArray,
     // only from a locale bundle or set via the cloning API,
     // *and* for as long as all the strings are in *private* fields, preventing
     // a subclass from creating these strings in an "unsafe" way (with respect to fastCopyFrom()).
+    if(srcArray == nullptr) {
+        // Do not attempt to copy bogus input (which will crash).
+        // Note that this assignArray method already had the potential to return a null dstArray;
+        // see handling below for "if(dstArray != nullptr)".
+        dstCount = 0;
+        dstArray = nullptr;
+        return;
+    }
     dstCount = srcCount;
     dstArray = newUnicodeStringArray(srcCount);
     if(dstArray != nullptr) {


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21940
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

Make DateFormatSymbols::assignArray handle a null srcArray without crashing (by setting dstArray = null and dstCount = 0).

See my explanation and rationale in https://unicode-org.atlassian.net/browse/ICU-21940?focusedCommentId=168805

