### PR TITLE
ICU-22270 Fix hex number formatting in icuexportdata

### DIFF
--- a/icu4c/source/tools/icuexportdata/icuexportdata.cpp
+++ b/icu4c/source/tools/icuexportdata/icuexportdata.cpp
@@ -164,7 +164,7 @@ void dumpBinaryProperty(UProperty uproperty, FILE* f) {
     fputs("[[binary_property]]\n", f);
     fprintf(f, "long_name = \"%s\"\n", fullPropName);
     if (shortPropName) fprintf(f, "short_name = \"%s\"\n", shortPropName);
-    fprintf(f, "uproperty_discr = %X\n", uproperty);
+    fprintf(f, "uproperty_discr = 0x%X\n", uproperty);
     dumpPropertyAliases(uproperty, f);
     usrc_writeUnicodeSet(f, uset, UPRV_TARGET_SYNTAX_TOML);
 }


### PR DESCRIPTION
Just for binary properties exported by icuexportdata, the value for the field `uproperty_discr` is formatted in hex but forgot the `0x` prefix (see https://github.com/unicode-org/icu/commit/6046af063ddd7ed9cbab601a3c6304ad9070545d).

For example, currently, PCM.toml looks like

```
...
icu_version = "72.1"
unicode_version = "15.0"

[[binary_property]]
long_name = "Prepended_Concatenation_Mark"
short_name = "PCM"
uproperty_discr = 3F
# Inclusive ranges of the code points in the set.
ranges = [
  [0x600, 0x605],
  [0x6dd, 0x6dd],
...
```

The fix should then make it look like

```
...
icu_version = "72.1"
unicode_version = "15.0"

[[binary_property]]
long_name = "Prepended_Concatenation_Mark"
short_name = "PCM"
uproperty_discr = 0x3F
# Inclusive ranges of the code points in the set.
ranges = [
  [0x600, 0x605],
  [0x6dd, 0x6dd],
...
```
fyi @Manishearth 

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22270
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable