### PR TITLE
ICU-22308 add alignas(16) to the data entry point definition

### DIFF
--- a/icu4c/source/stubdata/stubdata.cpp
+++ b/icu4c/source/stubdata/stubdata.cpp
@@ -17,12 +17,11 @@
 *
 *   The stub data library (for which this file is the source) is sufficient
 *   for running the data building tools.
-*
 */
 
 #include "stubdata.h"
 
-extern "C" U_EXPORT const ICU_Data_Header U_ICUDATA_ENTRY_POINT = {
+extern "C" U_EXPORT const ICU_Data_Header U_ICUDATA_ENTRY_POINT alignas(16) = {
     32,          /* headerSize */
     0xda,        /* magic1,  (see struct MappedData in udata.c)  */
     0x27,        /* magic2     */
@@ -39,18 +38,15 @@ extern "C" U_EXPORT const ICU_Data_Header U_ICUDATA_ENTRY_POINT = {
         U_CHARSET_FAMILY,
         sizeof(char16_t),
         0,               /* reserved      */
-        {                /* data format identifier */
-           0x54, 0x6f, 0x43, 0x50}, /* "ToCP" */
-           {1, 0, 0, 0},   /* format version major, minor, milli, micro */
-           {0, 0, 0, 0}    /* dataVersion   */
+        {0x54, 0x6f, 0x43, 0x50},   /* data format identifier: "ToCP" */
+        {1, 0, 0, 0},   /* format version major, minor, milli, micro */
+        {0, 0, 0, 0}    /* dataVersion   */
     },
-    {0,0,0,0,0,0,0,0},  /* Padding[8]   */ 
+    { 's', 't', 'u', 'b', 'd', 'a', 't', 'a' },  /* Padding[8] */
     0,                  /* count        */
     0,                  /* Reserved     */
     {                   /*  TOC structure */
-/*        {    */
-          0 , 0         /* name and data entries.  Count says there are none,  */
+        0 , 0           /* name and data entries.  Count says there are none,  */
                         /*  but put one in just in case.                       */
-/*        }  */
     }
 };

--- a/icu4c/source/stubdata/stubdata.h
+++ b/icu4c/source/stubdata/stubdata.h
@@ -8,7 +8,7 @@
 *******************************************************************************
 *   file name:  stubdata.h
 *
-*   This header file is intended to be internal and only included in the 
+*   This header file is intended to be internal and only included in the
 *   accompanying implementation file. This file declares a single entry
 *   point for visibility of tools like TAPI.
 *
@@ -21,7 +21,6 @@
 *
 *   The stub data library (for which this file is the source) is sufficient
 *   for running the data building tools.
-*
 */
 
 #ifndef __STUBDATA_H__


### PR DESCRIPTION
Judging from https://en.cppreference.com/w/cpp/language/alignas it should suffice to specify the alignment requirement on the struct type *declaration* (as in PR #2380), but apparently some compilers ignore it unless it is (also?) on the variable *definition*.

I also set the unused padding bytes to something useful for debugging, and cleaned up indentation a little.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22308
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
