### PR TITLE
ICU-22340 Fix it so that UNUM_NUMBERING_SYSTEM again always returns a RuleBasedNumberFormat.

### DIFF
--- a/icu4c/source/i18n/unum.cpp
+++ b/icu4c/source/i18n/unum.cpp
@@ -60,7 +60,6 @@ unum_open(  UNumberFormatStyle    style,
     case UNUM_CURRENCY_ACCOUNTING:
     case UNUM_CASH_CURRENCY:
     case UNUM_CURRENCY_STANDARD:
-    case UNUM_NUMBERING_SYSTEM:
         retVal = NumberFormat::createInstance(Locale(locale), style, *status);
         break;
 
@@ -113,6 +112,21 @@ unum_open(  UNumberFormatStyle    style,
     case UNUM_DURATION:
         retVal = new RuleBasedNumberFormat(URBNF_DURATION, Locale(locale), *status);
         break;
+
+    case UNUM_NUMBERING_SYSTEM: {
+        // if the locale ID specifies a numbering system, go through NumberFormat::createInstance()
+        // to handle it properly (we have to specify UNUM_DEFAULT to get it to handle the numbering
+        // system, but we'll always get a RuleBasedNumberFormat back); otherwise, just go ahead and
+        // create a RuleBasedNumberFormat ourselves
+        UErrorCode localErr = U_ZERO_ERROR;
+        Locale localeObj(locale);
+        int32_t keywordLength = localeObj.getKeywordValue("numbers", nullptr, 0, localErr);
+        if (keywordLength > 0) {
+            retVal = NumberFormat::createInstance(localeObj, UNUM_DEFAULT, *status);
+        } else {
+            retVal = new RuleBasedNumberFormat(URBNF_NUMBERING_SYSTEM, localeObj, *status);
+        }
+    } break;
 #endif
 
     case UNUM_DECIMAL_COMPACT_SHORT:


### PR DESCRIPTION
(cherry picked from commit c7029502947779b27562ff50a0b9af41fb30efa1)

Cherry-pick fix in https://github.com/unicode-org/icu/pull/2404 from main to maint/maint-73 branch, which is what it was intended for.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22340
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
