### PR TITLE
ICU-22349 Speed up pre-merge CI

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -308,12 +308,12 @@ jobs:
         PathtoPublish: 'icu4c/source/dist/icu-windows.zip'
         ArtifactName: '$(Build.BuildNumber)_ICU4C_MSVC_x86_Release'
 #-------------------------------------------------------------------------
-- job: ICU4C_MSVC_x64_ARM32_ARM64_Release_Distrelease
-  displayName: 'C: MSVC x64 ARM32 ARM64 Release (VS 2019) + Distrelease ARM64'
-  timeoutInMinutes: 60
+- job: ICU4C_MSVC_x64_ARM32_Release
+  displayName: 'C: MSVC x64 ARM32 Release (VS 2019)'
+  timeoutInMinutes: 35
   pool:
     vmImage: 'windows-2019'
-    demands: 
+    demands:
       - msbuild
       - visualstudio
       - Cmd
@@ -332,6 +332,26 @@ jobs:
       inputs:
         solution: icu4c/source/allinone/allinone.sln
         platform: ARM
+        configuration: Release
+#-------------------------------------------------------------------------
+- job: ICU4C_MSVC_x64_ARM64_Release_Distrelease
+  displayName: 'C: MSVC x64 ARM64 Release (VS 2019) + Distrelease'
+  timeoutInMinutes: 35
+  pool:
+    vmImage: 'windows-2019'
+    demands:
+      - msbuild
+      - visualstudio
+      - Cmd
+  steps:
+    - checkout: self
+      lfs: true
+      fetchDepth: 10
+    - task: VSBuild@1
+      displayName: 'Build Solution'
+      inputs:
+        solution: icu4c/source/allinone/allinone.sln
+        platform: x64
         configuration: Release
     - task: VSBuild@1
       displayName: 'Build ARM64'
@@ -352,9 +372,9 @@ jobs:
         PathtoPublish: 'icu4c/source/dist/icu-windows.zip'
         ArtifactName: '$(Build.BuildNumber)_ICU4C_MSVC_ARM64_Release'
 #-------------------------------------------------------------------------
-- job: ICU4C_MSVC_x64_ARM64_Debug
-  displayName: 'C: MSVC x64 ARM64 Debug (VS 2019)'
-  timeoutInMinutes: 45
+- job: ICU4C_MSVC_x64_Debug
+  displayName: 'C: MSVC x64 Debug (VS 2019)'
+  timeoutInMinutes: 35
   pool:
     vmImage: 'windows-2019'
     demands: 
@@ -376,6 +396,26 @@ jobs:
       inputs:
         filename: icu4c/source/allinone/icucheck.bat
         arguments: 'x64 Debug'
+#-------------------------------------------------------------------------
+- job: ICU4C_MSVC_ARM64_Debug
+  displayName: 'C: MSVC ARM64 Debug (VS 2019)'
+  timeoutInMinutes: 35
+  pool:
+    vmImage: 'windows-2019'
+    demands: 
+      - msbuild
+      - visualstudio
+      - Cmd
+  steps:
+    - checkout: self
+      lfs: true
+      fetchDepth: 10
+    - task: VSBuild@1
+      displayName: 'Build Solution'
+      inputs:
+        solution: icu4c/source/allinone/allinone.sln
+        platform: x64
+        configuration: Debug
     - task: VSBuild@1
       displayName: 'Build ARM64 Debug'
       inputs:


### PR DESCRIPTION
Split the 'C: MSVC x64 ARM32 ARM64 Release (VS 2019) + Distrelease ARM64' CI into two to run in parallel.

The x64 and ARM32 CI just build as how it was added in https://github.com/unicode-org/icu/pull/706
Split the  ARM64 CI build and also perform the Distrelease as how it was added in https://github.com/unicode-org/icu/pull/831
The x64 build seems required by the other two build so I have to include the x64 part in both.
This should reduce the CI to about 2/3 of the current run time with three machines building them in paralle.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22349
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
