### PR TITLE
ICU-22349 Build cygwin with -j  to run multiple cores

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -546,7 +546,7 @@ jobs:
 #-------------------------------------------------------------------------
 - job: ICU4C_Cygwin_GCC_x86_64_Release
   displayName: 'C: Cygwin GCC x86_64 Release'
-  timeoutInMinutes: 180
+  timeoutInMinutes: 40
   pool:
     vmImage: 'windows-2019'
   variables:
@@ -600,13 +600,13 @@ jobs:
         %CYG_ROOT%\\bin\\sh -lc 'echo Hello' && %CYG_ROOT%\\bin\\sh -lc 'uname -a'
       displayName: 'Check Cygwin environment'
     - script: |
-        %CYG_ROOT%\\bin\\bash -lc "cd $(cygpath \"$(Build.SourcesDirectory)\") && cd icu4c/source && ./runConfigureICU Cygwin && make tests"
+        %CYG_ROOT%\\bin\\bash -lc "cd $(cygpath \"$(Build.SourcesDirectory)\") && cd icu4c/source && ./runConfigureICU Cygwin && make tests -j "
       displayName: 'Build ICU (source and test)'
       env:
         CC: gcc
         CXX: g++
     - script: |
-        %CYG_ROOT%\\bin\\bash -lc "cd $(cygpath \"$(Build.SourcesDirectory)\") && cd icu4c/source && make check"
+        %CYG_ROOT%\\bin\\bash -lc "cd $(cygpath \"$(Build.SourcesDirectory)\") && cd icu4c/source && make -j check"
       displayName: 'Run Tests'
       env:
         CC: gcc


### PR DESCRIPTION
Trying -j in the make check to see would it speed up the build process in cygwin. See https://github.com/unicode-org/icu/pull/2422 for other changes.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22349
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
