### PR TITLE
ICU-22349 !!!DO NOT LOOK AT THIS PR YET!!!!- Parallel subdir in Makefile via rule

### DIFF
--- a/icu4c/source/test/Makefile.in
+++ b/icu4c/source/test/Makefile.in
@@ -85,7 +85,8 @@ all-recursive install-recursive clean-recursive distclean-recursive dist-recursi
 	  $(MAKE) "$$target-local" || exit; \
 	fi
 
-check-recursive: $(SUBDIRS) check-local
+check-recursive: $(SUBDIRS)
+	$(MAKE) check-local || exit;
 
 $(SUBDIRS): testdata
 	cd $@ && $(MAKE) -j -O check) || exit;

--- a/icu4c/source/test/Makefile.in
+++ b/icu4c/source/test/Makefile.in
@@ -85,11 +85,12 @@ all-recursive install-recursive clean-recursive distclean-recursive dist-recursi
 	  $(MAKE) "$$target-local" || exit; \
 	fi
 
-check-recursive: $(SUBDIRS)
+check-recursive: intltest $(IOTEST) cintltst $(LETEST) $(FUZZER)
 	$(MAKE) check-local || exit;
 
-$(SUBDIRS): testdata
-	cd $@ && $(MAKE) -j -O check) || exit;
+intltest $(IOTEST) cintltst $(LETEST) $(FUZZER):
+	(cd testdata; $(MAKE) -j all) || exit;
+	(cd $@ && $(MAKE) -j -O check) || exit;
 
 xcheck-recursive check-recursive check-exhaustive-recursive:
 	@$(MKINSTALLDIRS) $(STATUS_TMP)

--- a/icu4c/source/test/Makefile.in
+++ b/icu4c/source/test/Makefile.in
@@ -62,7 +62,6 @@ distclean : distclean-recursive distclean-local
 
 dist: dist-recursive dist-local
 check: everything check-recursive check-local
-check-recursive: all-recursive
 # the xcheck targets create a ../test-*.xml file in JUnit format.
 xcheck: everything xcheck-recursive xcheck-local
 xcheck-recursive: all-recursive
@@ -85,6 +84,11 @@ all-recursive install-recursive clean-recursive distclean-recursive dist-recursi
 	if test "$$dot_seen" = "no"; then \
 	  $(MAKE) "$$target-local" || exit; \
 	fi
+
+check-recursive: $(SUBDIRS) check-local
+
+$(SUBDIRS): testdata
+	cd $@ && $(MAKE) -j -O check) || exit;
 
 xcheck-recursive check-recursive check-exhaustive-recursive:
 	@$(MKINSTALLDIRS) $(STATUS_TMP)


### PR DESCRIPTION
Move the all-recursive from a shell script loop into Makefile dependency so we can utilize the make -j option to run them in parallel under different thread without blocking each other in a serial execution.

Also use -O option to make the output all together for the make command into test directory.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22349
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
