### PR TITLE
ICU-22356 Revert ICU-21833 change for ures.h

### DIFF
--- a/icu4c/source/common/unicode/ures.h
+++ b/icu4c/source/common/unicode/ures.h
@@ -812,7 +812,7 @@ inline UnicodeString
 ures_getUnicodeString(const UResourceBundle *resB, UErrorCode* status) {
     UnicodeString result;
     int32_t len = 0;
-    const char16_t *r = ures_getString(resB, &len, status);
+    const UChar *r = ures_getString(resB, &len, status);
     if(U_SUCCESS(*status)) {
         result.setTo(true, r, len);
     } else {
@@ -837,7 +837,7 @@ inline UnicodeString
 ures_getNextUnicodeString(UResourceBundle *resB, const char ** key, UErrorCode* status) {
     UnicodeString result;
     int32_t len = 0;
-    const char16_t* r = ures_getNextString(resB, &len, key, status);
+    const UChar* r = ures_getNextString(resB, &len, key, status);
     if(U_SUCCESS(*status)) {
         result.setTo(true, r, len);
     } else {
@@ -859,7 +859,7 @@ inline UnicodeString
 ures_getUnicodeStringByIndex(const UResourceBundle *resB, int32_t indexS, UErrorCode* status) {
     UnicodeString result;
     int32_t len = 0;
-    const char16_t* r = ures_getStringByIndex(resB, indexS, &len, status);
+    const UChar* r = ures_getStringByIndex(resB, indexS, &len, status);
     if(U_SUCCESS(*status)) {
         result.setTo(true, r, len);
     } else {
@@ -882,7 +882,7 @@ inline UnicodeString
 ures_getUnicodeStringByKey(const UResourceBundle *resB, const char* key, UErrorCode* status) {
     UnicodeString result;
     int32_t len = 0;
-    const char16_t* r = ures_getStringByKey(resB, key, &len, status);
+    const UChar* r = ures_getStringByKey(resB, key, &len, status);
     if(U_SUCCESS(*status)) {
         result.setTo(true, r, len);
     } else {


### PR DESCRIPTION
These usages of UChar are in inline functions for calling C API functions, so they should not be changed to char16_t or the code will fail to compile with `-DUCHAR_TYPE=`.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22356
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
