### PR TITLE
ICU-22356 Use ConstChar16Ptr to safely cast from UChar* to char16_t*

### DIFF
--- a/icu4c/source/common/unicode/ures.h
+++ b/icu4c/source/common/unicode/ures.h
@@ -25,6 +25,7 @@
 #ifndef URES_H
 #define URES_H
 
+#include "unicode/char16ptr.h"
 #include "unicode/utypes.h"
 #include "unicode/uloc.h"
 
@@ -812,7 +813,7 @@ inline UnicodeString
 ures_getUnicodeString(const UResourceBundle *resB, UErrorCode* status) {
     UnicodeString result;
     int32_t len = 0;
-    const char16_t *r = ures_getString(resB, &len, status);
+    const char16_t *r = ConstChar16Ptr(ures_getString(resB, &len, status));
     if(U_SUCCESS(*status)) {
         result.setTo(true, r, len);
     } else {
@@ -837,7 +838,7 @@ inline UnicodeString
 ures_getNextUnicodeString(UResourceBundle *resB, const char ** key, UErrorCode* status) {
     UnicodeString result;
     int32_t len = 0;
-    const char16_t* r = ures_getNextString(resB, &len, key, status);
+    const char16_t* r = ConstChar16Ptr(ures_getNextString(resB, &len, key, status));
     if(U_SUCCESS(*status)) {
         result.setTo(true, r, len);
     } else {
@@ -859,7 +860,7 @@ inline UnicodeString
 ures_getUnicodeStringByIndex(const UResourceBundle *resB, int32_t indexS, UErrorCode* status) {
     UnicodeString result;
     int32_t len = 0;
-    const char16_t* r = ures_getStringByIndex(resB, indexS, &len, status);
+    const char16_t* r = ConstChar16Ptr(ures_getStringByIndex(resB, indexS, &len, status));
     if(U_SUCCESS(*status)) {
         result.setTo(true, r, len);
     } else {
@@ -882,7 +883,7 @@ inline UnicodeString
 ures_getUnicodeStringByKey(const UResourceBundle *resB, const char* key, UErrorCode* status) {
     UnicodeString result;
     int32_t len = 0;
-    const char16_t* r = ures_getStringByKey(resB, key, &len, status);
+    const char16_t* r = ConstChar16Ptr(ures_getStringByKey(resB, key, &len, status));
     if(U_SUCCESS(*status)) {
         result.setTo(true, r, len);
     } else {

--- a/icu4c/source/test/intltest/Makefile.in
+++ b/icu4c/source/test/intltest/Makefile.in
@@ -70,7 +70,7 @@ numbertest_parse.o numbertest_doubleconversion.o numbertest_skeletons.o \
 static_unisets_test.o numfmtdatadriventest.o numbertest_range.o erarulestest.o \
 formattedvaluetest.o formatted_string_builder_test.o numbertest_permutation.o \
 units_data_test.o units_router_test.o units_test.o displayoptions_test.o \
-numbertest_simple.o
+numbertest_simple.o uchar_type_build_test.o
 
 DEPS = $(OBJECTS:.o=.d)
 

--- a/icu4c/source/test/intltest/intltest.vcxproj
+++ b/icu4c/source/test/intltest/intltest.vcxproj
@@ -291,6 +291,7 @@
     <ClCompile Include="units_data_test.cpp" />
     <ClCompile Include="units_router_test.cpp" />
     <ClCompile Include="units_test.cpp" />
+    <ClCompile Include="uchar_type_build_test.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="colldata.h" />

--- a/icu4c/source/test/intltest/intltest.vcxproj.filters
+++ b/icu4c/source/test/intltest/intltest.vcxproj.filters
@@ -568,6 +568,9 @@
     <ClCompile Include="units_test.cpp">
       <Filter>formatting</Filter>
     </ClCompile>
+    <ClCompile Include="uchar_type_build_test.cpp">
+      <Filter>configuration</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="itrbbi.h">

--- a/icu4c/source/test/intltest/uchar_type_build_test.cpp
+++ b/icu4c/source/test/intltest/uchar_type_build_test.cpp
@@ -1,0 +1,7 @@
+// © 2023 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html#License
+
+// ICU-22356 Test that client code can be built with UCHAR_TYPE redefined.
+#undef UCHAR_TYPE
+#define UCHAR_TYPE uint16_t
+#include "unicode/ures.h"


### PR DESCRIPTION
This is necessary for this header file to be usable by clients that define UCHAR_TYPE as a type not compatible with char16_t, eg. uint16_t.

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22356
- [X] Required: The PR title must be prefixed with a JIRA Issue number.
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number.
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
