### PR TITLE
ICU-22221 Add the -R flag to less to display ANSI colors.

### DIFF
--- a/tools/cldr/lib/install-cldr-jars.sh
+++ b/tools/cldr/lib/install-cldr-jars.sh
@@ -42,7 +42,7 @@ function run_with_logging() {
     read -p "Show log file? " -n 1 -r
     echo
     if [[ "${REPLY}" =~ ^[Yy]$ ]] ; then
-      less -X "${LOG_FILE}"
+      less -RX "${LOG_FILE}"
     fi
     echo "Log file: ${LOG_FILE}"
     exit 1


### PR DESCRIPTION
Without this flag, any ANSI color escape sequences in the Maven error log will be displayed in their escaped form, which isn't very readable.

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22221
- [X] Required: The PR title must be prefixed with a JIRA Issue number.
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number.
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
