### PR TITLE
ICU-22377 Fix errors found by gcc -fanalyzer

### DIFF
--- a/icu4c/source/tools/ctestfw/ctest.c
+++ b/icu4c/source/tools/ctestfw/ctest.c
@@ -688,7 +688,6 @@ static void vlog_err(const char *prefix, const char *pattern, va_list ap)
     }
     vfprintf(stdout, pattern, ap);
     fflush(stdout);
-    va_end(ap);
     if((*pattern==0) || (pattern[strlen(pattern)-1]!='\n')) {
     	HANGING_OUTPUT=1;
     } else {
@@ -730,7 +729,6 @@ vlog_info(const char *prefix, const char *pattern, va_list ap)
     }
     vfprintf(stdout, pattern, ap);
     fflush(stdout);
-    va_end(ap);
     if((*pattern==0) || (pattern[strlen(pattern)-1]!='\n')) {
     	HANGING_OUTPUT=1;
     } else {
@@ -779,7 +777,6 @@ static void vlog_verbose(const char *prefix, const char *pattern, va_list ap)
     }
     vfprintf(stdout, pattern, ap);
     fflush(stdout);
-    va_end(ap);
     GLOBAL_PRINT_COUNT++;
     if((*pattern==0) || (pattern[strlen(pattern)-1]!='\n')) {
     	HANGING_OUTPUT=1;
@@ -805,13 +802,16 @@ log_err(const char* pattern, ...)
     }
     va_start(ap, pattern);
     vlog_err(NULL, pattern, ap);
+    va_end(ap);
 }
 
 UBool T_CTEST_EXPORT2
 log_knownIssue(const char *ticket, const char *pattern, ...) {
   va_list ap;
   va_start(ap, pattern);
-  return vlog_knownIssue(ticket, pattern, ap);
+  UBool result = vlog_knownIssue(ticket, pattern, ap);
+  va_end(ap);
+  return result;
 }
 
 void T_CTEST_EXPORT2
@@ -845,6 +845,7 @@ log_err_status(UErrorCode status, const char* pattern, ...)
         }
         vlog_err(NULL, pattern, ap); /* no need for prefix in default case */
     }
+    va_end(ap);
 }
 
 void T_CTEST_EXPORT2
@@ -854,6 +855,7 @@ log_info(const char* pattern, ...)
 
     va_start(ap, pattern);
     vlog_info(NULL, pattern, ap);
+    va_end(ap);
 }
 
 void T_CTEST_EXPORT2
@@ -863,6 +865,7 @@ log_verbose(const char* pattern, ...)
 
     va_start(ap, pattern);
     vlog_verbose(NULL, pattern, ap);
+    va_end(ap);
 }
 
 
@@ -884,6 +887,7 @@ log_data_err(const char* pattern, ...)
     } else {
         vlog_info("[DATA] ", pattern, ap); 
     }
+    va_end(ap);
 }
 
 


### PR DESCRIPTION
Found using gcc -fanalyze.

Code built using the following configure command:
```
../configure --prefix=/usr --build=x86_64-pc-linux-gnu --host=x86_64-pc-linux-gnu --mandir=/usr/share/man --infodir=/usr/share/info --datadir=/usr/share --sysconfdir=/etc --localstatedir=/var/lib --datarootdir=/usr/share --docdir=/usr/share/doc/icu-73.1-r1 --htmldir=/usr/share/doc/icu-73.1-r1/html --libdir=/usr/lib64 --disable-renaming --disable-layoutex --disable-debug --disable-static --disable-tests --disable-samples build_alias=x86_64-pc-linux-gnu host_alias=x86_64-pc-linux-gnu CC=x86_64-pc-linux-gnu-gcc CFLAGS="-march=native -O2 -pipe -fanalyzer -Werror=analyzer-va-arg-type-mismatch -Werror=analyzer-va-list-exhausted -Werror=analyzer-va-list-leak -Werror=analyzer-va-list-use-after-va-end" LDFLAGS="-Wl,-O1 -Wl,--as-needed" CXX=x86_64-pc-linux-gnu-g++ CXXFLAGS="-march=native -O2 -pipe -Werror=analyzer-va-arg-type-mismatch -Werror=analyzer-va-list-exhausted -Werror=analyzer-va-list-leak -Werror=analyzer-va-list-use-after-va-end -std=c++14"
```

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22377
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
