### PR TITLE
ICU-22349 Use -l with make -j to limit jobs based on load average.

### DIFF
--- a/.ci-builds/.azure-exhaustive-tests.yml
+++ b/.ci-builds/.azure-exhaustive-tests.yml
@@ -62,7 +62,7 @@ jobs:
       lfs: true
       fetchDepth: 10
     - script: |
-        cd icu4c/source && ./runConfigureICU Linux && make -j2
+        cd icu4c/source && ./runConfigureICU Linux && make -j -l2.5
       displayName: 'Build'
     - script: |
         cd icu4c/source && make check-exhaustive

--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
       lfs: true
       fetchDepth: 10
     - script: |
-        cd icu4c/source && ./runConfigureICU Linux && make -j2 check
+        cd icu4c/source && ./runConfigureICU Linux && make -j -l2.5 check
       displayName: 'Build and Test'
       env:
         CC: clang
@@ -57,7 +57,7 @@ jobs:
     - script: |
         cd icu4c/source && \
         ICU_DATA_FILTER_FILE=../../.ci-builds/data-filter.json ./runConfigureICU Linux && \
-        make -j2 tests && \
+        make -j -l2.5 tests && \
         \[ ! -d data/out/build/icudt66l/translit \] && \
         (cd test/intltest && LD_LIBRARY_PATH=../../lib:../../tools/ctestfw ./intltest translit/TransliteratorTest/TestBasicTransliteratorEvenWithoutData)
       displayName: 'Build with Data Filter'
@@ -75,7 +75,7 @@ jobs:
       lfs: true
       fetchDepth: 10
     - script: |
-        export CXXFLAGS="-std=c++17 -Winvalid-constexpr" && cd icu4c/source && ./runConfigureICU --enable-debug --disable-release Linux && make -j2 check
+        export CXXFLAGS="-std=c++17 -Winvalid-constexpr" && cd icu4c/source && ./runConfigureICU --enable-debug --disable-release Linux && make -j -l2.5 check
       displayName: 'Build and Test C++17'
       env:
         CC: clang
@@ -91,7 +91,7 @@ jobs:
       lfs: true
       fetchDepth: 10
     - script: |
-        cd icu4c/source && ./runConfigureICU Linux && make -j2 check
+        cd icu4c/source && ./runConfigureICU Linux && make -j -l2.5 check
       displayName: 'Build and Test'
       env:
         CC: gcc
@@ -112,7 +112,7 @@ jobs:
         sudo apt install gcc-11 g++-11
       displayName: 'Install GCC-11'
     - script: |
-        cd icu4c/source && ./runConfigureICU Linux && make -j2 check
+        cd icu4c/source && ./runConfigureICU Linux && make -j -l2.5 check
       displayName: 'Build and Test'
       env:
         CC: gcc-11
@@ -129,7 +129,7 @@ jobs:
       lfs: true
       fetchDepth: 10
     - script: |
-        cd icu4c/source && ./runConfigureICU Linux && make -j2 check
+        cd icu4c/source && ./runConfigureICU Linux && make -j -l2.5 check
       displayName: 'Build and Test'
       env:
         CC: clang
@@ -153,7 +153,7 @@ jobs:
         sudo apt install -qy clang-14 lld-14 libc++-14-dev libc++abi-14-dev
       displayName: 'Install Clang-14'
     - script: |
-        cd icu4c/source && ./runConfigureICU Linux && make -j2 tests
+        cd icu4c/source && ./runConfigureICU Linux && make -j -l2.5 tests
       displayName: 'Build only (WarningsAsErrors)'
       env:
         CC: clang-14
@@ -177,7 +177,7 @@ jobs:
         sudo apt install -qy clang-14 lld-14 libc++-14-dev libc++abi-14-dev
       displayName: 'Install Clang-14'
     - script: |
-        cd icu4c/source && ./runConfigureICU Linux && make -j2 check
+        cd icu4c/source && ./runConfigureICU Linux && make -j -l2.5 check
       displayName: 'Build and Test'
       env:
         CC: clang-14
@@ -202,7 +202,7 @@ jobs:
         sudo apt install -qy clang-14 lld-14 libc++-14-dev libc++abi-14-dev
       displayName: 'Install Clang-14'
     - script: |
-        cd icu4c/source && ./runConfigureICU Linux && make -j2 check
+        cd icu4c/source && ./runConfigureICU Linux && make -j -l2.5 check
       displayName: 'Build and Test'
       env:
         CC: clang-14
@@ -556,7 +556,7 @@ jobs:
       displayName: 'Install mingw-w64-x86_64-toolchain'
     - script: |
        set MSYSTEM=MINGW64
-       c:\tools\msys64\usr\bin\bash.exe -lc "cd $BUILD_SOURCESDIRECTORY && cd icu4c/source && ./runConfigureICU MinGW --prefix='/tmp/build-icu' && make -j2 check"
+       c:\tools\msys64\usr\bin\bash.exe -lc "cd $BUILD_SOURCESDIRECTORY && cd icu4c/source && ./runConfigureICU MinGW --prefix='/tmp/build-icu' && make -j -l2.5 check"
       displayName: 'Build and Test'
     - script: |
        set MSYSTEM=MINGW64
@@ -578,7 +578,7 @@ jobs:
       lfs: true
       fetchDepth: 10
     - script: |
-        export CPPFLAGS="-Werror -Wall -Wextra -Wextra-semi -Wundef -Wnon-virtual-dtor" && cd icu4c/source && ./runConfigureICU MacOSX && make -j2 check
+        export CPPFLAGS="-Werror -Wall -Wextra -Wextra-semi -Wundef -Wnon-virtual-dtor" && cd icu4c/source && ./runConfigureICU MacOSX && make -j -l2.5 check
       displayName: 'Build and Test (WarningsAsErrors)'
       env:
         CC: clang
@@ -640,13 +640,13 @@ jobs:
         %CYG_ROOT%\\bin\\sh -lc 'echo Hello' && %CYG_ROOT%\\bin\\sh -lc 'uname -a'
       displayName: 'Check Cygwin environment'
     - script: |
-        %CYG_ROOT%\\bin\\bash -lc "cd $(cygpath \"$(Build.SourcesDirectory)\") && cd icu4c/source && ./runConfigureICU Cygwin && make tests -j "
+        %CYG_ROOT%\\bin\\bash -lc "cd $(cygpath \"$(Build.SourcesDirectory)\") && cd icu4c/source && ./runConfigureICU Cygwin && make tests -j -l2.5"
       displayName: 'Build ICU (source and test)'
       env:
         CC: gcc
         CXX: g++
     - script: |
-        %CYG_ROOT%\\bin\\bash -lc "cd $(cygpath \"$(Build.SourcesDirectory)\") && cd icu4c/source && make -j check"
+        %CYG_ROOT%\\bin\\bash -lc "cd $(cygpath \"$(Build.SourcesDirectory)\") && cd icu4c/source && make -j -l2.5 check"
       displayName: 'Run Tests'
       env:
         CC: gcc
@@ -662,7 +662,7 @@ jobs:
       lfs: true
       fetchDepth: 10
     - script: |
-        cd icu4c/source && ./runConfigureICU Linux && make -j2
+        cd icu4c/source && ./runConfigureICU Linux && make -j -l2.5
       displayName: 'Build'
       env:
         CC: clang

--- a/.github/workflows/icu_ci.yml
+++ b/.github/workflows/icu_ci.yml
@@ -139,7 +139,7 @@ jobs:
           cd icu4c/source;
           ICU_DATA_BUILDTOOL_OPTS=--include_uni_core_data ICU_DATA_FILTER_FILE=../../.github/lstm_for_th_my.json ./runConfigureICU --enable-debug --disable-release Linux -disable-layoutex;
           make clean;
-          make -j ICU4J_ROOT=../../../icu4j icu4j-data-install;
+          make -j -l2.5 ICU4J_ROOT=../../../icu4j icu4j-data-install;
           cd ../..
       - name: ICU4J
         run: |
@@ -171,7 +171,7 @@ jobs:
           cd icu4c/source;
           ICU_DATA_BUILDTOOL_OPTS=--include_uni_core_data ICU_DATA_FILTER_FILE=../../.github/adaboost.json CPPFLAGS=-DUCONFIG_USE_ML_PHRASE_BREAKING=1 ./runConfigureICU --enable-debug --disable-release Linux -disable-layoutex;
           make clean;
-          make -j ICU4J_ROOT=../../../icu4j icu4j-data-install;
+          make -j -l2.5 ICU4J_ROOT=../../../icu4j icu4j-data-install;
           cd ../..
       - name: ICU4J
         run: |
@@ -205,7 +205,7 @@ jobs:
           mkdir build;
           cd build;
           ../icu4c/source/runConfigureICU --enable-debug --disable-release Linux/gcc --prefix=$PREFIX --enable-tracing;
-          make -j check;
+          make -j -l2.5 check;
           ( cd ../icu4c/source/test/depstest && ./depstest.py ../../../../build/ );
           make install;
           PATH=$PREFIX/bin:$PATH make -C test/hdrtst check
@@ -232,7 +232,7 @@ jobs:
         run: |
           cd icu4c/source;
           ./runConfigureICU Linux;
-          make -j check;
+          make -j -l2.5 check;
       - name: Test Dependency
         run: |
           cd icu4c/source/test/depstest;
@@ -266,8 +266,8 @@ jobs:
           mkdir build;
           cd build;
           ../icu4c/source/runConfigureICU Linux --disable-layout --disable-layoutex --prefix=$PREFIX;
-          make -j check;
-          make -j install;
+          make -j -l2.5 check;
+          make -j -l2.5 install;
           cd $PREFIX/bin;
           LD_LIBRARY_PATH=../lib ./icuinfo
 
@@ -281,7 +281,7 @@ jobs:
         run: |
           cd icu4c/source;
           ./runConfigureICU --enable-debug --disable-release Linux --disable-renaming --enable-tracing;
-          make -j check;
+          make -j -l2.5 check;
         env:
           CPPFLAGS: -fsanitize=address
           LDFLAGS: -fsanitize=address
@@ -295,7 +295,7 @@ jobs:
         run: |
           cd icu4c/source;
           ./runConfigureICU --enable-debug --disable-release Linux --disable-renaming;
-          make -j check;
+          make -j -l2.5 check;
         env:
           CPPFLAGS: -fsanitize=undefined -fsanitize=alignment -fno-sanitize-recover=undefined,alignment
           CFLAGS: -fsanitize=undefined -fsanitize=alignment -fno-sanitize-recover=undefined,alignment
@@ -310,7 +310,7 @@ jobs:
         run: |
           cd icu4c/source;
           ./runConfigureICU Linux --disable-renaming;
-          make -j check;
+          make -j -l2.5 check;
         env:
           CC: clang
           CXX: clang++
@@ -329,9 +329,9 @@ jobs:
         run: |
           cd icu4c/source;
           ./runConfigureICU --enable-debug --disable-release Linux --disable-renaming
-          make -j ;
-          make -j -C test;
-          make -j -C test/intltest check
+          make -j -l2.5;
+          make -j -l2.5 -C test;
+          make -j -l2.5 -C test/intltest check
         env:
           INTLTEST_OPTS: utility/MultithreadTest
           CPPFLAGS: -fsanitize=thread
@@ -347,7 +347,7 @@ jobs:
         run: |
           cd icu4c/source;
           PYTHON=python3 ./runConfigureICU MacOSX;
-          make -j check
+          make -j -l2.5 check
 
   # Run ICU4C tests with stubdata.
   run-with-stubdata:
@@ -359,14 +359,14 @@ jobs:
         run: |
           cd icu4c/source;
           ./runConfigureICU Linux;
-          make -j check;
+          make -j -l2.5 check;
           rm lib/libicudata.so*;
           cp -P stubdata/libicudata.so* lib;
 
           cd test/cintltst;
           echo 'Running ICU4C cintltst with stubdata.';
           # Note: 'Elapsed Time: ' is printed by makefile upon final success.
-          CINTLTST_OPTS=-w make -j check 2>&1 | tee stubdata_ctest.log;
+          CINTLTST_OPTS=-w make -j -l2.5 check 2>&1 | tee stubdata_ctest.log;
           if ! grep 'Elapsed Time: ' stubdata_ctest.log
           then
             echo
@@ -380,7 +380,7 @@ jobs:
 
           cd ../intltest;
           echo 'Running ICU4C intltest with stubdata.';
-          INTLTEST_OPTS=-w make -j check 2>&1 | tee stubdata_intltest.log;
+          INTLTEST_OPTS=-w make -j -l2.5 check 2>&1 | tee stubdata_intltest.log;
           if ! grep 'Elapsed Time: ' stubdata_intltest.log
           then
             echo
@@ -400,7 +400,7 @@ jobs:
       - run: |
           cd icu4c/source;
           ./runConfigureICU Linux CPPFLAGS="-DU_CHARSET_IS_UTF8=1";
-          make -j check
+          make -j -l2.5 check
 
   # Test U_OVERRIDE_CXX_ALLOCATION-is-0-test
   u-override-cxx-allocation-is-0-test:
@@ -411,7 +411,7 @@ jobs:
           cd icu4c/source;
           ./runConfigureICU Linux CPPFLAGS="-DU_OVERRIDE_CXX_ALLOCATION=0";
           make clean;
-          make -j check
+          make -j -l2.5 check
 
   # Test LSTM
   lstm-test:
@@ -422,7 +422,7 @@ jobs:
           cd icu4c/source;
           ICU_DATA_FILTER_FILE=../../.github/lstm_for_th_my.json ./runConfigureICU --enable-debug --disable-release Linux -disable-layoutex;
           make clean;
-          make -j check
+          make -j -l2.5 check
 
   # Test adaboost
   adaboost-test:
@@ -433,7 +433,7 @@ jobs:
           cd icu4c/source;
           ICU_DATA_FILTER_FILE=../../.github/adaboost.json CPPFLAGS=-DUCONFIG_USE_ML_PHRASE_BREAKING=1 ./runConfigureICU --enable-debug --disable-release Linux -disable-layoutex;
           make clean;
-          make -j  check
+          make -j -l2.5 check
 
   # Build and run testmap
   testmap:
@@ -443,10 +443,10 @@ jobs:
       - run: |
           cd icu4c/source;
           ./runConfigureICU Linux;
-          make -j check;
+          make -j -l2.5 check;
           CONFIG_FILES=test/testmap/Makefile ./config.status;
           cd test/testmap;
-          make -j check | grep '*** PASS PASS PASS, test PASSED!!!!!!!!'
+          make -j -l2.5 check | grep '*** PASS PASS PASS, test PASSED!!!!!!!!'
 
   # Copyright scan
   copyright-scan:
@@ -520,7 +520,7 @@ jobs:
         run: |
           cd icu4c/source/;
           ./runConfigureICU Linux;
-          make -j tests;
+          make -j -l2.5 tests;
 
   # Run header tests with UCONFIG_NO_XXX variations.
   uconfig-header-tests:
@@ -564,7 +564,7 @@ jobs:
           cd icu4c/source/;
           mkdir /tmp/icu_cnfg;
           ./runConfigureICU Linux --prefix=/tmp/icu_cnfg;
-          make -j install;
+          make -j -l2.5 install;
       - name: Test
         env:
           UCONFIG_NO: ${{ matrix.uconfig_cppflags }}
@@ -674,7 +674,7 @@ jobs:
           CINTLTST_OPTS: -w
         run: |
           cd icu4c/source
-          make -j check
+          make -j -l2.5 check
   
   # https://unicode-org.github.io/icu/processes/release/tasks/healthy-code.html#test-uconfig_no_conversion
   icu4c-uconfig-no-version:
@@ -690,8 +690,8 @@ jobs:
       - name: Run make for stubdata, common, i18n
         run: |
           cd icu4c/source
-          pushd stubdata && make -j && popd
+          pushd stubdata && make -j -l2.5 && popd
           # Ensure lib directory for output object file exists
           mkdir -p lib
-          pushd common && make -j && popd
-          pushd i18n && make -j && popd
+          pushd common && make -j -l2.5 && popd
+          pushd i18n && make -j -l2.5 && popd

--- a/.github/workflows/icu_envtest.yml
+++ b/.github/workflows/icu_envtest.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           cd icu4c/source/;
           ./runConfigureICU Linux;
-          make -j tests;
+          make -j -l2.5 tests;
       - name: Test different locales as LC_ALL
         run: |
           echo "This job run the environment test of the following Locales";
@@ -62,7 +62,7 @@ jobs:
               for test_dir in iotest cintltst intltest
               do
                   cd $test_dir;
-                  LC_ALL=$loc make -j check;
+                  LC_ALL=$loc make -j -l2.5 check;
                   cd ..;
               done
 
@@ -104,7 +104,7 @@ jobs:
         run: |
           cd icu4c/source/;
           ./runConfigureICU Linux;
-          make -j tests;
+          make -j -l2.5 tests;
       - name: Test different locales as TZ
         run: |
           echo "This job run the environment test of the following TimeZones";
@@ -122,7 +122,7 @@ jobs:
               for test_dir in iotest cintltst intltest
               do
                   cd $test_dir;
-                  TZ=$tz make -j check;
+                  TZ=$tz make -j -l2.5 check;
                   cd ..;
               done
 

--- a/.github/workflows/icu_merge_ci.yml
+++ b/.github/workflows/icu_merge_ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           cd icu4c/source;
           ICU_DATA_BUILDTOOL_OPTS=--include_uni_core_data ./runConfigureICU Linux;
-          make -j check;
+          make -j -l2.5 check;
           mkdir /tmp/icu4j_data_test;
           cp -P data/out/tmp/icudt*l* /tmp/icu4j_data_test/
           cd ../../icu4j;
@@ -47,7 +47,7 @@ jobs:
         run: |
           cd icu4c/source;
           ./runConfigureICU Linux;
-          make -j all;
+          make -j -l2.5 all;
           cd lib;
           cp -Ps ../tools/ctestfw/libicutest* .
       - name: Upload ICU libraries
@@ -89,7 +89,7 @@ jobs:
         run: |
           cd icu4c/source;
           ./runConfigureICU Linux;
-          (cd test/perf && make -j everything && mkdir -p results && mkdir -p results/${{ matrix.perf }})
+          (cd test/perf && make -j -l2.5 everything && mkdir -p results && mkdir -p results/${{ matrix.perf }})
           LD_LIBRARY_PATH=lib ./test/perf/${{ matrix.perf }}/${{ matrix.perf }} ${{ matrix.flag }} -t 5 -p 10 ${{ matrix.file }} ${{ matrix.tests }} | tee test/perf/results/${{ matrix.perf }}/output.txt
 
       - name: Store performance test results
@@ -159,7 +159,7 @@ jobs:
         run: |
           cd icu4c/source;
           ./runConfigureICU Linux;
-          (cd test/perf && make -j everything && mkdir -p results && mkdir -p results/${{ matrix.perf }} && mkdir -p results/${{ matrix.perf }}/${{ matrix.data }})
+          (cd test/perf && make -j -l2.5 everything && mkdir -p results && mkdir -p results/${{ matrix.perf }} && mkdir -p results/${{ matrix.perf }}/${{ matrix.data }})
           LD_LIBRARY_PATH=lib ./test/perf/${{ matrix.perf }}/${{ matrix.perf }} ${{ matrix.flag }} -t 5 -p 10 -f $DATA_FILE_PATH/${{ matrix.data }}.txt ${{ matrix.tests }} | tee test/perf/results/${{ matrix.perf }}/${{ matrix.data }}/output.txt
 
       - name: Store performance test results
@@ -218,7 +218,7 @@ jobs:
         run: |
           cd icu4c/source;
           ./runConfigureICU Linux;
-          (cd test/perf && make -j everything && mkdir -p results && mkdir -p results/strsrchperf && mkdir -p results/strsrchperf/${{ matrix.locale }})
+          (cd test/perf && make -j -l2.5 everything && mkdir -p results && mkdir -p results/strsrchperf && mkdir -p results/strsrchperf/${{ matrix.locale }})
           LD_LIBRARY_PATH=lib ./test/perf/strsrchperf/strsrchperf -b Test_ICU_Forward_Search Test_ICU_Backward_Search -t 5 -p 10 -L ${{ matrix.locale }} -f $DATA_FILE_PATH/${{ matrix.data }}.txt | tee test/perf/results/strsrchperf/${{ matrix.locale }}/output.txt
 
       - name: Store performance test results

--- a/.github/workflows/icu_valgrind.yml
+++ b/.github/workflows/icu_valgrind.yml
@@ -31,7 +31,7 @@ jobs:
           CXX: clang++
         run: |
           cd icu4c/source;
-          ./runConfigureICU --enable-debug Linux --disable-renaming && make -j tests;
+          ./runConfigureICU --enable-debug Linux --disable-renaming && make -j -l2.5 tests;
       - name: Test iotest with valgrind
         run: |
           cd icu4c/source/test/iotest
@@ -74,7 +74,7 @@ jobs:
           CXX: clang++
         run: |
           cd icu4c/source;
-          ./runConfigureICU --enable-debug Linux --disable-renaming && make -j tests;
+          ./runConfigureICU --enable-debug Linux --disable-renaming && make -j -l2.5 tests;
       - name: Check all top path in intltest is covered
         run: |
           cd icu4c/source/test/intltest;

--- a/docs/processes/release/tasks/healthy-code.md
+++ b/docs/processes/release/tasks/healthy-code.md
@@ -402,7 +402,7 @@ variations" because the test suites cannot be built like this, but the library
 code must support it.
 
 The simplest is to take an ICU4C workspace, modify uconfig.h *==temporarily==*
-by changing the value of UCONFIG_NO_CONVERSION to 1, and do "make -j 6" (not
+by changing the value of UCONFIG_NO_CONVERSION to 1, and do "make -j -l2.5" (not
 "make check" or "make tests"). Verify that the stubdata, common & i18n libraries
 build fine; layout should build too but toolutil will fail, that's expected.
 
@@ -421,7 +421,7 @@ Linux,
 
 ```sh
 ./runConfigureICU Linux CPPFLAGS="-DU_CHARSET_IS_UTF8=1"
-make -j6 check
+make -j -l2.5 check
 ```
 
 Any problems will show up as compilation or test errors.
@@ -447,7 +447,7 @@ show as build failures.
 ```sh
 CPPFLAGS="-DU_OVERRIDE_CXX_ALLOCATION=0" ./runConfigureICU Linux
 make clean
-make -j12 check
+make -j -l2.5 check
 ```
 
 ## ~~Test ICU_USE_THREADS=0 \[Obsolete\]~~
@@ -597,7 +597,7 @@ For ICU4C, testing with an optimized build will help reduce the elapsed time
 required for the tests to complete.
 
 ```sh
-$ make -j6 check-exhaustive
+$ make -j -l2.5 check-exhaustive
 ```
 
 ---
@@ -611,5 +611,5 @@ compiler is required.
 ```sh
 $ CPPFLAGS=-fsanitize=thread LDFLAGS=-fsanitize=thread ./runConfigureICU --enable-debug --disable-release Linux --disable-renaming
 $ make clean
-$ make -j6 check
+$ make -j -l2.5 check
 ```

--- a/docs/processes/release/tasks/integration.md
+++ b/docs/processes/release/tasks/integration.md
@@ -148,7 +148,7 @@ Using an in-source build on Linux:
 ```sh
 cd icu4c/source
 ./runConfigureICU Linux
-make -j2 check
+make -j -l2.5 check
 rm lib/libicudata.so*
 cp -P stubdata/libicudata.so* lib/
 cd test/intltest
@@ -241,7 +241,7 @@ see ticket [ICU-10636](https://unicode-org.atlassian.net/browse/ICU-10636).
 
 ### Run the tests with data-errors-as-warnings
 
-`INTLTEST_OPTS=-w CINTLTST_OPTS=-w make -j5 check`
+`INTLTEST_OPTS=-w CINTLTST_OPTS=-w make -j -l2.5 check`
 
 See that they pass, or fix them to pass. See ticket #10636 test code changes for
 examples.
@@ -263,7 +263,7 @@ based on the following instructions for ICU 64+.
     <code><b>ICU_DATA_BUILDTOOL_OPTS=--include_uni_core_data</b>
     ./runConfigureICU Linux</code> or similar
     *   Should be little-endian for coverage
-*   Clean and build ICU4C: `make -j6 check`
+*   Clean and build ICU4C: `make -j -l2.5 check`
 *   Make a clean directory for testing
     *   Find the .data file in the build output area, e.g.,
         `icu4c/source/data/out/tmp/icudt64l.dat`
@@ -433,7 +433,7 @@ To run manually, on a Linux system with clang,
 cd icu4c/source
 CPPFLAGS=-fsanitize=thread LDFLAGS=-fsanitize=thread ./runConfigureICU --enable-debug --disable-release Linux
 make clean
-make -j6 check
+make -j -l2.5 check
 ```
 
 Errors are displayed at the point they occur, and stop further testing.
@@ -451,7 +451,7 @@ To run manually, on a Linux system with clang,
 cd icu4c/source
 CPPFLAGS=-fsanitize=address LDFLAGS=-fsanitize=address ./runConfigureICU --enable-debug --disable-release Linux
 make clean
-make -j6 check
+make -j -l2.5 check
 ```
 
 Memory leaks are summarized at the end. Other errors are displayed at the point

--- a/docs/processes/rules_update.md
+++ b/docs/processes/rules_update.md
@@ -84,7 +84,7 @@ The rule updates are done first for ICU4C, and then ported (code changes) or mov
     (We haven't updated the rules yet)
 
             cd icu/icu4c/source
-            make -j6 check
+            make -j -l2.5 check
 
     To run just the RBBI Tests (you will be doing this a lot)
 

--- a/icu4c/source/data/cldr-icu-readme.txt
+++ b/icu4c/source/data/cldr-icu-readme.txt
@@ -316,7 +316,7 @@ ICU_DATA_BUILDTOOL_OPTS=--include_uni_core_data ./runConfigureICU <platform>
 cd $ICU4C_DIR/source/data
 # The following 2 lines are required to include the unicore data:
 make clean
-make -j6
+make -j -l2.5
 make icu4j-data-install
 cd $ICU4C_DIR/source/test/testdata
 make icu4j-data-install

--- a/icu4c/source/test/intltest/numbertest_permutation.cpp
+++ b/icu4c/source/test/intltest/numbertest_permutation.cpp
@@ -73,7 +73,7 @@ static const double kNumbersToTest[]{0, 91827.3645, -0.22222};
  *     numberpermutationtest.txt
  * To regenerate that file, run intltest with the -e and -G options.
  * On Linux, from icu4c/source:
- *     make -j8 tests && (cd test/intltest && LD_LIBRARY_PATH=../../lib:../../tools/ctestfw ./intltest -e -G format/NumberTest/NumberPermutationTest)
+ *     make -j -l2.5 tests && (cd test/intltest && LD_LIBRARY_PATH=../../lib:../../tools/ctestfw ./intltest -e -G format/NumberTest/NumberPermutationTest)
  * After re-generating the file, copy it into icu4j:
  *     cp test/testdata/numberpermutationtest.txt ../../icu4j/main/tests/core/src/com/ibm/icu/dev/data/numberpermutationtest.txt
  */

--- a/tools/scripts/uconfig_vars_test.py
+++ b/tools/scripts/uconfig_vars_test.py
@@ -110,7 +110,7 @@ def RunUnitTests(uconfig_no_list, test_results):
             print('Last 25 lines:\n%s\n' % '\n'.join(conf_log.decode('utf-8').splitlines()[-25:]))
             sys.exit(1)
         print('Running unit tests with %s set to 1.' % uconfig_no)
-        run_log, exit_code = RunCmd('make -j2 check')
+        run_log, exit_code = RunCmd('make -j -l2.5 check')
         test_results[uconfig_no]['unit_test'] = (exit_code == 0)
         test_results[uconfig_no]['u_log_tail'] = \
             '\n'.join(run_log.decode('utf-8').splitlines()[-50:])
@@ -126,7 +126,7 @@ def RunUnitTests(uconfig_no_list, test_results):
         print('Last 25 lines:\n%s\n' % '\n'.join(conf_log.decode('utf-8').splitlines()[-25:]))
         sys.exit(1)
     print('Running unit tests with all flags set to 1.')
-    run_log, exit_code = RunCmd('make -j2 check')
+    run_log, exit_code = RunCmd('make -j -l2.5 check')
     test_results['all_flags']['unit_test'] = (exit_code == 0)
     test_results['all_flags']['u_log_tail'] = \
         '\n'.join(run_log.decode('utf-8').splitlines()[-50:])
@@ -153,7 +153,7 @@ def RunHeaderTests(uconfig_no_list, test_results):
         print('Last 25 lines:\n%s\n' % '\n'.join(conf_log.decode('utf-8').splitlines()[-25:]))
         sys.exit(1)
 
-    inst_log, exit_code = RunCmd('make -j2 install')
+    inst_log, exit_code = RunCmd('make -j -l2.5 install')
     if exit_code != 0:
         print('make install failed!')
         print('Last 25 lines:\n%s\n' % '\n'.join(inst_log.decode('utf-8').splitlines()[-25:]))


### PR DESCRIPTION
It has been proposed that make running too many parallel jobs recently has led to resource exhaustion in our CI, so that some kind of limit would be helpful to set.

The load average 2.5 limit choosen here is simply the limit used as an example in the make documentation, as we don't really have any way of picking an initial value that's certain to be better.

https://www.gnu.org/software/make/manual/html_node/Parallel.html

See #2421
See #2422

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22349
- [X] Required: The PR title must be prefixed with a JIRA Issue number.
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number.
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [X] API docs and/or User Guide docs changed or added, if applicable
