### PR TITLE
ICU-22261 Add validator for MessageFormat2 to icu4c

### DIFF
--- a/icu4c/source/i18n/messageformat2.cpp
+++ b/icu4c/source/i18n/messageformat2.cpp
@@ -1,0 +1,1487 @@
+// © 2016 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+
+#include "unicode/utypes.h"
+
+#if !UCONFIG_NO_FORMATTING
+
+#include "unicode/messageformat2.h"
+#include "uvector.h" // U_ASSERT
+
+// Syntactically significant characters
+#define LEFT_CURLY_BRACE ((UChar32)0x007B)
+#define RIGHT_CURLY_BRACE ((UChar32)0x007D)
+#define SPACE ((UChar32)0x0020)
+#define HTAB ((UChar32)0x0009)
+#define CR ((UChar32)0x000D)
+#define LF ((UChar32)0x000A)
+#define BACKSLASH ((UChar32)0x005C)
+#define PIPE ((UChar32)0x007C)
+#define EQUALS ((UChar32)0x003D)
+#define DOLLAR ((UChar32)0x0024)
+#define COLON ((UChar32)0x003A)
+#define PLUS ((UChar32)0x002B)
+#define HYPHEN ((UChar32)0x002D)
+#define PERIOD ((UChar32)0x002E)
+#define UNDERSCORE ((UChar32)0x005F)
+
+// Both used (in a `key` context) and reserved (in an annotation context)
+#define ASTERISK ((UChar32)0x002A)
+
+// Reserved sigils
+#define BANG ((UChar32)0x0021)
+#define AT ((UChar32)0x0040)
+#define POUND ((UChar32)0x0023)
+#define PERCENT ((UChar32)0x0025)
+#define CARET ((UChar32)0x005E)
+#define AMPERSAND ((UChar32)0x0026)
+#define LESS_THAN ((UChar32)0x003C)
+#define GREATER_THAN ((UChar32)0x003E)
+#define QUESTION ((UChar32)0x003F)
+#define TILDE ((UChar32)0x007E)
+
+U_NAMESPACE_BEGIN namespace message2 {
+
+// MessageFormat2 uses three keywords: `let`, `when`, and `match`.
+
+static constexpr UChar32 ID_LET[] = {
+    0x6C, 0x65, 0x74, 0 /* "let" */
+};
+
+static constexpr UChar32 ID_WHEN[] = {
+    0x77, 0x68, 0x65, 0x6E, 0 /* "when" */
+};
+
+static constexpr UChar32 ID_MATCH[] = {
+    0x6D, 0x61, 0x74, 0x63, 0x68, 0 /* "match" */
+};
+
+UOBJECT_DEFINE_RTTI_IMPLEMENTATION(MessageFormat2)
+
+// Used so `parseEscapeSequence()` can handle all types of escape sequences
+// (literal, text, and reserved)
+typedef enum { LITERAL, TEXT, RESERVED } EscapeKind;
+
+/*
+  Use an internal "parse error" structure to make it easier to translate
+  absolute offsets to line offsets.
+  This is translated back to a `UParseError` at the end of parsing.
+*/
+typedef struct MessageParseError {
+    // The line on which the error occurred
+    uint32_t line;
+    // The offset, relative to the erroneous line, on which the error occurred
+    uint32_t offset;
+    // The total number of characters seen before advancing to the current line. It has a value of 0 if line == 0.
+    // It includes newline characters, because the index does too.
+    uint32_t lengthBeforeCurrentLine;
+
+    // This parser doesn't yet use the last two fields.
+    UChar   preContext[U_PARSE_CONTEXT_LEN];
+    UChar   postContext[U_PARSE_CONTEXT_LEN];
+} MessageParseError;
+
+static const MessageParseError INITIAL_MESSAGE_PARSE_ERROR = {
+    0, 0, 0, {0}, {0}
+};
+
+/*
+    The `ERROR()` macro sets `errorCode` to `U_MESSAGE_PARSE_ERROR
+    and sets the offset in `parseError` to `index`. It does not alter control flow.
+
+    For now, all parse errors are denoted by U_MESSAGE_PARSE_ERROR.
+    common/unicode/utypes.h defines a broader set of formatting errors,
+    but it doesn't capture all possible MessageFormat2 errors and until the
+    spec is finalized, we'll just use the same error code for all parse errors.
+*/
+#define ERROR(parseError, errorCode, index)                                                             \
+    setParseError(parseError, index);                                                                   \
+    errorCode = U_MESSAGE_PARSE_ERROR;
+
+
+// Returns immediately if `errorCode` indicates failure
+#define CHECK_ERROR(errorCode)                                                                          \
+    if (U_FAILURE(errorCode)) {                                                                         \
+        return;                                                                                         \
+    }
+
+// Returns true iff `index` is a valid index for the string `source`
+static bool inBounds(const UnicodeString &source, uint32_t index) {
+    return (((int32_t)index) < source.length());
+}
+
+// Increments the line number and updates the "characters seen before
+// current line" count in `parseError`, iff `source[index]` is a newline
+static void maybeAdvanceLine(const UnicodeString& source,
+                             uint32_t index,
+                             MessageParseError &parseError) {
+    if (source[index] == LF) {
+        parseError.line++;
+        // add 1 to index to get the number of characters seen so far
+        // (including the newline)
+        parseError.lengthBeforeCurrentLine = index + 1;
+    }
+}
+
+/*
+    Signals an error and returns either if `parseError` already denotes an
+    error, or `index` is out of bounds for the string `source`
+*/
+#define CHECK_BOUNDS(source, index, parseError, errorCode)                                              \
+    if (U_FAILURE(errorCode)) {                                                                         \
+        return;                                                                                         \
+    }                                                                                                   \
+    if (!inBounds(source, index)) {                                                                     \
+        ERROR(parseError, errorCode, index);                                                            \
+        return;                                                                                         \
+    }
+
+// -------------------------------------
+// Creates a MessageFormat instance based on the pattern.
+
+MessageFormat2::MessageFormat2(const UnicodeString &pattern, UParseError &parseError,
+                               UErrorCode &success) {
+    // For now, all this constructor does is validate the pattern.
+    CHECK_ERROR(success);
+
+    parse(pattern, parseError, success);
+}
+
+MessageFormat2::~MessageFormat2() {}
+
+// -------------------------------------
+// Helper functions
+
+static void copyContext(const UChar in[U_PARSE_CONTEXT_LEN], UChar out[U_PARSE_CONTEXT_LEN]) {
+    for (size_t i = 0; i < U_PARSE_CONTEXT_LEN; i++) {
+        out[i] = in[i];
+        if (in[i] == '\0') {
+            break;
+        }
+    }
+}
+
+static void translateParseError(const MessageParseError &messageParseError, UParseError &parseError) {
+    parseError.line = messageParseError.line;
+    parseError.offset = messageParseError.offset;
+    copyContext(messageParseError.preContext, parseError.preContext);
+    copyContext(messageParseError.postContext, parseError.postContext);
+}
+
+static void setParseError(MessageParseError &parseError, uint32_t index) {
+    // Translate absolute to relative offset
+    parseError.offset = index                               // Start with total number of characters seen
+                      - parseError.lengthBeforeCurrentLine; // Subtract all characters before the current line
+    // TODO: Fill this in with actual pre and post-context
+    parseError.preContext[0] = 0;
+    parseError.postContext[0] = 0;
+}
+
+// -------------------------------------
+// Predicates
+
+// Returns true if `c` is in the interval [`first`, `last`]
+static bool inRange(UChar32 c, UChar32 first, UChar32 last) {
+    U_ASSERT(first < last);
+    return c >= first && c <= last;
+}
+
+// See `s` in the MessageFormat2 grammar
+static bool isWhitespace(UChar32 c) {
+    switch (c) {
+    case SPACE:
+    case HTAB:
+    case CR:
+    case LF:
+        return true;
+    default:
+        return false;
+    }
+}
+
+/*
+  The following helper predicates should exactly match nonterminals in the MessageFormat2 grammar:
+
+  `isTextChar()`      : `text-char`
+  `isReservedStart()` : `reserved-start`
+  `isReservedChar()`  : `reserved-char`
+  `isAlpha()`         : `ALPHA`
+  `isDigit()`         : `DIGIT`
+  `isNameStart()`     : `name-start`
+  `isNameChar()`      : `name-char`
+  `isLiteralChar()`   : `literal-char`
+*/
+static bool isTextChar(UChar32 c) {
+    return inRange(c, 0x0000, 0x005B)    // Omit backslash
+           || inRange(c, 0x005D, 0x007A) // Omit {
+           || c == 0x007C                // }
+           || inRange(c, 0x007E, 0xD7FF) // Omit surrogates
+           || inRange(c, 0xE000, 0x10FFFF);
+}
+
+static bool isReservedStart(UChar32 c) {
+    switch (c) {
+    case BANG:
+    case AT:
+    case POUND:
+    case PERCENT:
+    case CARET:
+    case AMPERSAND:
+    case ASTERISK:
+    case LESS_THAN:
+    case GREATER_THAN:
+    case QUESTION:
+    case TILDE:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static bool isReservedChar(UChar32 c) {
+    return inRange(c, 0x0000, 0x0008)    // Omit HTAB and LF
+           || inRange(c, 0x000B, 0x000C) // Omit CR
+           || inRange(c, 0x000E, 0x0019) // Omit SP
+           || inRange(c, 0x0021, 0x005B) // Omit backslash
+           || inRange(c, 0x005D, 0x007A) // Omit { | }
+           || inRange(c, 0x007E, 0xD7FF) // Omit surrogates
+           || inRange(c, 0xE000, 0x10FFFF);
+}
+
+static bool isAlpha(UChar32 c) { return inRange(c, 0x0041, 0x005A) || inRange(c, 0x0061, 0x007A); }
+
+static bool isDigit(UChar32 c) { return inRange(c, 0x0030, 0x0039); }
+
+static bool isNameStart(UChar32 c) {
+    return isAlpha(c) || c == UNDERSCORE || inRange(c, 0x00C0, 0x00D6) || inRange(c, 0x00D8, 0x00F6) ||
+           inRange(c, 0x00F8, 0x02FF) || inRange(c, 0x0370, 0x037D) || inRange(c, 0x037F, 0x1FFF) ||
+           inRange(c, 0x200C, 0x200D) || inRange(c, 0x2070, 0x218F) || inRange(c, 0x2C00, 0x2FEF) ||
+           inRange(c, 0x3001, 0xD7FF) || inRange(c, 0xF900, 0xFDCF) || inRange(c, 0xFDF0, 0xFFFD) ||
+           inRange(c, 0x10000, 0xEFFFF);
+}
+
+static bool isNameChar(UChar32 c) {
+    return isNameStart(c) || isDigit(c) || c == HYPHEN || c == PERIOD || c == COLON || c == 0x00B7 ||
+           inRange(c, 0x0300, 0x036F) || inRange(c, 0x203F, 0x2040);
+}
+
+static bool isLiteralChar(UChar32 c) {
+    return inRange(c, 0x0000, 0x005B)    // Omit backslash
+           || inRange(c, 0x005D, 0x007B) // Omit pipe
+           || inRange(c, 0x007D, 0xD7FF) // Omit surrogates
+           || inRange(c, 0xE000, 0x10FFFF);
+}
+
+// Returns true iff `c` can begin a `function` nonterminal
+static bool isFunctionStart(UChar32 c) {
+    switch (c) {
+    case COLON:
+    case PLUS:
+    case HYPHEN: {
+        return true;
+    }
+    default: {
+        return false;
+    }
+    }
+}
+
+// Returns true iff `c` can begin an `annotation` nonterminal
+static bool isAnnotationStart(UChar32 c) {
+    return isFunctionStart(c) || isReservedStart(c);
+}
+
+// Returns true iff `c` can begin either a `reserved-char` or `reserved-escape`
+// literal
+static bool reservedChunkFollows(UChar32 c) {
+   switch(c) {
+       // reserved-escape
+       case BACKSLASH:
+       // literal
+       case PIPE: {
+           return true;
+       }
+       default: {
+           // reserved-char
+           return (isReservedChar(c));
+       }
+    }
+}
+
+// -------------------------------------
+// Parsing functions
+
+/*
+    This is a recursive-descent scannerless parser that,
+    with a few exceptions, uses 1 character of lookahead.
+
+All the exceptions involve ambiguities about the meaning of whitespace.
+
+There are four ambiguities in the grammar that can't be resolved with finite
+lookahead (since whitespace sequences can be arbitrarily long). They are resolved
+with a form of backtracking (early exit). No state needs to be saved/restored
+since whitespace doesn't affect the shape of the resulting parse tree, so it's
+not true backtracking.
+
+In addition, the grammar has been refactored
+in a semantics-preserving way in some cases to make the code easier to structure.
+
+First: variant = when 1*(s key) [s] pattern
+   Example: when k     {a}
+   When reading the first space after 'k', it's ambiguous whether it's the
+   required space before another key, or the optional space before `pattern`.
+ (See comments in parseNonEmptyKeys())
+
+Second: expression = "{" [s] (((literal / variable) [s annotation]) / annotation) [s] "}"
+        annotation = (function *(s option)) / reserved
+   Example: {:f    }
+   When reading the first space after 'f', it's ambiguous whether it's the
+   required space before an option, or the optional trailing space after an options list
+   (in this case, the options list is empty).
+ (See comments in parseOptions() -- handling this case also meant it was easier to base
+  the code on a slightly refactored grammar, which should be semantically equivalent.)
+
+Third: expression = "{" [s] (((literal / variable) [s annotation]) / annotation) [s] "}"
+        annotation = (function *(s option)) / reserved
+   Example: {@a }
+   Similar to the previous case; see comments in parseReserved()
+
+Fourth: expression = "{" [s] (((literal / variable) [s annotation]) / annotation) [s] "}"
+   Example: {|foo|   }
+   When reading the first space after the '|', it's ambiguous whether it's the required
+   space before an annotation, or the optional trailing space before the '}'.
+  (See comments in parseLiteralOrVariableWithAnnotation(); handling this case relies on
+  the same grammar refactoring as the second exception.)
+
+    Most functions match a non-terminal in the grammar, except as explained
+    in comments.
+
+Unless otherwise noted in a comment, all helper functions that take
+    a `source` string, an `index` unsigned int, and an `errorCode` `UErrorCode`
+    have the precondition:
+      `index` < `source.length()`
+    and the postcondition:
+      `U_FAILURE(errorCode)` || `index < `source.length()`
+*/
+
+/*
+  No pre, no post.
+  A message may end with whitespace, so `index` may equal `source.length()` on exit.
+*/
+static void parseWhitespaceMaybeRequired(bool required,
+                                         const UnicodeString &source,
+                                         uint32_t &index,
+                                         MessageParseError &parseError,
+                                         UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode);
+
+    bool sawWhitespace = false;
+
+    // The loop exits either when we consume all the input,
+    // or when we see a non-whitespace character.
+    while (true) {
+        // Check if all input has been consumed
+        if (!inBounds(source, index)) {
+            // If whitespace isn't required -- or if we saw it already --
+            // then the caller is responsible for checking this case and
+            // setting an error if necessary.
+            if (!required || sawWhitespace) {
+                // Not an error.
+                return;
+            }
+            // Otherwise, whitespace is required; the end of the input has
+            // been reached without whitespace. This is an error.
+            ERROR(parseError, errorCode, index);
+            return;
+        }
+
+        // Input remains; process the next character if it's whitespace,
+        // exit the loop otherwise
+        if (isWhitespace(source[index])) {
+            sawWhitespace = true;
+            // Increment line number in parse error if we consume a newline
+            maybeAdvanceLine(source, index, parseError);
+            index++;
+        } else {
+            break;
+        }
+    }
+
+    if (!sawWhitespace && required) {
+        ERROR(parseError, errorCode, index);
+    }
+}
+
+/*
+  No pre, no post, for the same reason as `parseWhitespaceMaybeRequired()`.
+*/
+static void parseRequiredWhitespace(const UnicodeString &source,
+                                    uint32_t &index,
+                                    MessageParseError &parseError,
+                                    UErrorCode &errorCode) {
+    parseWhitespaceMaybeRequired(true, source, index, parseError, errorCode);
+}
+
+/*
+  No pre, no post, for the same reason as `parseWhitespaceMaybeRequired()`.
+*/
+static void parseOptionalWhitespace(const UnicodeString &source,
+                                    uint32_t &index,
+                                    MessageParseError &parseError,
+                                    UErrorCode &errorCode) {
+    parseWhitespaceMaybeRequired(false, source, index, parseError, errorCode);
+}
+
+// Consumes a single character, signaling an error if `source[index]` != `c`
+static void parseToken(UChar32 c,
+                       const UnicodeString &source,
+                       uint32_t &index,
+                       MessageParseError &parseError,
+                       UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode);
+
+    U_ASSERT(inBounds(source, index));
+    if (source[index] == c) {
+        index++;
+        // Guarantee postcondition
+        CHECK_BOUNDS(source, index, parseError, errorCode);
+        return;
+    }
+    // Next character didn't match -- error out
+    ERROR(parseError, errorCode, index);
+}
+
+/*
+   Consumes a fixed-length token, signaling an error if the token isn't a prefix of
+   the string beginning at `source[index]`
+*/
+template <size_t N>
+static void parseToken(const UChar32 (&token)[N],
+                       const UnicodeString &source,
+                       uint32_t &index,
+                       MessageParseError &parseError,
+                       UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode);
+
+    U_ASSERT(inBounds(source, index));
+
+    size_t tokenPos = 0;
+    while (tokenPos < N - 1) {
+        if (source[index] != token[tokenPos]) {
+            ERROR(parseError, errorCode, index);
+            return;
+        }
+        index++;
+        // Guarantee postcondition
+        CHECK_BOUNDS(source, index, parseError, errorCode);
+
+        tokenPos++;
+    }
+}
+
+/*
+   Consumes optional whitespace, possibly advancing `index` to `index'`,
+   then consumes a fixed-length token (signaling an error if the token isn't a prefix of
+   the string beginning at `source[index']`),
+   then consumes optional whitespace again
+*/
+template <size_t N>
+static void parseTokenWithWhitespace(const UChar32 (&token)[N],
+                                     const UnicodeString &source,
+                                     uint32_t &index,
+                                     MessageParseError &parseError,
+                                     UErrorCode &errorCode) {
+    // No need for error check or bounds check before parseOptionalWhitespace
+    parseOptionalWhitespace(source, index, parseError, errorCode);
+    // Establish precondition
+    CHECK_BOUNDS(source, index, parseError, errorCode);
+    parseToken(token, source, index, parseError, errorCode);
+    parseOptionalWhitespace(source, index, parseError, errorCode);
+    // Guarantee postcondition
+    CHECK_BOUNDS(source, index, parseError, errorCode);
+}
+
+/*
+   Consumes optional whitespace, possibly advancing `index` to `index'`,
+   then consumes a single character (signaling an error if it doesn't match
+   `source[index']`),
+   then consumes optional whitespace again
+*/
+static void parseTokenWithWhitespace(UChar32 c,
+                                     const UnicodeString &source,
+                                     uint32_t &index,
+                                     MessageParseError &parseError,
+                                     UErrorCode &errorCode) {
+    // No need for error check or bounds check before parseOptionalWhitespace
+    parseOptionalWhitespace(source, index, parseError, errorCode);
+    // Establish precondition
+    CHECK_BOUNDS(source, index, parseError, errorCode);
+    parseToken(c, source, index, parseError, errorCode);
+    parseOptionalWhitespace(source, index, parseError, errorCode);
+    // Guarantee postcondition
+    CHECK_BOUNDS(source, index, parseError, errorCode);
+}
+
+/*
+  Consumes a non-empty sequence of `name-char`s.
+
+  (Matches the `nmtoken` nonterminal in the grammar.)
+*/
+static void parseNmtoken(const UnicodeString &source,
+                         uint32_t &index,
+                         MessageParseError &parseError,
+                         UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode);
+
+    U_ASSERT(inBounds(source, index));
+    if (!isNameChar(source[index])) {
+        ERROR(parseError, errorCode, index);
+        return;
+    }
+
+    while (isNameChar(source[index])) {
+        index++;
+        CHECK_BOUNDS(source, index, parseError, errorCode);
+    }
+}
+
+/*
+  Consumes a non-empty sequence of `name-char`s, the first of which is
+  also a `name-start`.
+  that begins with a character `start` such that `isNameStart(start)`.
+
+  (Matches the `name` nonterminal in the grammar.)
+*/
+static void parseName(const UnicodeString &source,
+                      uint32_t &index,
+                      MessageParseError &parseError,
+                      UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode);
+
+    U_ASSERT(inBounds(source, index));
+
+    if (!isNameStart(source[index])) {
+        ERROR(parseError, errorCode, index);
+        return;
+    }
+
+    parseNmtoken(source, index, parseError, errorCode);
+}
+
+/*
+  Consumes a '$' followed by a `name`.
+
+  (Matches the `variable` nonterminal in the grammar.)
+*/
+static void parseVariableName(const UnicodeString &source,
+                              uint32_t &index,
+                              MessageParseError &parseError,
+                              UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode);
+
+    U_ASSERT(inBounds(source, index));
+    if (source[index] != DOLLAR) {
+        ERROR(parseError, errorCode, index);
+        return;
+    }
+
+    index++; // Consume the '$'
+    CHECK_BOUNDS(source, index, parseError, errorCode);
+    parseName(source, index, parseError, errorCode);
+}
+
+
+/*
+  Consumes a reference to a function, matching the `function` nonterminal in
+  the grammar.
+*/
+static void parseFunction(const UnicodeString &source,
+                          uint32_t &index,
+                          MessageParseError &parseError,
+                          UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode);
+
+    U_ASSERT(inBounds(source, index));
+    if (!isFunctionStart(source[index])) {
+        ERROR(parseError, errorCode, index);
+        return;
+    }
+
+    index++; // Consume the function start character
+    CHECK_BOUNDS(source, index, parseError, errorCode);
+    parseName(source, index, parseError, errorCode);
+}
+
+
+/*
+  Precondition: source[index] == BACKSLASH
+
+  Consume an escaped character.
+
+  Generalized to handle `reserved-escape`, `text-escape`,
+  or `literal-escape`, depending on the `kind` argument.
+*/
+static void parseEscapeSequence(const UnicodeString &source,
+                                uint32_t &index,
+                                EscapeKind kind,
+                                MessageParseError &parseError,
+                                UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode);
+
+    U_ASSERT(inBounds(source, index));
+    U_ASSERT(source[index] == BACKSLASH);
+    index++; // Skip the initial backslash
+    CHECK_BOUNDS(source, index, parseError, errorCode);
+
+    #define SUCCEED \
+       /* Consume the character */                         \
+       index++;                                             \
+       /* Guarantee postcondition */                        \
+       CHECK_BOUNDS(source, index, parseError, errorCode);  \
+       return;
+
+    // Expect a '{', '|' or '}'
+    switch (source[index]) {
+    case LEFT_CURLY_BRACE:
+    case RIGHT_CURLY_BRACE: {
+        // Allowed in a `text-escape` or `reserved-escape`
+        switch (kind) {
+        case TEXT:
+        case RESERVED: {
+            SUCCEED;
+        }
+        default: {
+            break;
+        }
+        }
+        break;
+    }
+    case PIPE: {
+        // Allowed in a `literal-escape` or `reserved-escape`
+        switch (kind) {
+           case LITERAL:
+           case RESERVED: {
+               SUCCEED;
+           }
+           default: {
+               break;
+           }
+        }
+        break;
+    }
+   case BACKSLASH: {
+       // Allowed in any escape sequence
+       SUCCEED;
+   }
+   default: {
+        // No other characters are allowed here
+        break;
+    }
+   }
+   // If control reaches here, there was an error
+   ERROR(parseError, errorCode, index);
+}
+
+/*
+  Consume an escaped pipe or backslash, matching the `literal-escape`
+  nonterminal in the grammar
+*/
+static void parseLiteralEscape(const UnicodeString &source,
+                               uint32_t &index,
+                               MessageParseError &parseError,
+                               UErrorCode &errorCode) {
+    parseEscapeSequence(source, index, LITERAL, parseError, errorCode);
+}
+
+/*
+  Consume a literal, matching the `literal` nonterminal in the grammar.
+*/
+static void parseLiteral(const UnicodeString &source,
+                         uint32_t &index,
+                         MessageParseError &parseError,
+                         UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode);
+    U_ASSERT(inBounds(source, index));
+
+    // Parse the opening '|'
+    parseToken(PIPE, source, index, parseError, errorCode);
+    CHECK_BOUNDS(source, index, parseError, errorCode);
+
+    // Parse the contents
+    bool done = false;
+    while (!done) {
+        if (source[index] == BACKSLASH) {
+            parseLiteralEscape(source, index, parseError, errorCode);
+        } else if (isLiteralChar(source[index])) {
+            index++; // Consume this character
+            maybeAdvanceLine(source, index, parseError);
+        } else {
+          // Assume the sequence of literal characters ends here
+          done = true;
+        }
+        CHECK_BOUNDS(source, index, parseError, errorCode);
+    }
+
+    // Parse the closing '|'
+    parseToken(PIPE, source, index, parseError, errorCode);
+
+    // Guarantee postcondition
+    CHECK_BOUNDS(source, index, parseError, errorCode);
+}
+
+/*
+  Consume a name-value pair, matching the `option` nonterminal in the grammar.
+*/
+static void parseOption(const UnicodeString &source,
+                        uint32_t &index,
+                        MessageParseError &parseError,
+                        UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode);
+
+    U_ASSERT(inBounds(source, index));
+
+    // Parse LHS
+    parseName(source, index, parseError, errorCode);
+
+    // Parse '='
+    parseTokenWithWhitespace(EQUALS, source, index, parseError, errorCode);
+
+    // Parse RHS, which is either a literal, nmtoken, or variable
+    switch (source[index]) {
+    case PIPE: {
+        parseLiteral(source, index, parseError, errorCode);
+        break;
+    }
+    case DOLLAR: {
+        parseVariableName(source, index, parseError, errorCode);
+        break;
+    }
+    default: {
+        // Not a literal or variable, so it must be an nmtoken
+        parseNmtoken(source, index, parseError, errorCode);
+        break;
+    }
+    }
+}
+
+/*
+  Consume optional whitespace followed by a sequence of options
+  (possibly empty), separated by whitespace
+*/
+static void parseOptions(const UnicodeString &source,
+                         uint32_t &index,
+                         MessageParseError &parseError,
+                         UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode);
+
+    U_ASSERT(inBounds(source, index));
+
+/*
+Arbitrary lookahead is required to parse option lists. To see why, consider
+these rules from the grammar:
+
+expression = "{" [s] (((literal / variable) [s annotation]) / annotation) [s] "}"
+annotation = (function *(s option)) / reserved
+
+And this example:
+{:foo  }
+
+Derivation:
+expression -> "{" [s] (((literal / variable) [s annotation]) / annotation) [s] "}"
+           -> "{" [s] annotation [s] "}"
+           -> "{" [s] ((function *(s option)) / reserved) [s] "}"
+           -> "{" [s] function *(s option) [s] "}"
+
+In this example, knowing whether to expect a '}' or the start of another option
+after the whitespace would require arbitrary lookahead -- in other words, which
+rule should we apply?
+    *(s option) -> s option *(s option)
+  or
+    *(s option) ->
+
+The same would apply to the example {:foo k=v } (note the trailing space after "v").
+
+This is addressed using a form of backtracking and (to make the backtracking easier
+to apply) a slight refactoring to the grammar.
+
+This code is written as if the grammar is:
+  expression = "{" [s] (((literal / variable) ([s] / [s annotation])) / annotation) "}"
+  annotation = (function *(s option) [s]) / (reserved [s])
+
+Parsing the `*(s option) [s]` sequence can be done within `parseOptions()`, meaning
+that `parseExpression()` can safely require a '}' after `parseOptions()` finishes.
+
+Note that when "backtracking" really just means early exit, since only whitespace
+is involved and there's no state to save.
+*/
+
+    while(true) {
+        // If the next character is not whitespace, that means we've already
+        // parsed the entire options list (which may have been empty) and there's
+        // no trailing whitespace. In that case, exit.
+        if (!isWhitespace(source[index])) {
+            break;
+        }
+
+        // In any case other than an empty options list, there must be at least
+        // one whitespace character.
+        parseRequiredWhitespace(source, index, parseError, errorCode);
+        // Restore precondition
+        CHECK_BOUNDS(source, index, parseError, errorCode);
+
+        // If a name character follows, then at least one more option remains
+        // in the list.
+        // Otherwise, we've consumed all the options and any trailing whitespace,
+        // and can exit.
+        // Note that exiting is sort of like backtracking: "(s option)" doesn't apply,
+        // so we back out to [s].
+        if (!isNameStart(source[index])) {
+            // We've consumed all the options (meaning that either we consumed non-empty
+            // whitespace, or consumed at least one option.)
+            // Done.
+            break;
+        }
+        parseOption(source, index, parseError, errorCode);
+    }
+}
+
+static void parseReservedEscape(const UnicodeString &source,
+                                uint32_t &index,
+                                MessageParseError &parseError,
+                                UErrorCode &errorCode) {
+    parseEscapeSequence(source, index, RESERVED, parseError, errorCode);
+}
+
+/*
+  Consumes a non-empty sequence of reserved-chars, reserved-escapes, and
+  literals (as in 1*(reserved-char / reserved-escape / literal) in the `reserved-body` rule)
+*/
+static void parseReservedChunk(const UnicodeString &source,
+                               uint32_t &index,
+                               MessageParseError &parseError,
+                               UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode);
+
+    bool empty = true;
+    while(reservedChunkFollows(source[index])) {
+        empty = false;
+        // reserved-char
+        if (isReservedChar(source[index])) {
+            // consume the char
+            index++;
+            // Restore precondition
+            CHECK_BOUNDS(source, index, parseError, errorCode);
+        } else if (source[index] == BACKSLASH) {
+            // reserved-escape
+            parseReservedEscape(source, index, parseError, errorCode);
+        } else if (source[index] == PIPE) {
+            parseLiteral(source, index, parseError, errorCode);
+        } else {
+            // The reserved chunk ends here
+            break;
+        }
+    }
+
+    if (empty) {
+        ERROR(parseError, errorCode, index);
+    }
+}
+
+/*
+  Consume a `reserved-start` character followed by a possibly-empty sequence
+  of non-empty sequences of reserved characters, separated by whitespace.
+  Matches the `reserved` nonterminal in the grammar
+*/
+static void parseReserved(const UnicodeString &source,
+                          uint32_t &index,
+                          MessageParseError &parseError,
+                          UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode);
+
+    U_ASSERT(inBounds(source, index));
+
+    // Require a `reservedStart` character
+    if (!isReservedStart(source[index])) {
+        ERROR(parseError, errorCode, index);
+        return;
+    }
+    // Consume reservedStart
+    index++;
+    // Restore precondition
+    CHECK_BOUNDS(source, index, parseError, errorCode);
+
+/*
+  Arbitrary lookahead is required to parse a `reserved`, for similar reasons
+  to why it's required for parsing function annotations.
+
+  In the grammar:
+
+  annotation = (function *(s option)) / reserved
+  expression = "{" [s] (((literal / variable) [s annotation]) / annotation) [s] "}"
+  reserved       = reserved-start reserved-body
+  reserved-body  = *( [s] 1*(reserved-char / reserved-escape / literal))
+
+  When reading a whitespace character, it's ambiguous whether it's the optional
+  whitespace in this rule, or the optional whitespace that precedes a '}' in an
+  expression.
+
+  The ambiguity is resolved using the same grammar refactoring as shown in
+  the comment in `parseOptions()`.
+*/
+    // Consume reserved characters / literals / reserved escapes
+    // until a character that can't be in a `reserved-body` is seen
+    while (true) {
+        /*
+          First, if there is whitespace, it means either a chunk follows it,
+          or this is the trailing whitespace before the '}' that terminates an
+          expression.
+
+          Next, if the next character can start a reserved-char, reserved-escape,
+          or literal, then parse a "chunk" of reserved things.
+          In any other case, we exit successfully, since per the refactored
+          grammar rule:
+               annotation = (function *(s option) [s]) / (reserved [s])
+          it's valid to consume whitespace after a `reserved`.
+          (`parseExpression()` is responsible for checking that the next
+          character is in fact a '}'.)
+         */
+        bool sawWhitespace = false;
+        if (isWhitespace(source[index])) {
+            sawWhitespace = true;
+            parseOptionalWhitespace(source, index, parseError, errorCode);
+            // Restore precondition
+            CHECK_BOUNDS(source, index, parseError, errorCode);
+        }
+
+        if (reservedChunkFollows(source[index])) {
+            parseReservedChunk(source, index, parseError, errorCode);
+
+            // Avoid looping infinitely
+            CHECK_BOUNDS(source, index, parseError, errorCode);
+        } else {
+            if (sawWhitespace) {
+                if (source[index] == RIGHT_CURLY_BRACE) {
+                    // Not an error: just means there's no trailing whitespace
+                    // after this `reserved`
+                    break;
+                }
+                // Error: if there's whitespace, it must either be followed
+                // by a non-empty sequence or by '}'
+                ERROR(parseError, errorCode, index);
+                return;
+            }
+            // If there was no whitespace, it's not an error,
+            // just the end of the reserved string
+            break;
+        }
+    }
+}
+
+
+/*
+  Consume a function call or reserved string, matching the `annotation`
+  nonterminal in the grammar
+*/
+static void parseAnnotation(const UnicodeString &source,
+                            uint32_t &index,
+                            MessageParseError &parseError,
+                            UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode);
+
+    U_ASSERT(inBounds(source, index));
+    if (isFunctionStart(source[index])) {
+        // Consume the function name
+        parseFunction(source, index, parseError, errorCode);
+
+        // Consume the options (which may be empty)
+        parseOptions(source, index, parseError, errorCode);
+    } else {
+        // Must be reserved
+        parseReserved(source, index, parseError, errorCode);
+    }
+}
+
+/*
+  Consume a literal or variable (depending on `isVariable`),
+  followed by either required whitespace followed by an annotation,
+  or optional whitespace.
+*/
+static void parseLiteralOrVariableWithAnnotation(const UnicodeString &source,
+                                                 uint32_t &index,
+                                                 bool isVariable,
+                                                 MessageParseError &parseError,
+                                                 UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode);
+
+    U_ASSERT(inBounds(source, index));
+
+    if (isVariable) {
+        parseVariableName(source, index, parseError, errorCode);
+    } else {
+        parseLiteral(source, index, parseError, errorCode);
+    }
+
+/*
+Parsing a literal or variable with an optional annotation requires arbitrary lookahead.
+To see why, consider this rule from the grammar:
+
+expression = "{" [s] (((literal / variable) [s annotation]) / annotation) [s] "}"
+
+And this example:
+
+{|foo|   }
+
+Derivation:
+expression -> "{" [s] (((literal / variable) [s annotation]) / annotation) [s] "}"
+           -> "{" [s] ((literal / variable) [s annotation]) [s] "}"
+           -> "{" [s] (literal [s annotation]) [s] "}"
+
+When reading the ' ' after the second '|', it's ambiguous whether that's the required
+space before an annotation, or the optional space before the '}'.
+
+To make this ambiguity easier to handle, this code is based on the same grammar
+refactoring for the `expression` nonterminal that `parseOptions()` relies on. See
+the comment in `parseOptions()` for details.
+*/
+
+    // If the next character is not whitespace, return.
+    if (!isWhitespace(source[index])) {
+        // This means there's no annotation, since an annotation is preceded by
+        // required whitespace. We're done.
+        return;
+    }
+
+    // If the next character is whitespace, either [s annotation] or [s] applies
+    // (the character is either the required space before an annotation, or optional
+    // trailing space after the literal or variable). It's still ambiguous which
+    // one does apply.
+    parseRequiredWhitespace(source, index, parseError, errorCode);
+    // Restore precondition
+    CHECK_BOUNDS(source, index, parseError, errorCode);
+
+    // This next check resolves the ambiguity between [s annotation] and [s]
+    if (isAnnotationStart(source[index])) {
+        // The previously consumed whitespace precedes an annotation
+        parseAnnotation(source, index, parseError, errorCode);
+        return;
+    }
+    // The previously consumed whitespace is the optional trailing whitespace;
+    // either the next character is '}' or the error will be handled by parseExpression.
+}
+
+/*
+  Consume an expression, matching the `expression` nonterminal in the grammar
+*/
+static void parseExpression(const UnicodeString &source,
+                            uint32_t &index,
+                            MessageParseError &parseError,
+                            UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode);
+
+    U_ASSERT(inBounds(source, index));
+    // Parse opening brace
+    parseToken(LEFT_CURLY_BRACE, source, index, parseError, errorCode);
+    // Optional whitespace after opening brace
+    parseOptionalWhitespace(source, index, parseError, errorCode);
+    // Restore precondition
+    CHECK_BOUNDS(source, index, parseError, errorCode);
+    // literal '|', variable '$' or annotation
+    switch (source[index]) {
+    case PIPE: {
+        // Literal
+        parseLiteralOrVariableWithAnnotation(source, index, false, parseError, errorCode);
+        break;
+    }
+    case DOLLAR: {
+        // Variable
+        parseLiteralOrVariableWithAnnotation(source, index, true, parseError, errorCode);
+        break;
+    }
+    default: {
+        if (isAnnotationStart(source[index])) {
+            parseAnnotation(source, index, parseError, errorCode);
+            break;
+        }
+        // Not a literal, variable or annotation -- error out
+        ERROR(parseError, errorCode, index);
+        return;
+    }
+    }
+    // For why we don't parse optional whitespace here, even though the grammar
+    // allows it, see comments in parseLiteralWithAnnotation() and parseOptions()
+
+    // Parse closing brace
+    parseToken(RIGHT_CURLY_BRACE, source, index, parseError, errorCode);
+}
+
+/*
+  Consume a possibly-empty sequence of declarations separated by whitespace;
+  each declaration matches the `declaration` nonterminal in the grammar
+*/
+static void parseDeclarations(const UnicodeString &source,
+                              uint32_t &index,
+                              MessageParseError &parseError,
+                              UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode);
+
+    // End-of-input here would be an error; even empty
+    // declarations must be followed by a body
+    CHECK_BOUNDS(source, index, parseError, errorCode);
+
+    while (source[index] == ID_LET[0]) {
+        parseToken(ID_LET, source, index, parseError, errorCode);
+        parseRequiredWhitespace(source, index, parseError, errorCode);
+        // Restore precondition
+        CHECK_BOUNDS(source, index, parseError, errorCode);
+        parseVariableName(source, index, parseError, errorCode);
+        parseTokenWithWhitespace(EQUALS, source, index, parseError, errorCode);
+        parseExpression(source, index, parseError, errorCode);
+        parseOptionalWhitespace(source, index, parseError, errorCode);
+        // Restore precondition
+        CHECK_BOUNDS(source, index, parseError, errorCode);
+    }
+}
+
+/*
+  Consume an escaped curly brace, or backslash, matching the `text-escape`
+  nonterminal in the grammar
+*/
+static void parseTextEscape(const UnicodeString &source,
+                            uint32_t &index,
+                            MessageParseError &parseError,
+                            UErrorCode &errorCode) {
+    parseEscapeSequence(source, index, TEXT, parseError, errorCode);
+}
+
+/*
+  Consume a non-empty sequence of text characters and escaped text characters,
+  matching the `text` nonterminal in the grammar
+*/
+static void parseText(const UnicodeString &source,
+                      uint32_t &index,
+                      MessageParseError &parseError,
+                      UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode)
+    U_ASSERT(inBounds(source, index));
+    bool empty = true;
+
+    while (true) {
+        if (source[index] == BACKSLASH) {
+            parseTextEscape(source, index, parseError, errorCode);
+        } else if (isTextChar(source[index])) {
+            index++;
+            maybeAdvanceLine(source, index, parseError);
+        } else {
+            break;
+        }
+        // Restore precondition
+        CHECK_BOUNDS(source, index, parseError, errorCode);
+        empty = false;
+    }
+
+    if (empty) {
+        // text must be non-empty
+        ERROR(parseError, errorCode, index);
+    }
+}
+
+/*
+  Consume an `nmtoken`, `literal`, or the string "*", matching
+  the `key` nonterminal in the grammar
+*/
+static void parseKey(const UnicodeString &source,
+                     uint32_t &index,
+                     MessageParseError &parseError,
+                     UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode);
+    U_ASSERT(inBounds(source, index));
+
+    // Literal | nmtoken | '*'
+    switch (source[index]) {
+    case PIPE: {
+        parseLiteral(source, index, parseError, errorCode);
+        break;
+    }
+    case ASTERISK: {
+        index++;
+        // Guarantee postcondition
+        CHECK_BOUNDS(source, index, parseError, errorCode);
+        break;
+    }
+    default: {
+        // nmtoken
+        parseNmtoken(source, index, parseError, errorCode);
+        break;
+    }
+    }
+}
+
+/*
+  Consume a non-empty sequence of `key`s separated by whitespace
+*/
+static void parseNonEmptyKeys(const UnicodeString &source,
+                              uint32_t &index,
+                              MessageParseError &parseError,
+                              UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode);
+    U_ASSERT(inBounds(source, index));
+
+/*
+Arbitrary lookahead is required to parse key lists. To see why, consider
+this rule from the grammar:
+
+variant = when 1*(s key) [s] pattern
+
+And this example:
+when k1    {a}
+
+Derivation:
+   variant -> when 1*(s key) [s] pattern
+           -> when s key *(s key) [s] pattern
+
+After matching ' ' to `s` and 'k1' to `key`, it would require arbitrary lookahead
+to know whether to expect the start of a pattern or the start of another key.
+In other words: is the second whitespace sequence the required space in 1*(s key),
+or the optional space in [s] pattern?
+
+This is addressed using "backtracking" (similarly to `parseOptions()`).
+*/
+
+    // Since the first key is required, it's simplest to parse the required
+    // whitespace and then the first key separately.
+    parseRequiredWhitespace(source, index, parseError, errorCode);
+    // Restore precondition
+    CHECK_BOUNDS(source, index, parseError, errorCode);
+    parseKey(source, index, parseError, errorCode);
+
+    // We've seen at least one whitespace-key pair, so now we can parse
+    // *(s key) [s]
+    while (isWhitespace(source[index])) {
+        parseRequiredWhitespace(source, index, parseError, errorCode);
+        // Restore precondition
+        CHECK_BOUNDS(source, index, parseError, errorCode);
+
+        // At this point, it's ambiguous whether we are inside (s key) or [s].
+        // This check resolves that ambiguity.
+        if (source[index] == LEFT_CURLY_BRACE) {
+            // A pattern follows, so what we just parsed was the optional
+            // trailing whitespace. All the keys have been parsed.
+            break;
+        }
+        parseKey(source, index, parseError, errorCode);
+    }
+}
+
+/*
+  Consume a `pattern`, matching the nonterminal in the grammar
+  No postcondition (on return, `index` might equal `source.length()` with U_SUCCESS(errorCode)),
+  because a message can end with a pattern
+*/
+static void parsePattern(const UnicodeString &source,
+                         uint32_t &index,
+                         MessageParseError &parseError,
+                         UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode);
+    U_ASSERT(inBounds(source, index));
+
+    parseToken(LEFT_CURLY_BRACE, source, index, parseError, errorCode);
+    while (source[index] != RIGHT_CURLY_BRACE) {
+        switch (source[index]) {
+        case LEFT_CURLY_BRACE: {
+            // Must be expression
+            parseExpression(source, index, parseError, errorCode);
+            break;
+        }
+        default: {
+            // Must be text
+            parseText(source, index, parseError, errorCode);
+            break;
+        }
+        }
+        // Need an explicit error check here so we don't loop infinitely
+        CHECK_ERROR(errorCode);
+    }
+    // Consume the closing brace
+    index++;
+}
+
+/*
+  Consume a `selectors` (matching the nonterminal in the grammar),
+  followed by a non-empty sequence of `variant`s (matching the nonterminal
+  in the grammar) preceded by whitespace
+  No postcondition (on return, `index` might equal `source.length()` with U_SUCCESS(errorCode)),
+  because a message can end with a variant
+*/
+static void parseSelectors(const UnicodeString &source,
+                           uint32_t &index,
+                           MessageParseError &parseError,
+                           UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode);
+    U_ASSERT(inBounds(source, index));
+
+    parseToken(ID_MATCH, source, index, parseError, errorCode);
+
+    bool selectorsEmpty = true;
+    // Parse selectors
+    while (isWhitespace(source[index]) || source[index] == LEFT_CURLY_BRACE) {
+        parseOptionalWhitespace(source, index, parseError, errorCode);
+        // Restore precondition
+        CHECK_BOUNDS(source, index, parseError, errorCode);
+
+        if (source[index] != LEFT_CURLY_BRACE) {
+            // This is not necessarily an error, but rather,
+            // means the whitespace we parsed was the optional
+            // whitespace preceding the first variant, not the
+            // optional whitespace preceding a subsequent expression.
+            break;
+        }
+
+        parseExpression(source, index, parseError, errorCode);
+        selectorsEmpty = false;
+    }
+
+    // At least one selector is required
+    if (selectorsEmpty) {
+        ERROR(parseError, errorCode, index);
+        return;
+    }
+
+    #define CHECK_END_OF_INPUT                     \
+        if (((int32_t)index) >= source.length()) { \
+            break;                                 \
+        }                                          \
+
+    // Parse variants
+    bool empty = true;
+    while (isWhitespace(source[index]) || source[index] == ID_WHEN[0]) {
+        parseOptionalWhitespace(source, index, parseError, errorCode);
+        // Restore the precondition, *without* erroring out if we've
+        // reached the end of input. That's because it's valid for the
+        // message to end with trailing whitespace that follows a variant.
+        CHECK_END_OF_INPUT
+
+        // Consume the "when"
+        parseToken(ID_WHEN, source, index, parseError, errorCode);
+
+        // At least one key is required
+        parseNonEmptyKeys(source, index, parseError, errorCode);
+
+        // parseNonEmptyKeys() consumes any trailing whitespace,
+        // so the pattern can be consumed next.
+        parsePattern(source, index, parseError, errorCode);
+        empty = false;
+
+        // Restore the precondition, *without* erroring out if we've
+        // reached the end of input. That's because it's valid for the
+        // message to end with a variant that has no trailing whitespace.
+        // Why do we need to check this condition twice inside the loop?
+        // Because if we don't check it here, the `isWhitespace()` call in
+        // the loop head will read off the end of the input string.
+        CHECK_END_OF_INPUT
+    }
+
+    // At least one variant is required
+    if (empty) {
+        ERROR(parseError, errorCode, index);
+    }
+}
+
+/*
+  Consume a `body` (matching the nonterminal in the grammar),
+  No postcondition (on return, `index` might equal `source.length()` with U_SUCCESS(errorCode)),
+  because a message can end with a body (trailing whitespace is optional)
+*/
+static void parseBody(const UnicodeString &source, uint32_t &index, MessageParseError &parseError,
+                      UErrorCode &errorCode) {
+    CHECK_ERROR(errorCode);
+    U_ASSERT(inBounds(source, index));
+
+    // Body must be either a pattern or selectors
+    switch (source[index]) {
+    case LEFT_CURLY_BRACE: {
+        // Pattern
+        parsePattern(source, index, parseError, errorCode);
+        break;
+    }
+    case ID_MATCH[0]: {
+        parseSelectors(source, index, parseError, errorCode);
+        // Selectors
+        break;
+    }
+    default: {
+        ERROR(parseError, errorCode, index);
+        break;
+    }
+    }
+}
+
+// -------------------------------------
+// The copy constructor currently does nothing, since a `MessageFormat`
+// object has no state.
+
+MessageFormat2::MessageFormat2(const MessageFormat2 &) {}
+
+// -------------------------------------
+// Creates a copy of this MessageFormat2; the caller owns the copy.
+
+MessageFormat2 *MessageFormat2::clone() const { return new MessageFormat2(*this); }
+
+// Not yet implemented
+bool MessageFormat2::operator==(const Format &other) const { return (this == &other); }
+// Not yet implemented
+bool MessageFormat2::operator!=(const Format &other) const { return (this != &other); }
+
+// Not yet implemented
+UnicodeString &MessageFormat2::format(const Formattable &, UnicodeString &appendTo, FieldPosition &,
+                                      UErrorCode &status) const {
+    status = U_UNSUPPORTED_ERROR;
+    return appendTo;
+}
+
+// Not yet implemented
+void MessageFormat2::parseObject(const UnicodeString &, Formattable &, ParsePosition &status) const {
+    status = U_UNSUPPORTED_ERROR;
+}
+
+// -------------------------------------
+// Parses (currently: validates) the source pattern.
+// Building a data model is not yet implemented.
+void MessageFormat2::parse(const UnicodeString &source,
+                           UParseError &parseError,
+                           UErrorCode &errorCode) const {
+    // Return immediately in the case of a previous error
+    CHECK_ERROR(errorCode);
+
+    uint32_t index = 0;
+
+    // Create a `MessageParseError` whose relevant fields will be copied
+    // into the `UParseError` on exit
+    MessageParseError messageParseError = INITIAL_MESSAGE_PARSE_ERROR;
+
+    // parseOptionalWhitespace() succeeds on an empty string, so don't check bounds yet
+    parseOptionalWhitespace(source, index, messageParseError, errorCode);
+    // parseDeclarations() requires there to be input left, so check to see if
+    // parseOptionalWhitespace() consumed it all
+    // Skip the check if errorCode is already set, so as to avoid overwriting a
+    // previous error offset
+    if (U_SUCCESS(errorCode) && !inBounds(source, index)) {
+        ERROR(messageParseError, errorCode, index);
+    }
+    parseDeclarations(source, index, messageParseError, errorCode);
+    parseBody(source, index, messageParseError, errorCode);
+    parseOptionalWhitespace(source, index, messageParseError, errorCode);
+
+    // There are no errors; finally, check that the entire input was consumed
+    // Skip the check if errorCode is already set, so as to avoid overwriting a
+    // previous error offset
+    if (U_SUCCESS(errorCode) && ((int32_t)index) != source.length()) {
+        ERROR(messageParseError, errorCode, index);
+    }
+
+    // Finally, copy the relevant fields of the `MessageParseError` into the `UParseError`
+    translateParseError(messageParseError, parseError);
+}
+} // namespace message2
+U_NAMESPACE_END
+
+#endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/i18n/sources.txt
+++ b/icu4c/source/i18n/sources.txt
@@ -94,6 +94,7 @@ measunit.cpp
 measunit_extra.cpp
 measure.cpp
 msgfmt.cpp
+messageformat2.cpp
 name2uni.cpp
 nfrs.cpp
 nfrule.cpp

--- a/icu4c/source/i18n/unicode/messageformat2.h
+++ b/icu4c/source/i18n/unicode/messageformat2.h
@@ -1,0 +1,139 @@
+// © 2016 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+
+#ifndef U_HIDE_DEPRECATED_API
+
+#ifndef MESSAGEFORMAT2_H
+#define MESSAGEFORMAT2_H
+
+#if U_SHOW_CPLUSPLUS_API
+
+/**
+ * \file
+ * \brief C++ API: Formats messages in a language-neutral way using the draft MessageFormat 2.0.
+ */
+
+#if !UCONFIG_NO_FORMATTING
+
+#include "unicode/format.h"
+#include "unicode/parseerr.h"
+#include "unicode/unistr.h"
+#include "unicode/utypes.h"
+
+U_NAMESPACE_BEGIN namespace message2 {
+
+/**
+ * <p>MessageFormat2 is a Technical Preview API implementing MessageFormat 2.0.
+ * Since it is not final, documentation has not yet been added everywhere.
+ *
+ * <p>See <a target="github" href="https://github.com/unicode-org/message-format-wg/blob/main/spec/syntax.md">the
+ * description of the syntax with examples and use cases</a> and the corresponding
+ * <a target="github" href="https://github.com/unicode-org/message-format-wg/blob/main/spec/message.abnf">ABNF</a> grammar.</p>
+ *
+ * @internal ICU 74.0 technology preview
+ * @deprecated This API is for technology preview only.
+ */
+
+class U_I18N_API MessageFormat2 : public Format {
+  public:
+    /**
+     * Constructs a new MessageFormat2 using the given pattern and the
+     * default locale.
+     *
+     * @param pattern   Pattern used to construct object.
+     * @param parseError Struct to receive information on the position
+     *                   of an error within the pattern.
+     * @param status    Input/output error code.  If the
+     *                  pattern cannot be parsed, set to failure code.
+     *
+     * @internal ICU 74.0 technology preview
+     * @deprecated This API is for technology preview only.
+     */
+    MessageFormat2(const UnicodeString &pattern, UParseError &parseError, UErrorCode &status);
+
+    /**
+     * Destructor.
+     *
+     * @internal ICU 74.0 technology preview
+     * @deprecated This API is for technology preview only.
+     */
+    virtual ~MessageFormat2();
+
+    // Not yet implemented
+    virtual bool operator==(const Format &other) const override;
+    // Not yet implemented
+    virtual bool operator!=(const Format &other) const;
+
+    // Not yet implemented
+    virtual UnicodeString &format(const Formattable &obj, UnicodeString &appendTo, FieldPosition &pos,
+                                  UErrorCode &status) const override;
+
+    // Not yet implemented
+    virtual void parseObject(const UnicodeString &source, Formattable &result,
+                             ParsePosition &pos) const override;
+
+    /**
+     * Clones this Format object polymorphically.  The caller owns the
+     * result and should delete it when done.
+     *
+     * @internal ICU 74.0 technology preview
+     * @deprecated This API is for technology preview only.
+     */
+
+    virtual MessageFormat2 *clone() const override;
+
+    /**
+     * Constructs a new MessageFormat2 from an existing one.
+     *
+     * @internal ICU 74.0 technology preview
+     * @deprecated This API is for technology preview only.
+     */
+    MessageFormat2(const MessageFormat2 &);
+
+    /**
+     * Returns a unique class ID POLYMORPHICALLY.  Pure virtual override.
+     * This method is to implement a simple version of RTTI, since not all
+     * C++ compilers support genuine RTTI.  Polymorphic operator==() and
+     * clone() methods call this method.
+     *
+     *
+     * @internal ICU 74.0 technology preview
+     * @deprecated This API is for technology preview only.
+     */
+    virtual UClassID getDynamicClassID(void) const override;
+
+    /**
+     * Return the class ID for this class.  This is useful only for
+     * comparing to a return value from getDynamicClassID().  For example:
+     * <pre>
+     * .   Base* polymorphic_pointer = createPolymorphicObject();
+     * .   if (polymorphic_pointer->getDynamicClassID() ==
+     * .      Derived::getStaticClassID()) ...
+     * </pre>
+     *
+     * @internal ICU 74.0 technology preview
+     * @deprecated This API is for technology preview only.
+     */
+    static UClassID U_EXPORT2 getStaticClassID(void);
+
+  private:
+    MessageFormat2() = delete; // default constructor not implemented
+
+    // Do not define default assignment operator
+    const MessageFormat2 &operator=(const MessageFormat2 &) = delete;
+
+    // The parser currently just validates the message
+    void parse(const UnicodeString &, UParseError &, UErrorCode &) const;
+}; // class MessageFormat2
+
+} // namespace message2
+U_NAMESPACE_END
+
+#endif /* #if !UCONFIG_NO_FORMATTING */
+
+#endif /* U_SHOW_CPLUSPLUS_API */
+
+#endif // MESSAGEFORMAT2_H
+
+#endif // U_HIDE_DEPRECATED_API
+// eof

--- a/icu4c/source/test/intltest/Makefile.in
+++ b/icu4c/source/test/intltest/Makefile.in
@@ -45,7 +45,7 @@ fldset.o dadrfmt.o dadrcal.o dcfmapts.o decoll.o dtfmapts.o dtfmrgts.o dtfmtrtts
 dtptngts.o encoll.o escoll.o ficoll.o frcoll.o g7coll.o intltest.o	\
 itercoll.o itformat.o itmajor.o itutil.o jacoll.o lcukocol.o	\
 loctest.o localebuildertest.o localematchertest.o \
-miscdtfm.o mnkytst.o msfmrgts.o nmfmapts.o nmfmtrt.o		\
+messageformat2test.o miscdtfm.o mnkytst.o msfmrgts.o nmfmapts.o nmfmtrt.o		\
 numfmtst.o numrgts.o  plurults.o plurfmts.o pptest.o regcoll.o restest.o restsnew.o \
 sdtfmtts.o svccoll.o tchcfmt.o	selfmts.o \
 tfsmalls.o tmsgfmt.o trcoll.o tscoll.o tsdate.o tsdcfmsy.o tsdtfmsy.o	\

--- a/icu4c/source/test/intltest/itformat.cpp
+++ b/icu4c/source/test/intltest/itformat.cpp
@@ -33,6 +33,7 @@
 #include "dtfmapts.h"       // DateFormatAPI
 #include "dtfmttst.h"       // DateFormatTest
 #include "tmsgfmt.h"        // TestMessageFormat
+#include "messageformat2test.h" // TestMessageFormat2
 #include "dtfmrgts.h"       // DateFormatRegressionTest
 #include "msfmrgts.h"       // MessageFormatRegressionTest
 #include "miscdtfm.h"       // DateFormatMiscTests
@@ -287,6 +288,7 @@ void IntlTestFormat::runIndexedTest( int32_t index, UBool exec, const char* &nam
             callTest(*test, par);
           }
           break;
+        TESTCLASS(60,TestMessageFormat2);
         default: name = ""; break; //needed to end loop
     }
     if (exec) {

--- a/icu4c/source/test/intltest/messageformat2test.cpp
+++ b/icu4c/source/test/intltest/messageformat2test.cpp
@@ -1,0 +1,560 @@
+// © 2016 and later: Unicode, Inc. and others.
+
+#include "unicode/utypes.h"
+
+#if !UCONFIG_NO_FORMATTING
+
+#include "unicode/messageformat2.h"
+#include "messageformat2test.h"
+
+using namespace icu::message2;
+
+/*
+Tests reflect the syntax specified in
+
+  https://github.com/unicode-org/message-format-wg/commits/main/spec/message.abnf
+
+as of the following commit from 2023-05-09:
+  https://github.com/unicode-org/message-format-wg/commit/194f6efcec5bf396df36a19bd6fa78d1fa2e0867
+
+   Since the MessageFormat2 "parser" is currently only a validator,
+   the following tests only verify that valid messages are validated by the parser
+   and that invalid messages are rejected with an error reflecting the correct line number
+   and offset for the unexpected character.
+*/
+
+// These tests are from the icu4j test suite under icu4j/main/tests/core/src/com/ibm/icu/dev/test/message2/
+UnicodeString validTestCases[] = {
+    // From Mf2IcuTest.java
+    "{There are {$count} files on {$where}}",
+    "{At {$when :datetime timestyle=default} on {$when :datetime datestyle=default}, \
+      there was {$what} on planet {$planet :number kind=integer}.}",
+    "{The disk \"{$diskName}\" contains {$fileCount} file(s).}",
+    "match {$userGender :select}\n\
+     when female {{$userName} est all\u00E9e \u00E0 Paris.} \
+     when  *     {{$userName} est all\u00E9 \u00E0 Paris.}",
+    "{{$when :datetime skeleton=MMMMd}}",
+    // Edited this from testMessageFormatDateTimeSkeleton() -- nmtokens can't contain spaces
+    "{{$when :datetime skeleton=|(   yMMMMd   )|}}",
+    "{Expiration: {$when :datetime skeleton=yMMM}!}",
+    "{Hello {$user}, today is {$today :datetime datestyle=long}.}",
+    // Edited this from testMessageFormatDateTimeSkeleton() -- nmtokens can't contain parentheses or single quotation marks
+    "{{$when :datetime pattern=|('::'yMMMMd)|}}",
+    // From CustomFormatterMessageRefTest.java
+    "match {$gcase :select} when genitive {Firefoxin} when * {Firefox}",
+    // From CustomFormatterPersonTest.java
+    "{Hello {$name :person formality=formal length=medium}}",
+    0
+};
+
+/*
+  These tests are mostly from the test suite created for the JavaScript implementation of MessageFormat v2:
+  <p>Original JSON file
+  <a href="https://github.com/messageformat/messageformat/blob/master/packages/mf2-messageformat/src/__fixtures/test-messages.json">here</a>.</p>
+  Some have been modified or added to reflect syntax changes that post-date the JSON file.
+
+ */
+UnicodeString jsonTestCasesValid[] = {
+    "{hello}",
+    "{hello {|world|}}",
+    "{hello {||}}",
+    "{hello {$place}}",
+    "{{$one} and {$two}}",
+    "{{$one} et {$two}}",
+    "{hello {|4.2| :number}}",
+    "{hello {|foo| :number}}",
+    "{hello {|foo| :number   }}",
+    "{hello {:number}}",
+    "{hello {|4.2| :number minimumFractionDigits=2}}",
+    "{hello {|4.2| :number minimumFractionDigits = 2}}",
+    "{hello {|4.2| :number minimumFractionDigits= 2}}",
+    "{hello {|4.2| :number minimumFractionDigits =2}}",
+    "{hello {|4.2| :number minimumFractionDigits=2  }}",
+    "{hello {|4.2| :number minimumFractionDigits=2 bar=3}}",
+    "{hello {|4.2| :number minimumFractionDigits=2 bar=3  }}",
+    "{hello {|4.2| :number minimumFractionDigits=|2|}}",
+    "{hello {|4.2| :number minimumFractionDigits=$foo}}",
+    "let $foo = {|bar|} {bar {$foo}}",
+    "let $foo = {$bar} {bar {$foo}}",
+    "let $foo = {$bar :number} {bar {$foo}}",
+    "let $foo = {$bar :number minimumFractionDigits=2} {bar {$foo}}",
+    "let $foo = {$bar :number minimumFractionDigits=foo} {bar {$foo}}",
+    "let $foo = {$bar :number} {bar {$foo}}",
+    "let $foo = {$bar} let $bar = {$baz} {bar {$foo}}",
+    "match {$foo} when |1| {one} when * {other}",
+    "match {$foo :select} when |1| {one} when * {other}",
+    "match {$foo :plural} when 1 {one} when * {other}",
+    "match {$foo} when 1 {one} when * {other}",
+    "match {$foo :plural} when 1 {one} when * {other}",
+    "match {$foo} when one {one} when * {other}",
+    "match {$foo :plural} when one {one} when * {other}",
+    "match {$foo} when 1 {=1} when one {one} when * {other}",
+    "match {$foo :plural} when 1 {=1} when one {one} when * {other}",
+    "match {$foo} when one {one} when 1 {=1} when * {other}",
+    "match {$foo :plural} when one {one} when 1 {=1} when * {other}",
+    "match {$foo} {$bar} when one one {one one} when one * {one other} when * * {other}",
+    "match {$foo :plural} {$bar :plural} when one one {one one} when one * {one other} when * * {other}",
+    "let $foo = {$bar} match {$foo} when one {one} when * {other}",
+    "let $foo = {$bar} match {$foo :plural} when one {one} when * {other}",
+    "let $foo = {$bar} match {$foo} when one {one} when * {other}",
+    "let $foo = {$bar} match {$foo :plural} when one {one} when * {other}",
+    "let $bar = {$none} match {$foo} when one {one} when * {{$bar}}",
+    "let $bar = {$none} match {$foo :plural} when one {one} when * {{$bar}}",
+    "let $bar = {$none} match {$foo} when one {one} when * {{$bar}}",
+    "let $bar = {$none :plural} match {$foo} when one {one} when * {{$bar}}",
+    "{{+tag}}", // Modified next few patterns to reflect lack of special markup syntax
+    "{{-tag}}",
+    // Modified next few patterns to reflect lack of special markup syntax
+    "match {+foo} when * {foo}",
+    "{{|content| +tag}}",
+    "{{|content| -tag}}",
+    "{{|content| +tag} {|content| -tag}}",
+    "{content -tag}",
+    "{{+tag foo=bar}}",
+    "{{+tag foo=|foo| bar=$bar}}",
+    "{{-tag foo=bar}}",
+    "{content {|foo| +markup}}",
+    "match {$foo} when * * {foo}", // Semantic error but syntactically correct
+    "{}",
+    // tests for reserved syntax
+    "{hello {|4.2| @number}}",
+    "{hello {|4.2| @n|um|ber}}",
+    "{hello {|4.2| &num|be|r}}",
+    "{hello {|4.2| ?num|be||r|s}}",
+    "{hello {|foo| !number}}",
+    "{hello {|foo| *number}}",
+    "{hello {#number}}",
+    "match {$foo !select} when |1| {one} when * {other}",
+    "match {$foo ^select} when |1| {one} when * {other}",
+    "{{<tag}}",
+    "let $bar = {$none ~plural} match {$foo} when * {{$bar}}",
+    // tests for reserved syntax with escaped chars
+    "{hello {|4.2| @num\\\\ber}}",
+    "{hello {|4.2| @num\\{be\\|r}}",
+    "{hello {|4.2| @num\\\\\\}ber}}",
+    // tests for reserved syntax
+    "{hello {|4.2| @}}",
+    "{hello {|4.2| #}}",
+    "{hello {|4.2| *}}",
+    "{hello {|4.2| ^abc|123||5|\\\\}}",
+    "{hello {|4.2| ^ abc|123||5|\\\\}}",
+    "{hello {|4.2| ^ abc|123||5|\\\\ \\|def |3.14||2|}}",
+    // tests for reserved syntax with trailing whitespace
+    "{hello {|4.2| ? }}",
+    "{hello {|4.2| @xyzz }}",
+    "{hello {|4.2| !xyzz   }}",
+    "{hello {$foo ~xyzz }}",
+    "{hello {$x   <xyzz   }}",
+    "{{@xyzz }}",
+    "{{  !xyzz   }}",
+    "{{~xyzz }}",
+    "{{ <xyzz   }}",
+    // tests for reserved syntax with space-separated sequences
+    "{hello {|4.2| @xy z z }}",
+    "{hello {|4.2| *num \\\\ b er}}",
+    "{hello {|4.2| %num \\\\ b |3.14| r    }}",
+    "{hello {|4.2|    #num xx \\\\ b |3.14| r  }}",
+    "{hello {$foo    #num x \\\\ abcde |3.14| r  }}",
+    "{hello {$foo    >num x \\\\ abcde |aaa||3.14||42| r  }}",
+    "{hello {$foo    >num x \\\\ abcde |aaa||3.14| |42| r  }}",
+    // tests for escape sequences in literals
+    "{{|hel\\\\lo|}}",
+    "{{|hel\\|lo|}}",
+    "{{|hel\\|\\\\lo|}}",
+    // tests for text escape sequences
+    "{hel\\{lo}",
+    "{hel\\}lo}",
+    "{hel\\\\lo}",
+    "{hel\\{\\\\lo}",
+    "{hel\\{\\}lo}",
+    // tests for ':' in nmtokens
+    "match {$foo} when o:ne {one} when * {other}",
+    "match {$foo} when one: {one} when * {other}",
+    "let $foo = {$bar :fun option=a:b} {bar {$foo}}",
+    "let $foo = {$bar :fun option=a:b:c} {bar {$foo}}",
+    "let $foo = {$bar} match {$foo} when :one {one} when * {other}",
+    "let $foo = {$bar :fun option=:a} {bar {$foo}}",
+    // tests for newlines in literals and text
+    "{hello {|wo\nrld|}}",
+    "{hello wo\nrld}",
+    // multiple scrutinees, with or without whitespace
+    "match {$foo} {$bar} when one * {one} when * * {other}",
+    "match {$foo} {$bar}when one * {one} when * * {other}",
+    "match {$foo}{$bar} when one * {one} when * * {other}",
+    "match {$foo}{$bar}when one * {one} when * * {other}",
+    "match{$foo} {$bar} when one * {one} when * * {other}",
+    "match{$foo} {$bar}when one * {one} when * * {other}",
+    "match{$foo}{$bar} when one * {one} when * * {other}",
+    "match{$foo}{$bar}when one * {one} when * * {other}",
+    // multiple variants, with or without whitespace
+    "match {$foo} {$bar} when one * {one} when * * {other}",
+    "match {$foo} {$bar} when one * {one}when * * {other}",
+    "match {$foo} {$bar}when one * {one} when * * {other}",
+    "match {$foo} {$bar}when one * {one}when * * {other}",
+    // one or multiple keys, with or without whitespace before pattern
+    "match {$foo} {$bar} when one{one}",
+    "match {$foo} {$bar} when one {one}",
+    "match {$foo} {$bar} when one  {one}",
+    "match {$foo} {$bar} when one *{one}",
+    "match {$foo} {$bar} when one * {one}",
+    "match {$foo} {$bar} when one *  {one}",
+    // zero, one or multiple options, with or without whitespace before '}'
+    "{{:foo}}",
+    "{{:foo }}",
+    "{{:foo   }}",
+    "{{:foo k=v}}",
+    "{{:foo k=v   }}",
+    "{{:foo k1=v1   k2=v2}}",
+    "{{:foo k1=v1   k2=v2   }}",
+    // literals or variables followed by space, with or without an annotation following
+    "{{|3.14| }}",
+    "{{|3.14|    }}",
+    "{{|3.14|    :foo}}",
+    "{{|3.14|    :foo   }}",
+    "{{$bar }}",
+    "{{$bar    }}",
+    "{{$bar    :foo}}",
+    "{{$bar    :foo   }}",
+    // Trailing whitespace at end of message should be accepted
+    "match {$foo} {$bar} when one * {one} when * * {other}   ",
+    "{hi} ",
+    // Variable names can contain '-' or ':'
+    "{{$bar:foo}}",
+    "{{$bar-foo}}",
+    0
+};
+
+// From CustomFormatterPersonTest.java
+UnicodeString complexMessage = "\
+    let $hostName = {$host :person length=long}\n\
+    let $guestName = {$guest :person length=long}\n\
+    let $guestsOther = {$guestCount :number offset=1}\n\
+    \n\
+    match {$hostGender :gender} {$guestCount :plural}\n\
+    when female 0 {{$hostName} does not give a party.}\n\
+    when female 1 {{$hostName} invites {$guestName} to her party.}\n\
+    when female 2 {{$hostName} invites {$guestName} and one other person to her party.}\n\
+    when female * {{$hostName} invites {$guestName} and {$guestsOther} other people to her party.}\n\
+    \n\
+    when male 0 {{$hostName} does not give a party.}\n\
+    when male 1 {{$hostName} invites {$guestName} to his party.}\n\
+    when male 2 {{$hostName} invites {$guestName} and one other person to his party.}\n\
+    when male * {{$hostName} invites {$guestName} and {$guestsOther} other people to his party.}\n\
+    \n\
+    when * 0 {{$hostName} does not give a party.}\n\
+    when * 1 {{$hostName} invites {$guestName} to their party.}\n\
+    when * 2 {{$hostName} invites {$guestName} and one other person to their party.}\n\
+    when * * {{$hostName} invites {$guestName} and {$guestsOther} other people to their party.}\n";
+
+void
+TestMessageFormat2::runIndexedTest(int32_t index, UBool exec,
+                                  const char* &name, char* /*par*/) {
+    TESTCASE_AUTO_BEGIN;
+    TESTCASE_AUTO(testInvalidPatterns);
+    TESTCASE_AUTO(testValidJsonPatterns);
+    TESTCASE_AUTO(testValidPatterns);
+    TESTCASE_AUTO(testComplexMessage);
+    TESTCASE_AUTO_END;
+}
+
+/*
+ Tests a single pattern, which is expected to be valid.
+
+ `s`: The pattern string.
+ `i`: Test number (only used for diagnostic output)
+ `testName`: String describing the test (only used for diagnostic output)
+*/
+void
+TestMessageFormat2::testPattern(const UnicodeString& s, uint32_t i, const char* testName) {
+    UParseError parseError;
+    IcuTestErrorCode errorCode(*this, testName);
+
+    MessageFormat2(s, parseError, errorCode);
+
+    if (U_FAILURE(errorCode)) {
+        dataerrln(s);
+        dataerrln("TestMessageFormat2::%s #%d - %s", testName, i, u_errorName(errorCode));
+        dataerrln("TestMessageFormat2::%s #%d - %d %d", testName, i, parseError.line, parseError.offset);
+        logln(UnicodeString("TestMessageFormat2::" + UnicodeString(testName) + " failed test #") + ((int32_t) i) + UnicodeString(" with error code ")+(int32_t)errorCode);
+    }
+}
+
+/*
+ Tests a fixed-size array of patterns, which are expected to be valid.
+
+ `patterns`: The patterns.
+ `testName`: String describing the test (only used for diagnostic output)
+*/
+template<size_t N>
+void TestMessageFormat2::testPatterns(const UnicodeString (&patterns)[N], const char* testName) {
+    for (uint32_t i = 0; i < N - 1; i++) {
+        testPattern(patterns[i], i, testName);
+    }
+}
+
+void TestMessageFormat2::testValidPatterns() {
+    testPatterns(validTestCases, "testValidPatterns");
+}
+
+void TestMessageFormat2::testValidJsonPatterns() {
+    testPatterns(jsonTestCasesValid, "testValidJsonPatterns");
+}
+
+/*
+ Tests a single pattern, which is expected to be invalid.
+
+ `testNum`: Test number (only used for diagnostic output)
+ `s`: The pattern string.
+
+ The error is assumed to be on line 0, offset `s.length()`.
+*/
+void TestMessageFormat2::testInvalidPattern(uint32_t testNum, const UnicodeString& s) {
+    testInvalidPattern(testNum, s, s.length(), 0);
+}
+
+/*
+ Tests a single pattern, which is expected to be invalid.
+
+ `testNum`: Test number (only used for diagnostic output)
+ `s`: The pattern string.
+
+ The error is assumed to be on line 0, offset `expectedErrorOffset`.
+*/
+void TestMessageFormat2::testInvalidPattern(uint32_t testNum, const UnicodeString& s, uint32_t expectedErrorOffset) {
+    testInvalidPattern(testNum, s, expectedErrorOffset, 0);
+}
+
+/*
+ Tests a single pattern, which is expected to be invalid.
+
+ `testNum`: Test number (only used for diagnostic output)
+ `s`: The pattern string.
+ `expectedErrorOffset`: The expected character offset for the parse error.
+
+ The error is assumed to be on line `expectedErrorLine`, offset `expectedErrorOffset`.
+*/
+void TestMessageFormat2::testInvalidPattern(uint32_t testNum, const UnicodeString& s, uint32_t expectedErrorOffset, uint32_t expectedErrorLine) {
+    UParseError parseError;
+    IcuTestErrorCode errorCode(*this, "testInvalidPattern");
+
+    MessageFormat2(s, parseError, errorCode);
+    if (!U_FAILURE(errorCode)) {
+        dataerrln("TestMessageFormat2::testInvalidPattern #%d - expected test to fail, but it passed", testNum);
+        logln(UnicodeString("TestMessageFormat2::testInvalidPattern failed test ") + s + UnicodeString(" with error code ")+(int32_t)errorCode);
+        return;
+    } else {
+        // Check the line and character numbers
+        if (parseError.line != ((int32_t) expectedErrorLine) || parseError.offset != ((int32_t) expectedErrorOffset)) {
+            dataerrln("TestMessageFormat2::testInvalidPattern #%d - wrong line or character offset in parse error; expected (line %d, offset %d), got (line %d, offset %d)",
+                      testNum, expectedErrorLine, expectedErrorOffset, parseError.line, parseError.offset);
+            logln(UnicodeString("TestMessageFormat2::testInvalidPattern failed #") + ((int32_t) testNum) + UnicodeString(" with error code ")+(int32_t)errorCode+" by returning the wrong line number or offset in the parse error");
+        } else {
+            errorCode.reset();
+        }
+    }
+}
+
+void TestMessageFormat2::testInvalidPatterns() {
+/*
+  These tests are mostly from the test suite created for the JavaScript implementation of MessageFormat v2:
+  <p>Original JSON file
+  <a href="https://github.com/messageformat/messageformat/blob/master/packages/mf2-messageformat/src/__fixtures/test-messages.json">here</a>.</p>
+  Some have been modified or added to reflect syntax changes that post-date the JSON file.
+
+ */
+    uint32_t i = 0;
+
+    // Unexpected end of input
+    testInvalidPattern(++i, "let    ");
+    testInvalidPattern(++i, "le");
+    testInvalidPattern(++i, "let $foo");
+    testInvalidPattern(++i, "let $foo =    ");
+    testInvalidPattern(++i, "{{:fszzz");
+    testInvalidPattern(++i, "{{:fszzz   ");
+    testInvalidPattern(++i, "match {$foo} when |xyz");
+    testInvalidPattern(++i, "{{:f aaa");
+    testInvalidPattern(++i, "{missing end brace");
+    testInvalidPattern(++i, "{missing end {$brace");
+
+    // Error should be reported at character 0, not end of input
+    testInvalidPattern(++i, "}{|xyz|", 0);
+    testInvalidPattern(++i, "}", 0);
+
+    // @xyz is a valid annotation (`reserved`) so the error should be at the end of input
+    testInvalidPattern(++i, "{{@xyz");
+    // Backslash followed by non-backslash followed by a '{' -- this should be an error
+    // immediately after the first backslash
+    testInvalidPattern(++i, "{{@\\y{}}", 4);
+
+    // Reserved chars followed by a '|' that doesn't begin a valid literal -- this should be
+    // an error at the first invalid char in the literal
+    testInvalidPattern(++i, "{{@abc|\\z}}", 8);
+
+    // Same pattern, but with a valid reserved-char following the erroneous reserved-escape
+    // -- the offset should be the same as with the previous one
+    testInvalidPattern(++i, "{{@\\y{p}}", 4);
+    // Erroneous literal inside a reserved string -- the error should be at the first
+    // erroneous literal char
+    testInvalidPattern(++i, "{{@ab|\\z|cd}}", 7);
+
+    // tests for reserved syntax with bad escaped chars
+    // Single backslash - not allowed
+    testInvalidPattern(++i, "{hello {|4.2| @num\\ber}}", 19);
+    // Unescaped '{' -- not allowed
+    testInvalidPattern(++i, "{hello {|4.2| @num{be\\|r}}", 18);
+    // Unescaped '}' -- will be interpreted as the end of the reserved
+    // string, and the error will be reported at the index of '|', which is
+    // when the parser determines that "\|" isn't a valid text-escape
+    testInvalidPattern(++i, "{hello {|4.2| @num}be\\|r}}", 22);
+    // Unescaped '|' -- will be interpreted as the beginning of a literal
+    // Error at end of input
+    testInvalidPattern(++i, "{hello {|4.2| @num\\{be|r}}", 26);
+
+    // Invalid escape sequence in a `text` -- the error should be at the character
+    // following the backslash
+    testInvalidPattern(++i, "{a\\qbc", 3);
+
+    // Missing space after `when` -- the error should be immediately after the
+    // `when` (not the error in the pattern)
+    testInvalidPattern(++i, "match {|y|} when|y| {|||}", 16);
+
+    // Missing spaces betwen keys in `when`-clause
+    testInvalidPattern(++i, "match {|y|} when |foo|bar {a}", 22);
+    testInvalidPattern(++i, "match {|y|} when |quux| |foo|bar {a}", 29);
+    testInvalidPattern(++i, "match {|y|} when |quux| |foo||bar| {a}", 29);
+
+    // Error parsing the first key -- the error should be there, not in the
+    // also-erroneous third key
+    testInvalidPattern(++i, "match {|y|} when |\\q| * @{! {z}", 19);
+
+    // Error parsing the second key -- the error should be there, not in the
+    // also-erroneous third key
+    testInvalidPattern(++i, "match {|y|} when * @{! {z} |\\q|", 19);
+
+    // Error parsing the last key -- the error should be there, not in the erroneous
+    // pattern
+    testInvalidPattern(++i, "match {|y|} when * |\\q| {\\z}", 21);
+
+    // Selectors not starting with `match` -- error should be on character 1,
+    // not the later erroneous key
+    testInvalidPattern(++i, "m {|y|} when @{! {z}", 1);
+
+    // Non-expression as scrutinee in pattern -- error should be at the first
+    // non-expression, not the later non-expression
+    testInvalidPattern(++i, "match {|y|} {abc} {$} when * * * {a}", 13);
+
+    // Non-key in variant -- error should be there, not in the next erroneous
+    // variant
+    testInvalidPattern(++i, "match {|y|} when $foo * {a} when * :bar {b}", 17);
+
+
+    // Error should be within the first erroneous `text` or expression
+    testInvalidPattern(++i, "{ foo {|bar|} \\q baz  ", 15);
+
+    // ':' has to be followed by a function name -- the error should be at the first
+    // whitespace character
+    testInvalidPattern(++i, "{{:    }}", 3);
+
+    // Expression not starting with a '{'
+    testInvalidPattern(++i, "let $x = }|foo|}", 9);
+
+    // Error should be at the first declaration not starting with a `let`
+    testInvalidPattern(++i, "let $x = {|foo|} l $y = {|bar|} let $z {|quux|}", 18);
+
+    // Missing '=' in `let` declaration
+    testInvalidPattern(++i, "let $bar {|foo|} {{$bar}}", 9);
+
+    // LHS of declaration doesn't start with a '$'
+    testInvalidPattern(++i, "let bar = {|foo|} {{$bar}}", 4);
+
+    // `let` RHS isn't an expression
+    testInvalidPattern(++i, "let $bar = |foo| {{$bar}}", 11);
+
+    // Non-expression
+    testInvalidPattern(++i, "no braces", 0);
+    testInvalidPattern(++i, "no braces {$foo}", 0);
+
+    // Trailing characters that are not whitespace
+    testInvalidPattern(++i, "{extra} content", 8);
+    testInvalidPattern(++i, "match {|x|} when * {foo} extra", 25);
+
+    // Empty expression
+    testInvalidPattern(++i, "{empty { }}", 9);
+    testInvalidPattern(++i, "match {} when * {foo}", 7);
+
+    // ':' not preceding a function name
+    testInvalidPattern(++i, "{bad {:}}", 7);
+
+    // 'placeholder' is not a literal, variable or annotation
+    testInvalidPattern(++i, "{bad {placeholder}}", 6);
+
+    // Missing '=' after option name
+    testInvalidPattern(++i, "{no-equal {|42| :number m }}", 26);
+    testInvalidPattern(++i, "{no-equal {|42| :number minimumFractionDigits 2}}", 46);
+    testInvalidPattern(++i, "{bad {:placeholder option value}}", 26);
+
+    // Extra '=' after option value
+    testInvalidPattern(++i, "{hello {|4.2| :number min=2=3}}", 27),
+    testInvalidPattern(++i, "{hello {|4.2| :number min=2max=3}}", 30),
+    // Missing whitespace between valid options
+    testInvalidPattern(++i, "{hello {|4.2| :number min=|a|max=3}}", 29),
+    // Ill-formed RHS of option -- the error should be within the RHS,
+    // not after parsing options
+    testInvalidPattern(++i, "{hello {|4.2| :number min=|\\a|}}", 28),
+
+
+    // Junk after annotation
+    testInvalidPattern(++i, "{no-equal {|42| :number   {}", 26);
+
+    // Missing RHS of option
+    testInvalidPattern(++i, "{bad {:placeholder option=}}", 26);
+    testInvalidPattern(++i, "{bad {:placeholder option}}", 25);
+
+    // Annotation is not a function or reserved text
+    testInvalidPattern(++i, "{bad {$placeholder option}}", 19);
+    testInvalidPattern(++i, "{no {$placeholder end}", 18);
+
+    // Missing whitespace before key in variant
+    testInvalidPattern(++i, "match {|foo|} when*{foo}", 18);
+    // Missing expression in selectors
+    testInvalidPattern(++i, "match when * {foo}", 6);
+    // Non-expression in selectors
+    testInvalidPattern(++i, "match |x| when * {foo}", 6);
+
+    // Missing RHS in variant
+    testInvalidPattern(++i, "match {|x|} when * foo");
+
+    // Text may include newlines; check that the missing closing '}' is
+    // reported on the correct line
+    testInvalidPattern(++i, "{hello wo\nrld", 3, 1);
+    testInvalidPattern(++i, "{hello wo\nr\nl\ndddd", 4, 3);
+    // Offset for end-of-input should be 0 here because the line begins
+    // after the '\n', but there is no character after the '\n'
+    testInvalidPattern(++i, "{hello wo\nr\nl\n", 0, 3);
+
+    // Literals may include newlines; check that the missing closing '|' is
+    // reported on the correct line
+    testInvalidPattern(++i, "{hello {|wo\nrld}", 4, 1);
+    testInvalidPattern(++i, "{hello {|wo\nr\nl\ndddd}", 5, 3);
+    // Offset for end-of-input should be 0 here because the line begins
+    // after the '\n', but there is no character after the '\n'
+    testInvalidPattern(++i, "{hello {|wo\nr\nl\n", 0, 3);
+
+    // Variable names can't start with a : or -
+    testInvalidPattern(++i, "{{$:abc}}", 3);
+    testInvalidPattern(++i, "{{$-abc}}", 3);
+
+    // Missing space before annotation
+    // Note that {{$bar:foo}} and {{$bar-foo}} are valid,
+    // because variable names can contain a ':' or a '-'
+    testInvalidPattern(++i, "{{$bar+foo}}", 6);
+    testInvalidPattern(++i, "{{|3.14|:foo}}", 8);
+    testInvalidPattern(++i, "{{|3.14|-foo}}", 8);
+    testInvalidPattern(++i, "{{|3.14|+foo}}", 8);
+}
+
+void TestMessageFormat2::testComplexMessage() {
+    testPattern(complexMessage, 0, "testComplexMessage");
+}
+
+#endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/test/intltest/messageformat2test.h
+++ b/icu4c/source/test/intltest/messageformat2test.h
@@ -1,0 +1,44 @@
+// © 2016 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+
+#ifndef _TESTMESSAGEFORMAT2
+#define _TESTMESSAGEFORMAT2
+
+#include "unicode/rep.h"
+#include "unicode/utypes.h"
+
+#if !UCONFIG_NO_FORMATTING
+
+#include "unicode/unistr.h"
+#include "unicode/fmtable.h"
+#include "unicode/parseerr.h"
+#include "intltest.h"
+
+/**
+ * TestMessageFormat2 tests MessageFormat2
+ */
+class TestMessageFormat2: public IntlTest {
+public:
+    void runIndexedTest( int32_t index, UBool exec, const char* &name, char* par = NULL ) override;
+
+    /** 
+     * test MessageFormat2 with various given patterns
+     **/
+    void testStaticFormat2(void);
+    void testComplexMessage(void);
+    void testValidPatterns(void);
+    void testValidJsonPatterns(void);
+    void testInvalidPatterns(void);
+
+private:
+    void testPattern(const UnicodeString&, uint32_t, const char*);
+    template<size_t N>
+    void testPatterns(const UnicodeString(&) [N], const char*);
+    void testInvalidPattern(uint32_t, const UnicodeString&);
+    void testInvalidPattern(uint32_t, const UnicodeString&, uint32_t);
+    void testInvalidPattern(uint32_t, const UnicodeString&, uint32_t, uint32_t);
+};
+
+#endif /* #if !UCONFIG_NO_FORMATTING */
+
+#endif


### PR DESCRIPTION
This commit does not implement the full MessageFormat2 spec; rather, as an incremental step, it adds a MessageFormat2 class with a `parse()` method that validates the input message. Building the data model and implementing formatting are left for future work.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22261
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
