### PR TITLE
ICU-22322 Revert extra parallelism for data-filter test in .azure-pipelines.yml

### DIFF
--- a/.ci-builds/.azure-pipelines.yml
+++ b/.ci-builds/.azure-pipelines.yml
@@ -54,10 +54,13 @@ jobs:
     - checkout: self
       lfs: true
       fetchDepth: 10
+    # Note: This job uses `make -j2` instead of `make -j -l2.5` because with more parallelism (PR #2456)
+    # this check became flaky. The build apparently was not done copying one or another .ucm file before
+    # calling makeconv for it, although the Makefile has appropriate dependencies.
     - script: |
         cd icu4c/source && \
         ICU_DATA_FILTER_FILE=../../.ci-builds/data-filter.json ./runConfigureICU Linux && \
-        make -j -l2.5 tests && \
+        make -j2 tests && \
         \[ ! -d data/out/build/icudt66l/translit \] && \
         (cd test/intltest && LD_LIBRARY_PATH=../../lib:../../tools/ctestfw ./intltest translit/TransliteratorTest/TestBasicTransliteratorEvenWithoutData)
       displayName: 'Build with Data Filter'


### PR DESCRIPTION
This reverts the change in e1e1c5feaf67652d9f124b23749a430d3278fe7b for only the data-filter test, which has become flaky since that change landed.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22322
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
