### PR TITLE
ICU-22350 Set minimal workflow token permissions

### DIFF
--- a/.github/workflows/cache_retain.yml
+++ b/.github/workflows/cache_retain.yml
@@ -26,6 +26,9 @@ on:
     # this cron schedule is set to run every 6 days to ensure retention
     - cron: '0 12 */6 * *'
 
+permissions:
+  contents: read
+
 jobs:
   retain-maven-cache:
     name: Run all tests with Maven

--- a/.github/workflows/icu_ci.yml
+++ b/.github/workflows/icu_ci.yml
@@ -13,6 +13,9 @@ on:
   pull_request:
     branches: '**'
 
+permissions:
+  contents: read
+
 jobs:
 
   # ICU4C docs build using doxygen..

--- a/.github/workflows/icu_envtest.yml
+++ b/.github/workflows/icu_envtest.yml
@@ -15,6 +15,9 @@ on:
     # This cron schedule is set to run 10:23 UTC every SAT
     - cron: '23 10 * * SAT'
 
+permissions:
+  contents: read
+
 jobs:
   #=================================================================
   # locale env tests.

--- a/.github/workflows/icu_merge_ci.yml
+++ b/.github/workflows/icu_merge_ci.yml
@@ -11,6 +11,9 @@ on:
       - main	
       - 'maint/maint*'
 
+permissions:
+  contents: read
+
 jobs:
 
   # Test ICU4J with little-endian ICU4C data only

--- a/.github/workflows/icu_valgrind.yml
+++ b/.github/workflows/icu_valgrind.yml
@@ -14,6 +14,9 @@ on:
   pull_request:
     branches: '**'
 
+permissions:
+  contents: read
+
 jobs:
   clang-valgrind-test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -21,11 +21,8 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -67,6 +64,9 @@ jobs:
 
   # Deployment job
   deploy:
+    permissions:
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -2,6 +2,10 @@ name: Publish icu4j.jar/utilities.jar to GH Maven
 on:
   release:
     types: [created]
+
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22350
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

As described in the issue, this PR sets read-only tokens for all workflows. Only the deployment job in `jekyll-gh-pages.yml` workflow receives a few additional permissions it needs.

This protects the project from supply-chain attacks.