### PR TITLE
ICU-22406 Fix test breakage w/ --disabled-shared

### DIFF
--- a/.github/workflows/icu_ci.yml
+++ b/.github/workflows/icu_ci.yml
@@ -250,6 +250,30 @@ jobs:
           cd icu4c/source;
           make dist
 
+  # clang build with some options
+  clang-options-build-and-test:
+    strategy:
+      # "fail-fast: false" lets other jobs keep running even if the test breaks in some other options.
+      fail-fast: false
+      matrix:
+        build_option:
+         - --enable-static
+         - --disable-shared
+         - --enable-static --disable-shared
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build ICU4C with clang
+        run: |
+          cd icu4c/source;
+          ./runConfigureICU Linux ${{ matrix.build_option }};
+          make -j -l2.5 tests;
+      - name: Test
+        run: |
+          cd icu4c/source;
+          make check;
+
   # Out of source build with gcc 10, c++14, and extra warnings; executes icuinfo.
   gcc-10-stdlib14:
     runs-on: ubuntu-latest

--- a/.github/workflows/icu_ci.yml
+++ b/.github/workflows/icu_ci.yml
@@ -257,9 +257,8 @@ jobs:
       fail-fast: false
       matrix:
         build_option:
-         - --enable-static
-         - --disable-shared
-         - --enable-static --disable-shared
+         [ --enable-static, --enable-static --disable-shared ]
+         # --disable-shared has a build problem.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/icu4c/source/python/icutools/databuilder/__main__.py
+++ b/icu4c/source/python/icutools/databuilder/__main__.py
@@ -288,7 +288,7 @@ def main(argv):
             "IN_DIR": "$(srcdir)",
             "INDEX_NAME": "res_index"
         }
-        makefile_env = ["ICUDATA_CHAR", "OUT_DIR", "TMP_DIR"]
+        makefile_env = ["ICUDATA_CHAR", "OUT_DIR", "TMP_DIR", "LIBRARY_DATA_DIR"]
         common = {
             key: "$(%s)" % key
             for key in list(makefile_vars.keys()) + makefile_env
@@ -306,7 +306,8 @@ def main(argv):
             "CWD_DIR": os.getcwd(),
             "INDEX_NAME": "res_index",
             # TODO: Pull this from configure script:
-            "ICUDATA_CHAR": "l"
+            "ICUDATA_CHAR": "l",
+            "LIBRARY_DATA_DIR": os.path.join(args.out_dir, "build"),
         }
 
     # Automatically load BUILDRULES from the src_dir

--- a/icu4c/source/test/testdata/BUILDRULES.py
+++ b/icu4c/source/test/testdata/BUILDRULES.py
@@ -63,7 +63,7 @@ def generate_rb(config, io, common_vars):
             input_files = [InFile("%s.txt" % bn) for bn in basenames],
             output_files = [OutFile("%s.res" % bn) for bn in basenames],
             tool = IcuTool("genrb"),
-            args = "-q -i {OUT_DIR}/../../../../data/out/build -s {IN_DIR} -d {OUT_DIR} {INPUT_FILE}",
+            args = "-q -i {LIBRARY_DATA_DIR} -s {IN_DIR} -d {OUT_DIR} {INPUT_FILE}",
             format_with = {},
             repeat_with = {}
         ),

--- a/icu4c/source/test/testdata/BUILDRULES.py
+++ b/icu4c/source/test/testdata/BUILDRULES.py
@@ -63,7 +63,7 @@ def generate_rb(config, io, common_vars):
             input_files = [InFile("%s.txt" % bn) for bn in basenames],
             output_files = [OutFile("%s.res" % bn) for bn in basenames],
             tool = IcuTool("genrb"),
-            args = "-q -s {IN_DIR} -d {OUT_DIR} {INPUT_FILE}",
+            args = "-q -i {OUT_DIR}/../../../../data/out/build -s {IN_DIR} -d {OUT_DIR} {INPUT_FILE}",
             format_with = {},
             repeat_with = {}
         ),

--- a/icu4c/source/test/testdata/Makefile.in
+++ b/icu4c/source/test/testdata/Makefile.in
@@ -92,6 +92,7 @@ TESTSRCDATADIR=$(top_srcdir)/test/testdata
 TESTOUTDIR=$(top_builddir)/test/testdata/out
 BUILD_DIRS = $(TESTOUTDIR) $(TESTBUILDDIR) $(TESTOUTDIR)/$(TESTDT)
 GENTEST=$(TOOLDIR)/gentest/gentest$(TOOLEXEEXT)
+LIBRARY_DATA_DIR=$(OUTDIR)/build
 
 ifeq ($(PKGDATA_MODE),common)
 ICU_DATA_OPT = -i $(OUTDIR)


### PR DESCRIPTION
1. Added github action to test against build with 
  a. --enable-static, AND
  b. --enable-static --disable-shared
2. Fix the issue which the test/testdata *.res build w/o ucadata.icu by using -i with the build directory..
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22406
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
