### PR TITLE
ICU-22410 Add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives us time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+Please submit the bug report as an [ICU Jira issue](https://icu.unicode.org/bugs).
+Be sure to set "Security level: Sensitive".
+This ensures the report will only be visible to the ICU team.
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is maintained by volunteers on a reasonable-effort basis. As such, we ask
+that you give us 90 days to work on a fix before public exposure.
+
+
+> Copyright © 2023 and later Unicode, Inc. and others. All Rights Reserved.
+Unicode and the Unicode Logo are registered trademarks
+of Unicode, Inc. in the U.S. and other countries.
+[Terms of Use and License](http://www.unicode.org/copyright.html)


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22410
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

As described in the JIRA issue, this PR adds a security policy to the unicode-org/icu repo, simply explaining how to submit a sensitive issue via JIRA.

A similar policy could be created in the unicode-org/.github repo. If created, the policy would be available in all unicode-org repos (unless "overwritten" by a policy in the repo itself). So, for example, creating one in /.github won't modify the one shown here if this PR is merged.