### PR TITLE
ICU-22350 Fix broken performance CI

### DIFF
--- a/.github/workflows/icu_merge_ci.yml
+++ b/.github/workflows/icu_merge_ci.yml
@@ -81,6 +81,10 @@ jobs:
             file: "-f ../../icu4j/perf-tests/data/conversion/xuzhimo.txt"
             flag: "-e gb18030"
 
+    permissions:
+      contents: write
+      deployments: write
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -151,6 +155,10 @@ jobs:
           - perf: normperf
             data: TestNames_Simplified_Chinese
 
+    permissions:
+      contents: write
+      deployments: write
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -212,6 +220,10 @@ jobs:
           - locale: zh
             data: udhr_cmn_hans
 
+    permissions:
+      contents: write
+      deployments: write
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -255,6 +267,10 @@ jobs:
       fail-fast: false
       matrix:
         perf: [UnicodeSetAdd, UnicodeSetContains, UnicodeSetIterate]
+
+    permissions:
+      contents: write
+      deployments: write
 
     runs-on: ubuntu-latest
     steps:
@@ -304,6 +320,10 @@ jobs:
     if: github.repository == 'unicode-org/icu' && github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false
+
+    permissions:
+      contents: write
+      deployments: write
 
     runs-on: ubuntu-latest
     steps:
@@ -355,6 +375,10 @@ jobs:
       matrix:
         perf: [TestICUConstruction, TestICUParse, TestICUFormat]
         locale: [en_US, de_DE]
+
+    permissions:
+      contents: write
+      deployments: write
 
     runs-on: ubuntu-latest
     steps:
@@ -411,6 +435,10 @@ jobs:
         perf: [TestICU_NFD_NFC_Text, TestICU_NFC_NFC_Text, TestICU_NFC_Orig_Text, TestICU_NFD_NFC_Text, TestICU_NFD_NFD_Text, TestICU_NFD_Orig_Text]
         source_text: [TestNames_Asian, TestNames_Chinese, TestNames_SerbianSH]
         mode: [-l]
+
+    permissions:
+      contents: write
+      deployments: write
 
     runs-on: ubuntu-latest
     steps:
@@ -538,6 +566,10 @@ jobs:
             source_text: english
             perf: TestCharsetEncoderICU
 
+    permissions:
+      contents: write
+      deployments: write
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout and setup
@@ -607,6 +639,10 @@ jobs:
           - locale: sw_KE
             parms: '"dddd MMM yyyy" "15 Jan 2007" 1'
             perf: TestICUFormat
+
+    permissions:
+      contents: write
+      deployments: write
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22350
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

This PR fixes an error in #2487 (sorry!) which caused the performance CI to fail.

I hadn't realized that the `gregtatum/github-action-benchmark` required additional permissions. Following its [documentation](https://github.com/benchmark-action/github-action-benchmark#charts-on-github-pages-1), all jobs that call this Action now have `contents` and `deployments: write` permissions.

I'm currently reusing the ICU-22350 bug ID used in #2487. Let me know if you'd rather I use a new ID and I'll edit the commits as needed.