### PR TITLE
ICU-22335 Remove `!!reverse`, `!!safe_reverse` and `!!safe_forward`

### DIFF
--- a/docs/userguide/boundaryanalysis/break-rules.md
+++ b/docs/userguide/boundaryanalysis/break-rules.md
@@ -277,14 +277,6 @@ See, for example, this snippet from the [line break rules](https://github.com/un
 | `!!chain`       |  Enable rule chaining. Default is no chaining. |
 | `!!forward`     |  The rules that follow are for forward iteration. Forward rules are now the only type of rules needed or used.   |
 
-### Deprecated Rule Options
-
-| Deprecated Option          | Description |
-| --------------- | ----------- |
-| ~~`!!reverse`~~     | ~~*[deprecated]* The rules that follow are for reverse iteration. No longer needed; any rules in a Reverse rule section are ignored.~~ |
-| ~~`!!safe_forward`~~ | ~~*[deprecated]* The rules that follow are for safe forward iteration. No longer needed; any rules in such a section are ignored.~~ |
-| ~~`!!safe_reverse`~~ | ~~*[deprecated]* The rules that follow are for safe reverse iteration. No longer needed; any rules in such a section are ignored.~~ |
-
 ## Rule Syntax
 
 Here is the syntax for the boundary rules. (The EBNF Syntax is given below.)
@@ -293,7 +285,7 @@ Here is the syntax for the boundary rules. (The EBNF Syntax is given below.)
 | ---------- | ----------- | ----- |
 | rules | statement+ | |
 | statement | assignment \| rule \| control |
-| control | (`!!forward` \| `!!reverse` \| `!!safe_forward` \| `!!safe_reverse` \| `!!chain`) `;`
+| control | (`!!forward` \| `!!chain`) `;`
 | assignment | variable `=` expr `;` | 5 |
 | rule | `^`? expr (`{`number`}`)? `;` | 8,9 |
 | number | [0-9]+ | 1 |

--- a/icu4c/source/test/intltest/rbbitst.cpp
+++ b/icu4c/source/test/intltest/rbbitst.cpp
@@ -1170,8 +1170,6 @@ end_test:
 void RBBITest::TestDictRules() {
     const char *rules =  "$dictionary = [a-z]; \n"
                          "!!forward; \n"
-                         "$dictionary $dictionary; \n"
-                         "!!reverse; \n"
                          "$dictionary $dictionary; \n";
     const char *text = "aa";
     UErrorCode status = U_ZERO_ERROR;
@@ -4371,7 +4369,7 @@ void RBBITest::TestBug7547() {
 
 
 void RBBITest::TestBug12797() {
-    UnicodeString rules = "!!chain; !!forward; $v=b c; a b; $v; !!reverse; .*;";
+    UnicodeString rules = "!!chain; !!forward; $v=b c; a b; $v; .*;";
     UErrorCode status = U_ZERO_ERROR;
     UParseError parseError;
     RuleBasedBreakIterator bi(rules, parseError, status);

--- a/icu4c/source/test/testdata/rbbitst.txt
+++ b/icu4c/source/test/testdata/rbbitst.txt
@@ -2073,7 +2073,6 @@ Bangkok)•</data>
 <rules>
 !!forward;
     Hello\ World;
-!!safe_reverse;
     .*;
 </rules>
 <data>•Hello World•</data>
@@ -2082,7 +2081,6 @@ Bangkok)•</data>
 !!quoted_literals_only;
 !!forward;
     Hello\ World;
-!!safe_reverse;
     .*;
 </badrules>
 
@@ -2090,7 +2088,6 @@ Bangkok)•</data>
 !!quoted_literals_only;
 !!forward;
     'Hello World';
-!!safe_reverse;
     .*;
 </rules>
 <data>•Hello World•</data>
@@ -2102,7 +2099,6 @@ Bangkok)•</data>
 <rules>
 !!forward;
 .;
-!!safe_reverse;
 .*;
 </rules>
 <data>•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•</data>

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/rbbi/RBBITest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/rbbi/RBBITest.java
@@ -367,7 +367,7 @@ public class RBBITest extends TestFmwk {
 
     @Test
     public void TestBug12797() {
-        String rules = "!!chain; !!forward; $v=b c; a b; $v; !!reverse; .*;";
+        String rules = "!!chain; !!forward; $v=b c; a b; $v; .*;";
         RuleBasedBreakIterator bi = new RuleBasedBreakIterator(rules);
 
         bi.setText("abc");

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/rbbi/rbbitst.txt
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/rbbi/rbbitst.txt
@@ -2073,7 +2073,6 @@ Bangkok)•</data>
 <rules>
 !!forward;
     Hello\ World;
-!!safe_reverse;
     .*;
 </rules>
 <data>•Hello World•</data>
@@ -2082,7 +2081,6 @@ Bangkok)•</data>
 !!quoted_literals_only;
 !!forward;
     Hello\ World;
-!!safe_reverse;
     .*;
 </badrules>
 
@@ -2090,7 +2088,6 @@ Bangkok)•</data>
 !!quoted_literals_only;
 !!forward;
     'Hello World';
-!!safe_reverse;
     .*;
 </rules>
 <data>•Hello World•</data>
@@ -2102,7 +2099,6 @@ Bangkok)•</data>
 <rules>
 !!forward;
 .;
-!!safe_reverse;
 .*;
 </rules>
 <data>•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•a•</data>


### PR DESCRIPTION
`!!reverse`, `!!safe_reverse` and `!!safe_forward` will be deprecated in future versions, we should delete all related code in the code tree.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22335
- [x] Required: The PR title must be prefixed with a JIRA Issue number.
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
