### PR TITLE
ICU-22412 Fix C API ucal_(g|s)etGregorianChange for iso8601 calendar

### DIFF
--- a/icu4c/source/i18n/ucal.cpp
+++ b/icu4c/source/i18n/ucal.cpp
@@ -24,6 +24,7 @@
 #include "unicode/localpointer.h"
 #include "cmemory.h"
 #include "cstring.h"
+#include "iso8601cal.h"
 #include "ustrenum.h"
 #include "uenumimp.h"
 #include "ulist.h"
@@ -307,7 +308,8 @@ ucal_setGregorianChange(UCalendar *cal, UDate date, UErrorCode *pErrorCode) {
         *pErrorCode = U_ILLEGAL_ARGUMENT_ERROR;
         return;
     }
-    if(typeid(*cpp_cal) != typeid(GregorianCalendar)) {
+    if(typeid(*cpp_cal) != typeid(GregorianCalendar) &&
+       typeid(*cpp_cal) != typeid(ISO8601Calendar)) {
         *pErrorCode = U_UNSUPPORTED_ERROR;
         return;
     }
@@ -329,7 +331,8 @@ ucal_getGregorianChange(const UCalendar *cal, UErrorCode *pErrorCode) {
         *pErrorCode = U_ILLEGAL_ARGUMENT_ERROR;
         return (UDate)0;
     }
-    if(typeid(*cpp_cal) != typeid(GregorianCalendar)) {
+    if(typeid(*cpp_cal) != typeid(GregorianCalendar) &&
+       typeid(*cpp_cal) != typeid(ISO8601Calendar)) {
         *pErrorCode = U_UNSUPPORTED_ERROR;
         return (UDate)0;
     }

--- a/icu4c/source/test/cintltst/ccaltst.c
+++ b/icu4c/source/test/cintltst/ccaltst.c
@@ -1568,6 +1568,24 @@ void TestGregorianChange() {
         }
     }
     ucal_close(cal);
+    /* Test ucal_setGregorianChange() on a iso8601 calendar and it should work
+     * as Gregorian. */
+    errorCode = U_ZERO_ERROR;
+    cal = ucal_open(utc, -1, "en@calendar=iso8601", UCAL_TRADITIONAL, &errorCode);
+    if(U_FAILURE(errorCode)) {
+        log_data_err("ucal_open(UTC) failed: %s - (Are you missing data?)\n", u_errorName(errorCode));
+        return;
+    }
+    ucal_setGregorianChange(cal, -365 * (dayMillis * (UDate)1), &errorCode);
+    if(U_FAILURE(errorCode)) {
+        log_err("ucal_setGregorianChange(1969) failed: %s\n", u_errorName(errorCode));
+    } else {
+        date = ucal_getGregorianChange(cal, &errorCode);
+        if(U_FAILURE(errorCode) || date != -365 * (dayMillis * (UDate)1)) {
+            log_err("ucal_getGregorianChange() failed: %s, date = %f\n", u_errorName(errorCode), date);
+        }
+    }
+    ucal_close(cal);
 
     /* Test ucal_setGregorianChange() on a non-Gregorian calendar where it should fail. */
     errorCode = U_ZERO_ERROR;


### PR DESCRIPTION
This is fixing a 73-1 regression. The test work in 72-maint
The fix came from https://phabricator.services.mozilla.com/D180796
and mentioned in https://unicode-org.atlassian.net/browse/ICU-22412 by @anba 
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22412
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
