### PR TITLE
ICU-22421 Remove two unused internal methods in gregorian cal

### DIFF
--- a/icu4c/source/i18n/gregocal.cpp
+++ b/icu4c/source/i18n/gregocal.cpp
@@ -611,38 +611,12 @@ GregorianCalendar::monthLength(int32_t month, int32_t year) const
 // -------------------------------------
 
 int32_t
-GregorianCalendar::yearLength(int32_t year) const
-{
-    return isLeapYear(year) ? 366 : 365;
-}
-
-// -------------------------------------
-
-int32_t
 GregorianCalendar::yearLength() const
 {
     return isLeapYear(internalGet(UCAL_YEAR)) ? 366 : 365;
 }
 
 // -------------------------------------
-
-/**
-* After adjustments such as add(MONTH), add(YEAR), we don't want the
-* month to jump around.  E.g., we don't want Jan 31 + 1 month to go to Mar
-* 3, we want it to go to Feb 28.  Adjustments which might run into this
-* problem call this method to retain the proper month.
-*/
-void 
-GregorianCalendar::pinDayOfMonth() 
-{
-    int32_t monthLen = monthLength(internalGetMonth());
-    int32_t dom = internalGet(UCAL_DATE);
-    if(dom > monthLen) 
-        set(UCAL_DATE, monthLen);
-}
-
-// -------------------------------------
-
 
 UBool
 GregorianCalendar::validateFields() const

--- a/icu4c/source/i18n/unicode/gregocal.h
+++ b/icu4c/source/i18n/unicode/gregocal.h
@@ -537,28 +537,12 @@ public:
 
 #ifndef U_HIDE_INTERNAL_API
     /**
-     * return the length of the given year.
-     * @param year    the given year.
-     * @return        the length of the given year.
-     * @internal
-     */
-    int32_t yearLength(int32_t year) const;
-    
-    /**
      * return the length of the year field.
      * @return    the length of the year field
      * @internal
      */
     int32_t yearLength(void) const;
 
-    /**
-     * After adjustments such as add(MONTH), add(YEAR), we don't want the
-     * month to jump around.  E.g., we don't want Jan 31 + 1 month to go to Mar
-     * 3, we want it to go to Feb 28.  Adjustments which might run into this
-     * problem call this method to retain the proper month.
-     * @internal
-     */
-    void pinDayOfMonth(void);
 #endif  /* U_HIDE_INTERNAL_API */
 
     /**


### PR DESCRIPTION
Remove pinDayOfMonth() and yearLength(int32_t year) from GregorianCalendar.

These two methods are
1. Unused by any code inside ICU, not in source/{common,i18n,test}.
2. Marked as @internal in the header.
3. Wrap inside #ifndef U_HIDE_INTERNAL_API block in the header
4. In "protected:" section.
5. No ICU4J counterpart.

The yearLength(int32_t year) dup the functionality as handleGetYearLength of the same class and that one is the correct one to be keep and used..
There is another yearLength() w/o the year as parameter should NOT be removed and still needed internally.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22421
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
