### PR TITLE
ICU-22425 Eliminate double map lookup for common case of present argument

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/text/MessageFormat.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/text/MessageFormat.java
@@ -1683,8 +1683,11 @@ public class MessageFormat extends UFormat {
                 }
             } else {
                 argId = argName;
-                if(argsMap!=null && argsMap.containsKey(argName)) {
+                if(argsMap!=null) {
                     arg=argsMap.get(argName);
+                    if (arg==null) {
+                        noArg=!argsMap.containsKey(argName);
+                    }
                 } else {
                     arg=null;
                     noArg=true;


### PR DESCRIPTION
In the uncommon case where the map lookup returns null, only then perform a second map lookup to determine whether it was an absent value or explicit null.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22425
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
