### PR TITLE
ICU-22354 Revert benchmark-action changes

### DIFF
--- a/.github/workflows/icu_merge_ci.yml
+++ b/.github/workflows/icu_merge_ci.yml
@@ -105,7 +105,7 @@ jobs:
           LD_LIBRARY_PATH=lib ./test/perf/${{ matrix.perf }}/${{ matrix.perf }} ${{ matrix.flag }} -t 5 -p 10 ${{ matrix.file }} ${{ matrix.tests }} | tee test/perf/results/${{ matrix.perf }}/output.txt
 
       - name: Store performance test results
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: gregtatum/github-action-benchmark@d3f06f738e9612988d575db23fae5ca0008d3d12
         with:
           # The perf tests result data is in ndjson format.
           tool: 'ndjson'
@@ -181,7 +181,7 @@ jobs:
           LD_LIBRARY_PATH=lib ./test/perf/${{ matrix.perf }}/${{ matrix.perf }} ${{ matrix.flag }} -t 5 -p 10 -f $DATA_FILE_PATH/${{ matrix.data }}.txt ${{ matrix.tests }} | tee test/perf/results/${{ matrix.perf }}/${{ matrix.data }}/output.txt
 
       - name: Store performance test results
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: gregtatum/github-action-benchmark@d3f06f738e9612988d575db23fae5ca0008d3d12
         with:
           # The perf tests result data is in ndjson format.
           tool: 'ndjson'
@@ -246,7 +246,7 @@ jobs:
           LD_LIBRARY_PATH=lib ./test/perf/strsrchperf/strsrchperf -b Test_ICU_Forward_Search Test_ICU_Backward_Search -t 5 -p 10 -L ${{ matrix.locale }} -f $DATA_FILE_PATH/${{ matrix.data }}.txt | tee test/perf/results/strsrchperf/${{ matrix.locale }}/output.txt
 
       - name: Store performance test results
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: gregtatum/github-action-benchmark@d3f06f738e9612988d575db23fae5ca0008d3d12
         with:
           # The perf tests result data is in ndjson format.
           tool: 'ndjson'
@@ -302,7 +302,7 @@ jobs:
           java -cp ./out/bin:../tools/misc/out/bin/:../icu4j.jar com.ibm.icu.dev.test.perf.UnicodeSetPerf ${{ matrix.perf }} -a -t 2 -p 4 [:Lt:] | tee perf/results/j_unicodesetperf/${{ matrix.perf }}/output.txt
 
       - name: Store performance test results
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: gregtatum/github-action-benchmark@d3f06f738e9612988d575db23fae5ca0008d3d12
         with:
           # The perf tests result data is in ndjson format.
           tool: 'ndjson'
@@ -355,7 +355,7 @@ jobs:
           java -cp ./out/bin:../tools/misc/out/bin/:../icu4j.jar com.ibm.icu.dev.test.perf.UCharacterPerf -a -t 2 -p 4 0 ffff | tee perf/results/j_ucharacterperf/output.txt
 
       - name: Store performance test results
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: gregtatum/github-action-benchmark@d3f06f738e9612988d575db23fae5ca0008d3d12
         with:
           # The perf tests result data is in ndjson format.
           tool: 'ndjson'
@@ -415,7 +415,7 @@ jobs:
           java -cp ./out/bin:../tools/misc/out/bin/:../icu4j.jar com.ibm.icu.dev.test.perf.DecimalFormatPerformanceTest ${{ matrix.perf }} -a -t 2 -p 4 -L ${{ matrix.locale }} "#,###.##" "1.234,56" -r 1 | tee perf/results/j_decimalformatperf/${{ matrix.locale }}/${{ matrix.perf }}/output.txt
 
       - name: Store performance test results
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: gregtatum/github-action-benchmark@d3f06f738e9612988d575db23fae5ca0008d3d12
         with:
           # The perf tests result data is in ndjson format.
           tool: 'ndjson'
@@ -479,7 +479,7 @@ jobs:
           cat perf/results/j_normperf/${{ matrix.source_text }}/${{ matrix.perf }}/output.txt
 
       - name: Store performance test results
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: gregtatum/github-action-benchmark@d3f06f738e9612988d575db23fae5ca0008d3d12
         with:
           # The perf tests result data is in ndjson format.
           tool: 'ndjson'
@@ -609,7 +609,7 @@ jobs:
           java -cp ./out/bin:../tools/misc/out/bin/:../icu4j.jar:../icu4j-charset.jar com.ibm.icu.dev.test.perf.ConverterPerformanceTest ${{ matrix.perf }} -a -t 2 -p 4 -f $DATA_FILE_PATH/${{ matrix.source_text }}.txt -e UTF-8 -T ${{ matrix.test_enc }} | tee perf/results/j_converterperf/${{ matrix.source_text }}/${{ matrix.test_enc }}/${{ matrix.perf }}/output.txt
 
       - name: Store performance test results
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: gregtatum/github-action-benchmark@d3f06f738e9612988d575db23fae5ca0008d3d12
         with:
           # The perf tests result data is in ndjson format.
           tool: 'ndjson'
@@ -687,7 +687,7 @@ jobs:
           java -cp ./out/bin:../tools/misc/out/bin/:../icu4j.jar com.ibm.icu.dev.test.perf.DateFormatPerformanceTest ${{ matrix.perf }} -a -t 2 -p 4 -L ${{ matrix.locale }} ${{ env.PARM }} -r 1 | tee perf/results/j_dateformatperf/${{ matrix.locale }}/${{ matrix.perf }}/${{ env.DDIR }}/output.txt
 
       - name: Store performance test results
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: gregtatum/github-action-benchmark@d3f06f738e9612988d575db23fae5ca0008d3d12
         with:
           # The perf tests result data is in ndjson format.
           tool: 'ndjson'


### PR DESCRIPTION
Revert the change of benchmark-action in
https://github.com/unicode-org/icu/pull/2428 which cause post merge test brekage.

See https://github.com/unicode-org/icu/actions/runs/5393383252/jobs/9793048045 for the problem

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22354
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
