### PR TITLE
ICU-22444 Remove "unknown" from Calendar.getKeywordValuesForLocale

### DIFF
--- a/icu4j/main/classes/core/src/com/ibm/icu/impl/CalType.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/impl/CalType.java
@@ -26,9 +26,7 @@ public enum CalType {
     ISLAMIC_UMALQURA("islamic-umalqura"),
     JAPANESE("japanese"),
     PERSIAN("persian"),
-    ROC("roc"),
-
-    UNKNOWN("unknown");
+    ROC("roc");
 
     String id;
 

--- a/icu4j/main/classes/core/src/com/ibm/icu/util/Calendar.java
+++ b/icu4j/main/classes/core/src/com/ibm/icu/util/Calendar.java
@@ -1814,14 +1814,14 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
                 }
             }
         }
-        return CalType.UNKNOWN;
+        return null;
     }
 
     private static Calendar createInstance(ULocale locale) {
         Calendar cal = null;
         TimeZone zone = TimeZone.forULocaleOrDefault(locale);
         CalType calType = getCalendarTypeForLocale(locale);
-        if (calType == CalType.UNKNOWN) {
+        if (calType == null) {
             // fallback to Gregorian
             calType = CalType.GREGORIAN;
         }

--- a/icu4j/main/tests/core/src/com/ibm/icu/dev/test/calendar/CalendarRegressionTest.java
+++ b/icu4j/main/tests/core/src/com/ibm/icu/dev/test/calendar/CalendarRegressionTest.java
@@ -2186,6 +2186,9 @@ public class CalendarRegressionTest extends com.ibm.icu.dev.test.TestFmwk {
         String[] ALL = Calendar.getKeywordValuesForLocale("calendar", ULocale.getDefault(), false);
         HashSet ALLSET = new HashSet();
         for (int i = 0; i < ALL.length; i++) {
+            if (ALL[i] == "unknown") {
+                errln("Calendar.getKeywordValuesForLocale should not return \"unknown\"");
+            }
             ALLSET.add(ALL[i]);
         }
 


### PR DESCRIPTION
Remove CalType enum value UNKNOWN and use null for unknown CalType This value is an internal enum and the only place use it is inside Calendar.java Use null for that instead (same as C++)

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22444
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
