### PR TITLE
ICU-22453 Fix non null terminated buffer issue.

### DIFF
--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -563,7 +563,7 @@ private:
                    LocalMemory<int32_t>& replacementIndexes,
                    int32_t &length,
                    void (*checkType)(const char* type),
-                   void (*checkReplacement)(const UnicodeString& replacement),
+                   void (*checkReplacement)(const UChar* replacement),
                    UErrorCode &status);
 
     // Read the languageAlias data from alias to
@@ -700,7 +700,7 @@ AliasDataBuilder::readAlias(
         LocalMemory<int32_t>& replacementIndexes,
         int32_t &length,
         void (*checkType)(const char* type),
-        void (*checkReplacement)(const UnicodeString& replacement),
+        void (*checkReplacement)(const UChar* replacement),
         UErrorCode &status) {
     if (U_FAILURE(status)) {
         return;
@@ -720,8 +720,8 @@ AliasDataBuilder::readAlias(
         LocalUResourceBundlePointer res(
             ures_getNextResource(alias, nullptr, &status));
         const char* aliasFrom = ures_getKey(res.getAlias());
-        UnicodeString aliasTo =
-            ures_getUnicodeStringByKey(res.getAlias(), "replacement", &status);
+        const UChar* aliasTo =
+            ures_getStringByKey(res.getAlias(), "replacement", nullptr, &status);
         if (U_FAILURE(status)) return;
 
         checkType(aliasFrom);
@@ -766,7 +766,7 @@ AliasDataBuilder::readLanguageAlias(
 #else
         [](const char*) {},
 #endif
-        [](const UnicodeString&) {}, status);
+        [](const UChar*) {}, status);
 }
 
 /**
@@ -790,12 +790,12 @@ AliasDataBuilder::readScriptAlias(
         [](const char* type) {
             U_ASSERT(uprv_strlen(type) == 4);
         },
-        [](const UnicodeString& replacement) {
-            U_ASSERT(replacement.length() == 4);
+        [](const UChar* replacement) {
+            U_ASSERT(u_strlen(replacement) == 4);
         },
 #else
         [](const char*) {},
-        [](const UnicodeString&) { },
+        [](const UChar*) { },
 #endif
         status);
 }
@@ -824,7 +824,7 @@ AliasDataBuilder::readTerritoryAlias(
 #else
         [](const char*) {},
 #endif
-        [](const UnicodeString&) { },
+        [](const UChar*) { },
         status);
 }
 
@@ -851,15 +851,16 @@ AliasDataBuilder::readVariantAlias(
             U_ASSERT(uprv_strlen(type) != 4 ||
                      (type[0] >= '0' && type[0] <= '9'));
         },
-        [](const UnicodeString& replacement) {
-            U_ASSERT(replacement.length() >= 4 && replacement.length() <= 8);
-            U_ASSERT(replacement.length() != 4 ||
-                     (replacement.charAt(0) >= u'0' &&
-                      replacement.charAt(0) <= u'9'));
+        [](const UChar* replacement) {
+            int32_t len = u_strlen(replacement);
+            U_ASSERT(len >= 4 && len <= 8);
+            U_ASSERT(len != 4 ||
+                     (*replacement >= u'0' &&
+                      *replacement <= u'9'));
         },
 #else
         [](const char*) {},
-        [](const UnicodeString&) { },
+        [](const UChar*) { },
 #endif
         status);
 }
@@ -888,7 +889,7 @@ AliasDataBuilder::readSubdivisionAlias(
 #else
         [](const char*) {},
 #endif
-        [](const UnicodeString&) { },
+        [](const UChar*) { },
         status);
 }
 


### PR DESCRIPTION
UniqueCharStrings was designed to ref to strings return by resource bundle which the strings will not be freed and is used in two places- inside locid.cpp and loclikelysubtags.cpp

But two months ago I misuse that in https://github.com/unicode-org/icu/pull/2458 to also store stack allocated UnicodeString that 1) may not be null terminated and 2) will be freed from the stack before the destruction of UniqueCharStrings. We discover the issue while work on https://github.com/unicode-org/icu/pull/2538

This PR has been changed several time because I found the fix is not safe nor efficient due to the fact that 
a. While the data came from the ResourceBundle, we should use the internal data without allocate unecessary memory.
b. While the data is generated from some computation, we need to keep the memory around until the destruction of the  UniqueCharStrings because the uhash internally use them and expect it to be null terminiated. 

After some face to face discussion with @sffc, we belive it should be address by changing UniqueCharStrings
1. Have a function add() which take a const chart16_t * , which UniqueCharStrings can safely assume it is always null-terminiated and the memory is guanantee around until the destruction of the UniqueCharStrings. We will use this version for all the data getting from the resource bundle. The caller will pass in the the getTerminatedBuffer() result from the UnicodeString. 
2. Have a new function addByValue() which take UnicodeString by value instead of const ref. In this version, we first try to call the getTerminatedBuffer() and do we already store it, if so, just return the stored value. Otherwise, clone a copy and store it and use the getTerminatedBuffer() of the newly clone() copy. We add a UVector to UniqueCharStrings to track these UnicodeString which need to be freed in the destruction. We use addByValue for the result of toLanguage(), toScript() and toRegion() calls.  We also make sure the UnicodeString created by these three functions were null-terminated in this PR.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22453
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
