### PR TITLE
ICU-22457 Fix the count() of StringEnumeration returned by createUnicodeKeywords 

### DIFF
--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -2403,8 +2403,9 @@ Locale::getLocaleCache()
 }
 
 class KeywordEnumeration : public StringEnumeration {
-private:
+protected:
     char *keywords;
+private:
     char *current;
     int32_t length;
     UnicodeString currUSKey;
@@ -2510,6 +2511,17 @@ public:
         }
         if (resultLength != nullptr) *resultLength = 0;
         return nullptr;
+    }
+    virtual int32_t count(UErrorCode &/*status*/) const override {
+        char *kw = keywords;
+        int32_t result = 0;
+        while(*kw) {
+            if (uloc_toUnicodeLocaleKey(kw) != nullptr) {
+                result++;
+            }
+            kw += uprv_strlen(kw)+1;
+        }
+        return result;
     }
 };
 

--- a/icu4c/source/test/intltest/loctest.cpp
+++ b/icu4c/source/test/intltest/loctest.cpp
@@ -3983,6 +3983,8 @@ LocaleTest::TestCreateUnicodeKeywords() {
     LocalPointer<StringEnumeration> keys(l.createUnicodeKeywords(status));
     status.errIfFailureAndReset("\"%s\"", l.getName());
 
+    assertEquals("count", 2, keys->count(status));
+
     const char* key;
     int32_t resultLength;
 
@@ -4133,6 +4135,11 @@ LocaleTest::TestCreateUnicodeKeywordSet() {
                result.find("ca") != result.end());
     assertTrue("set::find(\"co\")",
                result.find("co") != result.end());
+
+    LocalPointer<StringEnumeration> se(l.createUnicodeKeywords(status), status);
+    status.errIfFailureAndReset("\"%s\" createUnicodeKeywords()", l.getName());
+    assertEquals("count()", 2, se->count(status));
+    status.errIfFailureAndReset("\"%s\" count()", l.getName());
 }
 
 void
@@ -4148,6 +4155,10 @@ LocaleTest::TestCreateUnicodeKeywordSetEmpty() {
     status.errIfFailureAndReset("\"%s\"", l.getName());
 
     assertEquals("set::size()", 0, static_cast<int32_t>(result.size()));
+
+    LocalPointer<StringEnumeration> se(l.createUnicodeKeywords(status), status);
+    assertTrue("createUnicodeKeywords", se.isNull());
+    status.expectErrorAndReset(U_MEMORY_ALLOCATION_ERROR);
 }
 
 void
@@ -4168,6 +4179,12 @@ LocaleTest::TestCreateUnicodeKeywordSetWithPrivateUse() {
                result.find("x") == result.end());
     assertTrue("getUnicodeKeywords set::find(\"foo\")",
                result.find("foo") == result.end());
+    assertEquals("set::size()", 1, static_cast<int32_t>(result.size()));
+
+    LocalPointer<StringEnumeration> se(l.createUnicodeKeywords(status), status);
+    status.errIfFailureAndReset("\"%s\" createUnicodeKeywords()", l.getName());
+    assertEquals("count()", 1, se->count(status));
+    status.errIfFailureAndReset("\"%s\" count()", l.getName());
 }
 
 void


### PR DESCRIPTION
override the count() returned by Locale::createUnicodeKeyword by considering  extension other than -u- such as  -x-, -t-.


<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22457
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
