### PR TITLE
ICU-22465 Change .s to .data() for replacing TinyString with CharString.

### DIFF
--- a/icu4c/source/common/udata.cpp
+++ b/icu4c/source/common/udata.cpp
@@ -1196,7 +1196,7 @@ doOpenChoice(const char *path, const char *type, const char *name,
                 *p = U_FILE_SEP_CHAR;
             }
 #if defined (UDATA_DEBUG)
-            fprintf(stderr, "Changed path from [%s] to [%s]\n", path, altSepPath.s);
+            fprintf(stderr, "Changed path from [%s] to [%s]\n", path, altSepPath.data());
 #endif
             path = altSepPath.data();
         }


### PR DESCRIPTION
This was forgotten by ICU-7496 which replaced the local `TinyString` data type with the shared `CharString` data type, but as it's in code heavily nested in `#ifdef`'s it hasn't been noticed until now.

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22465
- [X] Required: The PR title must be prefixed with a JIRA Issue number.
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number.
- [ ] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [X] API docs and/or User Guide docs changed or added, if applicable
