### PR TITLE
ICU-22479 Limit the collator_compare_fuzzer

### DIFF
--- a/icu4c/source/test/fuzzer/collator_compare_fuzzer.cpp
+++ b/icu4c/source/test/fuzzer/collator_compare_fuzzer.cpp
@@ -33,6 +33,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   icu::Collator::ECollationStrength strength = kStrength[rnd16 % kStrength.size()];
   const icu::Locale& locale = GetRandomLocale(rnd16 / kStrength.size());
 
+  // Limit the comparison size to 4096 to avoid unnecessary timeout
+  if (size > 4096) {
+      size = 4096;
+  }
   std::unique_ptr<char16_t> compbuff1(new char16_t[size/4]);
   std::memcpy(compbuff1.get(), data, (size/4)*2);
   data = data + size/2;


### PR DESCRIPTION
Test only first 4K bytes of data, which means compare two UnicodeString each with 1024 Unicodes at most.

Avoid finding timeout issue due to large amount of data.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22479
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
