### PR TITLE
ICU-22507 Fix stack overflow in ChineseCalendar::isLeapMonthBetween

### DIFF
--- a/icu4c/source/i18n/chnsecal.h
+++ b/icu4c/source/i18n/chnsecal.h
@@ -252,7 +252,7 @@ class U_I18N_API ChineseCalendar : public Calendar {
   virtual void computeChineseFields(int32_t days, int32_t gyear,
                  int32_t gmonth, UBool setAllFields);
   virtual int32_t newYear(int32_t gyear) const;
-  virtual void offsetMonth(int32_t newMoon, int32_t dom, int32_t delta);
+  virtual void offsetMonth(int32_t newMoon, int32_t dom, int32_t delta, UErrorCode& status);
   const TimeZone* getChineseCalZoneAstroCalc() const;
 
   // UObject stuff

--- a/icu4c/source/test/intltest/caltest.cpp
+++ b/icu4c/source/test/intltest/caltest.cpp
@@ -187,6 +187,7 @@ void CalendarTest::runIndexedTest( int32_t index, UBool exec, const char* &name,
     TESTCASE_AUTO(TestClearMonth);
 
     TESTCASE_AUTO(TestFWWithISO8601);
+    TESTCASE_AUTO(TestDangiOverflowIsLeapMonthBetween22507);
 
     TESTCASE_AUTO_END;
 }
@@ -5497,6 +5498,22 @@ void CalendarTest::TestChineseCalendarMonthInSpecialYear() {
                   actual_month+1, ((actual_in_leap_month != 0) ? "L" : ""), actual_date );
         }
     }
+}
+
+// Test the stack will not overflow with dangi calendar during "roll".
+void CalendarTest::TestDangiOverflowIsLeapMonthBetween22507() {
+    Locale locale("en@calendar=dangi");
+    UErrorCode status = U_ZERO_ERROR;
+    LocalPointer<Calendar> cal(Calendar::createInstance(
+            *TimeZone::getGMT(), locale, status));
+    cal->clear();
+    status = U_ZERO_ERROR;
+    cal->add(UCAL_MONTH, 1242972234, status);
+    status = U_ZERO_ERROR;
+    cal->roll(UCAL_MONTH, 1249790538, status);
+    status = U_ZERO_ERROR;
+    // Without the fix, the stack will overflow during this roll().
+    cal->roll(UCAL_MONTH, 1246382666, status);
 }
 
 void CalendarTest::TestFWWithISO8601() {

--- a/icu4c/source/test/intltest/caltest.h
+++ b/icu4c/source/test/intltest/caltest.h
@@ -329,6 +329,7 @@ public: // package
     void TestCalendarRollOrdinalMonth();
     void TestLimitsOrdinalMonth();
     void TestActualLimitsOrdinalMonth();
+    void TestDangiOverflowIsLeapMonthBetween22507();
 
     void TestFWWithISO8601();
 


### PR DESCRIPTION
Rewrite the recursive call to while loop to avoid stack overflow when the two values have big gap.
Include tests to verify the problem in unit test.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22507
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
