### PR TITLE
ICU-22512 Fix broken TestHebrewCalendarInTemporalLeapYear

### DIFF
--- a/icu4c/source/test/intltest/caltest.cpp
+++ b/icu4c/source/test/intltest/caltest.cpp
@@ -4028,6 +4028,7 @@ void CalendarTest::TestHebrewCalendarInTemporalLeapYear() {
     for (gc.set(startYear, UCAL_JANUARY, 1);
          gc.get(UCAL_YEAR, status) <= stopYear;
          gc.add(UCAL_DATE, incrementDays, status)) {
+        cal->setTime(gc.getTime(status), status);
         if (failure(status, "add/get/set/getTime/setTime incorrect")) return;
 
         int32_t cal_year = cal->get(UCAL_EXTENDED_YEAR, status);
@@ -4036,6 +4037,7 @@ void CalendarTest::TestHebrewCalendarInTemporalLeapYear() {
             leapTest->set(UCAL_MONTH, 0);
             leapTest->set(UCAL_DATE, 1);
             // If 10 months after TISHRI is TAMUZ, then it is a leap year.
+            leapTest->add(UCAL_MONTH, 10, status);
             hasLeapMonth = leapTest->get(UCAL_MONTH, status) == icu::HebrewCalendar::TAMUZ;
             yearForHasLeapMonth = cal_year;
         }


### PR DESCRIPTION
Fix broken test mistakenly landed in
https://github.com/unicode-org/icu/pull/2274

Some important steps were accidentally removed in the last landing.

The corresponding Java tests at
https://github.com/unicode-org/icu/blob/d8659b476d4703b18bb9ea040798c1e62ff3329e/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/InTemporalLeapYearTest.java#L91 

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22512
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
