### PR TITLE
ICU-22509 Fix the RelativeDateFormat to reject unsupported dateStyle

### DIFF
--- a/icu4c/source/i18n/reldtfmt.cpp
+++ b/icu4c/source/i18n/reldtfmt.cpp
@@ -78,6 +78,14 @@ RelativeDateFormat::RelativeDateFormat( UDateFormatStyle timeStyle, UDateFormatS
     if(U_FAILURE(status) ) {
         return;
     }
+    if (dateStyle != UDAT_FULL_RELATIVE &&
+        dateStyle != UDAT_LONG_RELATIVE &&
+        dateStyle != UDAT_MEDIUM_RELATIVE &&
+        dateStyle != UDAT_SHORT_RELATIVE &&
+        dateStyle != UDAT_RELATIVE) {
+        status = U_ILLEGAL_ARGUMENT_ERROR;
+        return;
+    }
 
     if (timeStyle < UDAT_NONE || timeStyle > UDAT_SHORT) {
         // don't support other time styles (e.g. relative styles), for now


### PR DESCRIPTION
This is a follow up PR of https://github.com/unicode-org/icu/pull/2608 to reject the unsupported dateStyle and avoid infinty loop.

Revert back the fuzzer code back to pre PR 2608 then add the new call to ensure that both valid and invalid enum will be tested suggested by Rich

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22509
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
