### PR TITLE
ICU-22463 Fix the conversion from gasoline-equivalent units to kilograms-per-meter-squared-per-second

### DIFF
--- a/icu4c/source/i18n/units_converter.cpp
+++ b/icu4c/source/i18n/units_converter.cpp
@@ -372,11 +372,11 @@ void U_I18N_API addSingleFactorConstant(StringPiece baseStr, int32_t power, Sign
         factor.constantExponents[CONSTANT_FT2M] += 3 * power * signum;
     } else if (baseStr == "in3_to_m3") {
         factor.constantExponents[CONSTANT_FT2M] += 3 * power * signum;
-        factor.factorDen *= 12 * 12 * 12;
+        factor.factorDen *= std::pow(12 * 12 * 12, power * signum);
     } else if (baseStr == "gal_to_m3") {
-        factor.factorNum *= 231;
         factor.constantExponents[CONSTANT_FT2M] += 3 * power * signum;
-        factor.factorDen *= 12 * 12 * 12;
+        factor.factorNum *= std::pow(231, power * signum);
+        factor.factorDen *= std::pow(12 * 12 * 12, power * signum);
     } else if (baseStr == "gal_imp_to_m3") {
         factor.constantExponents[CONSTANT_GAL_IMP2M3] += power * signum;
     } else if (baseStr == "G") {

--- a/icu4c/source/test/intltest/units_test.cpp
+++ b/icu4c/source/test/intltest/units_test.cpp
@@ -449,11 +449,6 @@ void unitsTestDataLineFn(void *context, char *fields[][2], int32_t fieldCount, U
     StringPiece y = trimField(fields[2]);
     StringPiece commentConversionFormula = trimField(fields[3]);
     StringPiece utf8Expected = trimField(fields[4]);
-    StringPiece gasolineEnergyDensity("gasoline-energy-density");
-
-    if ( x.compare(gasolineEnergyDensity) == 0 && unitsTest->logKnownIssue("CLDR-17015", "Problem with gasoline-energy-density unit calculation")) {
-          return;
-    }
 
     UNumberFormat *nf = unum_open(UNUM_DEFAULT, nullptr, -1, "en_US", nullptr, status);
     if (status.errIfFailureAndReset("unum_open failed")) {


### PR DESCRIPTION
Correcting the conversion from gasoline-equivalent units to kilograms-per-meter-squared-per-second is essential. The issue doesn't lie with the Java segment, as Java code employs a more appropriate method for handling unit constants.
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22463
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
