### PR TITLE
ICU-22324 Mavenization, add -SNAPSHOT back to the maven version

### DIFF
--- a/icu4j/build.properties
+++ b/icu4j/build.properties
@@ -8,5 +8,5 @@ api.report.version = 74
 api.report.prev.version = 73
 release.file.ver = 74rc
 api.doc.version = 74
-maven.pom.ver = 74.1
+maven.pom.ver = 74.1-SNAPSHOT
 

--- a/icu4j/demos/pom.xml
+++ b/icu4j/demos/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.ibm.icu</groupId>
     <artifactId>icu4j-root</artifactId>
-    <version>74.1</version>
+    <version>74.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>demos</artifactId>

--- a/icu4j/main/charset/pom.xml
+++ b/icu4j/main/charset/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.ibm.icu</groupId>
     <artifactId>main</artifactId>
-    <version>74.1</version>
+    <version>74.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>icu4j-charset</artifactId>

--- a/icu4j/main/collate/pom.xml
+++ b/icu4j/main/collate/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.ibm.icu</groupId>
     <artifactId>main</artifactId>
-    <version>74.1</version>
+    <version>74.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>collate</artifactId>

--- a/icu4j/main/common_tests/pom.xml
+++ b/icu4j/main/common_tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.ibm.icu</groupId>
     <artifactId>main</artifactId>
-    <version>74.1</version>
+    <version>74.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>common_tests</artifactId>

--- a/icu4j/main/core/pom.xml
+++ b/icu4j/main/core/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.ibm.icu</groupId>
     <artifactId>main</artifactId>
-    <version>74.1</version>
+    <version>74.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>core</artifactId>

--- a/icu4j/main/currdata/pom.xml
+++ b/icu4j/main/currdata/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.ibm.icu</groupId>
     <artifactId>main</artifactId>
-    <version>74.1</version>
+    <version>74.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>currdata</artifactId>

--- a/icu4j/main/framework/pom.xml
+++ b/icu4j/main/framework/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.ibm.icu</groupId>
     <artifactId>main</artifactId>
-    <version>74.1</version>
+    <version>74.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>framework</artifactId>

--- a/icu4j/main/icu4j/pom.xml
+++ b/icu4j/main/icu4j/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.ibm.icu</groupId>
     <artifactId>main</artifactId>
-    <version>74.1</version>
+    <version>74.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>icu4j</artifactId>

--- a/icu4j/main/langdata/pom.xml
+++ b/icu4j/main/langdata/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.ibm.icu</groupId>
     <artifactId>main</artifactId>
-    <version>74.1</version>
+    <version>74.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>langdata</artifactId>

--- a/icu4j/main/localespi/pom.xml
+++ b/icu4j/main/localespi/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.ibm.icu</groupId>
     <artifactId>main</artifactId>
-    <version>74.1</version>
+    <version>74.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>icu4j-localespi</artifactId>

--- a/icu4j/main/pom.xml
+++ b/icu4j/main/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.ibm.icu</groupId>
     <artifactId>icu4j-root</artifactId>
-    <version>74.1</version>
+    <version>74.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>main</artifactId>

--- a/icu4j/main/regiondata/pom.xml
+++ b/icu4j/main/regiondata/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.ibm.icu</groupId>
     <artifactId>main</artifactId>
-    <version>74.1</version>
+    <version>74.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>regiondata</artifactId>

--- a/icu4j/main/translit/pom.xml
+++ b/icu4j/main/translit/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.ibm.icu</groupId>
     <artifactId>main</artifactId>
-    <version>74.1</version>
+    <version>74.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>translit</artifactId>

--- a/icu4j/perf-tests/pom.xml
+++ b/icu4j/perf-tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.ibm.icu</groupId>
     <artifactId>icu4j-root</artifactId>
-    <version>74.1</version>
+    <version>74.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>perf-tests</artifactId>

--- a/icu4j/pom.xml
+++ b/icu4j/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.ibm.icu</groupId>
   <artifactId>icu4j-root</artifactId>
-  <version>74.1</version>
+  <version>74.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>${proj-title} (${project.artifactId})</name>

--- a/icu4j/releases_tools/api_reports.sh
+++ b/icu4j/releases_tools/api_reports.sh
@@ -5,7 +5,7 @@
 export MAVEN_ARGS='--no-transfer-progress'
 
 # Version update!
-export artifact_version='74.1.0'
+export artifact_version='74.1-SNAPSHOT'
 export api_report_version='74'
 export api_report_prev_version='73'
 export out_dir=target

--- a/icu4j/samples/pom.xml
+++ b/icu4j/samples/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.ibm.icu</groupId>
     <artifactId>icu4j-root</artifactId>
-    <version>74.1</version>
+    <version>74.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>samples</artifactId>

--- a/icu4j/tools/build/pom.xml
+++ b/icu4j/tools/build/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.ibm.icu</groupId>
     <artifactId>icu4j-root</artifactId>
-    <version>74.1</version>
+    <version>74.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/icu4j/tools/misc/pom.xml
+++ b/icu4j/tools/misc/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.ibm.icu</groupId>
     <artifactId>icu4j-root</artifactId>
-    <version>74.1</version>
+    <version>74.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
Removing `-SNAPSHOT` means we can't publish the cldr utilities more than once per ICU version.
We will only remove `-SNAPSHOT` in the `main-<ver>` branch, closer to the release time.

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22324
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [X] API docs and/or User Guide docs changed or added, if applicable
