### PR TITLE
ICU-22518 Export monkeys

### DIFF
--- a/icu4c/source/test/intltest/rbbitst.cpp
+++ b/icu4c/source/test/intltest/rbbitst.cpp
@@ -3538,6 +3538,9 @@ RBBILineMonkey::~RBBILineMonkey() {
 //
 //       type = char | word | line | sent | title
 //
+//       export = (path)   Export test cases to (path)_(type).txt in the UCD
+//                         test case format.
+//
 //  Example:
 //     intltest  rbbi/RBBITest/TestMonkey@"type=line loop=-1"
 //
@@ -3974,6 +3977,8 @@ void RBBITest::TestMonkey() {
     UnicodeString  breakType = "all";
     Locale         locale("en");
     UBool          useUText  = false;
+    UBool          scalarsOnly = false;
+    std::string    exportPath;
 
     if (quick == false) {
         loopCount = 10000;
@@ -3998,6 +4003,19 @@ void RBBITest::TestMonkey() {
             p = u.replaceFirst("", status);
         }
 
+        RegexMatcher pathMatcher(" *export *= *([^ ]+) *", p, 0, status);
+        if (pathMatcher.find()) {
+            pathMatcher.group(1, status).toUTF8String(exportPath);
+            pathMatcher.reset();
+            p = pathMatcher.replaceFirst("", status);
+        }
+
+        RegexMatcher s(" *scalars_only", p, 0, status);
+        if (s.find()) {
+            scalarsOnly = true;
+            s.reset();
+            p = s.replaceFirst("", status);
+        }
 
         // m.reset(p);
         if (RegexMatcher(UNICODE_STRING_SIMPLE("\\S"), p, 0, status).find()) {
@@ -4013,64 +4031,80 @@ void RBBITest::TestMonkey() {
     }
 
     if (breakType == "char" || breakType == "all") {
+        FILE *file = exportPath.empty() ? nullptr : fopen((exportPath + "_char.txt").c_str(), "w");
         RBBICharMonkey  m;
         BreakIterator  *bi = BreakIterator::createCharacterInstance(locale, status);
         if (U_SUCCESS(status)) {
-            RunMonkey(bi, m, "char", seed, loopCount, useUText);
+            RunMonkey(bi, m, "char", seed, loopCount, useUText, file, scalarsOnly);
             if (breakType == "all" && useUText==false) {
                 // Also run a quick test with UText when "all" is specified
-                RunMonkey(bi, m, "char", seed, loopCount, true);
+                RunMonkey(bi, m, "char", seed, loopCount, true, nullptr, scalarsOnly);
             }
         }
         else {
             errcheckln(status, "Creation of character break iterator failed %s", u_errorName(status));
         }
         delete bi;
+        if (file != nullptr) {
+            fclose(file);
+        }
     }
 
     if (breakType == "word" || breakType == "all") {
         logln("Word Break Monkey Test");
+        FILE *file = exportPath.empty() ? nullptr : fopen((exportPath + "_word.txt").c_str(), "w");
         RBBIWordMonkey  m;
         BreakIterator  *bi = BreakIterator::createWordInstance(locale, status);
         if (U_SUCCESS(status)) {
-            RunMonkey(bi, m, "word", seed, loopCount, useUText);
+            RunMonkey(bi, m, "word", seed, loopCount, useUText, file, scalarsOnly);
         }
         else {
             errcheckln(status, "Creation of word break iterator failed %s", u_errorName(status));
         }
         delete bi;
+        if (file != nullptr) {
+            fclose(file);
+        }
     }
 
     if (breakType == "line" || breakType == "all") {
         logln("Line Break Monkey Test");
+        FILE *file = exportPath.empty() ? nullptr : fopen((exportPath + "_line.txt").c_str(), "w");
         RBBILineMonkey  m;
         BreakIterator  *bi = BreakIterator::createLineInstance(locale, status);
         if (loopCount >= 10) {
             loopCount = loopCount / 5;   // Line break runs slower than the others.
         }
         if (U_SUCCESS(status)) {
-            RunMonkey(bi, m, "line", seed, loopCount, useUText);
+            RunMonkey(bi, m, "line", seed, loopCount, useUText, file, scalarsOnly);
         }
         else {
             errcheckln(status, "Creation of line break iterator failed %s", u_errorName(status));
         }
         delete bi;
+        if (file != nullptr) {
+            fclose(file);
+        }
     }
 
     if (breakType == "sent" || breakType == "all"  ) {
         logln("Sentence Break Monkey Test");
+        FILE *file = exportPath.empty() ? nullptr : fopen((exportPath + "_sent.txt").c_str(), "w");
         RBBISentMonkey  m;
         BreakIterator  *bi = BreakIterator::createSentenceInstance(locale, status);
         if (loopCount >= 10) {
             loopCount = loopCount / 10;   // Sentence runs slower than the other break types
         }
         if (U_SUCCESS(status)) {
-            RunMonkey(bi, m, "sent", seed, loopCount, useUText);
+            RunMonkey(bi, m, "sent", seed, loopCount, useUText, file, scalarsOnly);
         }
         else {
             errcheckln(status, "Creation of line break iterator failed %s", u_errorName(status));
         }
         delete bi;
+        if (file != nullptr) {
+            fclose(file);
+        }
     }
 
 #endif
@@ -4079,14 +4113,19 @@ void RBBITest::TestMonkey() {
 //
 //  Run a RBBI monkey test.  Common routine, for all break iterator types.
 //    Parameters:
-//       bi      - the break iterator to use
-//       mk      - MonkeyKind, abstraction for obtaining expected results
-//       name    - Name of test (char, word, etc.) for use in error messages
-//       seed    - Seed for starting random number generator (parameter from user)
+//       bi          - the break iterator to use
+//       mk          - MonkeyKind, abstraction for obtaining expected results
+//       name        - Name of test (char, word, etc.) for use in error messages
+//       seed        - Seed for starting random number generator (parameter from user)
 //       numIterations
+//       exportFile  - Pointer to a file to which the test cases will be written in
+//                     UCD format.  May be null.
+//       scalarsOnly - Only test sequences of Unicode scalar values; if this is false,
+//                     arbitrary sequences of code points (including unpaired surrogates)
+//                     are tested.
 //
 void RBBITest::RunMonkey(BreakIterator *bi, RBBIMonkeyKind &mk, const char *name, uint32_t  seed,
-                         int32_t numIterations, UBool useUText) {
+                         int32_t numIterations, UBool useUText, FILE *exportFile, UBool scalarsOnly) {
 
 #if !UCONFIG_NO_REGULAR_EXPRESSIONS
 
@@ -4150,6 +4189,9 @@ void RBBITest::RunMonkey(BreakIterator *bi, RBBIMonkeyKind &mk, const char *name
             if (c < 0) {   // TODO:  deal with sets containing strings.
                 errln("%s:%d c < 0", __FILE__, __LINE__);
                 break;
+            }
+            if (scalarsOnly && U16_IS_SURROGATE(c)) {
+              continue;
             }
             // Do not assemble a supplementary character from randomly generated separate surrogates.
             //   (It could be a dictionary character)
@@ -4265,6 +4307,16 @@ void RBBITest::RunMonkey(BreakIterator *bi, RBBIMonkeyKind &mk, const char *name
                 }
                 lastBreakPos = breakPos;
             }
+        }
+
+        if (exportFile != nullptr) {
+            for (i = 0; i < testText.length();) {
+                fprintf(exportFile, expectedBreaks[i] ? "÷ " : "× ");
+                char32_t const c = testText.char32At(i);
+                fprintf(exportFile, "%04X ", static_cast<uint32_t>(c));
+                i += U16_LENGTH(c);
+            }
+            fprintf(exportFile, expectedBreaks[testText.length()] ? "÷  # 🐒\n" : "×  # 🐒\n");
         }
 
         // Compare the expected and actual results.

--- a/icu4c/source/test/intltest/rbbitst.h
+++ b/icu4c/source/test/intltest/rbbitst.h
@@ -17,6 +17,8 @@
 
 #if !UCONFIG_NO_BREAK_ITERATION
 
+#include <stdio.h>
+
 #include <memory>
 
 #include "intltest.h"
@@ -122,7 +124,7 @@ private:
      **/
 
     void RunMonkey(BreakIterator *bi, RBBIMonkeyKind &mk, const char *name, uint32_t  seed,
-        int32_t loopCount, UBool useUText);
+        int32_t loopCount, UBool useUText, FILE *exportFile, UBool scalarsOnly);
 
     // Run one of the Unicode Consortium boundary test data files.
     void runUnicodeTestData(const char *fileName, RuleBasedBreakIterator *bi);


### PR DESCRIPTION
Usage: `.\icu4c\source\test\intltest\x64\Release\intltest.exe
 "rbbi/RBBITest/TestMonkey@type=sent seed=1729 loop=20 scalars_only export=meow"`
produces a file meow_sent.txt with
```
÷ 1D5FE × 3001 × 11C53 × A949 × 3167 × 202F × 0455 × 04A4 × 12F1B × 1094 × 1113C × E7E7 × FE52 × FE52 ÷ 14A92 × 1D794 × FE18 × 2029 ÷ 1944 ÷ 10EBF × 19D2 × 2024 × 1680 × 0085 ÷ 0330 × A902 × FF0E × 0437 × 206B × 041B × 111D4 × 07F9 × FE11 × 765F × 2E1C × 111CD ÷ 3DF0 × 2068 × 202D × 1E2F6 × 112F7 × 1144B ÷ 125F6 × 3000 × 2E22 × 1343A × 002E × 2062 × 116C7 × 13434 × 208E × 01B6 × FF0E × 1122F × 0031 × FF24 × 11A92 × 1134C × FE48 × 11A02 × 14E1E × FF64 × 1D471 × 1D8B × 000D ÷ 814B × 1680 × 003A × 2008 × 2C64 × FE52 ÷ 6E15 × FE47 × 0DD8 × 1E945 × 10400 × 1C3C ÷ 2C6F × 0E38 × 002E × 1E66 × 060C × 1CF0C × FF0D × 14076 × FF3B × FE18 × 000D ÷ 1171F × 10F57 ÷ 14AE8 × 002E × 2028 ÷ 000A ÷ 1D588 × 19D7 × 00A0 × 1D728 × 2028 ÷ 923D × 4B4F × 4E31 × 2D7F × 0ED9 × 298C × 003A × 1FF3 × 13435 × 2006 × 0F3C × A1FB × FF0E × 104EF × FF5F × 2014 × 2E29 × 6905 × 139FD × FE3A × 01D7 × 000C × 0464 × FF0E × 00A0 × 000A ÷ 3016 × 1D60C × 4031 × 13E80 × 5787 × 2013 × A373 × 00A0 × FE5C × 11D44 × 0B6C × 002C × 024C × 1D57B × 09E8 × 11641 ÷ 1D7D5 × 2007 × 1573C × FE11 × 2000 × 2024 × 2029 ÷ 000A ÷ 201C × 09ED × 11943 × 2775 × FE58 × 000C × 2047 × FE52 × E0001 × 110BE × 3000 × FE31 × A7A2 × 044D × 000B × 16079 × A8EF × 03DE × 16B38 × 2E28 × 2014 × 11843 × 2002 × 2000 × 11B3D × 1951 × E004E × 2024 × 3000 ÷ 19D6 × 2029 ÷ 04C4 × E011B × 03F4 × 275F × 116AD × F6FE × 13438 × 0702 × 2E54 ÷ FF11 × 2000 × 000A ÷ 002E ÷ 1D67C × 00A0 × 2008 × FE52 × 111DE × 2069 × 2E07 × 110C0 ÷ 1819 × E0101 × 2769 × 114C2 × 11129 × FE41 × 055D × FF5F × FF2C × 2024 ÷ 2E2F × 1C81 × 207E × AAF0 × FE52 ÷ 1D47F × 06D4 × 2000 ÷ 194B × 2066 × 1E78 × 107F0 × 1D633 × 10F89 × 000D ÷ 04B1 × 000A ÷ 0009 × 1D628 × 14F93 × 11F43 ÷ 7B63 × 002E ÷ 3507 × 000A ÷ 000A ÷ 2029 ÷ 300A × 041E × FE52 × FF0E × 2024 × FF0E ÷ 1D5B1 × 2029 ÷ 206C × 151DA × 013C × 2043 × 15332 × 2029 ÷ 1808 × 1E12 × 2019 × 060D × FE31 × 2024 × FE63 × 09EF × 03C9 × 2008 × 3010 × 5F8A × 09E9 × 00E6 × 9715 × 1D43C × 007A × 2029 ÷ E01D1 × 04EE × 1D177 × 10A57 × FF0E × 002E × 000A ÷ 0C06 × FE52 ÷ 1058A × 002C × 2024 × E01A9 × 1A76 ÷ 0BC4 × E011A × 000D ÷ 205F × 2E3C ÷ 1625A × 0178 × 1D61E × 000D ÷ 200A × 206B × 000A ÷ 000D ÷ 0396 × 002E ÷ 16378 × FEFF × 8EDD × 0085 ÷ 2024 × 2004 × 1BCA0 ÷ 04F2 × 206D × 10D2B × 10568 × 10592 × 2E3C ÷ AA59 × E462 × 1809 × 13435 ÷ 13FDB × 16B38 ÷ 80AB × 09EC × 5D99 × 1777 × 2028 ÷ 9993 × 6998 × 1DA63 × 2005 × 162D × 1D174 × 0589 × E0075 ÷ 4C0F × 1D69F × 0085 ÷ E05B × 1FCA × FF0E × 118E4 × 2907 × 2024 × 1C44 × 0437 × 2567 × 2DE7 × 000B × 1163A × 2013 × FE52 × 1343A × 0085 ÷ 1040E × 1113A × FD3F × 5955 × 11340 × 104E5 × 2126 × 0091 × 000A ÷ 2013 × 13432 × 0ED2 × 1F678 × E0108 × 000C × 2005 × FFFA × 0151 × E6F3 × 407B × 2024 × 16AC0 × 6F39 × 24CB × FE11 × FE55 × 002E × 1BA6 × 111DF × 13435 ÷ 110CD × 2028 ÷ 180F × 13433 × FF1A × 16A63 × 0020 × FE10 × 1E951 × 0136 × 2C73 × 045D × 1A93 × 2013 × 0964 ÷ 3AC7 × 0DE6 × 1BAD × FE52 ÷ 1ED4 × 07F8 × 2024 ÷ 826F × 2069 × 07F8 × 1802 × A107 × FE56 × FE31 × 0CF3 × 2028 ÷ 2024 × FE52 × AB53 × 13F5 × 1D5A7 × 2E21 × FF0E × 2002 × 2069 × 1E045 × 000C × 2028 ÷ 202E × E089 × 1D51C × FF0E × 17E9 × FF0E × 2002 × 13439 × FE57 ÷ 118C0 × FE55 × 3AE2 × FE50 × 0188 × 35AE × 1D5CE × 15F4F × 1BCA1 × 6DE8 × ABEB × E0066 × 1D174 × 000D ÷ FE52 ÷ EDE2 × 6B9C × 5C23 × 9C2E × 3011 × 1DA02 × FF3B × 2068 × 1E05C × 2063 × 2001 × 2003 × 32EB × FE32 × FE3B × 1090 × 2024 × 275D × 0964 ÷ 0CE9 × 110F9 × 11529 × 2061 × 11555 × 15F58 × 020C × FE52 ÷ 10945 × 2029 ÷ 2014 × 98BB × 2048 × 00A0 ÷ 2C84 × FE52 × 003A × 03F9 × 3878 × 000D ÷ 12E20 × 3711 × 16240 × 1E3E × 043C × 16B34 × 95AE × 07F8 × 13450 × 200B ÷  # 🐒
÷ FF1A × 000D ÷ 0A6A × 14BE7 × 274D × 1EF9 × 1D4D2 × FE58 × FE55 × 2992 × 29D9 × 0028 × 2024 × 0D42 × 1D175 ÷ E7BE × 2024 × 2024 × FF1A × 2061 × 0602 × 118BE × 11C9E × 1D4F1 × 00A0 × ECB8 × 057F × FF61 × 2028 ÷ FF63 × 2024 × E0184 ÷ 11B76 × 9FF3 × 13434 × 2007 × 1EFD × 2C2A × 2009 × FE5D × 00AD × 13435 × FF1A × 5F5A × 2060 × FF1A × 1A59 × 2006 × 1291B × 002E × FF0E × 0039 × 0965 × 2007 × 000A ÷ 2068 × 2062 × 111BF × 003A × 007D × FE55 × 205F × AA5F ÷ 0272 × 002E × 002C × 1945 × 11EF8 ÷ 16A67 × 1714 × 000D ÷ 1344B × FE57 ÷ 1D60D × 1D7E8 × 2006 × 2024 × E0001 ÷ 13D3 × 02AF × F28A × 2172 × 1144C ÷ A034 × FF0D × 115D4 × 0FB0 ÷ 2C1C × 13A1 × 115CF × 2024 × 0022 × 206F × 202C × 002E × 0A75 × 1DA3B ÷ 91C8 × 061D × A876 ÷ 2EDB × A8CF ÷ 01DA × 14B83 × 11A42 ÷ 00F0 × FF5B × 1144C × 07F8 × 0195 × 2024 ÷ 83C7 × 000A ÷ 13CD × 1F56 × 0085 ÷ 20E6 × 01D6 × 1DA53 × 298C × 11142 × 1802 × 060D × 000A ÷ 13437 × FE13 × 0A3F × FE52 × 24E6 × 2000 × 0DD9 × 2C76 × FF0E × 000A ÷ 002E × 13435 × 002E × 000D ÷ 2060 × 1D77F × 002E × 16AC2 × 1E005 × FE52 × FF0D × 11143 × 275E × 2068 × 1935 × 13433 × 000D ÷ FE52 × FE43 ÷ 612C × 13438 × 2028 ÷ 3000 × 003A × FF0E × 202E ÷ 052A × 002E × 111C5 ÷ EE49 × 3000 × 1E2F6 × 1B7D ÷ 28F7 × 1712 × 104CF × 11EF6 × A9F3 × 759B × 0962 × E770 × 206A × FF0E × 000A ÷ 2000 × 111C5 × 1DE9 × 2E04 × FF0C × 3000 × 000D ÷ FE63 × 1343E × 000A ÷ 0E56 × 000D ÷ FF0E × 3001 × 16F71 × 0414 × FD3E × 1C59 × FF09 × 0027 × 12872 × 000D ÷ A620 × 000D ÷ 1123B × 1033 × A950 × 206E × 300F ÷ 773F × 0009 × 2029 ÷ 1D17A × 2002 × FE0A × 2C8A × A9D1 × FE5D × 2029 ÷ 15236 × 16AF5 ÷ A623 × 13430 × 000A ÷ 0496 × 002E × 3000 ÷ 4130 × 2008 × 002E × 114D0 × 000D ÷ 16AF5 ÷ 5F2F × 0029 × 2024 ÷ 1F2E × 12CB6 × 118AC × 24D2 × 000D ÷ 1D402 × 11BBC × 2028 ÷ 2C99 × 11C58 × 0965 × A4FF × FF0E × 0456 × FF0E × 2000 × 205F × 200E ÷ 1516D × 3001 × 1043 × EEEE × 0B67 × 0085 ÷ 1BCA0 × A9B9 × 119D3 × 5F09 × 20DD × 0085 ÷ 2C03 × 206D × 158F2 × 2C85 × 1F678 × FE52 × E7D5 × 27EB × ABF3 × 2008 × 11EC3 × FE58 × 2000 × 0E58 × 15B32 × 10B79 × 2C7B × 2007 × 1343E × 1808 × 205F × 002E × 11450 × 9B18 × 2024 × 000A ÷ A900 × 2006 × FE11 × 0FB2 × 1BCA1 × 1EFB × 0085 ÷ 1261 × 2024 ÷ 5437 × 2024 × 000A ÷ 1F176 × 118B1 × 000A ÷ FE50 × 2007 × FE13 × 150E8 × 2005 × 200B × 1D46C × 8E9F × 1042 × FE10 × 1DF11 × 1E947 × 10A8 × 13F99 × 2E9A × 17E9 × 118E5 × 12E47 × 491F × 2002 × 9C12 × 002E × A92D × 0085 ÷ 1808 × 5CB0 × 13435 × 1D6AA × 23DE × 10CE8 × 00AB × 115CD × 2029 ÷ 10449 × 0F9F × 04EA × 1D7B3 × 0702 × 002C × 03F9 × A4FF × 0670 ÷ 5BC5 × FE32 × FE32 × 7EEA × A68B × 09D6 × 07AF × 2002 × 11B7B × 2CB4 × 1D6BC × 00DE × 1498D × 2E00 × 1D174 × 06DD × 13431 × 2308 × 76CB × 10413 × 200A × 115E7 × 002E × FF64 × 0C6F × 276C × 2001 × 1D76A × 000A ÷ 3000 × 1D5A1 × FE11 × 774F × 2024 × 1BC9D × 1934 ÷ 1D6F9 × 1BB8 × 1BA7 × 002E × 0029 ÷ 9616 × 1D4D2 × 1F15E × 002E ÷ 228D × 2000 × 2E2E × 07F8 × FF0E ÷ 96EF × 2009 × FF64 × 1E05F × 301D × 000D ÷ 206B × FF11 × 0030 × 2DEF × 2024 × 2064 × 118D7 × 1DAA6 × E053 × 1802 × 0CC4 × 2E54 × FE3A ÷ 67DB × 2014 × 129E × 2024 × 00A0 × 2029 ÷ 104A0 × 2028 ÷ 301A × 061D × 0965 × A69F × 11F36 ÷ F868 × 2029 ÷ 16B37 × 055D × 002E × 200B ÷ 15C6E × 0241 × A60F × FE51 × 7188 × 2028 ÷ 2007 × 016E × 9047 × 891E × 0208 × 298E × 2060 × 11A34 × 2C40 × 3370 × 0020 × A9D9 × 13439 × 2006 × 1E04 × 2024 × 1C3B ÷ AA59 × 2028 ÷ 11953 × 000D ÷ FE57 ÷ 1E143 × 11237 × 111B5 × 10F59 × 11F44 × 0964 ÷ 11653 × 2064 × 2028 ÷ 1DF5 × 104B6 × 1814 × 2006 × 110BF × FE52 × FE52 × FFFB × 3001 × 1680 × FE10 × 2018 × 1C3C ÷ 118E1 × A692 × 07F8 × 3000 × 2028 ÷ 44CB × 2024 × 002E × 202F × 1F27 × EF10 × 000A ÷ 10F59 × FF0E ÷  # 🐒
```
(Only two lines because the loop count gets divided by ten for sentence segmentation.)


<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22518
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
