### PR TITLE
ICU-22526 Allow GMT-23:59 time zone

### DIFF
--- a/icu4c/source/i18n/calendar.cpp
+++ b/icu4c/source/i18n/calendar.cpp
@@ -636,7 +636,7 @@ static const int32_t kCalendarLimits[UCAL_FIELD_COUNT][4] = {
     {           0,            0,            59,            59  }, // MINUTE
     {           0,            0,            59,            59  }, // SECOND
     {           0,            0,           999,           999  }, // MILLISECOND
-    {-16*kOneHour, -16*kOneHour,   12*kOneHour,   30*kOneHour  }, // ZONE_OFFSET
+    {-24*kOneHour, -16*kOneHour,   12*kOneHour,   30*kOneHour  }, // ZONE_OFFSET
     { -1*kOneHour,  -1*kOneHour,    2*kOneHour,    2*kOneHour  }, // DST_OFFSET
     {/*N/A*/-1,       /*N/A*/-1,     /*N/A*/-1,       /*N/A*/-1}, // YEAR_WOY
     {           1,            1,             7,             7  }, // DOW_LOCAL

--- a/icu4c/source/test/intltest/tztest.cpp
+++ b/icu4c/source/test/intltest/tztest.cpp
@@ -80,6 +80,7 @@ void TimeZoneTest::runIndexedTest( int32_t index, UBool exec, const char* &name,
     TESTCASE_AUTO(TestCasablancaNameAndOffset22041);
     TESTCASE_AUTO(TestRawOffsetAndOffsetConsistency22041);
     TESTCASE_AUTO(TestGetIanaID);
+    TESTCASE_AUTO(TestGMTMinus24ICU22526);
     TESTCASE_AUTO_END;
 }
 
@@ -2663,5 +2664,14 @@ void TimeZoneTest::TestGetIanaID() {
             assertEquals(ianaID, ianaID, ianaID2);
         }
     }
+}
+
+void TimeZoneTest::TestGMTMinus24ICU22526() {
+    UErrorCode status = U_ZERO_ERROR;
+    LocalPointer<TimeZone> tz(TimeZone::createTimeZone("GMT-23:59"), status);
+    U_ASSERT(U_SUCCESS(status));
+    GregorianCalendar gc(tz.orphan(), status);
+    gc.setTime(123456789, status);
+    gc.get(UCAL_MONTH, status);
 }
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/test/intltest/tztest.h
+++ b/icu4c/source/test/intltest/tztest.h
@@ -105,6 +105,7 @@ public:
     void TestGetIDForWindowsID();
     void TestCasablancaNameAndOffset22041();
     void TestRawOffsetAndOffsetConsistency22041();
+    void TestGMTMinus24ICU22526();
 
     void TestGetIanaID();
 

--- a/icu4j/main/core/src/main/java/com/ibm/icu/util/Calendar.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/util/Calendar.java
@@ -4581,7 +4581,7 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
         {           0,            0,            59,            59  }, // MINUTE
         {           0,            0,            59,            59  }, // SECOND
         {           0,            0,           999,           999  }, // MILLISECOND
-        {-16*ONE_HOUR, -16*ONE_HOUR,   12*ONE_HOUR,   30*ONE_HOUR  }, // ZONE_OFFSET
+        {-24*ONE_HOUR, -16*ONE_HOUR,   12*ONE_HOUR,   30*ONE_HOUR  }, // ZONE_OFFSET
         {           0,            0,    2*ONE_HOUR,    2*ONE_HOUR  }, // DST_OFFSET
         {/*                                                      */}, // YEAR_WOY
         {           1,            1,             7,             7  }, // DOW_LOCAL

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timezone/TimeZoneTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timezone/TimeZoneTest.java
@@ -2419,6 +2419,13 @@ public class TimeZoneTest extends TestFmwk
             }
         }
     }
+    @Test
+    public void TestGMTMinus24ICU22526() {
+        TimeZone tz = TimeZone.getTimeZone("GMT-23:59");
+        GregorianCalendar gc = new GregorianCalendar(tz);
+        gc.setTimeInMillis(123456789);
+        gc.get(GregorianCalendar.MONTH);
+    }
 }
 
 //eof


### PR DESCRIPTION
ECMA402 now allow offset timezone from -23:59 to 23:59. We need to lower the minimum ZONE_OFFSET value to -23:59

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22526
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
