### PR TITLE
ICU-22536 Fix ICUServiceThreadTest flakiness

### DIFF
--- a/icu4j/main/core/src/main/java/com/ibm/icu/impl/ICUService.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/impl/ICUService.java
@@ -592,13 +592,17 @@ public class ICUService extends ICUNotifier {
                         Factory f = lIter.previous();
                         f.updateVisibleIDs(mutableMap);
                     }
-                    this.idcache = Collections.unmodifiableMap(mutableMap);
+                    // Capture the return value in a local variable.
+                    // Avoids returning an idcache value changed by another thread (could be null after clearCaches()).
+                    Map<String, Factory> result = Collections.unmodifiableMap(mutableMap);
+                    this.idcache = result;
+                    return result;
                 } finally {
                     factoryLock.releaseRead();
                 }
             }
+            return idcache;
         }
-        return idcache;
     }
     private Map<String, Factory> idcache;
 


### PR DESCRIPTION
Sometimes getVisibleIDs() method returns a null reference which might happend because of inaccurate concurrent access. This change attempts to fix this ICUServiceThreadTest flakiness.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [ ] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22536
- [ ] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
