### PR TITLE
Fix some links in documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
 <!--
 Thank you for your pull request!
 
-Please see http://site.icu-project.org/processes/contribute for general
-information on contributing to ICU.
+Please see https://github.com/unicode-org/icu/blob/main/CONTRIBUTING.md for
+general information on contributing to ICU.
 
 You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
 - sign: https://cla-assistant.io/unicode-org/icu

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ OpenSSF Scorecard | [![OpenSSF Scorecard](https://api.securityscorecards.dev/pro
 
 ### Subdirectories and Information
 
-- [`icu4c/`](./icu4c/) [ICU for C/C++](./icu4c/readme.html)
-- [`icu4j/`](./icu4j/) [ICU for Java](./icu4j/readme.html)
+- [`icu4c/`](./icu4c/) [ICU for C/C++](https://unicode-org.github.io/icu/userguide/icu4c/)
+- [`icu4j/`](./icu4j/) [ICU for Java](https://unicode-org.github.io/icu/userguide/icu4j/)
 - [`tools/`](./tools/) Tools
 - [`vendor/`](./vendor/) Vendor dependencies
 

--- a/docs/devsetup/cpp/index.md
+++ b/docs/devsetup/cpp/index.md
@@ -36,7 +36,7 @@ are visible as environment variables in the runConfigureICU shell script, rather
 than just options text.) See the sample runConfigureICU invocations below.
 
 See the ICU4C readme's [Recommended Build
-Options](https://htmlpreview.github.io/?https://github.com/unicode-org/icu/blob/master/icu4c/readme.html#RecBuild).
+Options](https://unicode-org.github.io/icu/userguide/icu4c/build.html#recommended-build-options).
 
 For example:
 

--- a/docs/devsetup/source/index.md
+++ b/docs/devsetup/source/index.md
@@ -102,7 +102,8 @@ There are many resources available to help you work with git, here are a few:
 *   <https://try.github.io/> - Resources to learn Git
 
 Want to contribute back to ICU? See
-[How to contribute](../../userguide/processes/contribute.md).
+[Contributing to ICU](https://github.com/unicode-org/icu/blob/main/CONTRIBUTING.md)
+and [the Contributors section of the User Guide](../../userguide/dev/).
 
 ## Repository Layout
 

--- a/docs/processes/release/tasks/publish/index.md
+++ b/docs/processes/release/tasks/publish/index.md
@@ -283,9 +283,9 @@ run \`make dist\`.
 #### Windows Binary:
 
 *   Manual process:
-    *   Build with MSVC x64 Release. (See the ICU
-        [readme.html](https://github.com/unicode-org/icu/main/blob/icu4c/readme.html)
-        file for details).
+    *   Build with MSVC x64 Release. (See
+        [Building ICU4C](https://unicode-org.github.io/icu/userguide/icu4c/build.html)
+        for details).
     *   Open a command prompt.
         ```
         cd C:\icu\icu4c\ (or wherever you have ICU located).
@@ -529,6 +529,10 @@ Jira.
 1.  Open <https://unicode-org.atlassian.net/issues/?filter=10007>
 2.  Use the drop-down to change the fix version to the next ICU version
 3.  Click "Save" next to the filter title
+
+## Update this document
+
+... because the next section is very much not up to date:
 
 ## Update readme
 

--- a/docs/userguide/icu4c/faq.md
+++ b/docs/userguide/icu4c/faq.md
@@ -42,7 +42,7 @@ versions of ICU, but we will assist in building other versions from source.
 **Why don't you provide project files for my MSVC version (MSVC 2008, etc)?**
 
 You can use the Cygwin build environment to build ICU from source against the
-MSVC compiler. See the [Building ICU4C](./icu4c/build) page.
+MSVC compiler. See the [Building ICU4C](./build.html) page.
 
 #### How do I install the binary versions of ICU?
 
@@ -69,8 +69,8 @@ MSVC compiler. See the [Building ICU4C](./icu4c/build) page.
 
 #### Can you help me build ICU4C for ...
 
-We can try ... make sure you read the [Building ICU4C](./icu4c/build) section and also the [ICU
-Data](../icudata.md) section. You might also [searching the icu-support
+We can try ... make sure you read the [Building ICU4C](./build.html) section and also the [ICU
+Data](../icu_data/) section. You might also [searching the icu-support
 archives](https://icu.unicode.org/contacts), and then posting a question
 there. Additionally, sites such as
 [StackOverflow](http://stackoverflow.com/search?q=icu) may have helpful tips for
@@ -146,7 +146,7 @@ upgrade-friendly.
 
 #### How do I build ICU?
 
-See the [Building ICU4C](./icu4c/build) section.
+See the [Building ICU4C](./build.html) section.
 
 #### How do I get 32- or 64-bit versions of the ICU libraries?
 

--- a/docs/userguide/icu4c/index.md
+++ b/docs/userguide/icu4c/index.md
@@ -313,11 +313,11 @@ In the descriptions below, `<ICU>` is the full path name of the ICU4C directory 
 
 ## How To Build And Install ICU
 
-See the page on [building ICU4C](./build).
+See the page on [building ICU4C](./build.html).
 
 ## How To Package ICU
 
-See the page on [packaging ICU4C](./packaging).
+See the page on [packaging ICU4C](./packaging.html).
 
 ## Important Notes About Using ICU
 

--- a/icu4c/source/data/icu4j-readme.txt
+++ b/icu4c/source/data/icu4j-readme.txt
@@ -30,7 +30,7 @@ In the following,
 
    For more instructions on downloading and building ICU4C,
    see the ICU4C readme at:
-        https://htmlpreview.github.io/?https://github.com/unicode-org/icu/blob/main/icu4c/readme.html#HowToBuild
+        https://unicode-org.github.io/icu/userguide/icu4c/build.html
         (Windows: build as 'x86, Release' otherwise you will have to set 'CFG' differently below.)
 
     *NOTE* You should do a full rebuild after any data changes.


### PR DESCRIPTION
WIP: maybe this should become part of ICU-22438 ?

- Skip over the manual redirects that are icu4[cj]/readme.html.
- Update links: site.icu-project.org/processes/contribute is no more.
- Update link paths: some relative links in moved docs were pointing at userguide/icu4c/icu4c
- Add .html suffixes, letting unicode-org.github.io sidebar correctly show which page is being viewed. However it would also break Markdown navigation. Which use case are we optimising for? GitHub Pages, or Markdown source?

I wasn't very thorough with my searches, this was based on broken links

rgrep processes/contribute .
rgrep 'icu4[cj]/readme.html' .
egrep -r '/packaging)|/build)' .

I've not fixed all the /icudata.md links yet for example. Should perhaps add all of those to this PR?

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [ ] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
- [ ] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
