### PR TITLE
ICU-22505 Ensure default TZ remains unchanged by each test

### DIFF
--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/TestLocaleNamePackaging.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/TestLocaleNamePackaging.java
@@ -23,7 +23,7 @@ import com.ibm.icu.text.LocaleDisplayNames.DialectHandling;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class TestLocaleNamePackaging extends TestFmwk {
+public class TestLocaleNamePackaging extends CoreTestFmwk {
     public TestLocaleNamePackaging() {
     }
 

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/calendar/DataDrivenCalendarTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/calendar/DataDrivenCalendarTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.calendar;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -21,7 +22,6 @@ import com.ibm.icu.dev.test.ModuleTest.TestDataPair;
 import com.ibm.icu.dev.test.TestDataModule;
 import com.ibm.icu.dev.test.TestDataModule.DataMap;
 import com.ibm.icu.dev.test.TestDataModule.TestData;
-import com.ibm.icu.dev.test.TestFmwk;
 import com.ibm.icu.dev.test.util.CalendarFieldsSet;
 import com.ibm.icu.text.DateFormat;
 import com.ibm.icu.text.SimpleDateFormat;
@@ -40,7 +40,7 @@ import junitparams.Parameters;
  *
  */
 @RunWith(JUnitParamsRunner.class)
-public class DataDrivenCalendarTest extends TestFmwk {
+public class DataDrivenCalendarTest extends CoreTestFmwk {
 
     public DataDrivenCalendarTest() {
         //super("com/ibm/icu/dev/data/testdata/", "calendar");
@@ -54,7 +54,6 @@ public class DataDrivenCalendarTest extends TestFmwk {
     /* (non-Javadoc)
      * @see com.ibm.icu.dev.test.ModuleTest#processModules()
      */
-    @Ignore  // TODO(ICU-22505)
     @Test
     @Parameters(method="getTestData")
     public void calendarTest(TestDataPair pair) {

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/CompactDecimalFormatTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/CompactDecimalFormatTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -28,7 +29,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.ibm.icu.dev.test.TestFmwk;
 import com.ibm.icu.impl.number.DecimalFormatProperties;
 import com.ibm.icu.impl.number.PatternStringParser;
 import com.ibm.icu.text.CompactDecimalFormat;
@@ -41,7 +41,7 @@ import com.ibm.icu.util.CurrencyAmount;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class CompactDecimalFormatTest extends TestFmwk {
+public class CompactDecimalFormatTest extends CoreTestFmwk {
     Object[][] EnglishTestData = {
             // default is 2 digits of accuracy
             {0.0d, "0"},

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/DataDrivenFormatTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/DataDrivenFormatTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.FieldPosition;
 import java.text.ParsePosition;
 import java.util.Date;
@@ -23,7 +24,6 @@ import com.ibm.icu.dev.test.ModuleTest.TestDataPair;
 import com.ibm.icu.dev.test.TestDataModule;
 import com.ibm.icu.dev.test.TestDataModule.DataMap;
 import com.ibm.icu.dev.test.TestDataModule.TestData;
-import com.ibm.icu.dev.test.TestFmwk;
 import com.ibm.icu.dev.test.util.CalendarFieldsSet;
 import com.ibm.icu.dev.test.util.DateTimeStyleSet;
 import com.ibm.icu.text.DateFormat;
@@ -41,7 +41,7 @@ import junitparams.Parameters;
  *
  */
 @RunWith(JUnitParamsRunner.class)
-public class DataDrivenFormatTest extends TestFmwk {
+public class DataDrivenFormatTest extends CoreTestFmwk {
 
     /**
      * @param baseName
@@ -59,7 +59,6 @@ public class DataDrivenFormatTest extends TestFmwk {
     /* (non-Javadoc)
      * @see com.ibm.icu.dev.test.ModuleTest#processModules()
      */
-    @Ignore  // TODO(ICU-22505)
     @Test
     @Parameters(method="getTestData")
     public void formatTest(TestDataPair pair) {

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/DateFormatTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/DateFormatTest.java
@@ -14,6 +14,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -69,7 +70,7 @@ import com.ibm.icu.util.UResourceBundle;
 import com.ibm.icu.util.VersionInfo;
 
 @RunWith(JUnit4.class)
-public class DateFormatTest extends TestFmwk {
+public class DateFormatTest extends CoreTestFmwk {
     /**
      * Verify that patterns have the correct values and could produce the
      * the DateFormat instances that contain the correct localized patterns.
@@ -614,7 +615,6 @@ public class DateFormatTest extends TestFmwk {
         expect(DATA, new Locale("en", "", ""));
     }
 
-    @Ignore  // TODO(ICU-22505)
     @Test
     public void TestGenericTime() {
 
@@ -720,7 +720,6 @@ public class DateFormatTest extends TestFmwk {
 
     }
 
-    @Ignore  // TODO(ICU-22505)
     @Test
     public void TestGenericTimeZoneOrder() {
         // generic times should parse the same no matter what the placement of the time zone string
@@ -2202,7 +2201,6 @@ public class DateFormatTest extends TestFmwk {
     /**
      * Test DateFormat(Calendar) API
      */
-    @Ignore  // TODO(ICU-22505)
     @Test
     public void TestDateFormatCalendar() {
         DateFormat date=null, time=null, full=null;

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/IntlTestDecimalFormatAPIC.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/IntlTestDecimalFormatAPIC.java
@@ -14,6 +14,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.AttributedCharacterIterator;
 import java.text.FieldPosition;
 import java.text.Format;
@@ -38,11 +39,12 @@ import com.ibm.icu.util.ULocale;
 // try to test the full functionality.  It just calls each function in the class and
 // verifies that it works on a basic level.
 @RunWith(JUnit4.class)
-public class IntlTestDecimalFormatAPIC extends TestFmwk {
+public class IntlTestDecimalFormatAPIC extends CoreTestFmwk {
 
     // This test checks various generic API methods in DecimalFormat to achieve 100% API coverage.
     @Test
     public void TestAPI() {
+        Locale startLocale = Locale.getDefault();
 
         logln("DecimalFormat API test---");
         logln("");
@@ -250,6 +252,7 @@ public class IntlTestDecimalFormatAPIC extends TestFmwk {
         //            errln("ERROR: Couldn't create a DecimalFormat");
         //        }
 
+        Locale.setDefault(startLocale);
     }
 
     @Test

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/IntlTestDecimalFormatSymbolsC.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/IntlTestDecimalFormatSymbolsC.java
@@ -14,6 +14,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.FieldPosition;
 import java.util.Locale;
 
@@ -29,7 +30,7 @@ import com.ibm.icu.text.DecimalFormatSymbols;
  * Tests for DecimalFormatSymbols
  **/
 @RunWith(JUnit4.class)
-public class IntlTestDecimalFormatSymbolsC extends TestFmwk {
+public class IntlTestDecimalFormatSymbolsC extends CoreTestFmwk {
     /**
      * Test the API of DecimalFormatSymbols; primarily a simple get/set set.
      */

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/MeasureUnitTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/MeasureUnitTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -60,7 +61,7 @@ import com.ibm.icu.util.ULocale;
  * @author markdavis
  */
 @RunWith(JUnit4.class)
-public class MeasureUnitTest extends TestFmwk {
+public class MeasureUnitTest extends CoreTestFmwk {
 
     static class OrderedPair<F extends Comparable, S extends Comparable> extends Pair<F, S> implements Comparable<OrderedPair<F, S>> {
 

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/NumberFormatRegressionTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/NumberFormatRegressionTest.java
@@ -14,6 +14,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -38,7 +39,7 @@ import com.ibm.icu.util.ULocale;
  * Performs regression test for MessageFormat
  **/
 @RunWith(JUnit4.class)
-public class NumberFormatRegressionTest extends TestFmwk {
+public class NumberFormatRegressionTest extends CoreTestFmwk {
     /**
      * alphaWorks upgrade
      */

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/NumberFormatSpecificationTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/NumberFormatSpecificationTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -24,7 +25,7 @@ import com.ibm.icu.util.ULocale;
  *
  */
 @RunWith(JUnit4.class)
-public class NumberFormatSpecificationTest extends TestFmwk {
+public class NumberFormatSpecificationTest extends CoreTestFmwk {
     @Test
     public void TestBasicPatterns() {
         double num = 1234.567;

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/NumberFormatTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/NumberFormatTest.java
@@ -40,7 +40,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.ibm.icu.dev.test.TestFmwk;
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import com.ibm.icu.dev.test.TestUtil;
 import com.ibm.icu.dev.test.format.IntlTestDecimalFormatAPIC.FieldContainer;
 import com.ibm.icu.impl.DontCareFieldPosition;
@@ -69,7 +69,7 @@ import com.ibm.icu.util.CurrencyAmount;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class NumberFormatTest extends TestFmwk {
+public class NumberFormatTest extends CoreTestFmwk {
 
     @Test
     public void TestRoundingScientific10542() {
@@ -208,7 +208,7 @@ public class NumberFormatTest extends TestFmwk {
             double value = parser.parse("-0,5").doubleValue();
             assertEquals("Expect -0.5", -0.5, value);
         } catch (ParseException e) {
-            TestFmwk.errln("Parsing -0.5 should have succeeded.");
+            errln("Parsing -0.5 should have succeeded.");
         }
     }
 
@@ -219,7 +219,7 @@ public class NumberFormatTest extends TestFmwk {
             double value = parser.parse("\u208B0.5").doubleValue();
             assertEquals("Expect -0.5", -0.5, value);
         } catch (ParseException e) {
-            TestFmwk.errln("Parsing -0.5 should have succeeded.");
+            errln("Parsing -0.5 should have succeeded.");
         }
     }
 
@@ -4625,14 +4625,14 @@ public class NumberFormatTest extends TestFmwk {
                 result = parser.parse(value2Parse).doubleValue();
                 assertEquals("wrong parsed value", parseValue, result);
             } catch (ParseException e) {
-                TestFmwk.errln("Parsing " + value2Parse + " should have succeeded with " + testPattern[i] +
+                errln("Parsing " + value2Parse + " should have succeeded with " + testPattern[i] +
                             " and isDecimalPointMatchRequired set to: " + parser.isDecimalPatternMatchRequired());
             }
             try {
                 result = parser.parse(value2ParseWithDecimal).doubleValue();
                 assertEquals("wrong parsed value", parseValueWithDecimal, result);
             } catch (ParseException e) {
-                TestFmwk.errln("Parsing " + value2ParseWithDecimal + " should have succeeded with " + testPattern[i] +
+                errln("Parsing " + value2ParseWithDecimal + " should have succeeded with " + testPattern[i] +
                             " and isDecimalPointMatchRequired set to: " + parser.isDecimalPatternMatchRequired());
             }
 
@@ -4640,7 +4640,7 @@ public class NumberFormatTest extends TestFmwk {
             try {
                 result = parser.parse(value2Parse).doubleValue();
                 if(hasDecimalPoint){
-                    TestFmwk.errln("Parsing " + value2Parse + " should NOT have succeeded with " + testPattern[i] +
+                    errln("Parsing " + value2Parse + " should NOT have succeeded with " + testPattern[i] +
                             " and isDecimalPointMatchRequired set to: " + parser.isDecimalPatternMatchRequired());
                 }
             } catch (ParseException e) {
@@ -4649,7 +4649,7 @@ public class NumberFormatTest extends TestFmwk {
             try {
                 result = parser.parse(value2ParseWithDecimal).doubleValue();
                 if(!hasDecimalPoint){
-                    TestFmwk.errln("Parsing " + value2ParseWithDecimal + " should NOT have succeeded with " + testPattern[i] +
+                    errln("Parsing " + value2ParseWithDecimal + " should NOT have succeeded with " + testPattern[i] +
                             " and isDecimalPointMatchRequired set to: " + parser.isDecimalPatternMatchRequired() +
                             " (got: " + result + ")");
                 }

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/NumberRegressionTests.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/NumberRegressionTests.java
@@ -43,7 +43,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.ibm.icu.dev.test.TestFmwk;
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import com.ibm.icu.impl.ICUData;
 import com.ibm.icu.impl.ICUResourceBundle;
 import com.ibm.icu.text.DateFormat;
@@ -56,7 +56,7 @@ import com.ibm.icu.util.ULocale;
 import com.ibm.icu.util.VersionInfo;
 
 @RunWith(JUnit4.class)
-public class NumberRegressionTests extends TestFmwk {
+public class NumberRegressionTests extends CoreTestFmwk {
     private static final char EURO = '\u20ac';
 
     /**

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/PluralRangesTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/PluralRangesTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Arrays;
 
 import org.junit.Test;
@@ -33,7 +34,7 @@ import com.ibm.icu.util.ULocale;
  *
  */
 @RunWith(JUnit4.class)
-public class PluralRangesTest extends TestFmwk {
+public class PluralRangesTest extends CoreTestFmwk {
     @Test
     public void TestLocaleData() {
         String[][] tests = {

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/PluralRulesTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/PluralRulesTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -73,7 +74,7 @@ import com.ibm.icu.util.ULocale;
  * @author markdavis (Mark Davis) [for fractional support]
  */
 @RunWith(JUnit4.class)
-public class PluralRulesTest extends TestFmwk {
+public class PluralRulesTest extends CoreTestFmwk {
 
     PluralRulesFactory factory = PluralRulesFactory.NORMAL;
 
@@ -1712,6 +1713,8 @@ public class PluralRulesTest extends TestFmwk {
 
     @Test
     public void testBug20264() {
+        Locale startLocale = Locale.getDefault();
+
         String expected = "1.23400";
         FixedDecimal fd = new FixedDecimal(1.234, 5, 2);
         assertEquals("FixedDecimal toString", expected, fd.toString());
@@ -1719,6 +1722,8 @@ public class PluralRulesTest extends TestFmwk {
         assertEquals("FixedDecimal toString", expected, fd.toString());
         Locale.setDefault(Locale.GERMAN);
         assertEquals("FixedDecimal toString", expected, fd.toString());
+
+        Locale.setDefault(startLocale);
     }
 
     @Test

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/RbnfTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/RbnfTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.math.BigInteger;
 import java.text.ParseException;
 import java.util.Locale;
@@ -31,7 +32,7 @@ import com.ibm.icu.util.ULocale;
  * introduces a dependency on collation.  See RbnfLenientScannerTest.
  */
 @RunWith(JUnit4.class)
-public class RbnfTest extends TestFmwk {
+public class RbnfTest extends CoreTestFmwk {
     static String fracRules =
         "%main:\n" +
         // this rule formats the number if it's 1 or more.  It formats

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/TestMessageFormat.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/TestMessageFormat.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.ibm.icu.dev.test.TestFmwk;
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import com.ibm.icu.text.DateFormat;
 import com.ibm.icu.text.DecimalFormat;
 import com.ibm.icu.text.DecimalFormatSymbols;
@@ -47,7 +47,7 @@ import com.ibm.icu.util.TimeZone;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class TestMessageFormat extends TestFmwk {
+public class TestMessageFormat extends CoreTestFmwk {
     @Test
     public void TestBug3()
     {
@@ -151,7 +151,6 @@ public class TestMessageFormat extends TestFmwk {
         }
     }
 
-    @Ignore  // TODO(ICU-22505)
     @Test
     public void TestPattern() // aka PatternTest()
     {
@@ -270,7 +269,6 @@ public class TestMessageFormat extends TestFmwk {
                      form.format(testArgs1, buffer2, fieldpos).toString());
     }
 
-    @Ignore  // TODO(ICU-22505)
     @Test
     public void TestStaticFormat()
     {
@@ -808,7 +806,6 @@ public class TestMessageFormat extends TestFmwk {
      * Verify that MessageFormat accommodates more than 10 arguments and
      * more than 10 subformats.
      */
-    @Ignore  // TODO(ICU-22505)
     @Test
     public void TestUnlimitedArgsAndSubformats() {
         final String pattern =
@@ -1226,7 +1223,6 @@ public class TestMessageFormat extends TestFmwk {
         } catch (IllegalArgumentException e) {}
     }
 
-    @Ignore  // TODO(ICU-22505)
     @Test
     public void testNumericFormatWithMap() {
         MessageFormat mf = new MessageFormat("X:{2} Y:{1}");
@@ -1603,7 +1599,6 @@ public class TestMessageFormat extends TestFmwk {
     }
 
     // Test case for formatToCharacterIterator
-    @Ignore  // TODO(ICU-22505)
     @Test
     public void TestFormatToCharacterIterator() {
         MessageFormat[] msgfmts = {

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/TimeZoneFormatTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/TimeZoneFormatTest.java
@@ -9,6 +9,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.FieldPosition;
 import java.text.ParseException;
 import java.text.ParsePosition;
@@ -53,7 +54,7 @@ import com.ibm.icu.util.TimeZoneTransition;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class TimeZoneFormatTest extends TestFmwk {
+public class TimeZoneFormatTest extends CoreTestFmwk {
 
     private static boolean JDKTZ = (TimeZone.getDefaultTimeZoneType() == TimeZone.TIMEZONE_JDK);
     private static final Pattern EXCL_TZ_PATTERN = Pattern.compile(".*/Riyadh8[7-9]");

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/message2/Mf2FeaturesTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/message2/Mf2FeaturesTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.ibm.icu.dev.test.TestFmwk;
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import com.ibm.icu.math.BigDecimal;
 import com.ibm.icu.util.Currency;
 import com.ibm.icu.util.CurrencyAmount;
@@ -27,7 +27,7 @@ import com.ibm.icu.util.CurrencyAmount;
  */
 @RunWith(JUnit4.class)
 @SuppressWarnings("javadoc")
-public class Mf2FeaturesTest extends TestFmwk {
+public class Mf2FeaturesTest extends CoreTestFmwk {
 
     // November 23, 2022 at 7:42:37.123 PM
     static final Date TEST_DATE = new Date(1669261357123L);
@@ -59,7 +59,6 @@ public class Mf2FeaturesTest extends TestFmwk {
                 .build());
     }
 
-    @Ignore  // TODO(ICU-22505)
     @Test
     public void testArgumentMissing() {
         // Test to check what happens if an argument name from the placeholder is not found
@@ -88,7 +87,6 @@ public class Mf2FeaturesTest extends TestFmwk {
                 .build());
     }
 
-    @Ignore  // TODO(ICU-22505)
     @Test
     public void testDefaultLocale() {
         String message = "{Date: {$date :datetime skeleton=yMMMMdEEEE}.}";
@@ -124,7 +122,6 @@ public class Mf2FeaturesTest extends TestFmwk {
         Locale.setDefault(originalLocale);
     }
 
-    @Ignore  // TODO(ICU-22505)
     @Test
     public void testAllKindOfDates() {
         // Default function
@@ -361,7 +358,6 @@ public class Mf2FeaturesTest extends TestFmwk {
                 .build());
     }
 
-    @Ignore  // TODO(ICU-22505)
     @Test
     public void testDefaultFunctionAndOptions() {
         TestUtils.runTestCase(new TestCase.Builder()
@@ -436,7 +432,6 @@ public class Mf2FeaturesTest extends TestFmwk {
 
     // Local Variables
 
-    @Ignore  // TODO(ICU-22505)
     @Test
     public void testSimpleLocaleVariable() {
         TestUtils.runTestCase(new TestCase.Builder()
@@ -448,7 +443,6 @@ public class Mf2FeaturesTest extends TestFmwk {
                 .build());
     }
 
-    @Ignore  // TODO(ICU-22505)
     @Test
     public void testLocaleVariableWithSelect() {
         String message = ""

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/normalizer/BasicTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/normalizer/BasicTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.ibm.icu.dev.test.TestFmwk;
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import com.ibm.icu.impl.Norm2AllModes;
 import com.ibm.icu.impl.Normalizer2Impl;
 import com.ibm.icu.impl.USerializedSet;
@@ -34,7 +34,7 @@ import com.ibm.icu.text.UnicodeSetIterator;
 
 
 @RunWith(JUnit4.class)
-public class BasicTest extends TestFmwk {
+public class BasicTest extends CoreTestFmwk {
     String[][] canonTests = {
         // Input                Decomposed              Composed
         { "cat",                "cat",                  "cat"               },

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
@@ -19,7 +19,7 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.ibm.icu.dev.test.TestFmwk;
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import com.ibm.icu.dev.test.format.FormattedValueTest;
 import com.ibm.icu.dev.test.serializable.SerializableTestUtility;
 import com.ibm.icu.impl.IllegalIcuArgumentException;
@@ -62,7 +62,7 @@ import com.ibm.icu.util.MeasureUnit;
 import com.ibm.icu.util.NoUnit;
 import com.ibm.icu.util.ULocale;
 
-public class NumberFormatterApiTest extends TestFmwk {
+public class NumberFormatterApiTest extends CoreTestFmwk {
 
     private static final Currency USD = Currency.getInstance("USD");
     private static final Currency GBP = Currency.getInstance("GBP");

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/number/NumberParserTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/number/NumberParserTest.java
@@ -2,10 +2,8 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 package com.ibm.icu.dev.test.number;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
+import com.ibm.icu.dev.test.CoreTestFmwk;
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.ibm.icu.impl.StringSegment;
@@ -30,7 +28,7 @@ import com.ibm.icu.util.ULocale;
  * @author sffc
  *
  */
-public class NumberParserTest {
+public class NumberParserTest extends CoreTestFmwk {
     @Test
     public void testBasic() {
         Object[][] cases = new Object[][] {
@@ -199,13 +197,13 @@ public class NumberParserTest {
 
         ParsedNumber resultObject = new ParsedNumber();
         parser.parse("epäluku", false, resultObject);
-        assertTrue(resultObject.success());
-        assertEquals(Double.NaN, resultObject.getNumber().doubleValue(), 0.0);
+        assertTrue("Parsing locale fi spellout number", resultObject.success());
+        Assert.assertEquals(Double.NaN, resultObject.getNumber().doubleValue(), 0.0);
 
         resultObject = new ParsedNumber();
         parser.parse("1,2e3", false, resultObject);
-        assertTrue(resultObject.success());
-        assertEquals(1200.0, resultObject.getNumber().doubleValue(), 0.0);
+        assertTrue("Parsing formatted compact decimal", resultObject.success());
+        Assert.assertEquals(1200.0, resultObject.getNumber().doubleValue(), 0.0);
     }
 
     @Test
@@ -219,9 +217,9 @@ public class NumberParserTest {
         series.addMatcher(IgnorablesMatcher.getInstance(0));
         series.freeze();
 
-        assertFalse(series.smokeTest(new StringSegment("x", false)));
-        assertFalse(series.smokeTest(new StringSegment("-", false)));
-        assertTrue(series.smokeTest(new StringSegment("+", false)));
+        Assert.assertFalse(series.smokeTest(new StringSegment("x", false)));
+        Assert.assertFalse(series.smokeTest(new StringSegment("-", false)));
+        Assert.assertTrue(series.smokeTest(new StringSegment("+", false)));
 
         Object[][] cases = new Object[][] {
                 { "", 0, true },

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/number/NumberPermutationTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/number/NumberPermutationTest.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 
 import org.junit.Test;
 
-import com.ibm.icu.dev.test.TestFmwk;
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import com.ibm.icu.dev.test.TestUtil;
 import com.ibm.icu.number.LocalizedNumberFormatter;
 import com.ibm.icu.number.NumberFormatter;
@@ -18,7 +18,7 @@ import com.ibm.icu.util.ULocale;
  * @author sffc
  *
  */
-public class NumberPermutationTest extends TestFmwk {
+public class NumberPermutationTest extends CoreTestFmwk {
 
     static final String[] kSkeletonParts = {
         // Notation

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/number/NumberRangeFormatterTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/number/NumberRangeFormatterTest.java
@@ -13,7 +13,7 @@ import java.util.Set;
 
 import org.junit.Test;
 
-import com.ibm.icu.dev.test.TestFmwk;
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import com.ibm.icu.dev.test.format.FormattedValueTest;
 import com.ibm.icu.impl.ICUData;
 import com.ibm.icu.impl.ICUResourceBundle;
@@ -41,7 +41,7 @@ import com.ibm.icu.util.UResourceBundle;
  * @author sffc
  *
  */
-public class NumberRangeFormatterTest extends TestFmwk {
+public class NumberRangeFormatterTest extends CoreTestFmwk {
 
     private static final Currency USD = Currency.getInstance("USD");
     private static final Currency CHF = Currency.getInstance("CHF");

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/number/PatternStringTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/number/PatternStringTest.java
@@ -5,6 +5,7 @@ package com.ibm.icu.dev.test.number;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 
 import com.ibm.icu.dev.test.format.FormattedValueTest;
@@ -21,7 +22,7 @@ import com.ibm.icu.util.Currency;
 import com.ibm.icu.util.ULocale;
 
 /** @author sffc */
-public class PatternStringTest {
+public class PatternStringTest extends CoreTestFmwk {
 
     @Test
     public void testLocalized() {
@@ -35,8 +36,8 @@ public class PatternStringTest {
         String localized = "’.'ab'c'b''a'''#,##0a0b'a%'";
         String toStandard = "+-'ab'c'b''a'''#,##0.0%'a%'";
 
-        assertEquals(localized, PatternStringUtils.convertLocalized(standard, symbols, true));
-        assertEquals(toStandard, PatternStringUtils.convertLocalized(localized, symbols, false));
+        assertEquals("Localized decimal format symbols", localized, PatternStringUtils.convertLocalized(standard, symbols, true));
+        assertEquals("Standard (unlocalized) decimal format symbols", toStandard, PatternStringUtils.convertLocalized(localized, symbols, false));
     }
 
     @Test

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/number/PropertiesTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/number/PropertiesTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -42,20 +43,20 @@ import com.ibm.icu.util.Currency.CurrencyUsage;
 import com.ibm.icu.util.MeasureUnit;
 import com.ibm.icu.util.ULocale;
 
-public class PropertiesTest {
+public class PropertiesTest extends CoreTestFmwk {
 
     @Test
     public void testBasicEquals() {
         DecimalFormatProperties p1 = new DecimalFormatProperties();
         DecimalFormatProperties p2 = new DecimalFormatProperties();
-        assertEquals(p1, p2);
+        assertEquals("DecimalFormatProperties.equals()", p1, p2);
 
         p1.setPositivePrefix("abc");
-        assertNotEquals(p1, p2);
+        assertNotEquals("DecimalFormatProperties.equals()", p1, p2);
         p2.setPositivePrefix("xyz");
-        assertNotEquals(p1, p2);
+        assertNotEquals("DecimalFormatProperties.equals()", p1, p2);
         p1.setPositivePrefix("xyz");
-        assertEquals(p1, p2);
+        assertEquals("DecimalFormatProperties.equals()", p1, p2);
     }
 
     @Test
@@ -124,50 +125,50 @@ public class PropertiesTest {
                 Object val0 = getSampleValueForType(field.getType(), 0);
                 Object val1 = getSampleValueForType(field.getType(), 1);
                 Object val2 = getSampleValueForType(field.getType(), 2);
-                assertNotEquals(val0, val1);
+                assertNotEquals("Test setup values should be different", val0, val1);
                 setter.invoke(p1, val0);
                 setter.invoke(p2, val0);
-                assertEquals(p1, p2);
-                assertEquals(p1.hashCode(), p2.hashCode());
-                assertEquals(getter.invoke(p1), getter.invoke(p2));
-                assertEquals(getter.invoke(p1), val0);
-                assertNotEquals(getter.invoke(p1), val1);
+                assertEquals("Equal outputs for equal DecimalFormatProperties inputs", p1, p2);
+                assertEquals("Equal outputs for equal DecimalFormatProperties inputs", p1.hashCode(), p2.hashCode());
+                assertEquals("Equal outputs for equal DecimalFormatProperties inputs", getter.invoke(p1), getter.invoke(p2));
+                assertEquals("Getter returns equal val set by setter for DecimalFormatProperties", getter.invoke(p1), val0);
+                assertNotEquals("Getter returns equal vals for equal inputs", getter.invoke(p1), val1);
                 hashCodes.add(p1.hashCode());
                 setter.invoke(p1, val1);
                 assertNotEquals("Field " + field + " is missing from equals()", p1, p2);
-                assertNotEquals(getter.invoke(p1), getter.invoke(p2));
-                assertNotEquals(getter.invoke(p1), val0);
-                assertEquals(getter.invoke(p1), val1);
+                assertNotEquals("Getter returns equal vals for equal inputs", getter.invoke(p1), getter.invoke(p2));
+                assertNotEquals("Getter returns equal vals for equal inputs", getter.invoke(p1), val0);
+                assertEquals("Getter returns equal vals for equal inputs", getter.invoke(p1), val1);
                 setter.invoke(p1, val0);
                 assertEquals("Field " + field + " setter might have side effects", p1, p2);
-                assertEquals(p1.hashCode(), p2.hashCode());
-                assertEquals(getter.invoke(p1), getter.invoke(p2));
+                assertEquals("Getter returns equal vals for equal inputs", p1.hashCode(), p2.hashCode());
+                assertEquals("Getter returns equal vals for equal inputs", getter.invoke(p1), getter.invoke(p2));
                 setter.invoke(p1, val1);
                 setter.invoke(p2, val1);
-                assertEquals(p1, p2);
-                assertEquals(p1.hashCode(), p2.hashCode());
-                assertEquals(getter.invoke(p1), getter.invoke(p2));
+                assertEquals("Getter returns equal vals for equal inputs", p1, p2);
+                assertEquals("Getter returns equal vals for equal inputs", p1.hashCode(), p2.hashCode());
+                assertEquals("Getter returns equal vals for equal inputs", getter.invoke(p1), getter.invoke(p2));
                 setter.invoke(p1, val2);
                 setter.invoke(p1, val1);
                 assertEquals("Field " + field + " setter might have side effects", p1, p2);
-                assertEquals(p1.hashCode(), p2.hashCode());
-                assertEquals(getter.invoke(p1), getter.invoke(p2));
+                assertEquals("Getter returns equal vals for equal inputs", p1.hashCode(), p2.hashCode());
+                assertEquals("Getter returns equal vals for equal inputs", getter.invoke(p1), getter.invoke(p2));
                 hashCodes.add(p1.hashCode());
 
                 // Check for clone behavior
                 DecimalFormatProperties copy = p1.clone();
                 assertEquals("Field " + field + " did not get copied in clone", p1, copy);
-                assertEquals(p1.hashCode(), copy.hashCode());
-                assertEquals(getter.invoke(p1), getter.invoke(copy));
+                assertEquals("Getter returns equal vals for equal inputs", p1.hashCode(), copy.hashCode());
+                assertEquals("Getter returns equal vals for equal inputs", getter.invoke(p1), getter.invoke(copy));
 
                 // Check for copyFrom behavior
                 setter.invoke(p1, val0);
-                assertNotEquals(p1, p2);
-                assertNotEquals(getter.invoke(p1), getter.invoke(p2));
+                assertNotEquals("Getter returns equal vals for equal inputs", p1, p2);
+                assertNotEquals("Getter returns equal vals for equal inputs", getter.invoke(p1), getter.invoke(p2));
                 p2.copyFrom(p1);
                 assertEquals("Field " + field + " is missing from copyFrom()", p1, p2);
-                assertEquals(p1.hashCode(), p2.hashCode());
-                assertEquals(getter.invoke(p1), getter.invoke(p2));
+                assertEquals("Getter returns equal vals for equal inputs", p1.hashCode(), p2.hashCode());
+                assertEquals("Getter returns equal vals for equal inputs", getter.invoke(p1), getter.invoke(p2));
 
                 // Load values into p3 and p4 for clear() behavior test
                 setter.invoke(p3, getSampleValueForType(field.getType(), 3));
@@ -184,7 +185,7 @@ public class PropertiesTest {
         }
 
         // Check for clear() behavior
-        assertNotEquals(p3, p4);
+        assertNotEquals("Setup for check for clear() behavior", p3, p4);
         p3.clear();
         p4.clear();
         assertEquals("A field is missing from the clear() function", p3, p4);

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/rbbi/LSTMBreakEngineTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/rbbi/LSTMBreakEngineTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.ibm.icu.dev.test.TestFmwk;
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import com.ibm.icu.impl.breakiter.DictionaryBreakEngine;
 import com.ibm.icu.impl.breakiter.LSTMBreakEngine;
 import com.ibm.icu.lang.UScript;
@@ -28,7 +28,7 @@ import com.ibm.icu.util.UResourceBundle;
  *
  */
 @RunWith(JUnit4.class)
-public class LSTMBreakEngineTest extends TestFmwk {
+public class LSTMBreakEngineTest extends CoreTestFmwk {
 
     private static final ClassLoader testLoader = LSTMBreakEngineTest.class.getClassLoader();
 

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/serializable/CompatibilityTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/serializable/CompatibilityTest.java
@@ -27,7 +27,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.ibm.icu.dev.test.TestFmwk;
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import com.ibm.icu.dev.test.serializable.SerializableTestUtility.Handler;
 
 import junitparams.JUnitParamsRunner;
@@ -38,7 +38,7 @@ import junitparams.Parameters;
  * @author emader
  */
 @RunWith(JUnitParamsRunner.class)
-public class CompatibilityTest extends TestFmwk
+public class CompatibilityTest extends CoreTestFmwk
 {
     private static final class FileHolder {
         String className;
@@ -78,7 +78,6 @@ public class CompatibilityTest extends TestFmwk
         }
     }
 
-    @Ignore  // TODO(ICU-22505)
     @Test
     @Parameters(method="generateClassList")
     public void testCompatibility(FileHolder holder) throws ClassNotFoundException, IOException {

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/serializable/CoverageTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/serializable/CoverageTest.java
@@ -15,7 +15,7 @@ import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.ibm.icu.dev.test.TestFmwk;
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import com.ibm.icu.dev.test.serializable.SerializableTestUtility.Handler;
 
 import junitparams.JUnitParamsRunner;
@@ -27,7 +27,7 @@ import junitparams.Parameters;
  *
  */
 @RunWith(JUnitParamsRunner.class)
-public class CoverageTest extends TestFmwk {
+public class CoverageTest extends CoreTestFmwk {
 
     @Test
     @Parameters(method="generateClassList")

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/stringprep/TestIDNARef.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/stringprep/TestIDNARef.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.ibm.icu.dev.test.TestFmwk;
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import com.ibm.icu.text.StringPrepParseException;
 import com.ibm.icu.text.UCharacterIterator;
 
@@ -23,7 +23,7 @@ import com.ibm.icu.text.UCharacterIterator;
  * Window>Preferences>Java>Code Generation>Code and Comments
  */
 @RunWith(JUnit4.class)
-public class TestIDNARef extends TestFmwk {
+public class TestIDNARef extends CoreTestFmwk {
     private StringPrepParseException unassignedException = new StringPrepParseException("",StringPrepParseException.UNASSIGNED_ERROR);
 
     @Test

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/stringprep/TestStringPrep.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/stringprep/TestStringPrep.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.ibm.icu.dev.test.TestFmwk;
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import com.ibm.icu.text.StringPrep;
 import com.ibm.icu.text.StringPrepParseException;
 
@@ -23,7 +23,7 @@ import com.ibm.icu.text.StringPrepParseException;
  *
  */
 @RunWith(JUnit4.class)
-public class TestStringPrep extends TestFmwk {
+public class TestStringPrep extends CoreTestFmwk {
     /*
        There are several special identifiers ("who") which need to be
        understood universally, rather than in the context of a particular

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/util/CurrencyTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/util/CurrencyTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.ibm.icu.dev.test.TestFmwk;
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import com.ibm.icu.impl.CurrencyData;
 import com.ibm.icu.text.CurrencyDisplayNames;
 import com.ibm.icu.text.CurrencyMetaInfo;
@@ -43,7 +43,7 @@ import com.ibm.icu.util.ULocale;
  * @summary General test of Currency
  */
 @RunWith(JUnit4.class)
-public class CurrencyTest extends TestFmwk {
+public class CurrencyTest extends CoreTestFmwk {
     /**
      * Test of basic API.
      */

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/util/ICUResourceBundleTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/util/ICUResourceBundleTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.ibm.icu.dev.test.TestFmwk;
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import com.ibm.icu.impl.ICUData;
 import com.ibm.icu.impl.ICUResourceBundle;
 import com.ibm.icu.impl.UResource;
@@ -44,7 +44,7 @@ import com.ibm.icu.util.UResourceBundleIterator;
 import com.ibm.icu.util.UResourceTypeMismatchException;
 
 @RunWith(JUnit4.class)
-public final class ICUResourceBundleTest extends TestFmwk {
+public final class ICUResourceBundleTest extends CoreTestFmwk {
     private static final ClassLoader testLoader = ICUResourceBundleTest.class.getClassLoader();
 
     @Test

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/util/ICUServiceTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/util/ICUServiceTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.ibm.icu.dev.test.TestFmwk;
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import com.ibm.icu.impl.ICULocaleService;
 import com.ibm.icu.impl.ICULocaleService.ICUResourceBundleFactory;
 import com.ibm.icu.impl.ICULocaleService.LocaleKey;
@@ -43,7 +43,7 @@ import com.ibm.icu.impl.LocaleUtility;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class ICUServiceTest extends TestFmwk
+public class ICUServiceTest extends CoreTestFmwk
 {
     private String lrmsg(String message, Object lhs, Object rhs) {
     return message + " lhs: " + lhs + " rhs: " + rhs;

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/util/LocaleDataTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/util/LocaleDataTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.ibm.icu.dev.test.TestFmwk;
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import com.ibm.icu.impl.ICUResourceBundle;
 import com.ibm.icu.lang.UScript;
 import com.ibm.icu.text.UnicodeSet;
@@ -32,7 +32,7 @@ import com.ibm.icu.util.ULocale;
  * Window>Preferences>Java>Code Generation>Code and Comments
  */
 @RunWith(JUnit4.class)
-public class LocaleDataTest extends TestFmwk{
+public class LocaleDataTest extends CoreTestFmwk{
     private ULocale[] availableLocales = null;
 
     public LocaleDataTest(){

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/util/ULocaleTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/util/ULocaleTest.java
@@ -33,7 +33,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.ibm.icu.dev.test.TestFmwk;
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import com.ibm.icu.dev.test.TestUtil;
 import com.ibm.icu.dev.test.TestUtil.JavaVendor;
 import com.ibm.icu.text.DateFormat;
@@ -59,7 +59,7 @@ import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 
 @RunWith(JUnitParamsRunner.class)
-public class ULocaleTest extends TestFmwk {
+public class ULocaleTest extends CoreTestFmwk {
 
     // Ticket #8078 and #11674
     private static final boolean JAVA7_OR_LATER =
@@ -4125,7 +4125,7 @@ public class ULocaleTest extends TestFmwk {
 
         cldrVersion = LocaleData.getCLDRVersion();
 
-        TestFmwk.logln("uloc_getCLDRVersion() returned: '"+cldrVersion+"'");
+        logln("uloc_getCLDRVersion() returned: '"+cldrVersion+"'");
 
         // why isn't this public for tests somewhere?
         final ClassLoader testLoader = ICUResourceBundleTest.class.getClassLoader();

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/CoreTestFmwk.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/CoreTestFmwk.java
@@ -1,0 +1,85 @@
+// © 2023 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+
+package com.ibm.icu.dev.test;
+
+import com.ibm.icu.util.ULocale;
+import org.junit.Rule;
+import org.junit.rules.TestName;
+
+/**
+ * A base class for testing within the cross-component tests in the `common_tests` component.
+ *
+ * <p>This subclass of TestFmwk allows the usage of functionality from the `core` component. TestFmwk
+ * is not able to depend on `core` since it is located in `framework`, while `core` tests already
+ * use TestFmwk, which requires that `core` depends on `framework`. We cannot have a cycle in our
+ * dependencies.
+ *
+ * <p>With the allowance for this test class to use functionality from components, we can do things
+ * like assert whether tests are properly resetting the ICU and JDK time zones to their original
+ * values at the end of their execution.
+ */
+public class CoreTestFmwk extends TestFmwk {
+
+  private com.ibm.icu.util.TimeZone testStartDefaultIcuTz;
+
+  private java.util.TimeZone testStartDefaultJdkTz;
+
+  private com.ibm.icu.util.ULocale testStartDefaultULocale;
+
+  private java.util.Locale testStartDefaultLocale;
+
+  @Rule
+  public TestName name = new TestName();
+
+  @Override
+  public void localTestInitialize() {
+    super.localTestInitialize();
+
+    // Just like TestFmwk initializes JDK TimeZone and Locale before every test,
+    // do the same for ICU TimeZone and ULocale.
+    ULocale.setDefault(ULocale.forLocale(defaultLocale));
+    com.ibm.icu.util.TimeZone.setDefault(
+        com.ibm.icu.util.TimeZone.getTimeZone(defaultTimeZone.getID()));
+
+    // Save starting timezones
+    testStartDefaultIcuTz = com.ibm.icu.util.TimeZone.getDefault();
+    testStartDefaultJdkTz = java.util.TimeZone.getDefault();
+
+    // Save starting locales
+    testStartDefaultULocale = com.ibm.icu.util.ULocale.getDefault();
+    testStartDefaultLocale = java.util.Locale.getDefault();
+  }
+
+  @Override
+  public void localTestTeardown() {
+    String testMethodName = name.getMethodName();
+
+    // Assert that timezones are in a good state
+
+    com.ibm.icu.util.TimeZone testEndDefaultIcuTz = com.ibm.icu.util.TimeZone.getDefault();
+    java.util.TimeZone testEndDefaultJdkTz = java.util.TimeZone.getDefault();
+
+    assertEquals("In [" + testMethodName + "] Test should keep in sync ICU & JDK TZs",
+        testEndDefaultIcuTz.getID(),
+        testEndDefaultJdkTz.getID());
+
+    assertEquals("In [" + testMethodName + "] Test should reset ICU default TZ",
+        testStartDefaultIcuTz.getID(), testEndDefaultIcuTz.getID());
+    assertEquals("In [" + testMethodName + "] Test should reset JDK default TZ",
+        testStartDefaultJdkTz.getID(), testEndDefaultJdkTz.getID());
+
+    // Assert that locales are in a good state
+
+    com.ibm.icu.util.ULocale testEndDefaultULocale = com.ibm.icu.util.ULocale.getDefault();
+    java.util.Locale testEndDefaultLocale = java.util.Locale.getDefault();
+
+    assertEquals("In [" + testMethodName + "] Test should reset ICU ULocale",
+        testStartDefaultULocale.toLanguageTag(), testEndDefaultULocale.toLanguageTag());
+    assertEquals("In [" + testMethodName + "] Test should reset JDK Locale",
+        testStartDefaultLocale.toLanguageTag(), testEndDefaultLocale.toLanguageTag());
+
+    super.localTestTeardown();
+  }
+
+}

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/bidi/BiDiConformanceTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/bidi/BiDiConformanceTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.bidi;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.BufferedReader;
 import java.io.IOException;
 
@@ -27,7 +28,7 @@ import com.ibm.icu.text.BidiClassifier;
  * Ported from ICU4C intltest/bidiconf.cpp .
  */
 @RunWith(JUnit4.class)
-public class BiDiConformanceTest extends TestFmwk {
+public class BiDiConformanceTest extends CoreTestFmwk {
     public BiDiConformanceTest() {}
 
     @Test

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/bidi/BidiFmwk.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/bidi/BidiFmwk.java
@@ -9,6 +9,7 @@
 
 package com.ibm.icu.dev.test.bidi;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Arrays;
 
 import com.ibm.icu.dev.test.TestFmwk;
@@ -24,7 +25,7 @@ import com.ibm.icu.util.VersionInfo;
  * @author Lina Kemmel, Matitiahu Allouche
  */
 
-public class BidiFmwk extends TestFmwk {
+public class BidiFmwk extends CoreTestFmwk {
 
     protected static final char[] charFromDirProp = {
          /* L      R    EN    ES    ET     AN    CS    B    S    WS    ON */

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/bidi/TestBidiTransform.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/bidi/TestBidiTransform.java
@@ -3,6 +3,7 @@
 
 package com.ibm.icu.dev.test.bidi;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -22,7 +23,7 @@ import com.ibm.icu.text.BidiTransform.Order;
  *
  */
 @RunWith(JUnit4.class)
-public class TestBidiTransform extends TestFmwk {
+public class TestBidiTransform extends CoreTestFmwk {
 
     static final char LATN_ZERO         = '\u0030';
     static final char ARAB_ZERO         = '\u0660';

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/bigdec/DiagBigDecimalTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/bigdec/DiagBigDecimalTest.java
@@ -11,6 +11,7 @@
 /* The generated code has been manually modified. */
 package com.ibm.icu.dev.test.bigdec;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.math.BigInteger;
 
 import org.junit.Test;
@@ -100,7 +101,7 @@ import com.ibm.icu.math.BigDecimal;
  */
 
 @RunWith(JUnit4.class)
-public class DiagBigDecimalTest extends TestFmwk {
+public class DiagBigDecimalTest extends CoreTestFmwk {
     private static final com.ibm.icu.math.BigDecimal zero = com.ibm.icu.math.BigDecimal.ZERO;
     private static final com.ibm.icu.math.BigDecimal one = com.ibm.icu.math.BigDecimal.ONE;
     private static final com.ibm.icu.math.BigDecimal two = new com.ibm.icu.math.BigDecimal(2);

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/AstroTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/AstroTest.java
@@ -10,6 +10,7 @@ package com.ibm.icu.dev.test.calendar;
 
 // AstroTest
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Date;
 import java.util.Locale;
 
@@ -30,7 +31,7 @@ import com.ibm.icu.util.TimeZone;
 // TODO: try finding next new moon after  07/28/1984 16:00 GMT
 
 @RunWith(JUnit4.class)
-public class AstroTest extends TestFmwk {
+public class AstroTest extends CoreTestFmwk {
     static final double PI = Math.PI;
 
     @Test

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/CalendarRegressionTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/CalendarRegressionTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.calendar;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -46,7 +47,7 @@ import com.ibm.icu.util.ULocale;
  * 4174361 4177484 4197699 4209071 4288792
  */
 @RunWith(JUnit4.class)
-public class CalendarRegressionTest extends com.ibm.icu.dev.test.TestFmwk {
+public class CalendarRegressionTest extends CoreTestFmwk {
     static final String[] FIELD_NAME = {
             "ERA", "YEAR", "MONTH", "WEEK_OF_YEAR", "WEEK_OF_MONTH",
             "DAY_OF_MONTH", "DAY_OF_YEAR", "DAY_OF_WEEK",

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/CalendarTestFmwk.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/CalendarTestFmwk.java
@@ -9,6 +9,7 @@
 
 package com.ibm.icu.dev.test.calendar;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
@@ -26,7 +27,7 @@ import com.ibm.icu.util.SimpleTimeZone;
  * A base class for classes that test individual Calendar subclasses.
  * Defines various useful utility methods and constants
  */
-public class CalendarTestFmwk extends TestFmwk {
+public class CalendarTestFmwk extends CoreTestFmwk {
 
     // Constants for use by subclasses, solely to save typing
     public final static int SUN = Calendar.SUNDAY;

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/CompatibilityTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/CompatibilityTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.calendar;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -29,7 +30,7 @@ import com.ibm.icu.util.SimpleTimeZone;
 import com.ibm.icu.util.TimeZone;
 
 @RunWith(JUnit4.class)
-public class CompatibilityTest extends TestFmwk {
+public class CompatibilityTest extends CoreTestFmwk {
     static final String[] FIELD_NAME = {
         "ERA", "YEAR", "MONTH", "WEEK_OF_YEAR", "WEEK_OF_MONTH",
         "DAY_OF_MONTH", "DAY_OF_YEAR", "DAY_OF_WEEK",

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/EraRulesTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/EraRulesTest.java
@@ -2,6 +2,7 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 package com.ibm.icu.dev.test.calendar;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -18,7 +19,7 @@ import com.ibm.icu.util.ULocale;
  * Tests for EraRules class
  */
 @RunWith(JUnit4.class)
-public class EraRulesTest extends TestFmwk {
+public class EraRulesTest extends CoreTestFmwk {
     @Test
     public void testAPIs() {
         for (CalType calType : CalType.values()) {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/HebrewTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/HebrewTest.java
@@ -8,6 +8,7 @@
  */
 
 package com.ibm.icu.dev.test.calendar;
+
 import java.util.Date;
 import java.util.Locale;
 import java.util.MissingResourceException;

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/HolidayTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/HolidayTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.calendar;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Date;
 import java.util.Locale;
 
@@ -31,12 +32,14 @@ import com.ibm.icu.util.ULocale;
  * Tests for the <code>Holiday</code> class.
  */
 @RunWith(JUnit4.class)
-public class HolidayTest extends TestFmwk {
+public class HolidayTest extends CoreTestFmwk {
 
     // Do not use Before annotation, because TestFmwk's Before
     // method must be executed first to initialize default time zone
     @Override
-    protected void localTestInitialize() {
+    public void localTestInitialize() {
+        super.localTestInitialize();
+
         cal = new GregorianCalendar(1, 0, 1);
         longTimeAgo = cal.getTime();
         now = new Date();

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/InTemporalLeapYearTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/InTemporalLeapYearTest.java
@@ -2,6 +2,7 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 package com.ibm.icu.dev.test.calendar;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -13,7 +14,7 @@ import com.ibm.icu.util.HebrewCalendar;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class InTemporalLeapYearTest extends com.ibm.icu.dev.test.TestFmwk {
+public class InTemporalLeapYearTest extends CoreTestFmwk {
     @Test
     public void TestGregorian() {
         // test from year 1800 to 2500

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/OrdinalMonthTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/OrdinalMonthTest.java
@@ -2,6 +2,7 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 package com.ibm.icu.dev.test.calendar;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -12,7 +13,7 @@ import com.ibm.icu.util.HebrewCalendar;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class OrdinalMonthTest extends com.ibm.icu.dev.test.TestFmwk {
+public class OrdinalMonthTest extends CoreTestFmwk {
 
     private void VerifyMonth(String message, Calendar cc, int expectedMonth,
                  int expectedOrdinalMonth, boolean expectedLeapMonth,

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/TemporalMonthCodeTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/TemporalMonthCodeTest.java
@@ -2,6 +2,7 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 package com.ibm.icu.dev.test.calendar;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -15,7 +16,7 @@ import com.ibm.icu.util.HebrewCalendar;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class TemporalMonthCodeTest extends com.ibm.icu.dev.test.TestFmwk {
+public class TemporalMonthCodeTest extends CoreTestFmwk {
     @Test
     public void TestChineseCalendarGetTemporalMonthCode() {
         RunChineseGetTemporalMonthCode(

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/charsetdet/TestCharsetDetector.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/charsetdet/TestCharsetDetector.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.charsetdet;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
@@ -41,7 +42,7 @@ import com.ibm.icu.text.CharsetMatch;
  * @author andy
  */
 @RunWith(JUnit4.class)
-public class TestCharsetDetector extends TestFmwk
+public class TestCharsetDetector extends CoreTestFmwk
 {
     public TestCharsetDetector()
     {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/compression/DecompressionTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/compression/DecompressionTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.compression;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -16,7 +17,7 @@ import com.ibm.icu.dev.test.TestFmwk;
 import com.ibm.icu.text.UnicodeDecompressor;
 
 @RunWith(JUnit4.class)
-public class DecompressionTest extends TestFmwk {
+public class DecompressionTest extends CoreTestFmwk {
     /** Print out a segment of a character array, if in verbose mode */
     private void log(char [] chars, int start, int count) {
         log("|");

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/compression/ExhaustiveTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/compression/ExhaustiveTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.compression;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -17,7 +18,7 @@ import com.ibm.icu.text.UnicodeCompressor;
 import com.ibm.icu.text.UnicodeDecompressor;
 
 @RunWith(JUnit4.class)
-public class ExhaustiveTest extends TestFmwk {
+public class ExhaustiveTest extends CoreTestFmwk {
     /** Test simple compress/decompress API, returning # of errors */
     @Test
     public void testSimple() throws Exception {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/duration/DataReadWriteTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/duration/DataReadWriteTest.java
@@ -11,6 +11,7 @@
 
 package com.ibm.icu.dev.test.duration;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.StringReader;
 import java.io.StringWriter;
 
@@ -23,7 +24,7 @@ import com.ibm.icu.impl.duration.impl.XMLRecordReader;
 import com.ibm.icu.impl.duration.impl.XMLRecordWriter;
 
 @RunWith(JUnit4.class)
-public class DataReadWriteTest extends TestFmwk {
+public class DataReadWriteTest extends CoreTestFmwk {
     // strip line ends and trailing spaces
     private String normalize(String str) {
         StringBuffer sb = new StringBuffer();

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/duration/ICUDurationTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/duration/ICUDurationTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.duration;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.math.BigDecimal;
 import java.text.FieldPosition;
 import java.util.Date;
@@ -33,7 +34,7 @@ import com.ibm.icu.util.ULocale;
  *
  */
 @RunWith(JUnit4.class)
-public class ICUDurationTest extends TestFmwk {
+public class ICUDurationTest extends CoreTestFmwk {
     /**
      * Allows us to not depend on javax.xml.datatype.DatatypeFactory.
      * We need just a tiny subset of the Duration API:

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/duration/LanguageTestFmwk.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/duration/LanguageTestFmwk.java
@@ -11,6 +11,7 @@
 
 package com.ibm.icu.dev.test.duration;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -40,7 +41,7 @@ import com.ibm.icu.impl.duration.impl.DataRecord.EUnitVariant;
  * Test cases for en
  */
 @RunWith(JUnit4.class)
-public abstract class LanguageTestFmwk extends TestFmwk implements TimeUnitConstants {
+public abstract class LanguageTestFmwk extends CoreTestFmwk implements TimeUnitConstants {
 
     private static final TimeUnit[] units = {
         TimeUnit.YEAR, TimeUnit.MONTH, TimeUnit.WEEK, TimeUnit.DAY, TimeUnit.HOUR,

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/duration/PeriodBuilderFactoryTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/duration/PeriodBuilderFactoryTest.java
@@ -11,6 +11,7 @@
 
 package com.ibm.icu.dev.test.duration;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -24,7 +25,7 @@ import com.ibm.icu.impl.duration.TimeUnit;
 import com.ibm.icu.impl.duration.TimeUnitConstants;
 
 @RunWith(JUnit4.class)
-public class PeriodBuilderFactoryTest extends TestFmwk implements TimeUnitConstants {
+public class PeriodBuilderFactoryTest extends CoreTestFmwk implements TimeUnitConstants {
     private PeriodBuilderFactory pbf;
 
     private static final long[] approxDurations = {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/duration/PeriodTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/duration/PeriodTest.java
@@ -11,6 +11,7 @@
 
 package com.ibm.icu.dev.test.duration;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -20,7 +21,7 @@ import com.ibm.icu.impl.duration.Period;
 import com.ibm.icu.impl.duration.TimeUnit;
 
 @RunWith(JUnit4.class)
-public class PeriodTest extends TestFmwk {
+public class PeriodTest extends CoreTestFmwk {
     @Test
     public void testIsSet() {
         Period p = Period.at(0, TimeUnit.YEAR);

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/duration/RegressionTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/duration/RegressionTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.duration;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -21,7 +22,7 @@ import com.ibm.icu.text.DurationFormat;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class RegressionTest extends TestFmwk {
+public class RegressionTest extends CoreTestFmwk {
     // bug6397
     @Test
     public void TestDisallowedMillis() {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/duration/ResourceBasedPeriodFormatterDataServiceTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/duration/ResourceBasedPeriodFormatterDataServiceTest.java
@@ -11,6 +11,7 @@
 
 package com.ibm.icu.dev.test.duration;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Collection;
 import java.util.Iterator;
 
@@ -23,7 +24,7 @@ import com.ibm.icu.impl.duration.impl.PeriodFormatterData;
 import com.ibm.icu.impl.duration.impl.ResourceBasedPeriodFormatterDataService;
 
 @RunWith(JUnit4.class)
-public class ResourceBasedPeriodFormatterDataServiceTest extends TestFmwk {
+public class ResourceBasedPeriodFormatterDataServiceTest extends CoreTestFmwk {
   @Test
   public void testAvailable() {
     ResourceBasedPeriodFormatterDataService service =

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/BigNumberFormatTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/BigNumberFormatTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.ParseException;
 import java.util.Locale;
 
@@ -26,7 +27,7 @@ import com.ibm.icu.text.NumberFormat;
  * General test of Big NumberFormat
  */
 @RunWith(JUnit4.class)
-public class BigNumberFormatTest extends TestFmwk {
+public class BigNumberFormatTest extends CoreTestFmwk {
 
     static final int ILLEGAL = -1;
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DataDrivenNumberFormatTestUtility.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DataDrivenNumberFormatTestUtility.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -22,7 +23,7 @@ import com.ibm.icu.impl.Utility;
 /**
  * A collection of methods to run the data driven number format test suite.
  */
-public class DataDrivenNumberFormatTestUtility extends TestFmwk {
+public class DataDrivenNumberFormatTestUtility extends CoreTestFmwk {
 
     /**
      * Base class for code under test.

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DateFormatMiscTests.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DateFormatMiscTests.java
@@ -14,6 +14,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.FieldPosition;
 import java.text.ParseException;
 import java.util.Date;
@@ -31,7 +32,7 @@ import com.ibm.icu.text.SimpleDateFormat;
  * Performs miscellaneous tests for DateFormat, SimpleDateFormat, DateFormatSymbols
  **/
 @RunWith(JUnit4.class)
-public class DateFormatMiscTests extends TestFmwk {
+public class DateFormatMiscTests extends CoreTestFmwk {
     /*
      * @bug 4097450
      */

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DateFormatRegressionTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DateFormatRegressionTest.java
@@ -14,6 +14,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -46,7 +47,7 @@ import com.ibm.icu.util.ULocale;
  * Performs regression test for DateFormat
  **/
 @RunWith(JUnit4.class)
-public class DateFormatRegressionTest extends TestFmwk {
+public class DateFormatRegressionTest extends CoreTestFmwk {
     /**
      * @bug 4029195
      */

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DateFormatRegressionTestJ.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DateFormatRegressionTestJ.java
@@ -13,6 +13,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.ParseException;
 import java.text.ParsePosition;
 import java.util.Date;
@@ -31,7 +32,7 @@ import com.ibm.icu.util.Calendar;
 import com.ibm.icu.util.TimeZone;
 
 @RunWith(JUnit4.class)
-public class DateFormatRegressionTestJ extends TestFmwk {
+public class DateFormatRegressionTestJ extends CoreTestFmwk {
 
     private static final String TIME_STRING = "2000/11/17 08:01:00";
     private static final long UTC_LONG = 974476860000L;
@@ -170,6 +171,8 @@ public class DateFormatRegressionTestJ extends TestFmwk {
     //about regression test
     @Test
     public void Test4266432() {
+        Locale startLocale = Locale.getDefault();
+
         Locale.setDefault(Locale.JAPAN);
         Locale loc = Locale.getDefault();
         String dateFormat = "MM/dd/yy HH:mm:ss zzz";
@@ -179,6 +182,8 @@ public class DateFormatRegressionTestJ extends TestFmwk {
         logln("Under  " + loc +"  locale");
         Date d = fmt.parse("01/22/92 04:52:00 GMT", p0);
         logln(d.toString());
+
+        Locale.setDefault(startLocale);
     }
 
     //SimpleDateFormat inconsistent for number of digits for years

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DateFormatRoundTripTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DateFormatRoundTripTest.java
@@ -14,6 +14,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.FieldPosition;
 import java.text.ParseException;
 import java.util.Date;
@@ -35,7 +36,7 @@ import com.ibm.icu.util.TimeZone;
  * Performs round-trip tests for DateFormat
  **/
 @RunWith(JUnit4.class)
-public class DateFormatRoundTripTest extends TestFmwk {
+public class DateFormatRoundTripTest extends CoreTestFmwk {
     public boolean INFINITE = false;
     public boolean quick = true;
     private SimpleDateFormat dateFormat;

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DateIntervalFormatTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DateIntervalFormatTest.java
@@ -15,6 +15,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.FieldPosition;
 import java.text.Format.Field;
 import java.text.ParseException;
@@ -49,7 +50,7 @@ import com.ibm.icu.util.TimeZone;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class DateIntervalFormatTest extends TestFmwk {
+public class DateIntervalFormatTest extends CoreTestFmwk {
 
     /**
      *

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DateTimeGeneratorTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DateTimeGeneratorTest.java
@@ -9,6 +9,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.ParsePosition;
 import java.util.Collection;
 import java.util.Date;
@@ -43,7 +44,7 @@ import com.ibm.icu.util.TimeZone;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class DateTimeGeneratorTest extends TestFmwk {
+public class DateTimeGeneratorTest extends CoreTestFmwk {
     public static boolean GENERATE_TEST_DATA;
     static {
         try {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/IntlTestDateFormat.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/IntlTestDateFormat.java
@@ -18,6 +18,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.FieldPosition;
 import java.text.ParseException;
 import java.util.Date;
@@ -34,7 +35,7 @@ import com.ibm.icu.text.SimpleDateFormat;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class IntlTestDateFormat extends TestFmwk {
+public class IntlTestDateFormat extends CoreTestFmwk {
     // Values in milliseconds (== Date)
     private static final long ONESECOND = 1000;
     private static final long ONEMINUTE = 60 * ONESECOND;

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/IntlTestDateFormatAPI.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/IntlTestDateFormatAPI.java
@@ -18,6 +18,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.FieldPosition;
 import java.text.ParseException;
 import java.text.ParsePosition;
@@ -35,7 +36,7 @@ import com.ibm.icu.util.Calendar;
 import com.ibm.icu.util.TimeZone;
 
 @RunWith(JUnit4.class)
-public class IntlTestDateFormatAPI extends TestFmwk
+public class IntlTestDateFormatAPI extends CoreTestFmwk
 {
     // Test that the equals method works correctly.
     @Test
@@ -74,6 +75,8 @@ public class IntlTestDateFormatAPI extends TestFmwk
     @Test
     public void TestAPI()
     {
+        Locale startLocale = Locale.getDefault();
+
         logln("DateFormat API test---"); logln("");
         Locale.setDefault(Locale.ENGLISH);
 
@@ -228,5 +231,7 @@ public class IntlTestDateFormatAPI extends TestFmwk
 //        catch (Exception e) {
 //            errln("ERROR: Couldn't create a DateFormat");
 //        }
+
+        Locale.setDefault(startLocale);
     }
 }

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/IntlTestDateFormatAPIC.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/IntlTestDateFormatAPIC.java
@@ -14,6 +14,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.FieldPosition;
 import java.text.ParsePosition;
 import java.util.Date;
@@ -34,7 +35,7 @@ import com.ibm.icu.text.SimpleDateFormat;
  * verifies that it works on a basic level.
  */
 @RunWith(JUnit4.class)
-public class IntlTestDateFormatAPIC extends TestFmwk {
+public class IntlTestDateFormatAPIC extends CoreTestFmwk {
     /**
      * Test hiding of parse() and format() APIs in the Format hierarchy.
      * We test the entire hierarchy, even though this test is located in

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/IntlTestDateFormatSymbols.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/IntlTestDateFormatSymbols.java
@@ -18,6 +18,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Locale;
 
 import org.junit.Test;
@@ -30,7 +31,7 @@ import com.ibm.icu.util.Calendar;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class IntlTestDateFormatSymbols extends TestFmwk
+public class IntlTestDateFormatSymbols extends CoreTestFmwk
 {
     // Test getMonths
     @Test

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/IntlTestDecimalFormatAPI.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/IntlTestDecimalFormatAPI.java
@@ -18,6 +18,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.FieldPosition;
 import java.text.Format;
 import java.text.ParseException;
@@ -36,7 +37,7 @@ import com.ibm.icu.text.DecimalFormatSymbols;
 import com.ibm.icu.text.NumberFormat;
 
 @RunWith(JUnit4.class)
-public class IntlTestDecimalFormatAPI extends TestFmwk
+public class IntlTestDecimalFormatAPI extends CoreTestFmwk
 {
     /**
      * Problem 1: simply running
@@ -101,6 +102,8 @@ public class IntlTestDecimalFormatAPI extends TestFmwk
     @Test
     public void TestAPI()
     {
+        Locale startLocale = Locale.getDefault();
+
         logln("DecimalFormat API test---"); logln("");
         Locale.setDefault(Locale.ENGLISH);
 
@@ -265,6 +268,8 @@ public class IntlTestDecimalFormatAPI extends TestFmwk
         if( ! s3.equals(p2) ) {
             errln("ERROR: toLocalizedPattern() result did not match pattern applied");
         }
+
+        Locale.setDefault(startLocale);
     }
 
     @Test

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/IntlTestDecimalFormatSymbols.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/IntlTestDecimalFormatSymbols.java
@@ -19,6 +19,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Arrays;
 import java.util.Locale;
 
@@ -34,7 +35,7 @@ import com.ibm.icu.util.Currency;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class IntlTestDecimalFormatSymbols extends TestFmwk
+public class IntlTestDecimalFormatSymbols extends CoreTestFmwk
 {
     // Test the API of DecimalFormatSymbols; primarily a simple get/set set.
     @Test

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/IntlTestNumberFormat.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/IntlTestNumberFormat.java
@@ -14,6 +14,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Locale;
 import java.util.Random;
 
@@ -31,7 +32,7 @@ import com.ibm.icu.util.ULocale;
  * NumberFormat.
  */
 @RunWith(JUnit4.class)
-public class IntlTestNumberFormat extends TestFmwk {
+public class IntlTestNumberFormat extends CoreTestFmwk {
 
     public NumberFormat fNumberFormat;
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/IntlTestNumberFormatAPI.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/IntlTestNumberFormatAPI.java
@@ -17,6 +17,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.math.BigInteger;
 import java.text.FieldPosition;
 import java.text.ParseException;
@@ -32,12 +33,14 @@ import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class IntlTestNumberFormatAPI extends TestFmwk
+public class IntlTestNumberFormatAPI extends CoreTestFmwk
 {
     // This test checks various generic API methods in DecimalFormat to achieve 100% API coverage.
     @Test
     public void TestAPI()
     {
+        Locale startLocale = Locale.getDefault();
+
         logln("NumberFormat API test---"); logln("");
         Locale.setDefault(Locale.ENGLISH);
 
@@ -204,6 +207,8 @@ public class IntlTestNumberFormatAPI extends TestFmwk
 //        catch (Exception e) {
 //            errln("ERROR: Couldn't create a DecimalFormat");
 //        }
+
+        Locale.setDefault(startLocale);
     }
 
     // Jitterbug 4451, for coverage

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/IntlTestSimpleDateFormatAPI.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/IntlTestSimpleDateFormatAPI.java
@@ -19,6 +19,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.FieldPosition;
 import java.text.Format;
 import java.text.ParseException;
@@ -39,12 +40,14 @@ import com.ibm.icu.text.SimpleDateFormat;
 * @summary test International Simple Date Format API
 */
 @RunWith(JUnit4.class)
-public class IntlTestSimpleDateFormatAPI extends TestFmwk
+public class IntlTestSimpleDateFormatAPI extends CoreTestFmwk
 {
     // This test checks various generic API methods in DecimalFormat to achieve 100% API coverage.
     @Test
     public void TestAPI()
     {
+        Locale startLocale = Locale.getDefault();
+
         logln("SimpleDateFormat API test---"); logln("");
 
         Locale.setDefault(Locale.ENGLISH);
@@ -185,6 +188,8 @@ public class IntlTestSimpleDateFormatAPI extends TestFmwk
 //        catch (Exception e) {
 //            errln("ERROR: Couldn't create a SimpleDateFormat");
 //        }
+
+        Locale.setDefault(startLocale);
     }
 
     // Jitterbug 4451, for coverage

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/ListFormatterTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/ListFormatterTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -26,7 +27,7 @@ import com.ibm.icu.text.ListFormatter.Width;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class ListFormatterTest extends TestFmwk {
+public class ListFormatterTest extends CoreTestFmwk {
     String[] HardcodedTestData = {
             "",
             "A",

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/MeasureUnitThreadTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/MeasureUnitThreadTest.java
@@ -3,6 +3,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -16,7 +17,7 @@ import com.ibm.icu.util.MeasureUnit;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class MeasureUnitThreadTest extends TestFmwk {
+public class MeasureUnitThreadTest extends CoreTestFmwk {
 
     @Test
     public void MUThreadTest() {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/MessagePatternUtilTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/MessagePatternUtilTest.java
@@ -11,6 +11,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -35,7 +36,7 @@ import com.ibm.icu.text.MessagePatternUtil.VariantNode;
  * by building parallel trees of nodes and verifying that they match.
  */
 @RunWith(JUnit4.class)
-public final class MessagePatternUtilTest extends TestFmwk {
+public final class MessagePatternUtilTest extends CoreTestFmwk {
     // The following nested "Expect..." classes are used to build
     // a tree structure parallel to what the MessagePatternUtil class builds.
     // These nested test classes are not static so that they have access to TestFmwk methods.

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/MessageRegressionTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/MessageRegressionTest.java
@@ -32,6 +32,7 @@ attribution to Taligent may not be removed.
 */
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -55,7 +56,7 @@ import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class MessageRegressionTest extends TestFmwk {
+public class MessageRegressionTest extends CoreTestFmwk {
     /* @bug 4074764
      * Null exception when formatting pattern with MessageFormat
      * with no parameters.

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/NumberFormatJavaCompatilityTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/NumberFormatJavaCompatilityTest.java
@@ -2,6 +2,7 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import static org.junit.Assert.assertEquals;
 
 import java.text.ParsePosition;

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/NumberFormatRegistrationTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/NumberFormatRegistrationTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Arrays;
 
 import org.junit.Test;
@@ -20,7 +21,7 @@ import com.ibm.icu.text.NumberFormat.SimpleNumberFormatFactory;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class NumberFormatRegistrationTest extends TestFmwk {
+public class NumberFormatRegistrationTest extends CoreTestFmwk {
     @Test
     public void TestRegistration() {
         final ULocale SRC_LOC = ULocale.FRANCE;

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/NumberFormatRoundTripTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/NumberFormatRoundTripTest.java
@@ -14,6 +14,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Locale;
 import java.util.Random;
 
@@ -29,7 +30,7 @@ import com.ibm.icu.text.NumberFormat;
  * Performs round-trip tests for NumberFormat
  **/
 @RunWith(JUnit4.class)
-public class NumberFormatRoundTripTest extends TestFmwk {
+public class NumberFormatRoundTripTest extends CoreTestFmwk {
 
     public double MAX_ERROR = 1e-14;
     public double max_numeric_error = 0.0;

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/PersonNameConsistencyTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/PersonNameConsistencyTest.java
@@ -2,6 +2,7 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -31,7 +32,7 @@ import junitparams.Parameters;
  * the CLDR project.
  */
 @RunWith(JUnitParamsRunner.class)
-public class PersonNameConsistencyTest extends TestFmwk {
+public class PersonNameConsistencyTest extends CoreTestFmwk {
     /**
      * Change this to true to cause the tests that would normally be skipped to also run (without
      * causing the test suite to fail).

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/PersonNameFormatterTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/PersonNameFormatterTest.java
@@ -2,6 +2,7 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Locale;
@@ -18,7 +19,7 @@ import com.ibm.icu.text.PersonNameFormatter;
 import com.ibm.icu.text.SimplePersonName;
 
 @RunWith(JUnit4.class)
-public class PersonNameFormatterTest extends TestFmwk{
+public class PersonNameFormatterTest extends CoreTestFmwk{
     private static class NameAndTestCases {
         public String nameFields;
         public String[][] testCases;

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/PluralFormatTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/PluralFormatTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -28,7 +29,7 @@ import com.ibm.icu.util.ULocale;
  *
  */
 @RunWith(JUnit4.class)
-public class PluralFormatTest extends TestFmwk {
+public class PluralFormatTest extends CoreTestFmwk {
   private void helperTestRules(String localeIDs, String testPattern, Map<Integer,String> changes) {
     String[] locales = Utility.split(localeIDs, ',');
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/PluralFormatUnitTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/PluralFormatUnitTest.java
@@ -9,6 +9,7 @@
 
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.FieldPosition;
 import java.text.ParsePosition;
 import java.util.Collection;
@@ -39,7 +40,7 @@ import com.ibm.icu.util.ULocale;
  *
  */
 @RunWith(JUnit4.class)
-public class PluralFormatUnitTest extends TestFmwk {
+public class PluralFormatUnitTest extends CoreTestFmwk {
     @Test
     public void TestConstructor() {
         // Test correct formatting of numbers.

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/RBNFParseTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/RBNFParseTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.ParseException;
 import java.util.Locale;
 
@@ -21,7 +22,7 @@ import com.ibm.icu.text.RuleBasedNumberFormat;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class RBNFParseTest extends TestFmwk {
+public class RBNFParseTest extends CoreTestFmwk {
     @Test
     public void TestParse() {
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/RbnfRoundTripTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/RbnfRoundTripTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Locale;
 
 import org.junit.Test;
@@ -18,7 +19,7 @@ import com.ibm.icu.dev.test.TestFmwk;
 import com.ibm.icu.text.RuleBasedNumberFormat;
 
 @RunWith(JUnit4.class)
-public class RbnfRoundTripTest extends TestFmwk {
+public class RbnfRoundTripTest extends CoreTestFmwk {
     /**
      * Perform an exhaustive round-trip test on the English spellout rules
      */

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/RelativeDateTimeFormatterTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/RelativeDateTimeFormatterTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Locale;
 
 import org.junit.Test;
@@ -29,7 +30,7 @@ import com.ibm.icu.text.RuleBasedNumberFormat;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class RelativeDateTimeFormatterTest extends TestFmwk {
+public class RelativeDateTimeFormatterTest extends CoreTestFmwk {
     @Test
     public void TestRelativeDateWithQuantity() {
         Object[][] data = {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/ScientificNumberFormatterTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/ScientificNumberFormatterTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -23,7 +24,7 @@ import com.ibm.icu.util.ULocale;
  *
  */
 @RunWith(JUnit4.class)
-public class ScientificNumberFormatterTest extends TestFmwk {
+public class ScientificNumberFormatterTest extends CoreTestFmwk {
     @Test
     public void TestBasic() {
         ScientificNumberFormatter markup = ScientificNumberFormatter.getMarkupInstance(

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/SelectFormatAPITest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/SelectFormatAPITest.java
@@ -9,6 +9,7 @@
  */
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.FieldPosition;
 import java.text.ParsePosition;
 
@@ -24,7 +25,7 @@ import com.ibm.icu.text.SelectFormat;
  * This class tests the API functionality of the SelectFormat
  */
 @RunWith(JUnit4.class)
-public class SelectFormatAPITest extends TestFmwk {
+public class SelectFormatAPITest extends CoreTestFmwk {
 
     static final String SIMPLE_PATTERN1 = "feminine {feminineVerbValue1} other{otherVerbValue1}";
     static final String SIMPLE_PATTERN2 = "feminine {feminineVerbValue2} other{otherVerbValue2}";

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/SelectFormatUnitTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/SelectFormatUnitTest.java
@@ -9,6 +9,7 @@
  */
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -21,7 +22,7 @@ import com.ibm.icu.text.SelectFormat;
  * This class does the unit testing for the SelectFormat
  */
 @RunWith(JUnit4.class)
-public class SelectFormatUnitTest extends TestFmwk {
+public class SelectFormatUnitTest extends CoreTestFmwk {
 
     static final String SIMPLE_PATTERN = "feminine {feminineVerbValue} other{otherVerbValue}";
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/TimeUnitTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/TimeUnitTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.format;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.ParseException;
 import java.text.ParsePosition;
 import java.util.Locale;
@@ -32,7 +33,7 @@ import com.ibm.icu.util.ULocale;
  *
  */
 @RunWith(JUnit4.class)
-public class TimeUnitTest extends TestFmwk {
+public class TimeUnitTest extends CoreTestFmwk {
     @Test
     public void Test10219FractionalPlurals() {
         TimeUnitFormat tuf = new TimeUnitFormat(ULocale.ENGLISH, TimeUnitFormat.FULL_NAME);

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/impl/CSCharacterIteratorTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/impl/CSCharacterIteratorTest.java
@@ -3,6 +3,7 @@
 
 package com.ibm.icu.dev.test.impl;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
 
@@ -14,7 +15,7 @@ import com.ibm.icu.dev.test.TestFmwk;
 import com.ibm.icu.impl.CSCharacterIterator;
 
 @RunWith(JUnit4.class)
-public class CSCharacterIteratorTest extends TestFmwk {
+public class CSCharacterIteratorTest extends CoreTestFmwk {
     public CSCharacterIteratorTest() {};
 
     @Test

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/impl/CacheTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/impl/CacheTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.impl;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -17,7 +18,7 @@ import com.ibm.icu.impl.CacheValue;
 import com.ibm.icu.impl.CacheValue.Strength;
 
 @RunWith(JUnit4.class)
-public class CacheTest extends TestFmwk {
+public class CacheTest extends CoreTestFmwk {
     public CacheTest() {}
 
     /** Code coverage for CacheValue. */

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/impl/StringSegmentTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/impl/StringSegmentTest.java
@@ -2,6 +2,7 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 package com.ibm.icu.dev.test.impl;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/iterator/TestUCharacterIterator.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/iterator/TestUCharacterIterator.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.iterator;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
 
@@ -29,7 +30,7 @@ import com.ibm.icu.text.UTF16;
  * Window>Preferences>Java>Code Generation.
  */
 @RunWith(JUnit4.class)
-public class TestUCharacterIterator extends TestFmwk{
+public class TestUCharacterIterator extends CoreTestFmwk{
 
     // constructor -----------------------------------------------------
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/DataDrivenUScriptTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/DataDrivenUScriptTest.java
@@ -3,6 +3,7 @@
 
 package com.ibm.icu.dev.test.lang;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
@@ -17,7 +18,7 @@ import com.ibm.icu.lang.UScript;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(Enclosed.class)
-public class DataDrivenUScriptTest extends TestFmwk {
+public class DataDrivenUScriptTest extends CoreTestFmwk {
 
     private static String scriptsToString(int[] scripts) {
         if (scripts == null) {
@@ -114,7 +115,7 @@ public class DataDrivenUScriptTest extends TestFmwk {
     }
 
     @RunWith(Parameterized.class)
-    public static class TestMultipleUScript extends TestFmwk {
+    public static class TestMultipleUScript extends CoreTestFmwk {
         private String testLocaleName;
         private Locale testLocale;
         private int[] expected;
@@ -165,7 +166,7 @@ public class DataDrivenUScriptTest extends TestFmwk {
     }
 
     @RunWith(Parameterized.class)
-    public static class GetCodeTest extends TestFmwk {
+    public static class GetCodeTest extends CoreTestFmwk {
         private String testName;
         private int expected;
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/TestUScript.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/TestUScript.java
@@ -9,6 +9,7 @@
 
 package com.ibm.icu.dev.test.lang;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.BitSet;
 
 import org.junit.Test;
@@ -22,7 +23,7 @@ import com.ibm.icu.lang.UScript.ScriptUsage;
 import com.ibm.icu.text.UnicodeSet;
 
 @RunWith(JUnit4.class)
-public class TestUScript extends TestFmwk {
+public class TestUScript extends CoreTestFmwk {
 
     /**
     * Constructor

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/TestUScriptRun.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/TestUScriptRun.java
@@ -9,6 +9,7 @@
 
 package com.ibm.icu.dev.test.lang;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -18,7 +19,7 @@ import com.ibm.icu.lang.UScript;
 import com.ibm.icu.lang.UScriptRun;
 
 @RunWith(JUnit4.class)
-public class TestUScriptRun extends TestFmwk
+public class TestUScriptRun extends CoreTestFmwk
 {
     public TestUScriptRun()
     {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UCharacterCaseTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UCharacterCaseTest.java
@@ -10,7 +10,7 @@
 
 package com.ibm.icu.dev.test.lang;
 
-
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.BufferedReader;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,7 +44,7 @@ import com.ibm.icu.util.ULocale;
 * @since march 14 2002
 */
 @RunWith(JUnit4.class)
-public final class UCharacterCaseTest extends TestFmwk
+public final class UCharacterCaseTest extends CoreTestFmwk
 {
     // constructor -----------------------------------------------------------
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UCharacterCategoryTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UCharacterCategoryTest.java
@@ -7,6 +7,8 @@
 *******************************************************************************
 */
 package com.ibm.icu.dev.test.lang;
+
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -20,7 +22,7 @@ import com.ibm.icu.lang.UCharacterCategory;
 * @since April 02 2002
 */
 @RunWith(JUnit4.class)
-public class UCharacterCategoryTest extends TestFmwk
+public class UCharacterCategoryTest extends CoreTestFmwk
 {
     // constructor -----------------------------------------------------------
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UCharacterDirectionTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UCharacterDirectionTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.lang;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -21,7 +22,7 @@ import com.ibm.icu.lang.UCharacterDirection;
 * @since July 22 2002
 */
 @RunWith(JUnit4.class)
-public class UCharacterDirectionTest extends TestFmwk
+public class UCharacterDirectionTest extends CoreTestFmwk
 {
     // constructor -----------------------------------------------------------
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UCharacterSurrogateTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UCharacterSurrogateTest.java
@@ -9,6 +9,7 @@
 
 package com.ibm.icu.dev.test.lang;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -22,7 +23,7 @@ import com.ibm.icu.text.UTF16;
  * Test JDK 1.5 cover APIs.
  */
 @RunWith(JUnit4.class)
-public final class UCharacterSurrogateTest extends TestFmwk {
+public final class UCharacterSurrogateTest extends CoreTestFmwk {
     @Test
     public void TestUnicodeBlockForName() {
       String[] names = {"Latin-1 Supplement",

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UCharacterTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UCharacterTest.java
@@ -9,6 +9,7 @@
 
 package com.ibm.icu.dev.test.lang;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.Arrays;
@@ -49,7 +50,7 @@ import com.ibm.icu.util.VersionInfo;
 * @since nov 04 2000
 */
 @RunWith(JUnit4.class)
-public final class UCharacterTest extends TestFmwk
+public final class UCharacterTest extends CoreTestFmwk
 {
     // private variables =============================================
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UCharacterThreadTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UCharacterThreadTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.lang;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
@@ -24,7 +25,7 @@ import com.ibm.icu.lang.UCharacter;
  *
  */
 @RunWith(JUnit4.class)
-public class UCharacterThreadTest extends TestFmwk {
+public class UCharacterThreadTest extends CoreTestFmwk {
   // constructor -----------------------------------------------------------
 
     /**

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UPropertyAliasesTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UPropertyAliasesTest.java
@@ -12,6 +12,7 @@
 */
 package com.ibm.icu.dev.test.lang;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -21,7 +22,7 @@ import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UProperty;
 
 @RunWith(JUnit4.class)
-public class UPropertyAliasesTest extends TestFmwk {
+public class UPropertyAliasesTest extends CoreTestFmwk {
 
     public UPropertyAliasesTest() {}
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UTF16Test.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UTF16Test.java
@@ -9,6 +9,7 @@
 
 package com.ibm.icu.dev.test.lang;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -27,7 +28,7 @@ import com.ibm.icu.text.UTF16.StringComparator;
 * @since feb 09 2001
 */
 @RunWith(JUnit4.class)
-public final class UTF16Test extends TestFmwk
+public final class UTF16Test extends CoreTestFmwk
 {
     // constructor ===================================================
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UnicodeSetStringSpanTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UnicodeSetStringSpanTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.lang;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Collection;
 
 import org.junit.Test;
@@ -26,7 +27,7 @@ import com.ibm.icu.util.OutputInt;
  * @summary General test of UnicodeSet string span.
  */
 @RunWith(JUnit4.class)
-public class UnicodeSetStringSpanTest extends TestFmwk {
+public class UnicodeSetStringSpanTest extends CoreTestFmwk {
     // Simple test first, easier to debug.
     @Test
     public void TestSimpleStringSpan() {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UnicodeSetTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UnicodeSetTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.lang;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.NumberFormat;
 import java.text.ParsePosition;
 import java.util.ArrayList;
@@ -56,7 +57,7 @@ import com.ibm.icu.util.OutputInt;
  * @summary General test of UnicodeSet
  */
 @RunWith(JUnit4.class)
-public class UnicodeSetTest extends TestFmwk {
+public class UnicodeSetTest extends CoreTestFmwk {
 
     static final String NOT = "%%%%";
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/message2/CustomFormatterGrammarCaseTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/message2/CustomFormatterGrammarCaseTest.java
@@ -3,6 +3,7 @@
 
 package com.ibm.icu.dev.test.message2;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Locale;
 import java.util.Map;
 
@@ -23,7 +24,7 @@ import com.ibm.icu.message2.PlainStringFormattedValue;
  */
 @RunWith(JUnit4.class)
 @SuppressWarnings("javadoc")
-public class CustomFormatterGrammarCaseTest extends TestFmwk {
+public class CustomFormatterGrammarCaseTest extends CoreTestFmwk {
 
     static class GrammarCasesFormatterFactory implements FormatterFactory {
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/message2/CustomFormatterListTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/message2/CustomFormatterListTest.java
@@ -3,6 +3,7 @@
 
 package com.ibm.icu.dev.test.message2;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
@@ -27,7 +28,7 @@ import com.ibm.icu.text.ListFormatter.Width;
  */
 @RunWith(JUnit4.class)
 @SuppressWarnings("javadoc")
-public class CustomFormatterListTest extends TestFmwk {
+public class CustomFormatterListTest extends CoreTestFmwk {
 
     static class ListFormatterFactory implements FormatterFactory {
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/message2/CustomFormatterMessageRefTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/message2/CustomFormatterMessageRefTest.java
@@ -3,6 +3,7 @@
 
 package com.ibm.icu.dev.test.message2;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
@@ -28,7 +29,7 @@ import com.ibm.icu.message2.PlainStringFormattedValue;
  */
 @RunWith(JUnit4.class)
 @SuppressWarnings("javadoc")
-public class CustomFormatterMessageRefTest extends TestFmwk {
+public class CustomFormatterMessageRefTest extends CoreTestFmwk {
 
     static class ResourceManagerFactory implements FormatterFactory {
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/message2/CustomFormatterPersonTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/message2/CustomFormatterPersonTest.java
@@ -3,6 +3,7 @@
 
 package com.ibm.icu.dev.test.message2;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -23,7 +24,7 @@ import com.ibm.icu.message2.PlainStringFormattedValue;
  */
 @RunWith(JUnit4.class)
 @SuppressWarnings("javadoc")
-public class CustomFormatterPersonTest extends TestFmwk {
+public class CustomFormatterPersonTest extends CoreTestFmwk {
 
     public static class Person {
         final String title;

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/message2/FromJsonTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/message2/FromJsonTest.java
@@ -3,6 +3,7 @@
 
 package com.ibm.icu.dev.test.message2;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -17,7 +18,7 @@ import com.ibm.icu.dev.test.TestFmwk;
  */
 @RunWith(JUnit4.class)
 @SuppressWarnings("javadoc")
-public class FromJsonTest extends TestFmwk {
+public class FromJsonTest extends CoreTestFmwk {
 
     static final TestCase[] TEST_CASES = {
             new TestCase.Builder()

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/message2/MessageFormat2Test.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/message2/MessageFormat2Test.java
@@ -3,6 +3,7 @@
 
 package com.ibm.icu.dev.test.message2;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
@@ -35,7 +36,7 @@ import com.ibm.icu.util.MeasureUnit;
  */
 @RunWith(JUnit4.class)
 @SuppressWarnings("javadoc")
-public class MessageFormat2Test extends TestFmwk {
+public class MessageFormat2Test extends CoreTestFmwk {
 
     @Test
     public void test() {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/message2/Mf2IcuTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/message2/Mf2IcuTest.java
@@ -3,6 +3,7 @@
 
 package com.ibm.icu.dev.test.message2;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
@@ -24,7 +25,7 @@ import com.ibm.icu.util.GregorianCalendar;
  */
 @RunWith(JUnit4.class)
 @SuppressWarnings("javadoc")
-public class Mf2IcuTest extends TestFmwk {
+public class Mf2IcuTest extends CoreTestFmwk {
 
     @Test
     public void testSample() {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/normalizer/ConformanceTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/normalizer/ConformanceTest.java
@@ -9,6 +9,7 @@
 
 package com.ibm.icu.dev.test.normalizer;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.text.StringCharacterIterator;
@@ -26,7 +27,7 @@ import com.ibm.icu.text.UTF16;
 import com.ibm.icu.text.UnicodeSet;
 
 @RunWith(JUnit4.class)
-public class ConformanceTest extends TestFmwk {
+public class ConformanceTest extends CoreTestFmwk {
 
     Normalizer normalizer;
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/normalizer/NormalizationMonkeyTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/normalizer/NormalizationMonkeyTest.java
@@ -9,6 +9,7 @@
 
 package com.ibm.icu.dev.test.normalizer;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Random;
 
 import org.junit.Test;
@@ -22,7 +23,7 @@ import com.ibm.icu.text.Normalizer;
 import com.ibm.icu.text.UTF16;
 
 @RunWith(JUnit4.class)
-public class NormalizationMonkeyTest extends TestFmwk {
+public class NormalizationMonkeyTest extends CoreTestFmwk {
     int loopCount = 100;
     int maxCharCount = 20;
     int maxCodePoint = 0x10ffff;

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/normalizer/NormalizerRegressionTests.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/normalizer/NormalizerRegressionTests.java
@@ -9,6 +9,7 @@
 
 package com.ibm.icu.dev.test.normalizer;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -17,7 +18,7 @@ import com.ibm.icu.dev.test.TestFmwk;
 import com.ibm.icu.text.Normalizer;
 
 @RunWith(JUnit4.class)
-public class NormalizerRegressionTests extends TestFmwk {
+public class NormalizerRegressionTests extends CoreTestFmwk {
     @Test
     public void TestJB4472() {
         // submitter's test case

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/normalizer/TestCanonicalIterator.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/normalizer/TestCanonicalIterator.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.normalizer;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
@@ -29,7 +30,7 @@ import com.ibm.icu.text.UTF16;
 // TODO: fit into test framework
 
 @RunWith(JUnit4.class)
-public class TestCanonicalIterator extends TestFmwk {
+public class TestCanonicalIterator extends CoreTestFmwk {
 
     static final boolean SHOW_NAMES = false;
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/normalizer/TestDeprecatedNormalizerAPI.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/normalizer/TestDeprecatedNormalizerAPI.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.normalizer;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -21,7 +22,7 @@ import com.ibm.icu.text.Normalizer;
 import com.ibm.icu.text.StringCharacterIterator;
 
 @RunWith(JUnit4.class)
-public class TestDeprecatedNormalizerAPI extends TestFmwk
+public class TestDeprecatedNormalizerAPI extends CoreTestFmwk
 {
     public TestDeprecatedNormalizerAPI() {
     }

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/normalizer/UTS46Test.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/normalizer/UTS46Test.java
@@ -8,6 +8,7 @@
 */
 package com.ibm.icu.dev.test.normalizer;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.Collections;
@@ -36,7 +37,7 @@ import com.ibm.icu.util.ICUInputTooLongException;
  * @since 2010jul10
  */
 @RunWith(JUnit4.class)
-public class UTS46Test extends TestFmwk {
+public class UTS46Test extends CoreTestFmwk {
     public UTS46Test() {
         int commonOptions=
             IDNA.USE_STD3_RULES|IDNA.CHECK_BIDI|

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/normalizer/UnicodeNormalizerConformanceTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/normalizer/UnicodeNormalizerConformanceTest.java
@@ -9,6 +9,7 @@
 
 package com.ibm.icu.dev.test.normalizer;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.BufferedReader;
 import java.io.IOException;
 
@@ -24,7 +25,7 @@ import com.ibm.icu.text.UnicodeSet;
 
 
 @RunWith(JUnit4.class)
-public class UnicodeNormalizerConformanceTest extends TestFmwk {
+public class UnicodeNormalizerConformanceTest extends CoreTestFmwk {
 
     UnicodeNormalizer normalizer_C, normalizer_D, normalizer_KC, normalizer_KD;
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/number/DecimalQuantityTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/number/DecimalQuantityTest.java
@@ -2,6 +2,7 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 package com.ibm.icu.dev.test.number;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.MathContext;
@@ -36,7 +37,7 @@ import com.ibm.icu.text.PluralRules.Operand;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class DecimalQuantityTest extends TestFmwk {
+public class DecimalQuantityTest extends CoreTestFmwk {
 
     @Ignore
     @Test

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/number/ExhaustiveNumberTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/number/ExhaustiveNumberTest.java
@@ -2,6 +2,7 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 package com.ibm.icu.dev.test.number;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import static com.ibm.icu.impl.StaticUnicodeSets.get;
 
 import java.math.BigDecimal;
@@ -28,7 +29,7 @@ import com.ibm.icu.util.ULocale;
  *
  * @author sffc
  */
-public class ExhaustiveNumberTest extends TestFmwk {
+public class ExhaustiveNumberTest extends CoreTestFmwk {
     @Before
     public void beforeMethod() {
         // Disable this test class except for exhaustive mode.

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/AbstractBreakIteratorTests.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/AbstractBreakIteratorTests.java
@@ -2,6 +2,7 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 package com.ibm.icu.dev.test.rbbi;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.CharacterIterator;
 
 import org.junit.Before;
@@ -17,7 +18,7 @@ import com.ibm.icu.text.BreakIterator;
  *
  */
 @RunWith(JUnit4.class)
-public class AbstractBreakIteratorTests extends TestFmwk {
+public class AbstractBreakIteratorTests extends CoreTestFmwk {
 
     private class AbstractBreakIterator extends BreakIterator {
         private int position = 0;

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/BreakIteratorRegTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/BreakIteratorRegTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.rbbi;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.CharacterIterator;
 import java.util.Arrays;
 import java.util.Locale;
@@ -20,7 +21,7 @@ import com.ibm.icu.dev.test.TestFmwk;
 import com.ibm.icu.text.BreakIterator;
 
 @RunWith(JUnit4.class)
-public class BreakIteratorRegTest extends TestFmwk
+public class BreakIteratorRegTest extends CoreTestFmwk
 {
     @Test
     public void TestRegUnreg() {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/BreakIteratorTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/BreakIteratorTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.rbbi;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.StringCharacterIterator;
 import java.util.Locale;
 
@@ -21,7 +22,7 @@ import com.ibm.icu.text.FilteredBreakIteratorBuilder;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class BreakIteratorTest extends TestFmwk
+public class BreakIteratorTest extends CoreTestFmwk
 {
     public BreakIteratorTest()
     {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBIAPITest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBIAPITest.java
@@ -14,6 +14,7 @@
 
 package com.ibm.icu.dev.test.rbbi;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.text.CharacterIterator;
@@ -35,7 +36,7 @@ import com.ibm.icu.util.ULocale;
  * API Test the RuleBasedBreakIterator class
  */
 @RunWith(JUnit4.class)
-public class RBBIAPITest extends TestFmwk {
+public class RBBIAPITest extends CoreTestFmwk {
     /**
      * Tests clone() and equals() methods of RuleBasedBreakIterator
      **/

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBILSTMTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBILSTMTest.java
@@ -2,6 +2,7 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 package com.ibm.icu.dev.test.rbbi;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,7 +26,7 @@ import com.ibm.icu.text.BreakIterator;
  *      See the data file for a description of the tests.
  */
 @RunWith(JUnit4.class)
-public class RBBILSTMTest extends TestFmwk {
+public class RBBILSTMTest extends CoreTestFmwk {
     public RBBILSTMTest() {
     }
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBIMonkeyTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBIMonkeyTest.java
@@ -3,6 +3,7 @@
 
 package com.ibm.icu.dev.test.rbbi;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -34,7 +35,7 @@ import com.ibm.icu.util.ULocale;
  */
 
 @RunWith(JUnit4.class)
-public class RBBIMonkeyTest extends TestFmwk {
+public class RBBIMonkeyTest extends CoreTestFmwk {
 
 
     //  class CharClass    Represents a single character class from the source break rules.

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBITest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBITest.java
@@ -16,6 +16,7 @@ package com.ibm.icu.dev.test.rbbi;
 //          Much of the remaining data has been moved into the rbbitst.txt test data file,
 //            which is common between ICU4C and ICU4J.  The remaining test data should also be moved,
 //            or simply retired if it is no longer interesting.
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.CharacterIterator;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,7 +35,7 @@ import com.ibm.icu.util.ULocale;
 
 
 @RunWith(JUnit4.class)
-public class RBBITest extends TestFmwk {
+public class RBBITest extends CoreTestFmwk {
     public RBBITest() {
     }
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBITestExtended.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBITestExtended.java
@@ -9,6 +9,7 @@
  */
 package com.ibm.icu.dev.test.rbbi;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -35,7 +36,7 @@ import com.ibm.icu.util.ULocale;
  *
  */
 @RunWith(JUnit4.class)
-public class RBBITestExtended extends TestFmwk {
+public class RBBITestExtended extends CoreTestFmwk {
 public RBBITestExtended() {
     }
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBITestMonkey.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBITestMonkey.java
@@ -13,6 +13,7 @@ package com.ibm.icu.dev.test.rbbi;
 //    The old, original monkey test. TODO: remove
 //    The new monkey test is class RBBIMonkeyTest.
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -42,7 +43,7 @@ import com.ibm.icu.text.UnicodeSet;
  *
  */
 @RunWith(JUnit4.class)
-public class RBBITestMonkey extends TestFmwk {
+public class RBBITestMonkey extends CoreTestFmwk {
     //
     //     class RBBIMonkeyKind
     //

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/shaping/ArabicShapingRegTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/shaping/ArabicShapingRegTest.java
@@ -9,6 +9,7 @@
 
 package com.ibm.icu.dev.test.shaping;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.lang.reflect.Method;
 
 import org.junit.Test;
@@ -22,7 +23,7 @@ import com.ibm.icu.text.ArabicShaping;
  * Regression test for Arabic shaping.
  */
 @RunWith(JUnit4.class)
-public class ArabicShapingRegTest extends TestFmwk {
+public class ArabicShapingRegTest extends CoreTestFmwk {
 
     /* constants copied from ArabicShaping for convenience */
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/shaping/DataDrivenArabicShapingRegTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/shaping/DataDrivenArabicShapingRegTest.java
@@ -3,6 +3,7 @@
 
 package com.ibm.icu.dev.test.shaping;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.MissingResourceException;
@@ -20,7 +21,7 @@ import com.ibm.icu.text.ArabicShapingException;
  * Regression test for Arabic shaping.
  */
 @RunWith(Enclosed.class)
-public class DataDrivenArabicShapingRegTest extends TestFmwk {
+public class DataDrivenArabicShapingRegTest extends CoreTestFmwk {
 
     /* constants copied from ArabicShaping for convenience */
 
@@ -48,7 +49,7 @@ public class DataDrivenArabicShapingRegTest extends TestFmwk {
     public static final int DIGIT_TYPE_AN_EXTENDED = 0x100;
 
     @RunWith(Parameterized.class)
-    public static class StandardDataTest extends TestFmwk {
+    public static class StandardDataTest extends CoreTestFmwk {
         private String source;
         private int flags;
         private String expected;
@@ -378,7 +379,7 @@ public class DataDrivenArabicShapingRegTest extends TestFmwk {
     }
 
     @RunWith(Parameterized.class)
-    public static class PreflightDataTest extends TestFmwk {
+    public static class PreflightDataTest extends CoreTestFmwk {
         private String source;
         private int flags;
         private int length;
@@ -429,7 +430,7 @@ public class DataDrivenArabicShapingRegTest extends TestFmwk {
     }
 
     @RunWith(Parameterized.class)
-    public static class ErrorDataTest extends TestFmwk {
+    public static class ErrorDataTest extends CoreTestFmwk {
         private String source;
         private int flags;
         private Class error;

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/stringprep/IDNAConformanceTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/stringprep/IDNAConformanceTest.java
@@ -11,6 +11,7 @@
 
 package com.ibm.icu.dev.test.stringprep;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -34,7 +35,7 @@ import com.ibm.icu.text.UTF16;
  *
  */
 @RunWith(JUnit4.class)
-public class IDNAConformanceTest extends TestFmwk {
+public class IDNAConformanceTest extends CoreTestFmwk {
     @Test
     public void TestConformance() {
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/stringprep/IDNAReference.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/stringprep/IDNAReference.java
@@ -8,6 +8,7 @@
 */
 package com.ibm.icu.dev.test.stringprep;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import com.ibm.icu.text.StringPrepParseException;
 import com.ibm.icu.text.UCharacterIterator;
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/stringprep/TestIDNA.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/stringprep/TestIDNA.java
@@ -8,6 +8,7 @@
 */
 package com.ibm.icu.dev.test.stringprep;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Random;
 
 import org.junit.Ignore;
@@ -27,7 +28,7 @@ import com.ibm.icu.text.UTF16;
  * @author ram
  */
 @RunWith(JUnit4.class)
-public class TestIDNA extends TestFmwk {
+public class TestIDNA extends CoreTestFmwk {
     private StringPrepParseException unassignedException = new StringPrepParseException("",StringPrepParseException.UNASSIGNED_ERROR);
 
     @Test

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/stringprep/TestStringPrepProfiles.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/stringprep/TestStringPrepProfiles.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.stringprep;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -21,7 +22,7 @@ import com.ibm.icu.text.StringPrepParseException;
  *
  */
 @RunWith(JUnit4.class)
-public class TestStringPrepProfiles extends TestFmwk {
+public class TestStringPrepProfiles extends CoreTestFmwk {
     /*
      * The format of the test cases should be the following:
      * {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/text/DisplayOptionsTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/text/DisplayOptionsTest.java
@@ -3,6 +3,7 @@
 
 package com.ibm.icu.dev.test.text;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -22,7 +23,7 @@ import com.ibm.icu.text.DisplayOptions.SubstituteHandling;
  * @summary Test of DisplayOptions Class.
  */
 @RunWith(JUnit4.class)
-public class DisplayOptionsTest extends TestFmwk {
+public class DisplayOptionsTest extends CoreTestFmwk {
 
     @Test
     public void TestDisplayOptionsDefault(){

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/text/SpoofCheckerTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/text/SpoofCheckerTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.text;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
@@ -42,7 +43,7 @@ import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class SpoofCheckerTest extends TestFmwk {
+public class SpoofCheckerTest extends CoreTestFmwk {
     /*
      * Identifiers for verifying that spoof checking is minimally alive and working.
      */

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timescale/TimeScaleAPITest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timescale/TimeScaleAPITest.java
@@ -10,6 +10,7 @@
 
 package com.ibm.icu.dev.test.timescale;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -22,7 +23,7 @@ import com.ibm.icu.util.UniversalTimeScale;
  * Test UniversalTimeScale API
  */
 @RunWith(JUnit4.class)
-public class TimeScaleAPITest extends TestFmwk
+public class TimeScaleAPITest extends CoreTestFmwk
 {
 
     /**

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timescale/TimeScaleDataTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timescale/TimeScaleDataTest.java
@@ -10,6 +10,7 @@
 
 package com.ibm.icu.dev.test.timescale;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Date;
 import java.util.Locale;
 
@@ -30,7 +31,7 @@ import com.ibm.icu.util.UniversalTimeScale;
  * Window - Preferences - Java - Code Style - Code Templates
  */
 @RunWith(JUnit4.class)
-public class TimeScaleDataTest extends TestFmwk
+public class TimeScaleDataTest extends CoreTestFmwk
 {
 
     /**

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timescale/TimeScaleMonkeyTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timescale/TimeScaleMonkeyTest.java
@@ -10,6 +10,7 @@
 
 package com.ibm.icu.dev.test.timescale;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Random;
 
 import org.junit.Test;
@@ -26,7 +27,7 @@ import com.ibm.icu.util.UniversalTimeScale;
  * that they round-trip correctly.
  */
 @RunWith(JUnit4.class)
-public class TimeScaleMonkeyTest extends TestFmwk
+public class TimeScaleMonkeyTest extends CoreTestFmwk
 {
 
     /**

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timezone/TimeZoneAliasTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timezone/TimeZoneAliasTest.java
@@ -8,6 +8,7 @@
 */
 package com.ibm.icu.dev.test.timezone;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.DateFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
@@ -37,7 +38,7 @@ import com.ibm.icu.util.TimeZone;
  *
  */
 @RunWith(JUnit4.class)
-public class TimeZoneAliasTest extends TestFmwk {
+public class TimeZoneAliasTest extends CoreTestFmwk {
     /**
      * There are two things to check aliases for:<br>
      * 1. the alias set must be uniform: if a isAlias b, then aliasSet(a) == aliasSet(b)<br>

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timezone/TimeZoneBoundaryTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timezone/TimeZoneBoundaryTest.java
@@ -7,6 +7,8 @@
  *******************************************************************************
  */
 package com.ibm.icu.dev.test.timezone;
+
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Date;
 
 import org.junit.Test;
@@ -26,7 +28,7 @@ import com.ibm.icu.util.TimeZone;
  * that they are correct.
  */
 @RunWith(JUnit4.class)
-public class TimeZoneBoundaryTest extends TestFmwk
+public class TimeZoneBoundaryTest extends CoreTestFmwk
 {
     static final int ONE_SECOND = 1000;
     static final int ONE_MINUTE = 60*ONE_SECOND;

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timezone/TimeZoneOffsetLocalTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timezone/TimeZoneOffsetLocalTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.timezone;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Date;
 
 import org.junit.Test;
@@ -31,7 +32,7 @@ import com.ibm.icu.util.TimeZone;
  * Testing getOffset APIs using local time
  */
 @RunWith(JUnit4.class)
-public class TimeZoneOffsetLocalTest extends TestFmwk {
+public class TimeZoneOffsetLocalTest extends CoreTestFmwk {
     /*
      * Testing getOffset APIs around rule transition by local standard/wall time.
      */

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timezone/TimeZoneRegressionTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timezone/TimeZoneRegressionTest.java
@@ -14,6 +14,8 @@
  */
 
 package com.ibm.icu.dev.test.timezone;
+
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -37,7 +39,7 @@ import com.ibm.icu.util.TimeZone;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class TimeZoneRegressionTest extends TestFmwk {
+public class TimeZoneRegressionTest extends CoreTestFmwk {
     @Test
     public void Test4052967() {
         logln("*** CHECK TIMEZONE AGAINST HOST OS SETTING ***");

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timezone/TimeZoneRuleTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timezone/TimeZoneRuleTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.timezone;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -42,7 +43,7 @@ import com.ibm.icu.util.VTimeZone;
  * Test cases for TimeZoneRule and RuleBasedTimeZone
  */
 @RunWith(JUnit4.class)
-public class TimeZoneRuleTest extends TestFmwk {
+public class TimeZoneRuleTest extends CoreTestFmwk {
 
     private static final int HOUR = 60 * 60 * 1000;
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timezone/TimeZoneTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timezone/TimeZoneTest.java
@@ -9,6 +9,7 @@
 
 package com.ibm.icu.dev.test.timezone;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -52,7 +53,7 @@ import com.ibm.icu.util.VersionInfo;
  * @build TimeZoneTest
  */
 @RunWith(JUnit4.class)
-public class TimeZoneTest extends TestFmwk
+public class TimeZoneTest extends CoreTestFmwk
 {
     static final int millisPerHour = 3600000;
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/BytesTrieTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/BytesTrieTest.java
@@ -12,6 +12,7 @@
 
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.NoSuchElementException;
@@ -26,7 +27,7 @@ import com.ibm.icu.util.BytesTrieBuilder;
 import com.ibm.icu.util.StringTrieBuilder;
 
 @RunWith(JUnit4.class)
-public class BytesTrieTest extends TestFmwk {
+public class BytesTrieTest extends CoreTestFmwk {
     public BytesTrieTest() {}
 
     // All test functions have a TestNN prefix where NN is a double-digit number.

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/CharsTrieTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/CharsTrieTest.java
@@ -12,6 +12,7 @@
 
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.NoSuchElementException;
 
 import org.junit.Test;
@@ -26,7 +27,7 @@ import com.ibm.icu.util.CharsTrieBuilder;
 import com.ibm.icu.util.StringTrieBuilder;
 
 @RunWith(JUnit4.class)
-public class CharsTrieTest extends TestFmwk {
+public class CharsTrieTest extends CoreTestFmwk {
     public CharsTrieTest() {}
 
     // All test functions have a TestNN prefix where NN is a double-digit number.

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/CodePointTrieTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/CodePointTrieTest.java
@@ -8,6 +8,7 @@
 
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -29,7 +30,7 @@ import com.ibm.icu.util.MutableCodePointTrie;
 import com.ibm.icu.util.VersionInfo;
 
 @RunWith(JUnit4.class)
-public final class CodePointTrieTest extends TestFmwk {
+public final class CodePointTrieTest extends CoreTestFmwk {
     /* Values for setting possibly overlapping, out-of-order ranges of values */
     private static class SetRange {
         SetRange(int start, int limit, int value) {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/CompactArrayTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/CompactArrayTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -21,7 +22,7 @@ import com.ibm.icu.util.CompactCharArray;
  * @since release 2.2
  */
 @RunWith(JUnit4.class)
-public final class CompactArrayTest extends TestFmwk
+public final class CompactArrayTest extends CoreTestFmwk
 {
     @Test
     public void TestByteArrayCoverage() {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/DebugUtilitiesTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/DebugUtilitiesTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -19,7 +20,7 @@ import com.ibm.icu.dev.test.TestFmwk;
  *
  */
 @RunWith(JUnit4.class)
-public class DebugUtilitiesTest extends TestFmwk {
+public class DebugUtilitiesTest extends CoreTestFmwk {
 
     @Test
     public void TestStrings() {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/DisplayNameTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/DisplayNameTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -35,7 +36,7 @@ import com.ibm.icu.util.UResourceBundle;
 // TODO(junit): test is broken in main branch
 
 @RunWith(JUnit4.class)
-public class DisplayNameTest extends TestFmwk {
+public class DisplayNameTest extends CoreTestFmwk {
     static final boolean SHOW_ALL = false;
 
     interface DisplayNameGetter {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/GenderInfoTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/GenderInfoTest.java
@@ -8,6 +8,7 @@
 */
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Arrays;
 import java.util.List;
 
@@ -21,7 +22,7 @@ import com.ibm.icu.util.GenderInfo.Gender;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class GenderInfoTest extends TestFmwk {
+public class GenderInfoTest extends CoreTestFmwk {
     public static GenderInfo NEUTRAL_LOCALE = GenderInfo.getInstance(ULocale.ENGLISH);
     public static GenderInfo MIXED_NEUTRAL_LOCALE = GenderInfo.getInstance(new ULocale("is"));
     public static GenderInfo MALE_TAINTS_LOCALE = GenderInfo.getInstance(ULocale.FRENCH);

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/ICUBinaryTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/ICUBinaryTest.java
@@ -9,6 +9,7 @@
 
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
@@ -27,7 +28,7 @@ import com.ibm.icu.impl.ICUBinary;
 * @since release 2.1 Jan 01 2002
 */
 @RunWith(JUnit4.class)
-public final class ICUBinaryTest extends TestFmwk
+public final class ICUBinaryTest extends CoreTestFmwk
 {
     // constructor ---------------------------------------------------
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/ICUServiceThreadTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/ICUServiceThreadTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.Collator;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,7 +37,7 @@ import com.ibm.icu.impl.ICUService.SimpleFactory;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class ICUServiceThreadTest extends TestFmwk
+public class ICUServiceThreadTest extends CoreTestFmwk
 {
     private static final boolean PRINTSTATS = false;
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/LocaleAliasTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/LocaleAliasTest.java
@@ -14,6 +14,7 @@
 
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.HashMap;
 
 import org.junit.Before;
@@ -29,7 +30,7 @@ import com.ibm.icu.util.ULocale;
 import com.ibm.icu.util.UResourceBundle;
 
 @RunWith(JUnit4.class)
-public class LocaleAliasTest extends TestFmwk {
+public class LocaleAliasTest extends CoreTestFmwk {
     private static final ULocale[][] _LOCALES = {
 
             {new ULocale("en", "RH"), new ULocale("en", "ZW")},

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/LocaleBuilderTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/LocaleBuilderTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Arrays;
 
 import org.junit.Test;
@@ -23,7 +24,7 @@ import com.ibm.icu.util.ULocale.Builder;
  * Test cases for ULocale.LocaleBuilder
  */
 @RunWith(JUnit4.class)
-public class LocaleBuilderTest extends TestFmwk {
+public class LocaleBuilderTest extends CoreTestFmwk {
     @Test
     public void TestLocaleBuilder() {
         // "L": +1 = language

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/LocaleDistanceTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/LocaleDistanceTest.java
@@ -2,6 +2,7 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,7 +27,7 @@ import com.ibm.icu.util.ULocale;
  * @author markdavis
  */
 @RunWith(JUnit4.class)
-public class LocaleDistanceTest extends TestFmwk {
+public class LocaleDistanceTest extends CoreTestFmwk {
     private static final boolean REFORMAT = false; // set to true to get a reformatted data file listed
 
     private LocaleDistance localeDistance = LocaleDistance.INSTANCE;

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/LocaleMatcherTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/LocaleMatcherTest.java
@@ -9,6 +9,7 @@
 
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.BufferedReader;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,7 +41,7 @@ import junitparams.Parameters;
  * @author markdavis
  */
 @RunWith(JUnitParamsRunner.class)
-public class LocaleMatcherTest extends TestFmwk {
+public class LocaleMatcherTest extends CoreTestFmwk {
     private static final ULocale ZH_MO = new ULocale("zh_MO");
     private static final ULocale ZH_HK = new ULocale("zh_HK");
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/LocalePriorityListTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/LocalePriorityListTest.java
@@ -9,6 +9,7 @@
 
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Set;
 
 import org.junit.Test;
@@ -24,7 +25,7 @@ import com.ibm.icu.util.ULocale;
  * @author markdavis@google.com
  */
 @RunWith(JUnit4.class)
-public class LocalePriorityListTest extends TestFmwk {
+public class LocalePriorityListTest extends CoreTestFmwk {
     @Test
     public void testLanguagePriorityList() {
         final String expected = "af, en, fr";

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/RegionTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/RegionTest.java
@@ -13,6 +13,7 @@
 
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.List;
 import java.util.Set;
 
@@ -30,7 +31,7 @@ import com.ibm.icu.util.Region.RegionType;
  */
 
 @RunWith(JUnit4.class)
-public class RegionTest extends TestFmwk {
+public class RegionTest extends CoreTestFmwk {
     String[][] knownRegions = {
             //   Code  , Numeric , Parent, Type, Containing Continent
             { "001", "001", null , "WORLD", null },

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/SimpleFormatterTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/SimpleFormatterTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -18,7 +19,7 @@ import com.ibm.icu.text.SimpleFormatter;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class SimpleFormatterTest extends TestFmwk {
+public class SimpleFormatterTest extends CoreTestFmwk {
 
     /**
      * Constructor

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/StringTokenizerTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/StringTokenizerTest.java
@@ -9,6 +9,7 @@
 
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,7 +26,7 @@ import com.ibm.icu.util.StringTokenizer;
 * @since oct 26 2002
 */
 @RunWith(JUnit4.class)
-public final class StringTokenizerTest extends TestFmwk
+public final class StringTokenizerTest extends CoreTestFmwk
 {
       // constructor ===================================================
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/TestLocaleValidity.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/TestLocaleValidity.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.LinkedHashSet;
@@ -34,7 +35,7 @@ import com.ibm.icu.util.ULocale;
  *
  */
 @RunWith(JUnit4.class)
-public class TestLocaleValidity extends TestFmwk {
+public class TestLocaleValidity extends CoreTestFmwk {
     @Test
     public void testBasic() {
         String[][] tests = {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/TextTrieMapTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/TextTrieMapTest.java
@@ -8,6 +8,7 @@
 */
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Arrays;
 import java.util.Iterator;
 
@@ -20,7 +21,7 @@ import com.ibm.icu.impl.TextTrieMap;
 import com.ibm.icu.text.UnicodeSet;
 
 @RunWith(JUnit4.class)
-public class TextTrieMapTest extends TestFmwk {
+public class TextTrieMapTest extends CoreTestFmwk {
 
     private static final Integer SUN = new Integer(1);
     private static final Integer MON = new Integer(2);

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/Trie2Test.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/Trie2Test.java
@@ -9,6 +9,7 @@
 
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -28,7 +29,7 @@ import com.ibm.icu.impl.Trie2_16;
 import com.ibm.icu.impl.Trie2_32;
 
 @RunWith(JUnit4.class)
-public class Trie2Test extends TestFmwk {
+public class Trie2Test extends CoreTestFmwk {
     /**
      * Constructor
      */

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/TrieMapTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/TrieMapTest.java
@@ -8,6 +8,7 @@
  */
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,7 +39,7 @@ import com.ibm.icu.util.StringTrieBuilder.Option;
 import com.ibm.icu.util.ULocale;
 
 @RunWith(JUnit4.class)
-public class TrieMapTest extends TestFmwk {
+public class TrieMapTest extends CoreTestFmwk {
     static final boolean SHORT = false;
     static final boolean HACK_TO_MAKE_TESTS_PASS = false;
     static final int MASK = 0x3;

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/TrieTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/TrieTest.java
@@ -9,6 +9,7 @@
 
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -31,7 +32,7 @@ import com.ibm.icu.util.RangeValueIterator;
 * @since release 2.1 Jan 01 2002
 */
 @RunWith(JUnit4.class)
-public final class TrieTest extends TestFmwk
+public final class TrieTest extends CoreTestFmwk
 {
     // constructor ---------------------------------------------------
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/UtilityTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/UtilityTest.java
@@ -12,6 +12,7 @@
 */
 package com.ibm.icu.dev.test.util;
 
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -36,7 +37,7 @@ import com.ibm.icu.util.CaseInsensitiveString;
  * @summary Test of internal Utility class
  */
 @RunWith(JUnit4.class)
-public class UtilityTest extends TestFmwk {
+public class UtilityTest extends CoreTestFmwk {
     @Test
     public void TestUnescape() {
         final String input =

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/VersionInfoTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/VersionInfoTest.java
@@ -10,7 +10,7 @@
 
 package com.ibm.icu.dev.test.util;
 
-
+import com.ibm.icu.dev.test.CoreTestFmwk;
 import java.util.Arrays;
 
 import org.junit.Test;
@@ -27,7 +27,7 @@ import com.ibm.icu.util.VersionInfo;
 * @since release 2.1 March 01 2002
 */
 @RunWith(JUnit4.class)
-public final class VersionInfoTest extends TestFmwk
+public final class VersionInfoTest extends CoreTestFmwk
 {
     // constructor ---------------------------------------------------
 

--- a/icu4j/main/framework/src/test/java/com/ibm/icu/dev/test/TestFmwk.java
+++ b/icu4j/main/framework/src/test/java/com/ibm/icu/dev/test/TestFmwk.java
@@ -38,12 +38,12 @@ abstract public class TestFmwk extends AbstractTestLog {
     /**
      * The default time zone for all of our tests. Used in @Before
      */
-    private final static TimeZone defaultTimeZone = TimeZone.getTimeZone("America/Los_Angeles");
+    protected final static TimeZone defaultTimeZone = TimeZone.getTimeZone("America/Los_Angeles");
 
     /**
      * The default locale used for all of our tests. Used in @Before
      */
-    private final static Locale defaultLocale = Locale.US;
+    protected final static Locale defaultLocale = Locale.US;
 
     private static final String EXHAUSTIVENESS = "ICU.exhaustive";
     private static final int DEFAULT_EXHAUSTIVENESS = 0;
@@ -86,6 +86,9 @@ abstract public class TestFmwk extends AbstractTestLog {
      * Because JUnit does not guarantee the order of multiple Before
      * methods, TestFmwk implementation class should override this
      * method, instead of annotating Before.
+     *
+     * <p>Any implementation of the override should be sure to call
+     * super.localTestInitialize().
      */
     protected void localTestInitialize() {
     }
@@ -94,6 +97,9 @@ abstract public class TestFmwk extends AbstractTestLog {
      * This method is called at the beginning of {@link #testTeardown()}.
      * TestFmwk implementation class should override this method, instead
      * of annotating After.
+     *
+     * <p>Any implementation of the override should be sure to call
+     * super.localTestTeardown().
      */
     protected void localTestTeardown() {
     }


### PR DESCRIPTION
Summary:
1. We extended the test framework base class so that we can automatically check that every test restores the default time zone to what it was when it began (both JDK and ICU TZ)
2. @mihnita checked, and the behavior of JDK `TimeZone.getDefault()` always checks the latest value, but ICU `TimeZone.getDefault()` gets whatever is cached.
3. All of the tests had already been properly restoring the default time zone. So what we think is that somewhere in the main (aka runtime) code is setting the ICU TimeZone, and it's throwing off our assumptions that the test code starts off with a proper and undisturbed state.
4. To counteract the problem, we are setting the ICU default TimeZone before every test to be the same default JDK TimeZone that is used for our testing purposes. Even though it might mask the source of the underlying problem, perhaps in our main code, it gets our tests working and enabled again.
5. This buys us time for ICU 75 to do a proper investigation and fix for whatever the source of the underlying problem is.
6. While we were at it, because we could, we also added checks to ensure that tests aren't changing the default locale (both ICU and JDK). It turns out that a couple didn't restore the default locale, so we fixed that, even though it wasn't causing test failures yet.

As @mihnita mentioned in the ICU-TC meeting on Thursday, the key to reproducing the problem was when he realized that there are 2 different systems for setting the default time zone on Linux, and Debian and Ubuntu differ on which one they prefer in their desktop UIs. He wrote:

> This is the "official" way if you search for changing time zone on Debian:
> `sudo timedatectl set-timezone "America/Los_Angeles"`
> Does nothing for Java. Seems to be in sync with the changes you do in UI.
> 
> ---
> The Ubuntu way (also works on Debian), and affects the Java behavior:
> `sudo dpkg-reconfigure tzdata`

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22505
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
