### PR TITLE
ICU-22548 Reduce the loop limit to fail faster

### DIFF
--- a/icu4c/source/i18n/collationbuilder.cpp
+++ b/icu4c/source/i18n/collationbuilder.cpp
@@ -1119,9 +1119,9 @@ CollationBuilder::addWithClosure(const UnicodeString &nfdPrefix, const UnicodeSt
 // Please let us know if you have a reasonable use case that needed
 // for a practical Collation rule that needs to increase this limit.
 // This value is needed for compiling a rule with eight Hangul syllables such as
-// "&a=b쫊쫊쫊쫊쫊쫊쫊쫊" without error, which should be more than realistic
+// "&a=b쫊쫊쫊쫊쫊쫊쫊" without error, which should be more than realistic
 // usage.
-static constexpr int32_t kClosureLoopLimit = 6560;
+static constexpr int32_t kClosureLoopLimit = 3000;
 
 uint32_t
 CollationBuilder::addOnlyClosure(const UnicodeString &nfdPrefix, const UnicodeString &nfdString,

--- a/icu4c/source/test/fuzzer/locale_util.h
+++ b/icu4c/source/test/fuzzer/locale_util.h
@@ -5,6 +5,7 @@
 #define I18N_ICU_FUZZ_LOCALE_UTIL_H_
 
 #include <string>
+#include "unicode/utypes.h"
 
 // Takes uint8_t data from fuzzer, and makes a zero terminated string.
 std::string MakeZeroTerminatedInput(const uint8_t* data, int32_t size);


### PR DESCRIPTION
Reduce the error return from about 100s to 30s to avoid fuzzer 60s timeout error.
Also add a include file to fix uint8_t build breakage.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22548
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
