### PR TITLE
ICU-22511 Fix "vi" locale collator hang in comparison

### DIFF
--- a/icu4c/source/test/fuzzer/collator_compare_fuzzer.cpp
+++ b/icu4c/source/test/fuzzer/collator_compare_fuzzer.cpp
@@ -37,10 +37,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   if (size > 4096) {
       size = 4096;
   }
-  std::unique_ptr<char16_t> compbuff1(new char16_t[size/4]);
+  std::unique_ptr<char16_t[]> compbuff1(new char16_t[size/4]);
   std::memcpy(compbuff1.get(), data, (size/4)*2);
   data = data + size/2;
-  std::unique_ptr<char16_t> compbuff2(new char16_t[size/4]);
+  std::unique_ptr<char16_t[]> compbuff2(new char16_t[size/4]);
   std::memcpy(compbuff2.get(), data, (size/4)*2);
 
 

--- a/icu4c/source/test/intltest/collationtest.cpp
+++ b/icu4c/source/test/intltest/collationtest.cpp
@@ -80,6 +80,7 @@ public:
     void TestDataDriven();
     void TestLongLocale();
     void TestBuilderContextsOverflow();
+    void TestWoHang22511();
     void TestHang22414();
 
 private:
@@ -154,6 +155,7 @@ void CollationTest::runIndexedTest(int32_t index, UBool exec, const char *&name,
     TESTCASE_AUTO(TestLongLocale);
     TESTCASE_AUTO(TestBuilderContextsOverflow);
     TESTCASE_AUTO(TestHang22414);
+    TESTCASE_AUTO(TestWoHang22511);
     TESTCASE_AUTO_END;
 }
 
@@ -1881,6 +1883,31 @@ void CollationTest::TestLongLocale() {
     LocalPointer<Collator> coll(Collator::createInstance(longLocale, errorCode));
 }
 
+void CollationTest::TestWoHang22511() {
+    IcuTestErrorCode errorCode(*this, "TestWoHang22511");
+    char16_t str1[] = {
+      0x0000, 0x0100, 0x032a, 0x01e0, 0xd804, 0xdd00, 0x031c,
+    };
+
+    int32_t num_locales = 0;
+    const icu::Locale* locales = icu::Locale::getAvailableLocales(num_locales);
+    for (int32_t i = 0; i < num_locales; i++) {
+        errorCode.reset();
+        icu::Locale l = locales[i];
+        LocalPointer<Collator> coll(Collator::createInstance(l, errorCode));
+        if(errorCode.isFailure()) {
+            logln("cannot built the Collator");
+            continue;
+        }
+        coll->setStrength(icu::Collator::IDENTICAL);
+
+        coll->compare(str1,
+                      sizeof(str1)/sizeof(char16_t),
+                      str1+1,
+                      (sizeof(str1)/sizeof(char16_t))-1,
+                      errorCode);
+    }
+}
 void CollationTest::TestHang22414() {
     IcuTestErrorCode errorCode(*this, "TestHang22414");
     const char* cases[] = {

--- a/icu4j/main/collate/src/test/java/com/ibm/icu/dev/test/collator/CollationTest.java
+++ b/icu4j/main/collate/src/test/java/com/ibm/icu/dev/test/collator/CollationTest.java
@@ -15,6 +15,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 import org.junit.Test;
@@ -1759,6 +1760,19 @@ public class CollationTest extends TestFmwk {
             }
         } catch (Exception e) {
             errln("unexpected type of exception: " + e);
+        }
+    }
+    @Test
+    public void TestWoHang22511() {
+        String str1 = "\u0000\u0100\u032a\u01e0\ud804\udd00\u031c";
+        String str2 = str1.substring(1);
+        for (Locale l : Collator.getAvailableLocales()) {
+            Collator col = Collator.getInstance(l);
+            col.setStrength(Collator.IDENTICAL);
+            try {
+                col.compare(str1, str2);
+            } catch (IllegalStateException e) {
+            }
         }
     }
 }


### PR DESCRIPTION
Avoid infinity loop by terminating and returning error if we loop the same for too many times.
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22511
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
