### PR TITLE
ICU-22513 Return error if days is too large in IslamicUmalquraCalendar

### DIFF
--- a/icu4c/source/i18n/gregocal.cpp
+++ b/icu4c/source/i18n/gregocal.cpp
@@ -472,17 +472,20 @@ GregorianCalendar::isLeapYear(int32_t year) const
 
 // -------------------------------------
 
-int32_t GregorianCalendar::handleComputeJulianDay(UCalendarDateFields bestField) 
+int32_t GregorianCalendar::handleComputeJulianDay(UCalendarDateFields bestField, UErrorCode& status)
 {
     fInvertGregorian = false;
 
-    int32_t jd = Calendar::handleComputeJulianDay(bestField);
+    int32_t jd = Calendar::handleComputeJulianDay(bestField, status);
+    if (U_FAILURE(status)) {
+        return 0;
+    }
 
     if((bestField == UCAL_WEEK_OF_YEAR) &&  // if we are doing WOY calculations, we are counting relative to Jan 1 *julian*
         (internalGet(UCAL_EXTENDED_YEAR)==fGregorianCutoverYear) && 
         jd >= fCutoverJulianDay) { 
             fInvertGregorian = true;  // So that the Julian Jan 1 will be used in handleComputeMonthStart
-            return Calendar::handleComputeJulianDay(bestField);
+            return Calendar::handleComputeJulianDay(bestField, status);
         }
 
 
@@ -495,7 +498,10 @@ int32_t GregorianCalendar::handleComputeJulianDay(UCalendarDateFields bestField)
                 __FILE__, __LINE__, jd);
 #endif
             fInvertGregorian = true;
-            jd = Calendar::handleComputeJulianDay(bestField);
+            jd = Calendar::handleComputeJulianDay(bestField, status);
+            if (U_FAILURE(status)) {
+                return 0;
+            }
 #if defined (U_DEBUG_CAL)
             fprintf(stderr, "%s:%d:  fIsGregorian %s, fInvertGregorian %s - ", 
                 __FILE__, __LINE__,fIsGregorian?"T":"F", fInvertGregorian?"T":"F");

--- a/icu4c/source/i18n/unicode/calendar.h
+++ b/icu4c/source/i18n/unicode/calendar.h
@@ -1704,10 +1704,11 @@ protected:
      * handleGetMonthLength() to obtain the calendar-specific month
      * length.
      * @param bestField which field to use to calculate the date
+     * @param status        ICU Error Code
      * @return julian day specified by calendar fields.
      * @internal
      */
-    virtual int32_t handleComputeJulianDay(UCalendarDateFields bestField);
+    virtual int32_t handleComputeJulianDay(UCalendarDateFields bestField, UErrorCode &status);
 
     /**
      * Subclasses must override this to convert from week fields
@@ -1731,10 +1732,11 @@ protected:
     /**
      * Compute the Julian day from fields.  Will determine whether to use
      * the JULIAN_DAY field directly, or other fields.
+     * @param status        ICU Error Code
      * @return the julian day
      * @internal
      */
-    int32_t computeJulianDay();
+    int32_t computeJulianDay(UErrorCode &status);
 
     /**
      * Compute the milliseconds in the day from the fields.  This is a

--- a/icu4c/source/i18n/unicode/gregocal.h
+++ b/icu4c/source/i18n/unicode/gregocal.h
@@ -495,10 +495,11 @@ public:
      * handleGetMonthLength() to obtain the calendar-specific month
      * length.
      * @param bestField which field to use to calculate the date 
+     * @param status Fill-in parameter which receives the status of this operation.
      * @return julian day specified by calendar fields.
      * @internal
      */
-    virtual int32_t handleComputeJulianDay(UCalendarDateFields bestField) override;
+    virtual int32_t handleComputeJulianDay(UCalendarDateFields bestField, UErrorCode& status) override;
 
     /**
      * Return the number of days in the given month of the given extended

--- a/icu4c/source/test/intltest/incaltst.cpp
+++ b/icu4c/source/test/intltest/incaltst.cpp
@@ -105,6 +105,7 @@ void IntlCalendarTest::runIndexedTest( int32_t index, UBool exec, const char* &n
     TESTCASE_AUTO(TestConsistencyIslamicUmalqura);
     TESTCASE_AUTO(TestConsistencyPersian);
     TESTCASE_AUTO(TestConsistencyJapanese);
+    TESTCASE_AUTO(TestIslamicUmalquraCalendarSlow);
     TESTCASE_AUTO_END;
 }
 
@@ -1120,6 +1121,18 @@ void IntlCalendarTest::checkConsistency(const char* locale) {
             status.errIfFailureAndReset();
         }
     }
+}
+
+void IntlCalendarTest::TestIslamicUmalquraCalendarSlow() {
+    IcuTestErrorCode status(*this, "TestIslamicUmalquraCalendarSlow");
+    Locale l("th@calendar=islamic-umalqura");
+    std::unique_ptr<Calendar> cal(
+        Calendar::createInstance(l, status));
+    cal->add(UCAL_YEAR, 1229080905, status);
+    cal->roll(UCAL_WEEK_OF_MONTH, 1499050699, status);
+    cal->fieldDifference(0.000000, UCAL_YEAR_WOY, status);
+    // Ignore the error
+    status.reset();
 }
 
 void IntlCalendarTest::simpleTest(const Locale& loc, const UnicodeString& expect, UDate expectDate, UErrorCode& status)

--- a/icu4c/source/test/intltest/incaltst.h
+++ b/icu4c/source/test/intltest/incaltst.h
@@ -60,6 +60,7 @@ public:
     void TestConsistencyIslamicUmalqura();
     void TestConsistencyPersian();
     void TestConsistencyJapanese();
+    void TestIslamicUmalquraCalendarSlow();
 
  protected:
     // Test a Gregorian-Like calendar

--- a/icu4j/main/core/src/main/java/com/ibm/icu/util/Calendar.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/util/Calendar.java
@@ -6233,6 +6233,10 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
 
         internalSet(EXTENDED_YEAR, year);
 
+        if (year > Long.MAX_VALUE / 400) {
+            throw new IllegalArgumentException("year is too large");
+        }
+
         int month = useMonth ? internalGetMonth(getDefaultMonthInYear(year)) : 0;
 
         // Get the Julian day of the day BEFORE the start of this year.

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/CalendarRegressionTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/CalendarRegressionTest.java
@@ -2710,5 +2710,17 @@ public class CalendarRegressionTest extends com.ibm.icu.dev.test.TestFmwk {
                     Calendar.getInstance(Locale.forLanguageTag(localeIds[i])).getFirstDayOfWeek());
         }
     }
+
+    @Test
+    public void TestIslamicUmalquraCalendarSlow() { // ICU-22513
+        Locale loc = new Locale("th@calendar=islamic-umalqura");
+        Calendar cal = Calendar.getInstance(loc);
+        cal.clear();
+        cal.add(Calendar.YEAR, 1229080905);
+        cal.roll(Calendar.WEEK_OF_MONTH, 1499050699);
+        cal.fieldDifference(new Date(0), Calendar.YEAR_WOY);
+
+    }
+
 }
 //eof


### PR DESCRIPTION
The computation in IslamicUmalquraCalendar is slower than others, if the days is more than 10,000 years from the epoch, we just return error to avoid hang.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22513
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
