### PR TITLE
ICU-22563 Limit the size for calendar fuzzer

### DIFF
--- a/icu4c/source/test/fuzzer/calendar_fuzzer.cpp
+++ b/icu4c/source/test/fuzzer/calendar_fuzzer.cpp
@@ -52,6 +52,9 @@ const char* GetRandomCalendarType(uint8_t rnd) {
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     uint16_t rnd;
+    // Set the limit for the test data to 1000 bytes to avoid timeout for a
+    // very long list of operations.
+    if (size > 1000) { size = 1000; }
     if (size < 2*sizeof(rnd) + 1) return 0;
     icu::StringPiece fuzzData(reinterpret_cast<const char *>(data), size);
     // Byte 0 and 1 randomly select a TimeZone


### PR DESCRIPTION
Limit to 1000 bytes of valid test data so the fuzzer will not timeout because of running many operations.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22563
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
