### PR TITLE
ICU-22589 Avoid timeout in TimeZone test

### DIFF
--- a/icu4c/source/test/fuzzer/timezone_create_fuzzer.cpp
+++ b/icu4c/source/test/fuzzer/timezone_create_fuzzer.cpp
@@ -11,6 +11,10 @@ IcuEnvironment* env = new IcuEnvironment();
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
+  // Limit the test for at most 1000 Unicode characters.
+  if (size > 2000) {
+    size = 2000;
+  }
   size_t unistr_size = size/2;
   std::unique_ptr<char16_t[]> fuzzbuff(new char16_t[unistr_size]);
   std::memcpy(fuzzbuff.get(), data, unistr_size * 2);


### PR DESCRIPTION
The bug was filed because the fuzzer test data is very large and take a long time to run. Not an infinity loop. This PR limit the data to at most 2000 bytes so it will complete in reasonable amount of time. 
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22589
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
