### PR TITLE
ICU-22584 Fix RBBI rule builder stack overflow.

### DIFF
--- a/icu4c/source/common/rbbinode.h
+++ b/icu4c/source/common/rbbinode.h
@@ -94,6 +94,7 @@ class RBBINode : public UMemory {
         RBBINode(NodeType t);
         RBBINode(const RBBINode &other);
         ~RBBINode();
+        static void  NRDeleteNode(RBBINode *node);
         
         RBBINode    *cloneTree();
         RBBINode    *flattenVariables();

--- a/icu4c/source/test/intltest/rbbitst.cpp
+++ b/icu4c/source/test/intltest/rbbitst.cpp
@@ -144,6 +144,7 @@ void RBBITest::runIndexedTest( int32_t index, UBool exec, const char* &name, cha
     TESTCASE_AUTO(TestRandomAccess);
     TESTCASE_AUTO(TestExternalBreakEngineWithFakeTaiLe);
     TESTCASE_AUTO(TestExternalBreakEngineWithFakeYue);
+    TESTCASE_AUTO(TestBug22584);
 
 #if U_ENABLE_TRACING
     TESTCASE_AUTO(TestTraceCreateCharacter);
@@ -5856,6 +5857,20 @@ void RBBITest::TestExternalBreakEngineWithFakeTaiLe() {
          70, 73, 76, 80, 86, 89, 92}});
     assertTrue("break Tai Le by Fake external breaker",
                expected2 == actual2);
+}
+
+void RBBITest::TestBug22584() {
+    // Creating a break iterator from a rule consisting of a very long
+    // literal input string caused a stack overflow when deleting the
+    // parse tree for the input during the rule building process.
+
+    // Failure of this test showed as a crash during the break iterator construction.
+
+    UnicodeString ruleStr(100000, (UChar32)0, 100000);
+    UParseError pe {};
+    UErrorCode ec {U_ZERO_ERROR};
+
+    RuleBasedBreakIterator bi(ruleStr, pe, ec);
 }
 
 #endif // #if !UCONFIG_NO_BREAK_ITERATION

--- a/icu4c/source/test/intltest/rbbitst.h
+++ b/icu4c/source/test/intltest/rbbitst.h
@@ -98,6 +98,7 @@ public:
     void TestRandomAccess();
     void TestExternalBreakEngineWithFakeTaiLe();
     void TestExternalBreakEngineWithFakeYue();
+    void TestBug22584();
 
 #if U_ENABLE_TRACING
     void TestTraceCreateCharacter();


### PR DESCRIPTION
The problem was found by fuzz testing.

A rule consisting of a long literal string produces a large, unbalanced parse tree, one node per string element. Deleting the tree was recursive, once per node, resulting in deep recursion.

This PR changes node deletion to use an iterative (non-recursive) approach.

This change only affects rule building. There is no change to the RBBI run time using pre-built rules.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22584
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
