### PR TITLE
ICU-22602 Fix stack overflow inside flattenVariables

### DIFF
--- a/icu4c/source/common/rbbinode.h
+++ b/icu4c/source/common/rbbinode.h
@@ -97,7 +97,7 @@ class RBBINode : public UMemory {
         static void  NRDeleteNode(RBBINode *node);
         
         RBBINode    *cloneTree();
-        RBBINode    *flattenVariables();
+        RBBINode    *flattenVariables(UErrorCode &status, int depth=0);
         void         flattenSets();
         void         findNodes(UVector *dest, RBBINode::NodeType kind, UErrorCode &status);
 

--- a/icu4c/source/common/rbbitblb.cpp
+++ b/icu4c/source/common/rbbitblb.cpp
@@ -81,7 +81,10 @@ void  RBBITableBuilder::buildForwardTable() {
     // Walk through the tree, replacing any references to $variables with a copy of the
     //   parse tree for the substitution expression.
     //
-    fTree = fTree->flattenVariables();
+    fTree = fTree->flattenVariables(*fStatus, 0);
+    if (U_FAILURE(*fStatus)) {
+        return;
+    }
 #ifdef RBBI_DEBUG
     if (fRB->fDebugEnv && uprv_strstr(fRB->fDebugEnv, "ftree")) {
         RBBIDebugPuts("\nParse tree after flattening variable references.");

--- a/icu4c/source/test/intltest/rbbitst.cpp
+++ b/icu4c/source/test/intltest/rbbitst.cpp
@@ -148,6 +148,7 @@ void RBBITest::runIndexedTest( int32_t index, UBool exec, const char* &name, cha
     TESTCASE_AUTO(TestBug22581);
     TESTCASE_AUTO(TestBug22584);
     TESTCASE_AUTO(TestBug22585);
+    TESTCASE_AUTO(TestBug22602);
 
 #if U_ENABLE_TRACING
     TESTCASE_AUTO(TestTraceCreateCharacter);
@@ -5877,6 +5878,15 @@ void RBBITest::TestBug22585() {
         .append("];");
     ec = U_ZERO_ERROR;
     RuleBasedBreakIterator bi2(rule, pe, ec);
+}
+
+// Test a long string with a ; in the end will not cause stack overflow.
+void RBBITest::TestBug22602() {
+    UnicodeString rule(25000, (UChar32)'A', 25000-1);
+    rule.append(u";");
+    UParseError pe {};
+    UErrorCode ec {U_ZERO_ERROR};
+    RuleBasedBreakIterator bi(rule, pe, ec);
 }
 
 void RBBITest::TestBug22584() {

--- a/icu4c/source/test/intltest/rbbitst.h
+++ b/icu4c/source/test/intltest/rbbitst.h
@@ -102,6 +102,7 @@ public:
     void TestBug22581();
     void TestBug22584();
     void TestBug22585();
+    void TestBug22602();
 
 #if U_ENABLE_TRACING
     void TestTraceCreateCharacter();

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/RBBINode.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/RBBINode.java
@@ -176,7 +176,6 @@ class RBBINode {
     }
 
 
-
     //-------------------------------------------------------------------------
     //
     //       flattenVariables Walk a parse tree, replacing any variable
@@ -195,7 +194,11 @@ class RBBINode {
     //                          nested references are handled by cloneTree(), not here.
     //
     //-------------------------------------------------------------------------
-    RBBINode flattenVariables() {
+    static final private int kRecursiveDepthLimit = 3500;
+    RBBINode flattenVariables(int depth) {
+        if (depth > kRecursiveDepthLimit) {
+            throw new IllegalArgumentException("The input is too long");
+        }
         if (fType == varRef) {
             RBBINode retNode  = fLeftChild.cloneTree();
             retNode.fRuleRoot = this.fRuleRoot;
@@ -204,11 +207,11 @@ class RBBINode {
         }
 
         if (fLeftChild != null) {
-            fLeftChild = fLeftChild.flattenVariables();
+            fLeftChild = fLeftChild.flattenVariables(depth+1);
             fLeftChild.fParent = this;
         }
         if (fRightChild != null) {
-            fRightChild = fRightChild.flattenVariables();
+            fRightChild = fRightChild.flattenVariables(depth+1);
             fRightChild.fParent = this;
         }
         return this;

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/RBBITableBuilder.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/RBBITableBuilder.java
@@ -116,7 +116,7 @@ class RBBITableBuilder {
            // Walk through the tree, replacing any references to $variables with a copy of the
            //   parse tree for the substitution expression.
            //
-           fRB.fTreeRoots[fRootIx] = fRB.fTreeRoots[fRootIx].flattenVariables();
+           fRB.fTreeRoots[fRootIx] = fRB.fTreeRoots[fRootIx].flattenVariables(0);
            if (fRB.fDebugEnv!=null && fRB.fDebugEnv.indexOf("ftree")>=0) {
                System.out.println("Parse tree after flattening variable references.");
                fRB.fTreeRoots[fRootIx].printTree(true);

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBITest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBITest.java
@@ -10,6 +10,7 @@ package com.ibm.icu.dev.test.rbbi;
 
 import java.text.CharacterIterator;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
@@ -982,6 +983,23 @@ public class RBBITest extends CoreTestFmwk {
         }
         catch (Exception e) {
             fail("TestBug22585: Unexpected exception while new RuleBasedBreakIterator() with unpaired low surrogate: " + e);
+        }
+    }
+    @Test
+    public void TestBug22602() {
+        try {
+            char[] charArray = new char[25000];
+            Arrays.fill(charArray, 'A');
+            charArray[charArray.length-1] = ';';
+            String rules = new String(charArray);
+            RuleBasedBreakIterator bi = new RuleBasedBreakIterator(rules);
+            fail("TestBug22602: RuleBasedBreakIterator() failed to throw an exception with a long string followed by a ';'.");
+        }
+        catch (IllegalArgumentException e) {
+            // expected exception with a long string followed by a ';'.
+        }
+        catch(StackOverflowError e) {
+            fail("TestBug22602: Unexpected exception while new RuleBasedBreakIterator() with a long string followed by a ';': " + e);
         }
     }
     /* Test preceding(index) and following(index), with semi-random indexes.


### PR DESCRIPTION
Limit the recursive call of flattenVariables to maximum depth 4000 since Java on my machine throw stack overflow exception around 4300.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22602
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
