### PR TITLE
ICU-22532 Remove redundant 'void' from empty C++ parameter lists

### DIFF
--- a/icu4c/source/common/unicode/brkiter.h
+++ b/icu4c/source/common/unicode/brkiter.h
@@ -146,14 +146,13 @@ public:
      * will return distinct unequal values.
      * @stable ICU 2.0
      */
-    virtual UClassID getDynamicClassID(void) const override = 0;
+    virtual UClassID getDynamicClassID() const override = 0;
 
     /**
      * Return a CharacterIterator over the text being analyzed.
      * @stable ICU 2.0
      */
-    virtual CharacterIterator& getText(void) const = 0;
-
+    virtual CharacterIterator& getText() const = 0;
 
     /**
       *  Get a UText for the text being analyzed.
@@ -228,14 +227,14 @@ public:
      * @return The offset of the beginning of the text, zero.
      * @stable ICU 2.0
      */
-    virtual int32_t first(void) = 0;
+    virtual int32_t first() = 0;
 
     /**
      * Set the iterator position to the index immediately BEYOND the last character in the text being scanned.
      * @return The index immediately BEYOND the last character in the text being scanned.
      * @stable ICU 2.0
      */
-    virtual int32_t last(void) = 0;
+    virtual int32_t last() = 0;
 
     /**
      * Set the iterator position to the boundary preceding the current boundary.
@@ -243,7 +242,7 @@ public:
      * boundaries have been returned.
      * @stable ICU 2.0
      */
-    virtual int32_t previous(void) = 0;
+    virtual int32_t previous() = 0;
 
     /**
      * Advance the iterator to the boundary following the current boundary.
@@ -251,14 +250,14 @@ public:
      * boundaries have been returned.
      * @stable ICU 2.0
      */
-    virtual int32_t next(void) = 0;
+    virtual int32_t next() = 0;
 
     /**
      * Return character index of the current iterator position within the text.
      * @return The boundary most recently returned.
      * @stable ICU 2.0
      */
-    virtual int32_t current(void) const = 0;
+    virtual int32_t current() const = 0;
 
     /**
      * Advance the iterator to the first boundary following the specified offset.
@@ -530,7 +529,7 @@ public:
      *   must be closed by an explicit call to the destructor (not delete).
      * @deprecated ICU 52. Always delete the BreakIterator.
      */
-    inline UBool isBufferClone(void);
+    inline UBool isBufferClone();
 
 #endif /* U_HIDE_DEPRECATED_API */
 
@@ -575,7 +574,7 @@ public:
      * @return a StringEnumeration over the locales available at the time of the call
      * @stable ICU 2.4
      */
-    static StringEnumeration* U_EXPORT2 getAvailableLocales(void);
+    static StringEnumeration* U_EXPORT2 getAvailableLocales();
 #endif
 
     /**

--- a/icu4c/source/common/unicode/chariter.h
+++ b/icu4c/source/common/unicode/chariter.h
@@ -133,8 +133,8 @@ public:
      * @return the hash code.
      * @stable ICU 2.0
      */
-    virtual int32_t hashCode(void) const = 0;
-    
+    virtual int32_t hashCode() const = 0;
+
     /**
      * Returns a UClassID for this ForwardCharacterIterator ("poor man's
      * RTTI").<P> Despite the fact that this function is public,
@@ -142,8 +142,8 @@ public:
      * @return a UClassID for this ForwardCharacterIterator 
      * @stable ICU 2.0
      */
-    virtual UClassID getDynamicClassID(void) const override = 0;
-    
+    virtual UClassID getDynamicClassID() const override = 0;
+
     /**
      * Gets the current code unit for returning and advances to the next code unit
      * in the iteration range
@@ -152,8 +152,8 @@ public:
      * @return the current code unit.
      * @stable ICU 2.0
      */
-    virtual char16_t         nextPostInc(void) = 0;
-    
+    virtual char16_t nextPostInc() = 0;
+
     /**
      * Gets the current code point for returning and advances to the next code point
      * in the iteration range
@@ -162,8 +162,8 @@ public:
      * @return the current code point.
      * @stable ICU 2.0
      */
-    virtual UChar32       next32PostInc(void) = 0;
-    
+    virtual UChar32 next32PostInc() = 0;
+
     /**
      * Returns false if there are no more code units or code points
      * at or after the current position in the iteration range.
@@ -389,7 +389,7 @@ public:
      * @return the first code unit in its iteration range.
      * @stable ICU 2.0
      */
-    virtual char16_t         first(void) = 0;
+    virtual char16_t first() = 0;
 
     /**
      * Sets the iterator to refer to the first code unit in its
@@ -399,7 +399,7 @@ public:
      * @return the first code unit in its iteration range.
      * @stable ICU 2.0
      */
-    virtual char16_t         firstPostInc(void);
+    virtual char16_t firstPostInc();
 
     /**
      * Sets the iterator to refer to the first code point in its
@@ -410,7 +410,7 @@ public:
      * @return the first code point in its iteration range.
      * @stable ICU 2.0
      */
-    virtual UChar32       first32(void) = 0;
+    virtual UChar32 first32() = 0;
 
     /**
      * Sets the iterator to refer to the first code point in its
@@ -420,7 +420,7 @@ public:
      * @return the first code point in its iteration range.
      * @stable ICU 2.0
      */
-    virtual UChar32       first32PostInc(void);
+    virtual UChar32 first32PostInc();
 
     /**
      * Sets the iterator to refer to the first code unit or code point in its
@@ -438,8 +438,8 @@ public:
      * @return the last code unit.
      * @stable ICU 2.0
      */
-    virtual char16_t         last(void) = 0;
-        
+    virtual char16_t last() = 0;
+
     /**
      * Sets the iterator to refer to the last code point in its
      * iteration range, and returns that code unit.
@@ -447,7 +447,7 @@ public:
      * @return the last code point.
      * @stable ICU 2.0
      */
-    virtual UChar32       last32(void) = 0;
+    virtual UChar32 last32() = 0;
 
     /**
      * Sets the iterator to the end of its iteration range, just behind
@@ -486,15 +486,15 @@ public:
      * @return the current code unit. 
      * @stable ICU 2.0
      */
-    virtual char16_t         current(void) const = 0;
-        
+    virtual char16_t current() const = 0;
+
     /**
      * Returns the code point the iterator currently refers to.  
      * @return the current code point.
      * @stable ICU 2.0
      */
-    virtual UChar32       current32(void) const = 0;
-        
+    virtual UChar32 current32() const = 0;
+
     /**
      * Advances to the next code unit in the iteration range
      * (toward endIndex()), and returns that code unit.  If there are
@@ -502,8 +502,8 @@ public:
      * @return the next code unit.
      * @stable ICU 2.0
      */
-    virtual char16_t         next(void) = 0;
-        
+    virtual char16_t next() = 0;
+
     /**
      * Advances to the next code point in the iteration range
      * (toward endIndex()), and returns that code point.  If there are
@@ -514,8 +514,8 @@ public:
      * @return the next code point.
      * @stable ICU 2.0
      */
-    virtual UChar32       next32(void) = 0;
-        
+    virtual UChar32 next32() = 0;
+
     /**
      * Advances to the previous code unit in the iteration range
      * (toward startIndex()), and returns that code unit.  If there are
@@ -523,7 +523,7 @@ public:
      * @return the previous code unit.
      * @stable ICU 2.0
      */
-    virtual char16_t         previous(void) = 0;
+    virtual char16_t previous() = 0;
 
     /**
      * Advances to the previous code point in the iteration range
@@ -532,7 +532,7 @@ public:
      * @return the previous code point. 
      * @stable ICU 2.0
      */
-    virtual UChar32       previous32(void) = 0;
+    virtual UChar32 previous32() = 0;
 
     /**
      * Returns false if there are no more code units or code points
@@ -555,8 +555,8 @@ public:
      * object of the character returned by first().
      * @stable ICU 2.0
      */
-    inline int32_t       startIndex(void) const;
-        
+    inline int32_t startIndex() const;
+
     /**
      * Returns the numeric index in the underlying text-storage
      * object of the position immediately BEYOND the character
@@ -566,8 +566,8 @@ public:
      * returned by last().
      * @stable ICU 2.0
      */
-    inline int32_t       endIndex(void) const;
-        
+    inline int32_t endIndex() const;
+
     /**
      * Returns the numeric index in the underlying text-storage
      * object of the character the iterator currently refers to
@@ -576,7 +576,7 @@ public:
      * the character the iterator currently refers to
      * @stable ICU 2.0
      */
-    inline int32_t       getIndex(void) const;
+    inline int32_t getIndex() const;
 
     /**
      * Returns the length of the entire text in the underlying
@@ -708,22 +708,22 @@ CharacterIterator::setToEnd() {
 }
 
 inline int32_t
-CharacterIterator::startIndex(void) const {
+CharacterIterator::startIndex() const {
     return begin;
 }
 
 inline int32_t
-CharacterIterator::endIndex(void) const {
+CharacterIterator::endIndex() const {
     return end;
 }
 
 inline int32_t
-CharacterIterator::getIndex(void) const {
+CharacterIterator::getIndex() const {
     return pos;
 }
 
 inline int32_t
-CharacterIterator::getLength(void) const {
+CharacterIterator::getLength() const {
     return textLength;
 }
 

--- a/icu4c/source/common/unicode/dtintrv.h
+++ b/icu4c/source/common/unicode/dtintrv.h
@@ -76,7 +76,7 @@ public:
      * @return          The class ID for all objects of this class.
      * @stable ICU 4.0
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * Returns a unique class ID POLYMORPHICALLY. Pure virtual override. This
@@ -89,9 +89,8 @@ public:
      *                  other classes have different class IDs.
      * @stable ICU 4.0
      */
-    virtual UClassID getDynamicClassID(void) const override;
+    virtual UClassID getDynamicClassID() const override;
 
-    
     /**
      * Copy constructor.
      * @stable ICU 4.0

--- a/icu4c/source/common/unicode/locid.h
+++ b/icu4c/source/common/unicode/locid.h
@@ -195,51 +195,50 @@ class UnicodeString;
 class U_COMMON_API Locale : public UObject {
 public:
     /** Useful constant for the Root locale. @stable ICU 4.4 */
-    static const Locale &U_EXPORT2 getRoot(void);
+    static const Locale& U_EXPORT2 getRoot();
     /** Useful constant for this language. @stable ICU 2.0 */
-    static const Locale &U_EXPORT2 getEnglish(void);
+    static const Locale& U_EXPORT2 getEnglish();
     /** Useful constant for this language. @stable ICU 2.0 */
-    static const Locale &U_EXPORT2 getFrench(void);
+    static const Locale& U_EXPORT2 getFrench();
     /** Useful constant for this language. @stable ICU 2.0 */
-    static const Locale &U_EXPORT2 getGerman(void);
+    static const Locale& U_EXPORT2 getGerman();
     /** Useful constant for this language. @stable ICU 2.0 */
-    static const Locale &U_EXPORT2 getItalian(void);
+    static const Locale& U_EXPORT2 getItalian();
     /** Useful constant for this language. @stable ICU 2.0 */
-    static const Locale &U_EXPORT2 getJapanese(void);
+    static const Locale& U_EXPORT2 getJapanese();
     /** Useful constant for this language. @stable ICU 2.0 */
-    static const Locale &U_EXPORT2 getKorean(void);
+    static const Locale& U_EXPORT2 getKorean();
     /** Useful constant for this language. @stable ICU 2.0 */
-    static const Locale &U_EXPORT2 getChinese(void);
+    static const Locale& U_EXPORT2 getChinese();
     /** Useful constant for this language. @stable ICU 2.0 */
-    static const Locale &U_EXPORT2 getSimplifiedChinese(void);
+    static const Locale& U_EXPORT2 getSimplifiedChinese();
     /** Useful constant for this language. @stable ICU 2.0 */
-    static const Locale &U_EXPORT2 getTraditionalChinese(void);
+    static const Locale& U_EXPORT2 getTraditionalChinese();
 
     /** Useful constant for this country/region. @stable ICU 2.0 */
-    static const Locale &U_EXPORT2 getFrance(void);
+    static const Locale& U_EXPORT2 getFrance();
     /** Useful constant for this country/region. @stable ICU 2.0 */
-    static const Locale &U_EXPORT2 getGermany(void);
+    static const Locale& U_EXPORT2 getGermany();
     /** Useful constant for this country/region. @stable ICU 2.0 */
-    static const Locale &U_EXPORT2 getItaly(void);
+    static const Locale& U_EXPORT2 getItaly();
     /** Useful constant for this country/region. @stable ICU 2.0 */
-    static const Locale &U_EXPORT2 getJapan(void);
+    static const Locale& U_EXPORT2 getJapan();
     /** Useful constant for this country/region. @stable ICU 2.0 */
-    static const Locale &U_EXPORT2 getKorea(void);
+    static const Locale& U_EXPORT2 getKorea();
     /** Useful constant for this country/region. @stable ICU 2.0 */
-    static const Locale &U_EXPORT2 getChina(void);
+    static const Locale& U_EXPORT2 getChina();
     /** Useful constant for this country/region. @stable ICU 2.0 */
-    static const Locale &U_EXPORT2 getPRC(void);
+    static const Locale& U_EXPORT2 getPRC();
     /** Useful constant for this country/region. @stable ICU 2.0 */
-    static const Locale &U_EXPORT2 getTaiwan(void);
+    static const Locale& U_EXPORT2 getTaiwan();
     /** Useful constant for this country/region. @stable ICU 2.0 */
-    static const Locale &U_EXPORT2 getUK(void);
+    static const Locale& U_EXPORT2 getUK();
     /** Useful constant for this country/region. @stable ICU 2.0 */
-    static const Locale &U_EXPORT2 getUS(void);
+    static const Locale& U_EXPORT2 getUS();
     /** Useful constant for this country/region. @stable ICU 2.0 */
-    static const Locale &U_EXPORT2 getCanada(void);
+    static const Locale& U_EXPORT2 getCanada();
     /** Useful constant for this country/region. @stable ICU 2.0 */
-    static const Locale &U_EXPORT2 getCanadaFrench(void);
-
+    static const Locale& U_EXPORT2 getCanadaFrench();
 
     /**
      * Construct a default locale object, a Locale for the default locale ID.
@@ -370,7 +369,7 @@ public:
      * @system
      * @stable ICU 2.0
      */
-    static const Locale& U_EXPORT2 getDefault(void);
+    static const Locale& U_EXPORT2 getDefault();
 
     /**
      * Sets the default. Normally set once at the beginning of a process,
@@ -792,7 +791,7 @@ public:
      * there is no Windows LCID value that corresponds to this locale, returns 0.
      * @stable ICU 2.0
      */
-    uint32_t        getLCID(void) const;
+    uint32_t getLCID() const;
 
     /**
      * Returns whether this locale's script is written right-to-left.
@@ -944,7 +943,7 @@ public:
      * Generates a hash code for the locale.
      * @stable ICU 2.0
      */
-    int32_t         hashCode(void) const;
+    int32_t hashCode() const;
 
     /**
      * Sets the locale to bogus
@@ -961,7 +960,7 @@ public:
      * @return false if it is a real locale, true if it is a bogus locale
      * @stable ICU 2.1
      */
-    inline UBool isBogus(void) const;
+    inline UBool isBogus() const;
 
     /**
      * Returns a list of all installed locales.
@@ -1147,7 +1146,7 @@ private:
     /**
      * Initialize the locale cache for commonly used locales
      */
-    static Locale *getLocaleCache(void);
+    static Locale* getLocaleCache();
 
     char language[ULOC_LANG_CAPACITY];
     char script[ULOC_SCRIPT_CAPACITY];
@@ -1273,7 +1272,7 @@ Locale::getUnicodeKeywordValue(StringPiece keywordName, UErrorCode& status) cons
 }
 
 inline UBool
-Locale::isBogus(void) const {
+Locale::isBogus() const {
     return fIsBogus;
 }
 

--- a/icu4c/source/common/unicode/normlzr.h
+++ b/icu4c/source/common/unicode/normlzr.h
@@ -466,7 +466,7 @@ public:
    * @return the current normalized code point
    * @deprecated ICU 56 Use Normalizer2 instead.
    */
-  UChar32              current(void);
+  UChar32 current();
 
   /**
    * Return the first character in the normalized text.
@@ -476,7 +476,7 @@ public:
    * @return the first normalized code point
    * @deprecated ICU 56 Use Normalizer2 instead.
    */
-  UChar32              first(void);
+  UChar32 first();
 
   /**
    * Return the last character in the normalized text.
@@ -486,7 +486,7 @@ public:
    * @return the last normalized code point
    * @deprecated ICU 56 Use Normalizer2 instead.
    */
-  UChar32              last(void);
+  UChar32 last();
 
   /**
    * Return the next character in the normalized text.
@@ -502,7 +502,7 @@ public:
    * @return the next normalized code point
    * @deprecated ICU 56 Use Normalizer2 instead.
    */
-  UChar32              next(void);
+  UChar32 next();
 
   /**
    * Return the previous character in the normalized text and decrement.
@@ -518,7 +518,7 @@ public:
    * @return the previous normalized code point
    * @deprecated ICU 56 Use Normalizer2 instead.
    */
-  UChar32              previous(void);
+  UChar32 previous();
 
   /**
    * Set the iteration position in the input text that is being normalized,
@@ -536,7 +536,7 @@ public:
    * This is equivalent to setIndexOnly(startIndex)).
    * @deprecated ICU 56 Use Normalizer2 instead.
    */
-  void                reset(void);
+  void reset();
 
   /**
    * Retrieve the current iteration position in the input text that is
@@ -552,7 +552,7 @@ public:
    * @return the current index in the input text
    * @deprecated ICU 56 Use Normalizer2 instead.
    */
-  int32_t            getIndex(void) const;
+  int32_t getIndex() const;
 
   /**
    * Retrieve the index of the start of the input text. This is the begin index
@@ -562,7 +562,7 @@ public:
    * @return the smallest index in the input text where the Normalizer operates
    * @deprecated ICU 56 Use Normalizer2 instead.
    */
-  int32_t            startIndex(void) const;
+  int32_t startIndex() const;
 
   /**
    * Retrieve the index of the end of the input text. This is the end index
@@ -574,7 +574,7 @@ public:
    * @return the first index in the input text where the Normalizer does not operate
    * @deprecated ICU 56 Use Normalizer2 instead.
    */
-  int32_t            endIndex(void) const;
+  int32_t endIndex() const;
 
   /**
    * Returns true when both iterators refer to the same character in the same
@@ -610,7 +610,7 @@ public:
    * @return the hash code
    * @deprecated ICU 56 Use Normalizer2 instead.
    */
-  int32_t                hashCode(void) const;
+  int32_t hashCode() const;
 
   //-------------------------------------------------------------------------
   // Property access methods
@@ -643,7 +643,7 @@ public:
    * @see #setMode
    * @deprecated ICU 56 Use Normalizer2 instead.
    */
-  UNormalizationMode getUMode(void) const;
+  UNormalizationMode getUMode() const;
 
   /**
    * Set options that affect this <code>Normalizer</code>'s operation.
@@ -749,7 +749,7 @@ private:
   UBool previousNormalize();
 
   void    init();
-  void    clearBuffer(void);
+  void clearBuffer();
 
   //-------------------------------------------------------------------------
   // Private data

--- a/icu4c/source/common/unicode/parsepos.h
+++ b/icu4c/source/common/unicode/parsepos.h
@@ -129,7 +129,7 @@ public:
      * @return the current index.
      * @stable ICU 2.0
      */
-    inline int32_t getIndex(void) const;
+    inline int32_t getIndex() const;
 
     /**
      * Set the current parse position.
@@ -152,7 +152,7 @@ public:
      * error index has not been set.
      * @stable ICU 2.0
      */
-    inline int32_t getErrorIndex(void) const;
+    inline int32_t getErrorIndex() const;
 
     /**
      * ICU "poor man's RTTI", returns a UClassID for this class.

--- a/icu4c/source/common/unicode/rbbi.h
+++ b/icu4c/source/common/unicode/rbbi.h
@@ -388,14 +388,14 @@ public:
      * @return A hash code
      *  @stable ICU 2.0
      */
-    virtual int32_t hashCode(void) const;
+    virtual int32_t hashCode() const;
 
     /**
      * Returns the description used to create this iterator
      * @return the description used to create this iterator
      *  @stable ICU 2.0
      */
-    virtual const UnicodeString& getRules(void) const;
+    virtual const UnicodeString& getRules() const;
 
     //=======================================================================
     // BreakIterator overrides
@@ -425,8 +425,7 @@ public:
      * @return An iterator over the text being analyzed.
      * @stable ICU 2.0
      */
-    virtual  CharacterIterator& getText(void) const override;
-
+    virtual CharacterIterator& getText() const override;
 
     /**
       *  Get a UText for the text being analyzed.
@@ -486,14 +485,14 @@ public:
      * @return The offset of the beginning of the text, zero.
      *  @stable ICU 2.0
      */
-    virtual int32_t first(void) override;
+    virtual int32_t first() override;
 
     /**
      * Sets the current iteration position to the end of the text.
      * @return The text's past-the-end offset.
      *  @stable ICU 2.0
      */
-    virtual int32_t last(void) override;
+    virtual int32_t last() override;
 
     /**
      * Advances the iterator either forward or backward the specified number of steps.
@@ -512,14 +511,14 @@ public:
      * @return The position of the first boundary after this one.
      *  @stable ICU 2.0
      */
-    virtual int32_t next(void) override;
+    virtual int32_t next() override;
 
     /**
      * Moves the iterator backwards, to the last boundary preceding this one.
      * @return The position of the last boundary position preceding this one.
      *  @stable ICU 2.0
      */
-    virtual int32_t previous(void) override;
+    virtual int32_t previous() override;
 
     /**
      * Sets the iterator to refer to the first boundary position following
@@ -557,8 +556,7 @@ public:
      * @return The current iteration position.
      * @stable ICU 2.0
      */
-    virtual int32_t current(void) const override;
-
+    virtual int32_t current() const override;
 
     /**
      * Return the status tag from the break rule that determined the boundary at
@@ -629,7 +627,7 @@ public:
      *                  other classes have different class IDs.
      * @stable ICU 2.0
      */
-    virtual UClassID getDynamicClassID(void) const override;
+    virtual UClassID getDynamicClassID() const override;
 
     /**
      * Returns the class ID for this class.  This is useful only for
@@ -642,7 +640,7 @@ public:
      * @return          The class ID for all objects of this class.
      * @stable ICU 2.0
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
 #ifndef U_FORCE_HIDE_DEPRECATED_API
     /**

--- a/icu4c/source/common/unicode/resbund.h
+++ b/icu4c/source/common/unicode/resbund.h
@@ -209,8 +209,7 @@ public:
      * @return number of resources in a given resource.
      * @stable ICU 2.0
      */
-    int32_t
-      getSize(void) const;
+    int32_t getSize() const;
 
     /**
      * returns a string from a string resource type
@@ -289,16 +288,14 @@ public:
      * @return true if there are more elements, false if there is no more elements
      * @stable ICU 2.0
      */
-    UBool
-      hasNext(void) const;
+    UBool hasNext() const;
 
     /**
      * Resets the internal context of a resource so that iteration starts from the first element.
      *
      * @stable ICU 2.0
      */
-    void
-      resetIterator(void);
+    void resetIterator();
 
     /**
      * Returns the key associated with this resource. Not all the resources have a key - only
@@ -307,8 +304,7 @@ public:
      * @return a key associated to this resource, or nullptr if it doesn't have a key
      * @stable ICU 2.0
      */
-    const char*
-      getKey(void) const;
+    const char* getKey() const;
 
     /**
      * Gets the locale ID of the resource bundle as a string.
@@ -317,9 +313,7 @@ public:
      * @return the locale ID of the resource bundle as a string
      * @stable ICU 2.0
      */
-    const char*
-      getName(void) const;
-
+    const char* getName() const;
 
     /**
      * Returns the type of a resource. Available types are defined in enum UResType
@@ -327,8 +321,7 @@ public:
      * @return type of the given resource.
      * @stable ICU 2.0
      */
-    UResType
-      getType(void) const;
+    UResType getType() const;
 
     /**
      * Returns the next resource in a given resource or nullptr if there are no more resources
@@ -424,8 +417,7 @@ public:
      * @see getVersion
      * @deprecated ICU 2.8 Use getVersion instead.
      */
-    const char*
-      getVersionNumber(void) const;
+    const char* getVersionNumber() const;
 #endif  /* U_HIDE_DEPRECATED_API */
 
     /**
@@ -445,8 +437,7 @@ public:
      * @return a Locale object
      * @deprecated ICU 2.8 Use getLocale(ULocDataLocaleType type, UErrorCode &status) overload instead.
      */
-    const Locale&
-      getLocale(void) const;
+    const Locale& getLocale() const;
 #endif  /* U_HIDE_DEPRECATED_API */
 
     /**

--- a/icu4c/source/common/unicode/schriter.h
+++ b/icu4c/source/common/unicode/schriter.h
@@ -156,14 +156,14 @@ public:
    * @return a class ID for this object.
    * @stable ICU 2.0
    */
-  virtual UClassID         getDynamicClassID(void) const override;
+  virtual UClassID getDynamicClassID() const override;
 
   /**
    * Return a class ID for this class (not really public)
    * @return a class ID for this class
    * @stable ICU 2.0
    */
-  static UClassID   U_EXPORT2 getStaticClassID(void);
+  static UClassID U_EXPORT2 getStaticClassID();
 
 protected:
   /**

--- a/icu4c/source/common/unicode/uchriter.h
+++ b/icu4c/source/common/unicode/uchriter.h
@@ -126,7 +126,7 @@ public:
    * @return the hash code.
    * @stable ICU 2.0
    */
-  virtual int32_t         hashCode(void) const override;
+  virtual int32_t hashCode() const override;
 
   /**
    * Returns a new UCharCharacterIterator referring to the same
@@ -144,7 +144,7 @@ public:
    * @return the first code unit in its iteration range.
    * @stable ICU 2.0
    */
-  virtual char16_t         first(void) override;
+  virtual char16_t first() override;
 
   /**
    * Sets the iterator to refer to the first code unit in its
@@ -154,7 +154,7 @@ public:
    * @return the first code unit in its iteration range
    * @stable ICU 2.0
    */
-  virtual char16_t         firstPostInc(void) override;
+  virtual char16_t firstPostInc() override;
 
   /**
    * Sets the iterator to refer to the first code point in its
@@ -165,7 +165,7 @@ public:
    * @return the first code point in its iteration range
    * @stable ICU 2.0
    */
-  virtual UChar32       first32(void) override;
+  virtual UChar32 first32() override;
 
   /**
    * Sets the iterator to refer to the first code point in its
@@ -175,7 +175,7 @@ public:
    * @return the first code point in its iteration range.
    * @stable ICU 2.0
    */
-  virtual UChar32       first32PostInc(void) override;
+  virtual UChar32 first32PostInc() override;
 
   /**
    * Sets the iterator to refer to the last code unit in its
@@ -184,7 +184,7 @@ public:
    * @return the last code unit in its iteration range.
    * @stable ICU 2.0
    */
-  virtual char16_t         last(void) override;
+  virtual char16_t last() override;
 
   /**
    * Sets the iterator to refer to the last code point in its
@@ -193,7 +193,7 @@ public:
    * @return the last code point in its iteration range.
    * @stable ICU 2.0
    */
-  virtual UChar32       last32(void) override;
+  virtual UChar32 last32() override;
 
   /**
    * Sets the iterator to refer to the "position"-th code unit
@@ -223,14 +223,14 @@ public:
    * @return the code unit the iterator currently refers to.
    * @stable ICU 2.0
    */
-  virtual char16_t         current(void) const override;
+  virtual char16_t current() const override;
 
   /**
    * Returns the code point the iterator currently refers to.
    * @return the code point the iterator currently refers to.
    * @stable ICU 2.0
    */
-  virtual UChar32       current32(void) const override;
+  virtual UChar32 current32() const override;
 
   /**
    * Advances to the next code unit in the iteration range (toward
@@ -239,7 +239,7 @@ public:
    * @return the next code unit in the iteration range.
    * @stable ICU 2.0
    */
-  virtual char16_t         next(void) override;
+  virtual char16_t next() override;
 
   /**
    * Gets the current code unit for returning and advances to the next code unit
@@ -249,7 +249,7 @@ public:
    * @return the current code unit.
    * @stable ICU 2.0
    */
-  virtual char16_t         nextPostInc(void) override;
+  virtual char16_t nextPostInc() override;
 
   /**
    * Advances to the next code point in the iteration range (toward
@@ -261,7 +261,7 @@ public:
    * @return the next code point in the iteration range.
    * @stable ICU 2.0
    */
-  virtual UChar32       next32(void) override;
+  virtual UChar32 next32() override;
 
   /**
    * Gets the current code point for returning and advances to the next code point
@@ -271,7 +271,7 @@ public:
    * @return the current point.
    * @stable ICU 2.0
    */
-  virtual UChar32       next32PostInc(void) override;
+  virtual UChar32 next32PostInc() override;
 
   /**
    * Returns false if there are no more code units or code points
@@ -291,7 +291,7 @@ public:
    * @return the previous code unit in the iteration range.
    * @stable ICU 2.0
    */
-  virtual char16_t         previous(void) override;
+  virtual char16_t previous() override;
 
   /**
    * Advances to the previous code point in the iteration range (toward
@@ -300,7 +300,7 @@ public:
    * @return the previous code point in the iteration range.
    * @stable ICU 2.0
    */
-  virtual UChar32       previous32(void) override;
+  virtual UChar32 previous32() override;
 
   /**
    * Returns false if there are no more code units or code points
@@ -363,14 +363,14 @@ public:
    * @return a class ID for this class
    * @stable ICU 2.0
    */
-  static UClassID         U_EXPORT2 getStaticClassID(void);
+  static UClassID U_EXPORT2 getStaticClassID();
 
   /**
    * Return a class ID for this object (not really public)
    * @return a class ID for this object.
    * @stable ICU 2.0
    */
-  virtual UClassID        getDynamicClassID(void) const override;
+  virtual UClassID getDynamicClassID() const override;
 
 protected:
   /**

--- a/icu4c/source/common/unicode/unifunct.h
+++ b/icu4c/source/common/unicode/unifunct.h
@@ -83,7 +83,7 @@ public:
      * @return          The class ID for all objects of this class.
      * @stable ICU 2.0
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * Returns a unique class ID <b>polymorphically</b>.  This method
@@ -100,7 +100,7 @@ public:
      * different class IDs.
      * @stable ICU 2.4
      */
-    virtual UClassID getDynamicClassID(void) const override = 0;
+    virtual UClassID getDynamicClassID() const override = 0;
 
     /**
      * Set the data object associated with this functor.  The data

--- a/icu4c/source/common/unicode/uniset.h
+++ b/icu4c/source/common/unicode/uniset.h
@@ -333,7 +333,7 @@ public:
      * @see setToBogus()
      * @stable ICU 4.0
      */
-    inline UBool isBogus(void) const;
+    inline UBool isBogus() const;
 
     /**
      * Make this UnicodeSet object invalid.
@@ -522,7 +522,7 @@ public:
      * @see Object#hashCode()
      * @stable ICU 2.0
      */
-    virtual int32_t hashCode(void) const;
+    virtual int32_t hashCode() const;
 
     /**
      * Get a UnicodeSet pointer from a USet
@@ -792,7 +792,7 @@ public:
      * @stable ICU 2.0
      * @see getRangeCount
      */
-    virtual int32_t size(void) const;
+    virtual int32_t size() const;
 
     /**
      * Returns <tt>true</tt> if this set contains no elements.
@@ -800,7 +800,7 @@ public:
      * @return <tt>true</tt> if this set contains no elements.
      * @stable ICU 2.0
      */
-    virtual UBool isEmpty(void) const;
+    virtual UBool isEmpty() const;
 
     /**
      * @return true if this set contains multi-character strings or the empty string.
@@ -1394,7 +1394,7 @@ public:
      * A frozen set will not be modified.
      * @stable ICU 2.0
      */
-    virtual UnicodeSet& clear(void);
+    virtual UnicodeSet& clear();
 
     /**
      * Close this set over the given attribute.  For the attribute
@@ -1440,7 +1440,7 @@ public:
      * @see #getRangeEnd
      * @stable ICU 2.4
      */
-    virtual int32_t getRangeCount(void) const;
+    virtual int32_t getRangeCount() const;
 
     /**
      * Iteration method that returns the first character in the
@@ -1529,7 +1529,7 @@ public:
      * @return          The class ID for all objects of this class.
      * @stable ICU 2.0
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * Implement UnicodeFunctor API.
@@ -1539,9 +1539,9 @@ public:
      * different class IDs.
      * @stable ICU 2.4
      */
-    virtual UClassID getDynamicClassID(void) const override;
+    virtual UClassID getDynamicClassID() const override;
 
-private:
+  private:
 
     // Private API for the USet API
 
@@ -1602,7 +1602,7 @@ private:
 
     bool ensureBufferCapacity(int32_t newLen);
 
-    void swapBuffers(void);
+    void swapBuffers();
 
     UBool allocateStrings(UErrorCode &status);
     int32_t stringsSize() const;

--- a/icu4c/source/common/unicode/unistr.h
+++ b/icu4c/source/common/unicode/unistr.h
@@ -1759,7 +1759,7 @@ public:
    * @see countChar32
    * @stable ICU 2.0
    */
-  inline int32_t length(void) const;
+  inline int32_t length() const;
 
   /**
    * Count Unicode code points in the length char16_t code units of the string.
@@ -1808,7 +1808,7 @@ public:
    * @return true if this string contains 0 characters, false otherwise.
    * @stable ICU 2.0
    */
-  inline UBool isEmpty(void) const;
+  inline UBool isEmpty() const;
 
   /**
    * Return the capacity of the internal buffer of the UnicodeString object.
@@ -1819,7 +1819,7 @@ public:
    * @see getBuffer
    * @stable ICU 2.0
    */
-  inline int32_t getCapacity(void) const;
+  inline int32_t getCapacity() const;
 
   /* Other operations */
 
@@ -1828,7 +1828,7 @@ public:
    * @return The hash code of this UnicodeString.
    * @stable ICU 2.0
    */
-  inline int32_t hashCode(void) const;
+  inline int32_t hashCode() const;
 
   /**
    * Determine if this object contains a valid string.
@@ -1842,8 +1842,7 @@ public:
    * @see setToBogus()
    * @stable ICU 2.0
    */
-  inline UBool isBogus(void) const;
-
+  inline UBool isBogus() const;
 
   //========================================
   // Write operations
@@ -2624,8 +2623,7 @@ public:
    * @return a reference to this
    * @stable ICU 2.0
    */
-  UnicodeString& trim(void);
-
+  UnicodeString& trim();
 
   /* Miscellaneous operations */
 
@@ -2634,7 +2632,7 @@ public:
    * @return a reference to this
    * @stable ICU 2.0
    */
-  inline UnicodeString& reverse(void);
+  inline UnicodeString& reverse();
 
   /**
    * Reverse the range [`start`, `start + length`) in
@@ -2653,7 +2651,7 @@ public:
    * @return A reference to this.
    * @stable ICU 2.0
    */
-  UnicodeString& toUpper(void);
+  UnicodeString& toUpper();
 
   /**
    * Convert the characters in this to UPPER CASE following the conventions of
@@ -2670,7 +2668,7 @@ public:
    * @return A reference to this.
    * @stable ICU 2.0
    */
-  UnicodeString& toLower(void);
+  UnicodeString& toLower();
 
   /**
    * Convert the characters in this to lower case following the conventions of
@@ -3590,12 +3588,12 @@ private:
                int32_t length);
 
   // calculate hash code
-  int32_t doHashCode(void) const;
+  int32_t doHashCode() const;
 
   // get pointer to start of array
   // these do not check for kOpenGetBuffer, unlike the public getBuffer() function
-  inline char16_t* getArrayStart(void);
-  inline const char16_t* getArrayStart(void) const;
+  inline char16_t* getArrayStart();
+  inline const char16_t* getArrayStart() const;
 
   inline UBool hasShortLength() const;
   inline int32_t getShortLength() const;
@@ -3622,7 +3620,7 @@ private:
   UBool allocate(int32_t capacity);
 
   // release the array if owned
-  void releaseArray(void);
+  void releaseArray();
 
   // turn a bogus string into an empty one
   void unBogus();
@@ -3702,9 +3700,9 @@ private:
           UStringCaseMapper *stringCaseMapper);
 
   // ref counting
-  void addRef(void);
-  int32_t removeRef(void);
-  int32_t refCount(void) const;
+  void addRef();
+  int32_t removeRef();
+  int32_t refCount() const;
 
   // constants
   enum {

--- a/icu4c/source/i18n/unicode/calendar.h
+++ b/icu4c/source/i18n/unicode/calendar.h
@@ -413,7 +413,7 @@ public:
      * @return   The current UTC time in milliseconds.
      * @stable ICU 2.0
      */
-    static UDate U_EXPORT2 getNow(void);
+    static UDate U_EXPORT2 getNow();
 
     /**
      * Gets this Calendar's time as milliseconds. May involve recalculation of time due
@@ -850,7 +850,7 @@ public:
      * @return   The time zone object associated with this calendar.
      * @stable ICU 2.0
      */
-    const TimeZone& getTimeZone(void) const;
+    const TimeZone& getTimeZone() const;
 
     /**
      * Returns the time zone owned by this calendar. The caller owns the returned object
@@ -860,7 +860,7 @@ public:
      * @return   The time zone object which was associated with this calendar.
      * @stable ICU 2.0
      */
-    TimeZone* orphanTimeZone(void);
+    TimeZone* orphanTimeZone();
 
     /**
      * Queries if the current date for this Calendar is in Daylight Savings Time.
@@ -892,7 +892,7 @@ public:
      * @return   True tells that date/time interpretation is to be lenient.
      * @stable ICU 2.0
      */
-    UBool isLenient(void) const;
+    UBool isLenient() const;
 
     /**
      * Sets the behavior for handling wall time repeating multiple times
@@ -925,7 +925,7 @@ public:
      * @see #setRepeatedWallTimeOption
      * @stable ICU 49
      */
-    UCalendarWallTimeOption getRepeatedWallTimeOption(void) const;
+    UCalendarWallTimeOption getRepeatedWallTimeOption() const;
 
     /**
      * Sets the behavior for handling skipped wall time at positive time zone offset
@@ -960,7 +960,7 @@ public:
      * @see #setSkippedWallTimeOption
      * @stable ICU 49
      */
-    UCalendarWallTimeOption getSkippedWallTimeOption(void) const;
+    UCalendarWallTimeOption getSkippedWallTimeOption() const;
 
     /**
      * Sets what the first day of the week is; e.g., Sunday in US, Monday in France.
@@ -977,7 +977,7 @@ public:
      * @return   The first day of the week.
      * @deprecated ICU 2.6 use the overload with error code
      */
-    EDaysOfWeek getFirstDayOfWeek(void) const;
+    EDaysOfWeek getFirstDayOfWeek() const;
 #endif  /* U_HIDE_DEPRECATED_API */
 
     /**
@@ -1009,7 +1009,7 @@ public:
      * @return   The minimal days required in the first week of the year.
      * @stable ICU 2.0
      */
-    uint8_t getMinimalDaysInFirstWeek(void) const;
+    uint8_t getMinimalDaysInFirstWeek() const;
 
 #ifndef U_FORCE_HIDE_DEPRECATED_API
     /**
@@ -1232,7 +1232,7 @@ public:
      * resolving of time into time fields.
      * @stable ICU 2.0
      */
-    void clear(void);
+    void clear();
 
     /**
      * Clears the value in the given time field, both making it unset and assigning it a
@@ -1260,7 +1260,7 @@ public:
      *           same class ID. Objects of other classes have different class IDs.
      * @stable ICU 2.0
      */
-    virtual UClassID getDynamicClassID(void) const override = 0;
+    virtual UClassID getDynamicClassID() const override = 0;
 
     /**
      * Returns the calendar type name string for this Calendar object.
@@ -1348,7 +1348,7 @@ public:
      * this calendar system, false otherwise.
      * @stable ICU 4.4
      */
-    virtual UBool isWeekend(void) const;
+    virtual UBool isWeekend() const;
 
 #ifndef U_FORCE_HIDE_DRAFT_API
     /**
@@ -1914,7 +1914,7 @@ protected:
      * @return     the current time without recomputing.
      * @stable ICU 2.0
      */
-    UDate        internalGetTime(void) const     { return fTime; }
+    UDate internalGetTime() const { return fTime; }
 
     /**
      * Set the current time without affecting flags or fields.
@@ -2362,7 +2362,7 @@ private:
      * @return a StringEnumeration over the locales available at the time of the call
      * @internal
      */
-    static StringEnumeration* getAvailableLocales(void);
+    static StringEnumeration* getAvailableLocales();
 
     /**
      * Register a new Calendar factory.  The factory will be adopted.

--- a/icu4c/source/i18n/unicode/choicfmt.h
+++ b/icu4c/source/i18n/unicode/choicfmt.h
@@ -454,7 +454,7 @@ public:
      *                  other classes have different class IDs.
      * @deprecated ICU 49 Use MessageFormat instead, with plural and select arguments.
      */
-    virtual UClassID getDynamicClassID(void) const override;
+    virtual UClassID getDynamicClassID() const override;
 
     /**
      * Returns the class ID for this class.  This is useful only for
@@ -467,7 +467,7 @@ public:
      * @return          The class ID for all objects of this class.
      * @deprecated ICU 49 Use MessageFormat instead, with plural and select arguments.
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
 private:
     /**

--- a/icu4c/source/i18n/unicode/coleitr.h
+++ b/icu4c/source/i18n/unicode/coleitr.h
@@ -171,7 +171,7 @@ public:
     * Resets the cursor to the beginning of the string.
     * @stable ICU 2.0
     */
-    void reset(void);
+    void reset();
 
     /**
     * Gets the ordering priority of the next character in the string.
@@ -263,7 +263,7 @@ public:
     * @return the offset of the character.
     * @stable ICU 2.0
     */
-    int32_t getOffset(void) const;
+    int32_t getOffset() const;
 
     /**
     * Sets the offset of the currently processed character in the source string.

--- a/icu4c/source/i18n/unicode/coll.h
+++ b/icu4c/source/i18n/unicode/coll.h
@@ -535,7 +535,7 @@ public:
      * Generates the hash code for the collation object
      * @stable ICU 2.0
      */
-    virtual int32_t hashCode(void) const = 0;
+    virtual int32_t hashCode() const = 0;
 
 #ifndef U_FORCE_HIDE_DEPRECATED_API
     /**
@@ -599,7 +599,7 @@ public:
      * @see Collator#setStrength
      * @deprecated ICU 2.6 Use getAttribute(UCOL_STRENGTH...) instead
      */
-    virtual ECollationStrength getStrength(void) const;
+    virtual ECollationStrength getStrength() const;
 
     /**
      * Sets the minimum strength to be used in comparison or transformation.
@@ -730,7 +730,7 @@ public:
      * @return a StringEnumeration over the locales available at the time of the call
      * @stable ICU 2.6
      */
-    static StringEnumeration* U_EXPORT2 getAvailableLocales(void);
+    static StringEnumeration* U_EXPORT2 getAvailableLocales();
 
     /**
      * Create a string enumerator of all possible keywords that are relevant to
@@ -864,7 +864,7 @@ public:
      *         IDs.
      * @stable ICU 2.0
      */
-    virtual UClassID getDynamicClassID(void) const override = 0;
+    virtual UClassID getDynamicClassID() const override = 0;
 
     /**
      * Universal attribute setter
@@ -1245,7 +1245,7 @@ public:
      * @return true if the factory is visible.
      * @stable ICU 2.6
      */
-    virtual UBool visible(void) const;
+    virtual UBool visible() const;
 
     /**
      * Return a collator for the provided locale.  If the locale

--- a/icu4c/source/i18n/unicode/datefmt.h
+++ b/icu4c/source/i18n/unicode/datefmt.h
@@ -532,7 +532,7 @@ public:
      * @return A date/time formatter which the caller owns.
      * @stable ICU 2.0
      */
-    static DateFormat* U_EXPORT2 createInstance(void);
+    static DateFormat* U_EXPORT2 createInstance();
 
     /**
      * Creates a time formatter with the given formatting style for the given
@@ -673,7 +673,7 @@ public:
      * numeric processing is lenient.
      * @stable ICU 2.0
      */
-    virtual UBool isLenient(void) const;
+    virtual UBool isLenient() const;
 
     /**
      * Specifies whether date/time parsing is to be lenient.  With
@@ -702,8 +702,7 @@ public:
      * Returns whether date/time parsing in the encapsulated Calendar object processing is lenient.
      * @stable ICU 53
      */
-    virtual UBool isCalendarLenient(void) const;
-
+    virtual UBool isCalendarLenient() const;
 
     /**
      * Specifies whether encapsulated Calendar date/time parsing is to be lenient.  With
@@ -725,7 +724,7 @@ public:
      * @return the calendar associated with this date/time formatter.
      * @stable ICU 2.0
      */
-    virtual const Calendar* getCalendar(void) const;
+    virtual const Calendar* getCalendar() const;
 
     /**
      * Set the calendar to be used by this date format. Initially, the default
@@ -754,7 +753,7 @@ public:
      * @return the number formatter which this date/time formatter uses.
      * @stable ICU 2.0
      */
-    virtual const NumberFormat* getNumberFormat(void) const;
+    virtual const NumberFormat* getNumberFormat() const;
 
     /**
      * Allows you to set the number formatter.  The caller should
@@ -776,7 +775,7 @@ public:
      * @return the time zone associated with the calendar of DateFormat.
      * @stable ICU 2.0
      */
-    virtual const TimeZone& getTimeZone(void) const;
+    virtual const TimeZone& getTimeZone() const;
 
     /**
      * Sets the time zone for the calendar of this DateFormat object. The caller

--- a/icu4c/source/i18n/unicode/dcfmtsym.h
+++ b/icu4c/source/i18n/unicode/dcfmtsym.h
@@ -455,13 +455,13 @@ public:
      * Returns that pattern stored in currency info. Internal API for use by NumberFormat API.
      * @internal
      */
-    inline const char16_t* getCurrencyPattern(void) const;
+    inline const char16_t* getCurrencyPattern() const;
 
     /**
      * Returns the numbering system with which this DecimalFormatSymbols was initialized.
      * @internal
      */
-    inline const char* getNumberingSystemName(void) const;
+    inline const char* getNumberingSystemName() const;
 #endif  /* U_HIDE_INTERNAL_API */
 
 private:

--- a/icu4c/source/i18n/unicode/decimfmt.h
+++ b/icu4c/source/i18n/unicode/decimfmt.h
@@ -1163,7 +1163,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * @see DecimalFormatSymbols
      * @stable ICU 2.0
      */
-    virtual const DecimalFormatSymbols* getDecimalFormatSymbols(void) const;
+    virtual const DecimalFormatSymbols* getDecimalFormatSymbols() const;
 
     /**
      * Sets the decimal format symbols, which is generally not changed
@@ -1188,7 +1188,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * @return desired CurrencyPluralInfo
      * @stable ICU 4.2
      */
-    virtual const CurrencyPluralInfo* getCurrencyPluralInfo(void) const;
+    virtual const CurrencyPluralInfo* getCurrencyPluralInfo() const;
 
     /**
      * Sets the currency plural format information,
@@ -1315,7 +1315,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * Examples: with 100, 1.23 -> "123", and "123" -> 1.23
      * @stable ICU 2.0
      */
-    int32_t getMultiplier(void) const;
+    int32_t getMultiplier() const;
 
     /**
      * Set the multiplier for use in percent, permill, etc.
@@ -1344,7 +1344,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * @return    the current value of the power-of-ten multiplier.
      * @stable ICU 62
      */
-    int32_t getMultiplierScale(void) const;
+    int32_t getMultiplierScale() const;
 
     /**
      * Sets a power of ten by which number should be multiplied before formatting, which
@@ -1376,7 +1376,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * @see #setRoundingMode
      * @stable ICU 2.0
      */
-    virtual double getRoundingIncrement(void) const;
+    virtual double getRoundingIncrement() const;
 
     /**
      * Set the rounding increment.  In the absence of a rounding increment,
@@ -1399,7 +1399,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * @see #setRoundingMode
      * @stable ICU 2.0
      */
-    virtual ERoundingMode getRoundingMode(void) const override;
+    virtual ERoundingMode getRoundingMode() const override;
 
     /**
      * Set the rounding mode.
@@ -1422,7 +1422,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * @see #setPadPosition
      * @stable ICU 2.0
      */
-    virtual int32_t getFormatWidth(void) const;
+    virtual int32_t getFormatWidth() const;
 
     /**
      * Set the width to which the output of format() is padded.
@@ -1485,7 +1485,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * @see #EPadPosition
      * @stable ICU 2.0
      */
-    virtual EPadPosition getPadPosition(void) const;
+    virtual EPadPosition getPadPosition() const;
 
     /**
      * Set the position at which padding will take place.  This is the location
@@ -1515,7 +1515,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * @see #setExponentSignAlwaysShown
      * @stable ICU 2.0
      */
-    virtual UBool isScientificNotation(void) const;
+    virtual UBool isScientificNotation() const;
 
     /**
      * Set whether or not scientific notation is used. When scientific notation
@@ -1544,7 +1544,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * @see #setExponentSignAlwaysShown
      * @stable ICU 2.0
      */
-    virtual int8_t getMinimumExponentDigits(void) const;
+    virtual int8_t getMinimumExponentDigits() const;
 
     /**
      * Set the minimum exponent digits that will be shown.  This has no
@@ -1572,7 +1572,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * @see #setExponentSignAlwaysShown
      * @stable ICU 2.0
      */
-    virtual UBool isExponentSignAlwaysShown(void) const;
+    virtual UBool isExponentSignAlwaysShown() const;
 
     /**
      * Set whether the exponent sign is always shown.  This has no effect
@@ -1600,7 +1600,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * @see DecimalFormatSymbols::getGroupingSeparator
      * @stable ICU 2.0
      */
-    int32_t getGroupingSize(void) const;
+    int32_t getGroupingSize() const;
 
     /**
      * Set the grouping size. Grouping size is the number of digits between
@@ -1633,7 +1633,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * @see DecimalFormatSymbols::getGroupingSeparator
      * @stable ICU 2.4
      */
-    int32_t getSecondaryGroupingSize(void) const;
+    int32_t getSecondaryGroupingSize() const;
 
     /**
      * Set the secondary grouping size. If set to a value less than 1,
@@ -1700,7 +1700,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * Example: Decimal ON: 12345 -> 12345.; OFF: 12345 -> 12345
      * @stable ICU 2.0
      */
-    UBool isDecimalSeparatorAlwaysShown(void) const;
+    UBool isDecimalSeparatorAlwaysShown() const;
 
     /**
      * Allows you to set the behavior of the decimal separator with integers.
@@ -1718,7 +1718,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * @return    true if input must contain a match to decimal mark in pattern
      * @stable ICU 54
      */
-    UBool isDecimalPatternMatchRequired(void) const;
+    UBool isDecimalPatternMatchRequired() const;
 
     /**
      * Allows you to set the parse behavior of the pattern decimal mark.
@@ -2124,7 +2124,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      * @return          The class ID for all objects of this class.
      * @stable ICU 2.0
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * Returns a unique class ID POLYMORPHICALLY.  Pure virtual override.
@@ -2137,7 +2137,7 @@ class U_I18N_API DecimalFormat : public NumberFormat {
      *                  other classes have different class IDs.
      * @stable ICU 2.0
      */
-    UClassID getDynamicClassID(void) const override;
+    UClassID getDynamicClassID() const override;
 
   private:
 

--- a/icu4c/source/i18n/unicode/dtfmtsym.h
+++ b/icu4c/source/i18n/unicode/dtfmtsym.h
@@ -567,7 +567,7 @@ public:
      * @return    the non-localized date-time pattern characters
      * @stable ICU 2.0
      */
-    static const char16_t * U_EXPORT2 getPatternUChars(void);
+    static const char16_t* U_EXPORT2 getPatternUChars();
 
     /**
      * Gets localized date-time pattern characters. For example: 'u', 't', etc.
@@ -971,7 +971,7 @@ private:
     /**
      * Delete all the storage owned by this object.
      */
-    void dispose(void);
+    void dispose();
 
     /**
      * Copy all of the other's data to this.
@@ -982,12 +982,12 @@ private:
     /**
      * Create zone strings array by locale if not yet available
      */
-    void initZoneStringsArray(void);
+    void initZoneStringsArray();
 
     /**
      * Delete just the zone strings.
      */
-    void disposeZoneStrings(void);
+    void disposeZoneStrings();
 
     /**
      * Returns the date format field index of the pattern character c,

--- a/icu4c/source/i18n/unicode/dtitvfmt.h
+++ b/icu4c/source/i18n/unicode/dtitvfmt.h
@@ -604,8 +604,7 @@ public:
      * this date interval formatter.
      * @stable ICU 4.0
      */
-    const DateIntervalInfo* getDateIntervalInfo(void) const;
-
+    const DateIntervalInfo* getDateIntervalInfo() const;
 
     /**
      * Set the date time interval patterns.
@@ -628,14 +627,14 @@ public:
      * @return the date formatter associated with this date interval formatter.
      * @stable ICU 4.0
      */
-    const DateFormat* getDateFormat(void) const;
+    const DateFormat* getDateFormat() const;
 
     /**
      * Returns a reference to the TimeZone used by this DateIntervalFormat's calendar.
      * @return the time zone associated with the calendar of DateIntervalFormat.
      * @stable ICU 4.8
      */
-    virtual const TimeZone& getTimeZone(void) const;
+    virtual const TimeZone& getTimeZone() const;
 
     /**
      * Sets the time zone for the calendar used by this DateIntervalFormat object. The
@@ -689,7 +688,7 @@ public:
      * @return          The class ID for all objects of this class.
      * @stable ICU 4.0
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * Returns a unique class ID POLYMORPHICALLY. Pure virtual override. This
@@ -702,7 +701,7 @@ public:
      *                  other classes have different class IDs.
      * @stable ICU 4.0
      */
-    virtual UClassID getDynamicClassID(void) const override;
+    virtual UClassID getDynamicClassID() const override;
 
 protected:
 

--- a/icu4c/source/i18n/unicode/dtptngen.h
+++ b/icu4c/source/i18n/unicode/dtptngen.h
@@ -571,7 +571,7 @@ public:
      *
      * @stable ICU 3.8
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
 private:
     /**

--- a/icu4c/source/i18n/unicode/dtrule.h
+++ b/icu4c/source/i18n/unicode/dtrule.h
@@ -160,7 +160,7 @@ public:
      * @return The date rule type.
      * @stable ICU 3.8
      */
-    DateRuleType getDateRuleType(void) const;
+    DateRuleType getDateRuleType() const;
 
     /**
      * Gets the time rule type
@@ -168,14 +168,14 @@ public:
      *         or <code>UTC_TIME</code>.
      * @stable ICU 3.8
      */
-    TimeRuleType getTimeRuleType(void) const;
+    TimeRuleType getTimeRuleType() const;
 
     /**
      * Gets the rule month.
      * @return The rule month.
      * @stable ICU 3.8
      */
-    int32_t getRuleMonth(void) const;
+    int32_t getRuleMonth() const;
 
     /**
      * Gets the rule day of month.  When the date rule type
@@ -183,7 +183,7 @@ public:
      * @return The rule day of month
      * @stable ICU 3.8
      */
-    int32_t getRuleDayOfMonth(void) const;
+    int32_t getRuleDayOfMonth() const;
 
     /**
      * Gets the rule day of week.  When the date rule type
@@ -191,7 +191,7 @@ public:
      * @return The rule day of week.
      * @stable ICU 3.8
      */
-    int32_t getRuleDayOfWeek(void) const;
+    int32_t getRuleDayOfWeek() const;
 
     /**
      * Gets the ordinal number of the occurrence of the day of week
@@ -200,16 +200,16 @@ public:
      * @return The rule day of week ordinal number in the month.
      * @stable ICU 3.8
      */
-    int32_t getRuleWeekInMonth(void) const;
+    int32_t getRuleWeekInMonth() const;
 
     /**
      * Gets the rule time in the rule day.
      * @return The time in the rule day in milliseconds.
      * @stable ICU 3.8
      */
-    int32_t getRuleMillisInDay(void) const;
+    int32_t getRuleMillisInDay() const;
 
-private:
+  private:
     int32_t fMonth;
     int32_t fDayOfMonth;
     int32_t fDayOfWeek;
@@ -230,7 +230,7 @@ public:
      * @return          The class ID for all objects of this class.
      * @stable ICU 3.8
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * Returns a unique class ID POLYMORPHICALLY. Pure virtual override. This
@@ -243,7 +243,7 @@ public:
      *                  other classes have different class IDs.
      * @stable ICU 3.8
      */
-    virtual UClassID getDynamicClassID(void) const override;
+    virtual UClassID getDynamicClassID() const override;
 };
 
 U_NAMESPACE_END

--- a/icu4c/source/i18n/unicode/fieldpos.h
+++ b/icu4c/source/i18n/unicode/fieldpos.h
@@ -192,14 +192,14 @@ public:
      * @return    the field identifier.
      * @stable ICU 2.0
      */
-    int32_t getField(void) const { return fField; }
+    int32_t getField() const { return fField; }
 
     /**
      * Retrieve the index of the first character in the requested field.
      * @return    the index of the first character in the requested field.
      * @stable ICU 2.0
      */
-    int32_t getBeginIndex(void) const { return fBeginIndex; }
+    int32_t getBeginIndex() const { return fBeginIndex; }
 
     /**
      * Retrieve the index of the character following the last character in the
@@ -208,8 +208,8 @@ public:
      *            requested field.
      * @stable ICU 2.0
      */
-    int32_t getEndIndex(void) const { return fEndIndex; }
- 
+    int32_t getEndIndex() const { return fEndIndex; }
+
     /**
      * Set the field.
      * @param f    the new value of the field.

--- a/icu4c/source/i18n/unicode/fmtable.h
+++ b/icu4c/source/i18n/unicode/fmtable.h
@@ -274,7 +274,7 @@ public:
      * @return    the data type of this Formattable object.
      * @stable ICU 2.0
      */
-    Type            getType(void) const;
+    Type getType() const;
 
     /**
      * Returns true if the data type of this Formattable object
@@ -290,7 +290,7 @@ public:
      * @return    the double value of this object.
      * @stable ICU 2.0
      */
-    double          getDouble(void) const { return fValue.fDouble; }
+    double getDouble() const { return fValue.fDouble; }
 
     /**
      * Gets the double value of this object. If this object is of type
@@ -312,7 +312,7 @@ public:
      * @return    the long value of this object.
      * @stable ICU 2.0
      */
-    int32_t         getLong(void) const { return (int32_t)fValue.fInt64; }
+    int32_t getLong() const { return (int32_t)fValue.fInt64; }
 
     /**
      * Gets the long value of this object. If the magnitude is too
@@ -338,7 +338,7 @@ public:
      * @return    the int64 value of this object.
      * @stable ICU 2.8
      */
-    int64_t         getInt64(void) const { return fValue.fInt64; }
+    int64_t getInt64() const { return fValue.fInt64; }
 
     /**
      * Gets the int64 value of this object. If this object is of a numeric
@@ -403,7 +403,7 @@ public:
      * @return   a const reference to the string value of this object.
      * @stable ICU 2.0
      */
-    inline const UnicodeString& getString(void) const;
+    inline const UnicodeString& getString() const;
 
     /**
      * Gets a const reference to the string value of this object.  If
@@ -421,7 +421,7 @@ public:
      * @return   a reference to the string value of this object.
      * @stable ICU 2.0
      */
-    inline UnicodeString& getString(void);
+    inline UnicodeString& getString();
 
     /**
      * Gets a reference to the string value of this object. If the
@@ -680,7 +680,7 @@ private:
      * Cleans up the memory for unwanted values.  For example, the adopted
      * string or array objects.
      */
-    void            dispose(void);
+    void dispose();
 
     /**
      * Common initialization, for use by constructors.
@@ -719,11 +719,11 @@ inline UDate Formattable::getDate(UErrorCode& status) const {
     return fValue.fDate;
 }
 
-inline const UnicodeString& Formattable::getString(void) const {
+inline const UnicodeString& Formattable::getString() const {
     return *fValue.fString;
 }
 
-inline UnicodeString& Formattable::getString(void) {
+inline UnicodeString& Formattable::getString() {
     return *fValue.fString;
 }
 

--- a/icu4c/source/i18n/unicode/fpositer.h
+++ b/icu4c/source/i18n/unicode/fpositer.h
@@ -67,7 +67,7 @@ public:
      * Constructs a new, empty iterator.
      * @stable ICU 4.4
      */
-    FieldPositionIterator(void);
+    FieldPositionIterator();
 
     /**
      * Copy constructor.  If the copy failed for some reason, the new iterator will

--- a/icu4c/source/i18n/unicode/gregocal.h
+++ b/icu4c/source/i18n/unicode/gregocal.h
@@ -324,7 +324,7 @@ public:
      * @return   The Gregorian cutover time for this calendar.
      * @stable ICU 2.0
      */
-    UDate getGregorianChange(void) const;
+    UDate getGregorianChange() const;
 
     /**
      * Return true if the given year is a leap year. Determination of whether a year is
@@ -435,7 +435,7 @@ public:
      *           same class ID. Objects of other classes have different class IDs.
      * @stable ICU 2.0
      */
-    virtual UClassID getDynamicClassID(void) const override;
+    virtual UClassID getDynamicClassID() const override;
 
     /**
      * Return the class ID for this class. This is useful only for comparing to a return
@@ -448,7 +448,7 @@ public:
      * @return   The class ID for all objects of this class.
      * @stable ICU 2.0
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * Returns the calendar type name string for this Calendar object.
@@ -542,7 +542,7 @@ public:
      * @return    the length of the year field
      * @internal
      */
-    int32_t yearLength(void) const;
+  int32_t yearLength() const;
 
 #endif  /* U_HIDE_INTERNAL_API */
 
@@ -631,7 +631,7 @@ public:
      * Validates the values of the set time fields.  True if they're all valid.
      * @return    True if the set time fields are all valid.
      */
-    UBool validateFields(void) const;
+    UBool validateFields() const;
 
     /**
      * Validates the value of the given time field.  True if it's valid.

--- a/icu4c/source/i18n/unicode/measfmt.h
+++ b/icu4c/source/i18n/unicode/measfmt.h
@@ -273,7 +273,7 @@ class U_I18N_API MeasureFormat : public Format {
      * @return          The class ID for all objects of this class.
      * @stable ICU 53
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * Returns a unique class ID POLYMORPHICALLY. Pure virtual override. This
@@ -286,7 +286,7 @@ class U_I18N_API MeasureFormat : public Format {
      *                  other classes have different class IDs.
      * @stable ICU 53
      */
-    virtual UClassID getDynamicClassID(void) const override;
+    virtual UClassID getDynamicClassID() const override;
 
  protected:
     /**

--- a/icu4c/source/i18n/unicode/measunit.h
+++ b/icu4c/source/i18n/unicode/measunit.h
@@ -690,7 +690,7 @@ class U_I18N_API MeasureUnit: public UObject {
      * @return          The class ID for all objects of this class.
      * @stable ICU 53
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * Returns a unique class ID POLYMORPHICALLY. Pure virtual override. This
@@ -703,7 +703,7 @@ class U_I18N_API MeasureUnit: public UObject {
      *                  other classes have different class IDs.
      * @stable ICU 53
      */
-    virtual UClassID getDynamicClassID(void) const override;
+    virtual UClassID getDynamicClassID() const override;
 
 #ifndef U_HIDE_INTERNAL_API
     /**

--- a/icu4c/source/i18n/unicode/measure.h
+++ b/icu4c/source/i18n/unicode/measure.h
@@ -124,7 +124,7 @@ class U_I18N_API Measure: public UObject {
      * @return          The class ID for all objects of this class.
      * @stable ICU 53
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * Returns a unique class ID POLYMORPHICALLY. Pure virtual override. This
@@ -137,7 +137,7 @@ class U_I18N_API Measure: public UObject {
      *                  other classes have different class IDs.
      * @stable ICU 53
      */
-    virtual UClassID getDynamicClassID(void) const override;
+    virtual UClassID getDynamicClassID() const override;
 
  protected:
     /**

--- a/icu4c/source/i18n/unicode/msgfmt.h
+++ b/icu4c/source/i18n/unicode/msgfmt.h
@@ -444,7 +444,7 @@ public:
      * @return    the locale of the object.
      * @stable ICU 2.0
      */
-    virtual const Locale& getLocale(void) const;
+    virtual const Locale& getLocale() const;
 
     /**
      * Applies the given pattern string to this message format.
@@ -850,7 +850,7 @@ public:
      *                  other classes have different class IDs.
      * @stable ICU 2.0
      */
-    virtual UClassID getDynamicClassID(void) const override;
+    virtual UClassID getDynamicClassID() const override;
 
     /**
      * Return the class ID for this class.  This is useful only for
@@ -863,7 +863,7 @@ public:
      * @return          The class ID for all objects of this class.
      * @stable ICU 2.0
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
 #ifndef U_HIDE_INTERNAL_API
     /**

--- a/icu4c/source/i18n/unicode/numfmt.h
+++ b/icu4c/source/i18n/unicode/numfmt.h
@@ -707,7 +707,7 @@ public:
      *            only.
      * @stable ICU 2.0
      */
-    UBool isParseIntegerOnly(void) const;
+    UBool isParseIntegerOnly() const;
 
     /**
      * Sets whether or not numbers should be parsed as integers only.
@@ -735,7 +735,7 @@ public:
      * @see #setLenient
      * @stable ICU 4.8
      */
-    virtual UBool isLenient(void) const;
+    virtual UBool isLenient() const;
 
     /**
      * Create a default style NumberFormat for the current default locale.
@@ -898,7 +898,7 @@ public:
      * @return a StringEnumeration over the locales available at the time of the call
      * @stable ICU 2.6
      */
-    static StringEnumeration* U_EXPORT2 getAvailableLocales(void);
+    static StringEnumeration* U_EXPORT2 getAvailableLocales();
 #endif /* UCONFIG_NO_SERVICE */
 
     /**
@@ -910,7 +910,7 @@ public:
      * @see setGroupingUsed
      * @stable ICU 2.0
      */
-    UBool isGroupingUsed(void) const;
+    UBool isGroupingUsed() const;
 
     /**
      * Set whether or not grouping will be used in this format.
@@ -928,7 +928,7 @@ public:
      * @see setMaximumIntegerDigits
      * @stable ICU 2.0
      */
-    int32_t getMaximumIntegerDigits(void) const;
+    int32_t getMaximumIntegerDigits() const;
 
     /**
      * Sets the maximum number of digits allowed in the integer portion of a
@@ -952,7 +952,7 @@ public:
      * @see setMinimumIntegerDigits
      * @stable ICU 2.0
      */
-    int32_t getMinimumIntegerDigits(void) const;
+    int32_t getMinimumIntegerDigits() const;
 
     /**
      * Sets the minimum number of digits allowed in the integer portion of a
@@ -974,7 +974,7 @@ public:
      * @see setMaximumFractionDigits
      * @stable ICU 2.0
      */
-    int32_t getMaximumFractionDigits(void) const;
+    int32_t getMaximumFractionDigits() const;
 
     /**
      * Sets the maximum number of digits allowed in the fraction portion of a
@@ -996,7 +996,7 @@ public:
      * @see setMinimumFractionDigits
      * @stable ICU 2.0
      */
-    int32_t getMinimumFractionDigits(void) const;
+    int32_t getMinimumFractionDigits() const;
 
     /**
      * Sets the minimum number of digits allowed in the fraction portion of a
@@ -1062,7 +1062,7 @@ public:
      * @return A rounding mode
      * @stable ICU 60
      */
-    virtual ERoundingMode getRoundingMode(void) const;
+    virtual ERoundingMode getRoundingMode() const;
 
     /**
      * Set the rounding mode. If a subclass does not support rounding, this will do nothing.
@@ -1081,7 +1081,7 @@ public:
      * @return The class ID for all objects of this class.
      * @stable ICU 2.0
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * Returns a unique class ID POLYMORPHICALLY.  Pure virtual override.
@@ -1094,7 +1094,7 @@ public:
      * other classes have different class IDs.
      * @stable ICU 2.0
      */
-    virtual UClassID getDynamicClassID(void) const override = 0;
+    virtual UClassID getDynamicClassID() const override = 0;
 
 protected:
 
@@ -1204,7 +1204,7 @@ public:
      * be listed by getAvailableLocales.
      * @stable ICU 2.6
      */
-    virtual UBool visible(void) const = 0;
+    virtual UBool visible() const = 0;
 
     /**
      * Return the locale names directly supported by this factory.  The number of names
@@ -1255,7 +1255,7 @@ public:
     /**
      * @stable ICU 2.6
      */
-    virtual UBool visible(void) const override;
+    virtual UBool visible() const override;
 
     /**
      * @stable ICU 2.6

--- a/icu4c/source/i18n/unicode/numsys.h
+++ b/icu4c/source/i18n/unicode/numsys.h
@@ -185,7 +185,7 @@ public:
      * @stable ICU 4.2
      *
     */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * ICU "poor man's RTTI", returns a UClassID for the actual class.

--- a/icu4c/source/i18n/unicode/plurfmt.h
+++ b/icu4c/source/i18n/unicode/plurfmt.h
@@ -513,7 +513,7 @@ public:
      * @stable ICU 4.0
      *
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * ICU "poor man's RTTI", returns a UClassID for the actual class.

--- a/icu4c/source/i18n/unicode/plurrule.h
+++ b/icu4c/source/i18n/unicode/plurrule.h
@@ -553,7 +553,7 @@ public:
      * @stable ICU 4.0
      *
     */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * ICU "poor man's RTTI", returns a UClassID for the actual class.

--- a/icu4c/source/i18n/unicode/rbnf.h
+++ b/icu4c/source/i18n/unicode/rbnf.h
@@ -764,7 +764,7 @@ public:
    * @return the number of locales for which we have localized rule set display names.
    * @stable ICU 3.2
    */
-  virtual int32_t getNumberOfRuleSetDisplayNameLocales(void) const;
+  virtual int32_t getNumberOfRuleSetDisplayNameLocales() const;
 
   /**
    * Return the index'th display name locale.
@@ -978,7 +978,7 @@ public:
    * @see #setLenient
    * @stable ICU 2.0
    */
-  virtual inline UBool isLenient(void) const override;
+  virtual inline UBool isLenient() const override;
 
 #endif
 
@@ -1017,7 +1017,7 @@ public:
      * @return A rounding mode
      * @stable ICU 60
      */
-    virtual ERoundingMode getRoundingMode(void) const override;
+    virtual ERoundingMode getRoundingMode() const override;
 
     /**
      * Set the rounding mode.
@@ -1032,14 +1032,14 @@ public:
      *
      * @stable ICU 2.8
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * ICU "poor man's RTTI", returns a UClassID for the actual class.
      *
      * @stable ICU 2.8
      */
-    virtual UClassID getDynamicClassID(void) const override;
+    virtual UClassID getDynamicClassID() const override;
 
     /**
      * Sets the decimal format symbols, which is generally not changed
@@ -1122,7 +1122,7 @@ private:
 #if !UCONFIG_NO_COLLATION
 
 inline UBool
-RuleBasedNumberFormat::isLenient(void) const {
+RuleBasedNumberFormat::isLenient() const {
     return lenient;
 }
 

--- a/icu4c/source/i18n/unicode/rbtz.h
+++ b/icu4c/source/i18n/unicode/rbtz.h
@@ -217,7 +217,7 @@ public:
      * @return   The TimeZone's raw GMT offset.
      * @stable ICU 3.8
      */
-    virtual int32_t getRawOffset(void) const override;
+    virtual int32_t getRawOffset() const override;
 
     /**
      * Queries if this time zone uses daylight savings time.
@@ -225,7 +225,7 @@ public:
      * false, otherwise.
      * @stable ICU 3.8
      */
-    virtual UBool useDaylightTime(void) const override;
+    virtual UBool useDaylightTime() const override;
 
 #ifndef U_FORCE_HIDE_DEPRECATED_API
     /**
@@ -313,8 +313,8 @@ public:
         int32_t& rawOffset, int32_t& dstOffset, UErrorCode& status) const override;
 
 private:
-    void deleteRules(void);
-    void deleteTransitions(void);
+    void deleteRules();
+    void deleteTransitions();
     UVector* copyRules(UVector* source);
     TimeZoneRule* findRuleInFinal(UDate date, UBool local,
         int32_t NonExistingTimeOpt, int32_t DuplicatedTimeOpt) const;
@@ -346,7 +346,7 @@ public:
      * @return          The class ID for all objects of this class.
      * @stable ICU 3.8
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * Returns a unique class ID POLYMORPHICALLY. Pure virtual override. This
@@ -359,7 +359,7 @@ public:
      *                  other classes have different class IDs.
      * @stable ICU 3.8
      */
-    virtual UClassID getDynamicClassID(void) const override;
+    virtual UClassID getDynamicClassID() const override;
 };
 
 U_NAMESPACE_END

--- a/icu4c/source/i18n/unicode/search.h
+++ b/icu4c/source/i18n/unicode/search.h
@@ -124,7 +124,7 @@ public:
      * @return current index in the text being searched.
      * @stable ICU 2.0
      */
-    virtual int32_t getOffset(void) const = 0;
+    virtual int32_t getOffset() const = 0;
 
     /**
     * Sets the text searching attributes located in the enum 
@@ -163,7 +163,7 @@ public:
     * @see #last
     * @stable ICU 2.0
     */
-    int32_t getMatchedStart(void) const;
+    int32_t getMatchedStart() const;
 
     /**
      * Returns the length of text in the string which matches the search 
@@ -179,8 +179,8 @@ public:
      * @see #last
      * @stable ICU 2.0
      */
-    int32_t getMatchedLength(void) const;
-    
+    int32_t getMatchedLength() const;
+
     /**
      * Returns the text that was matched by the most recent call to 
      * <tt>first</tt>, <tt>next</tt>, <tt>previous</tt>, or <tt>last</tt>.
@@ -224,7 +224,7 @@ public:
      * @see #setBreakIterator
      * @stable ICU 2.0
      */
-    const BreakIterator * getBreakIterator(void) const;
+    const BreakIterator* getBreakIterator() const;
 
     /**
      * Set the string text to be searched. Text iteration will hence begin at 
@@ -260,7 +260,7 @@ public:
      * @return text string to be searched.
      * @stable ICU 2.0
      */
-    const UnicodeString & getText(void) const;
+    const UnicodeString& getText() const;
 
     // operator overloading ----------------------------------------------
 
@@ -291,7 +291,7 @@ public:
      * @return cloned object
      * @stable ICU 2.0
      */
-    virtual SearchIterator* safeClone(void) const = 0;
+    virtual SearchIterator* safeClone() const = 0;
 
     /**
      * Returns the first index at which the string text matches the search 

--- a/icu4c/source/i18n/unicode/selfmt.h
+++ b/icu4c/source/i18n/unicode/selfmt.h
@@ -337,7 +337,7 @@ public:
      * ICU "poor man's RTTI", returns a UClassID for this class.
      * @stable ICU 4.4
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * ICU "poor man's RTTI", returns a UClassID for the actual class.

--- a/icu4c/source/i18n/unicode/simpletz.h
+++ b/icu4c/source/i18n/unicode/simpletz.h
@@ -636,7 +636,7 @@ public:
      * @return   The TimeZone's raw GMT offset.
      * @stable ICU 2.0
      */
-    virtual int32_t getRawOffset(void) const override;
+    virtual int32_t getRawOffset() const override;
 
     /**
      * Sets the TimeZone's raw GMT offset (i.e., the number of milliseconds to add
@@ -666,7 +666,7 @@ public:
      * but not 0.
      * @stable ICU 2.0
      */
-    virtual int32_t getDSTSavings(void) const override;
+    virtual int32_t getDSTSavings() const override;
 
     /**
      * Queries if this TimeZone uses Daylight Savings Time.
@@ -674,7 +674,7 @@ public:
      * @return   True if this TimeZone uses Daylight Savings Time; false otherwise.
      * @stable ICU 2.0
      */
-    virtual UBool useDaylightTime(void) const override;
+    virtual UBool useDaylightTime() const override;
 
 #ifndef U_FORCE_HIDE_DEPRECATED_API
     /**
@@ -773,7 +773,7 @@ public:
      *           same class ID. Objects of other classes have different class IDs.
      * @stable ICU 2.0
      */
-    virtual UClassID getDynamicClassID(void) const override;
+    virtual UClassID getDynamicClassID() const override;
 
     /**
      * Return the class ID for this class. This is useful only for comparing to a return
@@ -786,7 +786,7 @@ public:
      * @return   The class ID for all objects of this class.
      * @stable ICU 2.0
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
 private:
     /**
@@ -882,8 +882,8 @@ private:
     /* Private for BasicTimeZone implementation */
     void checkTransitionRules(UErrorCode& status) const;
     void initTransitionRules(UErrorCode& status);
-    void clearTransitionRules(void);
-    void deleteTransitionRules(void);
+    void clearTransitionRules();
+    void deleteTransitionRules();
     UBool   transitionRulesInitialized;
     InitialTimeZoneRule*    initialRule;
     TimeZoneTransition*     firstTransition;

--- a/icu4c/source/i18n/unicode/smpdtfmt.h
+++ b/icu4c/source/i18n/unicode/smpdtfmt.h
@@ -1057,7 +1057,7 @@ public:
      * with this date-time formatter.
      * @stable ICU 2.0
      */
-    virtual const DateFormatSymbols* getDateFormatSymbols(void) const;
+    virtual const DateFormatSymbols* getDateFormatSymbols() const;
 
     /**
      * Set the date/time formatting symbols.  The caller no longer owns the
@@ -1085,7 +1085,7 @@ public:
      * @return          The class ID for all objects of this class.
      * @stable ICU 2.0
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * Returns a unique class ID POLYMORPHICALLY. Pure virtual override. This
@@ -1098,7 +1098,7 @@ public:
      *                  other classes have different class IDs.
      * @stable ICU 2.0
      */
-    virtual UClassID getDynamicClassID(void) const override;
+    virtual UClassID getDynamicClassID() const override;
 
     /**
      * Set the calendar to be used by this date format. Initially, the default
@@ -1133,7 +1133,7 @@ public:
      * @return the time zone format associated with this date/time formatter.
      * @internal ICU 49 technology preview
      */
-    virtual const TimeZoneFormat* getTimeZoneFormat(void) const;
+    virtual const TimeZoneFormat* getTimeZoneFormat() const;
 
     /**
      * Set a particular UDisplayContext value in the formatter, such as
@@ -1216,16 +1216,16 @@ public:
      * @return   locale in this simple date formatter
      * @internal ICU 4.0
      */
-    const Locale& getSmpFmtLocale(void) const;
+    const Locale& getSmpFmtLocale() const;
 #endif  /* U_HIDE_INTERNAL_API */
 
 private:
     friend class DateFormat;
     friend class DateIntervalFormat;
 
-    void initializeDefaultCentury(void);
+    void initializeDefaultCentury();
 
-    void initializeBooleanAttributes(void);
+    void initializeBooleanAttributes();
 
     SimpleDateFormat() = delete; // default constructor not implemented
 

--- a/icu4c/source/i18n/unicode/sortkey.h
+++ b/icu4c/source/i18n/unicode/sortkey.h
@@ -162,7 +162,7 @@ public:
     * @return Returns true if the key is in an invalid, false otherwise.
     * @stable ICU 2.0
     */
-    UBool                   isBogus(void) const;
+    UBool isBogus() const;
 
     /**
     * Returns a pointer to the collation key values. The storage is owned
@@ -231,7 +231,7 @@ public:
     * @see UnicodeString#hashCode
     * @stable ICU 2.0
     */
-    int32_t                 hashCode(void) const;
+    int32_t hashCode() const;
 
     /**
      * ICU "poor man's RTTI", returns a UClassID for the actual class.
@@ -272,12 +272,12 @@ private:
     * Set the CollationKey to a "bogus" or invalid state
     * @return this CollationKey
     */
-    CollationKey&           setToBogus(void);
+    CollationKey& setToBogus();
     /**
     * Resets this CollationKey to an empty state
     * @return this CollationKey
     */
-    CollationKey&           reset(void);
+    CollationKey& reset();
 
     /**
     * Allow private access to RuleBasedCollator

--- a/icu4c/source/i18n/unicode/stsearch.h
+++ b/icu4c/source/i18n/unicode/stsearch.h
@@ -264,7 +264,7 @@ public:
     * If a collator is created in the constructor, it will be destroyed here.
     * @stable ICU 2.0
     */
-    virtual ~StringSearch(void);
+    virtual ~StringSearch();
 
     /**
      * Clone this object.
@@ -324,7 +324,7 @@ public:
      * @return current index in the text being searched.
      * @stable ICU 2.0
      */
-    virtual int32_t getOffset(void) const override;
+    virtual int32_t getOffset() const override;
 
     /**
      * Set the target text to be searched.

--- a/icu4c/source/i18n/unicode/tblcoll.h
+++ b/icu4c/source/i18n/unicode/tblcoll.h
@@ -449,7 +449,7 @@ public:
      *         IDs.
      * @stable ICU 2.0
      */
-    virtual UClassID getDynamicClassID(void) const override;
+    virtual UClassID getDynamicClassID() const override;
 
     /**
      * Returns the class ID for this class. This is useful only for comparing to
@@ -462,7 +462,7 @@ public:
      * @return The class ID for all objects of this class.
      * @stable ICU 2.0
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
 #ifndef U_HIDE_DEPRECATED_API
     /**

--- a/icu4c/source/i18n/unicode/timezone.h
+++ b/icu4c/source/i18n/unicode/timezone.h
@@ -163,7 +163,7 @@ public:
      * @see getUnknown
      * @stable ICU 2.0
      */
-    static const TimeZone* U_EXPORT2 getGMT(void);
+    static const TimeZone* U_EXPORT2 getGMT();
 
     /**
      * Creates a <code>TimeZone</code> for the given ID.
@@ -364,7 +364,7 @@ public:
      * @see getUnknown
      * @stable ICU 2.0
      */
-    static TimeZone* U_EXPORT2 createDefault(void);
+    static TimeZone* U_EXPORT2 createDefault();
 
 #ifndef U_HIDE_INTERNAL_API
     /**
@@ -644,7 +644,7 @@ public:
      * @return   The TimeZone's raw GMT offset.
      * @stable ICU 2.0
      */
-    virtual int32_t getRawOffset(void) const = 0;
+    virtual int32_t getRawOffset() const = 0;
 
     /**
      * Fills in "ID" with the TimeZone's ID.
@@ -813,7 +813,7 @@ public:
      * 
      * @stable ICU 2.0
      */
-    virtual UBool useDaylightTime(void) const = 0;
+    virtual UBool useDaylightTime() const = 0;
 
 #ifndef U_FORCE_HIDE_DEPRECATED_API
     /**
@@ -857,7 +857,7 @@ public:
      * @return The class ID for all objects of this class.
      * @stable ICU 2.0
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * Returns a unique class ID POLYMORPHICALLY. This method is to
@@ -870,8 +870,8 @@ public:
      *           same class ID. Objects of other classes have different class IDs.
      * @stable ICU 2.0
      */
-    virtual UClassID getDynamicClassID(void) const override = 0;
-    
+    virtual UClassID getDynamicClassID() const override = 0;
+
     /**
      * Returns the amount of time to be added to local standard time
      * to get local wall clock time.

--- a/icu4c/source/i18n/unicode/tmutamt.h
+++ b/icu4c/source/i18n/unicode/tmutamt.h
@@ -126,8 +126,7 @@ public:
      * @return          The class ID for all objects of this class.
      * @stable ICU 4.2
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
-
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * Returns a unique class ID POLYMORPHICALLY. Pure virtual override. This
@@ -140,8 +139,7 @@ public:
      *                  other classes have different class IDs.
      * @stable ICU 4.2
      */
-    virtual UClassID getDynamicClassID(void) const override;
-
+    virtual UClassID getDynamicClassID() const override;
 
     /**
      * Get the time unit.

--- a/icu4c/source/i18n/unicode/tmutfmt.h
+++ b/icu4c/source/i18n/unicode/tmutfmt.h
@@ -171,7 +171,7 @@ public:
      * @return          The class ID for all objects of this class.
      * @deprecated ICU 53
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * Returns a unique class ID POLYMORPHICALLY. Pure virtual override. This
@@ -184,7 +184,7 @@ public:
      *                  other classes have different class IDs.
      * @deprecated ICU 53
      */
-    virtual UClassID getDynamicClassID(void) const override;
+    virtual UClassID getDynamicClassID() const override;
 
 private:
     Hashtable*    fTimeUnitToCountToPatterns[TimeUnit::UTIMEUNIT_FIELD_COUNT];

--- a/icu4c/source/i18n/unicode/translit.h
+++ b/icu4c/source/i18n/unicode/translit.h
@@ -938,7 +938,7 @@ public:
      * transliterator needs to examine
      * @stable ICU 2.0
      */
-    int32_t getMaximumContextLength(void) const;
+    int32_t getMaximumContextLength() const;
 
 protected:
 
@@ -962,7 +962,7 @@ public:
      * @see #getAvailableIDs
      * @stable ICU 2.0
      */
-    virtual const UnicodeString& getID(void) const;
+    virtual const UnicodeString& getID() const;
 
     /**
      * Returns a name for this transliterator that is appropriate for
@@ -1008,7 +1008,7 @@ public:
      *         if this transliterator uses no filter.
      * @stable ICU 2.0
      */
-    const UnicodeFilter* getFilter(void) const;
+    const UnicodeFilter* getFilter() const;
 
     /**
      * Returns the filter used by this transliterator, or <tt>nullptr</tt> if this
@@ -1019,7 +1019,7 @@ public:
      *         transliterator uses no filter.
      * @stable ICU 2.4
      */
-    UnicodeFilter* orphanFilter(void);
+    UnicodeFilter* orphanFilter();
 
     /**
      * Changes the filter used by this transliterator.  If the filter
@@ -1374,7 +1374,7 @@ public:
      * @return the number of registered source specifiers.
      * @stable ICU 2.0
      */
-    static int32_t U_EXPORT2 countAvailableSources(void);
+    static int32_t U_EXPORT2 countAvailableSources();
 
     /**
      * Return a registered source specifier.
@@ -1448,7 +1448,7 @@ protected:
      * Non-mutexed internal method
      * @internal
      */
-    static int32_t _countAvailableSources(void);
+    static int32_t _countAvailableSources();
 
     /**
      * Non-mutexed internal method
@@ -1510,7 +1510,7 @@ public:
      * @return       The class ID for class Transliterator.
      * @stable ICU 2.0
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * Returns a unique class ID <b>polymorphically</b>.  This method
@@ -1527,7 +1527,7 @@ public:
      * different class IDs.
      * @stable ICU 2.0
      */
-    virtual UClassID getDynamicClassID(void) const override = 0;
+    virtual UClassID getDynamicClassID() const override = 0;
 
 private:
     static UBool initializeRegistry(UErrorCode &status);
@@ -1541,7 +1541,7 @@ public:
      * @return the number of IDs currently registered with the system.
      * @obsolete ICU 3.4 use getAvailableIDs() instead
      */
-    static int32_t U_EXPORT2 countAvailableIDs(void);
+    static int32_t U_EXPORT2 countAvailableIDs();
 
     /**
      * Return the index-th available ID.  index must be between 0
@@ -1559,7 +1559,7 @@ public:
 #endif  /* U_HIDE_OBSOLETE_API */
 };
 
-inline int32_t Transliterator::getMaximumContextLength(void) const {
+inline int32_t Transliterator::getMaximumContextLength() const {
     return maximumContextLength;
 }
 

--- a/icu4c/source/i18n/unicode/tzfmt.h
+++ b/icu4c/source/i18n/unicode/tzfmt.h
@@ -431,7 +431,7 @@ public:
      * @see ParseOption
      * @stable ICU 50
      */
-    uint32_t getDefaultParseOptions(void) const;
+    uint32_t getDefaultParseOptions() const;
 
     /**
      * Sets the default parse options.
@@ -656,7 +656,7 @@ public:
      * ICU "poor man's RTTI", returns a UClassID for this class.
      * @stable ICU 50
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * ICU "poor man's RTTI", returns a UClassID for the actual class.

--- a/icu4c/source/i18n/unicode/tzrule.h
+++ b/icu4c/source/i18n/unicode/tzrule.h
@@ -80,7 +80,7 @@ public:
      * @return  The standard time offset from UTC in milliseconds.
      * @stable ICU 3.8
      */
-    int32_t getRawOffset(void) const;
+    int32_t getRawOffset() const;
 
     /**
      * Gets the amount of daylight saving delta time from the standard time.
@@ -88,7 +88,7 @@ public:
      *          in milliseconds.
      * @stable ICU 3.8
      */
-    int32_t getDSTSavings(void) const;
+    int32_t getDSTSavings() const;
 
     /**
      * Returns if this rule represents the same rule and offsets as another.
@@ -340,7 +340,7 @@ public:
      * @return          The class ID for all objects of this class.
      * @stable ICU 3.8
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * Returns a unique class ID POLYMORPHICALLY. Pure virtual override. This
@@ -353,7 +353,7 @@ public:
      *                  other classes have different class IDs.
      * @stable ICU 3.8
      */
-    virtual UClassID getDynamicClassID(void) const override;
+    virtual UClassID getDynamicClassID() const override;
 };
 
 /**
@@ -461,7 +461,7 @@ public:
      *          rule used by this time zone rule.
      * @stable ICU 3.8
      */
-    const DateTimeRule* getRule(void) const;
+    const DateTimeRule* getRule() const;
 
     /**
      * Gets the first year when this rule takes effect.
@@ -469,7 +469,7 @@ public:
      *          with 0 == 1 BCE, -1 == 2 BCE, etc.
      * @stable ICU 3.8
      */
-    int32_t getStartYear(void) const;
+    int32_t getStartYear() const;
 
     /**
      * Gets the end year when this rule takes effect.
@@ -477,7 +477,7 @@ public:
      *          with 0 == 1 BCE, -1 == 2 BCE, etc.
      * @stable ICU 3.8
      */
-    int32_t getEndYear(void) const;
+    int32_t getEndYear() const;
 
     /**
      * Gets the time when this rule takes effect in the given year.
@@ -581,7 +581,7 @@ public:
      * @return          The class ID for all objects of this class.
      * @stable ICU 3.8
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * Returns a unique class ID POLYMORPHICALLY. Pure virtual override. This
@@ -594,7 +594,7 @@ public:
      *                  other classes have different class IDs.
      * @stable ICU 3.8
      */
-    virtual UClassID getDynamicClassID(void) const override;
+    virtual UClassID getDynamicClassID() const override;
 };
 
 /**
@@ -679,7 +679,7 @@ public:
      * @return The time type used of the start times used by this rule.
      * @stable ICU 3.8
      */
-    DateTimeRule::TimeRuleType getTimeType(void) const;
+    DateTimeRule::TimeRuleType getTimeType() const;
 
     /**
      * Gets a start time at the index stored in this rule.
@@ -697,7 +697,7 @@ public:
      * @return The number of start times.
      * @stable ICU 3.8
      */
-    int32_t countStartTimes(void) const;
+    int32_t countStartTimes() const;
 
     /**
      * Returns if this rule represents the same rule and offsets as another.
@@ -792,7 +792,7 @@ public:
      * @return          The class ID for all objects of this class.
      * @stable ICU 3.8
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * Returns a unique class ID POLYMORPHICALLY. Pure virtual override. This
@@ -805,7 +805,7 @@ public:
      *                  other classes have different class IDs.
      * @stable ICU 3.8
      */
-    virtual UClassID getDynamicClassID(void) const override;
+    virtual UClassID getDynamicClassID() const override;
 };
 
 

--- a/icu4c/source/i18n/unicode/tztrans.h
+++ b/icu4c/source/i18n/unicode/tztrans.h
@@ -102,7 +102,7 @@ public:
      * @return The time of the transition in milliseconds since the 1970 Jan 1 epoch time.
      * @stable ICU 3.8
      */
-    UDate getTime(void) const;
+    UDate getTime() const;
 
     /**
      * Sets the time of transition in milliseconds.
@@ -116,7 +116,7 @@ public:
      * @return The time zone rule used after the transition.
      * @stable ICU 3.8
      */
-    const TimeZoneRule* getFrom(void) const;
+    const TimeZoneRule* getFrom() const;
 
     /**
      * Sets the rule used before the transition.  The caller remains
@@ -155,7 +155,7 @@ public:
      * @return The time zone rule used after the transition.
      * @stable ICU 3.8
      */
-    const TimeZoneRule* getTo(void) const;
+    const TimeZoneRule* getTo() const;
 
 private:
     UDate   fTime;
@@ -174,7 +174,7 @@ public:
      * @return          The class ID for all objects of this class.
      * @stable ICU 3.8
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * Returns a unique class ID POLYMORPHICALLY. Pure virtual override. This
@@ -187,7 +187,7 @@ public:
      *                  other classes have different class IDs.
      * @stable ICU 3.8
      */
-    virtual UClassID getDynamicClassID(void) const override;
+    virtual UClassID getDynamicClassID() const override;
 };
 
 U_NAMESPACE_END

--- a/icu4c/source/i18n/unicode/vtzone.h
+++ b/icu4c/source/i18n/unicode/vtzone.h
@@ -289,7 +289,7 @@ public:
      * @return   The TimeZone's raw GMT offset.
      * @stable ICU 3.8
      */
-    virtual int32_t getRawOffset(void) const override;
+    virtual int32_t getRawOffset() const override;
 
     /**
      * Queries if this time zone uses daylight savings time.
@@ -297,7 +297,7 @@ public:
      * false, otherwise.
      * @stable ICU 3.8
      */
-    virtual UBool useDaylightTime(void) const override;
+    virtual UBool useDaylightTime() const override;
 
 #ifndef U_FORCE_HIDE_DEPRECATED_API
     /**
@@ -445,7 +445,7 @@ public:
      * @return          The class ID for all objects of this class.
      * @stable ICU 3.8
      */
-    static UClassID U_EXPORT2 getStaticClassID(void);
+    static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * Returns a unique class ID POLYMORPHICALLY. Pure virtual override. This
@@ -458,7 +458,7 @@ public:
      *                  other classes have different class IDs.
      * @stable ICU 3.8
      */
-    virtual UClassID getDynamicClassID(void) const override;
+    virtual UClassID getDynamicClassID() const override;
 };
 
 U_NAMESPACE_END


### PR DESCRIPTION
Follow-up to PR #2744, we might as well be consistent about this.

https://releases.llvm.org/16.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize/redundant-void-arg.html

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22532
- [X] Required: The PR title must be prefixed with a JIRA Issue number.
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number.
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
