### PR TITLE
ICU-22609 Fix nulldef w/ bogus locale in DateFormat::create*

### DIFF
--- a/icu4c/source/i18n/smpdtfmt.cpp
+++ b/icu4c/source/i18n/smpdtfmt.cpp
@@ -728,16 +728,17 @@ void SimpleDateFormat::construct(EStyle timeStyle,
         if (locale.getKeywordValue("rg", nullptr, 0, dummyErr1) > 0 || locale.getKeywordValue("hours", nullptr, 0, dummyErr2) > 0) {
             hasRgOrHcSubtag = true;
         }
-            
+
         const char* baseLocID = locale.getBaseName();
-        if (baseLocID[0]!=0 && uprv_strcmp(baseLocID,"und")!=0) {
+        if (baseLocID != nullptr && uprv_strcmp(baseLocID,"und")!=0) {
             UErrorCode useStatus = U_ZERO_ERROR;
             Locale baseLoc(baseLocID);
             Locale validLoc(getLocale(ULOC_VALID_LOCALE, useStatus));
             if (hasRgOrHcSubtag || (U_SUCCESS(useStatus) && validLoc!=baseLoc)) {
                 bool useDTPG = hasRgOrHcSubtag;
                 const char* baseReg = baseLoc.getCountry(); // empty string if no region
-                if ((baseReg[0]!=0 && uprv_strncmp(baseReg,validLoc.getCountry(),ULOC_COUNTRY_CAPACITY)!=0)
+                if ((baseReg != nullptr && baseReg[0] != 0 &&
+                     uprv_strncmp(baseReg,validLoc.getCountry(),ULOC_COUNTRY_CAPACITY)!=0)
                         || uprv_strncmp(baseLoc.getLanguage(),validLoc.getLanguage(),ULOC_LANG_CAPACITY)!=0) {
                     // use DTPG if
                     // * baseLoc has a region and validLoc does not have the same one (or has none), OR

--- a/icu4c/source/test/cintltst/cdattst.c
+++ b/icu4c/source/test/cintltst/cdattst.c
@@ -51,6 +51,7 @@ static void TestNarrowQuarters(void);
 static void TestExtraneousCharacters(void);
 static void TestParseTooStrict(void);
 static void TestHourCycle(void);
+static void TestLocaleNameCrash(void);
 
 void addDateForTest(TestNode** root);
 
@@ -76,6 +77,7 @@ void addDateForTest(TestNode** root)
     TESTCASE(TestExtraneousCharacters);
     TESTCASE(TestParseTooStrict);
     TESTCASE(TestHourCycle);
+    TESTCASE(TestLocaleNameCrash);
 }
 /* Testing the DateFormat API */
 static void TestDateFormat()
@@ -2127,6 +2129,19 @@ static void TestHourCycle(void) {
             }
         }
     }
+}
+
+static void TestLocaleNameCrash(void) {
+    UErrorCode status = U_ZERO_ERROR;
+    UDateFormat icudf;
+
+    icudf = udat_open(UDAT_MEDIUM, UDAT_NONE, "notalanguage", NULL, 0, NULL, 0, &status);
+    if ( U_SUCCESS(status) ) {
+        log_verbose("Success: did not crash on udat_open(locale=\"notalanguage\")\n");
+    } else {
+        log_err("FAIL: didn't crash on udat_open(locale=\"notalanguage\"), but got %s.\n", u_errorName(status));
+    }
+    udat_close(icudf);
 }
 
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/test/intltest/dtfmttst.cpp
+++ b/icu4c/source/test/intltest/dtfmttst.cpp
@@ -135,6 +135,7 @@ void DateFormatTest::runIndexedTest( int32_t index, UBool exec, const char* &nam
     TESTCASE_AUTO(TestNumericFieldStrictParse);
     TESTCASE_AUTO(TestHourCycle);
     TESTCASE_AUTO(TestHCInLocale);
+    TESTCASE_AUTO(TestBogusLocale);
 
     TESTCASE_AUTO_END;
 }
@@ -5874,6 +5875,14 @@ void DateFormatTest::TestHourCycle() {
         errorMessage.append(TEST_CASES[i].languageTag, err);
         assertEquals(errorMessage.data(), TEST_CASES[i].expectedResult, actualResult);
     }
+}
+
+void DateFormatTest::TestBogusLocale() {
+    IcuTestErrorCode status(*this, "TestBogusLocale");
+    LocalPointer<DateFormat> df;
+
+    df.adoptInstead(DateFormat::createDateTimeInstance(DateFormat::kNone, DateFormat::kMedium,
+                    Locale("notalanguage")));
 }
 
 void DateFormatTest::TestHCInLocale() {

--- a/icu4c/source/test/intltest/dtfmttst.h
+++ b/icu4c/source/test/intltest/dtfmttst.h
@@ -270,6 +270,7 @@ public:
     void TestNumericFieldStrictParse();
     void TestHourCycle();
     void TestHCInLocale();
+    void TestBogusLocale();
 
 private:
     UBool showParse(DateFormat &format, const UnicodeString &formattedString);


### PR DESCRIPTION
Copy the test from https://github.com/unicode-org/icu/pull/2747
This is my counter proposal for #2747 because the crash could still happen via C++ interface.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22609
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
