### PR TITLE
ICU-22615 Test TimeZoneNames API will not assert with non ASCII.

### DIFF
--- a/icu4c/source/i18n/tznames_impl.cpp
+++ b/icu4c/source/i18n/tznames_impl.cpp
@@ -34,6 +34,7 @@
 #include "ureslocs.h"
 #include "zonemeta.h"
 #include "ucln_in.h"
+#include "uinvchar.h"
 #include "uvector.h"
 #include "olsontz.h"
 
@@ -2280,6 +2281,10 @@ TZDBTimeZoneNames::getMetaZoneNames(const UnicodeString& mzID, UErrorCode& statu
         return nullptr;
     }
     mzIDKey[mzID.length()] = 0;
+    if (!uprv_isInvariantUString(mzIDKey, mzID.length())) {
+        status = U_ILLEGAL_ARGUMENT_ERROR;
+        return nullptr;
+    }
 
     static UMutex gTZDBNamesMapLock;
     umtx_lock(&gTZDBNamesMapLock);

--- a/icu4c/source/test/intltest/tzfmttst.h
+++ b/icu4c/source/test/intltest/tzfmttst.h
@@ -33,6 +33,7 @@ class TimeZoneFormatTest : public IntlTest {
     void TestCentralTime();
     void TestBogusLocale();
     void Test22614GetMetaZoneNamesNotCrash();
+    void Test22615NonASCIIID();
 
     void RunTimeRoundTripTests(int32_t threadNumber);
     void RunAdoptDefaultThreadSafeTests(int32_t threadNumber);


### PR DESCRIPTION
Add tests and avoid assertion when the ID has non-ASCII

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22615
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
