### PR TITLE
ICU-22616 fix value returned by Calendar::getTimeInMillis() after call to Calendar::set() during ambiguous time

### DIFF
--- a/icu4c/source/i18n/calendar.cpp
+++ b/icu4c/source/i18n/calendar.cpp
@@ -1216,6 +1216,15 @@ Calendar::set(UCalendarDateFields field, int32_t value)
     if (fAreFieldsVirtuallySet) {
         UErrorCode ec = U_ZERO_ERROR;
         computeFields(ec);
+
+        // handle the ambiguous time that occurs twice at the end of DST:
+        // if we're in DST, then we want the first occurrence of this time,
+        // otherwise we want the second occurrence of this time
+        if (fFields[UCAL_DST_OFFSET] != 0) {
+            setRepeatedWallTimeOption(UCAL_WALLTIME_FIRST);
+        } else {
+            setRepeatedWallTimeOption(UCAL_WALLTIME_LAST);
+        }
     }
     fFields[field]     = value;
     /* Ensure that the fNextStamp value doesn't go pass max value for int32_t */

--- a/icu4c/source/test/cintltst/cdattst.c
+++ b/icu4c/source/test/cintltst/cdattst.c
@@ -2146,9 +2146,6 @@ static void TestLocaleNameCrash(void) {
     udat_close(icudf);
 }
 
-#endif /* #if !UCONFIG_NO_FORMATTING */
-
-
 static void TestTimeAtEndOfDST(void) {
     // regression test for ICU-22616
     UErrorCode status;
@@ -2179,3 +2176,5 @@ static void TestTimeAtEndOfDST(void) {
     }
     ucal_close(cal);
 }
+
+#endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4j/main/core/src/main/java/com/ibm/icu/util/Calendar.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/util/Calendar.java
@@ -2228,6 +2228,15 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
     {
         if (areFieldsVirtuallySet) {
             computeFields();
+
+            // handle the ambiguous time that occurs twice at the end of DST:
+            // if we're in DST, then we want the first occurrence of this time,
+            // otherwise we want the second occurrence of this time
+            if (fields[DST_OFFSET] != 0) {
+                setRepeatedWallTimeOption(WALLTIME_FIRST);
+            } else {
+                setRepeatedWallTimeOption(WALLTIME_LAST);
+            }
         }
         fields[field] = value;
         /* Ensure that the fNextStamp value doesn't go pass max value for 32 bit integer */

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timezone/TimeZoneRuleTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timezone/TimeZoneRuleTest.java
@@ -1849,4 +1849,35 @@ public class TimeZoneRuleTest extends CoreTestFmwk {
             errln("Fail: Exception thrown - " + e.getMessage());
         }
     }
+
+    @Test
+    public void TestTimeAtEndOfDST() {
+        // regression test for ICU-22616
+    
+        // America/Los_Angeles -- end of DST
+        // start time:
+        //    UTC:   Sun Nov 05 2023 07:00:00
+        //    local: Sun Nov 05 2023 00:00:00
+        // step through three hours, 15 minutes at a time
+        // checking for mismatches between set millis and get millis
+        // during the hour that happens twice at the end of DST
+        final long start_millis = 1699167600000L;
+        long get_millis;
+        TimeZone losangeles = TimeZone.getTimeZone("America/Los_Angeles", TimeZone.TIMEZONE_ICU);
+        Calendar cal = new GregorianCalendar(losangeles);
+        for (long set_millis = start_millis; set_millis < start_millis + (1000*60*60*3); set_millis += (1000*60*15)) {
+            cal.clear();
+            cal.setTimeInMillis(set_millis);
+    
+            // Note that the call to cal.set() sets isTimeSet to false so then
+            // Calendar::getTimeInMillis() calls Calendar::updateTime()
+            // instead of just returning time.
+            cal.set(Calendar.ERA, GregorianCalendar.AD);
+            
+            get_millis = cal.getTimeInMillis();
+            if ( get_millis != set_millis) {
+                errln("FAIL: value returned by getTimeInMillis() does not match value set by setTimeInMillis()");
+            }
+        }
+    }
 }


### PR DESCRIPTION

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22616
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
