### PR TITLE
ICU-21107 Specify language standard versions C11 & C++17 also for Bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,28 @@
+# © 2024 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
+
+# By default, build ICU4C as C11 & C++17.
+
+build --enable_platform_specific_config
+
+build:android --conlyopt=-std=c11
+build:android --host_conlyopt=-std=c11
+build:ios --conlyopt=-std=c11
+build:ios --host_conlyopt=-std=c11
+build:linux --conlyopt=-std=c11
+build:linux --host_conlyopt=-std=c11
+build:macos --conlyopt=-std=c11
+build:macos --host_conlyopt=-std=c11
+build:windows --conlyopt=/std:c11
+build:windows --host_conlyopt=/std:c11
+
+build:android --cxxopt=-std=c++17
+build:android --host_cxxopt=-std=c++17
+build:ios --cxxopt=-std=c++17
+build:ios --host_cxxopt=-std=c++17
+build:linux --cxxopt=-std=c++17
+build:linux --host_cxxopt=-std=c++17
+build:macos --cxxopt=-std=c++17
+build:macos --host_cxxopt=-std=c++17
+build:windows --cxxopt=/std:c++17
+build:windows --host_cxxopt=/std:c++17


### PR DESCRIPTION
This is copied (with C11 added) from:

https://github.com/tensorflow/tensorflow/blob/v2.15.0/.bazelrc

There were until now no versions specified at all, relying on the default (or commandline overrides) to be sufficiently recent.

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21107
- [X] Required: The PR title must be prefixed with a JIRA Issue number.
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number.
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
