### PR TITLE
ICU-22549 Fix incorrect pointer in fuzzer

### DIFF
--- a/icu4c/source/test/fuzzer/collator_compare_fuzzer.cpp
+++ b/icu4c/source/test/fuzzer/collator_compare_fuzzer.cpp
@@ -39,9 +39,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   }
   std::unique_ptr<char16_t[]> compbuff1(new char16_t[size/4]);
   std::memcpy(compbuff1.get(), data, (size/4)*2);
-  data = data + size/2;
   std::unique_ptr<char16_t[]> compbuff2(new char16_t[size/4]);
-  std::memcpy(compbuff2.get(), data, (size/4)*2);
+  std::memcpy(compbuff2.get(), data + size/2, (size/4)*2);
 
 
   icu::LocalPointer<icu::Collator> fuzzCollator(


### PR DESCRIPTION
Remove the adjustment of data pointer to avoid buffer-overflow 
Fix bug https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65632

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22549
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
