### PR TITLE
ICU-22623 Null terminate CharString extract result

### DIFF
--- a/icu4c/source/common/uresbund.cpp
+++ b/icu4c/source/common/uresbund.cpp
@@ -3097,8 +3097,18 @@ ures_getFunctionalEquivalent(char *result, int32_t resultCapacity,
     ures_initStackObject(&bund1);
     ures_initStackObject(&bund2);
 
-    base.extract(parent, UPRV_LENGTHOF(parent), subStatus);
-    base.extract(found, UPRV_LENGTHOF(found), subStatus);
+    base.extract(parent, UPRV_LENGTHOF(parent)-1, subStatus);
+    // parent may not be null terminated if subStatus is
+    // U_STRING_NOT_TERMINATED_WARNING.
+    if (subStatus == U_STRING_NOT_TERMINATED_WARNING) {
+      parent[UPRV_LENGTHOF(parent)-1] = '\0'; // null terminate.
+    }
+    base.extract(found, UPRV_LENGTHOF(found)-1, subStatus);
+    // found may not be null terminated if subStatus is
+    // U_STRING_NOT_TERMINATED_WARNING.
+    if (subStatus == U_STRING_NOT_TERMINATED_WARNING) {
+      found[UPRV_LENGTHOF(found)-1] = '\0'; // null terminate.
+    }
 
     if(isAvailable) {
         UEnumeration *locEnum = ures_openAvailableLocales(path, &subStatus);
@@ -3173,8 +3183,18 @@ ures_getFunctionalEquivalent(char *result, int32_t resultCapacity,
     } while(!defVal[0] && *found && uprv_strcmp(found, "root") != 0 && U_SUCCESS(*status));
     
     /* Now, see if we can find the kwVal collator.. start the search over.. */
-    base.extract(parent, UPRV_LENGTHOF(parent), subStatus);
-    base.extract(found, UPRV_LENGTHOF(found), subStatus);
+    base.extract(parent, UPRV_LENGTHOF(parent)-1, subStatus);
+    // parent may not be null terminated if subStatus is
+    // U_STRING_NOT_TERMINATED_WARNING.
+    if (subStatus == U_STRING_NOT_TERMINATED_WARNING) {
+      parent[UPRV_LENGTHOF(parent)-1] = '\0'; // null terminate.
+    }
+    base.extract(found, UPRV_LENGTHOF(found)-1, subStatus);
+    // found may not be null terminated if subStatus is
+    // U_STRING_NOT_TERMINATED_WARNING.
+    if (subStatus == U_STRING_NOT_TERMINATED_WARNING) {
+      found[UPRV_LENGTHOF(found)-1] = '\0'; // null terminate.
+    }
 
     do {
         res = ures_open(path, parent, &subStatus);
@@ -3277,8 +3297,18 @@ ures_getFunctionalEquivalent(char *result, int32_t resultCapacity,
         fprintf(stderr, "Failed to locate kw %s - try default %s\n", kwVal.data(), defVal);
 #endif
         kwVal.clear().append(defVal, subStatus);
-        base.extract(parent, UPRV_LENGTHOF(parent), subStatus);
-        base.extract(found, UPRV_LENGTHOF(found), subStatus);
+        base.extract(parent, UPRV_LENGTHOF(parent)-1, subStatus);
+        // parent may not be null terminated if subStatus is
+        // U_STRING_NOT_TERMINATED_WARNING.
+        if (subStatus == U_STRING_NOT_TERMINATED_WARNING) {
+          parent[UPRV_LENGTHOF(parent)-1] = '\0'; // null terminate.
+        }
+        base.extract(found, UPRV_LENGTHOF(found)-1, subStatus);
+        // found may not be null terminated if subStatus is
+        // U_STRING_NOT_TERMINATED_WARNING.
+        if (subStatus == U_STRING_NOT_TERMINATED_WARNING) {
+          found[UPRV_LENGTHOF(found)-1] = '\0'; // null terminate.
+        }
 
         do { /* search for 'default' named item */
             res = ures_open(path, parent, &subStatus);

--- a/icu4c/source/test/intltest/dtfmttst.cpp
+++ b/icu4c/source/test/intltest/dtfmttst.cpp
@@ -136,6 +136,7 @@ void DateFormatTest::runIndexedTest( int32_t index, UBool exec, const char* &nam
     TESTCASE_AUTO(TestHourCycle);
     TESTCASE_AUTO(TestHCInLocale);
     TESTCASE_AUTO(TestBogusLocale);
+    TESTCASE_AUTO(TestLongLocale);
 
     TESTCASE_AUTO_END;
 }
@@ -5883,6 +5884,17 @@ void DateFormatTest::TestBogusLocale() {
 
     df.adoptInstead(DateFormat::createDateTimeInstance(DateFormat::kNone, DateFormat::kMedium,
                     Locale("notalanguage")));
+}
+
+void DateFormatTest::TestLongLocale() {
+    IcuTestErrorCode status(*this, "TestLongLocale");
+    LocalPointer<DateFormat> df;
+
+    // This should not cause a crash
+    std::string s(1023, ' ');
+    s[1] = '-';
+    df.adoptInstead(DateFormat::createDateTimeInstance(DateFormat::kDateTime, DateFormat::kMedium,
+                    Locale(s.c_str())));
 }
 
 void DateFormatTest::TestHCInLocale() {

--- a/icu4c/source/test/intltest/dtfmttst.h
+++ b/icu4c/source/test/intltest/dtfmttst.h
@@ -271,6 +271,7 @@ public:
     void TestHourCycle();
     void TestHCInLocale();
     void TestBogusLocale();
+    void TestLongLocale();
 
 private:
     UBool showParse(DateFormat &format, const UnicodeString &formattedString);


### PR DESCRIPTION
The CharString::extract method is not guaranteed to null terminate the string."If the string fits into dest but cannot be NUL-terminated (length()==capacity), then the error code is set to U_STRING_NOT_TERMINATED_WARNING." But the operations later assume the string is null terminated. So we should set extraction length one byte shorter and null terminate if the subStatus is U_STRING_NOT_TERMINATED_WARNING to avoid Stack-buffer-overflow read.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22623
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
