### PR TITLE
ICU-22626 Fix leakage when 2 '=' in PluralRules

### DIFF
--- a/icu4c/source/i18n/plurrule.cpp
+++ b/icu4c/source/i18n/plurrule.cpp
@@ -656,6 +656,11 @@ PluralRuleParser::parse(const UnicodeString& ruleData, PluralRules *prules, UErr
         case tEqual:
             {
                 U_ASSERT(curAndConstraint != nullptr);
+                if (curAndConstraint->rangeList != nullptr) {
+                    // Already get a '='.
+                    status = U_UNEXPECTED_TOKEN;
+                    break;
+                }
                 LocalPointer<UVector32> newRangeList(new UVector32(status), status);
                 if (U_FAILURE(status)) {
                     break;

--- a/icu4c/source/test/intltest/plurults.cpp
+++ b/icu4c/source/test/intltest/plurults.cpp
@@ -69,6 +69,7 @@ void PluralRulesTest::runIndexedTest( int32_t index, UBool exec, const char* &na
     TESTCASE_AUTO(testFixedDecimal);
     TESTCASE_AUTO(testSelectTrailingZeros);
     TESTCASE_AUTO(testLocaleExtension);
+    TESTCASE_AUTO(testDoubleEqualSign);
     TESTCASE_AUTO_END;
 }
 
@@ -1636,6 +1637,16 @@ void PluralRulesTest::compareLocaleResults(const char* loc1, const char* loc2, c
             errln("PluralRules.select(%d) does not return the same values for %s, %s, %s\n", value, loc1, loc2, loc3);
         }
     }
+}
+
+void PluralRulesTest::testDoubleEqualSign() {
+    IcuTestErrorCode errorCode(*this, "testDoubleEqualSign");
+
+    // ICU-22626
+    // Two '=' in the rul should not leak.
+    LocalPointer<PluralRules> rules(
+        PluralRules::createRules(u"e:c=2=", errorCode), errorCode);
+    errorCode.expectErrorAndReset(U_UNEXPECTED_TOKEN);
 }
 
 void PluralRulesTest::testLocaleExtension() {

--- a/icu4c/source/test/intltest/plurults.h
+++ b/icu4c/source/test/intltest/plurults.h
@@ -50,6 +50,7 @@ private:
     void testFixedDecimal();
     void testSelectTrailingZeros();
     void testLocaleExtension();
+    void testDoubleEqualSign();
 
     void assertRuleValue(const UnicodeString& rule, double expected);
     void assertRuleKeyValue(const UnicodeString& rule, const UnicodeString& key,


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22626
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
