### PR TITLE
ICU-22636 Return U_BRK_RULE_SYNTAX when status number is too large

### DIFF
--- a/icu4c/source/common/rbbiscan.cpp
+++ b/icu4c/source/common/rbbiscan.cpp
@@ -530,7 +530,13 @@ UBool RBBIRuleScanner::doParseActions(int32_t action)
             n = fNodeStack[fNodeStackPtr];
             uint32_t v = u_charDigitValue(fC.fChar);
             U_ASSERT(v < 10);
-            n->fVal = n->fVal*10 + v;
+            int64_t updated = static_cast<int64_t>(n->fVal)*10 + v;
+            // Avoid overflow n->fVal
+            if (updated > INT32_MAX) {
+                error(U_BRK_RULE_SYNTAX);
+                break;
+            }
+            n->fVal = static_cast<int32_t>(updated);
             break;
         }
 

--- a/icu4c/source/test/intltest/rbbitst.cpp
+++ b/icu4c/source/test/intltest/rbbitst.cpp
@@ -149,6 +149,7 @@ void RBBITest::runIndexedTest( int32_t index, UBool exec, const char* &name, cha
     TESTCASE_AUTO(TestBug22584);
     TESTCASE_AUTO(TestBug22585);
     TESTCASE_AUTO(TestBug22602);
+    TESTCASE_AUTO(TestBug22636);
 
 #if U_ENABLE_TRACING
     TESTCASE_AUTO(TestTraceCreateCharacter);
@@ -5887,6 +5888,19 @@ void RBBITest::TestBug22602() {
     UParseError pe {};
     UErrorCode ec {U_ZERO_ERROR};
     RuleBasedBreakIterator bi(rule, pe, ec);
+}
+
+void RBBITest::TestBug22636() {
+    UParseError pe {};
+    UErrorCode ec {U_ZERO_ERROR};
+    RuleBasedBreakIterator bi(u"A{77777777777777};", pe, ec);
+    assertEquals(WHERE, ec, U_BRK_RULE_SYNTAX);
+    ec = U_ZERO_ERROR;
+    RuleBasedBreakIterator bi2(u"A{2147483648};", pe, ec);
+    assertEquals(WHERE, ec, U_BRK_RULE_SYNTAX);
+    ec = U_ZERO_ERROR;
+    RuleBasedBreakIterator bi3(u"A{2147483647};", pe, ec);
+    assertEquals(WHERE, ec, U_ZERO_ERROR);
 }
 
 void RBBITest::TestBug22584() {

--- a/icu4c/source/test/intltest/rbbitst.h
+++ b/icu4c/source/test/intltest/rbbitst.h
@@ -103,6 +103,7 @@ public:
     void TestBug22584();
     void TestBug22585();
     void TestBug22602();
+    void TestBug22636();
 
 #if U_ENABLE_TRACING
     void TestTraceCreateCharacter();

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/RBBIRuleScanner.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/RBBIRuleScanner.java
@@ -412,7 +412,11 @@ class RBBIRuleScanner {
         {
             n = fNodeStack[fNodeStackPtr];
             int v = UCharacter.digit((char) fC.fChar, 10);
-            n.fVal = n.fVal * 10 + v;
+            long update = (long)(n.fVal) * 10 + v;
+            if (update > Integer.MAX_VALUE) {
+                error(RBBIRuleBuilder.U_BRK_RULE_SYNTAX);
+            }
+            n.fVal = (int)(update);
             break;
         }
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBITest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBITest.java
@@ -1002,6 +1002,24 @@ public class RBBITest extends CoreTestFmwk {
             fail("TestBug22602: Unexpected exception while new RuleBasedBreakIterator() with a long string followed by a ';': " + e);
         }
     }
+    @Test
+    public void TestBug22636() {
+        try {
+            RuleBasedBreakIterator bi = new RuleBasedBreakIterator("A{77777777777777};");
+            fail("TestBug22636: new RuleBasedBreakIterator() with a large status value inside {}:  should throw IllegalArgumentException");
+        }
+        catch (IllegalArgumentException e) {
+            // expected exception with a large status value inside {}.
+        }
+        try {
+            RuleBasedBreakIterator bi2 = new RuleBasedBreakIterator("A{2147483648};");
+            fail("TestBug22636: new RuleBasedBreakIterator() with a large status value inside {}:  should throw IllegalArgumentException");
+        }
+        catch (IllegalArgumentException e) {
+            // expected exception with a large status value inside {}.
+        }
+        RuleBasedBreakIterator bi3 = new RuleBasedBreakIterator("A{2147483647};");
+    }
     /* Test preceding(index) and following(index), with semi-random indexes.
      * The random indexes are produced in clusters that are relatively closely spaced,
      * to increase the occurrences of hits to the internal break cache.


### PR DESCRIPTION
To avoid overflow the parsing, we now return U_BRK_RULE_SYNTAX if the status value is in the rule is too large and overflow the int32_t

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22636
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
