### PR TITLE
ICU-22638 Use parseNumber to fix buffer-overflow

### DIFF
--- a/icu4c/source/common/util_props.cpp
+++ b/icu4c/source/common/util_props.cpp
@@ -198,12 +198,11 @@ int32_t ICU_Utility::parseNumber(const UnicodeString& text,
         if (d < 0) {
             break;
         }
-        n = radix*n + d;
-        // ASSUME that when a 32-bit integer overflows it becomes
-        // negative.  E.g., 214748364 * 10 + 8 => negative value.
-        if (n < 0) {
+        int64_t update = radix*static_cast<int64_t>(n) + d;
+        if (update > INT32_MAX) {
             return -1;
         }
+        n = static_cast<int32_t>(update);
         ++p;
     }
     if (p == pos) {

--- a/icu4c/source/i18n/plurrule.cpp
+++ b/icu4c/source/i18n/plurrule.cpp
@@ -678,20 +678,40 @@ PluralRuleParser::parse(const UnicodeString& ruleData, PluralRules *prules, UErr
             U_ASSERT(curAndConstraint != nullptr);
             if ( (curAndConstraint->op==AndConstraint::MOD)&&
                  (curAndConstraint->opNum == -1 ) ) {
-                curAndConstraint->opNum=getNumberValue(token);
+                int32_t num = getNumberValue(token);
+                if (num == -1) {
+                    status = U_UNEXPECTED_TOKEN;
+                    break;
+                }
+                curAndConstraint->opNum=num;
             }
             else {
                 if (curAndConstraint->rangeList == nullptr) {
                     // this is for an 'is' rule
-                    curAndConstraint->value = getNumberValue(token);
+                    int32_t num = getNumberValue(token);
+                    if (num == -1) {
+                        status = U_UNEXPECTED_TOKEN;
+                        break;
+                    }
+                    curAndConstraint->value = num;
                 } else {
                     // this is for an 'in' or 'within' rule
                     if (curAndConstraint->rangeList->elementAti(rangeLowIdx) == -1) {
-                        curAndConstraint->rangeList->setElementAt(getNumberValue(token), rangeLowIdx);
-                        curAndConstraint->rangeList->setElementAt(getNumberValue(token), rangeHiIdx);
+                        int32_t num = getNumberValue(token);
+                        if (num == -1) {
+                            status = U_UNEXPECTED_TOKEN;
+                            break;
+                        }
+                        curAndConstraint->rangeList->setElementAt(num, rangeLowIdx);
+                        curAndConstraint->rangeList->setElementAt(num, rangeHiIdx);
                     }
                     else {
-                        curAndConstraint->rangeList->setElementAt(getNumberValue(token), rangeHiIdx);
+                        int32_t num = getNumberValue(token);
+                        if (num == -1) {
+                            status = U_UNEXPECTED_TOKEN;
+                            break;
+                        }
+                        curAndConstraint->rangeList->setElementAt(num, rangeHiIdx);
                         if (curAndConstraint->rangeList->elementAti(rangeLowIdx) >
                                 curAndConstraint->rangeList->elementAti(rangeHiIdx)) {
                             // Range Lower bound > Range Upper bound.
@@ -1263,13 +1283,8 @@ PluralRuleParser::~PluralRuleParser() {
 
 int32_t
 PluralRuleParser::getNumberValue(const UnicodeString& token) {
-    int32_t i;
-    char digits[128];
-
-    i = token.extract(0, token.length(), digits, UPRV_LENGTHOF(digits), US_INV);
-    digits[i]='\0';
-
-    return((int32_t)atoi(digits));
+    int32_t pos = 0;
+    return ICU_Utility::parseNumber(token, pos, 10);
 }
 
 

--- a/icu4c/source/test/depstest/dependencies.txt
+++ b/icu4c/source/test/depstest/dependencies.txt
@@ -994,6 +994,7 @@ group: number_output
     # PluralRules internals:
     unifiedcache
     display_options
+    icu_utility_with_props
 
 group: numberformatter
     # ICU 60+ NumberFormatter API

--- a/icu4c/source/test/intltest/plurults.cpp
+++ b/icu4c/source/test/intltest/plurults.cpp
@@ -70,6 +70,7 @@ void PluralRulesTest::runIndexedTest( int32_t index, UBool exec, const char* &na
     TESTCASE_AUTO(testSelectTrailingZeros);
     TESTCASE_AUTO(testLocaleExtension);
     TESTCASE_AUTO(testDoubleEqualSign);
+    TESTCASE_AUTO(test22638LongNumberValue);
     TESTCASE_AUTO_END;
 }
 
@@ -1063,6 +1064,16 @@ PluralRulesTest::testDoubleValue() {
         UnicodeString message(u"FixedDecimal::doubleValue() for" + DoubleToUnicodeString(inputNum));
         assertEquals(message, expVal, fd.doubleValue());
     }
+}
+
+void
+PluralRulesTest::test22638LongNumberValue() {
+    IcuTestErrorCode errorCode(*this, "test22638LongNumberValue");
+    LocalPointer<PluralRules> pr(PluralRules::createRules(
+        u"g:c%4422322222232222222222232222222322222223222222232222222322222223"
+        u"2222222322222232222222322222223222232222222222222322222223222222",
+        errorCode));
+    errorCode.expectErrorAndReset(U_UNEXPECTED_TOKEN);
 }
 
 void

--- a/icu4c/source/test/intltest/plurults.h
+++ b/icu4c/source/test/intltest/plurults.h
@@ -51,6 +51,7 @@ private:
     void testSelectTrailingZeros();
     void testLocaleExtension();
     void testDoubleEqualSign();
+    void test22638LongNumberValue();
 
     void assertRuleValue(const UnicodeString& rule, double expected);
     void assertRuleKeyValue(const UnicodeString& rule, const UnicodeString& key,

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/PluralRulesTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/PluralRulesTest.java
@@ -1757,4 +1757,11 @@ public class PluralRulesTest extends CoreTestFmwk {
         form = xyz.select(range);
         assertEquals("Fallback form", "other", form);
     }
+    @Test
+    public void test22638LongNumberValue() {
+        PluralRules test = PluralRules.createRules(
+            "g:c%4422322222232222222222232222222322222223222222232222222322222223" +
+            "2222222322222232222222322222223222232222222222222322222223222222");
+        assertEquals("Long number value should get null", null, test);
+    }
 }


### PR DESCRIPTION
Fix the crash when the PluralRuleParser::parse hit a long number value in the rule.
Also fix parseNumber so it will not trigger undefined sanitizer

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22638
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
