### PR TITLE
ICU-22532 Move the definition of _POSIX_C_SOURCE to the Makefile

### DIFF
--- a/icu4c/source/tools/tzcode/Makefile.in
+++ b/icu4c/source/tools/tzcode/Makefile.in
@@ -27,7 +27,8 @@ TDATA =	$(PRIMARY_DATA) $(SUPPLEMENTAL_DATA)
 
 TZDIR=zoneinfo
 
-CFLAGS+=-D_POSIX_C_SOURCE
+# https://man7.org/linux/man-pages/man2/symlink.2.html
+CFLAGS+=-D_POSIX_C_SOURCE=200112L
 CPPFLAGS+= -DTZDIR=\"$(TZDIR)\" 
 
 # more data

--- a/icu4c/source/tools/tzcode/zic.c
+++ b/icu4c/source/tools/tzcode/zic.c
@@ -3,9 +3,6 @@
 ** 2006-07-17 by Arthur David Olson.
 */
 
-/* https://man7.org/linux/man-pages/man2/symlink.2.html */
-#define _POSIX_C_SOURCE 200112L
-
 /* Enable extensions and modifications for ICU. */
 #define ICU
 


### PR DESCRIPTION
This is already set in `Makefile.in` and therefore results in a macro redefined warning if also defined in the source file. It seems that setting this in the Makefile was how it was originally intended do be done (but then it was just never updated there).

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22532
- [X] Required: The PR title must be prefixed with a JIRA Issue number.
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number.
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
