### PR TITLE
ICU-22520 Bugfix: Use macro parameter name instead of variable name

### DIFF
--- a/icu4c/source/common/uloc.cpp
+++ b/icu4c/source/common/uloc.cpp
@@ -476,7 +476,7 @@ static const CanonicalizationMap CANONICALIZE_MAP[] = {
 
 /* ### BCP47 Conversion *******************************************/
 /* Test if the locale id has BCP47 u extension and does not have '@' */
-#define _hasBCP47Extension(id) (id && uprv_strstr(id, "@") == nullptr && getShortestSubtagLength(localeID) == 1)
+#define _hasBCP47Extension(id) (id && uprv_strstr(id, "@") == nullptr && getShortestSubtagLength(id) == 1)
 /* Gets the size of the shortest subtag in the given localeID. */
 static int32_t getShortestSubtagLength(const char *localeID) {
     int32_t localeIDLength = static_cast<int32_t>(uprv_strlen(localeID));


### PR DESCRIPTION
This was added by commit a998c7cac4d53415e8e699717fc641d6617c14b3 and must surely be a mistake. The old code that was replaced used the macro parameter name `id` but the new code replacing it instead (without any explanation) used the variable name `localeID` which at that point in time was the variable name that all invocations of the macro used as the argument (so the two names happened to be interchangeable in this context).

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22520
- [X] Required: The PR title must be prefixed with a JIRA Issue number.
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number.
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
