### PR TITLE
Fix icu4c source dists not including an actual LICENSE file

### DIFF
--- a/icu4c/source/config/dist.mk
+++ b/icu4c/source/config/dist.mk
@@ -66,8 +66,8 @@ $(DISTY_FILE_TGZ) $(DISTY_FILE_ZIP) $(DISTY_DATA_ZIP):  $(DISTY_DAT) $(DISTY_TMP
 	-$(RMV) $(DISTY_FILE) $(DISTY_TMP)
 	$(MKINSTALLDIRS) $(DISTY_TMP)
 	( cd $(ICU4CTOP)/.. && git archive --format=tar --prefix=icu/ HEAD:icu4c/ ) | ( cd "$(DISTY_TMP)" && tar xf - )
-    # special handling for LICENSE file. The symlinks will be included as files by tar and zip.
-	cp -fv $(ICU4CTOP)/LICENSE "$(DISTY_TMP)/LICENSE"
+    # special handling for LICENSE file to avoid a symlink being included as files by tar and zip.
+	cp -fvL $(ICU4CTOP)/LICENSE "$(DISTY_TMP)/LICENSE"
 	( cd $(DISTY_TMP)/icu/source ; zip -rlq $(DISTY_DATA_ZIP) data )
 	$(MKINSTALLDIRS) $(DISTY_IN)
 	echo DISTY_DAT=$(DISTY_DAT)


### PR DESCRIPTION
This fixes an issue introduced by https://unicode-org.atlassian.net/browse/ICU-21964

When attempting to build the library from the `icu4c-74_2-src.tgz` release artifact, I received an error from `make install` about a nonexistent file `../LICENSE`. This was because the symlink was included in the dist that then references a file outside of the dist. Simple fix, just make the actual file is included when building the dist in the pipeline.

##### Checklist

- [ ] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
- [ ] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
