### PR TITLE
ICU-22638 Fix cast overflow issue

### DIFF
--- a/icu4c/source/i18n/plurrule.cpp
+++ b/icu4c/source/i18n/plurrule.cpp
@@ -1778,7 +1778,9 @@ void FixedDecimal::init(double n, int32_t v, int64_t f, int32_t e, int32_t c) {
     if (exponent == 0) {
         exponent = c;
     }
-    if (_isNaN || _isInfinite) {
+    if (_isNaN || _isInfinite ||
+        source > static_cast<double>(U_INT64_MAX) ||
+        source < static_cast<double>(U_INT64_MIN)) {
         v = 0;
         f = 0;
         intValue = 0;

--- a/icu4c/source/test/intltest/plurults.cpp
+++ b/icu4c/source/test/intltest/plurults.cpp
@@ -243,8 +243,8 @@ void PluralRulesTest::testAPI(/*char *par*/)
         dataerrln("ERROR: Could not create PluralRules for testing fractions - exiting");
         return;
     }
-    double fData[] =     {-101, -100, -1,     -0.0,  0,     0.1,  1,     1.999,  2.0,   100,   100.001 };
-    bool isKeywordA[] = {true, false, false, false, false, true, false,  true,   false, false, true };
+    double fData[] =     {-101, -100, -1,     -0.0,  0,     0.1,  1,     1.999,  2.0,   100,   100.001, 1.39e188 };
+    bool isKeywordA[] = {true, false, false, false, false, true, false,  true,   false, false, true, true };
     for (int32_t i=0; i<UPRV_LENGTHOF(fData); i++) {
         if ((newRules->select(fData[i])== KEYWORD_A) != isKeywordA[i]) {
              errln("File %s, Line %d, ERROR: plural rules for decimal fractions test failed!\n"


### PR DESCRIPTION
Not calling (int64_t)source if source is out of the range of int64_t
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22638
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
