### PR TITLE
ICU-22661 Limit the size of variants in Locale

### DIFF
--- a/icu4c/source/common/uloc.cpp
+++ b/icu4c/source/common/uloc.cpp
@@ -1324,14 +1324,30 @@ _getVariant(const char* localeID,
             char prev,
             ByteSink* sink,
             const char** pEnd,
-            bool needSeparator) {
-    bool hasVariant = false;
+            bool needSeparator,
+            UErrorCode& status) {
+    if (U_FAILURE(status)) return;
     if (pEnd != nullptr) { *pEnd = localeID; }
 
+    // Reasonable upper limit for variants
+    // There are no strict limitation of the syntax of variant in the legacy
+    // locale format. If the locale is constructed from unicode_locale_id
+    // as defined in UTS35, then we know each unicode_variant_subtag
+    // could have max length of 8 ((alphanum{5,8} | digit alphanum{3})
+    // 179 would allow 20 unicode_variant_subtag with sep in the
+    // unicode_locale_id
+    // 8*20 + 1*(20-1) = 179
+    constexpr int32_t MAX_VARIANTS_LENGTH = 179;
+
     /* get one or more variant tags and separate them with '_' */
-    if(_isIDSeparator(prev)) {
+    int32_t index = 0;
+    if (_isIDSeparator(prev)) {
         /* get a variant string after a '-' or '_' */
-        while(!_isTerminator(*localeID)) {
+        for (index=0; !_isTerminator(localeID[index]); index++) {
+            if (index >= MAX_VARIANTS_LENGTH) { // same as length > MAX_VARIANTS_LENGTH
+                status = U_ILLEGAL_ARGUMENT_ERROR;
+                return;
+            }
             if (needSeparator) {
                 if (sink != nullptr) {
                     sink->Append("_", 1);
@@ -1339,26 +1355,28 @@ _getVariant(const char* localeID,
                 needSeparator = false;
             }
             if (sink != nullptr) {
-                char c = (char)uprv_toupper(*localeID);
+                char c = (char)uprv_toupper(localeID[index]);
                 if (c == '-') c = '_';
                 sink->Append(&c, 1);
             }
-            hasVariant = true;
-            localeID++;
         }
-        if (pEnd != nullptr) { *pEnd = localeID; }
+        if (pEnd != nullptr) { *pEnd = localeID+index; }
     }
 
     /* if there is no variant tag after a '-' or '_' then look for '@' */
-    if(!hasVariant) {
-        if(prev=='@') {
+    if (index == 0) {
+        if (prev=='@') {
             /* keep localeID */
         } else if((localeID=locale_getKeywordsStart(localeID))!=nullptr) {
             ++localeID; /* point after the '@' */
         } else {
             return;
         }
-        while(!_isTerminator(*localeID)) {
+        for(; !_isTerminator(localeID[index]); index++) {
+            if (index >= MAX_VARIANTS_LENGTH) { // same as length > MAX_VARIANTS_LENGTH
+                status = U_ILLEGAL_ARGUMENT_ERROR;
+                return;
+            }
             if (needSeparator) {
                 if (sink != nullptr) {
                     sink->Append("_", 1);
@@ -1366,13 +1384,12 @@ _getVariant(const char* localeID,
                 needSeparator = false;
             }
             if (sink != nullptr) {
-                char c = (char)uprv_toupper(*localeID);
+                char c = (char)uprv_toupper(localeID[index]);
                 if (c == '-' || c == ',') c = '_';
                 sink->Append(&c, 1);
             }
-            localeID++;
         }
-        if (pEnd != nullptr) { *pEnd = localeID; }
+        if (pEnd != nullptr) { *pEnd = localeID + index; }
     }
 }
 
@@ -1545,7 +1562,8 @@ ulocimp_getSubtags(
         }
         const char* begin = localeID + 1;
         const char* end = nullptr;
-        _getVariant(begin, *localeID, variant, &end, false);
+        _getVariant(begin, *localeID, variant, &end, false, status);
+        if (U_FAILURE(status)) { return; }
         U_ASSERT(end != nullptr);
         if (end != begin && pEnd != nullptr) { *pEnd = end; }
     }
@@ -1842,7 +1860,8 @@ _canonicalize(const char* localeID,
             }
 
             CharStringByteSink s(&tag);
-            _getVariant(tmpLocaleID+1, '@', &s, nullptr, !variant.isEmpty());
+            _getVariant(tmpLocaleID+1, '@', &s, nullptr, !variant.isEmpty(), err);
+            if (U_FAILURE(err)) { return; }
         }
 
         /* Look up the ID in the canonicalization map */

--- a/icu4c/source/common/unicode/locid.h
+++ b/icu4c/source/common/unicode/locid.h
@@ -1211,7 +1211,7 @@ Locale::getScript() const
 inline const char *
 Locale::getVariant() const
 {
-    return &baseName[variantBegin];
+    return fIsBogus ? "" : &baseName[variantBegin];
 }
 
 inline const char *

--- a/icu4c/source/i18n/dtptngen.cpp
+++ b/icu4c/source/i18n/dtptngen.cpp
@@ -511,6 +511,11 @@ enum AllowedHourFormat{
 void
 DateTimePatternGenerator::initData(const Locale& locale, UErrorCode &status, UBool skipStdPatterns) {
     //const char *baseLangName = locale.getBaseName(); // unused
+    if (U_FAILURE(status)) { return; }
+    if (locale.isBogus()) {
+        status = U_ILLEGAL_ARGUMENT_ERROR;
+        return;
+    }
 
     skipMatcher = nullptr;
     fAvailableFormatKeyHash=nullptr;

--- a/icu4c/source/test/cintltst/cloctst.h
+++ b/icu4c/source/test/cintltst/cloctst.h
@@ -25,6 +25,8 @@
  **/
 static void TestBasicGetters(void);
 static void TestPrefixes(void);
+static void TestVariantLengthLimit(void);
+
 /**
  * Use Locale to access Resource file data and compare against expected values
  **/

--- a/icu4c/source/test/intltest/loctest.cpp
+++ b/icu4c/source/test/intltest/loctest.cpp
@@ -202,6 +202,7 @@ void LocaleTest::runIndexedTest( int32_t index, UBool exec, const char* &name, c
     TESTCASE_AUTO_BEGIN;
     TESTCASE_AUTO(TestBug11421);         // Must run early in list to trigger failure.
     TESTCASE_AUTO(TestBasicGetters);
+    TESTCASE_AUTO(TestVariantLengthLimit);
     TESTCASE_AUTO(TestSimpleResourceInfo);
     TESTCASE_AUTO(TestDisplayNames);
     TESTCASE_AUTO(TestSimpleObjectStuff);
@@ -403,6 +404,69 @@ void LocaleTest::TestBasicGetters() {
         errln("Locale.clone() failed");
     }
     delete pb;
+}
+
+void LocaleTest::TestVariantLengthLimit() {
+    static constexpr char valid[] =
+        "_"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678";
+
+    static constexpr char invalid[] =
+        "_"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678"
+        "_12345678X";  // One character too long.
+
+    constexpr const char* variantsExpected = valid + 2;  // Skip initial "__".
+
+    Locale validLocale(valid);
+    if (validLocale.isBogus()) {
+        errln("Valid locale is unexpectedly bogus.");
+    } else if (uprv_strcmp(variantsExpected, validLocale.getVariant()) != 0) {
+        errln("Expected variants \"%s\" but got variants \"%s\"\n",
+              variantsExpected, validLocale.getVariant());
+    }
+
+    Locale invalidLocale(invalid);
+    if (!invalidLocale.isBogus()) {
+        errln("Invalid locale is unexpectedly NOT bogus.");
+    }
 }
 
 void LocaleTest::TestParallelAPIValues() {

--- a/icu4c/source/test/intltest/loctest.h
+++ b/icu4c/source/test/intltest/loctest.h
@@ -23,6 +23,7 @@ public:
      * Test methods to set and get data fields
      **/
     void TestBasicGetters();
+    void TestVariantLengthLimit();
     /**
      * Test methods to set and get data fields
      **/

--- a/icu4j/main/collate/src/test/java/com/ibm/icu/dev/test/util/ICUResourceBundleCollationTest.java
+++ b/icu4j/main/collate/src/test/java/com/ibm/icu/dev/test/util/ICUResourceBundleCollationTest.java
@@ -150,6 +150,70 @@ public final class ICUResourceBundleCollationTest extends TestFmwk {
     }
 
     @Test
+    public void TestGetFunctionalEquivalentVariantLengthWithinLimit() {
+        String valid =
+            "_" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678";
+
+        ULocale equivLocale = ICUResourceBundle.getFunctionalEquivalent(
+            ICUData.ICU_BASE_NAME, ICUResourceBundle.ICU_DATA_CLASS_LOADER,
+            "calendar", "calendar", new ULocale(valid), new boolean[1], false);
+        ULocale localeExpected = new ULocale("_@calendar=gregorian");
+        if(!equivLocale.equals(localeExpected)) {
+            errln("Get unexpected locale:" + equivLocale.toString() +
+                " while expecting " + localeExpected.toString());
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void TestGetFunctionalEquivalentVariantLengthOverLimit() {
+        String invalid =
+            "_" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678X";  // One character too long.
+        ULocale equivLocale2 = ICUResourceBundle.getFunctionalEquivalent(
+            ICUData.ICU_BASE_NAME, ICUResourceBundle.ICU_DATA_CLASS_LOADER,
+            "calendar", "calendar", new ULocale(invalid), new boolean[1], false);
+    }
+
+    @Test
     public void TestOpen(){
         UResourceBundle bundle = UResourceBundle.getBundleInstance(ICUData.ICU_COLLATION_BASE_NAME, "en_US_POSIX");
         if(bundle==null){

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/util/ULocaleTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/util/ULocaleTest.java
@@ -5438,6 +5438,63 @@ public class ULocaleTest extends CoreTestFmwk {
 
     }
 
+
+    @Test
+    public void TestVariantLengthWithinLimit() {
+        String valid =
+            "_" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678";
+
+        ULocale locale = new ULocale(valid);
+        Assert.assertEquals(valid.substring(2), locale.getVariant());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void TestVariantLengthOverLimit() {
+        String invalid =
+            "_" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678" +
+            "_12345678X";  // One character too long.
+        ULocale locale = new ULocale(invalid);
+    }
+
     @Test
     public void TestLocaleCanonicalizationFromFile() throws IOException {
         BufferedReader testFile = TestUtil.getDataReader("cldr/localeIdentifiers/localeCanonicalization.txt");

--- a/icu4j/main/core/src/main/java/com/ibm/icu/impl/LocaleIDParser.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/impl/LocaleIDParser.java
@@ -365,6 +365,15 @@ public final class LocaleIDParser {
         }
     }
 
+    // There are no strict limitation of the syntax of variant in the legacy
+    // locale format. If the locale is constructed from unicode_locale_id
+    // as defined in UTS35, then we know each unicode_variant_subtag
+    // could have max length of 8 ((alphanum{5,8} | digit alphanum{3})
+    // 179 would allow 20 unicode_variant_subtag with sep in the
+    // unicode_locale_id
+    // 8*20 + 1*(20-1) = 179
+    private static final int MAX_VARIANTS_LENGTH = 179;
+
     /**
      * Advance index past variant, and accumulate normalized variant in buffer.  This ignores
      * the codepage information from POSIX ids.  Index must be immediately after the country
@@ -432,10 +441,12 @@ public final class LocaleIDParser {
                     c = UNDERSCORE;
                 }
                 append(c);
+                if (buffer.length() - oldBlen > MAX_VARIANTS_LENGTH) {
+                    throw new IllegalArgumentException("variants is too long");
+                }
             }
         }
         --index; // unget
-
         return oldBlen;
     }
 


### PR DESCRIPTION
Limit the size of acceptable variants in Locale to avoid long running time of 
resource fallback look up when trying all different combinations of many variants.

I first try to limit to the max size of 10 variants but some test break, so I change it to 20 now.

Also ensure the Locale::getVariant will not return invalid address while the locale is bogus.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22661
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
