### PR TITLE
ICU-22520 Use C++ function signatures for internal C++ functions

### DIFF
--- a/icu4c/source/common/localebuilder.cpp
+++ b/icu4c/source/common/localebuilder.cpp
@@ -10,16 +10,14 @@
 #include "unicode/localebuilder.h"
 #include "unicode/locid.h"
 
-U_NAMESPACE_BEGIN
-
 namespace {
+
 inline bool UPRV_ISDIGIT(char c) { return c >= '0' && c <= '9'; }
 inline bool UPRV_ISALPHANUM(char c) { return uprv_isASCIILetter(c) || UPRV_ISDIGIT(c); }
-}  // namespace
 
 constexpr const char* kAttributeKey = "attribute";
 
-static bool _isExtensionSubtags(char key, const char* s, int32_t len) {
+bool _isExtensionSubtags(char key, const char* s, int32_t len) {
     switch (uprv_tolower(key)) {
         case 'u':
             return ultag_isUnicodeExtensionSubtags(s, len);
@@ -31,6 +29,10 @@ static bool _isExtensionSubtags(char key, const char* s, int32_t len) {
             return ultag_isExtensionSubtags(s, len);
     }
 }
+
+}  // namespace
+
+U_NAMESPACE_BEGIN
 
 LocaleBuilder::LocaleBuilder() : UObject(), status_(U_ZERO_ERROR), language_(),
     script_(), region_(), variant_(nullptr), extensions_(nullptr)
@@ -70,8 +72,10 @@ LocaleBuilder& LocaleBuilder::setLanguageTag(StringPiece tag)
     return *this;
 }
 
-static void setField(StringPiece input, char* dest, UErrorCode& errorCode,
-                     UBool (*test)(const char*, int32_t)) {
+namespace {
+
+void setField(StringPiece input, char* dest, UErrorCode& errorCode,
+              bool (*test)(const char*, int32_t)) {
     if (U_FAILURE(errorCode)) { return; }
     if (input.empty()) {
         dest[0] = '\0';
@@ -82,6 +86,8 @@ static void setField(StringPiece input, char* dest, UErrorCode& errorCode,
         errorCode = U_ILLEGAL_ARGUMENT_ERROR;
     }
 }
+
+}  // namespace
 
 LocaleBuilder& LocaleBuilder::setLanguage(StringPiece language)
 {
@@ -101,7 +107,9 @@ LocaleBuilder& LocaleBuilder::setRegion(StringPiece region)
     return *this;
 }
 
-static void transform(char* data, int32_t len) {
+namespace {
+
+void transform(char* data, int32_t len) {
     for (int32_t i = 0; i < len; i++, data++) {
         if (*data == '_') {
             *data = '-';
@@ -110,6 +118,8 @@ static void transform(char* data, int32_t len) {
         }
     }
 }
+
+}  // namespace
 
 LocaleBuilder& LocaleBuilder::setVariant(StringPiece variant)
 {
@@ -136,7 +146,9 @@ LocaleBuilder& LocaleBuilder::setVariant(StringPiece variant)
     return *this;
 }
 
-static bool
+namespace {
+
+bool
 _isKeywordValue(const char* key, const char* value, int32_t value_len)
 {
     if (key[1] == '\0') {
@@ -158,7 +170,7 @@ _isKeywordValue(const char* key, const char* value, int32_t value_len)
            ultag_isUnicodeLocaleType(unicode_locale_type, -1);
 }
 
-static void
+void
 _copyExtensions(const Locale& from, icu::StringEnumeration *keywords,
                 Locale& to, bool validate, UErrorCode& errorCode)
 {
@@ -188,7 +200,7 @@ _copyExtensions(const Locale& from, icu::StringEnumeration *keywords,
     }
 }
 
-void static
+void
 _clearUAttributesAndKeyType(Locale& locale, UErrorCode& errorCode)
 {
     // Clear Unicode attributes
@@ -203,7 +215,7 @@ _clearUAttributesAndKeyType(Locale& locale, UErrorCode& errorCode)
     }
 }
 
-static void
+void
 _setUnicodeExtensions(Locale& locale, const CharString& value, UErrorCode& errorCode)
 {
     // Add the unicode extensions to extensions_
@@ -213,6 +225,8 @@ _setUnicodeExtensions(Locale& locale, const CharString& value, UErrorCode& error
         Locale::forLanguageTag(locale_str.data(), errorCode), nullptr,
         locale, false, errorCode);
 }
+
+}  // namespace
 
 LocaleBuilder& LocaleBuilder::setExtension(char key, StringPiece value)
 {

--- a/icu4c/source/common/locavailable.cpp
+++ b/icu4c/source/common/locavailable.cpp
@@ -39,14 +39,10 @@ static icu::Locale*  availableLocaleList = nullptr;
 static int32_t  availableLocaleListCount;
 static icu::UInitOnce gInitOnceLocale {};
 
-U_NAMESPACE_END
+namespace {
 
-U_CDECL_BEGIN
-
-static UBool U_CALLCONV locale_available_cleanup()
+UBool U_CALLCONV locale_available_cleanup()
 {
-    U_NAMESPACE_USE
-
     if (availableLocaleList) {
         delete []availableLocaleList;
         availableLocaleList = nullptr;
@@ -57,9 +53,7 @@ static UBool U_CALLCONV locale_available_cleanup()
     return true;
 }
 
-U_CDECL_END
-
-U_NAMESPACE_BEGIN
+}  // namespace
 
 void U_CALLCONV locale_available_init() {
     // This function is a friend of class Locale.
@@ -196,7 +190,7 @@ class AvailableLocalesStringEnumeration : public StringEnumeration {
 
 /* ### Get available **************************************************/
 
-static UBool U_CALLCONV uloc_cleanup() {
+UBool U_CALLCONV uloc_cleanup() {
     for (int32_t i = 0; i < UPRV_LENGTHOF(gAvailableLocaleNames); i++) {
         uprv_free(gAvailableLocaleNames[i]);
         gAvailableLocaleNames[i] = nullptr;
@@ -209,7 +203,7 @@ static UBool U_CALLCONV uloc_cleanup() {
 // Load Installed Locales. This function will be called exactly once
 //   via the initOnce mechanism.
 
-static void U_CALLCONV loadInstalledLocales(UErrorCode& status) {
+void U_CALLCONV loadInstalledLocales(UErrorCode& status) {
     ucln_common_registerCleanup(UCLN_COMMON_ULOC, uloc_cleanup);
 
     icu::LocalUResourceBundlePointer rb(ures_openDirect(nullptr, "res_index", &status));
@@ -267,4 +261,3 @@ uloc_openAvailableByType(ULocAvailableType type, UErrorCode* status) {
     }
     return uenum_openFromStringEnumeration(result.orphan(), status);
 }
-

--- a/icu4c/source/common/locdistance.cpp
+++ b/icu4c/source/common/locdistance.cpp
@@ -399,7 +399,7 @@ int32_t LocaleDistance::trieNext(BytesTrie &iter, const char *s, bool wantValue)
     }
 }
 
-UBool LocaleDistance::isParadigmLSR(const LSR &lsr) const {
+bool LocaleDistance::isParadigmLSR(const LSR &lsr) const {
     // Linear search for a very short list (length 6 as of 2019),
     // because we look for equivalence not equality, and
     // because it's easy.

--- a/icu4c/source/common/locdistance.h
+++ b/icu4c/source/common/locdistance.h
@@ -62,7 +62,7 @@ public:
                                     ULocMatchFavorSubtag favorSubtag,
                                     ULocMatchDirection direction) const;
 
-    UBool isParadigmLSR(const LSR &lsr) const;
+    bool isParadigmLSR(const LSR &lsr) const;
 
     int32_t getDefaultScriptDistance() const {
         return defaultScriptDistance;
@@ -89,8 +89,8 @@ private:
 
     static void initLocaleDistance(UErrorCode &errorCode);
 
-    UBool isMatch(const LSR &desired, const LSR &supported,
-                  int32_t shiftedThreshold, ULocMatchFavorSubtag favorSubtag) const {
+    bool isMatch(const LSR &desired, const LSR &supported,
+                 int32_t shiftedThreshold, ULocMatchFavorSubtag favorSubtag) const {
         const LSR *pSupp = &supported;
         return getBestIndexAndDistance(
             desired, &pSupp, 1,

--- a/icu4c/source/common/locdspnm.cpp
+++ b/icu4c/source/common/locdspnm.cpp
@@ -264,7 +264,7 @@ class LocaleDisplayNamesImpl : public LocaleDisplayNames {
     };
     // Capitalization transforms. For each usage type, indicates whether to titlecase for
     // the context specified in capitalizationContext (which we know at construction time)
-     UBool fCapitalization[kCapContextUsageCount];
+     bool fCapitalization[kCapContextUsageCount];
 
 public:
     // constructor
@@ -300,12 +300,12 @@ private:
                                 UnicodeString& result, bool substitute) const;
     UnicodeString& appendWithSep(UnicodeString& buffer, const UnicodeString& src) const;
     UnicodeString& adjustForUsageAndContext(CapContextUsage usage, UnicodeString& result) const;
-    UnicodeString& scriptDisplayName(const char* script, UnicodeString& result, UBool skipAdjust) const;
-    UnicodeString& regionDisplayName(const char* region, UnicodeString& result, UBool skipAdjust) const;
-    UnicodeString& variantDisplayName(const char* variant, UnicodeString& result, UBool skipAdjust) const;
-    UnicodeString& keyDisplayName(const char* key, UnicodeString& result, UBool skipAdjust) const;
+    UnicodeString& scriptDisplayName(const char* script, UnicodeString& result, bool skipAdjust) const;
+    UnicodeString& regionDisplayName(const char* region, UnicodeString& result, bool skipAdjust) const;
+    UnicodeString& variantDisplayName(const char* variant, UnicodeString& result, bool skipAdjust) const;
+    UnicodeString& keyDisplayName(const char* key, UnicodeString& result, bool skipAdjust) const;
     UnicodeString& keyValueDisplayName(const char* key, const char* value,
-                                        UnicodeString& result, UBool skipAdjust) const;
+                                        UnicodeString& result, bool skipAdjust) const;
     void initialize();
 
     struct CapitalizationContextSink;
@@ -358,7 +358,7 @@ LocaleDisplayNamesImpl::LocaleDisplayNamesImpl(const Locale& locale,
 }
 
 struct LocaleDisplayNamesImpl::CapitalizationContextSink : public ResourceSink {
-    UBool hasCapitalizationUsage;
+    bool hasCapitalizationUsage;
     LocaleDisplayNamesImpl& parent;
 
     CapitalizationContextSink(LocaleDisplayNamesImpl& _parent)
@@ -449,7 +449,7 @@ LocaleDisplayNamesImpl::initialize() {
 #if !UCONFIG_NO_BREAK_ITERATION
     // Only get the context data if we need it! This is a const object so we know now...
     // Also check whether we will need a break iterator (depends on the data)
-    UBool needBrkIter = false;
+    bool needBrkIter = false;
     if (capitalizationContext == UDISPCTX_CAPITALIZATION_FOR_UI_LIST_OR_MENU || capitalizationContext == UDISPCTX_CAPITALIZATION_FOR_STANDALONE) {
         LocalUResourceBundlePointer resource(ures_open(nullptr, locale.getName(), &status));
         if (U_FAILURE(status)) { return; }
@@ -541,9 +541,9 @@ LocaleDisplayNamesImpl::localeDisplayName(const Locale& loc,
   const char* country = loc.getCountry();
   const char* variant = loc.getVariant();
 
-  UBool hasScript = uprv_strlen(script) > 0;
-  UBool hasCountry = uprv_strlen(country) > 0;
-  UBool hasVariant = uprv_strlen(variant) > 0;
+  bool hasScript = uprv_strlen(script) > 0;
+  bool hasCountry = uprv_strlen(country) > 0;
+  bool hasVariant = uprv_strlen(variant) > 0;
 
   if (dialectHandling == ULDN_DIALECT_NAMES) {
     UErrorCode status = U_ZERO_ERROR;
@@ -755,7 +755,7 @@ LocaleDisplayNamesImpl::languageDisplayName(const char* lang,
 UnicodeString&
 LocaleDisplayNamesImpl::scriptDisplayName(const char* script,
                                           UnicodeString& result,
-                                          UBool skipAdjust) const {
+                                          bool skipAdjust) const {
     if (nameLength == UDISPCTX_LENGTH_SHORT) {
         langData.getNoFallback("Scripts%short", script, result);
         if (!result.isBogus()) {
@@ -785,7 +785,7 @@ LocaleDisplayNamesImpl::scriptDisplayName(UScriptCode scriptCode,
 UnicodeString&
 LocaleDisplayNamesImpl::regionDisplayName(const char* region,
                                           UnicodeString& result,
-                                          UBool skipAdjust) const {
+                                          bool skipAdjust) const {
     if (nameLength == UDISPCTX_LENGTH_SHORT) {
          regionData.getNoFallback("Countries%short", region, result);
         if (!result.isBogus()) {
@@ -810,7 +810,7 @@ LocaleDisplayNamesImpl::regionDisplayName(const char* region,
 UnicodeString&
 LocaleDisplayNamesImpl::variantDisplayName(const char* variant,
                                            UnicodeString& result,
-                                           UBool skipAdjust) const {
+                                           bool skipAdjust) const {
     // don't have a resource for short variant names
     if (substitute == UDISPCTX_SUBSTITUTE) {
         langData.get("Variants", variant, result);
@@ -829,7 +829,7 @@ LocaleDisplayNamesImpl::variantDisplayName(const char* variant,
 UnicodeString&
 LocaleDisplayNamesImpl::keyDisplayName(const char* key,
                                        UnicodeString& result,
-                                       UBool skipAdjust) const {
+                                       bool skipAdjust) const {
     // don't have a resource for short key names
     if (substitute == UDISPCTX_SUBSTITUTE) {
         langData.get("Keys", key, result);
@@ -849,7 +849,7 @@ UnicodeString&
 LocaleDisplayNamesImpl::keyValueDisplayName(const char* key,
                                             const char* value,
                                             UnicodeString& result,
-                                            UBool skipAdjust) const {
+                                            bool skipAdjust) const {
     if (uprv_strcmp(key, "currency") == 0) {
         // ICU4C does not have ICU4J CurrencyDisplayInfo equivalent for now.
         UErrorCode sts = U_ZERO_ERROR;

--- a/icu4c/source/common/loclikelysubtags.cpp
+++ b/icu4c/source/common/loclikelysubtags.cpp
@@ -351,7 +351,7 @@ UBool U_CALLCONV cleanup() {
     return true;
 }
 
-static const char16_t* MACROREGION_HARDCODE[] = {
+constexpr const char16_t* MACROREGION_HARDCODE[] = {
     u"001~3",
     u"005",
     u"009",
@@ -378,8 +378,8 @@ static const char16_t* MACROREGION_HARDCODE[] = {
     u"UN",
 };
 
-static const char16_t RANGE_MARKER = 0x7E; /* '~' */
-static void processMacroregionRange(const UnicodeString& regionName, UVector* newMacroRegions, UErrorCode& status) {
+constexpr char16_t RANGE_MARKER = 0x7E; /* '~' */
+void processMacroregionRange(const UnicodeString& regionName, UVector* newMacroRegions, UErrorCode& status) {
     int32_t rangeMarkerLocation = regionName.indexOf(RANGE_MARKER);
     char16_t buf[6];
     regionName.extract(buf,6,status);

--- a/icu4c/source/common/locresdata.cpp
+++ b/icu4c/source/common/locresdata.cpp
@@ -150,21 +150,23 @@ uloc_getTableStringWithFallback(const char *path, const char *locale,
     return item;
 }
 
-static ULayoutType
+namespace {
+
+ULayoutType
 _uloc_getOrientationHelper(const char* localeId,
                            const char* key,
-                           UErrorCode *status)
+                           UErrorCode& status)
 {
     ULayoutType result = ULOC_LAYOUT_UNKNOWN;
 
-    if (!U_FAILURE(*status)) {
+    if (!U_FAILURE(status)) {
         icu::CharString localeBuffer;
         {
             icu::CharStringByteSink sink(&localeBuffer);
             ulocimp_canonicalize(localeId, sink, status);
         }
 
-        if (!U_FAILURE(*status)) {
+        if (!U_FAILURE(status)) {
             int32_t length = 0;
             const char16_t* const value =
                 uloc_getTableStringWithFallback(
@@ -174,9 +176,9 @@ _uloc_getOrientationHelper(const char* localeId,
                     nullptr,
                     key,
                     &length,
-                    status);
+                    &status);
 
-            if (!U_FAILURE(*status) && length != 0) {
+            if (!U_FAILURE(status) && length != 0) {
                 switch(value[0])
                 {
                 case 0x0062: /* 'b' */
@@ -192,7 +194,7 @@ _uloc_getOrientationHelper(const char* localeId,
                     result = ULOC_LAYOUT_TTB;
                     break;
                 default:
-                    *status = U_INTERNAL_PROGRAM_ERROR;
+                    status = U_INTERNAL_PROGRAM_ERROR;
                     break;
                 }
             }
@@ -202,11 +204,13 @@ _uloc_getOrientationHelper(const char* localeId,
     return result;
 }
 
+}  // namespace
+
 U_CAPI ULayoutType U_EXPORT2
 uloc_getCharacterOrientation(const char* localeId,
                              UErrorCode *status)
 {
-    return _uloc_getOrientationHelper(localeId, "characters", status);
+    return _uloc_getOrientationHelper(localeId, "characters", *status);
 }
 
 /**
@@ -220,5 +224,5 @@ U_CAPI ULayoutType U_EXPORT2
 uloc_getLineOrientation(const char* localeId,
                         UErrorCode *status)
 {
-    return _uloc_getOrientationHelper(localeId, "lines", status);
+    return _uloc_getOrientationHelper(localeId, "lines", *status);
 }

--- a/icu4c/source/common/locutil.cpp
+++ b/icu4c/source/common/locutil.cpp
@@ -262,7 +262,7 @@ LocaleUtility::getAvailableLocaleNames(const UnicodeString& bundleID)
     return htp;
 }
 
-UBool
+bool
 LocaleUtility::isFallbackOf(const UnicodeString& root, const UnicodeString& child)
 {
     return child.indexOf(root) == 0 &&
@@ -274,5 +274,3 @@ U_NAMESPACE_END
 
 /* !UCONFIG_NO_SERVICE */
 #endif
-
-

--- a/icu4c/source/common/locutil.h
+++ b/icu4c/source/common/locutil.h
@@ -28,7 +28,7 @@ public:
   static Locale& initLocaleFromName(const UnicodeString& id, Locale& result);
   static UnicodeString& initNameFromLocale(const Locale& locale, UnicodeString& result);
   static const Hashtable* getAvailableLocaleNames(const UnicodeString& bundleID);
-  static UBool isFallbackOf(const UnicodeString& root, const UnicodeString& child);
+  static bool isFallbackOf(const UnicodeString& root, const UnicodeString& child);
 };
 
 U_NAMESPACE_END

--- a/icu4c/source/common/ucurr.cpp
+++ b/icu4c/source/common/ucurr.cpp
@@ -352,7 +352,7 @@ _findMetaData(const char16_t* currency, UErrorCode& ec) {
 static CharString
 idForLocale(const char* locale, UErrorCode* ec)
 {
-    return ulocimp_getRegionForSupplementalData(locale, false, ec);
+    return ulocimp_getRegionForSupplementalData(locale, false, *ec);
 }
 
 // ------------------------------------------
@@ -526,7 +526,7 @@ ucurr_forLocale(const char* locale,
     CharString currency;
     {
         CharStringByteSink sink(&currency);
-        ulocimp_getKeywordValue(locale, "currency", sink, &localStatus);
+        ulocimp_getKeywordValue(locale, "currency", sink, localStatus);
     }
     int32_t resLen = currency.length();
 
@@ -605,7 +605,7 @@ ucurr_forLocale(const char* locale,
         CharString parent;
         {
             CharStringByteSink sink(&parent);
-            ulocimp_getParent(locale, sink, ec);
+            ulocimp_getParent(locale, sink, *ec);
         }
         *ec = U_USING_FALLBACK_WARNING;
         // TODO: Loop over the parent rather than recursing and
@@ -647,7 +647,7 @@ static UBool fallback(CharString& loc) {
     } else {
         CharString tmp;
         CharStringByteSink sink(&tmp);
-        ulocimp_getParent(loc.data(), sink, &status);
+        ulocimp_getParent(loc.data(), sink, status);
         loc = std::move(tmp);
     }
  /*
@@ -706,7 +706,7 @@ ucurr_getName(const char16_t* currency,
     CharString loc;
     {
         CharStringByteSink sink(&loc);
-        ulocimp_getName(locale, sink, &ec2);
+        ulocimp_getName(locale, sink, ec2);
     }
     if (U_FAILURE(ec2)) {
         *ec = U_ILLEGAL_ARGUMENT_ERROR;
@@ -808,7 +808,7 @@ ucurr_getPluralName(const char16_t* currency,
     CharString loc;
     {
         CharStringByteSink sink(&loc);
-        ulocimp_getName(locale, sink, &ec2);
+        ulocimp_getName(locale, sink, ec2);
     }
     if (U_FAILURE(ec2)) {
         *ec = U_ILLEGAL_ARGUMENT_ERROR;
@@ -1003,7 +1003,7 @@ collectCurrencyNames(const char* locale,
     CharString loc;
     {
         CharStringByteSink sink(&loc);
-        ulocimp_getName(locale, sink, &ec2);
+        ulocimp_getName(locale, sink, ec2);
     }
     if (U_FAILURE(ec2)) {
         ec = U_ILLEGAL_ARGUMENT_ERROR;
@@ -2583,7 +2583,7 @@ static const UEnumeration defaultKeywordValues = {
 
 U_CAPI UEnumeration *U_EXPORT2 ucurr_getKeywordValuesForLocale(const char *key, const char *locale, UBool commonlyUsed, UErrorCode* status) {
     // Resolve region
-    CharString prefRegion = ulocimp_getRegionForSupplementalData(locale, true, status);
+    CharString prefRegion = ulocimp_getRegionForSupplementalData(locale, true, *status);
 
     // Read value from supplementalData
     UList *values = ulist_createEmptyList(status);

--- a/icu4c/source/common/uloc.cpp
+++ b/icu4c/source/common/uloc.cpp
@@ -60,6 +60,8 @@ U_NAMESPACE_USE
 U_CFUNC void locale_set_default(const char *id);
 U_CFUNC const char *locale_get_default();
 
+namespace {
+
 /* ### Data tables **************************************************/
 
 /**
@@ -96,7 +98,7 @@ U_CFUNC const char *locale_get_default();
 /* Generated using org.unicode.cldr.icu.GenerateISO639LanguageTables */
 /* ISO639 table version is 20150505 */
 /* Subsequent hand addition of selected languages */
-static const char * const LANGUAGES[] = {
+constexpr const char* LANGUAGES[] = {
     "aa",  "ab",  "ace", "ach", "ada", "ady", "ae",  "aeb",
     "af",  "afh", "agq", "ain", "ak",  "akk", "akz", "ale",
     "aln", "alt", "am",  "an",  "ang", "anp", "ar",  "arc",
@@ -187,10 +189,10 @@ nullptr,
 nullptr
 };
 
-static const char* const DEPRECATED_LANGUAGES[]={
+constexpr const char* DEPRECATED_LANGUAGES[]={
     "in", "iw", "ji", "jw", "mo", nullptr, nullptr
 };
-static const char* const REPLACEMENT_LANGUAGES[]={
+constexpr const char* REPLACEMENT_LANGUAGES[]={
     "id", "he", "yi", "jv", "ro", nullptr, nullptr
 };
 
@@ -213,7 +215,7 @@ static const char* const REPLACEMENT_LANGUAGES[]={
 /* Generated using org.unicode.cldr.icu.GenerateISO639LanguageTables */
 /* ISO639 table version is 20150505 */
 /* Subsequent hand addition of selected languages */
-static const char * const LANGUAGES_3[] = {
+constexpr const char* LANGUAGES_3[] = {
     "aar", "abk", "ace", "ach", "ada", "ady", "ave", "aeb",
     "afr", "afh", "agq", "ain", "aka", "akk", "akz", "ale",
     "aln", "alt", "amh", "arg", "ang", "anp", "ara", "arc",
@@ -329,7 +331,7 @@ nullptr
  * RO(ROM) is now RO(ROU) according to
  * http://www.iso.org/iso/en/prods-services/iso3166ma/03updates-on-iso-3166/nlv3e-rou.html
  */
-static const char * const COUNTRIES[] = {
+constexpr const char* COUNTRIES[] = {
     "AD",  "AE",  "AF",  "AG",  "AI",  "AL",  "AM",
     "AO",  "AQ",  "AR",  "AS",  "AT",  "AU",  "AW",  "AX",  "AZ",
     "BA",  "BB",  "BD",  "BE",  "BF",  "BG",  "BH",  "BI",
@@ -365,10 +367,10 @@ nullptr,
 nullptr
 };
 
-static const char* const DEPRECATED_COUNTRIES[] = {
+constexpr const char* DEPRECATED_COUNTRIES[] = {
     "AN", "BU", "CS", "DD", "DY", "FX", "HV", "NH", "RH", "SU", "TP", "UK", "VD", "YD", "YU", "ZR", nullptr, nullptr /* deprecated country list */
 };
-static const char* const REPLACEMENT_COUNTRIES[] = {
+constexpr const char* REPLACEMENT_COUNTRIES[] = {
 /*  "AN", "BU", "CS", "DD", "DY", "FX", "HV", "NH", "RH", "SU", "TP", "UK", "VD", "YD", "YU", "ZR" */
     "CW", "MM", "RS", "DE", "BJ", "FR", "BF", "VU", "ZW", "RU", "TL", "GB", "VN", "YE", "RS", "CD", nullptr, nullptr  /* replacement country codes */
 };
@@ -386,7 +388,7 @@ static const char* const REPLACEMENT_COUNTRIES[] = {
  * second list, and another nullptr entry.  The two lists correspond to
  * the two lists in COUNTRIES.
  */
-static const char * const COUNTRIES_3[] = {
+constexpr const char* COUNTRIES_3[] = {
 /*  "AD",  "AE",  "AF",  "AG",  "AI",  "AL",  "AM",      */
     "AND", "ARE", "AFG", "ATG", "AIA", "ALB", "ARM",
 /*  "AO",  "AQ",  "AR",  "AS",  "AT",  "AU",  "AW",  "AX",  "AZ",     */
@@ -462,7 +464,7 @@ typedef struct CanonicalizationMap {
  * A map to canonicalize locale IDs.  This handles a variety of
  * different semantic kinds of transformations.
  */
-static const CanonicalizationMap CANONICALIZE_MAP[] = {
+constexpr CanonicalizationMap CANONICALIZE_MAP[] = {
     { "art__LOJBAN",    "jbo" }, /* registered name */
     { "hy__AREVELA",    "hy" }, /* Registered IANA variant */
     { "hy__AREVMDA",    "hyw" }, /* Registered IANA variant */
@@ -476,8 +478,6 @@ static const CanonicalizationMap CANONICALIZE_MAP[] = {
     { "zh_YUE",         "yue" }, /* registered name */
 };
 
-namespace {
-
 /* ### BCP47 Conversion *******************************************/
 /* Gets the size of the shortest subtag in the given localeID. */
 int32_t getShortestSubtagLength(const char *localeID) {
@@ -485,7 +485,7 @@ int32_t getShortestSubtagLength(const char *localeID) {
     int32_t length = localeIDLength;
     int32_t tmpLength = 0;
     int32_t i;
-    UBool reset = true;
+    bool reset = true;
 
     for (i = 0; i < localeIDLength; i++) {
         if (localeID[i] != '_' && localeID[i] != '-') {
@@ -544,24 +544,26 @@ locale_getKeywordsStart(const char *localeID) {
     return nullptr;
 }
 
+namespace {
+
 /**
  * @param keywordName incoming name to be canonicalized
  * @param status return status (keyword too long)
  * @return the keyword name
  */
-static CharString locale_canonKeywordName(const char *keywordName, UErrorCode *status)
+CharString locale_canonKeywordName(const char* keywordName, UErrorCode& status)
 {
   CharString result;
 
   for (; *keywordName != 0; keywordName++) {
     if (!UPRV_ISALPHANUM(*keywordName)) {
-      *status = U_ILLEGAL_ARGUMENT_ERROR; /* malformed keyword name */
+      status = U_ILLEGAL_ARGUMENT_ERROR; /* malformed keyword name */
       return result;
     }
-    result.append(uprv_tolower(*keywordName), *status);
+    result.append(uprv_tolower(*keywordName), status);
   }
   if (result.isEmpty()) {
-    *status = U_ILLEGAL_ARGUMENT_ERROR; /* empty keyword name */
+    status = U_ILLEGAL_ARGUMENT_ERROR; /* empty keyword name */
   }
 
   return result;
@@ -574,19 +576,21 @@ typedef struct {
     int32_t valueLen;
 } KeywordStruct;
 
-static int32_t U_CALLCONV
+int32_t U_CALLCONV
 compareKeywordStructs(const void * /*context*/, const void *left, const void *right) {
     const char* leftString = ((const KeywordStruct *)left)->keyword;
     const char* rightString = ((const KeywordStruct *)right)->keyword;
     return uprv_strcmp(leftString, rightString);
 }
 
-U_CFUNC void
-ulocimp_getKeywords(const char *localeID,
+}  // namespace
+
+U_EXPORT void
+ulocimp_getKeywords(const char* localeID,
                     char prev,
                     ByteSink& sink,
-                    UBool valuesToo,
-                    UErrorCode *status)
+                    bool valuesToo,
+                    UErrorCode& status)
 {
     KeywordStruct keywordList[ULOC_MAX_NO_KEYWORDS];
 
@@ -600,7 +604,7 @@ ulocimp_getKeywords(const char *localeID,
     if(prev == '@') { /* start of keyword definition */
         /* we will grab pairs, trim spaces, lowercase keywords, sort and return */
         do {
-            UBool duplicate = false;
+            bool duplicate = false;
             /* skip leading spaces */
             while(*pos == ' ') {
                 pos++;
@@ -609,7 +613,7 @@ ulocimp_getKeywords(const char *localeID,
                 break;
             }
             if(numKeywords == maxKeywords) {
-                *status = U_INTERNAL_PROGRAM_ERROR;
+                status = U_INTERNAL_PROGRAM_ERROR;
                 return;
             }
             equalSign = uprv_strchr(pos, '=');
@@ -617,13 +621,13 @@ ulocimp_getKeywords(const char *localeID,
             /* lack of '=' [foo@currency] is illegal */
             /* ';' before '=' [foo@currency;collation=pinyin] is illegal */
             if(!equalSign || (semicolon && semicolon<equalSign)) {
-                *status = U_INVALID_FORMAT_ERROR;
+                status = U_INVALID_FORMAT_ERROR;
                 return;
             }
             /* need to normalize both keyword and keyword name */
             if(equalSign - pos >= ULOC_KEYWORD_BUFFER_LEN) {
                 /* keyword name too long for internal buffer */
-                *status = U_INTERNAL_PROGRAM_ERROR;
+                status = U_INTERNAL_PROGRAM_ERROR;
                 return;
             }
             for(i = 0, n = 0; i < equalSign - pos; ++i) {
@@ -634,7 +638,7 @@ ulocimp_getKeywords(const char *localeID,
 
             /* zero-length keyword is an error. */
             if (n == 0) {
-                *status = U_INVALID_FORMAT_ERROR;
+                status = U_INVALID_FORMAT_ERROR;
                 return;
             }
 
@@ -649,7 +653,7 @@ ulocimp_getKeywords(const char *localeID,
 
             /* Premature end or zero-length value */
             if (!*equalSign || equalSign == semicolon) {
-                *status = U_INVALID_FORMAT_ERROR;
+                status = U_INVALID_FORMAT_ERROR;
                 return;
             }
 
@@ -684,7 +688,7 @@ ulocimp_getKeywords(const char *localeID,
 
         /* now we have a list of keywords */
         /* we need to sort it */
-        uprv_sortArray(keywordList, numKeywords, sizeof(KeywordStruct), compareKeywordStructs, nullptr, false, status);
+        uprv_sortArray(keywordList, numKeywords, sizeof(KeywordStruct), compareKeywordStructs, nullptr, false, &status);
 
         /* Now construct the keyword part */
         for(i = 0; i < numKeywords; i++) {
@@ -713,7 +717,7 @@ uloc_getKeywordValue(const char* localeID,
     }
 
     CheckedArrayByteSink sink(buffer, bufferCapacity);
-    ulocimp_getKeywordValue(localeID, keywordName, sink, status);
+    ulocimp_getKeywordValue(localeID, keywordName, sink, *status);
 
     int32_t reslen = sink.NumberOfBytesAppended();
 
@@ -730,33 +734,33 @@ uloc_getKeywordValue(const char* localeID,
     return reslen;
 }
 
-U_CAPI void U_EXPORT2
+U_EXPORT void
 ulocimp_getKeywordValue(const char* localeID,
                         const char* keywordName,
                         icu::ByteSink& sink,
-                        UErrorCode* status)
+                        UErrorCode& status)
 {
     const char* startSearchHere = nullptr;
     const char* nextSeparator = nullptr;
 
-    if(status && U_SUCCESS(*status) && localeID) {
+    if (localeID != nullptr && U_SUCCESS(status)) {
       CharString tempBuffer;
       const char* tmpLocaleID;
 
       if (keywordName == nullptr || keywordName[0] == 0) {
-        *status = U_ILLEGAL_ARGUMENT_ERROR;
+        status = U_ILLEGAL_ARGUMENT_ERROR;
         return;
       }
 
       CharString canonKeywordName = locale_canonKeywordName(keywordName, status);
-      if(U_FAILURE(*status)) {
+      if (U_FAILURE(status)) {
         return;
       }
 
       if (_hasBCP47Extension(localeID)) {
         CharStringByteSink sink(&tempBuffer);
         ulocimp_forLanguageTag(localeID, -1, sink, nullptr, status);
-        tmpLocaleID = U_SUCCESS(*status) && !tempBuffer.isEmpty() ? tempBuffer.data() : localeID;
+        tmpLocaleID = U_SUCCESS(status) && !tempBuffer.isEmpty() ? tempBuffer.data() : localeID;
       } else {
           tmpLocaleID=localeID;
       }
@@ -774,7 +778,7 @@ ulocimp_getKeywordValue(const char* localeID,
           startSearchHere++; /* skip @ or ; */
           nextSeparator = uprv_strchr(startSearchHere, '=');
           if(!nextSeparator) {
-              *status = U_ILLEGAL_ARGUMENT_ERROR; /* key must have =value */
+              status = U_ILLEGAL_ARGUMENT_ERROR; /* key must have =value */
               return;
           }
           /* strip leading & trailing spaces (TC decided to tolerate these) */
@@ -788,18 +792,18 @@ ulocimp_getKeywordValue(const char* localeID,
           /* now keyValueTail points to first char after the keyName */
           /* copy & normalize keyName from locale */
           if (startSearchHere == keyValueTail) {
-              *status = U_ILLEGAL_ARGUMENT_ERROR; /* empty keyword name in passed-in locale */
+              status = U_ILLEGAL_ARGUMENT_ERROR; /* empty keyword name in passed-in locale */
               return;
           }
           CharString localeKeywordName;
           while (startSearchHere < keyValueTail) {
             if (!UPRV_ISALPHANUM(*startSearchHere)) {
-              *status = U_ILLEGAL_ARGUMENT_ERROR; /* malformed keyword name */
+              status = U_ILLEGAL_ARGUMENT_ERROR; /* malformed keyword name */
               return;
             }
-            localeKeywordName.append(uprv_tolower(*startSearchHere++), *status);
+            localeKeywordName.append(uprv_tolower(*startSearchHere++), status);
           }
-          if (U_FAILURE(*status)) {
+          if (U_FAILURE(status)) {
               return;
           }
 
@@ -818,12 +822,12 @@ ulocimp_getKeywordValue(const char* localeID,
               }
               /* Now copy the value, but check well-formedness */
               if (nextSeparator == keyValueTail) {
-                *status = U_ILLEGAL_ARGUMENT_ERROR; /* empty key value name in passed-in locale */
+                status = U_ILLEGAL_ARGUMENT_ERROR; /* empty key value name in passed-in locale */
                 return;
               }
               while (nextSeparator < keyValueTail) {
                 if (!UPRV_ISALPHANUM(*nextSeparator) && !UPRV_OK_VALUE_PUNCTUATION(*nextSeparator)) {
-                  *status = U_ILLEGAL_ARGUMENT_ERROR; /* malformed key value */
+                  status = U_ILLEGAL_ARGUMENT_ERROR; /* malformed key value */
                   return;
                 }
                 /* Should we lowercase value to return here? Tests expect as-is. */
@@ -863,7 +867,7 @@ uloc_setKeywordValue(const char* keywordName,
     CheckedArrayByteSink sink(keywords == nullptr ? buffer + bufLen : keywords,
                               bufferCapacity - baseLen - 1);
     int32_t reslen = ulocimp_setKeywordValue(
-            keywords, keywordName, keywordValue, sink, status);
+            keywords, keywordName, keywordValue, sink, *status);
 
     if (U_FAILURE(*status)) {
         // A positive return value is a length, otherwise it's an error code.
@@ -878,13 +882,13 @@ uloc_setKeywordValue(const char* keywordName,
     return u_terminateChars(buffer, bufferCapacity, reslen + baseLen, status);
 }
 
-U_EXPORT void U_EXPORT2
+U_EXPORT void
 ulocimp_setKeywordValue(const char* keywordName,
                         const char* keywordValue,
                         CharString& localeID,
-                        UErrorCode* status)
+                        UErrorCode& status)
 {
-    if (U_FAILURE(*status)) return;
+    if (U_FAILURE(status)) { return; }
     // This is safe because CharString::truncate() doesn't actually erase any
     // data, but simply sets the position for where new data will be written.
     const char* keywords = locale_getKeywordsStart(localeID.data());
@@ -893,12 +897,12 @@ ulocimp_setKeywordValue(const char* keywordName,
     ulocimp_setKeywordValue(keywords, keywordName, keywordValue, sink, status);
 }
 
-U_EXPORT int32_t U_EXPORT2
+U_EXPORT int32_t
 ulocimp_setKeywordValue(const char* keywords,
                         const char* keywordName,
                         const char* keywordValue,
                         ByteSink& sink,
-                        UErrorCode* status)
+                        UErrorCode& status)
 {
     /* TODO: sorting. removal. */
     int32_t needLen = 0;
@@ -907,21 +911,21 @@ ulocimp_setKeywordValue(const char* keywords,
     const char* nextEqualsign = nullptr;
     const char* keywordStart = nullptr;
     CharString updatedKeysAndValues;
-    UBool handledInputKeyAndValue = false;
+    bool handledInputKeyAndValue = false;
     char keyValuePrefix = '@';
 
-    if(U_FAILURE(*status)) {
+    if (U_FAILURE(status)) {
         return -1;
     }
-    if (*status == U_STRING_NOT_TERMINATED_WARNING) {
-        *status = U_ZERO_ERROR;
+    if (status == U_STRING_NOT_TERMINATED_WARNING) {
+        status = U_ZERO_ERROR;
     }
     if (keywordName == nullptr || keywordName[0] == 0) {
-        *status = U_ILLEGAL_ARGUMENT_ERROR;
+        status = U_ILLEGAL_ARGUMENT_ERROR;
         return 0;
     }
     CharString canonKeywordName = locale_canonKeywordName(keywordName, status);
-    if(U_FAILURE(*status)) {
+    if (U_FAILURE(status)) {
         return 0;
     }
 
@@ -929,20 +933,20 @@ ulocimp_setKeywordValue(const char* keywords,
     if(keywordValue) {
         while (*keywordValue != 0) {
             if (!UPRV_ISALPHANUM(*keywordValue) && !UPRV_OK_VALUE_PUNCTUATION(*keywordValue)) {
-                *status = U_ILLEGAL_ARGUMENT_ERROR; /* malformed key value */
+                status = U_ILLEGAL_ARGUMENT_ERROR; /* malformed key value */
                 return 0;
             }
             /* Should we force lowercase in value to set? */
-            canonKeywordValue.append(*keywordValue++, *status);
+            canonKeywordValue.append(*keywordValue++, status);
         }
     }
-    if (U_FAILURE(*status)) {
+    if (U_FAILURE(status)) {
         return 0;
     }
 
     if (keywords == nullptr || keywords[1] == '\0') {
         if (canonKeywordValue.isEmpty()) { /* no keywords = nothing to remove */
-            U_ASSERT(*status != U_STRING_NOT_TERMINATED_WARNING);
+            U_ASSERT(status != U_STRING_NOT_TERMINATED_WARNING);
             return 0;
         }
 
@@ -951,7 +955,7 @@ ulocimp_setKeywordValue(const char* keywords,
         char* buffer = sink.GetAppendBuffer(
                 needLen, needLen, nullptr, needLen, &capacity);
         if (capacity < needLen || buffer == nullptr) {
-            *status = U_BUFFER_OVERFLOW_ERROR;
+            status = U_BUFFER_OVERFLOW_ERROR;
             return needLen; /* no change */
         }
         char* it = buffer;
@@ -962,7 +966,7 @@ ulocimp_setKeywordValue(const char* keywords,
         *it++ = '=';
         uprv_memcpy(it, canonKeywordValue.data(), canonKeywordValue.length());
         sink.Append(buffer, needLen);
-        U_ASSERT(*status != U_STRING_NOT_TERMINATED_WARNING);
+        U_ASSERT(status != U_STRING_NOT_TERMINATED_WARNING);
         return needLen;
     } /* end shortcut - no @ */
 
@@ -974,7 +978,7 @@ ulocimp_setKeywordValue(const char* keywords,
         keywordStart++; /* skip @ or ; */
         nextEqualsign = uprv_strchr(keywordStart, '=');
         if (!nextEqualsign) {
-            *status = U_ILLEGAL_ARGUMENT_ERROR; /* key must have =value */
+            status = U_ILLEGAL_ARGUMENT_ERROR; /* key must have =value */
             return 0;
         }
         /* strip leading & trailing spaces (TC decided to tolerate these) */
@@ -988,18 +992,18 @@ ulocimp_setKeywordValue(const char* keywords,
         /* now keyValueTail points to first char after the keyName */
         /* copy & normalize keyName from locale */
         if (keywordStart == keyValueTail) {
-            *status = U_ILLEGAL_ARGUMENT_ERROR; /* empty keyword name in passed-in locale */
+            status = U_ILLEGAL_ARGUMENT_ERROR; /* empty keyword name in passed-in locale */
             return 0;
         }
         CharString localeKeywordName;
         while (keywordStart < keyValueTail) {
             if (!UPRV_ISALPHANUM(*keywordStart)) {
-                *status = U_ILLEGAL_ARGUMENT_ERROR; /* malformed keyword name */
+                status = U_ILLEGAL_ARGUMENT_ERROR; /* malformed keyword name */
                 return 0;
             }
-            localeKeywordName.append(uprv_tolower(*keywordStart++), *status);
+            localeKeywordName.append(uprv_tolower(*keywordStart++), status);
         }
-        if (U_FAILURE(*status)) {
+        if (U_FAILURE(status)) {
             return 0;
         }
 
@@ -1016,7 +1020,7 @@ ulocimp_setKeywordValue(const char* keywords,
             keyValueTail--;
         }
         if (nextEqualsign == keyValueTail) {
-            *status = U_ILLEGAL_ARGUMENT_ERROR; /* empty key value in passed-in locale */
+            status = U_ILLEGAL_ARGUMENT_ERROR; /* empty key value in passed-in locale */
             return 0;
         }
 
@@ -1024,38 +1028,38 @@ ulocimp_setKeywordValue(const char* keywords,
         if(rc == 0) {
             /* Current entry matches the input keyword. Update the entry */
             if (!canonKeywordValue.isEmpty()) { /* updating a value */
-                updatedKeysAndValues.append(keyValuePrefix, *status);
+                updatedKeysAndValues.append(keyValuePrefix, status);
                 keyValuePrefix = ';'; /* for any subsequent key-value pair */
-                updatedKeysAndValues.append(canonKeywordName, *status);
-                updatedKeysAndValues.append('=', *status);
-                updatedKeysAndValues.append(canonKeywordValue, *status);
+                updatedKeysAndValues.append(canonKeywordName, status);
+                updatedKeysAndValues.append('=', status);
+                updatedKeysAndValues.append(canonKeywordValue, status);
             } /* else removing this entry, don't emit anything */
             handledInputKeyAndValue = true;
         } else {
            /* input keyword sorts earlier than current entry, add before current entry */
             if (rc < 0 && !canonKeywordValue.isEmpty() && !handledInputKeyAndValue) {
                 /* insert new entry at this location */
-                updatedKeysAndValues.append(keyValuePrefix, *status);
+                updatedKeysAndValues.append(keyValuePrefix, status);
                 keyValuePrefix = ';'; /* for any subsequent key-value pair */
-                updatedKeysAndValues.append(canonKeywordName, *status);
-                updatedKeysAndValues.append('=', *status);
-                updatedKeysAndValues.append(canonKeywordValue, *status);
+                updatedKeysAndValues.append(canonKeywordName, status);
+                updatedKeysAndValues.append('=', status);
+                updatedKeysAndValues.append(canonKeywordValue, status);
                 handledInputKeyAndValue = true;
             }
             /* copy the current entry */
-            updatedKeysAndValues.append(keyValuePrefix, *status);
+            updatedKeysAndValues.append(keyValuePrefix, status);
             keyValuePrefix = ';'; /* for any subsequent key-value pair */
-            updatedKeysAndValues.append(localeKeywordName, *status);
-            updatedKeysAndValues.append('=', *status);
-            updatedKeysAndValues.append(nextEqualsign, static_cast<int32_t>(keyValueTail-nextEqualsign), *status);
+            updatedKeysAndValues.append(localeKeywordName, status);
+            updatedKeysAndValues.append('=', status);
+            updatedKeysAndValues.append(nextEqualsign, static_cast<int32_t>(keyValueTail-nextEqualsign), status);
         }
         if (!nextSeparator && !canonKeywordValue.isEmpty() && !handledInputKeyAndValue) {
             /* append new entry at the end, it sorts later than existing entries */
-            updatedKeysAndValues.append(keyValuePrefix, *status);
+            updatedKeysAndValues.append(keyValuePrefix, status);
             /* skip keyValuePrefix update, no subsequent key-value pair */
-            updatedKeysAndValues.append(canonKeywordName, *status);
-            updatedKeysAndValues.append('=', *status);
-            updatedKeysAndValues.append(canonKeywordValue, *status);
+            updatedKeysAndValues.append(canonKeywordName, status);
+            updatedKeysAndValues.append('=', status);
+            updatedKeysAndValues.append(canonKeywordValue, status);
             handledInputKeyAndValue = true;
         }
         keywordStart = nextSeparator;
@@ -1069,10 +1073,10 @@ ulocimp_setKeywordValue(const char* keywords,
      * error return but the passed-in locale is unmodified and the original bufLen is
      * returned.
      */
-    if (!handledInputKeyAndValue || U_FAILURE(*status)) {
+    if (!handledInputKeyAndValue || U_FAILURE(status)) {
         /* if input key/value specified removal of a keyword not present in locale, or
          * there was an error in CharString.append, leave original locale alone. */
-        U_ASSERT(*status != U_STRING_NOT_TERMINATED_WARNING);
+        U_ASSERT(status != U_STRING_NOT_TERMINATED_WARNING);
         return (int32_t)uprv_strlen(keywords);
     }
 
@@ -1088,13 +1092,13 @@ ulocimp_setKeywordValue(const char* keywords,
         char* buffer = sink.GetAppendBuffer(
                 needLen, needLen, nullptr, needLen, &capacity);
         if (capacity < needLen || buffer == nullptr) {
-            *status = U_BUFFER_OVERFLOW_ERROR;
+            status = U_BUFFER_OVERFLOW_ERROR;
             return needLen;
         }
         uprv_memcpy(buffer, updatedKeysAndValues.data(), needLen);
         sink.Append(buffer, needLen);
     }
-    U_ASSERT(*status != U_STRING_NOT_TERMINATED_WARNING);
+    U_ASSERT(status != U_STRING_NOT_TERMINATED_WARNING);
     return needLen;
 }
 
@@ -1121,8 +1125,6 @@ inline bool _isBCP47Extension(const char* p) {
            p[2] == '-';
 }
 
-}  // namespace
-
 /**
  * Lookup 'key' in the array 'list'.  The array 'list' should contain
  * a nullptr entry, followed by more entries, and a second nullptr entry.
@@ -1130,7 +1132,7 @@ inline bool _isBCP47Extension(const char* p) {
  * The 'list' param should be LANGUAGES, LANGUAGES_3, COUNTRIES, or
  * COUNTRIES_3.
  */
-static int16_t _findIndex(const char* const* list, const char* key)
+int16_t _findIndex(const char* const* list, const char* key)
 {
     const char* const* anchor = list;
     int32_t pass = 0;
@@ -1148,6 +1150,8 @@ static int16_t _findIndex(const char* const* list, const char* key)
     return -1;
 }
 
+}  // namespace
+
 U_CFUNC const char*
 uloc_getCurrentCountryID(const char* oldID){
     int32_t offset = _findIndex(DEPRECATED_COUNTRIES, oldID);
@@ -1164,6 +1168,9 @@ uloc_getCurrentLanguageID(const char* oldID){
     }
     return oldID;
 }
+
+namespace {
+
 /*
  * the internal functions _getLanguage(), _getScript(), _getRegion(), _getVariant()
  * avoid duplicating code to handle the earlier locale ID pieces
@@ -1172,7 +1179,8 @@ uloc_getCurrentLanguageID(const char* oldID){
  *
  * TODO try to use this in Locale
  */
-static void
+
+void
 _getLanguage(const char* localeID,
              ByteSink* sink,
              const char** pEnd,
@@ -1233,7 +1241,7 @@ _getLanguage(const char* localeID,
     sink->Append(buffer, len);
 }
 
-static void
+void
 _getScript(const char* localeID,
            ByteSink* sink,
            const char** pEnd) {
@@ -1266,7 +1274,7 @@ _getScript(const char* localeID,
     sink->Append(buffer, LENGTH);
 }
 
-static void
+void
 _getRegion(const char* localeID,
            ByteSink* sink,
            const char** pEnd) {
@@ -1318,13 +1326,13 @@ _getRegion(const char* localeID,
  * @param needSeparator if true, then add leading '_' if any variants
  * are added to 'variant'
  */
-static void
+void
 _getVariant(const char* localeID,
             char prev,
             ByteSink* sink,
             const char** pEnd,
-            UBool needSeparator) {
-    UBool hasVariant = false;
+            bool needSeparator) {
+    bool hasVariant = false;
     if (pEnd != nullptr) { *pEnd = localeID; }
 
     /* get one or more variant tags and separate them with '_' */
@@ -1375,7 +1383,9 @@ _getVariant(const char* localeID,
     }
 }
 
-U_EXPORT CharString U_EXPORT2
+}  // namespace
+
+U_EXPORT CharString
 ulocimp_getLanguage(const char* localeID, UErrorCode& status) {
     CharString language;
     CharStringByteSink sink(&language);
@@ -1390,7 +1400,7 @@ ulocimp_getLanguage(const char* localeID, UErrorCode& status) {
     return language;
 }
 
-U_EXPORT CharString U_EXPORT2
+U_EXPORT CharString
 ulocimp_getScript(const char* localeID, UErrorCode& status) {
     CharString script;
     CharStringByteSink sink(&script);
@@ -1405,7 +1415,7 @@ ulocimp_getScript(const char* localeID, UErrorCode& status) {
     return script;
 }
 
-U_EXPORT CharString U_EXPORT2
+U_EXPORT CharString
 ulocimp_getRegion(const char* localeID, UErrorCode& status) {
     CharString region;
     CharStringByteSink sink(&region);
@@ -1420,7 +1430,7 @@ ulocimp_getRegion(const char* localeID, UErrorCode& status) {
     return region;
 }
 
-U_EXPORT CharString U_EXPORT2
+U_EXPORT CharString
 ulocimp_getVariant(const char* localeID, UErrorCode& status) {
     CharString variant;
     CharStringByteSink sink(&variant);
@@ -1435,7 +1445,7 @@ ulocimp_getVariant(const char* localeID, UErrorCode& status) {
     return variant;
 }
 
-U_EXPORT void U_EXPORT2
+U_EXPORT void
 ulocimp_getSubtags(
         const char* localeID,
         CharString* language,
@@ -1464,7 +1474,7 @@ ulocimp_getSubtags(
             status);
 }
 
-U_EXPORT void U_EXPORT2
+U_EXPORT void
 ulocimp_getSubtags(
         const char* localeID,
         ByteSink* language,
@@ -1647,7 +1657,7 @@ uloc_openKeywords(const char* localeID,
 
     if (_hasBCP47Extension(localeID)) {
         CharStringByteSink sink(&tempBuffer);
-        ulocimp_forLanguageTag(localeID, -1, sink, nullptr, status);
+        ulocimp_forLanguageTag(localeID, -1, sink, nullptr, *status);
         tmpLocaleID = U_SUCCESS(*status) && !tempBuffer.isEmpty() ? tempBuffer.data() : localeID;
     } else {
         if (localeID==nullptr) {
@@ -1672,7 +1682,7 @@ uloc_openKeywords(const char* localeID,
     if((tmpLocaleID = locale_getKeywordsStart(tmpLocaleID)) != nullptr) {
         CharString keywords;
         CharStringByteSink sink(&keywords);
-        ulocimp_getKeywords(tmpLocaleID+1, '@', sink, false, status);
+        ulocimp_getKeywords(tmpLocaleID+1, '@', sink, false, *status);
         if (U_FAILURE(*status)) {
             return nullptr;
         }
@@ -1693,8 +1703,6 @@ inline bool OPTION_SET(uint32_t options, uint32_t mask) { return (options & mask
 constexpr char i_default[] = {'i', '-', 'd', 'e', 'f', 'a', 'u', 'l', 't'};
 constexpr int32_t I_DEFAULT_LENGTH = UPRV_LENGTHOF(i_default);
 
-}  // namespace
-
 /**
  * Canonicalize the given localeID, to level 1 or to level 2,
  * depending on the options.  To specify level 1, pass in options=0.
@@ -1702,12 +1710,12 @@ constexpr int32_t I_DEFAULT_LENGTH = UPRV_LENGTHOF(i_default);
  *
  * This is the code underlying uloc_getName and uloc_canonicalize.
  */
-static void
+void
 _canonicalize(const char* localeID,
               ByteSink& sink,
               uint32_t options,
-              UErrorCode* err) {
-    if (U_FAILURE(*err)) {
+              UErrorCode& err) {
+    if (U_FAILURE(err)) {
         return;
     }
 
@@ -1724,8 +1732,8 @@ _canonicalize(const char* localeID,
 
         // convert all underbars to hyphens, unless the "BCP47 extension" comes at the beginning of the string
         if (uprv_strchr(localeID, '_') != nullptr && localeID[1] != '-' && localeID[1] != '_') {
-            localeIDWithHyphens.append(localeID, -1, *err);
-            if (U_SUCCESS(*err)) {
+            localeIDWithHyphens.append(localeID, -1, err);
+            if (U_SUCCESS(err)) {
                 for (char* p = localeIDWithHyphens.data(); *p != '\0'; ++p) {
                     if (*p == '_') {
                         *p = '-';
@@ -1737,7 +1745,7 @@ _canonicalize(const char* localeID,
 
         CharStringByteSink tempSink(&tempBuffer);
         ulocimp_forLanguageTag(localeIDPtr, -1, tempSink, nullptr, err);
-        tmpLocaleID = U_SUCCESS(*err) && !tempBuffer.isEmpty() ? tempBuffer.data() : localeIDPtr;
+        tmpLocaleID = U_SUCCESS(err) && !tempBuffer.isEmpty() ? tempBuffer.data() : localeIDPtr;
     } else {
         if (localeID==nullptr) {
            localeID=uloc_getDefault();
@@ -1759,36 +1767,36 @@ _canonicalize(const char* localeID,
             &country,
             &variant,
             &tmpLocaleID,
-            *err);
+            err);
 
     if (tag.length() == I_DEFAULT_LENGTH &&
             uprv_strncmp(origLocaleID, i_default, I_DEFAULT_LENGTH) == 0) {
         tag.clear();
-        tag.append(uloc_getDefault(), *err);
+        tag.append(uloc_getDefault(), err);
     } else {
         if (!script.isEmpty()) {
             ++fieldCount;
-            tag.append('_', *err);
-            tag.append(script, *err);
+            tag.append('_', err);
+            tag.append(script, err);
         }
         if (!country.isEmpty()) {
             ++fieldCount;
-            tag.append('_', *err);
-            tag.append(country, *err);
+            tag.append('_', err);
+            tag.append(country, err);
         }
         if (!variant.isEmpty()) {
             ++fieldCount;
             if (country.isEmpty()) {
-                tag.append('_', *err);
+                tag.append('_', err);
             }
-            tag.append('_', *err);
-            tag.append(variant, *err);
+            tag.append('_', err);
+            tag.append(variant, err);
         }
     }
 
     /* Copy POSIX-style charset specifier, if any [mr.utf8] */
     if (!OPTION_SET(options, _ULOC_CANONICALIZE) && *tmpLocaleID == '.') {
-        UBool done = false;
+        bool done = false;
         do {
             char c = *tmpLocaleID;
             switch (c) {
@@ -1797,7 +1805,7 @@ _canonicalize(const char* localeID,
                 done = true;
                 break;
             default:
-                tag.append(c, *err);
+                tag.append(c, err);
                 ++tmpLocaleID;
                 break;
             }
@@ -1819,7 +1827,7 @@ _canonicalize(const char* localeID,
             if (c == 0) {
                 break;
             }
-            tag.append(c, *err);
+            tag.append(c, err);
             ++tmpLocaleID;
         }
     }
@@ -1830,7 +1838,7 @@ _canonicalize(const char* localeID,
             /* Add missing '_' if needed */
             if (fieldCount < 2 || (fieldCount < 3 && !script.isEmpty())) {
                 do {
-                    tag.append('_', *err);
+                    tag.append('_', err);
                     ++fieldCount;
                 } while(fieldCount<2);
             }
@@ -1847,7 +1855,7 @@ _canonicalize(const char* localeID,
                     break; /* Don't remap "" if keywords present */
                 }
                 tag.clear();
-                tag.append(CANONICALIZE_MAP[j].canonicalID, *err);
+                tag.append(CANONICALIZE_MAP[j].canonicalID, err);
                 break;
             }
         }
@@ -1865,6 +1873,8 @@ _canonicalize(const char* localeID,
     }
 }
 
+}  // namespace
+
 /* ### ID parsing API **************************************************/
 
 U_CAPI int32_t  U_EXPORT2
@@ -1878,7 +1888,7 @@ uloc_getParent(const char*    localeID,
     }
 
     CheckedArrayByteSink sink(parent, parentCapacity);
-    ulocimp_getParent(localeID, sink, err);
+    ulocimp_getParent(localeID, sink, *err);
 
     int32_t reslen = sink.NumberOfBytesAppended();
 
@@ -1895,15 +1905,15 @@ uloc_getParent(const char*    localeID,
     return reslen;
 }
 
-U_CAPI void U_EXPORT2
+U_EXPORT void
 ulocimp_getParent(const char* localeID,
                   icu::ByteSink& sink,
-                  UErrorCode* err)
+                  UErrorCode& err)
 {
     const char *lastUnderscore;
     int32_t i;
 
-    if (U_FAILURE(*err))
+    if (U_FAILURE(err))
         return;
 
     if (localeID == nullptr)
@@ -2074,7 +2084,7 @@ uloc_getName(const char* localeID,
     }
 
     CheckedArrayByteSink sink(name, nameCapacity);
-    ulocimp_getName(localeID, sink, err);
+    ulocimp_getName(localeID, sink, *err);
 
     int32_t reslen = sink.NumberOfBytesAppended();
 
@@ -2091,10 +2101,10 @@ uloc_getName(const char* localeID,
     return reslen;
 }
 
-U_CAPI void U_EXPORT2
+U_EXPORT void
 ulocimp_getName(const char* localeID,
                 ByteSink& sink,
-                UErrorCode* err)
+                UErrorCode& err)
 {
     _canonicalize(localeID, sink, 0, err);
 }
@@ -2110,7 +2120,7 @@ uloc_getBaseName(const char* localeID,
     }
 
     CheckedArrayByteSink sink(name, nameCapacity);
-    ulocimp_getBaseName(localeID, sink, err);
+    ulocimp_getBaseName(localeID, sink, *err);
 
     int32_t reslen = sink.NumberOfBytesAppended();
 
@@ -2127,10 +2137,10 @@ uloc_getBaseName(const char* localeID,
     return reslen;
 }
 
-U_CAPI void U_EXPORT2
+U_EXPORT void
 ulocimp_getBaseName(const char* localeID,
                     ByteSink& sink,
-                    UErrorCode* err)
+                    UErrorCode& err)
 {
     _canonicalize(localeID, sink, _ULOC_STRIP_KEYWORDS, err);
 }
@@ -2146,7 +2156,7 @@ uloc_canonicalize(const char* localeID,
     }
 
     CheckedArrayByteSink sink(name, nameCapacity);
-    ulocimp_canonicalize(localeID, sink, err);
+    ulocimp_canonicalize(localeID, sink, *err);
 
     int32_t reslen = sink.NumberOfBytesAppended();
 
@@ -2163,10 +2173,10 @@ uloc_canonicalize(const char* localeID,
     return reslen;
 }
 
-U_CAPI void U_EXPORT2
+U_EXPORT void
 ulocimp_canonicalize(const char* localeID,
                      ByteSink& sink,
-                     UErrorCode* err)
+                     UErrorCode& err)
 {
     _canonicalize(localeID, sink, _ULOC_CANONICALIZE, err);
 }
@@ -2243,15 +2253,15 @@ uloc_getLCID(const char* localeID)
         CharString collVal;
         {
             CharStringByteSink sink(&collVal);
-            ulocimp_getKeywordValue(localeID, "collation", sink, &status);
+            ulocimp_getKeywordValue(localeID, "collation", sink, status);
         }
         if (U_SUCCESS(status) && !collVal.isEmpty()) {
             CharString tmpLocaleID;
             {
                 CharStringByteSink sink(&tmpLocaleID);
-                ulocimp_getBaseName(localeID, sink, &status);
+                ulocimp_getBaseName(localeID, sink, status);
             }
-            ulocimp_setKeywordValue("collation", collVal.data(), tmpLocaleID, &status);
+            ulocimp_setKeywordValue("collation", collVal.data(), tmpLocaleID, status);
             if (U_SUCCESS(status)) {
                 return uprv_convertToLCID(langID.data(), tmpLocaleID.data(), &status);
             }
@@ -2337,7 +2347,9 @@ uloc_toUnicodeLocaleType(const char* keyword, const char* value)
     return bcpType;
 }
 
-static UBool
+namespace {
+
+bool
 isWellFormedLegacyKey(const char* legacyKey)
 {
     const char* p = legacyKey;
@@ -2350,7 +2362,7 @@ isWellFormedLegacyKey(const char* legacyKey)
     return true;
 }
 
-static UBool
+bool
 isWellFormedLegacyType(const char* legacyType)
 {
     const char* p = legacyType;
@@ -2370,6 +2382,8 @@ isWellFormedLegacyType(const char* legacyType)
     }
     return (alphaNumLen != 0);
 }
+
+}  // namespace
 
 U_CAPI const char* U_EXPORT2
 uloc_toLegacyKey(const char* keyword)

--- a/icu4c/source/common/uloc_keytype.cpp
+++ b/icu4c/source/common/uloc_keytype.cpp
@@ -74,8 +74,9 @@ uloc_key_type_cleanup() {
 
 U_CDECL_END
 
+namespace {
 
-static void U_CALLCONV
+void U_CALLCONV
 initFromResourceBundle(UErrorCode& sts) {
     U_NAMESPACE_USE
     ucln_common_registerCleanup(UCLN_COMMON_LOCALE_KEY_TYPE, uloc_key_type_cleanup);
@@ -141,7 +142,7 @@ initFromResourceBundle(UErrorCode& sts) {
             bcpKeyId = bcpKeyIdBuf->data();
         }
 
-        UBool isTZ = uprv_strcmp(legacyKeyId, "timezone") == 0;
+        bool isTZ = uprv_strcmp(legacyKeyId, "timezone") == 0;
 
         UHashtable* typeDataMap = uhash_open(uhash_hashIChars, uhash_compareIChars, nullptr, &sts);
         if (U_FAILURE(sts)) {
@@ -351,7 +352,7 @@ initFromResourceBundle(UErrorCode& sts) {
     }
 }
 
-static UBool
+bool
 init() {
     UErrorCode sts = U_ZERO_ERROR;
     umtx_initOnce(gLocExtKeyMapInitOnce, &initFromResourceBundle, sts);
@@ -361,7 +362,7 @@ init() {
     return true;
 }
 
-static UBool
+bool
 isSpecialTypeCodepoints(const char* val) {
     int32_t subtagLen = 0;
     const char* p = val;
@@ -383,7 +384,7 @@ isSpecialTypeCodepoints(const char* val) {
     return (subtagLen >= 4 && subtagLen <= 6);
 }
 
-static UBool
+bool
 isSpecialTypeReorderCode(const char* val) {
     int32_t subtagLen = 0;
     const char* p = val;
@@ -403,7 +404,7 @@ isSpecialTypeReorderCode(const char* val) {
     return (subtagLen >=3 && subtagLen <=8);
 }
 
-static UBool
+bool
 isSpecialTypeRgKeyValue(const char* val) {
     int32_t subtagLen = 0;
     const char* p = val;
@@ -419,7 +420,9 @@ isSpecialTypeRgKeyValue(const char* val) {
     return (subtagLen == 6);
 }
 
-U_CFUNC const char*
+}  // namespace
+
+U_EXPORT const char*
 ulocimp_toBcpKey(const char* key) {
     if (!init()) {
         return nullptr;
@@ -432,7 +435,7 @@ ulocimp_toBcpKey(const char* key) {
     return nullptr;
 }
 
-U_CFUNC const char*
+U_EXPORT const char*
 ulocimp_toLegacyKey(const char* key) {
     if (!init()) {
         return nullptr;
@@ -445,8 +448,8 @@ ulocimp_toLegacyKey(const char* key) {
     return nullptr;
 }
 
-U_CFUNC const char*
-ulocimp_toBcpType(const char* key, const char* type, UBool* isKnownKey, UBool* isSpecialType) {
+U_EXPORT const char*
+ulocimp_toBcpType(const char* key, const char* type, bool* isKnownKey, bool* isSpecialType) {
     if (isKnownKey != nullptr) {
         *isKnownKey = false;
     }
@@ -468,7 +471,7 @@ ulocimp_toBcpType(const char* key, const char* type, UBool* isKnownKey, UBool* i
             return t->bcpId;
         }
         if (keyData->specialTypes != SPECIALTYPE_NONE) {
-            UBool matched = false;
+            bool matched = false;
             if (keyData->specialTypes & SPECIALTYPE_CODEPOINTS) {
                 matched = isSpecialTypeCodepoints(type);
             }
@@ -490,8 +493,8 @@ ulocimp_toBcpType(const char* key, const char* type, UBool* isKnownKey, UBool* i
 }
 
 
-U_CFUNC const char*
-ulocimp_toLegacyType(const char* key, const char* type, UBool* isKnownKey, UBool* isSpecialType) {
+U_EXPORT const char*
+ulocimp_toLegacyType(const char* key, const char* type, bool* isKnownKey, bool* isSpecialType) {
     if (isKnownKey != nullptr) {
         *isKnownKey = false;
     }
@@ -513,7 +516,7 @@ ulocimp_toLegacyType(const char* key, const char* type, UBool* isKnownKey, UBool
             return t->legacyId;
         }
         if (keyData->specialTypes != SPECIALTYPE_NONE) {
-            UBool matched = false;
+            bool matched = false;
             if (keyData->specialTypes & SPECIALTYPE_CODEPOINTS) {
                 matched = isSpecialTypeCodepoints(type);
             }
@@ -533,4 +536,3 @@ ulocimp_toLegacyType(const char* key, const char* type, UBool* isKnownKey, UBool
     }
     return nullptr;
 }
-

--- a/icu4c/source/common/ulocimp.h
+++ b/icu4c/source/common/ulocimp.h
@@ -53,60 +53,60 @@ uloc_getCurrentCountryID(const char* oldID);
 U_CFUNC const char* 
 uloc_getCurrentLanguageID(const char* oldID);
 
-U_CFUNC void
-ulocimp_getKeywords(const char *localeID,
-             char prev,
-             icu::ByteSink& sink,
-             UBool valuesToo,
-             UErrorCode *status);
+U_EXPORT void
+ulocimp_getKeywords(const char* localeID,
+                    char prev,
+                    icu::ByteSink& sink,
+                    bool valuesToo,
+                    UErrorCode& status);
 
-U_CAPI void U_EXPORT2
+U_EXPORT void
 ulocimp_getName(const char* localeID,
                 icu::ByteSink& sink,
-                UErrorCode* err);
+                UErrorCode& err);
 
-U_CAPI void U_EXPORT2
+U_EXPORT void
 ulocimp_getBaseName(const char* localeID,
                     icu::ByteSink& sink,
-                    UErrorCode* err);
+                    UErrorCode& err);
 
-U_CAPI void U_EXPORT2
+U_EXPORT void
 ulocimp_canonicalize(const char* localeID,
                      icu::ByteSink& sink,
-                     UErrorCode* err);
+                     UErrorCode& err);
 
-U_CAPI void U_EXPORT2
+U_EXPORT void
 ulocimp_getKeywordValue(const char* localeID,
                         const char* keywordName,
                         icu::ByteSink& sink,
-                        UErrorCode* status);
+                        UErrorCode& status);
 
-U_EXPORT icu::CharString U_EXPORT2
+U_EXPORT icu::CharString
 ulocimp_getLanguage(const char* localeID, UErrorCode& status);
 
-U_EXPORT icu::CharString U_EXPORT2
+U_EXPORT icu::CharString
 ulocimp_getScript(const char* localeID, UErrorCode& status);
 
-U_EXPORT icu::CharString U_EXPORT2
+U_EXPORT icu::CharString
 ulocimp_getRegion(const char* localeID, UErrorCode& status);
 
-U_EXPORT icu::CharString U_EXPORT2
+U_EXPORT icu::CharString
 ulocimp_getVariant(const char* localeID, UErrorCode& status);
 
-U_EXPORT void U_EXPORT2
+U_EXPORT void
 ulocimp_setKeywordValue(const char* keywordName,
                         const char* keywordValue,
                         icu::CharString& localeID,
-                        UErrorCode* status);
+                        UErrorCode& status);
 
-U_EXPORT int32_t U_EXPORT2
+U_EXPORT int32_t
 ulocimp_setKeywordValue(const char* keywords,
                         const char* keywordName,
                         const char* keywordValue,
                         icu::ByteSink& sink,
-                        UErrorCode* status);
+                        UErrorCode& status);
 
-U_EXPORT void U_EXPORT2
+U_EXPORT void
 ulocimp_getSubtags(
         const char* localeID,
         icu::CharString* language,
@@ -116,7 +116,7 @@ ulocimp_getSubtags(
         const char** pEnd,
         UErrorCode& status);
 
-U_EXPORT void U_EXPORT2
+U_EXPORT void
 ulocimp_getSubtags(
         const char* localeID,
         icu::ByteSink* language,
@@ -126,7 +126,7 @@ ulocimp_getSubtags(
         const char** pEnd,
         UErrorCode& status);
 
-inline void U_EXPORT2
+inline void
 ulocimp_getSubtags(
         const char* localeID,
         std::nullptr_t,
@@ -145,10 +145,10 @@ ulocimp_getSubtags(
             status);
 }
 
-U_CAPI void U_EXPORT2
+U_EXPORT void
 ulocimp_getParent(const char* localeID,
                   icu::ByteSink& sink,
-                  UErrorCode* err);
+                  UErrorCode& err);
 
 /**
  * Writes a well-formed language tag for this locale ID.
@@ -169,11 +169,11 @@ ulocimp_getParent(const char* localeID,
  *
  * @internal ICU 64
  */
-U_CAPI void U_EXPORT2
+U_EXPORT void
 ulocimp_toLanguageTag(const char* localeID,
                       icu::ByteSink& sink,
-                      UBool strict,
-                      UErrorCode* err);
+                      bool strict,
+                      UErrorCode& err);
 
 /**
  * Returns a locale ID for the specified BCP47 language tag string.
@@ -201,12 +201,12 @@ ulocimp_toLanguageTag(const char* localeID,
  *                  failed.
  * @internal ICU 63
  */
-U_CAPI void U_EXPORT2
+U_EXPORT void
 ulocimp_forLanguageTag(const char* langtag,
                        int32_t tagLen,
                        icu::ByteSink& sink,
                        int32_t* parsedLength,
-                       UErrorCode* err);
+                       UErrorCode& err);
 
 /**
  * Get the region to use for supplemental data lookup. Uses
@@ -228,9 +228,9 @@ ulocimp_forLanguageTag(const char* langtag,
  *     The region code found, empty if none found.
  * @internal ICU 57
  */
-U_EXPORT icu::CharString U_EXPORT2
-ulocimp_getRegionForSupplementalData(const char *localeID, UBool inferRegion,
-                                     UErrorCode* status);
+U_EXPORT icu::CharString
+ulocimp_getRegionForSupplementalData(const char *localeID, bool inferRegion,
+                                     UErrorCode& status);
 
 /**
  * Add the likely subtags for a provided locale ID, per the algorithm described
@@ -261,10 +261,10 @@ ulocimp_getRegionForSupplementalData(const char *localeID, UBool inferRegion,
  * or the localeId is not well-formed, the error code is U_ILLEGAL_ARGUMENT_ERROR.
  * @internal ICU 64
  */
-U_CAPI void U_EXPORT2
+U_EXPORT void
 ulocimp_addLikelySubtags(const char* localeID,
                          icu::ByteSink& sink,
-                         UErrorCode* err);
+                         UErrorCode& err);
 
 /**
  * Minimize the subtags for a provided locale ID, per the algorithm described
@@ -296,70 +296,72 @@ ulocimp_addLikelySubtags(const char* localeID,
  * or the localeId is not well-formed, the error code is U_ILLEGAL_ARGUMENT_ERROR.
  * @internal ICU 64
  */
-U_CAPI void U_EXPORT2
+U_EXPORT void
 ulocimp_minimizeSubtags(const char* localeID,
                         icu::ByteSink& sink,
                         bool favorScript,
-                        UErrorCode* err);
+                        UErrorCode& err);
 
 U_CAPI const char * U_EXPORT2
 locale_getKeywordsStart(const char *localeID);
 
-U_CFUNC UBool
+bool
 ultag_isExtensionSubtags(const char* s, int32_t len);
 
-U_CFUNC UBool
+bool
 ultag_isLanguageSubtag(const char* s, int32_t len);
 
-U_CFUNC UBool
+bool
 ultag_isPrivateuseValueSubtags(const char* s, int32_t len);
 
-U_CFUNC UBool
+bool
 ultag_isRegionSubtag(const char* s, int32_t len);
 
-U_CFUNC UBool
+bool
 ultag_isScriptSubtag(const char* s, int32_t len);
 
-U_CFUNC UBool
+bool
 ultag_isTransformedExtensionSubtags(const char* s, int32_t len);
 
-U_CFUNC UBool
+bool
 ultag_isUnicodeExtensionSubtags(const char* s, int32_t len);
 
-U_CFUNC UBool
+bool
 ultag_isUnicodeLocaleAttribute(const char* s, int32_t len);
 
-U_CFUNC UBool
+bool
 ultag_isUnicodeLocaleAttributes(const char* s, int32_t len);
 
-U_CFUNC UBool
+bool
 ultag_isUnicodeLocaleKey(const char* s, int32_t len);
 
-U_CFUNC UBool
+bool
 ultag_isUnicodeLocaleType(const char* s, int32_t len);
 
-U_CFUNC UBool
+bool
 ultag_isVariantSubtags(const char* s, int32_t len);
 
-U_CAPI const char * U_EXPORT2
-ultag_getTKeyStart(const char *localeID);
+const char*
+ultag_getTKeyStart(const char* localeID);
 
-U_CFUNC const char*
+U_EXPORT const char*
 ulocimp_toBcpKey(const char* key);
 
-U_CFUNC const char*
+U_EXPORT const char*
 ulocimp_toLegacyKey(const char* key);
 
-U_CFUNC const char*
-ulocimp_toBcpType(const char* key, const char* type, UBool* isKnownKey, UBool* isSpecialType);
+U_EXPORT const char*
+ulocimp_toBcpType(const char* key, const char* type, bool* isKnownKey, bool* isSpecialType);
 
-U_CFUNC const char*
-ulocimp_toLegacyType(const char* key, const char* type, UBool* isKnownKey, UBool* isSpecialType);
+U_EXPORT const char*
+ulocimp_toLegacyType(const char* key, const char* type, bool* isKnownKey, bool* isSpecialType);
 
 /* Function for testing purpose */
-U_CAPI const char* const* ulocimp_getKnownCanonicalizedLocaleForTest(int32_t* length);
+U_EXPORT const char* const*
+ulocimp_getKnownCanonicalizedLocaleForTest(int32_t& length);
 
 // Return true if the value is already canonicalized.
-U_CAPI bool ulocimp_isCanonicalizedLocaleForTest(const char* localeName);
+U_EXPORT bool
+ulocimp_isCanonicalizedLocaleForTest(const char* localeName);
 
 #endif

--- a/icu4c/source/common/uresbund.cpp
+++ b/icu4c/source/common/uresbund.cpp
@@ -2721,7 +2721,7 @@ ures_openWithType(UResourceBundle *r, const char* path, const char* localeID,
         CharString canonLocaleID;
         {
             CharStringByteSink sink(&canonLocaleID);
-            ulocimp_getBaseName(localeID, sink, status);
+            ulocimp_getBaseName(localeID, sink, *status);
         }
         if(U_FAILURE(*status)) {
             *status = U_ILLEGAL_ARGUMENT_ERROR;
@@ -3062,7 +3062,7 @@ static void getParentForFunctionalEquivalent(const char*      localeID,
         parent.clear();
         {
             CharStringByteSink sink(&parent);
-            ulocimp_getParent(localeID, sink, &subStatus);
+            ulocimp_getParent(localeID, sink, subStatus);
         }
     }
 }
@@ -3086,14 +3086,14 @@ ures_getFunctionalEquivalent(char *result, int32_t resultCapacity,
     CharString kwVal;
     {
         CharStringByteSink sink(&kwVal);
-        ulocimp_getKeywordValue(locid, keyword, sink, &subStatus);
+        ulocimp_getKeywordValue(locid, keyword, sink, subStatus);
     }
     if(kwVal == DEFAULT_TAG) {
         kwVal.clear();
     }
     {
         CharStringByteSink sink(&base);
-        ulocimp_getBaseName(locid, sink, &subStatus);
+        ulocimp_getBaseName(locid, sink, subStatus);
     }
 #if defined(URES_TREE_DEBUG)
     fprintf(stderr, "getFunctionalEquivalent: \"%s\" [%s=%s] in %s - %s\n", 

--- a/icu4c/source/common/uscript.cpp
+++ b/icu4c/source/common/uscript.cpp
@@ -135,7 +135,7 @@ uscript_getCode(const char* nameOrAbbrOrLocale,
     icu::CharString likely;
     {
         icu::CharStringByteSink sink(&likely);
-        ulocimp_addLikelySubtags(nameOrAbbrOrLocale, sink, &internalErrorCode);
+        ulocimp_addLikelySubtags(nameOrAbbrOrLocale, sink, internalErrorCode);
     }
     if(U_SUCCESS(internalErrorCode) && internalErrorCode != U_STRING_NOT_TERMINATED_WARNING) {
         length = getCodesFromLocale(likely.data(), fillIn, capacity, err);

--- a/icu4c/source/i18n/calendar.cpp
+++ b/icu4c/source/i18n/calendar.cpp
@@ -262,7 +262,7 @@ static ECalType getCalendarTypeForLocale(const char *locid) {
     CharString canonicalName;
     {
         CharStringByteSink sink(&canonicalName);
-        ulocimp_canonicalize(locid, sink, &status);
+        ulocimp_canonicalize(locid, sink, status);
     }
     if (U_FAILURE(status)) {
         return CALTYPE_GREGORIAN;
@@ -271,7 +271,7 @@ static ECalType getCalendarTypeForLocale(const char *locid) {
     CharString calTypeBuf;
     {
         CharStringByteSink sink(&calTypeBuf);
-        ulocimp_getKeywordValue(canonicalName.data(), "calendar", sink, &status);
+        ulocimp_getKeywordValue(canonicalName.data(), "calendar", sink, status);
     }
     if (U_SUCCESS(status)) {
         calType = getCalendarType(calTypeBuf.data());
@@ -283,7 +283,7 @@ static ECalType getCalendarTypeForLocale(const char *locid) {
 
     // when calendar keyword is not available or not supported, read supplementalData
     // to get the default calendar type for the locale's region
-    CharString region = ulocimp_getRegionForSupplementalData(canonicalName.data(), true, &status);
+    CharString region = ulocimp_getRegionForSupplementalData(canonicalName.data(), true, status);
     if (U_FAILURE(status)) {
         return CALTYPE_GREGORIAN;
     }
@@ -4035,7 +4035,7 @@ Calendar::setWeekData(const Locale& desiredLocale, const char *type, UErrorCode&
         return;
     }
 
-    CharString region = ulocimp_getRegionForSupplementalData(desiredLocale.getName(), true, &status);
+    CharString region = ulocimp_getRegionForSupplementalData(desiredLocale.getName(), true, status);
 
     // Read week data values from supplementalData week data
     UResourceBundle *rb = ures_openDirect(nullptr, "supplementalData", &status);

--- a/icu4c/source/i18n/collationruleparser.cpp
+++ b/icu4c/source/i18n/collationruleparser.cpp
@@ -610,7 +610,7 @@ CollationRuleParser::parseSetting(UErrorCode &errorCode) {
             int32_t parsedLength;
             {
                 CharStringByteSink sink(&localeID);
-                ulocimp_forLanguageTag(lang.data(), -1, sink, &parsedLength, &errorCode);
+                ulocimp_forLanguageTag(lang.data(), -1, sink, &parsedLength, errorCode);
             }
             if(U_FAILURE(errorCode) || parsedLength != lang.length()) {
                 errorCode = U_ZERO_ERROR;
@@ -635,7 +635,7 @@ CollationRuleParser::parseSetting(UErrorCode &errorCode) {
             CharString collationType;
             {
                 CharStringByteSink sink(&collationType);
-                ulocimp_getKeywordValue(localeID.data(), "collation", sink, &errorCode);
+                ulocimp_getKeywordValue(localeID.data(), "collation", sink, errorCode);
             }
             if(U_FAILURE(errorCode)) {
                 errorCode = U_ZERO_ERROR;

--- a/icu4c/source/i18n/dayperiodrules.cpp
+++ b/icu4c/source/i18n/dayperiodrules.cpp
@@ -363,7 +363,7 @@ const DayPeriodRules *DayPeriodRules::getInstance(const Locale &locale, UErrorCo
         if (ruleSetNum == 0) {
             CharString parent;
             CharStringByteSink sink(&parent);
-            ulocimp_getParent(name, sink, &errorCode);
+            ulocimp_getParent(name, sink, errorCode);
             if (parent.isEmpty()) {
                 // Saves a lookup in the hash table.
                 break;

--- a/icu4c/source/i18n/dtitvinf.cpp
+++ b/icu4c/source/i18n/dtitvinf.cpp
@@ -408,7 +408,7 @@ DateIntervalInfo::initializeData(const Locale& locale, UErrorCode& status)
     CharString calendarType;
     {
         CharStringByteSink sink(&calendarType);
-        ulocimp_getKeywordValue(localeWithCalendarKey, "calendar", sink, &status);
+        ulocimp_getKeywordValue(localeWithCalendarKey, "calendar", sink, status);
     }
     if (U_SUCCESS(status)) {
         calendarTypeToUse = calendarType.data();

--- a/icu4c/source/i18n/dtptngen.cpp
+++ b/icu4c/source/i18n/dtptngen.cpp
@@ -658,7 +658,7 @@ void DateTimePatternGenerator::getAllowedHourFormats(const Locale &locale, UErro
     if (U_FAILURE(status)) { return; }
 
     const char *language = locale.getLanguage();
-    CharString baseCountry = ulocimp_getRegionForSupplementalData(locale.getName(), false, &status);
+    CharString baseCountry = ulocimp_getRegionForSupplementalData(locale.getName(), false, status);
     const char* country = baseCountry.data();
 
     Locale maxLocale;  // must be here for correct lifetime
@@ -911,7 +911,7 @@ DateTimePatternGenerator::getCalendarTypeToUse(const Locale& locale, CharString&
                 localeWithCalendarKey,
                 "calendar",
                 sink,
-                &localStatus);
+                localStatus);
         }
         // If the input locale was invalid, don't fail with missing resource error, instead
         // continue with default of Gregorian.

--- a/icu4c/source/i18n/gender.cpp
+++ b/icu4c/source/i18n/gender.cpp
@@ -158,7 +158,7 @@ const GenderInfo* GenderInfo::loadInstance(const Locale& locale, UErrorCode& sta
       {
         CharString tmp;
         CharStringByteSink sink(&tmp);
-        ulocimp_getParent(parentLocaleName.data(), sink, &status);
+        ulocimp_getParent(parentLocaleName.data(), sink, status);
         if (tmp.isEmpty()) break;
         parentLocaleName = std::move(tmp);
       }

--- a/icu4c/source/i18n/plurrule.cpp
+++ b/icu4c/source/i18n/plurrule.cpp
@@ -863,7 +863,7 @@ PluralRules::getRuleFromResource(const Locale& locale, UPluralType type, UErrorC
             {
                 CharString tmp;
                 CharStringByteSink sink(&tmp);
-                ulocimp_getParent(parentLocaleName.data(), sink, &status);
+                ulocimp_getParent(parentLocaleName.data(), sink, status);
                 if (tmp.isEmpty()) break;
                 parentLocaleName = std::move(tmp);
             }

--- a/icu4c/source/i18n/rulebasedcollator.cpp
+++ b/icu4c/source/i18n/rulebasedcollator.cpp
@@ -1583,7 +1583,7 @@ RuleBasedCollator::internalGetShortDefinitionString(const char *locale,
     {
         CharString collation;
         CharStringByteSink sink(&collation);
-        ulocimp_getKeywordValue(resultLocale, "collation", sink, &errorCode);
+        ulocimp_getKeywordValue(resultLocale, "collation", sink, errorCode);
         appendSubtag(result, 'K', collation.data(), collation.length(), errorCode);
     }
     CharString language;

--- a/icu4c/source/i18n/tmutfmt.cpp
+++ b/icu4c/source/i18n/tmutfmt.cpp
@@ -566,7 +566,7 @@ TimeUnitFormat::searchInLocaleChain(UTimeUnitFormatStyle style, const char* key,
         {
             CharString tmp;
             CharStringByteSink sink(&tmp);
-            ulocimp_getParent(parentLocale.data(), sink, &status);
+            ulocimp_getParent(parentLocale.data(), sink, status);
             parentLocale = std::move(tmp);
         }
         // look for pattern for srcPluralCount in locale tree

--- a/icu4c/source/i18n/tzfmt.cpp
+++ b/icu4c/source/i18n/tzfmt.cpp
@@ -331,7 +331,7 @@ TimeZoneFormat::TimeZoneFormat(const Locale& locale, UErrorCode& status)
         CharString loc;
         {
             CharStringByteSink sink(&loc);
-            ulocimp_addLikelySubtags(fLocale.getName(), sink, &tempStatus);
+            ulocimp_addLikelySubtags(fLocale.getName(), sink, tempStatus);
         }
 
         regionLen = uloc_getCountry(loc.data(), fTargetRegion, sizeof(fTargetRegion), &tempStatus);

--- a/icu4c/source/i18n/tzgnames.cpp
+++ b/icu4c/source/i18n/tzgnames.cpp
@@ -413,7 +413,7 @@ TZGNCore::initialize(const Locale& locale, UErrorCode& status) {
         CharString loc;
         {
             CharStringByteSink sink(&loc);
-            ulocimp_addLikelySubtags(fLocale.getName(), sink, &status);
+            ulocimp_addLikelySubtags(fLocale.getName(), sink, status);
         }
 
         ulocimp_getSubtags(loc.data(), nullptr, nullptr, &fTargetRegion, nullptr, nullptr, status);

--- a/icu4c/source/i18n/tznames_impl.cpp
+++ b/icu4c/source/i18n/tznames_impl.cpp
@@ -2164,7 +2164,7 @@ TZDBTimeZoneNames::TZDBTimeZoneNames(const Locale& locale)
         CharString loc;
         {
             CharStringByteSink sink(&loc);
-            ulocimp_addLikelySubtags(fLocale.getName(), sink, &status);
+            ulocimp_addLikelySubtags(fLocale.getName(), sink, status);
         }
         ulocimp_getSubtags(loc.data(), nullptr, nullptr, &fRegion, nullptr, nullptr, status);
         if (U_SUCCESS(status)) {

--- a/icu4c/source/i18n/ucal.cpp
+++ b/icu4c/source/i18n/ucal.cpp
@@ -172,7 +172,7 @@ ucal_open(  const char16_t*  zoneID,
           locale = uloc_getDefault();
       }
       CharString localeBuf(locale, *status);
-      ulocimp_setKeywordValue("calendar", "gregorian", localeBuf, status);
+      ulocimp_setKeywordValue("calendar", "gregorian", localeBuf, *status);
       if (U_FAILURE(*status)) {
           return nullptr;
       }
@@ -716,7 +716,7 @@ static const char * const CAL_TYPES[] = {
 U_CAPI UEnumeration* U_EXPORT2
 ucal_getKeywordValuesForLocale(const char * /* key */, const char* locale, UBool commonlyUsed, UErrorCode *status) {
     // Resolve region
-    CharString prefRegion = ulocimp_getRegionForSupplementalData(locale, true, status);
+    CharString prefRegion = ulocimp_getRegionForSupplementalData(locale, true, *status);
 
     // Read preferred calendar values from supplementalData calendarPreference
     UResourceBundle *rb = ures_openDirect(nullptr, "supplementalData", status);

--- a/icu4c/source/i18n/ucol_sit.cpp
+++ b/icu4c/source/i18n/ucol_sit.cpp
@@ -454,7 +454,7 @@ ucol_prepareShortStringOpen( const char *definition,
     CharString buffer;
     {
         CharStringByteSink sink(&buffer);
-        ulocimp_canonicalize(s.locale.data(), sink, status);
+        ulocimp_canonicalize(s.locale.data(), sink, *status);
     }
 
     UResourceBundle *b = ures_open(U_ICUDATA_COLL, buffer.data(), status);
@@ -465,7 +465,7 @@ ucol_prepareShortStringOpen( const char *definition,
     {
         // if there is a keyword, we pick it up and try to get elements
         CharStringByteSink sink(&keyBuffer);
-        ulocimp_getKeywordValue(buffer.data(), "collation", sink, status);
+        ulocimp_getKeywordValue(buffer.data(), "collation", sink, *status);
     }
     if(keyBuffer.isEmpty()) {
       // no keyword
@@ -526,7 +526,7 @@ ucol_openFromShortString( const char *definition,
     CharString buffer;
     {
         CharStringByteSink sink(&buffer);
-        ulocimp_canonicalize(s.locale.data(), sink, status);
+        ulocimp_canonicalize(s.locale.data(), sink, *status);
     }
 
     UCollator *result = ucol_open(buffer.data(), status);

--- a/icu4c/source/i18n/ulocdata.cpp
+++ b/icu4c/source/i18n/ulocdata.cpp
@@ -198,11 +198,13 @@ ulocdata_getDelimiter(ULocaleData *uld, ULocaleDataDelimiterType type,
     return len;
 }
 
-static UResourceBundle * measurementTypeBundleForLocale(const char *localeID, const char *measurementType, UErrorCode *status){
+namespace {
+
+UResourceBundle * measurementTypeBundleForLocale(const char *localeID, const char *measurementType, UErrorCode *status){
     UResourceBundle *rb;
     UResourceBundle *measTypeBundle = nullptr;
 
-    icu::CharString region = ulocimp_getRegionForSupplementalData(localeID, true, status);
+    icu::CharString region = ulocimp_getRegionForSupplementalData(localeID, true, *status);
 
     rb = ures_openDirect(nullptr, "supplementalData", status);
     ures_getByKey(rb, "measurementData", rb, status);
@@ -224,6 +226,8 @@ static UResourceBundle * measurementTypeBundleForLocale(const char *localeID, co
     ures_close(rb);
     return measTypeBundle;
 }
+
+}  // namespace
 
 U_CAPI UMeasurementSystem U_EXPORT2
 ulocdata_getMeasurementSystem(const char *localeID, UErrorCode *status){

--- a/icu4c/source/i18n/units_data.cpp
+++ b/icu4c/source/i18n/units_data.cpp
@@ -444,7 +444,7 @@ MaybeStackVector<UnitPreference>
         }
     }
 
-    CharString region = ulocimp_getRegionForSupplementalData(locale.getName(), false, &status);
+    CharString region = ulocimp_getRegionForSupplementalData(locale.getName(), false, status);
 
     // Check the locale system tag, e.g `ms=metric`.
     UErrorCode internalMeasureTagStatus = U_ZERO_ERROR;

--- a/icu4c/source/i18n/windtfmt.cpp
+++ b/icu4c/source/i18n/windtfmt.cpp
@@ -107,7 +107,7 @@ static UErrorCode GetEquivalentWindowsLocaleName(const Locale& locale, UnicodeSt
     CharString asciiBCP47Tag;
     {
         CharStringByteSink sink(&asciiBCP47Tag);
-        ulocimp_toLanguageTag(locale.getName(), sink, false, &status);
+        ulocimp_toLanguageTag(locale.getName(), sink, false, status);
     }
 
     if (U_SUCCESS(status))
@@ -412,4 +412,3 @@ U_NAMESPACE_END
 #endif /* #if !UCONFIG_NO_FORMATTING */
 
 #endif // U_PLATFORM_USES_ONLY_WIN32_API
-

--- a/icu4c/source/i18n/winnmfmt.cpp
+++ b/icu4c/source/i18n/winnmfmt.cpp
@@ -152,7 +152,7 @@ static UErrorCode GetEquivalentWindowsLocaleName(const Locale& locale, UnicodeSt
     CharString asciiBCP47Tag;
     {
         CharStringByteSink sink(&asciiBCP47Tag);
-        ulocimp_toLanguageTag(locale.getName(), sink, false, &status);
+        ulocimp_toLanguageTag(locale.getName(), sink, false, status);
     }
 
     if (U_SUCCESS(status))

--- a/icu4c/source/test/intltest/loctest.cpp
+++ b/icu4c/source/test/intltest/loctest.cpp
@@ -5790,7 +5790,7 @@ void LocaleTest::TestKnownCanonicalizedListCorrect()
     IcuTestErrorCode status(*this, "TestKnownCanonicalizedListCorrect");
     int32_t numOfKnownCanonicalized;
     const char* const* knownCanonicalized =
-        ulocimp_getKnownCanonicalizedLocaleForTest(&numOfKnownCanonicalized);
+        ulocimp_getKnownCanonicalizedLocaleForTest(numOfKnownCanonicalized);
     for (int32_t i = 0; i < numOfKnownCanonicalized; i++) {
         std::string msg("Known Canonicalized Locale is not canonicalized: ");
         assertTrue((msg + knownCanonicalized[i]).c_str(),


### PR DESCRIPTION
Some of this code was originally written as C code and some of this code was originally written as C++ code but made to resemble the then already existing code that had once been C code. Changing it all to normal C++ now will make it easier and safer to work with going forward.

- Use unnamed namespace instead of static.
- Use reference instead of non-nullable pointer.
- Use bool instead of UBool.
- Use constexpr for static data.
- Use U_EXPORT instead of U_CAPI or U_CFUNC.
- Use the default calling convention instead of U_EXPORT2.

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22520
- [X] Required: The PR title must be prefixed with a JIRA Issue number.
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number.
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
