### PR TITLE
ICU-22520 Standardize return on error for all locale functions

### DIFF
--- a/icu4c/source/common/localebuilder.cpp
+++ b/icu4c/source/common/localebuilder.cpp
@@ -203,6 +203,7 @@ _copyExtensions(const Locale& from, icu::StringEnumeration *keywords,
 void
 _clearUAttributesAndKeyType(Locale& locale, UErrorCode& errorCode)
 {
+    if (U_FAILURE(errorCode)) { return; }
     // Clear Unicode attributes
     locale.setKeywordValue(kAttributeKey, "", errorCode);
 
@@ -218,6 +219,7 @@ _clearUAttributesAndKeyType(Locale& locale, UErrorCode& errorCode)
 void
 _setUnicodeExtensions(Locale& locale, const CharString& value, UErrorCode& errorCode)
 {
+    if (U_FAILURE(errorCode)) { return; }
     // Add the unicode extensions to extensions_
     CharString locale_str("und-u-", errorCode);
     locale_str.append(value, errorCode);

--- a/icu4c/source/common/localematcher.cpp
+++ b/icu4c/source/common/localematcher.cpp
@@ -4,6 +4,8 @@
 // localematcher.cpp
 // created: 2019may08 Markus W. Scherer
 
+#include <optional>
+
 #include "unicode/utypes.h"
 #include "unicode/localebuilder.h"
 #include "unicode/localematcher.h"
@@ -605,10 +607,11 @@ private:
 
 const Locale *LocaleMatcher::getBestMatch(const Locale &desiredLocale, UErrorCode &errorCode) const {
     if (U_FAILURE(errorCode)) { return nullptr; }
-    int32_t suppIndex = getBestSuppIndex(
+    std::optional<int32_t> suppIndex = getBestSuppIndex(
         getMaximalLsrOrUnd(likelySubtags, desiredLocale, errorCode),
         nullptr, errorCode);
-    return U_SUCCESS(errorCode) && suppIndex >= 0 ? supportedLocales[suppIndex] : defaultLocale;
+    return U_SUCCESS(errorCode) && suppIndex.has_value() ? supportedLocales[suppIndex.value()]
+                                                         : defaultLocale;
 }
 
 const Locale *LocaleMatcher::getBestMatch(Locale::Iterator &desiredLocales,
@@ -618,12 +621,14 @@ const Locale *LocaleMatcher::getBestMatch(Locale::Iterator &desiredLocales,
         return defaultLocale;
     }
     LocaleLsrIterator lsrIter(likelySubtags, desiredLocales, ULOCMATCH_TEMPORARY_LOCALES);
-    int32_t suppIndex = getBestSuppIndex(lsrIter.next(errorCode), &lsrIter, errorCode);
-    return U_SUCCESS(errorCode) && suppIndex >= 0 ? supportedLocales[suppIndex] : defaultLocale;
+    std::optional<int32_t> suppIndex = getBestSuppIndex(lsrIter.next(errorCode), &lsrIter, errorCode);
+    return U_SUCCESS(errorCode) && suppIndex.has_value() ? supportedLocales[suppIndex.value()]
+                                                         : defaultLocale;
 }
 
 const Locale *LocaleMatcher::getBestMatchForListString(
         StringPiece desiredLocaleList, UErrorCode &errorCode) const {
+    if (U_FAILURE(errorCode)) { return nullptr; }
     LocalePriorityList list(desiredLocaleList, errorCode);
     LocalePriorityList::Iterator iter = list.iterator();
     return getBestMatch(iter, errorCode);
@@ -634,13 +639,13 @@ LocaleMatcher::Result LocaleMatcher::getBestMatchResult(
     if (U_FAILURE(errorCode)) {
         return Result(nullptr, defaultLocale, -1, -1, false);
     }
-    int32_t suppIndex = getBestSuppIndex(
+    std::optional<int32_t> suppIndex = getBestSuppIndex(
         getMaximalLsrOrUnd(likelySubtags, desiredLocale, errorCode),
         nullptr, errorCode);
-    if (U_FAILURE(errorCode) || suppIndex < 0) {
+    if (U_FAILURE(errorCode) || !suppIndex.has_value()) {
         return Result(nullptr, defaultLocale, -1, -1, false);
     } else {
-        return Result(&desiredLocale, supportedLocales[suppIndex], 0, suppIndex, false);
+        return Result(&desiredLocale, supportedLocales[suppIndex.value()], 0, suppIndex.value(), false);
     }
 }
 
@@ -650,18 +655,19 @@ LocaleMatcher::Result LocaleMatcher::getBestMatchResult(
         return Result(nullptr, defaultLocale, -1, -1, false);
     }
     LocaleLsrIterator lsrIter(likelySubtags, desiredLocales, ULOCMATCH_TEMPORARY_LOCALES);
-    int32_t suppIndex = getBestSuppIndex(lsrIter.next(errorCode), &lsrIter, errorCode);
-    if (U_FAILURE(errorCode) || suppIndex < 0) {
+    std::optional<int32_t> suppIndex = getBestSuppIndex(lsrIter.next(errorCode), &lsrIter, errorCode);
+    if (U_FAILURE(errorCode) || !suppIndex.has_value()) {
         return Result(nullptr, defaultLocale, -1, -1, false);
     } else {
-        return Result(lsrIter.orphanRemembered(), supportedLocales[suppIndex],
-                      lsrIter.getBestDesiredIndex(), suppIndex, true);
+        return Result(lsrIter.orphanRemembered(), supportedLocales[suppIndex.value()],
+                      lsrIter.getBestDesiredIndex(), suppIndex.value(), true);
     }
 }
 
-int32_t LocaleMatcher::getBestSuppIndex(LSR desiredLSR, LocaleLsrIterator *remainingIter,
-                                        UErrorCode &errorCode) const {
-    if (U_FAILURE(errorCode)) { return -1; }
+std::optional<int32_t> LocaleMatcher::getBestSuppIndex(LSR desiredLSR,
+                                                       LocaleLsrIterator *remainingIter,
+                                                       UErrorCode &errorCode) const {
+    if (U_FAILURE(errorCode)) { return std::nullopt; }
     int32_t desiredIndex = 0;
     int32_t bestSupportedLsrIndex = -1;
     for (int32_t bestShiftedDistance = LocaleDistance::shiftDistance(thresholdDistance);;) {
@@ -684,7 +690,7 @@ int32_t LocaleMatcher::getBestSuppIndex(LSR desiredLSR, LocaleLsrIterator *remai
             bestShiftedDistance = LocaleDistance::getShiftedDistance(bestIndexAndDistance);
             if (remainingIter != nullptr) {
                 remainingIter->rememberCurrent(desiredIndex, errorCode);
-                if (U_FAILURE(errorCode)) { return -1; }
+                if (U_FAILURE(errorCode)) { return std::nullopt; }
             }
             bestSupportedLsrIndex = LocaleDistance::getIndex(bestIndexAndDistance);
         }
@@ -695,20 +701,21 @@ int32_t LocaleMatcher::getBestSuppIndex(LSR desiredLSR, LocaleLsrIterator *remai
             break;
         }
         desiredLSR = remainingIter->next(errorCode);
-        if (U_FAILURE(errorCode)) { return -1; }
+        if (U_FAILURE(errorCode)) { return std::nullopt; }
         ++desiredIndex;
     }
     if (bestSupportedLsrIndex < 0) {
         // no good match
-        return -1;
+        return std::nullopt;
     }
     return supportedIndexes[bestSupportedLsrIndex];
 }
 
 UBool LocaleMatcher::isMatch(const Locale &desired, const Locale &supported,
                              UErrorCode &errorCode) const {
+    if (U_FAILURE(errorCode)) { return false; }
     LSR suppLSR = getMaximalLsrOrUnd(likelySubtags, supported, errorCode);
-    if (U_FAILURE(errorCode)) { return 0; }
+    if (U_FAILURE(errorCode)) { return false; }
     const LSR *pSuppLSR = &suppLSR;
     int32_t indexAndDistance = localeDistance.getBestIndexAndDistance(
             getMaximalLsrOrUnd(likelySubtags, desired, errorCode),
@@ -718,9 +725,10 @@ UBool LocaleMatcher::isMatch(const Locale &desired, const Locale &supported,
 }
 
 double LocaleMatcher::internalMatch(const Locale &desired, const Locale &supported, UErrorCode &errorCode) const {
+    if (U_FAILURE(errorCode)) { return 0.; }
     // Returns the inverse of the distance: That is, 1-distance(desired, supported).
     LSR suppLSR = getMaximalLsrOrUnd(likelySubtags, supported, errorCode);
-    if (U_FAILURE(errorCode)) { return 0; }
+    if (U_FAILURE(errorCode)) { return 0.; }
     const LSR *pSuppLSR = &suppLSR;
     int32_t indexAndDistance = localeDistance.getBestIndexAndDistance(
             getMaximalLsrOrUnd(likelySubtags, desired, errorCode),

--- a/icu4c/source/common/locavailable.cpp
+++ b/icu4c/source/common/locavailable.cpp
@@ -101,10 +101,9 @@ icu::UInitOnce ginstalledLocalesInitOnce {};
 class AvailableLocalesSink : public ResourceSink {
   public:
     void put(const char *key, ResourceValue &value, UBool /*noFallback*/, UErrorCode &status) override {
+        if (U_FAILURE(status)) { return; }
         ResourceTable resIndexTable = value.getTable(status);
-        if (U_FAILURE(status)) {
-            return;
-        }
+        if (U_FAILURE(status)) { return; }
         for (int32_t i = 0; resIndexTable.getKeyAndValue(i, key, value); ++i) {
             ULocAvailableType type;
             if (uprv_strcmp(key, "InstalledLocales") == 0) {
@@ -138,7 +137,8 @@ class AvailableLocalesStringEnumeration : public StringEnumeration {
     AvailableLocalesStringEnumeration(ULocAvailableType type) : fType(type) {
     }
 
-    const char* next(int32_t *resultLength, UErrorCode&) override {
+    const char* next(int32_t *resultLength, UErrorCode &status) override {
+        if (U_FAILURE(status)) { return nullptr; }
         ULocAvailableType actualType = fType;
         int32_t actualIndex = fIndex++;
 
@@ -170,11 +170,13 @@ class AvailableLocalesStringEnumeration : public StringEnumeration {
         return result;
     }
 
-    void reset(UErrorCode&) override {
+    void reset(UErrorCode &status) override {
+        if (U_FAILURE(status)) { return; }
         fIndex = 0;
     }
 
-    int32_t count(UErrorCode&) const override {
+    int32_t count(UErrorCode &status) const override {
+        if (U_FAILURE(status)) { return 0; }
         if (fType == ULOC_AVAILABLE_WITH_LEGACY_ALIASES) {
             return gAvailableLocaleCounts[ULOC_AVAILABLE_DEFAULT]
                 + gAvailableLocaleCounts[ULOC_AVAILABLE_ONLY_LEGACY_ALIASES];

--- a/icu4c/source/common/locdispnames.cpp
+++ b/icu4c/source/common/locdispnames.cpp
@@ -306,6 +306,7 @@ _getStringOrCopyKey(const char *path, const char *locale,
                     const char *substitute,
                     char16_t *dest, int32_t destCapacity,
                     UErrorCode &errorCode) {
+    if (U_FAILURE(errorCode)) { return 0; }
     const char16_t *s = nullptr;
     int32_t length = 0;
 
@@ -368,13 +369,9 @@ _getDisplayNameForComponent(const char *locale,
                             UDisplayNameGetter *getter,
                             const char *tag,
                             UErrorCode &errorCode) {
+    if (U_FAILURE(errorCode)) { return 0; }
     UErrorCode localStatus;
     const char* root = nullptr;
-
-    /* argument checking */
-    if (U_FAILURE(errorCode)) {
-        return 0;
-    }
 
     if(destCapacity<0 || (destCapacity>0 && dest==nullptr)) {
         errorCode = U_ILLEGAL_ARGUMENT_ERROR;
@@ -422,6 +419,7 @@ uloc_getDisplayScript(const char* locale,
                       char16_t *dest, int32_t destCapacity,
                       UErrorCode *pErrorCode)
 {
+    if (U_FAILURE(*pErrorCode)) { return 0; }
     UErrorCode err = U_ZERO_ERROR;
     int32_t res = _getDisplayNameForComponent(locale, displayLocale, dest, destCapacity,
                 ulocimp_getScript, _kScriptsStandAlone, err);

--- a/icu4c/source/common/locresdata.cpp
+++ b/icu4c/source/common/locresdata.cpp
@@ -50,6 +50,7 @@ uloc_getTableStringWithFallback(const char *path, const char *locale,
                               int32_t *pLength,
                               UErrorCode *pErrorCode)
 {
+    if (U_FAILURE(*pErrorCode)) { return nullptr; }
 /*    char localeBuffer[ULOC_FULLNAME_CAPACITY*4];*/
     const char16_t *item=nullptr;
     UErrorCode errorCode;
@@ -159,45 +160,47 @@ _uloc_getOrientationHelper(const char* localeId,
 {
     ULayoutType result = ULOC_LAYOUT_UNKNOWN;
 
-    if (!U_FAILURE(status)) {
-        icu::CharString localeBuffer;
+    if (U_FAILURE(status)) { return result; }
+
+    icu::CharString localeBuffer;
+    {
+        icu::CharStringByteSink sink(&localeBuffer);
+        ulocimp_canonicalize(localeId, sink, status);
+    }
+
+    if (U_FAILURE(status)) { return result; }
+
+    int32_t length = 0;
+    const char16_t* const value =
+        uloc_getTableStringWithFallback(
+            nullptr,
+            localeBuffer.data(),
+            "layout",
+            nullptr,
+            key,
+            &length,
+            &status);
+
+    if (U_FAILURE(status)) { return result; }
+
+    if (length != 0) {
+        switch(value[0])
         {
-            icu::CharStringByteSink sink(&localeBuffer);
-            ulocimp_canonicalize(localeId, sink, status);
-        }
-
-        if (!U_FAILURE(status)) {
-            int32_t length = 0;
-            const char16_t* const value =
-                uloc_getTableStringWithFallback(
-                    nullptr,
-                    localeBuffer.data(),
-                    "layout",
-                    nullptr,
-                    key,
-                    &length,
-                    &status);
-
-            if (!U_FAILURE(status) && length != 0) {
-                switch(value[0])
-                {
-                case 0x0062: /* 'b' */
-                    result = ULOC_LAYOUT_BTT;
-                    break;
-                case 0x006C: /* 'l' */
-                    result = ULOC_LAYOUT_LTR;
-                    break;
-                case 0x0072: /* 'r' */
-                    result = ULOC_LAYOUT_RTL;
-                    break;
-                case 0x0074: /* 't' */
-                    result = ULOC_LAYOUT_TTB;
-                    break;
-                default:
-                    status = U_INTERNAL_PROGRAM_ERROR;
-                    break;
-                }
-            }
+        case 0x0062: /* 'b' */
+            result = ULOC_LAYOUT_BTT;
+            break;
+        case 0x006C: /* 'l' */
+            result = ULOC_LAYOUT_LTR;
+            break;
+        case 0x0072: /* 'r' */
+            result = ULOC_LAYOUT_RTL;
+            break;
+        case 0x0074: /* 't' */
+            result = ULOC_LAYOUT_TTB;
+            break;
+        default:
+            status = U_INTERNAL_PROGRAM_ERROR;
+            break;
         }
     }
 

--- a/icu4c/source/common/uloc_tag.cpp
+++ b/icu4c/source/common/uloc_tag.cpp
@@ -1169,12 +1169,9 @@ void _sortVariants(VariantListEntry* first) {
 
 void
 _appendVariantsToLanguageTag(const char* localeID, icu::ByteSink& sink, bool strict, bool& hadPosix, UErrorCode& status) {
+    if (U_FAILURE(status)) { return; }
+
     UErrorCode tmpStatus = U_ZERO_ERROR;
-
-    if (U_FAILURE(status)) {
-        return;
-    }
-
     icu::CharString buf = ulocimp_getVariant(localeID, tmpStatus);
     if (U_FAILURE(tmpStatus) || tmpStatus == U_STRING_NOT_TERMINATED_WARNING) {
         if (strict) {
@@ -1280,6 +1277,8 @@ _appendVariantsToLanguageTag(const char* localeID, icu::ByteSink& sink, bool str
 
 void
 _appendKeywordsToLanguageTag(const char* localeID, icu::ByteSink& sink, bool strict, bool hadPosix, UErrorCode& status) {
+    if (U_FAILURE(status)) { return; }
+
     icu::MemoryPool<AttributeListEntry> attrPool;
     icu::MemoryPool<ExtensionListEntry> extPool;
     icu::MemoryPool<icu::CharString> strPool;
@@ -1522,6 +1521,8 @@ _appendKeywordsToLanguageTag(const char* localeID, icu::ByteSink& sink, bool str
  */
 void
 _appendLDMLExtensionAsKeywords(const char* ldmlext, ExtensionListEntry** appendTo, icu::MemoryPool<ExtensionListEntry>& extPool, icu::MemoryPool<icu::CharString>& kwdBuf, bool& posixVariant, UErrorCode& status) {
+    if (U_FAILURE(status)) { return; }
+
     const char *pTag;   /* beginning of current subtag */
     const char *pKwds;  /* beginning of key-type pairs */
     bool variantExists = posixVariant;
@@ -1782,6 +1783,8 @@ _appendLDMLExtensionAsKeywords(const char* ldmlext, ExtensionListEntry** appendT
 
 void
 _appendKeywords(ULanguageTag* langtag, icu::ByteSink& sink, UErrorCode& status) {
+    if (U_FAILURE(status)) { return; }
+
     int32_t i, n;
     int32_t len;
     ExtensionListEntry *kwdFirst = nullptr;
@@ -1790,10 +1793,6 @@ _appendKeywords(ULanguageTag* langtag, icu::ByteSink& sink, UErrorCode& status) 
     icu::MemoryPool<ExtensionListEntry> extPool;
     icu::MemoryPool<icu::CharString> kwdBuf;
     bool posixVariant = false;
-
-    if (U_FAILURE(status)) {
-        return;
-    }
 
     n = ultag_getExtensionsSize(langtag);
 
@@ -1877,14 +1876,10 @@ _appendKeywords(ULanguageTag* langtag, icu::ByteSink& sink, UErrorCode& status) 
 }
 
 void
-_appendPrivateuseToLanguageTag(const char* localeID, icu::ByteSink& sink, bool strict, bool hadPosix, UErrorCode& status) {
-    (void)hadPosix;
+_appendPrivateuseToLanguageTag(const char* localeID, icu::ByteSink& sink, bool strict, bool /*hadPosix*/, UErrorCode& status) {
+    if (U_FAILURE(status)) { return; }
+
     UErrorCode tmpStatus = U_ZERO_ERROR;
-
-    if (U_FAILURE(status)) {
-        return;
-    }
-
     icu::CharString buf = ulocimp_getVariant(localeID, tmpStatus);
     if (U_FAILURE(tmpStatus)) {
         if (strict) {
@@ -1986,6 +1981,8 @@ _appendPrivateuseToLanguageTag(const char* localeID, icu::ByteSink& sink, bool s
 
 ULanguageTag*
 ultag_parse(const char* tag, int32_t tagLen, int32_t* parsedLen, UErrorCode& status) {
+    if (U_FAILURE(status)) { return nullptr; }
+
     char *tagBuf;
     int16_t next;
     char *pSubtag, *pNext, *pLastGoodPosition;
@@ -1999,10 +1996,6 @@ ultag_parse(const char* tag, int32_t tagLen, int32_t* parsedLen, UErrorCode& sta
 
     if (parsedLen != nullptr) {
         *parsedLen = 0;
-    }
-
-    if (U_FAILURE(status)) {
-        return nullptr;
     }
 
     if (tagLen < 0) {
@@ -2583,12 +2576,11 @@ uloc_toLanguageTag(const char* localeID,
 
     icu::CheckedArrayByteSink sink(langtag, langtagCapacity);
     ulocimp_toLanguageTag(localeID, sink, strict, *status);
+    if (U_FAILURE(*status)) {
+        return 0;
+    }
 
     int32_t reslen = sink.NumberOfBytesAppended();
-
-    if (U_FAILURE(*status)) {
-        return reslen;
-    }
 
     if (sink.Overflowed()) {
         *status = U_BUFFER_OVERFLOW_ERROR;
@@ -2605,6 +2597,8 @@ ulocimp_toLanguageTag(const char* localeID,
                       icu::ByteSink& sink,
                       bool strict,
                       UErrorCode& status) {
+    if (U_FAILURE(status)) { return; }
+
     icu::CharString canonical;
     UErrorCode tmpStatus = U_ZERO_ERROR;
     bool hadPosix = false;
@@ -2684,12 +2678,11 @@ uloc_forLanguageTag(const char* langtag,
 
     icu::CheckedArrayByteSink sink(localeID, localeIDCapacity);
     ulocimp_forLanguageTag(langtag, -1, sink, parsedLength, *status);
+    if (U_FAILURE(*status)) {
+        return 0;
+    }
 
     int32_t reslen = sink.NumberOfBytesAppended();
-
-    if (U_FAILURE(*status)) {
-        return reslen;
-    }
 
     if (sink.Overflowed()) {
         *status = U_BUFFER_OVERFLOW_ERROR;
@@ -2707,6 +2700,8 @@ ulocimp_forLanguageTag(const char* langtag,
                        icu::ByteSink& sink,
                        int32_t* parsedLength,
                        UErrorCode& status) {
+    if (U_FAILURE(status)) { return; }
+
     bool isEmpty = true;
     const char *subtag, *p;
     int32_t len;

--- a/icu4c/source/common/ulocale.cpp
+++ b/icu4c/source/common/ulocale.cpp
@@ -19,15 +19,17 @@ U_NAMESPACE_USE
 
 ULocale*
 ulocale_openForLocaleID(const char* localeID, int32_t length, UErrorCode* err) {
+    if (U_FAILURE(*err)) { return nullptr; }
     CharString str(length < 0 ? StringPiece(localeID) : StringPiece(localeID, length), *err);
-    if (U_FAILURE(*err)) return nullptr;
+    if (U_FAILURE(*err)) { return nullptr; }
     return EXTERNAL(icu::Locale::createFromName(str.data()).clone());
 }
 
 ULocale*
 ulocale_openForLanguageTag(const char* tag, int32_t length, UErrorCode* err) {
+  if (U_FAILURE(*err)) { return nullptr; }
   Locale l = icu::Locale::forLanguageTag(length < 0 ? StringPiece(tag) : StringPiece(tag, length), *err);
-  if (U_FAILURE(*err)) return nullptr;
+  if (U_FAILURE(*err)) { return nullptr; }
   return EXTERNAL(l.clone());
 }
 
@@ -57,10 +59,10 @@ int32_t ulocale_get ##N ( \
     CONST_INTERNAL(locale)->get ## N( \
         keywordLength < 0 ? StringPiece(keyword) : StringPiece(keyword, keywordLength), \
         sink, *err); \
-    int32_t reslen = sink.NumberOfBytesAppended(); \
     if (U_FAILURE(*err)) { \
-        return reslen; \
+        return 0; \
     } \
+    int32_t reslen = sink.NumberOfBytesAppended(); \
     if (sink.Overflowed()) { \
         *err = U_BUFFER_OVERFLOW_ERROR; \
     } else { \

--- a/icu4c/source/common/ulocbuilder.cpp
+++ b/icu4c/source/common/ulocbuilder.cpp
@@ -112,12 +112,13 @@ ULocale* ulocbld_buildULocale(ULocaleBuilder* builder, UErrorCode* err) {
 
 int32_t ulocbld_buildLocaleID(ULocaleBuilder* builder,
                               char* buffer, int32_t bufferCapacity, UErrorCode* err) {
+    if (U_FAILURE(*err)) { return 0; }
     if (builder == nullptr) {
         *err = U_ILLEGAL_ARGUMENT_ERROR;
         return 0;
     }
     icu::Locale l = INTERNAL(builder)->build(*err);
-    if (U_FAILURE(*err)) return 0;
+    if (U_FAILURE(*err)) { return 0; }
     int32_t length = (int32_t)(uprv_strlen(l.getName()));
     if (0 < length && length <= bufferCapacity) {
         uprv_memcpy(buffer, l.getName(), length);
@@ -127,18 +128,17 @@ int32_t ulocbld_buildLocaleID(ULocaleBuilder* builder,
 
 int32_t ulocbld_buildLanguageTag(ULocaleBuilder* builder,
                   char* buffer, int32_t bufferCapacity, UErrorCode* err) {
+    if (U_FAILURE(*err)) { return 0; }
     if (builder == nullptr) {
         *err = U_ILLEGAL_ARGUMENT_ERROR;
         return 0;
     }
     icu::Locale l = INTERNAL(builder)->build(*err);
-    if (U_FAILURE(*err)) return 0;
+    if (U_FAILURE(*err)) { return 0; }
     CheckedArrayByteSink sink(buffer, bufferCapacity);
     l.toLanguageTag(sink, *err);
+    if (U_FAILURE(*err)) { return 0; }
     int32_t reslen = sink.NumberOfBytesAppended();
-    if (U_FAILURE(*err)) {
-        return reslen;
-    }
     if (sink.Overflowed()) {
         *err = U_BUFFER_OVERFLOW_ERROR;
     } else {

--- a/icu4c/source/common/unicode/localematcher.h
+++ b/icu4c/source/common/unicode/localematcher.h
@@ -11,6 +11,8 @@
 
 #if U_SHOW_CPLUSPLUS_API
 
+#include <optional>
+
 #include "unicode/locid.h"
 #include "unicode/stringpiece.h"
 #include "unicode/uobject.h"
@@ -678,7 +680,7 @@ private:
 
     int32_t putIfAbsent(const LSR &lsr, int32_t i, int32_t suppLength, UErrorCode &errorCode);
 
-    int32_t getBestSuppIndex(LSR desiredLSR, LocaleLsrIterator *remainingIter, UErrorCode &errorCode) const;
+    std::optional<int32_t> getBestSuppIndex(LSR desiredLSR, LocaleLsrIterator *remainingIter, UErrorCode &errorCode) const;
 
     const LikelySubtags &likelySubtags;
     const LocaleDistance &localeDistance;

--- a/icu4c/source/common/unicode/locid.h
+++ b/icu4c/source/common/unicode/locid.h
@@ -1183,6 +1183,7 @@ Locale::operator!=(const    Locale&     other) const
 template<typename StringClass> inline StringClass
 Locale::toLanguageTag(UErrorCode& status) const
 {
+    if (U_FAILURE(status)) { return {}; }
     StringClass result;
     StringByteSink<StringClass> sink(&result);
     toLanguageTag(sink, status);
@@ -1222,6 +1223,7 @@ Locale::getName() const
 template<typename StringClass, typename OutputIterator> inline void
 Locale::getKeywords(OutputIterator iterator, UErrorCode& status) const
 {
+    if (U_FAILURE(status)) { return; }
     LocalPointer<StringEnumeration> keys(createKeywords(status));
     if (U_FAILURE(status) || keys.isNull()) {
         return;
@@ -1239,6 +1241,7 @@ Locale::getKeywords(OutputIterator iterator, UErrorCode& status) const
 template<typename StringClass, typename OutputIterator> inline void
 Locale::getUnicodeKeywords(OutputIterator iterator, UErrorCode& status) const
 {
+    if (U_FAILURE(status)) { return; }
     LocalPointer<StringEnumeration> keys(createUnicodeKeywords(status));
     if (U_FAILURE(status) || keys.isNull()) {
         return;
@@ -1256,6 +1259,7 @@ Locale::getUnicodeKeywords(OutputIterator iterator, UErrorCode& status) const
 template<typename StringClass> inline StringClass
 Locale::getKeywordValue(StringPiece keywordName, UErrorCode& status) const
 {
+    if (U_FAILURE(status)) { return {}; }
     StringClass result;
     StringByteSink<StringClass> sink(&result);
     getKeywordValue(keywordName, sink, status);
@@ -1265,6 +1269,7 @@ Locale::getKeywordValue(StringPiece keywordName, UErrorCode& status) const
 template<typename StringClass> inline StringClass
 Locale::getUnicodeKeywordValue(StringPiece keywordName, UErrorCode& status) const
 {
+    if (U_FAILURE(status)) { return {}; }
     StringClass result;
     StringByteSink<StringClass> sink(&result);
     getUnicodeKeywordValue(keywordName, sink, status);

--- a/icu4c/source/i18n/ulocdata.cpp
+++ b/icu4c/source/i18n/ulocdata.cpp
@@ -201,6 +201,8 @@ ulocdata_getDelimiter(ULocaleData *uld, ULocaleDataDelimiterType type,
 namespace {
 
 UResourceBundle * measurementTypeBundleForLocale(const char *localeID, const char *measurementType, UErrorCode *status){
+    if (U_FAILURE(*status)) { return nullptr; }
+
     UResourceBundle *rb;
     UResourceBundle *measTypeBundle = nullptr;
 
@@ -279,6 +281,7 @@ ulocdata_getPaperSize(const char* localeID, int32_t *height, int32_t *width, UEr
 
 U_CAPI void U_EXPORT2
 ulocdata_getCLDRVersion(UVersionInfo versionArray, UErrorCode *status) {
+    if (U_FAILURE(*status)) { return; }
     UResourceBundle *rb = nullptr;
     rb = ures_openDirect(nullptr, "supplementalData", status);
     ures_getVersionByKey(rb, "cldrVersion", versionArray, status);

--- a/icu4c/source/test/cintltst/cloctst.c
+++ b/icu4c/source/test/cintltst/cloctst.c
@@ -5946,19 +5946,19 @@ const errorData maximizeErrors[] = {
         "enfueiujhytdf",
         NULL,
         U_ILLEGAL_ARGUMENT_ERROR,
-        -1
+        0
     },
     {
         "en_THUJIOGIURJHGJFURYHFJGURYYYHHGJURHG",
         NULL,
         U_ILLEGAL_ARGUMENT_ERROR,
-        -1
+        0
     },
     {
         "en_THUJIOGIURJHGJFURYHFJGURYYYHHGJURHG",
         NULL,
         U_ILLEGAL_ARGUMENT_ERROR,
-        -1
+        0
     },
     {
         "en_Latn_US_POSIX@currency=EURO",
@@ -5979,13 +5979,13 @@ const errorData minimizeErrors[] = {
         "enfueiujhytdf",
         NULL,
         U_ILLEGAL_ARGUMENT_ERROR,
-        -1
+        0
     },
     {
         "en_THUJIOGIURJHGJFURYHFJGURYYYHHGJURHG",
         NULL,
         U_ILLEGAL_ARGUMENT_ERROR,
-        -1
+        0
     },
     {
         "en_Latn_US_POSIX@currency=EURO",
@@ -6010,7 +6010,7 @@ static int32_t getExpectedReturnValue(const errorData* data)
     }
     else
     {
-        return -1;
+        return 0;
     }
 }
 


### PR DESCRIPTION
- No function should do anything if an error has already occurred.
- On error, a value of `0`, `nullptr`, `{}`, etc., should be returned.
- Values shouldn't have overloaded meanings (eg. _index_ or _found_).
- Values that are never used should not be returned at all.

This will make it easier to refactor out shared code.

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22520
- [X] Required: The PR title must be prefixed with a JIRA Issue number.
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number.
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
