### PR TITLE
ICU-22556 Prefer cc and c++ compilers

### DIFF
--- a/.github/workflows/icu4c.yml
+++ b/.github/workflows/icu4c.yml
@@ -89,7 +89,7 @@ jobs:
           CXXFLAGS: -Wimplicit-fallthrough
         run: |
           cd icu4c/source;
-          ./runConfigureICU Linux;
+          ./runConfigureICU Linux/clang;
           make -j -l4.5 check;
       - name: Test Dependency
         run: |
@@ -124,7 +124,7 @@ jobs:
       - name: Build ICU4C with clang
         run: |
           cd icu4c/source;
-          ./runConfigureICU Linux ${{ matrix.build_option }};
+          ./runConfigureICU Linux/clang ${{ matrix.build_option }};
           make -j -l4.5 tests;
       - name: Test
         run: |
@@ -161,7 +161,7 @@ jobs:
       - name: ICU4C with clang and asan
         run: |
           cd icu4c/source;
-          ./runConfigureICU --enable-debug --disable-release Linux --disable-renaming --enable-tracing;
+          ./runConfigureICU --enable-debug --disable-release Linux/clang --disable-renaming --enable-tracing;
           make -j -l4.5 check;
         env:
           CPPFLAGS: -fsanitize=address
@@ -175,7 +175,7 @@ jobs:
       - name: ICU4C with clang and ubsan +alignment
         run: |
           cd icu4c/source;
-          ./runConfigureICU --enable-debug --disable-release Linux --disable-renaming;
+          ./runConfigureICU --enable-debug --disable-release Linux/clang --disable-renaming;
           make -j -l4.5 check;
         env:
           CPPFLAGS: -fsanitize=undefined -fsanitize=alignment -fno-sanitize-recover=undefined,alignment
@@ -209,7 +209,7 @@ jobs:
       - name: ICU4C with clang and tsan
         run: |
           cd icu4c/source;
-          ./runConfigureICU --enable-debug --disable-release Linux --disable-renaming
+          ./runConfigureICU --enable-debug --disable-release Linux/clang --disable-renaming
           make -j -l4.5;
           make -j -l4.5 -C test;
           make -j -l4.5 -C test/intltest check

--- a/docs/devsetup/cpp/index.md
+++ b/docs/devsetup/cpp/index.md
@@ -70,11 +70,11 @@ For example:
         --disable-release Linux --prefix=/home/*your_user_name*/icu/mine/inst >
         config.out 2>&1`
     *   build: make -j5 check > out.txt 2>&1
-    *   Be sure to test with gcc and g++ too! `CC=gcc CXX=g++
-        CXXFLAGS="-DU_USING_ICU_NAMESPACE=0"
+    *   Be sure to test with both gcc/g++ and clang/clang++!
+        `CXXFLAGS="-DU_USING_ICU_NAMESPACE=0"
         CPPFLAGS="-DU_NO_DEFAULT_INCLUDE_UTF_HEADERS=1"
         ../../src/icu4c/source/runConfigureICU --enable-debug --disable-release
-        Linux`
+        Linux/clang`
 *   `~/icu/mine/icu4c/**nm_utf8**`
     *   not-using-namespace and default-hardcoded-UTF-8
     *   setup: mkdir+cd to here, then something like

--- a/docs/devsetup/cpp/linux.md
+++ b/docs/devsetup/cpp/linux.md
@@ -81,7 +81,7 @@ the configure options for building ICU with the address checker:
 
 ```
 CPPFLAGS=-fsanitize=address LDFLAGS=-fsanitize=address ./runConfigureICU
---enable-debug --disable-release Linux --disable-renaming
+--enable-debug --disable-release Linux/clang --disable-renaming
 ```
 
 The other available sanitizers are `thread`, `memory` and `undefined` behavior.

--- a/docs/processes/release/tasks/healthy-code.md
+++ b/docs/processes/release/tasks/healthy-code.md
@@ -605,7 +605,7 @@ tests. These instructions run the sanitizer on the entire test suite. The clang
 compiler is required.
 
 ```sh
-$ CPPFLAGS=-fsanitize=thread LDFLAGS=-fsanitize=thread ./runConfigureICU --enable-debug --disable-release Linux --disable-renaming
+$ CPPFLAGS=-fsanitize=thread LDFLAGS=-fsanitize=thread ./runConfigureICU --enable-debug --disable-release Linux/clang --disable-renaming
 $ make clean
 $ make -j -l2.5 check
 ```

--- a/docs/processes/release/tasks/integration.md
+++ b/docs/processes/release/tasks/integration.md
@@ -431,7 +431,7 @@ To run manually, on a Linux system with clang,
 
 ```sh
 cd icu4c/source
-CPPFLAGS=-fsanitize=thread LDFLAGS=-fsanitize=thread ./runConfigureICU --enable-debug --disable-release Linux
+CPPFLAGS=-fsanitize=thread LDFLAGS=-fsanitize=thread ./runConfigureICU --enable-debug --disable-release Linux/clang
 make clean
 make -j -l2.5 check
 ```
@@ -449,7 +449,7 @@ To run manually, on a Linux system with clang,
 
 ```sh
 cd icu4c/source
-CPPFLAGS=-fsanitize=address LDFLAGS=-fsanitize=address ./runConfigureICU --enable-debug --disable-release Linux
+CPPFLAGS=-fsanitize=address LDFLAGS=-fsanitize=address ./runConfigureICU --enable-debug --disable-release Linux/clang
 make clean
 make -j -l2.5 check
 ```

--- a/icu4c/source/configure
+++ b/icu4c/source/configure
@@ -2870,7 +2870,7 @@ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 if test -n "$ac_tool_prefix"; then
-  for ac_prog in clang gcc cc c99 c89 xlc_r xlc cl.exe icc
+  for ac_prog in cc clang gcc c99 c89 xlc_r xlc cl.exe icc
   do
     # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
 set dummy $ac_tool_prefix$ac_prog; ac_word=$2
@@ -2914,7 +2914,7 @@ fi
 fi
 if test -z "$CC"; then
   ac_ct_CC=$CC
-  for ac_prog in clang gcc cc c99 c89 xlc_r xlc cl.exe icc
+  for ac_prog in cc clang gcc c99 c89 xlc_r xlc cl.exe icc
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2
@@ -3461,8 +3461,6 @@ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
-# Make sure that we try clang++ first, which provides C++17 support.
-# The g++ compiler is less likely to support C++17.
 ac_ext=cpp
 ac_cpp='$CXXCPP $CPPFLAGS'
 ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -3473,7 +3471,7 @@ if test -z "$CXX"; then
     CXX=$CCC
   else
     if test -n "$ac_tool_prefix"; then
-  for ac_prog in clang++ g++ c++ gpp xlC_r xlC aCC CC cxx cc++ cl.exe icc FCC KCC RCC
+  for ac_prog in c++ clang++ g++ gpp xlC_r xlC aCC CC cxx cc++ cl.exe icc FCC KCC RCC
   do
     # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
 set dummy $ac_tool_prefix$ac_prog; ac_word=$2
@@ -3517,7 +3515,7 @@ fi
 fi
 if test -z "$CXX"; then
   ac_ct_CXX=$CXX
-  for ac_prog in clang++ g++ c++ gpp xlC_r xlC aCC CC cxx cc++ cl.exe icc FCC KCC RCC
+  for ac_prog in c++ clang++ g++ gpp xlC_r xlC aCC CC cxx cc++ cl.exe icc FCC KCC RCC
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2

--- a/icu4c/source/configure.ac
+++ b/icu4c/source/configure.ac
@@ -147,10 +147,8 @@ AC_SUBST(ENABLE_RELEASE)
 : ${CXXFLAGS=""}
 
 # Checks for compilers
-AC_PROG_CC([clang gcc cc c99 c89 xlc_r xlc cl.exe icc])
-# Make sure that we try clang++ first, which provides C++17 support.
-# The g++ compiler is less likely to support C++17.
-AC_PROG_CXX([clang++ g++ c++ gpp xlC_r xlC aCC CC cxx cc++ cl.exe icc FCC KCC RCC])
+AC_PROG_CC([cc clang gcc c99 c89 xlc_r xlc cl.exe icc])
+AC_PROG_CXX([c++ clang++ g++ gpp xlC_r xlC aCC CC cxx cc++ cl.exe icc FCC KCC RCC])
 
 # pkg-config is needed for harfbuzz support
 PKG_PROG_PKG_CONFIG([0.20])

--- a/icu4c/source/runConfigureICU
+++ b/icu4c/source/runConfigureICU
@@ -46,7 +46,8 @@ The following names can be supplied as the argument for platform:
     FreeBSD             Use the clang/clang++ or GNU gcc/g++ compilers on FreeBSD
     HP-UX/ACC           Use the HP ANSI C/Advanced C++ compilers on HP-UX 11
     IBMi                Use the iCC compilers on IBM i, i5/OS, OS/400
-    Linux               Use the clang/clang++ or GNU gcc/g++ compilers on Linux
+    Linux               Use the default cc/c++ compilers on Linux
+    Linux/clang         Use the clang/clang++ compilers on Linux
     Linux/gcc           Use the GNU gcc/g++ compilers on Linux
     Linux/ECC           Use the Intel ECC compiler on Linux
     Linux/ICC           Use the Intel ICC compiler on Linux
@@ -259,9 +260,19 @@ case $platform in
         DEBUG_CFLAGS='-g'
         DEBUG_CXXFLAGS='-g'
         ;;
+    Linux/clang)
+        THE_OS="Linux"
+        THE_COMP="the Clang C++"
+        CC=clang; export CC
+        CXX=clang++; export CXX
+        RELEASE_CFLAGS='-O3'
+        RELEASE_CXXFLAGS='-O3'
+        DEBUG_CFLAGS='-g'
+        DEBUG_CXXFLAGS='-g'
+        ;;
     Linux*)
         THE_OS="Linux"
-        THE_COMP="the clang or else GNU C++"
+        THE_COMP="the default C++"
         RELEASE_CFLAGS='-O3'
         RELEASE_CXXFLAGS='-O3'
         DEBUG_CFLAGS='-g'


### PR DESCRIPTION
When building icu4c, it defaults to clang instead of gcc when the default compiler, cc / c++, is a symlink to gcc / g++. This is not the expected behavior when building C and C++ code. It appears that this behavior was put in place originally for supporting C++11, which hopefully is no longer such a concern. This PR adjusts the configure.ac for icu4c to prefer the cc and c++ compilers first.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22556
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable

ALLOW_MANY_COMMITS=true