### PR TITLE
ICU-22532 Don't dereference nullptr (-Wtautological-undefined-compare)

### DIFF
--- a/icu4c/source/test/intltest/transtst.cpp
+++ b/icu4c/source/test/intltest/transtst.cpp
@@ -219,35 +219,35 @@ void TransliteratorTest::TestInstantiation() {
     assertSuccess("count()", ec);
     UnicodeString name;
     for (int32_t i=0; i<n; ++i) {
-        const UnicodeString& id = *avail->snext(ec);
+        const UnicodeString* const id = avail->snext(ec);
         if (!assertSuccess("snext()", ec) ||
-            !assertTrue("snext()!=nullptr", (&id)!=nullptr, true)) {
+            !assertTrue("snext()!=nullptr", id != nullptr, true)) {
             break;
         }
         UnicodeString id2 = Transliterator::getAvailableID(i);
-        if (id.length() < 1) {
+        if (id->length() < 1) {
             errln(UnicodeString("FAIL: getAvailableID(") +
                   i + ") returned empty string");
             continue;
         }
-        if (id != id2) {
+        if (*id != id2) {
             errln(UnicodeString("FAIL: getAvailableID(") +
                   i + ") != getAvailableIDs().snext()");
             continue;
         }
         UParseError parseError;
         UErrorCode status = U_ZERO_ERROR;
-        Transliterator* t = Transliterator::createInstance(id,
+        Transliterator* t = Transliterator::createInstance(*id,
                               UTRANS_FORWARD, parseError,status);
         name.truncate(0);
-        Transliterator::getDisplayName(id, name);
+        Transliterator::getDisplayName(*id, name);
         if (t == 0) {
 #if UCONFIG_NO_BREAK_ITERATION
             // If UCONFIG_NO_BREAK_ITERATION is on, then only Thai should fail.
-            if (id.compare((UnicodeString)"Thai-Latn") != 0 &&
-                id.compare((UnicodeString)"Thai-Latin") != 0)
+            if (id->compare((UnicodeString)"Thai-Latn") != 0 &&
+                id->compare((UnicodeString)"Thai-Latin") != 0)
 #endif
-                dataerrln(UnicodeString("FAIL: Couldn't create ") + id +
+                dataerrln(UnicodeString("FAIL: Couldn't create ") + *id +
                       /*", parse error " + parseError.code +*/
                       ", line " + parseError.line +
                       ", offset " + parseError.offset +
@@ -263,7 +263,7 @@ void TransliteratorTest::TestInstantiation() {
                 --i; // Compensate for deleted entry
             }
         } else {
-            logln(UnicodeString("OK: ") + name + " (" + id + ")");
+            logln(UnicodeString("OK: ") + name + " (" + *id + ")");
 
             // Now test toRules
             UnicodeString rules;
@@ -271,7 +271,7 @@ void TransliteratorTest::TestInstantiation() {
             Transliterator *u = Transliterator::createFromRules("x",
                                     rules, UTRANS_FORWARD, parseError,status);
             if (u == 0) {
-                errln(UnicodeString("FAIL: ") + id +
+                errln(UnicodeString("FAIL: ") + *id +
                       ".createFromRules() => bad rules" +
                       /*", parse error " + parseError.code +*/
                       ", line " + parseError.line +


### PR DESCRIPTION
A reference can't be bound to dereferenced nullptr in well-defined C++ code.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22532
- [x] Required: The PR title must be prefixed with a JIRA Issue number.
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number.
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
