### PR TITLE
ICU-22532 Increase timeout for exhaustive ICU4J tests

### DIFF
--- a/.ci-builds/.azure-exhaustive-tests.yml
+++ b/.ci-builds/.azure-exhaustive-tests.yml
@@ -35,7 +35,7 @@ jobs:
 # Note: The exhaustive tests can take more than 1 hour to complete.
 - job: ICU4J_OpenJDK_Ubuntu_2204
   displayName: 'J: Linux OpenJDK (Ubuntu 22.04)'
-  timeoutInMinutes: 120
+  timeoutInMinutes: 180
   pool:
     vmImage: 'ubuntu-22.04'
     demands: ant


### PR DESCRIPTION
ICU4J tests have started to fail often in the post-merge CI (~50% of the time?), and it is always due to the timeout being exceeded.

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22532
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
