### PR TITLE
ICU-21952 fix draft version of withoutLocale to ICU 75

### DIFF
--- a/icu4c/source/i18n/unicode/numberformatter.h
+++ b/icu4c/source/i18n/unicode/numberformatter.h
@@ -2616,7 +2616,7 @@ class U_I18N_API LocalizedNumberFormatter
      * Disassociate the locale from this formatter.
      *
      * @return The fluent chain.
-     * @draft ICU 74
+     * @draft ICU 75
      */
     UnlocalizedNumberFormatter withoutLocale() const &;
 
@@ -2625,7 +2625,7 @@ class U_I18N_API LocalizedNumberFormatter
      *
      * @return The fluent chain.
      * @see #withoutLocale
-     * @draft ICU 74
+     * @draft ICU 75
      */
     UnlocalizedNumberFormatter withoutLocale() &&;
 #endif // U_HIDE_DRAFT_API

--- a/icu4c/source/i18n/unicode/numberrangeformatter.h
+++ b/icu4c/source/i18n/unicode/numberrangeformatter.h
@@ -508,7 +508,7 @@ class U_I18N_API LocalizedNumberRangeFormatter
      * Disassociate the locale from this formatter.
      *
      * @return The fluent chain.
-     * @draft ICU 74
+     * @draft ICU 75
      */
     UnlocalizedNumberRangeFormatter withoutLocale() const &;
 
@@ -517,7 +517,7 @@ class U_I18N_API LocalizedNumberRangeFormatter
      *
      * @return The fluent chain.
      * @see #withoutLocale
-     * @draft ICU 74
+     * @draft ICU 75
      */
     UnlocalizedNumberRangeFormatter withoutLocale() &&;
 #endif // U_HIDE_DRAFT_API


### PR DESCRIPTION
This corrects the ICU version number of these APIs to ICU 75. PR #2483 was merged after 74 but accidentally with `@draft ICU 74`.

Note that the JIRA issue is still marked as "accepted".
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21952
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
