### PR TITLE
ICU-22274 Mark known issue for 3 timezones for EnvTest

### DIFF
--- a/icu4c/source/test/intltest/tztest.cpp
+++ b/icu4c/source/test/intltest/tztest.cpp
@@ -156,10 +156,18 @@ TimeZoneTest::TestGenericAPI()
         // Africa/Casablanca Europe/Dublin America/Godthab America/Nuuk
         if (id == u"Africa/Casablanca" || id == u"Europe/Dublin" ||
             id == u"America/Godthab" || id == u"America/Nuuk" ||
-            id == u"Africa/El_Aaiun") {
+            id == u"Africa/El_Aaiun" ||
+            id == u"Asia/Qostanay" ||  // Due to changes in tz2024a
+            id == u"Asia/Almaty" ||  // Due to changes in tz2024a
+            id == u"America/Scoresbysund"  // break after the update of tz2023d
+            ) {
           logKnownIssue( "ICU-22274", "detectHostTimeZone()'s raw offset != host timezone's offset in TimeZone " + id);
         } else {
-          errln("FAIL: detectHostTimeZone()'s raw offset != host timezone's offset");
+          errln("FAIL: detectHostTimeZone()'s raw offset != host timezone's offset.\n"
+                "hostZone->getRawOffset()=%d\n"
+                "but uprv_timezone() return %d and "
+                "uprv_timezone() * -1000=%d",
+                hostZoneRawOffset, tzoffset, tzoffset * -1000);
         }
     }
     delete hostZone;


### PR DESCRIPTION
1. Mark  "Asia/Qostanay" "Asia/Almaty", and "America/Scoresbysund" TimeZone as known issue for ICU-22274: 
  a. tz2024a change "Asia/Qostanay" "Asia/Almaty" but test machines has not yet update their zoneinfo to 2024a so we mark them as known issues
  b. extern long timezone; in <time.h> (set man tzset on Linux shell) returns wrong value when TZ=America/Scoresbysund
2. Also print out more infomation on test error for easier debuggin in the future.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22274
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
