### PR TITLE
ICU-22633 Test and fix int32_t overflow for Calendar set

### DIFF
--- a/icu4c/source/i18n/buddhcal.cpp
+++ b/icu4c/source/i18n/buddhcal.cpp
@@ -74,9 +74,12 @@ int32_t BuddhistCalendar::handleGetExtendedYear(UErrorCode& status)
     if (newerField(UCAL_EXTENDED_YEAR, UCAL_YEAR) == UCAL_EXTENDED_YEAR) {
         year = internalGet(UCAL_EXTENDED_YEAR, kGregorianEpoch);
     } else {
-        // extended year is a gregorian year, where 1 = 1AD,  0 = 1BC, -1 = 2BC, etc 
-        year = internalGet(UCAL_YEAR, kGregorianEpoch - kBuddhistEraStart)
-                + kBuddhistEraStart;
+        // extended year is a gregorian year, where 1 = 1AD,  0 = 1BC, -1 = 2BC, etc
+        year = internalGet(UCAL_YEAR, kGregorianEpoch - kBuddhistEraStart);
+        if (uprv_add32_overflow(year, kBuddhistEraStart, &year)) {
+            status = U_ILLEGAL_ARGUMENT_ERROR;
+            return 0;
+        }
     }
     return year;
 }

--- a/icu4c/source/i18n/cecal.cpp
+++ b/icu4c/source/i18n/cecal.cpp
@@ -77,7 +77,7 @@ CECalendar::operator=(const CECalendar& right)
 //-------------------------------------------------------------------------
 
 int64_t
-CECalendar::handleComputeMonthStart(int32_t eyear,int32_t emonth, UBool /*useMonth*/) const
+CECalendar::handleComputeMonthStart(int32_t eyear,int32_t emonth, UBool /*useMonth*/, UErrorCode& /*status*/) const
 {
     int64_t year64 = eyear;
     // handle month > 12, < 0 (e.g. from add/set)

--- a/icu4c/source/i18n/cecal.h
+++ b/icu4c/source/i18n/cecal.h
@@ -98,7 +98,7 @@ protected:
      * Return JD of start of given month/extended year
      * @internal
      */
-    virtual int64_t handleComputeMonthStart(int32_t eyear, int32_t month, UBool useMonth) const override;
+    virtual int64_t handleComputeMonthStart(int32_t eyear, int32_t month, UBool useMonth, UErrorCode& status) const override;
 
     /**
      * Calculate the limit for a specified type of limit and field

--- a/icu4c/source/i18n/chnsecal.h
+++ b/icu4c/source/i18n/chnsecal.h
@@ -207,8 +207,8 @@ class U_I18N_API ChineseCalendar : public Calendar {
 
  protected:
   virtual int32_t handleGetLimit(UCalendarDateFields field, ELimitType limitType) const override;
-  virtual int32_t handleGetMonthLength(int32_t extendedYear, int32_t month) const override;
-  virtual int64_t handleComputeMonthStart(int32_t eyear, int32_t month, UBool useMonth) const override;
+  virtual int32_t handleGetMonthLength(int32_t extendedYear, int32_t month, UErrorCode& status) const override;
+  virtual int64_t handleComputeMonthStart(int32_t eyear, int32_t month, UBool useMonth, UErrorCode& status) const override;
   virtual int32_t handleGetExtendedYear(UErrorCode& status) override;
   virtual void handleComputeFields(int32_t julianDay, UErrorCode &status) override;
   virtual const UFieldResolutionTable* getFieldResolutionTable() const override;
@@ -286,9 +286,9 @@ class U_I18N_API ChineseCalendar : public Calendar {
   virtual const char * getType() const override;
 
  protected:
-  virtual int32_t internalGetMonth(int32_t defaultValue) const override;
+  virtual int32_t internalGetMonth(int32_t defaultValue, UErrorCode& status) const override;
 
-  virtual int32_t internalGetMonth() const override;
+  virtual int32_t internalGetMonth(UErrorCode& status) const override;
 
  protected:
   /**

--- a/icu4c/source/i18n/dangical.cpp
+++ b/icu4c/source/i18n/dangical.cpp
@@ -51,6 +51,8 @@ U_NAMESPACE_BEGIN
 // Constructors...
 //-------------------------------------------------------------------------
 
+const TimeZone* getDangiCalZoneAstroCalc(UErrorCode &status);
+
 DangiCalendar::DangiCalendar(const Locale& aLocale, UErrorCode& success)
 :   ChineseCalendar(aLocale, DANGI_EPOCH_YEAR, getDangiCalZoneAstroCalc(success), success)
 {
@@ -136,7 +138,7 @@ static void U_CALLCONV initDangiCalZoneAstroCalc(UErrorCode &status) {
     ucln_i18n_registerCleanup(UCLN_I18N_DANGI_CALENDAR, calendar_dangi_cleanup);
 }
 
-const TimeZone* DangiCalendar::getDangiCalZoneAstroCalc(UErrorCode &status) const {
+const TimeZone* getDangiCalZoneAstroCalc(UErrorCode &status) {
     umtx_initOnce(gDangiCalendarInitOnce, &initDangiCalZoneAstroCalc, status);
     return gDangiCalendarZoneAstroCalc;
 }

--- a/icu4c/source/i18n/dangical.h
+++ b/icu4c/source/i18n/dangical.h
@@ -88,8 +88,6 @@ class DangiCalendar : public ChineseCalendar {
 
  private:
 
-  const TimeZone* getDangiCalZoneAstroCalc(UErrorCode &status) const;
-
   // UObject stuff
  public: 
   /**

--- a/icu4c/source/i18n/ethpccal.cpp
+++ b/icu4c/source/i18n/ethpccal.cpp
@@ -70,7 +70,12 @@ EthiopicCalendar::handleGetExtendedYear(UErrorCode& status)
     if (internalGet(UCAL_ERA, AMETE_MIHRET) == AMETE_MIHRET) {
         return internalGet(UCAL_YEAR, 1); // Default to year 1
     }
-    return internalGet(UCAL_YEAR, 1) - AMETE_MIHRET_DELTA;
+    int32_t year = internalGet(UCAL_YEAR, 1);
+    if (uprv_add32_overflow(year, -AMETE_MIHRET_DELTA, &year)) {
+        status = U_ILLEGAL_ARGUMENT_ERROR;
+        return 0;
+    }
+    return year;
 }
 
 void
@@ -194,8 +199,13 @@ EthiopicAmeteAlemCalendar::handleGetExtendedYear(UErrorCode& status)
     if (newerField(UCAL_EXTENDED_YEAR, UCAL_YEAR) == UCAL_EXTENDED_YEAR) {
         return internalGet(UCAL_EXTENDED_YEAR, 1); // Default to year 1
     }
-    return internalGet(UCAL_YEAR, 1 + AMETE_MIHRET_DELTA)
-            - AMETE_MIHRET_DELTA; // Default to year 1 of Amelete Mihret
+    // Default to year 1 of Amelete Mihret
+    int32_t year = internalGet(UCAL_YEAR, 1 + AMETE_MIHRET_DELTA);
+    if (uprv_add32_overflow(year, -AMETE_MIHRET_DELTA, &year)) {
+        status = U_ILLEGAL_ARGUMENT_ERROR;
+        return 0;
+    }
+    return year;
 }
 
 void

--- a/icu4c/source/i18n/hebrwcal.h
+++ b/icu4c/source/i18n/hebrwcal.h
@@ -319,7 +319,7 @@ public:
      * implementation than the default implementation in Calendar.
      * @internal
      */
-    virtual int32_t handleGetMonthLength(int32_t extendedYear, int32_t month) const override;
+    virtual int32_t handleGetMonthLength(int32_t extendedYear, int32_t month, UErrorCode& status) const override;
 
     /**
      * Return the number of days in the given extended year of this
@@ -369,7 +369,7 @@ public:
      * @internal
      */
     virtual int64_t handleComputeMonthStart(int32_t eyear, int32_t month,
-                                                   UBool useMonth) const override;
+                                                   UBool useMonth, UErrorCode& status) const override;
 
 
     /**
@@ -443,7 +443,7 @@ public:
   virtual void setTemporalMonthCode(const char* code, UErrorCode& status ) override;
 
  protected:
-   virtual int32_t internalGetMonth() const override;
+   virtual int32_t internalGetMonth(UErrorCode& status) const override;
 
  private: // Calendar-specific implementation
     /**

--- a/icu4c/source/i18n/indiancal.cpp
+++ b/icu4c/source/i18n/indiancal.cpp
@@ -108,7 +108,7 @@ static UBool isGregorianLeap(int32_t year)
  * @param eyear  The year in Saka Era
  * @param month  The month(0-based) in Indian calendar
  */
-int32_t IndianCalendar::handleGetMonthLength(int32_t eyear, int32_t month) const {
+int32_t IndianCalendar::handleGetMonthLength(int32_t eyear, int32_t month, UErrorCode& /* status */) const {
    if (month < 0 || month > 11) {
       eyear += ClockMath::floorDivide(month, 12, &month);
    }
@@ -203,14 +203,20 @@ static double IndianToJD(int32_t year, int32_t month, int32_t date) {
  * @param eyear The year in Indian Calendar measured from Saka Era (78 AD).
  * @param month The month in Indian calendar
  */
-int64_t IndianCalendar::handleComputeMonthStart(int32_t eyear, int32_t month, UBool /* useMonth */ ) const {
+int64_t IndianCalendar::handleComputeMonthStart(int32_t eyear, int32_t month, UBool /* useMonth */, UErrorCode& status) const {
+   if (U_FAILURE(status)) {
+       return 0;
+   }
 
    //month is 0 based; converting it to 1-based 
    int32_t imonth;
 
     // If the month is out of range, adjust it into range, and adjust the extended year accordingly
    if (month < 0 || month > 11) {
-      eyear += (int32_t)ClockMath::floorDivide(month, 12, &month);
+      if (uprv_add32_overflow(eyear, ClockMath::floorDivide(month, 12, &month), &eyear)) {
+          status = U_ILLEGAL_ARGUMENT_ERROR;
+          return 0;
+      }
    }
 
    if(month == 12){

--- a/icu4c/source/i18n/indiancal.h
+++ b/icu4c/source/i18n/indiancal.h
@@ -209,7 +209,7 @@ public:
    * @param year  The month(0-based) in Indian year
    * @internal
    */
-  virtual int32_t handleGetMonthLength(int32_t extendedYear, int32_t month) const override;
+  virtual int32_t handleGetMonthLength(int32_t extendedYear, int32_t month, UErrorCode& status) const override;
   
   /**
    * Return the number of days in the given Indian year
@@ -225,7 +225,7 @@ public:
   /**
    * @internal
    */
-  virtual int64_t handleComputeMonthStart(int32_t eyear, int32_t month, UBool useMonth) const override;
+  virtual int64_t handleComputeMonthStart(int32_t eyear, int32_t month, UBool useMonth, UErrorCode& status) const override;
 
   //-------------------------------------------------------------------------
   // Functions for converting from milliseconds to field values

--- a/icu4c/source/i18n/islamcal.cpp
+++ b/icu4c/source/i18n/islamcal.cpp
@@ -321,8 +321,19 @@ int64_t IslamicCalendar::yearStart(int32_t year) const{
 * @param year  The hijri year
 * @param month The hijri month, 0-based (assumed to be in range 0..11)
 */
-int64_t IslamicCalendar::monthStart(int32_t year, int32_t month) const {
-    return trueMonthStart(12*(year-1) + month);
+int64_t IslamicCalendar::monthStart(int32_t year, int32_t month, UErrorCode& status) const {
+    if (U_FAILURE(status)) {
+        return 0;
+    }
+    int32_t temp;
+    if (uprv_add32_overflow(year, -1, &temp) ||
+        uprv_mul32_overflow(temp, 12, &temp) ||
+        uprv_add32_overflow(temp, month, &month)) {
+        status = U_ILLEGAL_ARGUMENT_ERROR;
+        return 0;
+    }
+
+    return trueMonthStart(month);
 }
 
 /**
@@ -427,7 +438,8 @@ double IslamicCalendar::moonAge(UDate time, UErrorCode &status)
 * @param year  The hijri month, 0-based
 * @draft ICU 2.4
 */
-int32_t IslamicCalendar::handleGetMonthLength(int32_t extendedYear, int32_t month) const {
+int32_t IslamicCalendar::handleGetMonthLength(int32_t extendedYear, int32_t month,
+                                              UErrorCode& /* status */) const {
     month = 12*(extendedYear-1) + month;
     return trueMonthStart(month+1) - trueMonthStart(month) ;
 }
@@ -453,18 +465,30 @@ int32_t IslamicCalendar::handleGetYearLength(int32_t extendedYear) const {
 /**
 * @draft ICU 2.4
 */
-int64_t IslamicCalendar::handleComputeMonthStart(int32_t eyear, int32_t month, UBool /* useMonth */) const {
+int64_t IslamicCalendar::handleComputeMonthStart(int32_t eyear, int32_t month,
+                                                 UBool /* useMonth */,
+                                                 UErrorCode& status) const {
+    if (U_FAILURE(status)) {
+        return 0;
+    }
     // This may be called by Calendar::handleComputeJulianDay with months out of the range
     // 0..11. Need to handle that here since monthStart requires months in the range 0.11.
     if (month > 11) {
         eyear += (month / 12);
+        if (uprv_add32_overflow(eyear, (month / 12), &eyear)) {
+            status = U_ILLEGAL_ARGUMENT_ERROR;
+            return 0;
+        }
         month %= 12;
     } else if (month < 0) {
         month++;
-        eyear += (month / 12) - 1;
+        if (uprv_add32_overflow(eyear, (month / 12) - 1, &eyear)) {
+            status = U_ILLEGAL_ARGUMENT_ERROR;
+            return 0;
+        }
         month = (month % 12) + 11;
     }
-    return monthStart(eyear, month) + getEpoc() - 1;
+    return monthStart(eyear, month, status) + getEpoc() - 1;
 }
 
 //-------------------------------------------------------------------------
@@ -531,14 +555,20 @@ void IslamicCalendar::handleComputeFields(int32_t julianDay, UErrorCode &status)
 
     int32_t year = month >=  0 ? ((month / 12) + 1) : ((month + 1 ) / 12);
     month = ((month % 12) + 12 ) % 12;
-    int64_t dayOfMonth = (days - monthStart(year, month)) + 1;
+    int64_t dayOfMonth = (days - monthStart(year, month, status)) + 1;
+    if (U_FAILURE(status)) {
+        return;
+    }
     if (dayOfMonth > INT32_MAX || dayOfMonth < INT32_MIN) {
         status = U_ILLEGAL_ARGUMENT_ERROR;
         return;
     }
 
     // Now figure out the day of the year.
-    int64_t dayOfYear = (days - monthStart(year, 0)) + 1;
+    int64_t dayOfYear = (days - monthStart(year, 0, status)) + 1;
+    if (U_FAILURE(status)) {
+        return;
+    }
     if (dayOfYear > INT32_MAX || dayOfYear < INT32_MIN) {
         status = U_ILLEGAL_ARGUMENT_ERROR;
         return;
@@ -697,10 +727,10 @@ int64_t IslamicCivilCalendar::yearStart(int32_t year) const{
 * @param year  The hijri year
 * @param month The hijri month, 0-based (assumed to be in range 0..11)
 */
-int64_t IslamicCivilCalendar::monthStart(int32_t year, int32_t month) const {
+int64_t IslamicCivilCalendar::monthStart(int32_t year, int32_t month, UErrorCode& /*status*/) const {
     // This does not handle months out of the range 0..11
     return static_cast<int64_t>(
-        uprv_ceil(29.5*month) + 354LL*(year-1) +
+        uprv_ceil(29.5*month) + 354LL*(year-1LL) +
         ClockMath::floorDivideInt64(
              11LL*static_cast<int64_t>(year) + 3LL, 30LL));
 }
@@ -712,7 +742,8 @@ int64_t IslamicCivilCalendar::monthStart(int32_t year, int32_t month) const {
 * @param year  The hijri month, 0-based
 * @draft ICU 2.4
 */
-int32_t IslamicCivilCalendar::handleGetMonthLength(int32_t extendedYear, int32_t month) const {
+int32_t IslamicCivilCalendar::handleGetMonthLength(int32_t extendedYear, int32_t month,
+                                                   UErrorCode& /* status */) const {
     int32_t length = 29 + (month+1) % 2;
     if (month == DHU_AL_HIJJAH && civilLeapYear(extendedYear)) {
         length++;
@@ -755,14 +786,20 @@ void IslamicCivilCalendar::handleComputeFields(int32_t julianDay, UErrorCode &st
         uprv_ceil((days - 29 - yearStart(year)) / 29.5 ));
     month = month<11?month:11;
 
-    int64_t dayOfMonth = (days - monthStart(year, month)) + 1;
+    int64_t dayOfMonth = (days - monthStart(year, month, status)) + 1;
+    if (U_FAILURE(status)) {
+        return;
+    }
     if (dayOfMonth > INT32_MAX || dayOfMonth < INT32_MIN) {
         status = U_ILLEGAL_ARGUMENT_ERROR;
         return;
     }
 
     // Now figure out the day of the year.
-    int64_t dayOfYear = (days - monthStart(year, 0)) + 1;
+    int64_t dayOfYear = (days - monthStart(year, 0, status)) + 1;
+    if (U_FAILURE(status)) {
+        return;
+    }
     if (dayOfYear > INT32_MAX || dayOfYear < INT32_MIN) {
         status = U_ILLEGAL_ARGUMENT_ERROR;
         return;
@@ -826,7 +863,7 @@ IslamicUmalquraCalendar* IslamicUmalquraCalendar::clone() const {
 */
 int64_t IslamicUmalquraCalendar::yearStart(int32_t year) const {
     if (year < UMALQURA_YEAR_START || year > UMALQURA_YEAR_END) {
-        return 354LL * (year-1) +
+        return 354LL * (year-1LL) +
             ClockMath::floorDivideInt64((11LL*year+3LL), 30LL);
     }
     year -= UMALQURA_YEAR_START;
@@ -844,10 +881,16 @@ int64_t IslamicUmalquraCalendar::yearStart(int32_t year) const {
 * @param year  The hijri year
 * @param month The hijri month, 0-based (assumed to be in range 0..11)
 */
-int64_t IslamicUmalquraCalendar::monthStart(int32_t year, int32_t month) const {
+int64_t IslamicUmalquraCalendar::monthStart(int32_t year, int32_t month, UErrorCode& status) const {
+    if (U_FAILURE(status)) {
+        return 0;
+    }
     int64_t ms = yearStart(year);
     for(int i=0; i< month; i++){
-        ms+= handleGetMonthLength(year, i);
+        ms+= handleGetMonthLength(year, i, status);
+        if (U_FAILURE(status)) {
+            return 0;
+        }
     }
     return ms;
 }
@@ -858,7 +901,8 @@ int64_t IslamicUmalquraCalendar::monthStart(int32_t year, int32_t month) const {
 * @param year  The hijri year
 * @param year  The hijri month, 0-based
 */
-int32_t IslamicUmalquraCalendar::handleGetMonthLength(int32_t extendedYear, int32_t month) const {
+int32_t IslamicUmalquraCalendar::handleGetMonthLength(int32_t extendedYear, int32_t month,
+                                                      UErrorCode& /* status */) const {
     int32_t length = 0;
     if (extendedYear<UMALQURA_YEAR_START || extendedYear>UMALQURA_YEAR_END) {
         length = 29 + (month+1) % 2;
@@ -880,9 +924,11 @@ int32_t IslamicUmalquraCalendar::handleGetYearLength(int32_t extendedYear) const
         return 354 + (civilLeapYear(extendedYear) ? 1 : 0);
     }
     int len = 0;
+    UErrorCode internalStatus = U_ZERO_ERROR;
     for(int i=0; i<12; i++) {
-        len += handleGetMonthLength(extendedYear, i);
+        len += handleGetMonthLength(extendedYear, i, internalStatus);
     }
+    U_ASSERT(U_SUCCESS(internalStatus));
     return len;
 }
 
@@ -933,10 +979,13 @@ void IslamicUmalquraCalendar::handleComputeFields(int32_t julianDay, UErrorCode 
                 break;
             }
             if (d < yearLength){
-                int32_t monthLen = handleGetMonthLength(year, month);
+                int32_t monthLen = handleGetMonthLength(year, month, status);
                 for (month = 0;
                      d > monthLen;
-                     monthLen = handleGetMonthLength(year, ++month)) {
+                     monthLen = handleGetMonthLength(year, ++month, status)) {
+                    if (U_FAILURE(status)) {
+                        return;
+                    }
                     d -= monthLen;
                 }
                 break;
@@ -944,14 +993,20 @@ void IslamicUmalquraCalendar::handleComputeFields(int32_t julianDay, UErrorCode 
         }
     }
 
-    dayOfMonth = (days - monthStart(year, month)) + 1;
+    dayOfMonth = (days - monthStart(year, month, status)) + 1;
+    if (U_FAILURE(status)) {
+        return;
+    }
     if (dayOfMonth > INT32_MAX || dayOfMonth < INT32_MIN) {
         status = U_ILLEGAL_ARGUMENT_ERROR;
         return;
     }
 
     // Now figure out the day of the year.
-    dayOfYear = (days - monthStart(year, 0)) + 1;
+    dayOfYear = (days - monthStart(year, 0, status)) + 1;
+    if (U_FAILURE(status)) {
+        return;
+    }
     if (dayOfYear > INT32_MAX || dayOfYear < INT32_MIN) {
         status = U_ILLEGAL_ARGUMENT_ERROR;
         return;

--- a/icu4c/source/i18n/islamcal.h
+++ b/icu4c/source/i18n/islamcal.h
@@ -210,7 +210,7 @@ class U_I18N_API IslamicCalendar : public Calendar {
    * @param year  The hijri year
    * @param year  The hijri month, 0-based
    */
-  virtual int64_t monthStart(int32_t year, int32_t month) const;
+  virtual int64_t monthStart(int32_t year, int32_t month, UErrorCode& status) const;
     
   /**
    * Find the day number on which a particular month of the true/lunar
@@ -250,7 +250,7 @@ class U_I18N_API IslamicCalendar : public Calendar {
    * @param year  The hijri month, 0-based
    * @internal
    */
-  virtual int32_t handleGetMonthLength(int32_t extendedYear, int32_t month) const override;
+  virtual int32_t handleGetMonthLength(int32_t extendedYear, int32_t month, UErrorCode& status) const override;
   
   /**
    * Return the number of days in the given Islamic year
@@ -266,7 +266,7 @@ class U_I18N_API IslamicCalendar : public Calendar {
   /**
    * @internal
    */
-  virtual int64_t handleComputeMonthStart(int32_t eyear, int32_t month, UBool useMonth) const override;
+  virtual int64_t handleComputeMonthStart(int32_t eyear, int32_t month, UBool useMonth, UErrorCode& status) const override;
 
   //-------------------------------------------------------------------------
   // Functions for converting from milliseconds to field values
@@ -468,7 +468,7 @@ class U_I18N_API IslamicCivilCalendar : public IslamicCalendar {
    * @param year  The hijri month, 0-based
    * @internal
    */
-  virtual int64_t monthStart(int32_t year, int32_t month) const override;
+  virtual int64_t monthStart(int32_t year, int32_t month, UErrorCode& status) const override;
 
   /**
    * Return the length (in days) of the given month.
@@ -477,7 +477,7 @@ class U_I18N_API IslamicCivilCalendar : public IslamicCalendar {
    * @param year  The hijri month, 0-based
    * @internal
    */
-  virtual int32_t handleGetMonthLength(int32_t extendedYear, int32_t month) const override;
+  virtual int32_t handleGetMonthLength(int32_t extendedYear, int32_t month, UErrorCode& status) const override;
 
   /**
    * Return the number of days in the given Islamic year
@@ -651,7 +651,7 @@ class U_I18N_API IslamicUmalquraCalendar : public IslamicCalendar {
    * @param year  The hijri month, 0-based
    * @internal
    */
-  virtual int64_t monthStart(int32_t year, int32_t month) const override;
+  virtual int64_t monthStart(int32_t year, int32_t month, UErrorCode& status) const override;
 
   /**
    * Return the length (in days) of the given month.
@@ -660,7 +660,7 @@ class U_I18N_API IslamicUmalquraCalendar : public IslamicCalendar {
    * @param year  The hijri month, 0-based
    * @internal
    */
-  virtual int32_t handleGetMonthLength(int32_t extendedYear, int32_t month) const override;
+  virtual int32_t handleGetMonthLength(int32_t extendedYear, int32_t month, UErrorCode& status) const override;
 
   /**
    * Return the number of days in the given Islamic year

--- a/icu4c/source/i18n/japancal.h
+++ b/icu4c/source/i18n/japancal.h
@@ -212,7 +212,7 @@ protected:
      * @param eyear the extended year
      * @internal
      */
-    virtual int32_t getDefaultMonthInYear(int32_t eyear) override;
+    virtual int32_t getDefaultMonthInYear(int32_t eyear, UErrorCode& status) override;
 
     /***
      * Called by computeJulianDay.  Returns the default day (1-based) for the month,

--- a/icu4c/source/i18n/persncal.h
+++ b/icu4c/source/i18n/persncal.h
@@ -176,7 +176,7 @@ class PersianCalendar : public Calendar {
    * Return the day # on which the given year starts.  Days are counted
    * from the Hijri epoch, origin 0.
    */
-  int32_t yearStart(int32_t year);
+  int32_t yearStart(int32_t year, UErrorCode& status);
 
   /**
    * Return the day # on which the given month starts.  Days are counted
@@ -185,7 +185,7 @@ class PersianCalendar : public Calendar {
    * @param year  The hijri shamsi year
    * @param year  The hijri shamsi month, 0-based
    */
-  int32_t monthStart(int32_t year, int32_t month) const;
+  int32_t monthStart(int32_t year, int32_t month, UErrorCode& status) const;
     
   //----------------------------------------------------------------------
   // Calendar framework
@@ -203,7 +203,7 @@ class PersianCalendar : public Calendar {
    * @param year  The hijri shamsi month, 0-based
    * @internal
    */
-  virtual int32_t handleGetMonthLength(int32_t extendedYear, int32_t month) const override;
+  virtual int32_t handleGetMonthLength(int32_t extendedYear, int32_t month, UErrorCode& status) const override;
   
   /**
    * Return the number of days in the given Persian year
@@ -219,7 +219,7 @@ class PersianCalendar : public Calendar {
   /**
    * @internal
    */
-  virtual int64_t handleComputeMonthStart(int32_t eyear, int32_t month, UBool useMonth) const override;
+  virtual int64_t handleComputeMonthStart(int32_t eyear, int32_t month, UBool useMonth, UErrorCode& status) const override;
 
   //-------------------------------------------------------------------------
   // Functions for converting from milliseconds to field values

--- a/icu4c/source/i18n/simpletz.cpp
+++ b/icu4c/source/i18n/simpletz.cpp
@@ -519,7 +519,12 @@ SimpleTimeZone::getOffsetFromLocal(UDate date, UTimeZoneLocalOption nonExistingT
 
     rawOffsetGMT = getRawOffset();
     int32_t year, month, dom, dow, millis;
-    int32_t day = ClockMath::floorDivide(date, U_MILLIS_PER_DAY, &millis);
+    double dday = ClockMath::floorDivide(date, U_MILLIS_PER_DAY, &millis);
+    if (dday > INT32_MAX || dday < INT32_MIN) {
+        status = U_ILLEGAL_ARGUMENT_ERROR;
+        return;
+    }
+    int32_t day = dday;
 
     Grego::dayToFields(day, year, month, dom, dow);
 

--- a/icu4c/source/i18n/taiwncal.cpp
+++ b/icu4c/source/i18n/taiwncal.cpp
@@ -78,10 +78,17 @@ int32_t TaiwanCalendar::handleGetExtendedYear(UErrorCode& status)
         year = internalGet(UCAL_EXTENDED_YEAR, kGregorianEpoch);
     } else {
         int32_t era = internalGet(UCAL_ERA, MINGUO);
+        year = internalGet(UCAL_YEAR, 1);
         if(era == MINGUO) {
-            year =     internalGet(UCAL_YEAR, 1) + kTaiwanEraStart;
+            if (uprv_add32_overflow(year, kTaiwanEraStart, &year)) {
+                status = U_ILLEGAL_ARGUMENT_ERROR;
+                return 0;
+            }
         } else if(era == BEFORE_MINGUO) {
-            year = 1 - internalGet(UCAL_YEAR, 1) + kTaiwanEraStart;
+            if (uprv_add32_overflow(1 + kTaiwanEraStart, -year, &year)) {
+                status = U_ILLEGAL_ARGUMENT_ERROR;
+                return 0;
+            }
         } else {
             status = U_ILLEGAL_ARGUMENT_ERROR;
             return 0;

--- a/icu4c/source/i18n/unicode/calendar.h
+++ b/icu4c/source/i18n/unicode/calendar.h
@@ -1558,7 +1558,7 @@ protected:
      * @return       The value for the UCAL_MONTH.
      * @internal
      */
-    virtual int32_t internalGetMonth() const;
+    virtual int32_t internalGetMonth(UErrorCode& status) const;
 
     /**
      * Use this function instead of internalGet(UCAL_MONTH, defaultValue). The implementation
@@ -1568,10 +1568,12 @@ protected:
      *
      * @param defaultValue a default value used if the UCAL_MONTH and
      *   UCAL_ORDINAL are both unset.
+     * @param status Output param set to failure code on function return
+     *          when this function fails.
      * @return       The value for the UCAL_MONTH.
      * @internal
      */
-    virtual int32_t internalGetMonth(int32_t defaultValue) const;
+    virtual int32_t internalGetMonth(int32_t defaultValue, UErrorCode& status) const;
 
 #ifndef U_HIDE_DEPRECATED_API
     /**
@@ -1660,12 +1662,14 @@ protected:
      * @param useMonth if false, compute the day before the first day of
      * the given year, otherwise, compute the day before the first day of
      * the given month
+     * @param status Output param set to failure code on function return
+     *          when this function fails.
      * @return the Julian day number of the day before the first
      * day of the given month and year
      * @internal
      */
     virtual int64_t handleComputeMonthStart(int32_t eyear, int32_t month,
-                                                   UBool useMonth) const  = 0;
+                                            UBool useMonth, UErrorCode& status) const  = 0;
 
     /**
      * Return the number of days in the given month of the given extended
@@ -1674,7 +1678,7 @@ protected:
      * implementation than the default implementation in Calendar.
      * @internal
      */
-    virtual int32_t handleGetMonthLength(int32_t extendedYear, int32_t month) const ;
+    virtual int32_t handleGetMonthLength(int32_t extendedYear, int32_t month, UErrorCode& status) const ;
 
     /**
      * Return the number of days in the given extended year of this
@@ -1716,7 +1720,7 @@ protected:
      * @return the extended year, UCAL_EXTENDED_YEAR
      * @internal
      */
-    virtual int32_t handleGetExtendedYearFromWeekFields(int32_t yearWoy, int32_t woy);
+    virtual int32_t handleGetExtendedYearFromWeekFields(int32_t yearWoy, int32_t woy, UErrorCode& status);
 
     /**
      * Validate a single field of this calendar.  Subclasses should
@@ -2022,9 +2026,11 @@ protected:
      * Called by computeJulianDay.  Returns the default month (0-based) for the year,
      * taking year and era into account.  Defaults to 0 for Gregorian, which doesn't care.
      * @param eyear The extended year
+     * @param status Output param set to failure code on function return
+     *          when this function fails.
      * @internal
      */
-    virtual int32_t getDefaultMonthInYear(int32_t eyear) ;
+    virtual int32_t getDefaultMonthInYear(int32_t eyear, UErrorCode& status);
 
 
     /**
@@ -2155,7 +2161,7 @@ protected:
      * returns the local DOW, valid range 0..6
      * @internal
      */
-    int32_t getLocalDOW();
+    int32_t getLocalDOW(UErrorCode& status);
 #endif  /* U_HIDE_INTERNAL_API */
 
 private:

--- a/icu4c/source/i18n/unicode/gregocal.h
+++ b/icu4c/source/i18n/unicode/gregocal.h
@@ -483,12 +483,13 @@ public:
      * @param useMonth if false, compute the day before the first day of
      * the given year, otherwise, compute the day before the first day of
      * the given month
+     * @param status Fill-in parameter which receives the status of this operation.
      * @return the Julian day number of the day before the first
      * day of the given month and year
      * @internal
      */
     virtual int64_t handleComputeMonthStart(int32_t eyear, int32_t month,
-                                                   UBool useMonth) const override;
+                                            UBool useMonth, UErrorCode& status) const override;
 
     /**
      * Subclasses may override this.  This method calls
@@ -508,7 +509,7 @@ public:
      * implementation than the default implementation in Calendar.
      * @internal
      */
-    virtual int32_t handleGetMonthLength(int32_t extendedYear, int32_t month) const override;
+    virtual int32_t handleGetMonthLength(int32_t extendedYear, int32_t month, UErrorCode& status) const override;
 
     /**
      * Return the number of days in the given extended year of this
@@ -522,10 +523,11 @@ public:
     /**
      * return the length of the given month.
      * @param month    the given month.
+     * @param status Fill-in parameter which receives the status of this operation.
      * @return    the length of the given month.
      * @internal
      */
-    virtual int32_t monthLength(int32_t month) const;
+    virtual int32_t monthLength(int32_t month, UErrorCode& status) const;
 
     /**
      * return the length of the month according to the given year.
@@ -597,7 +599,7 @@ public:
      * @return the extended year, UCAL_EXTENDED_YEAR
      * @internal
      */
-    virtual int32_t handleGetExtendedYearFromWeekFields(int32_t yearWoy, int32_t woy) override;
+    virtual int32_t handleGetExtendedYearFromWeekFields(int32_t yearWoy, int32_t woy, UErrorCode& status) override;
 
 
     /**

--- a/icu4c/source/test/intltest/caltest.h
+++ b/icu4c/source/test/intltest/caltest.h
@@ -340,6 +340,7 @@ public: // package
     void Test22633PersianOverflow();
     void Test22633HebrewOverflow();
     void Test22633AMPMOverflow();
+    void Test22633SetGetTimeOverflow();
 
     void verifyFirstDayOfWeek(const char* locale, UCalendarDaysOfWeek expected);
     void TestFirstDayOfWeek();


### PR DESCRIPTION
Add test to set with INT32_MAX and INT32_MIN then call getTime() and fix all the undefined errors.

There are a lot of fuzzer found int32_t overflow in the area of calendar. I write a test trying to trigger all possible condition and fix allt he found issues here. 

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22633
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
