### PR TITLE
ICU-22610 Use Requires.private to prevent overlinking

### DIFF
--- a/icu4c/source/Makefile.in
+++ b/icu4c/source/Makefile.in
@@ -275,24 +275,24 @@ config/icu-uc.pc: config/icu.pc Makefile icudefs.mk
 	@cat config/icu.pc > $@
 	@echo "Description: $(PACKAGE_ICU_DESCRIPTION): Common and Data libraries" >> $@
 	@echo "Name: $(PACKAGE)-uc" >> $@
-	@echo "Libs:" '-L$${libdir}' "${ICULIBS_UC}" "${ICULIBS_DT}" >> $@
-	@echo "Libs.private:" '$${baselibs}' >> $@
+	@echo "Libs:" '-L$${libdir}' "${ICULIBS_UC}" >> $@
+	@echo "Libs.private:" "${ICULIBS_DT}" '$${baselibs}' >> $@
 	@echo $@ updated.
 
 config/icu-i18n.pc: config/icu.pc Makefile icudefs.mk
 	@cat config/icu.pc > $@
 	@echo "Description: $(PACKAGE_ICU_DESCRIPTION): Internationalization library" >> $@
 	@echo "Name: $(PACKAGE)-i18n" >> $@
-	@echo "Requires: icu-uc" >> $@
-	@echo "Libs:" "${ICULIBS_I18N}" >> $@
+	@echo "Requires.private: icu-uc" >> $@
+	@echo "Libs:" '-L$${libdir}' "${ICULIBS_I18N}" >> $@
 	@echo $@ updated.
 
 config/icu-io.pc: config/icu.pc Makefile icudefs.mk
 	@cat config/icu.pc > $@
 	@echo "Description: $(PACKAGE_ICU_DESCRIPTION): Stream and I/O Library" >> $@
 	@echo "Name: $(PACKAGE)-io" >> $@
-	@echo "Requires: icu-i18n" >> $@
-	@echo "Libs:" "${ICULIBS_IO}" >> $@
+	@echo "Requires.private: icu-i18n" >> $@
+	@echo "Libs:" '-L$${libdir}' "${ICULIBS_IO}" >> $@
 	@echo $@ updated.
 
 ICULEHB_LIBS=@ICULEHB_LIBS@
@@ -307,11 +307,11 @@ config/icu-lx.pc: config/icu.pc Makefile icudefs.mk
 	@echo "Description: $(PACKAGE_ICU_DESCRIPTION): Paragraph Layout library $(USING_HB)" >> $@
 	@echo "Name: $(PACKAGE)-lx" >> $@
 ifneq ($(ICULEHB_LIBS),)
-	@echo "Requires: icu-le-hb icu-uc" >> $@
+	@echo "Requires.private: icu-le-hb icu-uc" >> $@
 else
-	@echo "Requires: icu-le" >> $@
+	@echo "Requires.private: icu-le" >> $@
 endif
-	@echo "Libs:" "${ICULIBS_LX}" >> $@
+	@echo "Libs:" '-L$${libdir}' "${ICULIBS_LX}" >> $@
 	@echo $@ updated.
 
 


### PR DESCRIPTION
Replace Requires with Requires.private in icu-i18n.pc, icu-io.pc, and icu-lx.pc, so that clients will not link ICU internal dependencies when linking each library.

The pkg-config documentation recommends the following:

    https://people.freedesktop.org/~dbn/pkg-config-guide.html#writing

    It is usually preferred to use the private variant of Requires
    to avoid exposing unnecessary libraries to the program that is
    linking with your library. If the program will not be using the
    symbols of the required library, it should not be linking directly
    to that library. See the discussion of overlinking for a more
    thorough explanation.

    Since pkg-config always exposes the link flags of the Requires
    libraries, these modules will become direct dependencies of the
    program. On the other hand, libraries from Requires.private will
    only be included when static linking. For this reason, it is
    usually only appropriate to add modules from the same package
    in Requires.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22610
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
