### PR TITLE
ICU-22611 Fixed the RBNF MultiplierSubstitution to only perform floor…

### DIFF
--- a/icu4c/source/i18n/nfrule.cpp
+++ b/icu4c/source/i18n/nfrule.cpp
@@ -721,6 +721,14 @@ int64_t NFRule::getDivisor() const
     return util64_pow(radix, exponent);
 }
 
+/**
+ * Internal function to facilitate numerical rounding.  See the explanation in MultiplierSubstitution::transformNumber().
+ */
+bool NFRule::hasModulusSubstitution() const
+{
+    return (sub1 != nullptr && sub1->isModulusSubstitution()) || (sub2 != nullptr && sub2->isModulusSubstitution());
+}
+
 
 //-----------------------------------------------------------------------
 // formatting

--- a/icu4c/source/i18n/nfrule.h
+++ b/icu4c/source/i18n/nfrule.h
@@ -66,6 +66,8 @@ public:
     char16_t getDecimalPoint() const { return decimalPoint; }
 
     int64_t getDivisor() const;
+    
+    bool hasModulusSubstitution() const;
 
     void doFormat(int64_t number, UnicodeString& toAppendTo, int32_t pos, int32_t recursionCount, UErrorCode& status) const;
     void doFormat(double  number, UnicodeString& toAppendTo, int32_t pos, int32_t recursionCount, UErrorCode& status) const;
@@ -117,6 +119,9 @@ private:
 
     NFRule(const NFRule &other); // forbid copying of this class
     NFRule &operator=(const NFRule &other); // forbid copying of this class
+    
+    // TODO: temporary hack to allow MultiplierSubstitution to get to formatter's rounding mode
+    friend class MultiplierSubstitution;
 };
 
 U_NAMESPACE_END

--- a/icu4c/source/i18n/nfsubs.cpp
+++ b/icu4c/source/i18n/nfsubs.cpp
@@ -73,6 +73,7 @@ SameValueSubstitution::~SameValueSubstitution() {}
 
 class MultiplierSubstitution : public NFSubstitution {
     int64_t divisor;
+    const NFRule* owningRule;
 
 public:
     MultiplierSubstitution(int32_t _pos,
@@ -80,7 +81,7 @@ public:
         const NFRuleSet* _ruleSet,
         const UnicodeString& description,
         UErrorCode& status)
-        : NFSubstitution(_pos, _ruleSet, description, status), divisor(rule->getDivisor())
+        : NFSubstitution(_pos, _ruleSet, description, status), divisor(rule->getDivisor()), owningRule(rule)
     {
         if (divisor == 0) {
             status = U_PARSE_ERROR;
@@ -103,25 +104,22 @@ public:
     }
 
     virtual double transformNumber(double number) const override {
-        bool doFloor = getRuleSet() != nullptr;
-        if (!doFloor) {
-            // This is a HACK that partially addresses ICU-22313.  The original code wanted us to do
-            // floor() on the result if we were passing it to another rule set, but not if we were passing
-            // it to a DecimalFormat.  But the DurationRules rule set has multiplier substitutions where
-            // we DO want to do the floor() operation.  What we REALLY want is to do floor() any time
-            // the owning rule also has a ModulusSubsitution, but we don't have access to that information
-            // here, so instead we're doing a floor() any time the DecimalFormat has maxFracDigits equal to
-            // 0.  This seems to work with our existing rule sets, but could be a problem in the future,
-            // but the "real" fix for DurationRules isn't worth doing, since we're deprecating DurationRules
-            // anyway.  This is enough to keep it from being egregiously wrong, without obvious side
-            // effects.     --rtg 8/16/23
-            const DecimalFormat* decimalFormat = getNumberFormat();
-            if (decimalFormat == nullptr || decimalFormat->getMaximumFractionDigits() == 0) {
-                doFloor = true;
-            }
-        }
-        
-        if (doFloor) {
+        // Most of the time, when a number is handled by an NFSubstitution, we do a floor() on it, but
+        // if a substitution uses a DecimalFormat to format the number instead of a ruleset, we generally
+        // don't want to do a floor()-- we want to keep the value intact so that the DecimalFormat can
+        // either include the fractional part or round properly.  The big exception to this is here in
+        // MultiplierSubstitution.  If the rule includes two substitutions, the MultiplierSubstitution
+        // (which is handling the larger part of the number) really _does_ want to do a floor(), because
+        // the ModulusSubstitution (which is handling the smaller part of the number) will take
+        // care of the fractional part.  (Consider something like `1/12: <0< feet >0.0> inches;`.)
+        // But if there is no ModulusSubstitution, we're shortening the number in some way-- the "larger part"
+        // of the number is the only part we're keeping.  Even if the DecimalFormat doesn't include the
+        // fractional part in its output, we still want it to round.  (Consider something like `1/1000: <0<K;`.)
+        // (TODO: The kRoundFloor thing is a kludge to preserve the previous floor-always behavior.  What we
+        // probably really want to do is just set the rounding mode on the DecimalFormat to match the rounding
+        // mode on the RuleBasedNumberFormat and then pass the number to it whole and let it do its own rounding.
+        // But before making that change, we'd have to make sure it didn't have undesirable side effects.)
+        if (getRuleSet() != nullptr || owningRule->hasModulusSubstitution() || owningRule->formatter->getRoundingMode() == NumberFormat::kRoundFloor) {
             return uprv_floor(number / divisor);
         } else {
             return number / divisor;
@@ -598,17 +596,11 @@ NFSubstitution::doSubstitution(int64_t number, UnicodeString& toInsertInto, int3
         ruleSet->format(transformNumber(number), toInsertInto, _pos + this->pos, recursionCount, status);
     } else if (numberFormat != nullptr) {
         if (number <= MAX_INT64_IN_DOUBLE) {
-            // or perform the transformation on the number (preserving
-            // the result's fractional part if the formatter it set
-            // to show it), then use that formatter's format() method
+            // or perform the transformation on the number,
+            // then use that formatter's format() method
             // to format the result
-            double numberToFormat = transformNumber((double)number);
-            if (numberFormat->getMaximumFractionDigits() == 0) {
-                numberToFormat = uprv_floor(numberToFormat);
-            }
-
             UnicodeString temp;
-            numberFormat->format(numberToFormat, temp, status);
+            numberFormat->format(transformNumber((double)number), temp, status);
             toInsertInto.insert(_pos + this->pos, temp);
         } 
         else { 

--- a/icu4c/source/i18n/unicode/rbnf.h
+++ b/icu4c/source/i18n/unicode/rbnf.h
@@ -436,7 +436,16 @@ enum URBNFRuleSetTag {
  *   <tr>
  *     <td>&lt;&lt;</td>
  *     <td>in normal rule</td>
- *     <td>Divide the number by the rule's divisor and format the quotient</td>
+ *     <td>Divide the number by the rule's divisor, perform floor() on the quotient,
+ *         and format the resulting value.<br>
+ *         If there is a DecimalFormat pattern between the &lt; characters and the
+ *         rule does NOT also contain a &gt;&gt; substitution, we DON'T perform
+ *         floor() on the quotient-- the quotient is passed through to the DecimalFormat
+ *         intact.  That is, for the value 1,900:<br>
+ *         - "1/1000: &lt;&lt; thousand;" will produce "one thousand"<br>
+ *         - "1/1000: &lt;0&lt; thousand;" will produce "2 thousand" (NOT "1 thousand")<br>
+ *         - "1/1000: &lt;0&lt; seconds &gt;0&gt; milliseconds;" will produce "1 second 900 milliseconds"
+ *     </td>
  *   </tr>
  *   <tr>
  *     <td></td>

--- a/icu4c/source/test/intltest/itrbnf.h
+++ b/icu4c/source/test/intltest/itrbnf.h
@@ -60,6 +60,12 @@ class IntlTestRBNF : public IntlTest {
    * Perform a simple spot check on the duration-formatting rules
    */
   void TestDurations();
+    
+  /**
+   * Test that rounding works correctly on multiplier substitutions that use
+   * a DecimalFormat.
+   */
+  void TestDFRounding();
 
   /**
    * Perform a simple spot check on the Spanish spellout rules

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/NFRule.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/NFRule.java
@@ -112,7 +112,7 @@ final class NFRule {
     /**
      * The RuleBasedNumberFormat that owns this rule
      */
-    private final RuleBasedNumberFormat formatter;
+    final RuleBasedNumberFormat formatter;
 
     //-----------------------------------------------------------------------
     // construction
@@ -728,6 +728,13 @@ final class NFRule {
      */
     public long getDivisor() {
         return power(radix, exponent);
+    }
+
+    /**
+     * Internal function used by the rounding code in MultiplierSubstitution.
+     */
+    boolean hasModulusSubstitution() {
+        return (sub1 instanceof ModulusSubstitution) || (sub2 instanceof ModulusSubstitution);
     }
 
     //-----------------------------------------------------------------------

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/RuleBasedNumberFormat.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/RuleBasedNumberFormat.java
@@ -404,7 +404,16 @@ import com.ibm.icu.util.UResourceBundleIterator;
  *     <td style="width: 37;"></td>
  *     <td style="width: 23;">&lt;&lt;</td>
  *     <td style="width: 165; vertical-align: top;">in normal rule</td>
- *     <td>Divide the number by the rule's divisor and format the quotient</td>
+ *     <td>Divide the number by the rule's divisor, perform floor() on the quotient,
+ *         and format the resulting value.<br>
+ *         If there is a DecimalFormat pattern between the &lt; characters and the
+ *         rule does NOT also contain a &gt;&gt; substitution, we DON'T perform
+ *         floor() on the quotient-- the quotient is passed through to the DecimalFormat
+ *         intact.  That is, for the value 1,900:<br>
+ *         - "1/1000: &lt;&lt; thousand;" will produce "one thousand"<br>
+ *         - "1/1000: &lt;0&lt; thousand;" will produce "2 thousand" (NOT "1 thousand")<br>
+ *         - "1/1000: &lt;0&lt; seconds &gt;0&gt; milliseconds;" will produce "1 second 900 milliseconds"
+ *     </td>
  *   </tr>
  *   <tr>
  *     <td style="width: 37;"></td>


### PR DESCRIPTION
…() on the value being formatted when the

substitution is using a DecimalFormat and its owning rule also has a modulus substitution.  Took out a redundant call to floor().  Added appropriate unit tests.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22611
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
