### PR TITLE
ICU-22679 Remove getType and string comparsion

### DIFF
--- a/icu4c/source/i18n/buddhcal.h
+++ b/icu4c/source/i18n/buddhcal.h
@@ -177,6 +177,8 @@ private:
      * @internal
      */
     virtual int32_t defaultCenturyStartYear() const override;
+
+    virtual bool isEra0CountingBackward() const override { return false; }
 };
 
 U_NAMESPACE_END

--- a/icu4c/source/i18n/coptccal.h
+++ b/icu4c/source/i18n/coptccal.h
@@ -204,7 +204,7 @@ protected:
      */
     virtual int32_t getJDEpochOffset() const override;
 
-
+    virtual bool isEra0CountingBackward() const override { return true; }
 public:
     /**
      * Override Calendar Returns a unique class ID POLYMORPHICALLY. Pure virtual

--- a/icu4c/source/i18n/iso8601cal.h
+++ b/icu4c/source/i18n/iso8601cal.h
@@ -90,6 +90,8 @@ class ISO8601Calendar : public GregorianCalendar {
    */
   virtual const char * getType() const override;
 
+ protected:
+  virtual bool isEra0CountingBackward() const override { return false; }
 
  private:
  

--- a/icu4c/source/i18n/japancal.h
+++ b/icu4c/source/i18n/japancal.h
@@ -223,6 +223,8 @@ protected:
      * @internal
      */
     virtual int32_t getDefaultDayInMonth(int32_t eyear, int32_t month) override;
+
+    virtual bool isEra0CountingBackward() const override { return false; }
 };
 
 U_NAMESPACE_END

--- a/icu4c/source/i18n/unicode/calendar.h
+++ b/icu4c/source/i18n/unicode/calendar.h
@@ -1547,6 +1547,13 @@ protected:
      * @internal
      */
     inline int32_t internalGet(UCalendarDateFields field) const {return fFields[field];}
+
+    /**
+     * The year in this calendar is counting from 1 backward if the era is 0.
+     * @return The year in era 0 of this calendar is counting backward from 1.
+     * @internal
+     */
+    virtual bool isEra0CountingBackward() const { return false; }
 #endif  /* U_HIDE_INTERNAL_API */
 
     /**

--- a/icu4c/source/i18n/unicode/gregocal.h
+++ b/icu4c/source/i18n/unicode/gregocal.h
@@ -619,6 +619,15 @@ public:
      */
     virtual void handleComputeFields(int32_t julianDay, UErrorCode &status) override;
 
+#ifndef U_HIDE_INTERNAL_API
+    /**
+     * The year in this calendar is counting from 1 backward if the era is 0.
+     * @return The year in era 0 of this calendar is counting backward from 1.
+     * @internal
+     */
+    virtual bool isEra0CountingBackward() const override { return true; }
+#endif  // U_HIDE_INTERNAL_API
+
  private:
     /**
      * Compute the julian day number of the given year.

--- a/icu4j/main/core/src/main/java/com/ibm/icu/util/BuddhistCalendar.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/util/BuddhistCalendar.java
@@ -244,4 +244,15 @@ public class BuddhistCalendar extends GregorianCalendar {
     public String getType() {
         return "buddhist";
     }
+
+    /*
+     * {@inheritDoc}
+     * @internal
+     * @deprecated This API is ICU internal only.
+     */
+    @Override
+    @Deprecated
+    protected boolean isEra0CountingBackward() {
+        return false;
+    }
 }

--- a/icu4j/main/core/src/main/java/com/ibm/icu/util/Calendar.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/util/Calendar.java
@@ -3072,14 +3072,9 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
             // * Until we have new API per #9393, we temporarily hardcode knowledge of
             //   which calendars have era 0 years that go backwards.
         {
-            boolean era0WithYearsThatGoBackwards = false;
             int era = get(ERA);
-            if (era == 0) {
-                String calType = getType();
-                if (calType.equals("gregorian") || calType.equals("roc") || calType.equals("coptic")) {
-                    amount = -amount;
-                    era0WithYearsThatGoBackwards = true;
-                }
+            if (era == 0 && isEra0CountingBackward()) {
+                amount = -amount;
             }
             int newYear = internalGet(field) + amount;
             if (era > 0 || newYear >= 1) {
@@ -3098,7 +3093,7 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
                 // else we are in era 0 with newYear < 1;
                 // calendars with years that go backwards must pin the year value at 0,
                 // other calendars can have years < 0 in era 0
-            } else if (era0WithYearsThatGoBackwards) {
+            } else if (era == 0 && isEra0CountingBackward()) {
                 newYear = 1;
             }
             set(field, newYear);
@@ -3415,11 +3410,8 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
             //   also handle YEAR the same way.
         {
             int era = get(ERA);
-            if (era == 0) {
-                String calType = getType();
-                if (calType.equals("gregorian") || calType.equals("roc") || calType.equals("coptic")) {
-                    amount = -amount;
-                }
+            if (era == 0 && isEra0CountingBackward()) {
+                amount = -amount;
             }
         }
         // Fall through into standard handling
@@ -4096,6 +4088,17 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
         } else if (fields[field] < min) {
             set(field, min);
         }
+    }
+
+    /*
+     * The year in this calendar is counting from 1 backward if the era is 0.
+     * @return The year in era 0 of this calendar is counting backward from 1.
+     * @internal
+     * @deprecated This API is ICU internal only.
+     */
+    @Deprecated
+    protected boolean isEra0CountingBackward() {
+        return false;
     }
 
     /**

--- a/icu4j/main/core/src/main/java/com/ibm/icu/util/CopticCalendar.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/util/CopticCalendar.java
@@ -242,6 +242,17 @@ public final class CopticCalendar extends CECalendar
         return "coptic";
     }
 
+    /*
+     * {@inheritDoc}
+     * @internal
+     * @deprecated This API is ICU internal only.
+     */
+    @Override
+    @Deprecated
+    protected boolean isEra0CountingBackward() {
+        return true;
+    }
+
     /**
      * {@inheritDoc}
      * @internal

--- a/icu4j/main/core/src/main/java/com/ibm/icu/util/GregorianCalendar.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/util/GregorianCalendar.java
@@ -897,6 +897,17 @@ public class GregorianCalendar extends Calendar {
     }
 
     /*
+     * {@inheritDoc}
+     * @internal
+     * @deprecated This API is ICU internal only.
+     */
+    @Override
+    @Deprecated
+    protected boolean isEra0CountingBackward() {
+        return true;
+    }
+
+    /*
     private static CalendarFactory factory;
     public static CalendarFactory factory() {
         if (factory == null) {

--- a/icu4j/main/core/src/main/java/com/ibm/icu/util/JapaneseCalendar.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/util/JapaneseCalendar.java
@@ -484,4 +484,14 @@ public class JapaneseCalendar extends GregorianCalendar {
         return super.getActualMaximum(field);
     }
 
+    /*
+     * {@inheritDoc}
+     * @internal
+     * @deprecated This API is ICU internal only.
+     */
+    @Override
+    @Deprecated
+    protected boolean isEra0CountingBackward() {
+        return false;
+    }
 }


### PR DESCRIPTION
Change the logic of handling year in era 0 counting backwards to depend on a boolean virtual function instead of adding string comparsion code in the base class to have specific knowledge of behavior of subclass.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22679
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
