### PR TITLE
ICU-22698 Clean up CalendarAstronomer

### DIFF
--- a/icu4c/source/i18n/astro.cpp
+++ b/icu4c/source/i18n/astro.cpp
@@ -242,7 +242,7 @@ inline static  double normPI(double angle)  {
  * @deprecated ICU 2.4. This class may be removed or modified.
  */
 CalendarAstronomer::CalendarAstronomer():
-  fTime(Calendar::getNow()), fLongitude(0.0), fLatitude(0.0), fGmtOffset(0.0), moonPosition(0,0), moonPositionSet(false) {
+  fTime(Calendar::getNow()), moonPosition(0,0), moonPositionSet(false) {
   clearCache();
 }
 
@@ -252,30 +252,7 @@ CalendarAstronomer::CalendarAstronomer():
  * @internal
  * @deprecated ICU 2.4. This class may be removed or modified.
  */
-CalendarAstronomer::CalendarAstronomer(UDate d): fTime(d), fLongitude(0.0), fLatitude(0.0), fGmtOffset(0.0), moonPosition(0,0), moonPositionSet(false) {
-  clearCache();
-}
-
-/**
- * Construct a new <code>CalendarAstronomer</code> object with the given
- * latitude and longitude.  The object's time is set to the current
- * date and time.
- * <p>
- * @param longitude The desired longitude, in <em>degrees</em> east of
- *                  the Greenwich meridian.
- *
- * @param latitude  The desired latitude, in <em>degrees</em>.  Positive
- *                  values signify North, negative South.
- *
- * @see java.util.Date#getTime()
- * @internal
- * @deprecated ICU 2.4. This class may be removed or modified.
- */
-CalendarAstronomer::CalendarAstronomer(double longitude, double latitude) :
-  fTime(Calendar::getNow()), moonPosition(0,0), moonPositionSet(false) {
-  fLongitude = normPI(longitude * (double)DEG_RAD);
-  fLatitude  = normPI(latitude  * (double)DEG_RAD);
-  fGmtOffset = (double)(fLongitude * 24. * (double)HOUR_MS / (double)CalendarAstronomer_PI2);
+CalendarAstronomer::CalendarAstronomer(UDate d): fTime(d), moonPosition(0,0), moonPositionSet(false) {
   clearCache();
 }
 
@@ -301,29 +278,7 @@ CalendarAstronomer::~CalendarAstronomer()
  */
 void CalendarAstronomer::setTime(UDate aTime) {
     fTime = aTime;
-    U_DEBUG_ASTRO_MSG(("setTime(%.1lf, %sL)\n", aTime, debug_astro_date(aTime+fGmtOffset)));
     clearCache();
-}
-
-/**
- * Set the current date and time of this <code>CalendarAstronomer</code> object.  All
- * astronomical calculations are performed based on this time setting.
- *
- * @param jdn   the desired time, expressed as a "julian day number",
- *              which is the number of elapsed days since
- *              1/1/4713 BC (Julian), 12:00 GMT.  Note that julian day
- *              numbers start at <em>noon</em>.  To get the jdn for
- *              the corresponding midnight, subtract 0.5.
- *
- * @see #getJulianDay
- * @see #JULIAN_EPOCH_MS
- * @internal
- * @deprecated ICU 2.4. This class may be removed or modified.
- */
-void CalendarAstronomer::setJulianDay(double jdn) {
-    fTime = (double)(jdn * DAY_MS) + JULIAN_EPOCH_MS;
-    clearCache();
-    julianDay = jdn;
 }
 
 /**
@@ -357,96 +312,9 @@ double CalendarAstronomer::getJulianDay() {
     return julianDay;
 }
 
-/**
- * Return this object's time expressed in julian centuries:
- * the number of centuries after 1/1/1900 AD, 12:00 GMT
- *
- * @see #getJulianDay
- * @internal
- * @deprecated ICU 2.4. This class may be removed or modified.
- */
-double CalendarAstronomer::getJulianCentury() {
-    if (isINVALID(julianCentury)) {
-        julianCentury = (getJulianDay() - 2415020.0) / 36525.0;
-    }
-    return julianCentury;
-}
-
-/**
- * Returns the current Greenwich sidereal time, measured in hours
- * @internal
- * @deprecated ICU 2.4. This class may be removed or modified.
- */
-double CalendarAstronomer::getGreenwichSidereal() {
-    if (isINVALID(siderealTime)) {
-        // See page 86 of "Practical Astronomy with your Calculator",
-        // by Peter Duffet-Smith, for details on the algorithm.
-
-        double UT = normalize(fTime/(double)HOUR_MS, 24.);
-
-        siderealTime = normalize(getSiderealOffset() + UT*1.002737909, 24.);
-    }
-    return siderealTime;
-}
-
-double CalendarAstronomer::getSiderealOffset() {
-    if (isINVALID(siderealT0)) {
-        double JD  = uprv_floor(getJulianDay() - 0.5) + 0.5;
-        double S   = JD - 2451545.0;
-        double T   = S / 36525.0;
-        siderealT0 = normalize(6.697374558 + 2400.051336*T + 0.000025862*T*T, 24);
-    }
-    return siderealT0;
-}
-
-/**
- * Returns the current local sidereal time, measured in hours
- * @internal
- * @deprecated ICU 2.4. This class may be removed or modified.
- */
-double CalendarAstronomer::getLocalSidereal() {
-    return normalize(getGreenwichSidereal() + (fGmtOffset/(double)HOUR_MS), 24.);
-}
-
-/**
- * Converts local sidereal time to Universal Time.
- *
- * @param lst   The Local Sidereal Time, in hours since sidereal midnight
- *              on this object's current date.
- *
- * @return      The corresponding Universal Time, in milliseconds since
- *              1 Jan 1970, GMT.
- */
-double CalendarAstronomer::lstToUT(double lst) {
-    // Convert to local mean time
-    double lt = normalize((lst - getSiderealOffset()) * 0.9972695663, 24);
-
-    // Then find local midnight on this day
-    double base = (DAY_MS * ClockMath::floorDivide(fTime + fGmtOffset,(double)DAY_MS)) - fGmtOffset;
-
-    //out("    lt  =" + lt + " hours");
-    //out("    base=" + new Date(base));
-
-    return base + (long)(lt * HOUR_MS);
-}
-
-
 //-------------------------------------------------------------------------
 // Coordinate transformations, all based on the current time of this object
 //-------------------------------------------------------------------------
-
-/**
- * Convert from ecliptic to equatorial coordinates.
- *
- * @param ecliptic  A point in the sky in ecliptic coordinates.
- * @return          The corresponding point in equatorial coordinates.
- * @internal
- * @deprecated ICU 2.4. This class may be removed or modified.
- */
-CalendarAstronomer::Equatorial& CalendarAstronomer::eclipticToEquatorial(CalendarAstronomer::Equatorial& result, const CalendarAstronomer::Ecliptic& ecliptic)
-{
-    return eclipticToEquatorial(result, ecliptic.longitude, ecliptic.latitude);
-}
 
 /**
  * Convert from ecliptic to equatorial coordinates.
@@ -478,46 +346,6 @@ CalendarAstronomer::Equatorial& CalendarAstronomer::eclipticToEquatorial(Calenda
         asin(sinB*cosE + cosB*sinE*sinL) );
     return result;
 }
-
-/**
- * Convert from ecliptic longitude to equatorial coordinates.
- *
- * @param eclipLong     The ecliptic longitude
- *
- * @return              The corresponding point in equatorial coordinates.
- * @internal
- * @deprecated ICU 2.4. This class may be removed or modified.
- */
-CalendarAstronomer::Equatorial& CalendarAstronomer::eclipticToEquatorial(CalendarAstronomer::Equatorial& result, double eclipLong)
-{
-    return eclipticToEquatorial(result, eclipLong, 0);  // TODO: optimize
-}
-
-/**
- * @internal
- * @deprecated ICU 2.4. This class may be removed or modified.
- */
-CalendarAstronomer::Horizon& CalendarAstronomer::eclipticToHorizon(CalendarAstronomer::Horizon& result, double eclipLong)
-{
-    Equatorial equatorial;
-    eclipticToEquatorial(equatorial, eclipLong);
-
-    double H = getLocalSidereal()*CalendarAstronomer::PI/12 - equatorial.ascension;     // Hour-angle
-
-    double sinH = ::sin(H);
-    double cosH = cos(H);
-    double sinD = ::sin(equatorial.declination);
-    double cosD = cos(equatorial.declination);
-    double sinL = ::sin(fLatitude);
-    double cosL = cos(fLatitude);
-
-    double altitude = asin(sinD*sinL + cosD*cosL*cosH);
-    double azimuth  = atan2(-cosD*cosL*sinH, sinD - sinL * ::sin(altitude));
-
-    result.set(azimuth, altitude);
-    return result;
-}
-
 
 //-------------------------------------------------------------------------
 // The Sun
@@ -658,50 +486,6 @@ double CalendarAstronomer::getSunLongitude()
 }
 
 /**
- * The position of the sun at this object's current date and time,
- * in equatorial coordinates.
- * @internal
- * @deprecated ICU 2.4. This class may be removed or modified.
- */
-CalendarAstronomer::Equatorial& CalendarAstronomer::getSunPosition(CalendarAstronomer::Equatorial& result) {
-    return eclipticToEquatorial(result, getSunLongitude(), 0);
-}
-
-
-/**
- * Constant representing the vernal equinox.
- * For use with {@link #getSunTime getSunTime}.
- * Note: In this case, "vernal" refers to the northern hemisphere's seasons.
- * @internal
- * @deprecated ICU 2.4. This class may be removed or modified.
- */
-/*double CalendarAstronomer::VERNAL_EQUINOX() {
-  return 0;
-}*/
-
-/**
- * Constant representing the summer solstice.
- * For use with {@link #getSunTime getSunTime}.
- * Note: In this case, "summer" refers to the northern hemisphere's seasons.
- * @internal
- * @deprecated ICU 2.4. This class may be removed or modified.
- */
-double CalendarAstronomer::SUMMER_SOLSTICE() {
-    return  (CalendarAstronomer::PI/2);
-}
-
-/**
- * Constant representing the autumnal equinox.
- * For use with {@link #getSunTime getSunTime}.
- * Note: In this case, "autumn" refers to the northern hemisphere's seasons.
- * @internal
- * @deprecated ICU 2.4. This class may be removed or modified.
- */
-/*double CalendarAstronomer::AUTUMN_EQUINOX() {
-  return  (CalendarAstronomer::PI);
-}*/
-
-/**
  * Constant representing the winter solstice.
  * For use with {@link #getSunTime getSunTime}.
  * Note: In this case, "winter" refers to the northern hemisphere's seasons.
@@ -737,310 +521,6 @@ UDate CalendarAstronomer::getSunTime(double desired, UBool next)
                         MINUTE_MS,
                         next);
 }
-
-CalendarAstronomer::CoordFunc::~CoordFunc() {}
-
-class RiseSetCoordFunc : public CalendarAstronomer::CoordFunc {
-public:
-    virtual ~RiseSetCoordFunc();
-    virtual void eval(CalendarAstronomer::Equatorial& result, CalendarAstronomer& a) override { a.getSunPosition(result); }
-};
-
-RiseSetCoordFunc::~RiseSetCoordFunc() {}
-
-UDate CalendarAstronomer::getSunRiseSet(UBool rise)
-{
-    UDate t0 = fTime;
-
-    // Make a rough guess: 6am or 6pm local time on the current day
-    double noon = ClockMath::floorDivide(fTime + fGmtOffset, (double)DAY_MS)*DAY_MS - fGmtOffset + (12*HOUR_MS);
-
-    U_DEBUG_ASTRO_MSG(("Noon=%.2lf, %sL, gmtoff %.2lf\n", noon, debug_astro_date(noon+fGmtOffset), fGmtOffset));
-    setTime(noon +  ((rise ? -6 : 6) * HOUR_MS));
-    U_DEBUG_ASTRO_MSG(("added %.2lf ms as a guess,\n", ((rise ? -6. : 6.) * HOUR_MS)));
-
-    RiseSetCoordFunc func;
-    double t = riseOrSet(func,
-                         rise,
-                         .533 * DEG_RAD,        // Angular Diameter
-                         34. /60.0 * DEG_RAD,    // Refraction correction
-                         MINUTE_MS / 12.);       // Desired accuracy
-
-    setTime(t0);
-    return t;
-}
-
-// Commented out - currently unused. ICU 2.6, Alan
-//    //-------------------------------------------------------------------------
-//    // Alternate Sun Rise/Set
-//    // See Duffett-Smith p.93
-//    //-------------------------------------------------------------------------
-//
-//    // This yields worse results (as compared to USNO data) than getSunRiseSet().
-//    /**
-//     * TODO Make this when the entire class is package-private.
-//     */
-//    /*public*/ long getSunRiseSet2(boolean rise) {
-//        // 1. Calculate coordinates of the sun's center for midnight
-//        double jd = uprv_floor(getJulianDay() - 0.5) + 0.5;
-//        double[] sl = getSunLongitude(jd);//        double lambda1 = sl[0];
-//        Equatorial pos1 = eclipticToEquatorial(lambda1, 0);
-//
-//        // 2. Add ... to lambda to get position 24 hours later
-//        double lambda2 = lambda1 + 0.985647*DEG_RAD;
-//        Equatorial pos2 = eclipticToEquatorial(lambda2, 0);
-//
-//        // 3. Calculate LSTs of rising and setting for these two positions
-//        double tanL = ::tan(fLatitude);
-//        double H = ::acos(-tanL * ::tan(pos1.declination));
-//        double lst1r = (CalendarAstronomer_PI2 + pos1.ascension - H) * 24 / CalendarAstronomer_PI2;
-//        double lst1s = (pos1.ascension + H) * 24 / CalendarAstronomer_PI2;
-//               H = ::acos(-tanL * ::tan(pos2.declination));
-//        double lst2r = (CalendarAstronomer_PI2-H + pos2.ascension ) * 24 / CalendarAstronomer_PI2;
-//        double lst2s = (H + pos2.ascension ) * 24 / CalendarAstronomer_PI2;
-//        if (lst1r > 24) lst1r -= 24;
-//        if (lst1s > 24) lst1s -= 24;
-//        if (lst2r > 24) lst2r -= 24;
-//        if (lst2s > 24) lst2s -= 24;
-//
-//        // 4. Convert LSTs to GSTs.  If GST1 > GST2, add 24 to GST2.
-//        double gst1r = lstToGst(lst1r);
-//        double gst1s = lstToGst(lst1s);
-//        double gst2r = lstToGst(lst2r);
-//        double gst2s = lstToGst(lst2s);
-//        if (gst1r > gst2r) gst2r += 24;
-//        if (gst1s > gst2s) gst2s += 24;
-//
-//        // 5. Calculate GST at 0h UT of this date
-//        double t00 = utToGst(0);
-//
-//        // 6. Calculate GST at 0h on the observer's longitude
-//        double offset = ::round(fLongitude*12/PI); // p.95 step 6; he _rounds_ to nearest 15 deg.
-//        double t00p = t00 - offset*1.002737909;
-//        if (t00p < 0) t00p += 24; // do NOT normalize
-//
-//        // 7. Adjust
-//        if (gst1r < t00p) {
-//            gst1r += 24;
-//            gst2r += 24;
-//        }
-//        if (gst1s < t00p) {
-//            gst1s += 24;
-//            gst2s += 24;
-//        }
-//
-//        // 8.
-//        double gstr = (24.07*gst1r-t00*(gst2r-gst1r))/(24.07+gst1r-gst2r);
-//        double gsts = (24.07*gst1s-t00*(gst2s-gst1s))/(24.07+gst1s-gst2s);
-//
-//        // 9. Correct for parallax, refraction, and sun's diameter
-//        double dec = (pos1.declination + pos2.declination) / 2;
-//        double psi = ::acos(sin(fLatitude) / cos(dec));
-//        double x = 0.830725 * DEG_RAD; // parallax+refraction+diameter
-//        double y = ::asin(sin(x) / ::sin(psi)) * RAD_DEG;
-//        double delta_t = 240 * y / cos(dec) / 3600; // hours
-//
-//        // 10. Add correction to GSTs, subtract from GSTr
-//        gstr -= delta_t;
-//        gsts += delta_t;
-//
-//        // 11. Convert GST to UT and then to local civil time
-//        double ut = gstToUt(rise ? gstr : gsts);
-//        //System.out.println((rise?"rise=":"set=") + ut + ", delta_t=" + delta_t);
-//        long midnight = DAY_MS * (time / DAY_MS); // Find UT midnight on this day
-//        return midnight + (long) (ut * 3600000);
-//    }
-
-// Commented out - currently unused. ICU 2.6, Alan
-//    /**
-//     * Convert local sidereal time to Greenwich sidereal time.
-//     * Section 15.  Duffett-Smith p.21
-//     * @param lst in hours (0..24)
-//     * @return GST in hours (0..24)
-//     */
-//    double lstToGst(double lst) {
-//        double delta = fLongitude * 24 / CalendarAstronomer_PI2;
-//        return normalize(lst - delta, 24);
-//    }
-
-// Commented out - currently unused. ICU 2.6, Alan
-//    /**
-//     * Convert UT to GST on this date.
-//     * Section 12.  Duffett-Smith p.17
-//     * @param ut in hours
-//     * @return GST in hours
-//     */
-//    double utToGst(double ut) {
-//        return normalize(getT0() + ut*1.002737909, 24);
-//    }
-
-// Commented out - currently unused. ICU 2.6, Alan
-//    /**
-//     * Convert GST to UT on this date.
-//     * Section 13.  Duffett-Smith p.18
-//     * @param gst in hours
-//     * @return UT in hours
-//     */
-//    double gstToUt(double gst) {
-//        return normalize(gst - getT0(), 24) * 0.9972695663;
-//    }
-
-// Commented out - currently unused. ICU 2.6, Alan
-//    double getT0() {
-//        // Common computation for UT <=> GST
-//
-//        // Find JD for 0h UT
-//        double jd = uprv_floor(getJulianDay() - 0.5) + 0.5;
-//
-//        double s = jd - 2451545.0;
-//        double t = s / 36525.0;
-//        double t0 = 6.697374558 + (2400.051336 + 0.000025862*t)*t;
-//        return t0;
-//    }
-
-// Commented out - currently unused. ICU 2.6, Alan
-//    //-------------------------------------------------------------------------
-//    // Alternate Sun Rise/Set
-//    // See sci.astro FAQ
-//    // http://www.faqs.org/faqs/astronomy/faq/part3/section-5.html
-//    //-------------------------------------------------------------------------
-//
-//    // Note: This method appears to produce inferior accuracy as
-//    // compared to getSunRiseSet().
-//
-//    /**
-//     * TODO Make this when the entire class is package-private.
-//     */
-//    /*public*/ long getSunRiseSet3(boolean rise) {
-//
-//        // Compute day number for 0.0 Jan 2000 epoch
-//        double d = (double)(time - EPOCH_2000_MS) / DAY_MS;
-//
-//        // Now compute the Local Sidereal Time, LST:
-//        //
-//        double LST  =  98.9818  +  0.985647352 * d  +  /*UT*15  +  long*/
-//            fLongitude*RAD_DEG;
-//        //
-//        // (east long. positive).  Note that LST is here expressed in degrees,
-//        // where 15 degrees corresponds to one hour.  Since LST really is an angle,
-//        // it's convenient to use one unit---degrees---throughout.
-//
-//        //    COMPUTING THE SUN'S POSITION
-//        //    ----------------------------
-//        //
-//        // To be able to compute the Sun's rise/set times, you need to be able to
-//        // compute the Sun's position at any time.  First compute the "day
-//        // number" d as outlined above, for the desired moment.  Next compute:
-//        //
-//        double oblecl = 23.4393 - 3.563E-7 * d;
-//        //
-//        double w  =  282.9404  +  4.70935E-5   * d;
-//        double M  =  356.0470  +  0.9856002585 * d;
-//        double e  =  0.016709  -  1.151E-9     * d;
-//        //
-//        // This is the obliquity of the ecliptic, plus some of the elements of
-//        // the Sun's apparent orbit (i.e., really the Earth's orbit): w =
-//        // argument of perihelion, M = mean anomaly, e = eccentricity.
-//        // Semi-major axis is here assumed to be exactly 1.0 (while not strictly
-//        // true, this is still an accurate approximation).  Next compute E, the
-//        // eccentric anomaly:
-//        //
-//        double E = M + e*(180/PI) * ::sin(M*DEG_RAD) * ( 1.0 + e*cos(M*DEG_RAD) );
-//        //
-//        // where E and M are in degrees.  This is it---no further iterations are
-//        // needed because we know e has a sufficiently small value.  Next compute
-//        // the true anomaly, v, and the distance, r:
-//        //
-//        /*      r * cos(v)  =  */ double A  =  cos(E*DEG_RAD) - e;
-//        /*      r * ::sin(v)  =  */ double B  =  ::sqrt(1 - e*e) * ::sin(E*DEG_RAD);
-//        //
-//        // and
-//        //
-//        //      r  =  sqrt( A*A + B*B )
-//        double v  =  ::atan2( B, A )*RAD_DEG;
-//        //
-//        // The Sun's true longitude, slon, can now be computed:
-//        //
-//        double slon  =  v + w;
-//        //
-//        // Since the Sun is always at the ecliptic (or at least very very close to
-//        // it), we can use simplified formulae to convert slon (the Sun's ecliptic
-//        // longitude) to sRA and sDec (the Sun's RA and Dec):
-//        //
-//        //                   ::sin(slon) * cos(oblecl)
-//        //     tan(sRA)  =  -------------------------
-//        //            cos(slon)
-//        //
-//        //     ::sin(sDec) =  ::sin(oblecl) * ::sin(slon)
-//        //
-//        // As was the case when computing az, the Azimuth, if possible use an
-//        // atan2() function to compute sRA.
-//
-//        double sRA = ::atan2(sin(slon*DEG_RAD) * cos(oblecl*DEG_RAD), cos(slon*DEG_RAD))*RAD_DEG;
-//
-//        double sin_sDec = ::sin(oblecl*DEG_RAD) * ::sin(slon*DEG_RAD);
-//        double sDec = ::asin(sin_sDec)*RAD_DEG;
-//
-//        //    COMPUTING RISE AND SET TIMES
-//        //    ----------------------------
-//        //
-//        // To compute when an object rises or sets, you must compute when it
-//        // passes the meridian and the HA of rise/set.  Then the rise time is
-//        // the meridian time minus HA for rise/set, and the set time is the
-//        // meridian time plus the HA for rise/set.
-//        //
-//        // To find the meridian time, compute the Local Sidereal Time at 0h local
-//        // time (or 0h UT if you prefer to work in UT) as outlined above---name
-//        // that quantity LST0.  The Meridian Time, MT, will now be:
-//        //
-//        //     MT  =  RA - LST0
-//        double MT = normalize(sRA - LST, 360);
-//        //
-//        // where "RA" is the object's Right Ascension (in degrees!).  If negative,
-//        // add 360 deg to MT.  If the object is the Sun, leave the time as it is,
-//        // but if it's stellar, multiply MT by 365.2422/366.2422, to convert from
-//        // sidereal to solar time.  Now, compute HA for rise/set, name that
-//        // quantity HA0:
-//        //
-//        //                 ::sin(h0)  -  ::sin(lat) * ::sin(Dec)
-//        // cos(HA0)  =  ---------------------------------
-//        //                      cos(lat) * cos(Dec)
-//        //
-//        // where h0 is the altitude selected to represent rise/set.  For a purely
-//        // mathematical horizon, set h0 = 0 and simplify to:
-//        //
-//        //    cos(HA0)  =  - tan(lat) * tan(Dec)
-//        //
-//        // If you want to account for refraction on the atmosphere, set h0 = -35/60
-//        // degrees (-35 arc minutes), and if you want to compute the rise/set times
-//        // for the Sun's upper limb, set h0 = -50/60 (-50 arc minutes).
-//        //
-//        double h0 = -50/60 * DEG_RAD;
-//
-//        double HA0 = ::acos(
-//          (sin(h0) - ::sin(fLatitude) * sin_sDec) /
-//          (cos(fLatitude) * cos(sDec*DEG_RAD)))*RAD_DEG;
-//
-//        // When HA0 has been computed, leave it as it is for the Sun but multiply
-//        // by 365.2422/366.2422 for stellar objects, to convert from sidereal to
-//        // solar time.  Finally compute:
-//        //
-//        //    Rise time  =  MT - HA0
-//        //    Set  time  =  MT + HA0
-//        //
-//        // convert the times from degrees to hours by dividing by 15.
-//        //
-//        // If you'd like to check that your calculations are accurate or just
-//        // need a quick result, check the USNO's Sun or Moon Rise/Set Table,
-//        // <URL:http://aa.usno.navy.mil/AA/data/docs/RS_OneYear.html>.
-//
-//        double result = MT + (rise ? -HA0 : HA0); // in degrees
-//
-//        // Find UT midnight on this day
-//        long midnight = DAY_MS * (time / DAY_MS);
-//
-//        return midnight + (long) (result * 3600000 / 15);
-//    }
 
 //-------------------------------------------------------------------------
 // The Moon
@@ -1083,7 +563,7 @@ const CalendarAstronomer::Equatorial& CalendarAstronomer::getMoonPosition()
         // Calculate the mean longitude and anomaly of the moon, based on
         // a circular orbit.  Similar to the corresponding solar calculation.
         double meanLongitude = norm2PI(13.1763966*PI/180*day + moonL0);
-        meanAnomalyMoon = norm2PI(meanLongitude - 0.1114041*PI/180 * day - moonP0);
+        double meanAnomalyMoon = norm2PI(meanLongitude - 0.1114041*PI/180 * day - moonP0);
 
         //
         // Calculate the following corrections:
@@ -1109,7 +589,7 @@ const CalendarAstronomer::Equatorial& CalendarAstronomer::getMoonPosition()
         double a4 =     0.2140*PI/180 * ::sin(2 * meanAnomalyMoon);
 
         // Now find the moon's corrected longitude
-        moonLongitude = meanLongitude + evection + center - annual + a4;
+        double moonLongitude = meanLongitude + evection + center - annual + a4;
 
         //
         // And finally, find the variation, caused by the fact that the sun's
@@ -1149,7 +629,6 @@ const CalendarAstronomer::Equatorial& CalendarAstronomer::getMoonPosition()
  * current ecliptic longitudes of the sun and the moon,
  * measured in radians.
  *
- * @see #getMoonPhase
  * @internal
  * @deprecated ICU 2.4. This class may be removed or modified.
  */
@@ -1166,27 +645,6 @@ double CalendarAstronomer::getMoonAge() {
 }
 
 /**
- * Calculate the phase of the moon at the time set in this object.
- * The returned phase is a <code>double</code> in the range
- * <code>0 <= phase < 1</code>, interpreted as follows:
- * <ul>
- * <li>0.00: New moon
- * <li>0.25: First quarter
- * <li>0.50: Full moon
- * <li>0.75: Last quarter
- * </ul>
- *
- * @see #getMoonAge
- * @internal
- * @deprecated ICU 2.4. This class may be removed or modified.
- */
-double CalendarAstronomer::getMoonPhase() {
-    // See page 147 of "Practical Astronomy with your Calculator",
-    // by Peter Duffet-Smith, for details on the algorithm.
-    return 0.5 * (1 - cos(getMoonAge()));
-}
-
-/**
  * Constant representing a new moon.
  * For use with {@link #getMoonTime getMoonTime}
  * @internal
@@ -1196,25 +654,6 @@ CalendarAstronomer::MoonAge CalendarAstronomer::NEW_MOON() {
     return  CalendarAstronomer::MoonAge(0);
 }
 
-/**
- * Constant representing the moon's first quarter.
- * For use with {@link #getMoonTime getMoonTime}
- * @internal
- * @deprecated ICU 2.4. This class may be removed or modified.
- */
-/*const CalendarAstronomer::MoonAge CalendarAstronomer::FIRST_QUARTER() {
-  return   CalendarAstronomer::MoonAge(CalendarAstronomer::PI/2);
-}*/
-
-/**
- * Constant representing a full moon.
- * For use with {@link #getMoonTime getMoonTime}
- * @internal
- * @deprecated ICU 2.4. This class may be removed or modified.
- */
-CalendarAstronomer::MoonAge CalendarAstronomer::FULL_MOON() {
-    return   CalendarAstronomer::MoonAge(CalendarAstronomer::PI);
-}
 /**
  * Constant representing the moon's last quarter.
  * For use with {@link #getMoonTime getMoonTime}
@@ -1235,26 +674,6 @@ MoonTimeAngleFunc::~MoonTimeAngleFunc() {}
 }*/
 
 /**
- * Find the next or previous time at which the Moon's ecliptic
- * longitude will have the desired value.
- * <p>
- * @param desired   The desired longitude.
- * @param next      <tt>true</tt> if the next occurrence of the phase
- *                  is desired, <tt>false</tt> for the previous occurrence.
- * @internal
- * @deprecated ICU 2.4. This class may be removed or modified.
- */
-UDate CalendarAstronomer::getMoonTime(double desired, UBool next)
-{
-    MoonTimeAngleFunc func;
-    return timeOfAngle( func,
-                        desired,
-                        SYNODIC_MONTH,
-                        MINUTE_MS,
-                        next);
-}
-
-/**
  * Find the next or previous time at which the moon will be in the
  * desired phase.
  * <p>
@@ -1265,31 +684,12 @@ UDate CalendarAstronomer::getMoonTime(double desired, UBool next)
  * @deprecated ICU 2.4. This class may be removed or modified.
  */
 UDate CalendarAstronomer::getMoonTime(const CalendarAstronomer::MoonAge& desired, UBool next) {
-    return getMoonTime(desired.value, next);
-}
-
-class MoonRiseSetCoordFunc : public CalendarAstronomer::CoordFunc {
-public:
-    virtual ~MoonRiseSetCoordFunc();
-    virtual void eval(CalendarAstronomer::Equatorial& result, CalendarAstronomer& a) override { result = a.getMoonPosition(); }
-};
-
-MoonRiseSetCoordFunc::~MoonRiseSetCoordFunc() {}
-
-/**
- * Returns the time (GMT) of sunrise or sunset on the local date to which
- * this calendar is currently set.
- * @internal
- * @deprecated ICU 2.4. This class may be removed or modified.
- */
-UDate CalendarAstronomer::getMoonRiseSet(UBool rise)
-{
-    MoonRiseSetCoordFunc func;
-    return riseOrSet(func,
-                     rise,
-                     .533 * DEG_RAD,        // Angular Diameter
-                     34 /60.0 * DEG_RAD,    // Refraction correction
-                     MINUTE_MS);            // Desired accuracy
+    MoonTimeAngleFunc func;
+    return timeOfAngle( func,
+                        desired.value,
+                        SYNODIC_MONTH,
+                        MINUTE_MS,
+                        next);
 }
 
 //-------------------------------------------------------------------------
@@ -1364,48 +764,7 @@ UDate CalendarAstronomer::timeOfAngle(AngleFunc& func, double desired,
     return fTime;
 }
 
-UDate CalendarAstronomer::riseOrSet(CoordFunc& func, UBool rise,
-                                    double diameter, double refraction,
-                                    double epsilon)
-{
-    Equatorial pos;
-    double      tanL   = ::tan(fLatitude);
-    double     deltaT = 0;
-    int32_t         count = 0;
-
-    //
-    // Calculate the object's position at the current time, then use that
-    // position to calculate the time of rising or setting.  The position
-    // will be different at that time, so iterate until the error is allowable.
-    //
-    U_DEBUG_ASTRO_MSG(("setup rise=%s, dia=%.3lf, ref=%.3lf, eps=%.3lf\n",
-        rise?"T":"F", diameter, refraction, epsilon));
-    do {
-        // See "Practical Astronomy With Your Calculator, section 33.
-        func.eval(pos, *this);
-        double angle = ::acos(-tanL * ::tan(pos.declination));
-        double lst = ((rise ? CalendarAstronomer_PI2-angle : angle) + pos.ascension ) * 24 / CalendarAstronomer_PI2;
-
-        // Convert from LST to Universal Time.
-        UDate newTime = lstToUT( lst );
-
-        deltaT = newTime - fTime;
-        setTime(newTime);
-        U_DEBUG_ASTRO_MSG(("%d] dT=%.3lf, angle=%.3lf, lst=%.3lf,   A=%.3lf/D=%.3lf\n",
-            count, deltaT, angle, lst, pos.ascension, pos.declination));
-    }
-    while (++ count < 5 && uprv_fabs(deltaT) > epsilon);
-
-    // Calculate the correction due to refraction and the object's angular diameter
-    double cosD  = ::cos(pos.declination);
-    double psi   = ::acos(sin(fLatitude) / cosD);
-    double x     = diameter / 2 + refraction;
-    double y     = ::asin(sin(x) / ::sin(psi));
-    long  delta  = (long)((240 * y * RAD_DEG / cosD)*SECOND_MS);
-
-    return fTime + (rise ? -delta : delta);
-}
-											   /**
+/**
  * Return the obliquity of the ecliptic (the angle between the ecliptic
  * and the earth's equator) at the current time.  This varies due to
  * the precession of the earth's axis.
@@ -1414,19 +773,16 @@ UDate CalendarAstronomer::riseOrSet(CoordFunc& func, UBool rise,
  *          measured in radians.
  */
 double CalendarAstronomer::eclipticObliquity() {
-    if (isINVALID(eclipObliquity)) {
-        const double epoch = 2451545.0;     // 2000 AD, January 1.5
+    const double epoch = 2451545.0;     // 2000 AD, January 1.5
 
-        double T = (getJulianDay() - epoch) / 36525;
+    double T = (getJulianDay() - epoch) / 36525;
 
-        eclipObliquity = 23.439292
-            - 46.815/3600 * T
-            - 0.0006/3600 * T*T
-            + 0.00181/3600 * T*T*T;
+    double eclipObliquity = 23.439292
+        - 46.815/3600 * T
+        - 0.0006/3600 * T*T
+        + 0.00181/3600 * T*T*T;
 
-        eclipObliquity *= DEG_RAD;
-    }
-    return eclipObliquity;
+    return eclipObliquity * DEG_RAD;
 }
 
 
@@ -1437,44 +793,12 @@ void CalendarAstronomer::clearCache() {
     const double INVALID = uprv_getNaN();
 
     julianDay       = INVALID;
-    julianCentury   = INVALID;
     sunLongitude    = INVALID;
     meanAnomalySun  = INVALID;
-    moonLongitude   = INVALID;
     moonEclipLong   = INVALID;
-    meanAnomalyMoon = INVALID;
-    eclipObliquity  = INVALID;
-    siderealTime    = INVALID;
-    siderealT0      = INVALID;
+
     moonPositionSet = false;
 }
-
-//private static void out(String s) {
-//    System.out.println(s);
-//}
-
-//private static String deg(double rad) {
-//    return Double.toString(rad * RAD_DEG);
-//}
-
-//private static String hours(long ms) {
-//    return Double.toString((double)ms / HOUR_MS) + " hours";
-//}
-
-/**
- * @internal
- * @deprecated ICU 2.4. This class may be removed or modified.
- */
-/*UDate CalendarAstronomer::local(UDate localMillis) {
-  // TODO - srl ?
-  TimeZone *tz = TimeZone::createDefault();
-  int32_t rawOffset;
-  int32_t dstOffset;
-  UErrorCode status = U_ZERO_ERROR;
-  tz->getOffset(localMillis, true, rawOffset, dstOffset, status);
-  delete tz;
-  return localMillis - rawOffset;
-}*/
 
 // Debugging functions
 UnicodeString CalendarAstronomer::Ecliptic::toString() const
@@ -1499,34 +823,6 @@ UnicodeString CalendarAstronomer::Equatorial::toString() const
     return UnicodeString();
 #endif
 }
-
-UnicodeString CalendarAstronomer::Horizon::toString() const
-{
-#ifdef U_DEBUG_ASTRO
-    char tmp[800];
-    snprintf(tmp, sizeof(tmp), "[%.5f,%.5f]", altitude*RAD_DEG, azimuth*RAD_DEG);
-    return UnicodeString(tmp, "");
-#else
-    return UnicodeString();
-#endif
-}
-
-
-//  static private String radToHms(double angle) {
-//    int hrs = (int) (angle*RAD_HOUR);
-//    int min = (int)((angle*RAD_HOUR - hrs) * 60);
-//    int sec = (int)((angle*RAD_HOUR - hrs - min/60.0) * 3600);
-
-//    return Integer.toString(hrs) + "h" + min + "m" + sec + "s";
-//  }
-
-//  static private String radToDms(double angle) {
-//    int deg = (int) (angle*RAD_DEG);
-//    int min = (int)((angle*RAD_DEG - deg) * 60);
-//    int sec = (int)((angle*RAD_DEG - deg - min/60.0) * 3600);
-
-//    return Integer.toString(deg) + "\u00b0" + min + "'" + sec + "\"";
-//  }
 
 // =============== Calendar Cache ================
 

--- a/icu4c/source/i18n/astro.h
+++ b/icu4c/source/i18n/astro.h
@@ -31,7 +31,7 @@ U_NAMESPACE_BEGIN
  * at a given moment in time.  Accordingly, each <code>CalendarAstronomer</code>
  * object has a <code>time</code> property that determines the date
  * and time for which its calculations are performed.  You can set and
- * retrieve this property with {@link #setDate setDate}, {@link #getDate getDate}
+ * retrieve this property with {@link #setTime setTime}, {@link #getTime getTime}
  * and related methods.
  * <p>
  * Almost all of the calculations performed by this class, or by any
@@ -72,7 +72,6 @@ public:
    * value without worrying about whether other code will modify them.
    *
    * @see CalendarAstronomer.Equatorial
-   * @see CalendarAstronomer.Horizon
    * @internal
    */
   class U_I18N_API Ecliptic : public UMemory {
@@ -141,7 +140,6 @@ public:
    * value without worrying about whether other code will modify them.
    *
    * @see CalendarAstronomer.Ecliptic
-   * @see CalendarAstronomer.Horizon
    * @internal
    */
   class U_I18N_API Equatorial : public UMemory {
@@ -201,66 +199,6 @@ public:
     double declination;
   };
 
-  /**
-   * Represents the position of an  object in the sky relative to
-   * the local horizon.
-   * The <i>Altitude</i> represents the object's elevation above the horizon,
-   * with objects below the horizon having a negative altitude.
-   * The <i>Azimuth</i> is the geographic direction of the object from the
-   * observer's position, with 0 representing north.  The azimuth increases
-   * clockwise from north.
-   * <p>
-   * Note that Horizon objects are immutable and cannot be modified
-   * once they are constructed.  This allows them to be passed and returned by
-   * value without worrying about whether other code will modify them.
-   *
-   * @see CalendarAstronomer.Ecliptic
-   * @see CalendarAstronomer.Equatorial
-   * @internal
-   */
-  class U_I18N_API Horizon : public UMemory {
-  public:
-    /**
-     * Constructs a Horizon coordinate object.
-     * <p>
-     * @param alt  The altitude, measured in radians above the horizon.
-     * @param azim The azimuth, measured in radians clockwise from north.
-     * @internal
-     */
-    Horizon(double alt=0, double azim=0)
-      : altitude(alt), azimuth(azim) { }
-
-    /**
-     * Setter for Ecliptic Coordinate object
-     * @param alt  The altitude, measured in radians above the horizon.
-     * @param azim The azimuth, measured in radians clockwise from north.
-     * @internal
-     */
-    void set(double alt, double azim) {
-      altitude = alt;
-      azimuth = azim;
-    }
-
-    /**
-     * Return a string representation of this object, with the
-     * angles measured in degrees.
-     * @internal
-     */
-    UnicodeString toString() const;
-
-    /**
-     * The object's altitude above the horizon, in radians.
-     * @internal
-     */
-    double altitude;
-
-    /**
-     * The object's direction, in radians clockwise from north.
-     * @internal
-     */
-    double azimuth;
-  };
-
 public:
   //-------------------------------------------------------------------------
   // Assorted private data used for conversions
@@ -301,22 +239,6 @@ public:
   CalendarAstronomer(UDate d);
 
   /**
-   * Construct a new <code>CalendarAstronomer</code> object with the given
-   * latitude and longitude.  The object's time is set to the current
-   * date and time.
-   * <p>
-   * @param longitude The desired longitude, in <em>degrees</em> east of
-   *                  the Greenwich meridian.
-   *
-   * @param latitude  The desired latitude, in <em>degrees</em>.  Positive
-   *                  values signify North, negative South.
-   *
-   * @see java.util.Date#getTime()
-   * @internal
-   */
-  CalendarAstronomer(double longitude, double latitude);
-
-  /**
    * Destructor
    * @internal
    */
@@ -333,40 +255,10 @@ public:
    * @param aTime the date and time, expressed as the number of milliseconds since
    *              1/1/1970 0:00 GMT (Gregorian).
    *
-   * @see #setDate
    * @see #getTime
    * @internal
    */
   void setTime(UDate aTime);
-
-
-  /**
-   * Set the current date and time of this <code>CalendarAstronomer</code> object.  All
-   * astronomical calculations are performed based on this time setting.
-   *
-   * @param aTime the date and time, expressed as the number of milliseconds since
-   *              1/1/1970 0:00 GMT (Gregorian).
-   *
-   * @see #getTime
-   * @internal
-   */
-  void setDate(UDate aDate) { setTime(aDate); }
-
-  /**
-   * Set the current date and time of this <code>CalendarAstronomer</code> object.  All
-   * astronomical calculations are performed based on this time setting.
-   *
-   * @param jdn   the desired time, expressed as a "julian day number",
-   *              which is the number of elapsed days since
-   *              1/1/4713 BC (Julian), 12:00 GMT.  Note that julian day
-   *              numbers start at <em>noon</em>.  To get the jdn for
-   *              the corresponding midnight, subtract 0.5.
-   *
-   * @see #getJulianDay
-   * @see #JULIAN_EPOCH_MS
-   * @internal
-   */
-  void setJulianDay(double jdn);
 
   /**
    * Get the current time of this <code>CalendarAstronomer</code> object,
@@ -374,7 +266,6 @@ public:
    * 1/1/1970 AD 0:00 GMT (Gregorian).
    *
    * @see #setTime
-   * @see #getDate
    * @internal
    */
   UDate getTime();
@@ -384,58 +275,12 @@ public:
    * expressed as a "julian day number", which is the number of elapsed
    * days since 1/1/4713 BC (Julian), 12:00 GMT.
    *
-   * @see #setJulianDay
    * @see #JULIAN_EPOCH_MS
    * @internal
    */
   double getJulianDay();
 
-  /**
-   * Return this object's time expressed in julian centuries:
-   * the number of centuries after 1/1/1900 AD, 12:00 GMT
-   *
-   * @see #getJulianDay
-   * @internal
-   */
-  double getJulianCentury();
-
-  /**
-   * Returns the current Greenwich sidereal time, measured in hours
-   * @internal
-   */
-  double getGreenwichSidereal();
-
-private:
-  double getSiderealOffset();
 public:
-  /**
-   * Returns the current local sidereal time, measured in hours
-   * @internal
-   */
-  double getLocalSidereal();
-
-  /**
-   * Converts local sidereal time to Universal Time.
-   *
-   * @param lst   The Local Sidereal Time, in hours since sidereal midnight
-   *              on this object's current date.
-   *
-   * @return      The corresponding Universal Time, in milliseconds since
-   *              1 Jan 1970, GMT.
-   */
-  //private:
-  double lstToUT(double lst);
-
-  /**
-   *
-   * Convert from ecliptic to equatorial coordinates.
-   *
-   * @param ecliptic     The ecliptic
-   * @param result       Fillin result
-   * @return reference to result
-   */
-  Equatorial& eclipticToEquatorial(Equatorial& result, const Ecliptic& ecliptic);
-
   /**
    * Convert from ecliptic to equatorial coordinates.
    *
@@ -446,21 +291,6 @@ public:
    * @internal
    */
   Equatorial& eclipticToEquatorial(Equatorial& result, double eclipLong, double eclipLat);
-
-  /**
-   * Convert from ecliptic longitude to equatorial coordinates.
-   *
-   * @param eclipLong     The ecliptic longitude
-   *
-   * @return              The corresponding point in equatorial coordinates.
-   * @internal
-   */
-  Equatorial& eclipticToEquatorial(Equatorial& result, double eclipLong) ;
-
-  /**
-   * @internal
-   */
-  Horizon& eclipticToHorizon(Horizon& result, double eclipLong) ;
 
   //-------------------------------------------------------------------------
   // The Sun
@@ -484,39 +314,7 @@ public:
    */
   /*public*/ void getSunLongitude(double julianDay, double &longitude, double &meanAnomaly);
 
-  /**
-   * The position of the sun at this object's current date and time,
-   * in equatorial coordinates.
-   * @param result fillin for the result
-   * @internal
-   */
-  Equatorial& getSunPosition(Equatorial& result);
-
 public:
-  /**
-   * Constant representing the vernal equinox.
-   * For use with {@link #getSunTime getSunTime}.
-   * Note: In this case, "vernal" refers to the northern hemisphere's seasons.
-   * @internal
-   */
-//  static double VERNAL_EQUINOX();
-
-  /**
-   * Constant representing the summer solstice.
-   * For use with {@link #getSunTime getSunTime}.
-   * Note: In this case, "summer" refers to the northern hemisphere's seasons.
-   * @internal
-   */
-  static double SUMMER_SOLSTICE();
-
-  /**
-   * Constant representing the autumnal equinox.
-   * For use with {@link #getSunTime getSunTime}.
-   * Note: In this case, "autumn" refers to the northern hemisphere's seasons.
-   * @internal
-   */
-//  static double AUTUMN_EQUINOX();
-
   /**
    * Constant representing the winter solstice.
    * For use with {@link #getSunTime getSunTime}.
@@ -531,20 +329,6 @@ public:
    * @internal
    */
   UDate getSunTime(double desired, UBool next);
-
-  /**
-   * Returns the time (GMT) of sunrise or sunset on the local date to which
-   * this calendar is currently set.
-   *
-   * NOTE: This method only works well if this object is set to a
-   * time near local noon.  Because of variations between the local
-   * official time zone and the geographic longitude, the
-   * computation can flop over into an adjacent day if this object
-   * is set to a time near local midnight.
-   *
-   * @internal
-   */
-  UDate getSunRiseSet(UBool rise);
 
   //-------------------------------------------------------------------------
   // The Moon
@@ -569,22 +353,6 @@ public:
    */
   double getMoonAge();
 
-  /**
-   * Calculate the phase of the moon at the time set in this object.
-   * The returned phase is a <code>double</code> in the range
-   * <code>0 <= phase < 1</code>, interpreted as follows:
-   * <ul>
-   * <li>0.00: New moon
-   * <li>0.25: First quarter
-   * <li>0.50: Full moon
-   * <li>0.75: Last quarter
-   * </ul>
-   *
-   * @see #getMoonAge
-   * @internal
-   */
-  double getMoonPhase();
-
   class U_I18N_API MoonAge : public UMemory {
   public:
     MoonAge(double l)
@@ -601,27 +369,6 @@ public:
   static MoonAge NEW_MOON();
 
   /**
-   * Constant representing the moon's first quarter.
-   * For use with {@link #getMoonTime getMoonTime}
-   * @internal
-   */
-//  static const MoonAge FIRST_QUARTER();
-
-  /**
-   * Constant representing a full moon.
-   * For use with {@link #getMoonTime getMoonTime}
-   * @internal
-   */
-  static MoonAge FULL_MOON();
-
-  /**
-   * Constant representing the moon's last quarter.
-   * For use with {@link #getMoonTime getMoonTime}
-   * @internal
-   */
-//  static const MoonAge LAST_QUARTER();
-
-  /**
    * Find the next or previous time at which the Moon's ecliptic
    * longitude will have the desired value.
    * <p>
@@ -630,21 +377,13 @@ public:
    *                  is desired, <tt>false</tt> for the previous occurrence.
    * @internal
    */
-  UDate getMoonTime(double desired, UBool next);
   UDate getMoonTime(const MoonAge& desired, UBool next);
-
-  /**
-   * Returns the time (GMT) of sunrise or sunset on the local date to which
-   * this calendar is currently set.
-   * @internal
-   */
-  UDate getMoonRiseSet(UBool rise);
 
   //-------------------------------------------------------------------------
   // Interpolation methods for finding the time at which a given event occurs
   //-------------------------------------------------------------------------
 
-  // private
+public:
   class AngleFunc : public UMemory {
   public:
     virtual double eval(CalendarAstronomer&) = 0;
@@ -652,19 +391,9 @@ public:
   };
   friend class AngleFunc;
 
+private:
   UDate timeOfAngle(AngleFunc& func, double desired,
                     double periodDays, double epsilon, UBool next);
-
-  class CoordFunc : public UMemory {
-  public:
-    virtual void eval(Equatorial& result, CalendarAstronomer&) = 0;
-    virtual ~CoordFunc();
-  };
-  friend class CoordFunc;
-
-  double riseOrSet(CoordFunc& func, UBool rise,
-                   double diameter, double refraction,
-                   double epsilon);
 
   //-------------------------------------------------------------------------
   // Other utility methods
@@ -691,29 +420,13 @@ private:
    */
   UDate fTime;
 
-  /* These aren't used yet, but they'll be needed for sunset calculations
-   * and equatorial to horizon coordinate conversions
-   */
-  double fLongitude;
-  double fLatitude;
-  double fGmtOffset;
-
-  //
   // The following fields are used to cache calculated results for improved
   // performance.  These values all depend on the current time setting
   // of this object, so the clearCache method is provided.
-  //
-
   double    julianDay;
-  double    julianCentury;
   double    sunLongitude;
   double    meanAnomalySun;
-  double    moonLongitude;
   double    moonEclipLong;
-  double    meanAnomalyMoon;
-  double    eclipObliquity;
-  double    siderealT0;
-  double    siderealTime;
 
   void clearCache();
 

--- a/icu4c/source/i18n/islamcal.h
+++ b/icu4c/source/i18n/islamcal.h
@@ -211,28 +211,7 @@ class U_I18N_API IslamicCalendar : public Calendar {
    * @param year  The hijri month, 0-based
    */
   virtual int64_t monthStart(int32_t year, int32_t month, UErrorCode& status) const;
-    
-  /**
-   * Find the day number on which a particular month of the true/lunar
-   * Islamic calendar starts.
-   *
-   * @param month The month in question, origin 0 from the Hijri epoch
-   *
-   * @return The day number on which the given month starts.
-   */
-  int32_t trueMonthStart(int32_t month) const;
 
- private:
-  /**
-   * Return the "age" of the moon at the given time; this is the difference
-   * in ecliptic latitude between the moon and the sun.  This method simply
-   * calls CalendarAstronomer.moonAge, converts to degrees, 
-   * and adjusts the resultto be in the range [-180, 180].
-   *
-   * @param time  The time at which the moon's age is desired,
-   *              in millis since 1/1/1970.
-   */
-  static double moonAge(UDate time, UErrorCode &status);
 
   //----------------------------------------------------------------------
   // Calendar framework

--- a/icu4c/source/test/intltest/astrotst.h
+++ b/icu4c/source/test/intltest/astrotst.h
@@ -34,16 +34,13 @@ public:
 
     void TestCoverage();
 
-    void TestSunriseTimes();
-
     void TestBasics();
     
     void TestMoonAge();
  private:
-    void initAstro(UErrorCode&);
-    void closeAstro(UErrorCode&);
+    void init(UErrorCode&);
+    void close(UErrorCode&);
     
-    CalendarAstronomer *astro;
     Calendar *gc;
     
 };

--- a/icu4j/main/core/src/main/java/com/ibm/icu/impl/CalendarAstronomer.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/impl/CalendarAstronomer.java
@@ -205,15 +205,6 @@ public class CalendarAstronomer {
 
     /**
      * Construct a new <code>CalendarAstronomer</code> object that is initialized to
-     * the specified date and time.
-     * @internal
-     */
-    public CalendarAstronomer(Date d) {
-        this(d.getTime());
-    }
-
-    /**
-     * Construct a new <code>CalendarAstronomer</code> object that is initialized to
      * the specified time.  The time is expressed as a number of milliseconds since
      * January 1, 1970 AD (Gregorian).
      *
@@ -224,32 +215,9 @@ public class CalendarAstronomer {
         time = aTime;
     }
 
-    /**
-     * Construct a new <code>CalendarAstronomer</code> object with the given
-     * latitude and longitude.  The object's time is set to the current
-     * date and time.
-     * <p>
-     * @param longitude The desired longitude, in <em>degrees</em> east of
-     *                  the Greenwich meridian.
-     *
-     * @param latitude  The desired latitude, in <em>degrees</em>.  Positive
-     *                  values signify North, negative South.
-     *
-     * @see java.util.Date#getTime()
-     * @internal
-     */
-    public CalendarAstronomer(double longitude, double latitude) {
-        this();
-        fLongitude = normPI(longitude * DEG_RAD);
-        fLatitude  = normPI(latitude  * DEG_RAD);
-        fGmtOffset = (long)(fLongitude * 24 * HOUR_MS / PI2);
-    }
-
-
     //-------------------------------------------------------------------------
     // Time and date getters and setters
     //-------------------------------------------------------------------------
-
     /**
      * Set the current date and time of this <code>CalendarAstronomer</code> object.  All
      * astronomical calculations are performed based on this time setting.
@@ -266,19 +234,6 @@ public class CalendarAstronomer {
         clearCache();
     }
 
-    /**
-     * Set the current date and time of this <code>CalendarAstronomer</code> object.  All
-     * astronomical calculations are performed based on this time setting.
-     *
-     * @param date the time and date, expressed as a <code>Date</code> object.
-     *
-     * @see #setTime
-     * @see #getDate
-     * @internal
-     */
-    public void setDate(Date date) {
-        setTime(date.getTime());
-    }
 
     /**
      * Set the current date and time of this <code>CalendarAstronomer</code> object.  All
@@ -341,92 +296,9 @@ public class CalendarAstronomer {
         return julianDay;
     }
 
-    /**
-     * Return this object's time expressed in julian centuries:
-     * the number of centuries after 1/1/1900 AD, 12:00 GMT
-     *
-     * @see #getJulianDay
-     * @internal
-     */
-    public double getJulianCentury() {
-        if (julianCentury == INVALID) {
-            julianCentury = (getJulianDay() - 2415020.0) / 36525;
-        }
-        return julianCentury;
-    }
-
-    /**
-     * Returns the current Greenwich sidereal time, measured in hours
-     * @internal
-     */
-    public double getGreenwichSidereal() {
-        if (siderealTime == INVALID) {
-            // See page 86 of "Practical Astronomy with your Calculator",
-            // by Peter Duffet-Smith, for details on the algorithm.
-
-            double UT = normalize((double)time/HOUR_MS, 24);
-
-            siderealTime = normalize(getSiderealOffset() + UT*1.002737909, 24);
-        }
-        return siderealTime;
-    }
-
-    private double getSiderealOffset() {
-        if (siderealT0 == INVALID) {
-            double JD  = Math.floor(getJulianDay() - 0.5) + 0.5;
-            double S   = JD - 2451545.0;
-            double T   = S / 36525.0;
-            siderealT0 = normalize(6.697374558 + 2400.051336*T + 0.000025862*T*T, 24);
-        }
-        return siderealT0;
-    }
-
-    /**
-     * Returns the current local sidereal time, measured in hours
-     * @internal
-     */
-    public double getLocalSidereal() {
-        return normalize(getGreenwichSidereal() + (double)fGmtOffset/HOUR_MS, 24);
-    }
-
-    /**
-     * Converts local sidereal time to Universal Time.
-     *
-     * @param lst   The Local Sidereal Time, in hours since sidereal midnight
-     *              on this object's current date.
-     *
-     * @return      The corresponding Universal Time, in milliseconds since
-     *              1 Jan 1970, GMT.
-     */
-    private long lstToUT(double lst) {
-        // Convert to local mean time
-        double lt = normalize((lst - getSiderealOffset()) * 0.9972695663, 24);
-
-        // Then find local midnight on this day
-        long base = DAY_MS * ((time + fGmtOffset)/DAY_MS) - fGmtOffset;
-
-        //out("    lt  =" + lt + " hours");
-        //out("    base=" + new Date(base));
-
-        return base + (long)(lt * HOUR_MS);
-    }
-
-
     //-------------------------------------------------------------------------
     // Coordinate transformations, all based on the current time of this object
     //-------------------------------------------------------------------------
-
-    /**
-     * Convert from ecliptic to equatorial coordinates.
-     *
-     * @param ecliptic  A point in the sky in ecliptic coordinates.
-     * @return          The corresponding point in equatorial coordinates.
-     * @internal
-     */
-    public final Equatorial eclipticToEquatorial(Ecliptic ecliptic)
-    {
-        return eclipticToEquatorial(ecliptic.longitude, ecliptic.latitude);
-    }
 
     /**
      * Convert from ecliptic to equatorial coordinates.
@@ -456,42 +328,6 @@ public class CalendarAstronomer {
         return new Equatorial(Math.atan2(sinL*cosE - tanB*sinE, cosL),
                                Math.asin(sinB*cosE + cosB*sinE*sinL) );
     }
-
-    /**
-     * Convert from ecliptic longitude to equatorial coordinates.
-     *
-     * @param eclipLong     The ecliptic longitude
-     *
-     * @return              The corresponding point in equatorial coordinates.
-     * @internal
-     */
-    public final Equatorial eclipticToEquatorial(double eclipLong)
-    {
-        return eclipticToEquatorial(eclipLong, 0);  // TODO: optimize
-    }
-
-    /**
-     * @internal
-     */
-    public Horizon eclipticToHorizon(double eclipLong)
-    {
-        Equatorial equatorial = eclipticToEquatorial(eclipLong);
-
-        double H = getLocalSidereal()*PI/12 - equatorial.ascension;     // Hour-angle
-
-        double sinH = Math.sin(H);
-        double cosH = Math.cos(H);
-        double sinD = Math.sin(equatorial.declination);
-        double cosD = Math.cos(equatorial.declination);
-        double sinL = Math.sin(fLatitude);
-        double cosL = Math.cos(fLatitude);
-
-        double altitude = Math.asin(sinD*sinL + cosD*cosL*cosH);
-        double azimuth  = Math.atan2(-cosD*cosL*sinH, sinD - sinL * Math.sin(altitude));
-
-        return new Horizon(azimuth, altitude);
-    }
-
 
     //-------------------------------------------------------------------------
     // The Sun
@@ -606,43 +442,10 @@ public class CalendarAstronomer {
         };
     }
 
-    /**
-     * The position of the sun at this object's current date and time,
-     * in equatorial coordinates.
-     * @internal
-     */
-    public Equatorial getSunPosition() {
-        return eclipticToEquatorial(getSunLongitude(), 0);
-    }
-
     private static class SolarLongitude {
         double value;
         SolarLongitude(double val) { value = val; }
     }
-
-    /**
-     * Constant representing the vernal equinox.
-     * For use with {@link #getSunTime(SolarLongitude, boolean) getSunTime}.
-     * Note: In this case, "vernal" refers to the northern hemisphere's seasons.
-     * @internal
-     */
-    public static final SolarLongitude VERNAL_EQUINOX  = new SolarLongitude(0);
-
-    /**
-     * Constant representing the summer solstice.
-     * For use with {@link #getSunTime(SolarLongitude, boolean) getSunTime}.
-     * Note: In this case, "summer" refers to the northern hemisphere's seasons.
-     * @internal
-     */
-    public static final SolarLongitude SUMMER_SOLSTICE = new SolarLongitude(PI/2);
-
-    /**
-     * Constant representing the autumnal equinox.
-     * For use with {@link #getSunTime(SolarLongitude, boolean) getSunTime}.
-     * Note: In this case, "autumn" refers to the northern hemisphere's seasons.
-     * @internal
-     */
-    public static final SolarLongitude AUTUMN_EQUINOX  = new SolarLongitude(PI);
 
     /**
      * Constant representing the winter solstice.
@@ -675,312 +478,6 @@ public class CalendarAstronomer {
     public long getSunTime(SolarLongitude desired, boolean next) {
         return getSunTime(desired.value, next);
     }
-
-    /**
-     * Returns the time (GMT) of sunrise or sunset on the local date to which
-     * this calendar is currently set.
-     *
-     * NOTE: This method only works well if this object is set to a
-     * time near local noon.  Because of variations between the local
-     * official time zone and the geographic longitude, the
-     * computation can flop over into an adjacent day if this object
-     * is set to a time near local midnight.
-     *
-     * @internal
-     */
-    public long getSunRiseSet(boolean rise) {
-        long t0 = time;
-
-        // Make a rough guess: 6am or 6pm local time on the current day
-        long noon = ((time + fGmtOffset)/DAY_MS)*DAY_MS - fGmtOffset + 12*HOUR_MS;
-
-        setTime(noon + (rise ? -6L : 6L) * HOUR_MS);
-
-        long t = riseOrSet(new CoordFunc() {
-            @Override
-            public Equatorial eval() { return getSunPosition(); }
-            },
-                rise,
-                .533 * DEG_RAD,        // Angular Diameter
-                34 /60.0 * DEG_RAD,    // Refraction correction
-                MINUTE_MS / 12);       // Desired accuracy
-
-            setTime(t0);
-            return t;
-        }
-
-// Commented out - currently unused. ICU 2.6, Alan
-//    //-------------------------------------------------------------------------
-//    // Alternate Sun Rise/Set
-//    // See Duffett-Smith p.93
-//    //-------------------------------------------------------------------------
-//
-//    // This yields worse results (as compared to USNO data) than getSunRiseSet().
-//    /**
-//     * TODO Make this public when the entire class is package-private.
-//     */
-//    /*public*/ long getSunRiseSet2(boolean rise) {
-//        // 1. Calculate coordinates of the sun's center for midnight
-//        double jd = Math.floor(getJulianDay() - 0.5) + 0.5;
-//        double[] sl = getSunLongitude(jd);
-//        double lambda1 = sl[0];
-//        Equatorial pos1 = eclipticToEquatorial(lambda1, 0);
-//
-//        // 2. Add ... to lambda to get position 24 hours later
-//        double lambda2 = lambda1 + 0.985647*DEG_RAD;
-//        Equatorial pos2 = eclipticToEquatorial(lambda2, 0);
-//
-//        // 3. Calculate LSTs of rising and setting for these two positions
-//        double tanL = Math.tan(fLatitude);
-//        double H = Math.acos(-tanL * Math.tan(pos1.declination));
-//        double lst1r = (PI2 + pos1.ascension - H) * 24 / PI2;
-//        double lst1s = (pos1.ascension + H) * 24 / PI2;
-//               H = Math.acos(-tanL * Math.tan(pos2.declination));
-//        double lst2r = (PI2-H + pos2.ascension ) * 24 / PI2;
-//        double lst2s = (H + pos2.ascension ) * 24 / PI2;
-//        if (lst1r > 24) lst1r -= 24;
-//        if (lst1s > 24) lst1s -= 24;
-//        if (lst2r > 24) lst2r -= 24;
-//        if (lst2s > 24) lst2s -= 24;
-//
-//        // 4. Convert LSTs to GSTs.  If GST1 > GST2, add 24 to GST2.
-//        double gst1r = lstToGst(lst1r);
-//        double gst1s = lstToGst(lst1s);
-//        double gst2r = lstToGst(lst2r);
-//        double gst2s = lstToGst(lst2s);
-//        if (gst1r > gst2r) gst2r += 24;
-//        if (gst1s > gst2s) gst2s += 24;
-//
-//        // 5. Calculate GST at 0h UT of this date
-//        double t00 = utToGst(0);
-//
-//        // 6. Calculate GST at 0h on the observer's longitude
-//        double offset = Math.round(fLongitude*12/PI); // p.95 step 6; he _rounds_ to nearest 15 deg.
-//        double t00p = t00 - offset*1.002737909;
-//        if (t00p < 0) t00p += 24; // do NOT normalize
-//
-//        // 7. Adjust
-//        if (gst1r < t00p) {
-//            gst1r += 24;
-//            gst2r += 24;
-//        }
-//        if (gst1s < t00p) {
-//            gst1s += 24;
-//            gst2s += 24;
-//        }
-//
-//        // 8.
-//        double gstr = (24.07*gst1r-t00*(gst2r-gst1r))/(24.07+gst1r-gst2r);
-//        double gsts = (24.07*gst1s-t00*(gst2s-gst1s))/(24.07+gst1s-gst2s);
-//
-//        // 9. Correct for parallax, refraction, and sun's diameter
-//        double dec = (pos1.declination + pos2.declination) / 2;
-//        double psi = Math.acos(Math.sin(fLatitude) / Math.cos(dec));
-//        double x = 0.830725 * DEG_RAD; // parallax+refraction+diameter
-//        double y = Math.asin(Math.sin(x) / Math.sin(psi)) * RAD_DEG;
-//        double delta_t = 240 * y / Math.cos(dec) / 3600; // hours
-//
-//        // 10. Add correction to GSTs, subtract from GSTr
-//        gstr -= delta_t;
-//        gsts += delta_t;
-//
-//        // 11. Convert GST to UT and then to local civil time
-//        double ut = gstToUt(rise ? gstr : gsts);
-//        //System.out.println((rise?"rise=":"set=") + ut + ", delta_t=" + delta_t);
-//        long midnight = DAY_MS * (time / DAY_MS); // Find UT midnight on this day
-//        return midnight + (long) (ut * 3600000);
-//    }
-
-// Commented out - currently unused. ICU 2.6, Alan
-//    /**
-//     * Convert local sidereal time to Greenwich sidereal time.
-//     * Section 15.  Duffett-Smith p.21
-//     * @param lst in hours (0..24)
-//     * @return GST in hours (0..24)
-//     */
-//    double lstToGst(double lst) {
-//        double delta = fLongitude * 24 / PI2;
-//        return normalize(lst - delta, 24);
-//    }
-
-// Commented out - currently unused. ICU 2.6, Alan
-//    /**
-//     * Convert UT to GST on this date.
-//     * Section 12.  Duffett-Smith p.17
-//     * @param ut in hours
-//     * @return GST in hours
-//     */
-//    double utToGst(double ut) {
-//        return normalize(getT0() + ut*1.002737909, 24);
-//    }
-
-// Commented out - currently unused. ICU 2.6, Alan
-//    /**
-//     * Convert GST to UT on this date.
-//     * Section 13.  Duffett-Smith p.18
-//     * @param gst in hours
-//     * @return UT in hours
-//     */
-//    double gstToUt(double gst) {
-//        return normalize(gst - getT0(), 24) * 0.9972695663;
-//    }
-
-// Commented out - currently unused. ICU 2.6, Alan
-//    double getT0() {
-//        // Common computation for UT <=> GST
-//
-//        // Find JD for 0h UT
-//        double jd = Math.floor(getJulianDay() - 0.5) + 0.5;
-//
-//        double s = jd - 2451545.0;
-//        double t = s / 36525.0;
-//        double t0 = 6.697374558 + (2400.051336 + 0.000025862*t)*t;
-//        return t0;
-//    }
-
-// Commented out - currently unused. ICU 2.6, Alan
-//    //-------------------------------------------------------------------------
-//    // Alternate Sun Rise/Set
-//    // See sci.astro FAQ
-//    // http://www.faqs.org/faqs/astronomy/faq/part3/section-5.html
-//    //-------------------------------------------------------------------------
-//
-//    // Note: This method appears to produce inferior accuracy as
-//    // compared to getSunRiseSet().
-//
-//    /**
-//     * TODO Make this public when the entire class is package-private.
-//     */
-//    /*public*/ long getSunRiseSet3(boolean rise) {
-//
-//        // Compute day number for 0.0 Jan 2000 epoch
-//        double d = (double)(time - EPOCH_2000_MS) / DAY_MS;
-//
-//        // Now compute the Local Sidereal Time, LST:
-//        //
-//        double LST  =  98.9818  +  0.985647352 * d  +  /*UT*15  +  long*/
-//            fLongitude*RAD_DEG;
-//        //
-//        // (east long. positive).  Note that LST is here expressed in degrees,
-//        // where 15 degrees corresponds to one hour.  Since LST really is an angle,
-//        // it's convenient to use one unit---degrees---throughout.
-//
-//        //     COMPUTING THE SUN'S POSITION
-//        //     ----------------------------
-//        //
-//        // To be able to compute the Sun's rise/set times, you need to be able to
-//        // compute the Sun's position at any time.  First compute the "day
-//        // number" d as outlined above, for the desired moment.  Next compute:
-//        //
-//        double oblecl = 23.4393 - 3.563E-7 * d;
-//        //
-//        double w  =  282.9404  +  4.70935E-5   * d;
-//        double M  =  356.0470  +  0.9856002585 * d;
-//        double e  =  0.016709  -  1.151E-9     * d;
-//        //
-//        // This is the obliquity of the ecliptic, plus some of the elements of
-//        // the Sun's apparent orbit (i.e., really the Earth's orbit): w =
-//        // argument of perihelion, M = mean anomaly, e = eccentricity.
-//        // Semi-major axis is here assumed to be exactly 1.0 (while not strictly
-//        // true, this is still an accurate approximation).  Next compute E, the
-//        // eccentric anomaly:
-//        //
-//        double E = M + e*(180/PI) * Math.sin(M*DEG_RAD) * ( 1.0 + e*Math.cos(M*DEG_RAD) );
-//        //
-//        // where E and M are in degrees.  This is it---no further iterations are
-//        // needed because we know e has a sufficiently small value.  Next compute
-//        // the true anomaly, v, and the distance, r:
-//        //
-//        /*      r * cos(v)  =  */ double A  =  Math.cos(E*DEG_RAD) - e;
-//        /*      r * sin(v)  =  */ double B  =  Math.sqrt(1 - e*e) * Math.sin(E*DEG_RAD);
-//        //
-//        // and
-//        //
-//        //      r  =  sqrt( A*A + B*B )
-//        double v  =  Math.atan2( B, A )*RAD_DEG;
-//        //
-//        // The Sun's true longitude, slon, can now be computed:
-//        //
-//        double slon  =  v + w;
-//        //
-//        // Since the Sun is always at the ecliptic (or at least very very close to
-//        // it), we can use simplified formulae to convert slon (the Sun's ecliptic
-//        // longitude) to sRA and sDec (the Sun's RA and Dec):
-//        //
-//        //                   sin(slon) * cos(oblecl)
-//        //     tan(sRA)  =  -------------------------
-//        //             cos(slon)
-//        //
-//        //     sin(sDec) =  sin(oblecl) * sin(slon)
-//        //
-//        // As was the case when computing az, the Azimuth, if possible use an
-//        // atan2() function to compute sRA.
-//
-//        double sRA = Math.atan2(Math.sin(slon*DEG_RAD) * Math.cos(oblecl*DEG_RAD), Math.cos(slon*DEG_RAD))*RAD_DEG;
-//
-//        double sin_sDec = Math.sin(oblecl*DEG_RAD) * Math.sin(slon*DEG_RAD);
-//        double sDec = Math.asin(sin_sDec)*RAD_DEG;
-//
-//        //     COMPUTING RISE AND SET TIMES
-//        //     ----------------------------
-//        //
-//        // To compute when an object rises or sets, you must compute when it
-//        // passes the meridian and the HA of rise/set.  Then the rise time is
-//        // the meridian time minus HA for rise/set, and the set time is the
-//        // meridian time plus the HA for rise/set.
-//        //
-//        // To find the meridian time, compute the Local Sidereal Time at 0h local
-//        // time (or 0h UT if you prefer to work in UT) as outlined above---name
-//        // that quantity LST0.  The Meridian Time, MT, will now be:
-//        //
-//        //     MT  =  RA - LST0
-//        double MT = normalize(sRA - LST, 360);
-//        //
-//        // where "RA" is the object's Right Ascension (in degrees!).  If negative,
-//        // add 360 deg to MT.  If the object is the Sun, leave the time as it is,
-//        // but if it's stellar, multiply MT by 365.2422/366.2422, to convert from
-//        // sidereal to solar time.  Now, compute HA for rise/set, name that
-//        // quantity HA0:
-//        //
-//        //                 sin(h0)  -  sin(lat) * sin(Dec)
-//        // cos(HA0)  =  ---------------------------------
-//        //                      cos(lat) * cos(Dec)
-//        //
-//        // where h0 is the altitude selected to represent rise/set.  For a purely
-//        // mathematical horizon, set h0 = 0 and simplify to:
-//        //
-//        //     cos(HA0)  =  - tan(lat) * tan(Dec)
-//        //
-//        // If you want to account for refraction on the atmosphere, set h0 = -35/60
-//        // degrees (-35 arc minutes), and if you want to compute the rise/set times
-//        // for the Sun's upper limb, set h0 = -50/60 (-50 arc minutes).
-//        //
-//        double h0 = -50/60 * DEG_RAD;
-//
-//        double HA0 = Math.acos(
-//          (Math.sin(h0) - Math.sin(fLatitude) * sin_sDec) /
-//          (Math.cos(fLatitude) * Math.cos(sDec*DEG_RAD)))*RAD_DEG;
-//
-//        // When HA0 has been computed, leave it as it is for the Sun but multiply
-//        // by 365.2422/366.2422 for stellar objects, to convert from sidereal to
-//        // solar time.  Finally compute:
-//        //
-//        //    Rise time  =  MT - HA0
-//        //    Set  time  =  MT + HA0
-//        //
-//        // convert the times from degrees to hours by dividing by 15.
-//        //
-//        // If you'd like to check that your calculations are accurate or just
-//        // need a quick result, check the USNO's Sun or Moon Rise/Set Table,
-//        // <URL:http://aa.usno.navy.mil/AA/data/docs/RS_OneYear.html>.
-//
-//        double result = MT + (rise ? -HA0 : HA0); // in degrees
-//
-//        // Find UT midnight on this day
-//        long midnight = DAY_MS * (time / DAY_MS);
-//
-//        return midnight + (long) (result * 3600000 / 15);
-//    }
 
     //-------------------------------------------------------------------------
     // The Moon
@@ -1048,7 +545,7 @@ public class CalendarAstronomer {
             double a4 =     0.2140*PI/180 * Math.sin(2 * meanAnomalyMoon);
 
             // Now find the moon's corrected longitude
-            moonLongitude = meanLongitude + evection + center - annual + a4;
+            double moonLongitude = meanLongitude + evection + center - annual + a4;
 
             //
             // And finally, find the variation, caused by the fact that the sun's
@@ -1102,26 +599,6 @@ public class CalendarAstronomer {
         return norm2PI(moonEclipLong - sunLongitude);
     }
 
-    /**
-     * Calculate the phase of the moon at the time set in this object.
-     * The returned phase is a <code>double</code> in the range
-     * <code>0 <= phase < 1</code>, interpreted as follows:
-     * <ul>
-     * <li>0.00: New moon
-     * <li>0.25: First quarter
-     * <li>0.50: Full moon
-     * <li>0.75: Last quarter
-     * </ul>
-     *
-     * @see #getMoonAge
-     * @internal
-     */
-    public double getMoonPhase() {
-        // See page 147 of "Practical Astronomy with your Calculator",
-        // by Peter Duffet-Smith, for details on the algorithm.
-        return 0.5 * (1 - Math.cos(getMoonAge()));
-    }
-
     private static class MoonAge {
         double value;
         MoonAge(double val) { value = val; }
@@ -1133,27 +610,6 @@ public class CalendarAstronomer {
      * @internal
      */
     public static final MoonAge NEW_MOON      = new MoonAge(0);
-
-    /**
-     * Constant representing the moon's first quarter.
-     * For use with {@link #getMoonTime(MoonAge, boolean) getMoonTime}
-     * @internal
-     */
-    public static final MoonAge FIRST_QUARTER = new MoonAge(PI/2);
-
-    /**
-     * Constant representing a full moon.
-     * For use with {@link #getMoonTime(MoonAge, boolean) getMoonTime}
-     * @internal
-     */
-    public static final MoonAge FULL_MOON     = new MoonAge(PI);
-
-    /**
-     * Constant representing the moon's last quarter.
-     * For use with {@link #getMoonTime(MoonAge, boolean) getMoonTime}
-     * @internal
-     */
-    public static final MoonAge LAST_QUARTER  = new MoonAge((PI*3)/2);
 
     /**
      * Find the next or previous time at which the Moon's ecliptic
@@ -1186,23 +642,6 @@ public class CalendarAstronomer {
      */
     public long getMoonTime(MoonAge desired, boolean next) {
         return getMoonTime(desired.value, next);
-    }
-
-    /**
-     * Returns the time (GMT) of sunrise or sunset on the local date to which
-     * this calendar is currently set.
-     * @internal
-     */
-    public long getMoonRiseSet(boolean rise)
-    {
-        return riseOrSet(new CoordFunc() {
-                            @Override
-                            public Equatorial eval() { return getMoonPosition(); }
-                         },
-                         rise,
-                         .533 * DEG_RAD,        // Angular Diameter
-                         34 /60.0 * DEG_RAD,    // Refraction correction
-                         MINUTE_MS);            // Desired accuracy
     }
 
     //-------------------------------------------------------------------------
@@ -1281,48 +720,6 @@ public class CalendarAstronomer {
         return time;
     }
 
-    private interface CoordFunc {
-        public Equatorial eval();
-    }
-
-    private long riseOrSet(CoordFunc func, boolean rise,
-                           double diameter, double refraction,
-                           long epsilon)
-    {
-        Equatorial  pos = null;
-        double      tanL   = Math.tan(fLatitude);
-        long        deltaT = Long.MAX_VALUE;
-        int         count = 0;
-
-        //
-        // Calculate the object's position at the current time, then use that
-        // position to calculate the time of rising or setting.  The position
-        // will be different at that time, so iterate until the error is allowable.
-        //
-        do {
-            // See "Practical Astronomy With Your Calculator, section 33.
-            pos = func.eval();
-            double angle = Math.acos(-tanL * Math.tan(pos.declination));
-            double lst = ((rise ? PI2-angle : angle) + pos.ascension ) * 24 / PI2;
-
-            // Convert from LST to Universal Time.
-            long newTime = lstToUT( lst );
-
-            deltaT = newTime - time;
-            setTime(newTime);
-        }
-        while (++ count < 5 && Math.abs(deltaT) > epsilon);
-
-        // Calculate the correction due to refraction and the object's angular diameter
-        double cosD  = Math.cos(pos.declination);
-        double psi   = Math.acos(Math.sin(fLatitude) / cosD);
-        double x     = diameter / 2 + refraction;
-        double y     = Math.asin(Math.sin(x) / Math.sin(psi));
-        long  delta  = (long)((240 * y * RAD_DEG / cosD)*SECOND_MS);
-
-        return time + (rise ? -delta : delta);
-    }
-
     //-------------------------------------------------------------------------
     // Other utility methods
     //-------------------------------------------------------------------------
@@ -1389,19 +786,16 @@ public class CalendarAstronomer {
      *          measured in radians.
      */
     private double eclipticObliquity() {
-        if (eclipObliquity == INVALID) {
-            final double epoch = 2451545.0;     // 2000 AD, January 1.5
+        final double epoch = 2451545.0;     // 2000 AD, January 1.5
 
-            double T = (getJulianDay() - epoch) / 36525;
+        double T = (getJulianDay() - epoch) / 36525;
 
-            eclipObliquity = 23.439292
+        double eclipObliquity = 23.439292
                            - 46.815/3600 * T
                            - 0.0006/3600 * T*T
                            + 0.00181/3600 * T*T*T;
 
-            eclipObliquity *= DEG_RAD;
-        }
-        return eclipObliquity;
+        return eclipObliquity * DEG_RAD;
     }
 
 
@@ -1415,13 +809,6 @@ public class CalendarAstronomer {
      */
     private long time;
 
-    /* These aren't used yet, but they'll be needed for sunset calculations
-     * and equatorial to horizon coordinate conversions
-     */
-    private double fLongitude = 0.0;
-    private double fLatitude  = 0.0;
-    private long   fGmtOffset = 0;
-
     //
     // The following fields are used to cache calculated results for improved
     // performance.  These values all depend on the current time setting
@@ -1430,51 +817,19 @@ public class CalendarAstronomer {
     static final private double INVALID = Double.MIN_VALUE;
 
     private transient double    julianDay       = INVALID;
-    private transient double    julianCentury   = INVALID;
     private transient double    sunLongitude    = INVALID;
     private transient double    meanAnomalySun  = INVALID;
-    private transient double    moonLongitude   = INVALID;
     private transient double    moonEclipLong   = INVALID;
-    //private transient double    meanAnomalyMoon = INVALID;
-    private transient double    eclipObliquity  = INVALID;
-    private transient double    siderealT0      = INVALID;
-    private transient double    siderealTime    = INVALID;
 
     private transient Equatorial  moonPosition = null;
 
     private void clearCache() {
         julianDay       = INVALID;
-        julianCentury   = INVALID;
         sunLongitude    = INVALID;
         meanAnomalySun  = INVALID;
-        moonLongitude   = INVALID;
         moonEclipLong   = INVALID;
-        //meanAnomalyMoon = INVALID;
-        eclipObliquity  = INVALID;
-        siderealTime    = INVALID;
-        siderealT0      = INVALID;
         moonPosition    = null;
     }
-
-    //private static void out(String s) {
-    //    System.out.println(s);
-    //}
-
-    //private static String deg(double rad) {
-    //    return Double.toString(rad * RAD_DEG);
-    //}
-
-    //private static String hours(long ms) {
-    //    return Double.toString((double)ms / HOUR_MS) + " hours";
-    //}
-
-    /**
-     * @internal
-     */
-    public String local(long localMillis) {
-        return new Date(localMillis - TimeZone.getDefault().getRawOffset()).toString();
-    }
-
 
     /**
      * Represents the position of an object in the sky relative to the ecliptic,
@@ -1490,7 +845,6 @@ public class CalendarAstronomer {
      * value without worrying about whether other code will modify them.
      *
      * @see CalendarAstronomer.Equatorial
-     * @see CalendarAstronomer.Horizon
      * @internal
      */
     public static final class Ecliptic {
@@ -1550,7 +904,6 @@ public class CalendarAstronomer {
      * value without worrying about whether other code will modify them.
      *
      * @see CalendarAstronomer.Ecliptic
-     * @see CalendarAstronomer.Horizon
      * @internal
      */
     public static final class Equatorial {
@@ -1601,59 +954,6 @@ public class CalendarAstronomer {
          * @internal
          */
         public final double declination;
-    }
-
-    /**
-     * Represents the position of an  object in the sky relative to
-     * the local horizon.
-     * The <i>Altitude</i> represents the object's elevation above the horizon,
-     * with objects below the horizon having a negative altitude.
-     * The <i>Azimuth</i> is the geographic direction of the object from the
-     * observer's position, with 0 representing north.  The azimuth increases
-     * clockwise from north.
-     * <p>
-     * Note that Horizon objects are immutable and cannot be modified
-     * once they are constructed.  This allows them to be passed and returned by
-     * value without worrying about whether other code will modify them.
-     *
-     * @see CalendarAstronomer.Ecliptic
-     * @see CalendarAstronomer.Equatorial
-     * @internal
-     */
-    public static final class Horizon {
-        /**
-         * Constructs a Horizon coordinate object.
-         * <p>
-         * @param alt  The altitude, measured in radians above the horizon.
-         * @param azim The azimuth, measured in radians clockwise from north.
-         * @internal
-         */
-        public Horizon(double alt, double azim) {
-            altitude = alt;
-            azimuth = azim;
-        }
-
-        /**
-         * Return a string representation of this object, with the
-         * angles measured in degrees.
-         * @internal
-         */
-        @Override
-        public String toString() {
-            return Double.toString(altitude*RAD_DEG) + "," + (azimuth*RAD_DEG);
-        }
-
-        /**
-         * The object's altitude above the horizon, in radians.
-         * @internal
-         */
-        public final double altitude;
-
-        /**
-         * The object's direction, in radians clockwise from north.
-         * @internal
-         */
-        public final double azimuth;
     }
 
     static private String radToHms(double angle) {

--- a/icu4j/main/core/src/main/java/com/ibm/icu/util/IslamicCalendar.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/util/IslamicCalendar.java
@@ -938,12 +938,7 @@ public class IslamicCalendar extends Calendar {
      */
     static final double moonAge(long time)
     {
-        double age = 0;
-
-        synchronized(astro) {
-            astro.setTime(time);
-            age = astro.getMoonAge();
-        }
+        double age = (new CalendarAstronomer(time)).getMoonAge();
         // Convert to degrees and normalize...
         age = age * 180 / Math.PI;
         if (age > 180) {
@@ -956,9 +951,6 @@ public class IslamicCalendar extends Calendar {
     //-------------------------------------------------------------------------
     // Internal data....
     //
-
-    // And an Astronomer object for the moon age calculations
-    private static CalendarAstronomer astro = new CalendarAstronomer();
 
     private static CalendarCache cache = new CalendarCache();
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/AstroTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/AstroTest.java
@@ -36,7 +36,6 @@ public class AstroTest extends CoreTestFmwk {
     @Test
     public void TestSolarLongitude() {
         GregorianCalendar gc = new GregorianCalendar(new SimpleTimeZone(0, "UTC"));
-        CalendarAstronomer astro = new CalendarAstronomer();
         // year, month, day, hour, minute, longitude (radians), ascension(radians), declination(radians)
         final double tests[][] = {
             { 1980, 7, 27, 00, 00, 2.166442986535465, 2.2070499713207730, 0.3355704075759270 },
@@ -47,7 +46,7 @@ public class AstroTest extends CoreTestFmwk {
             gc.clear();
             gc.set((int)tests[i][0], (int)tests[i][1]-1, (int)tests[i][2], (int)tests[i][3], (int) tests[i][4]);
 
-            astro.setDate(gc.getTime());
+            CalendarAstronomer astro = new CalendarAstronomer(gc.getTimeInMillis());
 
             double longitude = astro.getSunLongitude();
             if (longitude != tests[i][5]) {
@@ -61,36 +60,12 @@ public class AstroTest extends CoreTestFmwk {
                             ") for test " + i);
                 }
             }
-            Equatorial result = astro.getSunPosition();
-            if (result.ascension != tests[i][6]) {
-                if ((float)result.ascension == (float)tests[i][6]) {
-                    logln("result.ascension(" + result.ascension +
-                            ") !=  tests[i][6](" + tests[i][6] +
-                            ") in double for test " + i);
-                } else {
-                    errln("FAIL: result.ascension(" + result.ascension +
-                            ") !=  tests[i][6](" + tests[i][6] +
-                            ") for test " + i);
-                }
-            }
-            if (result.declination != tests[i][7]) {
-                if ((float)result.declination == (float)tests[i][7]) {
-                    logln("result.declination(" + result.declination +
-                            ") !=  tests[i][7](" + tests[i][7] +
-                            ") in double for test " + i);
-                } else {
-                    errln("FAIL: result.declination(" + result.declination +
-                            ") !=  tests[i][7](" + tests[i][7] +
-                            ") for test " + i);
-                }
-            }
         }
     }
 
     @Test
     public void TestLunarPosition() {
         GregorianCalendar gc = new GregorianCalendar(new SimpleTimeZone(0, "UTC"));
-        CalendarAstronomer astro = new CalendarAstronomer();
         // year, month, day, hour, minute, ascension(radians), declination(radians)
         final double tests[][] = {
             { 1979, 2, 26, 16, 00, -0.3778379118188744, -0.1399698825594198 },
@@ -100,7 +75,7 @@ public class AstroTest extends CoreTestFmwk {
         for (int i = 0; i < tests.length; i++) {
             gc.clear();
             gc.set((int)tests[i][0], (int)tests[i][1]-1, (int)tests[i][2], (int)tests[i][3], (int) tests[i][4]);
-            astro.setDate(gc.getTime());
+            CalendarAstronomer astro = new CalendarAstronomer(gc.getTimeInMillis());
 
             Equatorial result = astro.getMoonPosition();
             if (result.ascension != tests[i][5]) {
@@ -138,24 +113,17 @@ public class AstroTest extends CoreTestFmwk {
     @Test
     public void TestCoverage() {
         GregorianCalendar cal = new GregorianCalendar(1958, Calendar.AUGUST, 15);
-        Date then = cal.getTime();
-        CalendarAstronomer myastro = new CalendarAstronomer(then);
+        CalendarAstronomer myastro = new CalendarAstronomer(cal.getTimeInMillis());
 
         //Latitude:  34 degrees 05' North
         //Longitude:  118 degrees 22' West
         double laLat = 34 + 5d/60, laLong = 360 - (118 + 22d/60);
-        CalendarAstronomer myastro2 = new CalendarAstronomer(laLong, laLat);
 
         double eclLat = laLat * Math.PI / 360;
         double eclLong = laLong * Math.PI / 360;
-        Ecliptic ecl = new Ecliptic(eclLat, eclLong);
-        logln("ecliptic: " + ecl);
-
-        CalendarAstronomer myastro3 = new CalendarAstronomer();
-        myastro3.setJulianDay((4713 + 2000) * 365.25);
 
         CalendarAstronomer[] astronomers = {
-            myastro, myastro2, myastro3, myastro2 // check cache
+            myastro, myastro, myastro // check cache
 
         };
 
@@ -165,176 +133,21 @@ public class AstroTest extends CoreTestFmwk {
             logln("astro: " + astro);
             logln("   time: " + astro.getTime());
             logln("   date: " + astro.getDate());
-            logln("   cent: " + astro.getJulianCentury());
-            logln("   gw sidereal: " + astro.getGreenwichSidereal());
-            logln("   loc sidereal: " + astro.getLocalSidereal());
-            logln("   equ ecl: " + astro.eclipticToEquatorial(ecl));
-            logln("   equ long: " + astro.eclipticToEquatorial(eclLong));
-            logln("   horiz: " + astro.eclipticToHorizon(eclLong));
-            logln("   sunrise: " + new Date(astro.getSunRiseSet(true)));
-            logln("   sunset: " + new Date(astro.getSunRiseSet(false)));
-            logln("   moon phase: " + astro.getMoonPhase());
-            logln("   moonrise: " + new Date(astro.getMoonRiseSet(true)));
-            logln("   moonset: " + new Date(astro.getMoonRiseSet(false)));
-            logln("   prev summer solstice: " + new Date(astro.getSunTime(CalendarAstronomer.SUMMER_SOLSTICE, false)));
-            logln("   next summer solstice: " + new Date(astro.getSunTime(CalendarAstronomer.SUMMER_SOLSTICE, true)));
-            logln("   prev full moon: " + new Date(astro.getMoonTime(CalendarAstronomer.FULL_MOON, false)));
-            logln("   next full moon: " + new Date(astro.getMoonTime(CalendarAstronomer.FULL_MOON, true)));
+            logln("   equ long: " + astro.eclipticToEquatorial(eclLat, eclLong));
         }
 
-    }
-
-    static final long DAY_MS = 24*60*60*1000L;
-
-    @Test
-    public void TestSunriseTimes() {
-
-        //        logln("Sunrise/Sunset times for San Jose, California, USA");
-        //        CalendarAstronomer astro = new CalendarAstronomer(-121.55, 37.20);
-        //        TimeZone tz = TimeZone.getTimeZone("America/Los_Angeles");
-
-        // We'll use a table generated by the UNSO website as our reference
-        // From: http://aa.usno.navy.mil/
-        //-Location: W079 25, N43 40
-        //-Rise and Set for the Sun for 2001
-        //-Zone:  4h West of Greenwich
-        int[] USNO = {
-             6,59, 19,45,
-             6,57, 19,46,
-             6,56, 19,47,
-             6,54, 19,48,
-             6,52, 19,49,
-             6,50, 19,51,
-             6,48, 19,52,
-             6,47, 19,53,
-             6,45, 19,54,
-             6,43, 19,55,
-             6,42, 19,57,
-             6,40, 19,58,
-             6,38, 19,59,
-             6,36, 20, 0,
-             6,35, 20, 1,
-             6,33, 20, 3,
-             6,31, 20, 4,
-             6,30, 20, 5,
-             6,28, 20, 6,
-             6,27, 20, 7,
-             6,25, 20, 8,
-             6,23, 20,10,
-             6,22, 20,11,
-             6,20, 20,12,
-             6,19, 20,13,
-             6,17, 20,14,
-             6,16, 20,16,
-             6,14, 20,17,
-             6,13, 20,18,
-             6,11, 20,19,
-        };
-
-        logln("Sunrise/Sunset times for Toronto, Canada");
-        CalendarAstronomer astro = new CalendarAstronomer(-(79+25/60), 43+40/60);
-
-        // As of ICU4J 2.8 the ICU4J time zones implement pass-through
-        // to the underlying JDK.  Because of variation in the
-        // underlying JDKs, we have to use a fixed-offset
-        // SimpleTimeZone to get consistent behavior between JDKs.
-        // The offset we want is [-18000000, 3600000] (raw, dst).
-        // [aliu 10/15/03]
-
-        // TimeZone tz = TimeZone.getTimeZone("America/Montreal");
-        TimeZone tz = new SimpleTimeZone(-18000000 + 3600000, "Montreal(FIXED)");
-
-        GregorianCalendar cal = new GregorianCalendar(tz, Locale.US);
-        GregorianCalendar cal2 = new GregorianCalendar(tz, Locale.US);
-        cal.clear();
-        cal.set(Calendar.YEAR, 2001);
-        cal.set(Calendar.MONTH, Calendar.APRIL);
-        cal.set(Calendar.DAY_OF_MONTH, 1);
-        cal.set(Calendar.HOUR_OF_DAY, 12); // must be near local noon for getSunRiseSet to work
-
-        DateFormat df = DateFormat.getTimeInstance(cal, DateFormat.MEDIUM, Locale.US);
-        DateFormat df2 = DateFormat.getDateTimeInstance(cal, DateFormat.MEDIUM, DateFormat.MEDIUM, Locale.US);
-        DateFormat day = DateFormat.getDateInstance(cal, DateFormat.MEDIUM, Locale.US);
-
-        for (int i=0; i < 30; i++) {
-            astro.setDate(cal.getTime());
-
-            Date sunrise = new Date(astro.getSunRiseSet(true));
-            Date sunset = new Date(astro.getSunRiseSet(false));
-
-            cal2.setTime(cal.getTime());
-            cal2.set(Calendar.SECOND,      0);
-            cal2.set(Calendar.MILLISECOND, 0);
-
-            cal2.set(Calendar.HOUR_OF_DAY, USNO[4*i+0]);
-            cal2.set(Calendar.MINUTE,      USNO[4*i+1]);
-            Date exprise = cal2.getTime();
-            cal2.set(Calendar.HOUR_OF_DAY, USNO[4*i+2]);
-            cal2.set(Calendar.MINUTE,      USNO[4*i+3]);
-            Date expset = cal2.getTime();
-            // Compute delta of what we got to the USNO data, in seconds
-            int deltarise = Math.abs((int)(sunrise.getTime() - exprise.getTime()) / 1000);
-            int deltaset = Math.abs((int)(sunset.getTime() - expset.getTime()) / 1000);
-
-            // Allow a deviation of 0..MAX_DEV seconds
-            // It would be nice to get down to 60 seconds, but at this
-            // point that appears to be impossible without a redo of the
-            // algorithm using something more advanced than Duffett-Smith.
-            final int MAX_DEV = 180;
-            if (deltarise > MAX_DEV || deltaset > MAX_DEV) {
-                if (deltarise > MAX_DEV) {
-                    errln("FAIL: " + day.format(cal.getTime()) +
-                          ", Sunrise: " + df2.format(sunrise) +
-                          " (USNO " + df.format(exprise) +
-                          " d=" + deltarise + "s)");
-                } else {
-                    logln(day.format(cal.getTime()) +
-                          ", Sunrise: " + df.format(sunrise) +
-                          " (USNO " + df.format(exprise) + ")");
-                }
-                if (deltaset > MAX_DEV) {
-                    errln("FAIL: " + day.format(cal.getTime()) +
-                          ", Sunset: " + df2.format(sunset) +
-                          " (USNO " + df.format(expset) +
-                          " d=" + deltaset + "s)");
-                } else {
-                    logln(day.format(cal.getTime()) +
-                          ", Sunset: " + df.format(sunset) +
-                          " (USNO " + df.format(expset) + ")");
-                }
-            } else {
-                logln(day.format(cal.getTime()) +
-                      ", Sunrise: " + df.format(sunrise) +
-                      " (USNO " + df.format(exprise) + ")" +
-                      ", Sunset: " + df.format(sunset) +
-                      " (USNO " + df.format(expset) + ")");
-            }
-            cal.add(Calendar.DATE, 1);
-        }
-
-//        CalendarAstronomer a = new CalendarAstronomer(-(71+5/60), 42+37/60);
-//        cal.clear();
-//        cal.set(cal.YEAR, 1986);
-//        cal.set(cal.MONTH, cal.MARCH);
-//        cal.set(cal.DATE, 10);
-//        cal.set(cal.YEAR, 1988);
-//        cal.set(cal.MONTH, cal.JULY);
-//        cal.set(cal.DATE, 27);
-//        a.setDate(cal.getTime());
-//        long r = a.getSunRiseSet2(true);
     }
 
     @Test
     public void TestBasics() {
         // Check that our JD computation is the same as the book's (p. 88)
-        CalendarAstronomer astro = new CalendarAstronomer();
         GregorianCalendar cal3 = new GregorianCalendar(TimeZone.getTimeZone("GMT"), Locale.US);
         DateFormat d3 = DateFormat.getDateTimeInstance(cal3, DateFormat.MEDIUM,DateFormat.MEDIUM,Locale.US);
         cal3.clear();
         cal3.set(Calendar.YEAR, 1980);
         cal3.set(Calendar.MONTH, Calendar.JULY);
         cal3.set(Calendar.DATE, 27);
-        astro.setDate(cal3.getTime());
+        CalendarAstronomer astro = new CalendarAstronomer(cal3.getTimeInMillis());
         double jd = astro.getJulianDay() - 2447891.5;
         double exp = -3444;
         if (jd == exp) {
@@ -357,7 +170,6 @@ public class AstroTest extends CoreTestFmwk {
     @Test
     public void TestMoonAge(){
         GregorianCalendar gc = new GregorianCalendar(new SimpleTimeZone(0,"GMT"));
-        CalendarAstronomer calastro = new CalendarAstronomer();
         // more testcases are around the date 05/20/2012
         //ticket#3785  UDate ud0 = 1337557623000.0;
         double testcase[][] = {{2012, 5, 20 , 16 , 48, 59},
@@ -380,7 +192,7 @@ public class AstroTest extends CoreTestFmwk {
                                     (int)testcase[i][2]+" Hour "+(int)testcase[i][3]+" Minutes "+(int)testcase[i][4]+
                                     " Seconds "+(int)testcase[i][5];
             gc.set((int)testcase[i][0],(int)testcase[i][1]-1,(int)testcase[i][2],(int)testcase[i][3],(int)testcase[i][4], (int)testcase[i][5]);
-            calastro.setDate(gc.getTime());
+            CalendarAstronomer calastro = new CalendarAstronomer(gc.getTimeInMillis());
             double expectedAge = (angle[i]*PI)/180;
             double got = calastro.getMoonAge();
             logln(testString);

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/IBMCalendarTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/IBMCalendarTest.java
@@ -975,7 +975,6 @@ public class IBMCalendarTest extends CalendarTestFmwk {
         // CalendarAstronomer
         // (This class should probably be made package-private.)
         CalendarAstronomer astro = new CalendarAstronomer();
-        /*String s = */astro.local(0);
 
         // ChineseCalendar
         ChineseCalendar ccal = new ChineseCalendar(TimeZone.getDefault(),


### PR DESCRIPTION
1. Remove dead code inside CalendarAstronomer that was not used.
The following methhods are not used and unneeded for the Chinese and Islamic calendar usage and therefore removed:
getJulianCentury(), getGreenwichSidereal(), getLocalSidereal(), lstToUT(), eclipticToHorizon(), getSunPosition(), getSunRiseSet(), getMoonPhase(), getMoonRiseSet(), 
We also removed 6 double member data from CalendarAstronomer since they were only used by removed functions and/or never with complete implementation (for example, lat/long in this class). This save us 48 bytes per CalendarAstronomer object.

3. Since all the current usage call setTime then get a value, the cache inside CalendarAstronomer is not used across different call. Change to allocate the object on stack instead of using mutex to share a singlton since it is cheap to create a new one and there are no benefit to share across different calls. This reduce unnecessary multi thread concerns.
4. Remove many unneeded member data inside CalendarAstronomer that is needed for methods that no code use. 

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22698
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
