### PR TITLE
ICU-22633 Fix hang on large negative day in hebrew calendar

### DIFF
--- a/icu4c/source/i18n/calendar.cpp
+++ b/icu4c/source/i18n/calendar.cpp
@@ -2368,6 +2368,7 @@ int32_t Calendar::fieldDifference(UDate targetMs, UCalendarDateFields field, UEr
                     __FILE__, __LINE__, fldName(field));
 #endif
                 ec = U_ILLEGAL_ARGUMENT_ERROR;
+                return 0;
             }
         }
         // Do a binary search
@@ -2405,6 +2406,7 @@ int32_t Calendar::fieldDifference(UDate targetMs, UCalendarDateFields field, UEr
                         __FILE__, __LINE__, fldName(field));
 #endif
                     ec = U_ILLEGAL_ARGUMENT_ERROR;
+                    return 0;
                 }
             }
         }

--- a/icu4c/source/i18n/hebrwcal.cpp
+++ b/icu4c/source/i18n/hebrwcal.cpp
@@ -420,6 +420,9 @@ int32_t HebrewCalendar::startOfYear(int32_t year, UErrorCode &status)
 {
     ucln_i18n_registerCleanup(UCLN_I18N_HEBREW_CALENDAR, calendar_hebrew_cleanup);
     int64_t day = CalendarCache::get(&gCache, year, status);
+    if(U_FAILURE(status)) {
+        return 0;
+    }
 
     if (day == 0) {
         // # of months before year
@@ -533,7 +536,10 @@ int32_t HebrewCalendar::handleGetLimit(UCalendarDateFields field, ELimitType lim
 * Returns the length of the given month in the given year
 * @internal
 */
-int32_t HebrewCalendar::handleGetMonthLength(int32_t extendedYear, int32_t month, UErrorCode& /* status */) const {
+int32_t HebrewCalendar::handleGetMonthLength(int32_t extendedYear, int32_t month, UErrorCode& status) const {
+    if(U_FAILURE(status)) {
+        return 0;
+    }
     // Resolve out-of-range months.  This is necessary in order to
     // obtain the correct year.  We correct to
     // a 12- or 13-month year (add/subtract 12 or 13, depending
@@ -606,16 +612,25 @@ void HebrewCalendar::validateField(UCalendarDateFields field, UErrorCode &status
 * @internal
 */
 void HebrewCalendar::handleComputeFields(int32_t julianDay, UErrorCode &status) {
+    if (U_FAILURE(status)) {
+        return;
+    }
     int32_t d = julianDay - 347997;
     double m = ClockMath::floorDivide((d * (double)DAY_PARTS), (double) MONTH_PARTS);  // Months (approx)
     int32_t year = (int32_t)(ClockMath::floorDivide((19. * m + 234.), 235.) + 1.);     // Years (approx)
     int32_t ys  = startOfYear(year, status);                   // 1st day of year
+    if (U_FAILURE(status)) {
+        return;
+    }
     int32_t dayOfYear = (d - ys);
 
     // Because of the postponement rules, it's possible to guess wrong.  Fix it.
     while (dayOfYear < 1) {
         year--;
         ys  = startOfYear(year, status);
+        if (U_FAILURE(status)) {
+            return;
+        }
         dayOfYear = (d - ys);
     }
 

--- a/icu4c/source/test/intltest/caltest.cpp
+++ b/icu4c/source/test/intltest/caltest.cpp
@@ -204,6 +204,8 @@ void CalendarTest::runIndexedTest( int32_t index, UBool exec, const char* &name,
     TESTCASE_AUTO(Test22633AddTwiceGetTimeOverflow);
     TESTCASE_AUTO(Test22633RollTwiceGetTimeOverflow);
 
+    TESTCASE_AUTO(Test22633HebrewLargeNegativeDay);
+
     TESTCASE_AUTO(TestAddOverflow);
 
 
@@ -5868,6 +5870,17 @@ void CalendarTest::TestChineseCalendarComputeMonthStart() {  // ICU-22639
     // Calling a const method must not haved changed the state of the object.
     assertFalse("hasLeapMonthBetweenWinterSolstices [#2]",
                 chinese.hasLeapMonthBetweenWinterSolstices);
+}
+
+void CalendarTest::Test22633HebrewLargeNegativeDay() {
+    UErrorCode status = U_ZERO_ERROR;
+    LocalPointer<Calendar> calendar(
+        Calendar::createInstance(Locale("en-u-ca-hebrew"), status),
+        status);
+    calendar->clear();
+    calendar->set(UCAL_DAY_OF_YEAR, -2147483648);
+    calendar->get(UCAL_HOUR, status);
+    assertEquals("status return without hang", status, U_ILLEGAL_ARGUMENT_ERROR);
 }
 
 void CalendarTest::TestAddOverflow() {

--- a/icu4c/source/test/intltest/caltest.h
+++ b/icu4c/source/test/intltest/caltest.h
@@ -352,6 +352,7 @@ public: // package
     void TestFirstDayOfWeek();
 
     void TestChineseCalendarComputeMonthStart();
+    void Test22633HebrewLargeNegativeDay();
 
     void RunChineseCalendarInTemporalLeapYearTest(Calendar* cal);
     void RunIslamicCalendarInTemporalLeapYearTest(Calendar* cal);


### PR DESCRIPTION
Check error status and return error in the loop

Left over bug fix for ICU-22633 bug fix for Hebrew Calendar. 
Found by fuzzer in https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=67463

It is not really a infinity loop but a very slow loop because we should return the error inside the loop right after it happen.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22633
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
