### PR TITLE
ICU-22643 Make UCHAR_TYPE work as intended with C++11, C11 & macOS.

### DIFF
--- a/icu4c/source/common/unicode/platform.h
+++ b/icu4c/source/common/unicode/platform.h
@@ -711,9 +711,9 @@
     /*
      * Notes:
      * C++11 and C11 require support for UTF-16 literals
-     * TODO: Fix for plain C. Doesn't work on Mac.
+     * Doesn't work on Mac C11 (see workaround in ptypes.h).
      */
-#   if U_CPLUSPLUS_VERSION >= 11 || (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
+#   if defined(__cplusplus) || !U_PLATFORM_IS_DARWIN_BASED
 #       define U_HAVE_CHAR16_T 1
 #   else
 #       define U_HAVE_CHAR16_T 0

--- a/icu4c/source/common/unicode/ptypes.h
+++ b/icu4c/source/common/unicode/ptypes.h
@@ -51,4 +51,16 @@
 
 #include <stdint.h>
 
+// C++11 and C11 both specify that the data type char16_t should exist, C++11
+// as a keyword and C11 as a typedef in the uchar.h header file, but not all
+// implementations (looking at you, Apple, spring 2024) actually do this, so
+// ICU4C must detect and deal with that.
+#if !defined(__cplusplus) && !defined(U_IN_DOXYGEN)
+#   if U_HAVE_CHAR16_T
+#       include <uchar.h>
+#   else
+        typedef uint16_t char16_t;
+#   endif
+#endif
+
 #endif /* _PTYPES_H */

--- a/icu4c/source/common/unicode/umachine.h
+++ b/icu4c/source/common/unicode/umachine.h
@@ -370,22 +370,14 @@ typedef int8_t UBool;
 #if 1
     // #if 1 is normal. UChar defaults to char16_t in C++.
     // For configuration testing of UChar=uint16_t temporarily change this to #if 0.
-    // The intltest Makefile #defines UCHAR_TYPE=char16_t,
-    // so we only #define it to uint16_t if it is undefined so far.
-#elif !defined(UCHAR_TYPE)
+#else
 #   define UCHAR_TYPE uint16_t
 #endif
 
-#if defined(U_COMBINED_IMPLEMENTATION) || defined(U_COMMON_IMPLEMENTATION) || \
-        defined(U_I18N_IMPLEMENTATION) || defined(U_IO_IMPLEMENTATION)
-    // Inside the ICU library code, never configurable.
+#if defined(U_ALL_IMPLEMENTATION) || !defined(UCHAR_TYPE)
     typedef char16_t UChar;
-#elif defined(UCHAR_TYPE)
-    typedef UCHAR_TYPE UChar;
-#elif U_CPLUSPLUS_VERSION != 0
-    typedef char16_t UChar;  // C++
 #else
-    typedef uint16_t UChar;  // C
+    typedef UCHAR_TYPE UChar;
 #endif
 
 /**

--- a/icu4c/source/icudefs.mk.in
+++ b/icu4c/source/icudefs.mk.in
@@ -129,7 +129,7 @@ SED = @SED@
 # configure prevents user defined DEFS, and configure's DEFS is not needed
 # So we ignore the DEFS that comes from configure
 # U_ATTRIBUTE_DEPRECATED is defined to hide warnings about deprecated API warnings.
-DEFS = -DU_ATTRIBUTE_DEPRECATED=
+DEFS = -DU_ALL_IMPLEMENTATION -DU_ATTRIBUTE_DEPRECATED=
 # CFLAGS is for C only flags
 CFLAGS = @CFLAGS@
 # CXXFLAGS is for C++ only flags

--- a/icu4c/source/test/intltest/Makefile.in
+++ b/icu4c/source/test/intltest/Makefile.in
@@ -35,7 +35,7 @@ BUILDDIR := $(BUILDDIR:test\\intltest/../../=)
 BUILDDIR := $(BUILDDIR:TEST\\INTLTEST/../../=)
 
 CPPFLAGS += -I$(srcdir) -I$(top_srcdir)/common -I$(top_srcdir)/i18n -I$(top_srcdir)/tools/toolutil -I$(top_srcdir)/tools/ctestfw
-CPPFLAGS += -DUNISTR_FROM_CHAR_EXPLICIT= -DUNISTR_FROM_STRING_EXPLICIT= -DUCHAR_TYPE=char16_t
+CPPFLAGS += -DUNISTR_FROM_CHAR_EXPLICIT= -DUNISTR_FROM_STRING_EXPLICIT=
 ifdef QNX_TARGET
 DEFS += -D'U_TOPSRCDIR="/var/icu_tests"' -D'U_TOPBUILDDIR="/var/icu_tests/"'
 else

--- a/icu4c/source/test/intltest/uchar_type_build_test.cpp
+++ b/icu4c/source/test/intltest/uchar_type_build_test.cpp
@@ -2,6 +2,7 @@
 // License & terms of use: http://www.unicode.org/copyright.html#License
 
 // ICU-22356 Test that client code can be built with UCHAR_TYPE redefined.
+#undef U_ALL_IMPLEMENTATION
 #undef UCHAR_TYPE
 #define UCHAR_TYPE uint16_t
 #include "unicode/ures.h"


### PR DESCRIPTION
Since ICU4C requires C++11 and C11 the `char16_t` data type can be used everywhere, as long as the `uchar.h` header file gets included when building as C (where it isn't a keyword as in C++), but this doesn't work on macOS which for unknown reasons lacks the `uchar.h` header file and therefore needs a workaround to define `char16_t`.

For any ICU4C internal code the `char16_t` data type should always be used and `UCHAR_TYPE` ignored, which this PR solves by setting `U_ALL_IMPLEMENTATION` in its own build system.

There shouldn't really be any reason to ever use the `UCHAR_TYPE` feature on any platform that doesn't use the autoconf build system so I think it'd be fine to leave this without adding the `U_ALL_IMPLEMENTATION` define to any other build systems (which would be something that I couldn't test myself).

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22643
- [x] Required: The PR title must be prefixed with a JIRA Issue number.
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number.
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
