### PR TITLE
ICU-22701 Bugfix: Make test independent of the default locale

### DIFF
--- a/icu4c/source/test/cintltst/creststn.c
+++ b/icu4c/source/test/cintltst/creststn.c
@@ -2783,7 +2783,7 @@ static void TestGetFunctionalEquivalent(void) {
 
 static void TestGetFunctionalEquivalentVariantLengthLimit(void) {
     static const char valid[] =
-        "_"
+        "en_001"
         "_12345678"
         "_12345678"
         "_12345678"
@@ -2806,7 +2806,7 @@ static void TestGetFunctionalEquivalentVariantLengthLimit(void) {
         "_12345678";
 
     static const char invalid[] =
-        "_"
+        "en_001"
         "_12345678"
         "_12345678"
         "_12345678"
@@ -2828,7 +2828,7 @@ static void TestGetFunctionalEquivalentVariantLengthLimit(void) {
         "_12345678"
         "_12345678X";  // One character too long.
 
-    static const char localeExpected[] = "_@calendar=gregorian";
+    static const char localeExpected[] = "en_001@calendar=gregorian";
     const int32_t reslenExpected = uprv_strlen(localeExpected);
 
     char buffer[UPRV_LENGTHOF(invalid)];


### PR DESCRIPTION
The original intention behind this test case was to use the root locale, but ures`_getFunctionalEquivalent()` is implemented by calling `ures_open()` which sets `URES_OPEN_LOCALE_DEFAULT_ROOT` which will cause the default locale to be loaded before the root locale.

To avoid that, pick a locale other than the root locale for the test.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22701
- [x] Required: The PR title must be prefixed with a JIRA Issue number.
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number.
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
