### PR TITLE
ICU-21812 move Age/Block/Script to a separate trie

### DIFF
--- a/icu4c/source/common/uprops.h
+++ b/icu4c/source/common/uprops.h
@@ -39,7 +39,7 @@ enum {
 
     UPROPS_SCRIPT_EXTENSIONS_INDEX,
 
-    UPROPS_RESERVED_INDEX_7,
+    UPROPS_ABS_TRIE_INDEX,
     UPROPS_RESERVED_INDEX_8,
 
     /* size of the data file (number of 32-bit units after the header) */
@@ -49,6 +49,8 @@ enum {
     UPROPS_MAX_VALUES_INDEX=10,
     /* maximum values for code values in vector word 2 */
     UPROPS_MAX_VALUES_2_INDEX,
+    /* maximum values for code values in the Age/Block/Script trie */
+    UPROPS_MAX_VALUES_ABS_INDEX,
 
     UPROPS_INDEX_COUNT=16
 };
@@ -117,6 +119,7 @@ enum {
 /* number of properties vector words */
 #define UPROPS_VECTOR_WORDS     3
 
+// TODO: update
 /*
  * Properties in vector word 0
  * Bits
@@ -236,6 +239,8 @@ enum {
 
 #ifdef __cplusplus
 
+namespace {
+
 // https://www.unicode.org/reports/tr39/#Identifier_Status_and_Type
 // The Identifier_Type maps each code point to a *set* of one or more values.
 // Some can be combined with others, some can only occur alone.
@@ -296,6 +301,8 @@ inline constexpr uint8_t uprops_idTypeToEncoded[] = {
     UPROPS_ID_TYPE_RECOMMENDED
 };
 
+};  // namespace
+
 #endif  // __cplusplus
 
 #define UPROPS_LB_MASK          0x03f00000
@@ -311,6 +318,47 @@ inline constexpr uint8_t uprops_idTypeToEncoded[] = {
 #define UPROPS_GCB_SHIFT        5
 
 #define UPROPS_DT_MASK          0x0000001f
+
+#ifdef __cplusplus
+
+namespace {
+
+// New, additional code point trie added in ICU 76 for Age, Block, and Script (ABS).
+//
+// Bits
+// 31..26   Age major version (0..63)
+// 25..23   Age minor version (0..7)
+// 22..13   UBlockCode
+// 12..11   3..1: Bits 10..0 = Script_Extensions index
+//          3: Script value from Script_Extensions
+//          2: Script=Inherited
+//          1: Script=Common
+//          0: Script=bits 21..20 & 7..0
+// 10.. 0   UScriptCode, or index to Script_Extensions
+
+inline constexpr uint32_t UPROPS_ABS_AGE_MASK = 0xff800000;
+inline constexpr int32_t UPROPS_ABS_AGE_SHIFT = 23;
+
+inline constexpr uint8_t UPROPS_ABS_AGE_MAJOR_MAX = 63;
+inline constexpr uint8_t UPROPS_ABS_AGE_MINOR_MAX = 7;
+
+inline constexpr uint32_t UPROPS_ABS_BLOCK_MASK = 0x007fe000;
+inline constexpr int32_t UPROPS_ABS_BLOCK_SHIFT = 13;
+
+// Script_Extensions: mask includes Script
+inline constexpr uint32_t UPROPS_ABS_SCRIPT_X_MASK = 0x00001fff;
+inline constexpr int32_t UPROPS_ABS_SCRIPT_X_SHIFT = 11;
+
+inline constexpr int32_t UPROPS_ABS_MAX_SCRIPT = 0x7ff;
+
+// UPROPS_ABS_SCRIPT_X_WITH_COMMON must be the lowest value that involves Script_Extensions.
+inline constexpr uint32_t UPROPS_ABS_SCRIPT_X_WITH_COMMON = 0x0800;
+inline constexpr uint32_t UPROPS_ABS_SCRIPT_X_WITH_INHERITED = 0x1000;
+inline constexpr uint32_t UPROPS_ABS_SCRIPT_X_WITH_OTHER = 0x1800;
+
+};  // namespace
+
+#endif  // __cplusplus
 
 /**
  * Gets the main properties value for a code point.

--- a/icu4c/source/tools/toolutil/toolutil.h
+++ b/icu4c/source/tools/toolutil/toolutil.h
@@ -26,6 +26,7 @@
 #ifdef __cplusplus
 
 #include "unicode/errorcode.h"
+#include "unicode/umutablecptrie.h"
 
 U_NAMESPACE_BEGIN
 
@@ -45,6 +46,27 @@ protected:
 private:
     const char *location;
 };
+
+namespace toolutil {
+
+/**
+ * Sets one bit in the trie values of the start..end range,
+ * without changing the other bits in the trie values of that range.
+ */
+U_TOOLUTIL_API void
+setCPTrieBit(UMutableCPTrie *mutableCPTrie,
+             UChar32 start, UChar32 end, int32_t shift, bool on, UErrorCode &errorCode);
+
+/**
+ * Sets a bit set (defined by the mask) in the trie values of the start..end range,
+ * without changing the other bits in the trie values of that range.
+ * The given value must not have any bits set outside of the mask.
+ */
+U_TOOLUTIL_API void
+setCPTrieBits(UMutableCPTrie *mutableCPTrie,
+              UChar32 start, UChar32 end, uint32_t mask, uint32_t value, UErrorCode &errorCode);
+
+}  // toolutil
 
 U_NAMESPACE_END
 


### PR DESCRIPTION
Move Age/Block/Script to a separate trie; because
- The properties vectors in uprops.icu/uprops.h are full, and making them longer is expensive.
- We are about to overflow the bits for the Age property.
- These properties seem correlated fairly well with each other but not with other properties.

Also
- Move some bit-set-setting code from the emojipropsbuilder to toolutil so that it can be shared.
- Some code cleanup, such as in the corepropsbuilder distinguish end vs. pvecEnd.
- Making a uprops.icu major-version change allows us to move the Script+Script_Extensions bits back together into a contiguous bit set.

Problem: Pulling these three properties out makes uprops.icu significantly larger. Based on Unicode 15.1 data:

Original:
```
trie size in bytes:                    46328
size in bytes of additional props trie:65584
number of additional props vectors:     2499
number of 32-bit words per vector:         3
number of 16-bit scriptExtensions:       298
data size:                            142560
```
(The data size includes 64 bytes for the file header and the indexes array.)

Pulling Age/Block/Script into a separate trie (fast, 32-bit code point trie):
```
trie size in bytes:                    46328
size in bytes of additional props trie:54760
number of additional props vectors:      673
number of 32-bit words per vector:         3
size in bytes of ABS trie:             86748
number of 16-bit scriptExtensions:       298
data size:                            196572
```

Pulling them out into separate tries:
- Age: fast 8-bit
- Block: small 16-bit indexed by code point/16
- Script/scx: fast 16-bit
```
trie size in bytes:                    46328
size in bytes of additional props trie:54760
number of additional props vectors:      673
number of 32-bit words per vector:         3
size in bytes of Age trie:             21596
size in bytes of Block trie:            7600
size in bytes of Script trie:          34420
number of 16-bit scriptExtensions:       298
data size:                            173440
```

Same, but small tries for Age & Script:
```
trie size in bytes:                    46328
size in bytes of additional props trie:54760
number of additional props vectors:      673
number of 32-bit words per vector:         3
size in bytes of Age trie:             17128
size in bytes of Block trie:            7600
size in bytes of Script trie:          25984
number of 16-bit scriptExtensions:       298
data size:                            160536
```

Pulling only Block out into a separate trie:
```
trie size in bytes:                    46328
size in bytes of additional props trie:62752
number of additional props vectors:     2026
number of 32-bit words per vector:         3
size in bytes of Block trie:            7600
number of 16-bit scriptExtensions:       298
data size:                            141652
```

Only this last version actually makes uprops.icu slightly smaller than the original.

FYI @echeran

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21812
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
