### PR TITLE
ICU-9972 Fix Chinese/Dangi Calendar getActualMaximum(UCAL_DAY_OF_YEAR)

### DIFF
--- a/icu4c/source/i18n/chnsecal.h
+++ b/icu4c/source/i18n/chnsecal.h
@@ -27,6 +27,7 @@
 
 U_NAMESPACE_BEGIN
 
+class CalendarCache;
 /**
  * <code>ChineseCalendar</code> is a concrete subclass of {@link Calendar}
  * that implements a traditional Chinese calendar.  The traditional Chinese
@@ -152,23 +153,6 @@ class U_I18N_API ChineseCalendar : public Calendar {
    */
   virtual void setTemporalMonthCode(const char* code, UErrorCode& status) override;
 
- protected:
- 
-   /**
-   * Constructs a ChineseCalendar based on the current time in the default time zone
-   * with the given locale, using the specified epoch year and time zone for
-   * astronomical calculations.
-   *
-   * @param aLocale         The given locale.
-   * @param epochYear       The epoch year to use for calculation.
-   * @param zoneAstroCalc   The TimeZone to use for astronomical calculations. If null,
-   *                        will be set appropriately for Chinese calendar (UTC + 8:00).
-   * @param success         Indicates the status of ChineseCalendar object construction;
-   *                        if successful, will not be changed to an error value.
-   * @internal
-   */
-  ChineseCalendar(const Locale& aLocale, int32_t epochYear, const TimeZone* zoneAstroCalc, UErrorCode &success);
-
  public:
   /**
    * Copy Constructor
@@ -197,9 +181,6 @@ class U_I18N_API ChineseCalendar : public Calendar {
   // this value could be false for a date prior to the Winter Solstice of that
   // year but that year still has a leap month and therefor is a leap year.
   UBool hasLeapMonthBetweenWinterSolstices;
-  int32_t fEpochYear;   // Start year of this Chinese calendar instance.
-  const TimeZone* fAstronomerTimeZone;   // Zone used for the astronomical calculation
-                                         // of this Chinese calendar instance.
 
   //----------------------------------------------------------------------
   // Calendar framework
@@ -273,7 +254,14 @@ class U_I18N_API ChineseCalendar : public Calendar {
    */
   virtual const char * getType() const override;
 
+  struct Setting {
+      int32_t epochYear;
+      const TimeZone* zoneAstroCalc;
+      CalendarCache** winterSolsticeCache;
+      CalendarCache** newYearCache;
+  };
  protected:
+  virtual Setting getSetting(UErrorCode& status) const;
   virtual int32_t internalGetMonth(int32_t defaultValue, UErrorCode& status) const override;
 
   virtual int32_t internalGetMonth(UErrorCode& status) const override;

--- a/icu4c/source/i18n/dangical.h
+++ b/icu4c/source/i18n/dangical.h
@@ -118,6 +118,8 @@ class DangiCalendar : public ChineseCalendar {
    */
   const char * getType() const override;
 
+ protected:
+  virtual Setting getSetting(UErrorCode& status) const override;
 
  private:
  

--- a/icu4c/source/test/intltest/callimts.cpp
+++ b/icu4c/source/test/intltest/callimts.cpp
@@ -416,50 +416,19 @@ CalendarLimitTest::doLimitsTest(Calendar& cal,
                       ", actual_min=" + minActual);
             }
             if (maxActual < maxLow || maxActual > maxHigh) {
-                if ( uprv_strcmp(cal.getType(), "chinese") == 0 &&
-                        testMillis >= 1802044800000.0 &&
-                     logKnownIssue("ICU-12620", "chinese calendar failures for some actualMax tests")) {
-                    logln((UnicodeString)"KnownFail: [" + cal.getType() + "] " +
-                          ymdToString(cal, ymd) +
-                          " Range for max of " + FIELD_NAME[f] + "(" + f +
-                          ")=" + maxLow + ".." + maxHigh +
-                          ", actual_max=" + maxActual);
-                } else {
-                    errln((UnicodeString)"Fail: [" + cal.getType() + "] " +
-                          ymdToString(cal, ymd) +
-                          " Range for max of " + FIELD_NAME[f] + "(" + f +
-                          ")=" + maxLow + ".." + maxHigh +
-                          ", actual_max=" + maxActual);
-                }
+                errln((UnicodeString)"Fail: [" + cal.getType() + "] " +
+                      ymdToString(cal, ymd) +
+                      " Range for max of " + FIELD_NAME[f] + "(" + f +
+                      ")=" + maxLow + ".." + maxHigh +
+                      ", actual_max=" + maxActual);
             }
             if (v < minActual || v > maxActual) {
-                // timebomb per #9967, fix with #9972
-                if ( uprv_strcmp(cal.getType(), "dangi") == 0 &&
-                        testMillis >= 1865635198000.0  &&
-                     logKnownIssue("ICU-9972", "as per #9967")) { // Feb 2029 gregorian, end of dangi 4361
-                    logln((UnicodeString)"KnownFail: [" + cal.getType() + "] " +
-                          ymdToString(cal, ymd) +
-                          " " + FIELD_NAME[f] + "(" + f + ")=" + v +
-                          ", actual=" + minActual + ".." + maxActual +
-                          ", allowed=(" + minLow + ".." + minHigh + ")..(" +
-                          maxLow + ".." + maxHigh + ")");
-                } else if ( uprv_strcmp(cal.getType(), "chinese") == 0 &&
-                        testMillis >= 1832544000000.0 &&
-                     logKnownIssue("ICU-12620", "chinese calendar failures for some actualMax tests")) {
-                    logln((UnicodeString)"KnownFail: [" + cal.getType() + "] " +
-                          ymdToString(cal, ymd) +
-                          " " + FIELD_NAME[f] + "(" + f + ")=" + v +
-                          ", actual=" + minActual + ".." + maxActual +
-                          ", allowed=(" + minLow + ".." + minHigh + ")..(" +
-                          maxLow + ".." + maxHigh + ")");
-                } else {
-                    errln((UnicodeString)"Fail: [" + cal.getType() + "] " +
-                          ymdToString(cal, ymd) +
-                          " " + FIELD_NAME[f] + "(" + f + ")=" + v +
-                          ", actual=" + minActual + ".." + maxActual +
-                          ", allowed=(" + minLow + ".." + minHigh + ")..(" +
-                          maxLow + ".." + maxHigh + ")");
-                }
+                errln((UnicodeString)"Fail: [" + cal.getType() + "] " +
+                      ymdToString(cal, ymd) +
+                      " " + FIELD_NAME[f] + "(" + f + ")=" + v +
+                      ", actual=" + minActual + ".." + maxActual +
+                      ", allowed=(" + minLow + ".." + minHigh + ")..(" +
+                      maxLow + ".." + maxHigh + ")");
             }
         }
         greg.add(UCAL_DAY_OF_YEAR, 1, status);

--- a/icu4c/source/test/intltest/incaltst.cpp
+++ b/icu4c/source/test/intltest/incaltst.cpp
@@ -1004,7 +1004,6 @@ void IntlCalendarTest::checkConsistency(const char* locale) {
     const char* type = base->getType();
     // Do not ignore in quick mode
     bool ignoreOrdinaryMonth12Bug = (!quick) && (strcmp("chinese", type) == 0 || strcmp("dangi", type) == 0);
-    bool ignoreICU22258 = (!quick) && (strcmp("dangi", type) == 0);
     UDate test = Calendar::getNow();
     base->setTimeZone(*(TimeZone::getGMT()));
     int32_t j;
@@ -1100,12 +1099,6 @@ void IntlCalendarTest::checkConsistency(const char* locale) {
             int32_t year = base->get(UCAL_YEAR, status);
             int32_t month = base->get(UCAL_MONTH, status) + 1;
             int32_t date = base->get(UCAL_DATE, status);
-            if (ignoreICU22258 && (year == 4 || year == 34) && month == 12 && date == 30) {
-                logKnownIssue("ICU-22258",
-                              "Dangi Problem in 1988/2/17=>4/12/30 and 1958/2/18=>34/12/30");
-                status.reset();
-                continue;
-            }
 
             errln((UnicodeString)"Round trip conversion produces different "
                   "time from " + test + " to  " + result + " delta: " +

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/IBMCalendarTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/IBMCalendarTest.java
@@ -2192,7 +2192,6 @@ public class IBMCalendarTest extends CalendarTestFmwk {
         int lastDay = 1;
         String type = base.getType();
         boolean ignoreOrdinaryMonth12Bug = (!quick) && (type.equals("chinese") || type.equals("dangi"));
-        boolean ignoreICU22258 = (!quick) && type.equals("dangi");
         for (int j = 0; j < numOfDaysToTest; j++, test.setTime(test.getTime() - msInADay)) {
             g.setTime(test);
             base.clear();
@@ -2244,11 +2243,6 @@ public class IBMCalendarTest extends CalendarTestFmwk {
                 int year = base.get(Calendar.YEAR);
                 int month = base.get(Calendar.MONTH) + 1;
                 int date = base.get(Calendar.DATE);
-                if (ignoreICU22258 && (year == 4 || year == 34) && month == 12 && date == 30) {
-                    logKnownIssue("ICU-22258",
-                                  "Dangi Problem in 1988/2/17=>4/12/30 and 1958/2/18=>34/12/30");
-                    continue;
-                }
 
                 errln("Round trip conversion produces different time from " + test + " to  " +
                     result + " delta: " + (result.getTime() - test.getTime()) +


### PR DESCRIPTION
Also fix ICU-12620, which is mark duplicate of ICU-9972 just now, and ICU-22258.

Separate the new year and winter solstice cache since the calculated value for these two calendar are mostly but not always the same due to slightly different observation timeZone.

Remove the epochYear and zoneAstroCalc from the member data and instead return them from a getStting() method with the two caches since all four of them are constant per subclass of ChineseCalendar and do not need to be different per object.

The known issues in the TestLimit is caused by both Calendar get/put the value from the same cache while the calculated result depends on the timeZone zoneAstroCalc.

We do not have this issue in Java because both the new year and winter solstice cache in ICU4J 's ChineseCalendar are not global but per object cache. So the value in these cache is always agree with to the result of the same zoneAstro.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-9972
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
