### PR TITLE
ICU-22534 BRS75 Remove fixed CLDR17099  logKnownIssue

### DIFF
--- a/icu4c/source/test/intltest/loctest.cpp
+++ b/icu4c/source/test/intltest/loctest.cpp
@@ -5722,14 +5722,6 @@ public:
     }
 };
 
-bool isKnownSourceForCLDR17099(const std::string& s) {
-    if (s == "qaa-Cyrl-CH") {
-        return true;
-    }
-
-	return false;
-}
-
 void U_CALLCONV
 testLikelySubtagsLineFn(void *context,
                char *fields[][2], int32_t fieldCount,
@@ -5740,9 +5732,6 @@ testLikelySubtagsLineFn(void *context,
     (void)fieldCount;
     LocaleTest* THIS = (LocaleTest*)context;
     std::string source(trim(std::string(fields[0][0], fields[0][1]-fields[0][0])));
-    if (isKnownSourceForCLDR17099(source) && THIS->logKnownIssue("CLDR-17099", "likelySubtags.txt wrong for qaa-Cyrl-CH")) {
-      return;
-    }
     std::string addLikely(trim(std::string(fields[1][0], fields[1][1]-fields[1][0])));
     std::string removeFavorScript(trim(std::string(fields[2][0], fields[2][1]-fields[2][0])));
     if (removeFavorScript.length() == 0) {


### PR DESCRIPTION
CLDR-17099 is fixed in CLDR44 and the test now passed. Remove the logKnownIssue so it will test and report future breakage.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22534
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
