### PR TITLE
ICU-22261 Add missing API tags for MessageFormat 2 methods/constants

### DIFF
--- a/icu4c/source/common/unicode/utypes.h
+++ b/icu4c/source/common/unicode/utypes.h
@@ -571,19 +571,19 @@ typedef enum UErrorCode {
     U_NUMBER_SKELETON_SYNTAX_ERROR,   /**< The number skeleton passed to C++ NumberFormatter or C UNumberFormatter was invalid or contained a syntax error. @stable ICU 62 */
 
     /* MessageFormat 2.0 errors */
-    U_MF_UNRESOLVED_VARIABLE_ERROR,    /** A variable is referred to but not bound by any definition */
-    U_MF_SYNTAX_ERROR,                 /** Includes all syntax errors */
-    U_MF_UNKNOWN_FUNCTION_ERROR,       /** An annotation refers to a function not defined by the standard or custom function registry */
-    U_MF_VARIANT_KEY_MISMATCH_ERROR,   /** In a match-construct, one or more variants had a different number of keys from the number of selectors */
-    U_MF_FORMATTING_ERROR,             /** Covers all runtime errors: for example, an internally inconsistent set of options. */
-    U_MF_NONEXHAUSTIVE_PATTERN_ERROR,  /** In a match-construct, the variants do not cover all possible values */
-    U_MF_DUPLICATE_OPTION_NAME_ERROR,  /** In an annotation, the same option name appears more than once */
-    U_MF_SELECTOR_ERROR,               /** A selector function is applied to an operand of the wrong type */
-    U_MF_MISSING_SELECTOR_ANNOTATION_ERROR,  /** A selector expression evaluates to an unannotated operand */
-    U_MF_DUPLICATE_DECLARATION_ERROR, /** The same variable is declared in more than one .local or .input declaration */
-    U_MF_OPERAND_MISMATCH_ERROR,     /** An operand provided to a function does not have the required form for that function */
-    U_MF_UNSUPPORTED_STATEMENT_ERROR, /** A message includes a reserved statement */
-    U_MF_UNSUPPORTED_EXPRESSION_ERROR, /** A message includes syntax reserved for future standardization or private implementation use */
+    U_MF_UNRESOLVED_VARIABLE_ERROR,    /**< A variable is referred to but not bound by any definition @internal ICU 75.0 technology preview @deprecated This API is for technology preview only. */
+    U_MF_SYNTAX_ERROR,                 /**< Includes all syntax errors @internal ICU 75.0 technology preview @deprecated This API is for technology preview only. */
+    U_MF_UNKNOWN_FUNCTION_ERROR,       /**< An annotation refers to a function not defined by the standard or custom function registry @internal ICU 75.0 technology preview @deprecated This API is for technology preview only. */
+    U_MF_VARIANT_KEY_MISMATCH_ERROR,   /**< In a match-construct, one or more variants had a different number of keys from the number of selectors @internal ICU 75.0 technology preview @deprecated This API is for technology preview only. */
+    U_MF_FORMATTING_ERROR,             /**< Covers all runtime errors: for example, an internally inconsistent set of options. @internal ICU 75.0 technology preview @deprecated This API is for technology preview only. */
+    U_MF_NONEXHAUSTIVE_PATTERN_ERROR,  /**< In a match-construct, the variants do not cover all possible values @internal ICU 75.0 technology preview @deprecated This API is for technology preview only. */
+    U_MF_DUPLICATE_OPTION_NAME_ERROR,  /**< In an annotation, the same option name appears more than once @internal ICU 75.0 technology preview @deprecated This API is for technology preview only. */
+    U_MF_SELECTOR_ERROR,               /**< A selector function is applied to an operand of the wrong type @internal ICU 75.0 technology preview @deprecated This API is for technology preview only. */
+    U_MF_MISSING_SELECTOR_ANNOTATION_ERROR,  /**< A selector expression evaluates to an unannotated operand. @internal ICU 75.0 technology preview @deprecated This API is for technology preview only. */
+    U_MF_DUPLICATE_DECLARATION_ERROR, /**< The same variable is declared in more than one .local or .input declaration. @internal ICU 75.0 technology preview @deprecated This API is for technology preview only. */
+    U_MF_OPERAND_MISMATCH_ERROR,     /**< An operand provided to a function does not have the required form for that function @internal ICU 75.0 technology preview @deprecated This API is for technology preview only. */
+    U_MF_UNSUPPORTED_STATEMENT_ERROR, /**< A message includes a reserved statement. @internal ICU 75.0 technology preview @deprecated This API is for technology preview only. */
+    U_MF_UNSUPPORTED_EXPRESSION_ERROR, /**< A message includes syntax reserved for future standardization or private implementation use. @internal ICU 75.0 technology preview @deprecated This API is for technology preview only. */
 #ifndef U_HIDE_DEPRECATED_API
     /**
      * One more than the highest normal formatting API error code.

--- a/icu4c/source/i18n/unicode/messageformat2_data_model.h
+++ b/icu4c/source/i18n/unicode/messageformat2_data_model.h
@@ -2933,6 +2933,9 @@ namespace message2 {
              * @param status Input/output error code. Set to U_DUPLICATE_DECLARATION_ERROR
              *                   if `addBinding()` was previously called with a binding
              *                   with the same variable name as `b`.
+             *
+             * @internal ICU 75.0 technology preview
+             * @deprecated This API is for technology preview only.
              */
             Builder& addBinding(Binding&& b, UErrorCode& status);
             /**
@@ -2940,6 +2943,10 @@ namespace message2 {
              *
              * @param s The statement. Passed by move.
              * @param status Input/output error code.
+             *
+             *
+             * @internal ICU 75.0 technology preview
+             * @deprecated This API is for technology preview only.
              */
             Builder& addUnsupportedStatement(UnsupportedStatement&& s, UErrorCode& status);
             /**

--- a/icu4c/source/i18n/unicode/messageformat2_formattable.h
+++ b/icu4c/source/i18n/unicode/messageformat2_formattable.h
@@ -549,6 +549,12 @@ class U_I18N_API FunctionOptions : public UObject {
      * @deprecated This API is for technology preview only.
      */
     FunctionOptions(FunctionOptions&&);
+    /**
+     * Copy constructor.
+     *
+     * @internal ICU 75.0 technology preview
+     * @deprecated This API is for technology preview only.
+     */
     FunctionOptions& operator=(const FunctionOptions&) = delete;
  private:
     friend class MessageFormatter;

--- a/icu4c/source/i18n/unicode/messageformat2_function_registry.h
+++ b/icu4c/source/i18n/unicode/messageformat2_function_registry.h
@@ -53,7 +53,19 @@ namespace message2 {
          * @deprecated This API is for technology preview only.
          */
         virtual Formatter* createFormatter(const Locale& locale, UErrorCode& status) = 0;
+        /**
+         * Destructor.
+         *
+         * @internal ICU 75.0 technology preview
+         * @deprecated This API is for technology preview only.
+         */
         virtual ~FormatterFactory();
+        /**
+         * Copy constructor.
+         *
+         * @internal ICU 75.0 technology preview
+         * @deprecated This API is for technology preview only.
+         */
         FormatterFactory& operator=(const FormatterFactory&) = delete;
     }; // class FormatterFactory
 
@@ -76,7 +88,19 @@ namespace message2 {
          * @deprecated This API is for technology preview only.
          */
         virtual Selector* createSelector(const Locale& locale, UErrorCode& status) const = 0;
+        /**
+         * Destructor.
+         *
+         * @internal ICU 75.0 technology preview
+         * @deprecated This API is for technology preview only.
+         */
         virtual ~SelectorFactory();
+        /**
+         * Copy constructor.
+         *
+         * @internal ICU 75.0 technology preview
+         * @deprecated This API is for technology preview only.
+         */
         SelectorFactory& operator=(const SelectorFactory&) = delete;
     }; // class SelectorFactory
 
@@ -331,6 +355,12 @@ namespace message2 {
         virtual FormattedPlaceholder format(FormattedPlaceholder&& toFormat,
                                       FunctionOptions&& options,
                                       UErrorCode& status) const = 0;
+        /**
+         * Destructor.
+         *
+         * @internal ICU 75.0 technology preview
+         * @deprecated This API is for technology preview only.
+         */
         virtual ~Formatter();
     }; // class Formatter
 
@@ -373,6 +403,12 @@ namespace message2 {
                                UErrorCode& status) const = 0;
         // Note: This takes array arguments because the internal MessageFormat code has to
         // call this method, and can't include any code that constructs std::vectors.
+        /**
+         * Destructor.
+         *
+         * @internal ICU 75.0 technology preview
+         * @deprecated This API is for technology preview only.
+         */
         virtual ~Selector();
     }; // class Selector
 


### PR DESCRIPTION
This PR adds `@internal` and `@deprecated` tags to some methods and enum constants that weren't tagged.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22261
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
