### PR TITLE
ICU-22534 BRS75 Remove fixed logKnownIssue for CLDR-17024

### DIFF
--- a/icu4c/source/test/intltest/tzfmttst.cpp
+++ b/icu4c/source/test/intltest/tzfmttst.cpp
@@ -337,8 +337,7 @@ TimeZoneFormatTest::TestTimeZoneRoundTrip() {
                             }
                         } else {
                             // Specific or generic: raw offset must be preserved.
-                            if (inRaw != outRaw && !(uprv_strncmp(LOCALES[locidx].getName(),"ku",2)==0 && tzid->compare(u"America/Miquelon",16)==0
-                                    && logKnownIssue("CLDR-17024", "TestTimeZoneRoundTrip exhaustive fail with tz=America/Miquelon, locale=ku"))) {
+                            if (inRaw != outRaw) {
                                 errln((UnicodeString)"Raw offset round trip failed; tz=" + *tzid
                                     + ", locale=" + LOCALES[locidx].getName() + ", pattern=" + PATTERNS[patidx]
                                     + ", time=" + DATES[datidx] + ", str=" + tzstr

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/TimeZoneFormatTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/TimeZoneFormatTest.java
@@ -274,8 +274,7 @@ public class TimeZoneFormatTest extends CoreTestFmwk {
                                 }
                             } else {
                                 // Specific or generic: raw offset must be preserved.
-                                if (inOffsets[0] != outOffsets[0] && !(LOCALES[locidx].getName().startsWith("ku") && tzids[tzidx].equals("America/Miquelon")
-                                        && logKnownIssue("CLDR-17024", "TestTimeZoneRoundTrip exhaust. fail with tz=America/Miquelon, locale=ku"))) {
+                                if (inOffsets[0] != outOffsets[0] ) {
                                     if (JDKTZ && tzids[tzidx].startsWith("SystemV/")) {
                                         // JDK uses rule SystemV for these zones while
                                         // ICU handles these zones as aliases of existing time zones
@@ -423,13 +422,6 @@ public class TimeZoneFormatTest extends CoreTestFmwk {
                     if ((id.equals("Pacific/Apia") || id.equals("Pacific/Midway") || id.equals("Pacific/Pago_Pago"))
                             && PATTERNS[patidx].equals("vvvv")
                             && logKnownIssue("11052", "Ambiguous zone name - Samoa Time")) {
-                        continue;
-                    }
-
-                    if ((id.equals("America/Miquelon") || id.equals("America/Hermosillo") || id.equals("America/Mazatlan"))
-                            && PATTERNS[patidx].equals("v")
-                            && LOCALES[locidx].getName().startsWith("ku")
-                            && logKnownIssue("CLDR-17024", "TestTimeRoundTrip fail with tz=America/Miquelon, pattern=v, locale=ku")) {
                         continue;
                     }
 


### PR DESCRIPTION
CLDR-17024 is fixed in CLDR45 and the test now passed. Remove the logKnownIssue so it will test and report future breakage.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22534
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
