### PR TITLE
ICU-22261 Refactor MF2 attributes and options parsing code

### DIFF
--- a/icu4c/source/i18n/messageformat2_parser.h
+++ b/icu4c/source/i18n/messageformat2_parser.h
@@ -26,6 +26,34 @@ namespace message2 {
 
     using namespace data_model;
 
+    // Used for parameterizing options parsing code
+    // over the two builders that use it (Operator and Markup)
+    template <class T>
+    class OptionAdder {
+        private:
+            T& builder;
+        public:
+            OptionAdder(T& b) : builder(b) {}
+            void addOption(const UnicodeString& k, Operand&& r, UErrorCode& s) {
+                builder.addOption(k, std::move(r), s);
+            }
+    };
+
+    // Used for parameterizing attributes parsing code
+    // over the two builders that use it (Expression and Markup)
+    // Unfortunately the same OptionAdder class can't just be reused,
+    // becaues duplicate options are forbidden while duplicate attributes are not
+    template <class T>
+    class AttributeAdder {
+        private:
+            T& builder;
+        public:
+            AttributeAdder(T& b) : builder(b) {}
+            void addAttribute(const UnicodeString& k, Operand&& r, UErrorCode& s) {
+                builder.addAttribute(k, std::move(r), s);
+            }
+    };
+
     // Parser class (private)
     class Parser : public UMemory {
     public:
@@ -98,12 +126,14 @@ namespace message2 {
         Literal parseUnquotedLiteral(UErrorCode&);
         Literal parseQuotedLiteral(UErrorCode&);
 	Literal parseLiteral(UErrorCode&);
-        void parseAttribute(UVector&, UErrorCode&);
-        OptionMap parseAttributes(UErrorCode&);
-        void parseOption(Operator::Builder&, UErrorCode&);
-        void parseOption(UVector&, UErrorCode&);
-        void parseOptions(Operator::Builder&, UErrorCode&);
-        OptionMap parseOptions(UErrorCode&);
+        template<class T>
+        void parseAttribute(AttributeAdder<T>&, UErrorCode&);
+        template<class T>
+        void parseAttributes(AttributeAdder<T>&, UErrorCode&);
+        template<class T>
+        void parseOption(OptionAdder<T>&, UErrorCode&);
+        template<class T>
+        void parseOptions(OptionAdder<T>&, UErrorCode&);
 	void parseReservedEscape(UnicodeString&, UErrorCode&);
 	void parseReservedChunk(Reserved::Builder&, UErrorCode&);
 	Reserved parseReserved(UErrorCode&);


### PR DESCRIPTION
Previously, there were separate overrides for the options and attributes parsing methods in the parser that were used in different context. (Options can appear in Operator and Markup, while attributes can appear in Expression and Markup.)

This is a refactoring that eliminates this duplicated code. To enable it, a builder is added for the internal OptionMap type.

This doesn't change any public APIs, but is also not an urgent change.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22261
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
