### PR TITLE
ICU-22610 Use Requires.private and Libs.private

### DIFF
--- a/icu4c/source/Makefile.in
+++ b/icu4c/source/Makefile.in
@@ -275,24 +275,36 @@ config/icu-uc.pc: config/icu.pc Makefile icudefs.mk
 	@cat config/icu.pc > $@
 	@echo "Description: $(PACKAGE_ICU_DESCRIPTION): Common and Data libraries" >> $@
 	@echo "Name: $(PACKAGE)-uc" >> $@
-	@echo "Libs:" '-L$${libdir}' "${ICULIBS_UC}" "${ICULIBS_DT}" >> $@
-	@echo "Libs.private:" '$${baselibs}' >> $@
+ifeq ($(ENABLE_SHARED),)
+	@echo "Libs:" '-L$${libdir}' "${ICULIBS_UC}" "${ICULIBS_DT}" '$${baselibs}' >> $@
+else
+	@echo "Libs:" '-L$${libdir}' "${ICULIBS_UC}" >> $@
+	@echo "Libs.private:" "${ICULIBS_DT}" '$${baselibs}' >> $@
+endif
 	@echo $@ updated.
 
 config/icu-i18n.pc: config/icu.pc Makefile icudefs.mk
 	@cat config/icu.pc > $@
 	@echo "Description: $(PACKAGE_ICU_DESCRIPTION): Internationalization library" >> $@
 	@echo "Name: $(PACKAGE)-i18n" >> $@
+ifeq ($(ENABLE_SHARED),)
 	@echo "Requires: icu-uc" >> $@
-	@echo "Libs:" "${ICULIBS_I18N}" >> $@
+else
+	@echo "Requires.private: icu-uc" >> $@
+endif
+	@echo "Libs:" '-L$${libdir}' "${ICULIBS_I18N}" >> $@
 	@echo $@ updated.
 
 config/icu-io.pc: config/icu.pc Makefile icudefs.mk
 	@cat config/icu.pc > $@
 	@echo "Description: $(PACKAGE_ICU_DESCRIPTION): Stream and I/O Library" >> $@
 	@echo "Name: $(PACKAGE)-io" >> $@
+ifeq ($(ENABLE_SHARED),)
 	@echo "Requires: icu-i18n" >> $@
-	@echo "Libs:" "${ICULIBS_IO}" >> $@
+else
+	@echo "Requires.private: icu-i18n" >> $@
+endif
+	@echo "Libs:" '-L$${libdir}' "${ICULIBS_IO}" >> $@
 	@echo $@ updated.
 
 ICULEHB_LIBS=@ICULEHB_LIBS@
@@ -306,12 +318,20 @@ config/icu-lx.pc: config/icu.pc Makefile icudefs.mk
 	@cat config/icu.pc > $@
 	@echo "Description: $(PACKAGE_ICU_DESCRIPTION): Paragraph Layout library $(USING_HB)" >> $@
 	@echo "Name: $(PACKAGE)-lx" >> $@
+ifeq ($(ENABLE_SHARED),)
 ifneq ($(ICULEHB_LIBS),)
 	@echo "Requires: icu-le-hb icu-uc" >> $@
 else
 	@echo "Requires: icu-le" >> $@
 endif
-	@echo "Libs:" "${ICULIBS_LX}" >> $@
+else
+ifneq ($(ICULEHB_LIBS),)
+	@echo "Requires.private: icu-le-hb icu-uc" >> $@
+else
+	@echo "Requires.private: icu-le" >> $@
+endif
+endif
+	@echo "Libs:" '-L$${libdir}' "${ICULIBS_LX}" >> $@
 	@echo $@ updated.
 
 


### PR DESCRIPTION
To prevent overlinking when publishing shared libraries, specify internal dependencies using Requires.private and Libs.private.

Use Libs.private in icu-uc.pc for libicudata.so, and Requires.private in icu-i18n.pc, icu-io.pc, and icu-lx.pc, so that ICU internal dependencies will not be bound into clients.

The resulting *.pc files will produce the following output for icu-i18n and icu-lx, provided pkgconf has commit 78d53ea0 (2.2.0 or later) which de-duplicates multiple -L options:

    commit 78d53ea012dfbaf397bf8e6907efac5b51abac56
    Author: Kai Pastor <dg0yt@darc.de>
    Date:   Fri Feb 23 15:18:08 2024 +0100

        Revise serials, traversal, flattening

  `./configure --enable-shared ...`

    #
    # icu-i18n
    #

    % pkgconf --libs  icu-i18n
    -L/opt/local/lib -licui18n

    % pkgconf --libs --static icu-i18n
    -L/opt/local/lib -licui18n -licuuc -licudata -lpthread -lm

    #
    # icu-lx
    #

    % pkgconf  --libs icu-lx
    -L/opt/local/lib -liculx

    % pkgconf  --libs --static icu-lx
    -L/opt/local/lib -liculx -L/usr/lib/x86_64-linux-gnu -licu-le-hb -lharfbuzz -lm -licuuc -licudata -lpthread -lm

  `./configure --disable-shared --enable-static ...`

    #
    # icu-i18n
    #

    % pkgconf --libs  icu-i18n
    -L/opt/local/lib -licui18n -licuuc -licudata -lpthread -lm

    % pkgconf  --libs --static icu-i18n
    -L/opt/local/lib -licui18n -licuuc -licudata -lpthread -lm

    #
    # icu-lx
    #

    % pkgconf  --libs icu-lx
    -L/opt/local/lib -liculx -L/usr/lib/x86_64-linux-gnu -licu-le-hb

    % pkgconf  --libs --static icu-lx
    -L/opt/local/lib -liculx -L/usr/lib/x86_64-linux-gnu -licu-le-hb -lharfbuzz -licuuc -licudata -lpthread -lm

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22610
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
