### PR TITLE
ICU-22730 Fix Japanese extended year int32 overflow

### DIFF
--- a/icu4c/source/i18n/japancal.cpp
+++ b/icu4c/source/i18n/japancal.cpp
@@ -227,8 +227,16 @@ void JapaneseCalendar::handleComputeFields(int32_t julianDay, UErrorCode& status
     int32_t year = internalGet(UCAL_EXTENDED_YEAR); // Gregorian year
     int32_t eraIdx = gJapaneseEraRules->getEraIndex(year, internalGetMonth(status) + 1, internalGet(UCAL_DAY_OF_MONTH), status);
 
+    int32_t startYear = gJapaneseEraRules->getStartYear(eraIdx, status) - 1;
+    if (U_FAILURE(status)) {
+        return;
+    }
+    if (uprv_add32_overflow(year, -startYear,  &year)) {
+        status = U_ILLEGAL_ARGUMENT_ERROR;
+        return;
+    }
     internalSet(UCAL_ERA, eraIdx);
-    internalSet(UCAL_YEAR, year - gJapaneseEraRules->getStartYear(eraIdx, status) + 1);
+    internalSet(UCAL_YEAR, year);
 }
 
 /*

--- a/icu4c/source/test/intltest/caltest.cpp
+++ b/icu4c/source/test/intltest/caltest.cpp
@@ -205,6 +205,7 @@ void CalendarTest::runIndexedTest( int32_t index, UBool exec, const char* &name,
     TESTCASE_AUTO(Test22633RollTwiceGetTimeOverflow);
 
     TESTCASE_AUTO(Test22633HebrewLargeNegativeDay);
+    TESTCASE_AUTO(Test22730JapaneseOverflow);
 
     TESTCASE_AUTO(TestAddOverflow);
 
@@ -5874,6 +5875,16 @@ void CalendarTest::Test22633HebrewLargeNegativeDay() {
     calendar->set(UCAL_DAY_OF_YEAR, -2147483648);
     calendar->get(UCAL_HOUR, status);
     assertEquals("status return without hang", status, U_ILLEGAL_ARGUMENT_ERROR);
+}
+
+void CalendarTest::Test22730JapaneseOverflow() {
+    UErrorCode status = U_ZERO_ERROR;
+    LocalPointer<Calendar> calendar(
+        Calendar::createInstance(Locale("en-u-ca-japanese"), status),
+        status);
+    calendar->clear();
+    calendar->roll(UCAL_EXTENDED_YEAR, -1946156856, status);
+    assertEquals("status return without overflow", status, U_ILLEGAL_ARGUMENT_ERROR);
 }
 
 void CalendarTest::TestAddOverflow() {

--- a/icu4c/source/test/intltest/caltest.h
+++ b/icu4c/source/test/intltest/caltest.h
@@ -346,6 +346,7 @@ public: // package
     void Test22633SetRollGetTimeOverflow();
     void Test22633AddTwiceGetTimeOverflow();
     void Test22633RollTwiceGetTimeOverflow();
+    void Test22730JapaneseOverflow();
     void RunTestOnCalendars(void(TestFunc)(Calendar*, UCalendarDateFields));
 
     void verifyFirstDayOfWeek(const char* locale, UCalendarDaysOfWeek expected);


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22730
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
