### PR TITLE
Fix apparent typo in mf2.md.

### DIFF
--- a/docs/userguide/format_parse/messages/mf2.md
+++ b/docs/userguide/format_parse/messages/mf2.md
@@ -96,7 +96,7 @@ public void testMf2() {
 ```java
 @Test
 public void testMf2Selection() {
-   final String message = "match {$count :plural}"
+   final String message = ".match {$count :plural}"
            + " when 1 {You have one notification.}"
            + " when one {You have {$count} notification.}"
            + " when * {You have {$count} notifications.}";


### PR DESCRIPTION
IIUC you need a dot before directies like .match.
See https://github.com/unicode-org/message-format-wg/blob/main/spec/syntax.md.
Do you really want me to file a JIRA issue for this?

##### Checklist

- [ ] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
- [ ] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
