### PR TITLE
ICU-22261 Improved identification of the MSVC compiler and library

### DIFF
--- a/icu4c/source/common/unicode/localpointer.h
+++ b/icu4c/source/common/unicode/localpointer.h
@@ -162,11 +162,11 @@ protected:
     T *ptr;
 private:
     // No comparison operators with other LocalPointerBases.
-    bool operator==(const LocalPointerBase<T> &other);
-    bool operator!=(const LocalPointerBase<T> &other);
+    bool operator==(const LocalPointerBase<T> &other) = delete;
+    bool operator!=(const LocalPointerBase<T> &other) = delete;
     // No ownership sharing: No copy constructor, no assignment operator.
-    LocalPointerBase(const LocalPointerBase<T> &other);
-    void operator=(const LocalPointerBase<T> &other);
+    LocalPointerBase(const LocalPointerBase<T> &other) = delete;
+    void operator=(const LocalPointerBase<T> &other) = delete;
 };
 
 /**

--- a/icu4c/source/common/unicode/platform.h
+++ b/icu4c/source/common/unicode/platform.h
@@ -207,6 +207,17 @@
 #endif
 
 /**
+ * \def U_REAL_MSVC
+ * Defined if the compiler is the real MSVC compiler (and not something like
+ * Clang setting _MSC_VER in order to compile Windows code that requires it).
+ * Otherwise undefined.
+ * @internal
+ */
+#if (defined(_MSC_VER) && !(defined(__clang__) && __clang__)) || defined(U_IN_DOXYGEN)
+#   define U_REAL_MSVC
+#endif
+
+/**
  * \def CYGWINMSVC
  * Defined if this is Windows with Cygwin, but using MSVC rather than gcc.
  * Otherwise undefined.

--- a/icu4c/source/i18n/unicode/messageformat2_arguments.h
+++ b/icu4c/source/i18n/unicode/messageformat2_arguments.h
@@ -34,19 +34,10 @@ U_NAMESPACE_BEGIN
 // (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
 // for similar examples.)
 #if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-#if defined(_MSC_VER)
-// Ignore warning 4661 as LocalPointerBase does not use operator== or operator!=
-#pragma warning(push)
-#pragma warning(disable: 4661)
-#endif
 template class U_I18N_API LocalPointerBase<UnicodeString>;
 template class U_I18N_API LocalPointerBase<message2::Formattable>;
 template class U_I18N_API LocalArray<UnicodeString>;
 template class U_I18N_API LocalArray<message2::Formattable>;
-#if defined(_MSC_VER)
-// Ignore warning 4661 as LocalPointerBase does not use operator== or operator!=
-#pragma warning(pop)
-#endif
 #endif
 /// @endcond
 

--- a/icu4c/source/i18n/unicode/messageformat2_data_model.h
+++ b/icu4c/source/i18n/unicode/messageformat2_data_model.h
@@ -42,34 +42,12 @@ static inline std::vector<T> toStdVector(const T* arr, int32_t len) {
     return result;
 }
 
-namespace message2 {
-
-    namespace data_model {
-        class Binding;
-        class Literal;
-        class Operator;
-    } // namespace data_model
-} // namespace message2
-
-/// @cond DOXYGEN_IGNORE
-// Export an explicit template instantiation of the LocalPointer that is used as a
-// data member of various MFDataModel classes.
-// (When building DLLs for Windows this is required.)
-// (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
-// for similar examples.)
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-#if defined(_MSC_VER)
-// Ignore warning 4661 as LocalPointerBase does not use operator== or operator!=
+#if defined(U_REAL_MSVC)
 #pragma warning(push)
-#pragma warning(disable: 4661)
+// Ignore warning 4251 as these templates are instantiated later in this file,
+// after the classes used to instantiate them have been defined.
+#pragma warning(disable: 4251)
 #endif
-template class U_I18N_API LocalPointerBase<message2::data_model::Literal>;
-template class U_I18N_API LocalArray<message2::data_model::Literal>;
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
-#endif
-/// @endcond
 
 namespace message2 {
     class Checker;
@@ -80,6 +58,10 @@ namespace message2 {
 
 
   namespace data_model {
+        class Binding;
+        class Literal;
+        class Operator;
+
         /**
          * The `Reserved` class represents a `reserved` annotation, as in the `reserved` nonterminal
          * in the MessageFormat 2 grammar or the `Reserved` interface
@@ -369,6 +351,21 @@ namespace message2 {
   } // namespace data_model
 } // namespace message2
 
+/// @cond DOXYGEN_IGNORE
+// Export an explicit template instantiation of the LocalPointer that is used as a
+// data member of various MFDataModel classes.
+// (When building DLLs for Windows this is required.)
+// (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
+// for similar examples.)
+#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
+template class U_I18N_API LocalPointerBase<message2::data_model::Literal>;
+template class U_I18N_API LocalArray<message2::data_model::Literal>;
+#endif
+#if defined(U_REAL_MSVC)
+#pragma warning(pop)
+#endif
+/// @endcond
+
 U_NAMESPACE_END
 
 /// @cond DOXYGEN_IGNORE
@@ -378,7 +375,7 @@ U_NAMESPACE_END
 // (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
 // for similar examples.)
 #if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-#if defined(_MSC_VER)
+#if defined(U_REAL_MSVC) && defined(_MSVC_STL_VERSION)
 struct U_I18N_API std::_Nontrivial_dummy_type;
 template class U_I18N_API std::_Variant_storage_<false, icu::UnicodeString, icu::message2::data_model::Literal>;
 #endif
@@ -652,16 +649,8 @@ namespace message2 {
 // (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
 // for similar examples.)
 #if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-#if defined(_MSC_VER)
-// Ignore warning 4661 as LocalPointerBase does not use operator== or operator!=
-#pragma warning(push)
-#pragma warning(disable: 4661)
-#endif
 template class U_I18N_API LocalPointerBase<message2::data_model::Key>;
 template class U_I18N_API LocalArray<message2::data_model::Key>;
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
 #endif
 /// @endcond
 
@@ -928,16 +917,8 @@ namespace message2 {
 // (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
 // for similar examples.)
 #if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-#if defined(_MSC_VER)
-// Ignore warning 4661 as LocalPointerBase does not use operator== or operator!=
-#pragma warning(push)
-#pragma warning(disable: 4661)
-#endif
 template class U_I18N_API LocalPointerBase<message2::data_model::Option>;
 template class U_I18N_API LocalArray<message2::data_model::Option>;
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
 #endif
 /// @endcond
 
@@ -1033,7 +1014,7 @@ U_NAMESPACE_END
 // (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
 // for similar examples.)
 #if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-#if defined(_MSC_VER)
+#if defined(U_REAL_MSVC) && defined(_MSVC_STL_VERSION)
 template class U_I18N_API std::_Variant_storage_<false, icu::message2::data_model::Reserved,icu::message2::data_model::Callable>;
 #endif
 template class U_I18N_API std::variant<icu::message2::data_model::Reserved,icu::message2::data_model::Callable>;
@@ -1757,16 +1738,8 @@ namespace message2 {
 // (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
 // for similar examples.)
 #if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-#if defined(_MSC_VER)
-// Ignore warning 4661 as LocalPointerBase does not use operator== or operator!=
-#pragma warning(push)
-#pragma warning(disable: 4661)
-#endif
 template class U_I18N_API LocalPointerBase<message2::data_model::Expression>;
 template class U_I18N_API LocalArray<message2::data_model::Expression>;
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
 #endif
 /// @endcond
 
@@ -2129,18 +2102,10 @@ namespace message2 {
 // (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
 // for similar examples.)
 #if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-#if defined(_MSC_VER)
-// Ignore warning 4661 as LocalPointerBase does not use operator== or operator!=
-#pragma warning(push)
-#pragma warning(disable: 4661)
-#endif
 template class U_I18N_API LocalPointerBase<message2::data_model::PatternPart>;
 template class U_I18N_API LocalArray<message2::data_model::PatternPart>;
 template class U_I18N_API LocalPointerBase<message2::data_model::UnsupportedStatement>;
 template class U_I18N_API LocalArray<message2::data_model::UnsupportedStatement>;
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
 #endif
 /// @endcond
 
@@ -2641,18 +2606,10 @@ namespace message2 {
 // (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
 // for similar examples.)
 #if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-#if defined(_MSC_VER)
-// Ignore warning 4661 as LocalPointerBase does not use operator== or operator!=
-#pragma warning(push)
-#pragma warning(disable: 4661)
-#endif
 template class U_I18N_API LocalPointerBase<message2::data_model::Variant>;
 template class U_I18N_API LocalPointerBase<message2::data_model::Binding>;
 template class U_I18N_API LocalArray<message2::data_model::Variant>;
 template class U_I18N_API LocalArray<message2::data_model::Binding>;
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
 #endif
 /// @endcond
 
@@ -2719,7 +2676,7 @@ U_NAMESPACE_END
 // (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
 // for similar examples.)
 #if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-#if defined(_MSC_VER)
+#if defined(U_REAL_MSVC) && defined(_MSVC_STL_VERSION)
 template class U_I18N_API std::_Variant_storage_<false, icu::message2::Matcher,icu::message2::data_model::Pattern>;
 #endif
 template class U_I18N_API std::variant<icu::message2::Matcher,icu::message2::data_model::Pattern>;

--- a/icu4c/source/i18n/unicode/messageformat2_formattable.h
+++ b/icu4c/source/i18n/unicode/messageformat2_formattable.h
@@ -76,12 +76,7 @@ U_NAMESPACE_END
 // (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
 // for similar examples.)
 #if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-#if defined(_MSC_VER)
-// Ignore warning 4661 as LocalPointerBase does not use operator== or operator!=
-#pragma warning(push)
-#pragma warning(disable: 4661)
-#endif
-#if defined(_MSC_VER)
+#if defined(U_REAL_MSVC) && defined(_MSVC_STL_VERSION)
 template class U_I18N_API std::_Variant_storage_<false,
   double,
   int64_t,
@@ -97,9 +92,6 @@ template class U_I18N_API std::variant<double,
 				       icu::Formattable,
 				       const icu::message2::FormattableObject*,
                                        P>;
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
 #endif
 /// @endcond
 


### PR DESCRIPTION
It's not uncommon for code for Windows to use the `_MSC_VER` preprocessor macro to identify that it's being compiled for Windows so it's also not uncommon for compilers other than the real MSVC compiler to also set this to be able to compile such code.

It's also not possible to use `_MSC_VER` to determine whether the C++ standard library implementation used is the Microsoft STL.

Clang will however refuse to instantiate a template with a forward declared type, so the code that currently does this needs to be moved to after the type has been properly defined, which in turn makes MSVC warn that those templates aren't instantiated, so those warnings need to be disabled, but then the disabling of warning C4661 doesn't work any longer (for some unknown reason) but this can be resolved by properly deleting the non-existent operators instead of disabling the warning.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22261
- [x] Required: The PR title must be prefixed with a JIRA Issue number.
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number.
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
