### PR TITLE
ICU-22722 Fix missing starter character for MF2 keyword in User Guide

### DIFF
--- a/docs/userguide/format_parse/messages/mf2.md
+++ b/docs/userguide/format_parse/messages/mf2.md
@@ -96,7 +96,7 @@ public void testMf2() {
 ```java
 @Test
 public void testMf2Selection() {
-   final String message = "match {$count :plural}"
+   final String message = ".match {$count :plural}"
            + " when 1 {You have one notification.}"
            + " when one {You have {$count} notification.}"
            + " when * {You have {$count} notifications.}";


### PR DESCRIPTION

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22722
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [X] API docs and/or User Guide docs changed or added, if applicable
