### PR TITLE
ICU-22727 Fix uloc_addLikelySubtags for alpha{5,8} unicode_language_subtag

### DIFF
--- a/icu4c/source/common/loclikely.cpp
+++ b/icu4c/source/common/loclikely.cpp
@@ -157,14 +157,17 @@ _uloc_addLikelySubtags(const char* localeID,
         return;
     }
 
-    if (lang.length() > 3) {
-        if (lang.length() == 4 && script.isEmpty()) {
+    if (lang.length() == 4) {
+        if (script.isEmpty()) {
             script = std::move(lang);
             lang.clear();
         } else {
             err = U_ILLEGAL_ARGUMENT_ERROR;
             return;
         }
+    } else if (lang.length() > 8) {
+        err = U_ILLEGAL_ARGUMENT_ERROR;
+        return;
     }
 
     int32_t trailingLength = (int32_t)uprv_strlen(trailing);

--- a/icu4c/source/test/cintltst/cloctst.c
+++ b/icu4c/source/test/cintltst/cloctst.c
@@ -3868,6 +3868,27 @@ const char* const basic_maximize_data[][2] = {
     "aaaa",
     "aaaa",
   }, {
+    // ICU-22727
+    // unicode_language_subtag = alpha{2,3} | alpha{5,8};
+    // so "bbbbb", "cccccc", "ddddddd", "eeeeeeee" are
+    // well-formed unicode_language_subtag and therefore
+    // well-formed unicode_language_id
+    // but "fffffffff" is not.
+    "bbbbb",
+    "bbbbb",
+  }, {
+    // ICU-22727
+    "cccccc",
+    "cccccc",
+  }, {
+    // ICU-22727
+    "ddddddd",
+    "ddddddd",
+  }, {
+    // ICU-22727
+    "eeeeeeee",
+    "eeeeeeee",
+  }, {
     // ICU-22546
     "und-Zzzz",
     "en_Latn_US" // If change, please also update common/unicode/uloc.h
@@ -6048,6 +6069,16 @@ const errorData maximizeErrors[] = {
         "en_Latn_US_POSIX@currency=EURO",
         U_STRING_NOT_TERMINATED_WARNING,
         30
+    },
+    {
+        // ICU-22727
+        // unicode_language_subtag = alpha{2,3} | alpha{5,8};
+        // so "bbbbb", "cccccc", "ddddddd", "eeeeeeee" are
+        // well-formed unicode_language_id but "fffffffff" is not.
+        "fffffffff",
+        NULL,
+        U_ILLEGAL_ARGUMENT_ERROR,
+        0
     }
 };
 

--- a/icu4c/source/test/intltest/loctest.cpp
+++ b/icu4c/source/test/intltest/loctest.cpp
@@ -3916,6 +3916,31 @@ LocaleTest::TestAddLikelyAndMinimizeSubtags() {
             "aaaa",
             "aaaa",
         }, {
+            // ICU-22727
+            // unicode_language_subtag = alpha{2,3} | alpha{5,8};
+            // so "bbbbb", "cccccc", "ddddddd", "eeeeeeee" are
+            // well-formed unicode_language_subtag and therefore
+            // well-formed unicode_language_id
+            // but "fffffffff" is not.
+            "bbbbb",
+            "bbbbb",
+            "bbbbb",
+        }, {
+            // ICU-22727
+            "cccccc",
+            "cccccc",
+            "cccccc",
+        }, {
+            // ICU-22727
+            "ddddddd",
+            "ddddddd",
+            "ddddddd",
+        }, {
+            // ICU-22727
+            "eeeeeeee",
+            "eeeeeeee",
+            "eeeeeeee",
+        }, {
             // ICU-22546
             "und-Zzzz",
             "en_Latn_US", // If change, please also update common/unicode/locid.h

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/util/ULocaleTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/util/ULocaleTest.java
@@ -1926,6 +1926,26 @@ public class ULocaleTest extends CoreTestFmwk {
                     "aaaa",
                     "aaaa",
                 }, {
+                    // ICU-22727
+                    // unicode_language_subtag = alpha{2,3} | alpha{5,8};
+                    // so "bbbbb", "cccccc", "ddddddd", "eeeeeeee" are
+                    // well-formed unicode_language_subtag and therefore
+                    // well-formed unicode_language_id
+                    "bbbbb",
+                    "bbbbb",
+                }, {
+                    // ICU-22727
+                    "cccccc",
+                    "cccccc",
+                }, {
+                    // ICU-22727
+                    "ddddddd",
+                    "ddddddd",
+                }, {
+                    // ICU-22727
+                    "eeeeeeee",
+                    "eeeeeeee",
+                }, {
                     // ICU-22546
                     "und-Zzzz",
                     "en_Latn_US" // If change, please also update ULocale.java


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22727
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
