### PR TITLE
ICU-21172 fix install race

### DIFF
--- a/icu4c/source/Makefile.in
+++ b/icu4c/source/Makefile.in
@@ -77,7 +77,7 @@ EXTRA_DATA =
 
 ## List of phony targets
 .PHONY : all all-local all-recursive install install-local install-udata install-udata-files install-udata-dlls		\
-install-recursive clean clean-local clean-recursive distclean		\
+install-recursive install-manx clean clean-local clean-recursive distclean		\
 distclean-local distclean-recursive doc dist dist-local dist-recursive	\
 check check-local check-recursive clean-recursive-with-twist install-icu \
 doc install-doc tests icu4j-data icu4j-data-install update-windows-makefiles xcheck-local xcheck-recursive xperf xcheck xperf-recursive \
@@ -88,9 +88,9 @@ check-exhaustive check-exhaustive-local check-exhaustive-recursive releaseDist
 
 ## List of standard targets
 all: all-local all-recursive
-install: install-recursive install-local
+install: install-recursive
 clean: clean-recursive-with-twist clean-local
-distclean : distclean-recursive distclean-local
+distclean : distclean-recursive
 dist: dist-recursive
 check: all check-recursive
 check-recursive: all
@@ -377,7 +377,7 @@ config.status: $(srcdir)/configure $(srcdir)/common/unicode/uvernum.h
 install-manx: $(MANX_FILES)
 	$(MKINSTALLDIRS) $(DESTDIR)$(mandir)/man$(SECTION)
 ifneq ($(MANX_FILES),)
-	$(INSTALL_DATA) $? $(DESTDIR)$(mandir)/man$(SECTION)
+	$(INSTALL_DATA) $^ $(DESTDIR)$(mandir)/man$(SECTION)
 endif
 
 config/%.$(SECTION): $(srcdir)/config/%.$(SECTION).in


### PR DESCRIPTION
The generic recursive target calls target-local so also adding it to the dependency list results in races due to install-local being executed twice in parallel.  For example, install-manx can fail if the two install processes race and one process tries to chown a file that the other process has just deleted.

Also install-manx should be a phony target, and for clarity use `$^` instead of `$?` in the install command.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21172
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
