### PR TITLE
ICU-22520 doc: uloc_getName() & others may fail

### DIFF
--- a/icu4c/source/common/unicode/uloc.h
+++ b/icu4c/source/common/unicode/uloc.h
@@ -399,6 +399,9 @@ uloc_setDefault(const char* localeID,
 /**
  * Gets the language code for the specified locale.
  *
+ * This function may return with a failure error code for certain kinds of inputs
+ * but does not fully check for well-formed locale IDs / language tags.
+ *
  * @param localeID the locale to get the ISO language code with
  * @param language the language code for localeID
  * @param languageCapacity the size of the language buffer to store the  
@@ -416,6 +419,9 @@ uloc_getLanguage(const char*    localeID,
 
 /**
  * Gets the script code for the specified locale.
+ *
+ * This function may return with a failure error code for certain kinds of inputs
+ * but does not fully check for well-formed locale IDs / language tags.
  *
  * @param localeID the locale to get the ISO language code with
  * @param script the language code for localeID
@@ -435,6 +441,9 @@ uloc_getScript(const char*    localeID,
 /**
  * Gets the  country code for the specified locale.
  *
+ * This function may return with a failure error code for certain kinds of inputs
+ * but does not fully check for well-formed locale IDs / language tags.
+ *
  * @param localeID the locale to get the country code with
  * @param country the country code for localeID
  * @param countryCapacity the size of the country buffer to store the  
@@ -452,6 +461,9 @@ uloc_getCountry(const char*    localeID,
 
 /**
  * Gets the variant code for the specified locale.
+ *
+ * This function may return with a failure error code for certain kinds of inputs
+ * but does not fully check for well-formed locale IDs / language tags.
  *
  * @param localeID the locale to get the variant code with
  * @param variant the variant code for localeID
@@ -471,6 +483,10 @@ uloc_getVariant(const char*    localeID,
 
 /**
  * Gets the full name for the specified locale.
+ *
+ * This function may return with a failure error code for certain kinds of inputs
+ * but does not fully check for well-formed locale IDs / language tags.
+ *
  * Note: This has the effect of 'canonicalizing' the ICU locale ID to
  * a certain extent. Upper and lower case are set as needed.
  * It does NOT map aliased names in any way.


### PR DESCRIPTION
for example with a U_ILLEGAL_ARGUMENT_ERROR since PR #2813 in some cases where the implementation may have
returned with a misleading U_BUFFER_OVERFLOW_ERROR

API docs wording from 20240411 ICU-TC meeting.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22520
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
