### PR TITLE
ICU-22721 Prevent inconsistent ICU4J Maven deploys via CI

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -17,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+    outputs:
+      version: ${{ steps.mvn-proj-version.outputs.version }}
+      version-type: ${{ steps.mvn-proj-version-type.outputs.version-type }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
@@ -25,16 +28,54 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-      - name: icu4j and releaseCLDR
+      - name: Store Maven project version
+        id: mvn-proj-version
+        run: |
+          cd icu4j
+          version="`mvn help:evaluate -Dexpression=project.version -q -DforceStdout`"
+          echo "version=$version"  # debug/info logging for our own purposes, before sending to Github
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      # Set version-type=snapshot for tags that contain SNAPSHOT,  
+      # as well as for unicode-org-internal artifacts with a dash like `icu4j-for-cldr`. 
+      - name: Assess Maven version release/snapshot
+        id: mvn-proj-version-type
+        run: |
+          if echo "${{ steps.mvn-proj-version.outputs.version }}" | grep -E "\-|SNAPSHOT"
+          then echo "version-type=snapshot" >> "$GITHUB_OUTPUT"
+          else echo "version-type=release" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Prevent manual deployment attempts of full release
+        if: github.event_name == 'workflow_dispatch' && steps.mvn-proj-version-type.outputs.version-type == 'release'
+        run: |
+          echo "Manual deployments of publishing artifacts should only be attempted for snapshot versions"
+          exit 1;
+      - name: Build artifacts (icu4j, utilities-for-cldr)
         run: |
           cd icu4j
           mvn ${SHARED_MVN_ARGS} clean install -DskipTests -DskipIT -P with_sources
-      - name: deploy it
+      # For snapshot versions, publish icu4j & utilities-for-cldr
+      - name: Deploy to Github (snapshot version)
+        if: steps.mvn-proj-version-type.outputs.version-type == 'snapshot'
         run: |
           echo Github Ref ${GITHUB_REF} @ ${GITHUB_SHA};
           cd icu4j
           mvn deploy ${SHARED_MVN_ARGS} \
             -pl :icu4j,:utilities-for-cldr,:icu4j-root \
+            -DaltDeploymentRepository=github::https://maven.pkg.github.com/${GITHUB_REPOSITORY} \
+            -P cldr_utilities,with_sources
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # For release versions, publish utilities-for-cldr,
+      # but do not publish icu4j because the Maven artifact "coordinates"
+      # will conflict with the public-facing coordinates on Maven Central
+      # ("coordinates" = groupId, artifactId, version)
+      - name: Deploy to Github (release version)
+        if: steps.mvn-proj-version-type.outputs.version-type == 'release'
+        run: |
+          echo Github Ref ${GITHUB_REF} @ ${GITHUB_SHA};
+          cd icu4j
+          mvn deploy ${SHARED_MVN_ARGS} \
+            -pl :utilities-for-cldr,:icu4j-root \
             -DaltDeploymentRepository=github::https://maven.pkg.github.com/${GITHUB_REPOSITORY} \
             -P cldr_utilities,with_sources
         env:


### PR DESCRIPTION
Update the CI workflow that deploys Maven artifacts to Github for ICU4J so that:

* We don't publish the `icu4j` artifact to Github for release (non-snapshot) versions. This preserves Maven Central as the single source of truth for `icu4j` artifacts for release versions
  - Note: we keep the current behavior for snapshot versions, which is to publish to Github
*  We automatically prevent any manual attempts to publish a release version artifact

Trial runs in my personal fork:
- succeeding workflow run of the PR branch, triggered manually: https://github.com/echeran/icu/actions/runs/8730613164/job/23954716091
  * the condition execution of steps within the job shows that the workflow output variables are being captured as expected
- a previous iteration that failed when the version number looked like a release version (`1`), triggered manually: https://github.com/echeran/icu/actions/runs/8730537899/job/23954536566
  -   the automatic check is activated to prevent a manual deploy of a release version artifact

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22721
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
