### PR TITLE
ICU-22740 Add missing template arguments in MF2 parser

### DIFF
--- a/.ci-builds/.azure-pipelines-icu4c.yml
+++ b/.ci-builds/.azure-pipelines-icu4c.yml
@@ -164,7 +164,7 @@ jobs:
       displayName: 'Build only (WarningsAsErrors)'
       env:
         CC: clang-16
-        CPPFLAGS: '-Werror -Wno-strict-prototypes -Wall -Wextra -Wextra-semi -Wundef -Wnon-virtual-dtor -Wsuggest-override'
+        CPPFLAGS: '-Werror -Wno-strict-prototypes -Wall -Wextra -Wextra-semi -Wundef -Wnon-virtual-dtor -Wsuggest-override -Wctad-maybe-unsupported'
         CXX: clang++-16
 #-------------------------------------------------------------------------
 - job: ICU4C_Clang16_Cpp20_Ubuntu_2004
@@ -555,7 +555,7 @@ jobs:
       lfs: true
       fetchDepth: 10
     - script: |
-        export CPPFLAGS="-Werror -Wall -Wextra -Wextra-semi -Wundef -Wnon-virtual-dtor" && cd icu4c/source && ./runConfigureICU MacOSX && make -j -l2.5 check
+        export CPPFLAGS="-Werror -Wall -Wextra -Wextra-semi -Wundef -Wnon-virtual-dtor -Wctad-maybe-unsupported" && cd icu4c/source && ./runConfigureICU MacOSX && make -j -l2.5 check
       displayName: 'Build and Test (WarningsAsErrors)'
       env:
         CC: clang

--- a/icu4c/source/i18n/messageformat2_parser.cpp
+++ b/icu4c/source/i18n/messageformat2_parser.cpp
@@ -1523,7 +1523,7 @@ Expression Parser::parseExpression(UErrorCode& status) {
     }
 
     // Parse attributes
-    AttributeAdder attrAdder(exprBuilder);
+    AttributeAdder<Expression::Builder> attrAdder(exprBuilder);
     parseAttributes(attrAdder, status);
 
     // Parse optional space
@@ -1985,7 +1985,7 @@ Markup Parser::parseMarkup(UErrorCode& status) {
     // Parse the attributes, which also must begin
     // with a ' '
     if (inBounds(source, index) && isWhitespace(source[index])) {
-        AttributeAdder attrAdder(builder);
+        AttributeAdder<Markup::Builder> attrAdder(builder);
         parseAttributes(attrAdder, status);
     }
 


### PR DESCRIPTION
This fixes a clang-17 `-Wctad-maybe-unsupported` warning.

<!--
Thank you for your pull request!

* General info on contributing: please see https://github.com/unicode-org/icu/blob/main/CONTRIBUTING.md
* Ticket numbers for minor changes: for minor changes (ex: docs typos), you can reuse one of the open catch-all tickets for our next release
  - ICU 76 ticket: docs minor fixes: typos/etc./version updates / User Guide & API docs: ICU-22722
  - ICU 76 ticket: code warnings/version updates: ICU-22721
* Contributors license agreement (CLA): 
  You will be automatically asked to sign the CLA before the PR is accepted.
  To sign the CLA: https://cla-assistant.io/unicode-org/icu

  For terms of use and license, see https://www.unicode.org/terms_of_use.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22740
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable

ALLOW_MANY_COMMITS=true