### PR TITLE
ICU-22721 Remove now obsolete disabled warnings for LocalPointerBase

### DIFF
--- a/icu4c/source/i18n/erarules.h
+++ b/icu4c/source/i18n/erarules.h
@@ -18,16 +18,8 @@ U_NAMESPACE_BEGIN
 // When building DLLs for Windows this is required even though no direct access leaks out of the i18n library.
 // See digitlst.h, pluralaffix.h, datefmt.h, and others for similar examples.
 #if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-#if defined(_MSC_VER)
-// Ignore warning 4661 as LocalPointerBase does not use operator== or operator!=
-#pragma warning(push)
-#pragma warning(disable: 4661)
-#endif
 template class U_I18N_API LocalPointerBase<int32_t>;
 template class U_I18N_API LocalMemory<int32_t>;
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
 #endif
 
 class U_I18N_API EraRules : public UMemory {

--- a/icu4c/source/i18n/measunit_impl.h
+++ b/icu4c/source/i18n/measunit_impl.h
@@ -356,16 +356,8 @@ template class U_I18N_API MaybeStackVector<MeasureUnitImplWithIndex, 8>;
 // Export an explicit template instantiation of the LocalPointer that is used as a
 // data member of MeasureUnitImpl.
 // (When building DLLs for Windows this is required.)
-#if defined(_MSC_VER)
-// Ignore warning 4661 as LocalPointerBase does not use operator== or operator!=
-#pragma warning(push)
-#pragma warning(disable : 4661)
-#endif
 template class U_I18N_API LocalPointerBase<MeasureUnitImpl>;
 template class U_I18N_API LocalPointer<MeasureUnitImpl>;
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
 #endif
 
 U_NAMESPACE_END

--- a/icu4c/source/i18n/number_decimfmtprops.h
+++ b/icu4c/source/i18n/number_decimfmtprops.h
@@ -21,16 +21,8 @@ U_NAMESPACE_BEGIN
 // data member of CurrencyPluralInfoWrapper.
 // (When building DLLs for Windows this is required.)
 #if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-#if defined(_MSC_VER)
-// Ignore warning 4661 as LocalPointerBase does not use operator== or operator!=
-#pragma warning(push)
-#pragma warning(disable: 4661)
-#endif
 template class U_I18N_API LocalPointerBase<CurrencyPluralInfo>;
 template class U_I18N_API LocalPointer<CurrencyPluralInfo>;
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
 #endif
 
 namespace number::impl {

--- a/icu4c/source/i18n/number_patternmodifier.h
+++ b/icu4c/source/i18n/number_patternmodifier.h
@@ -21,16 +21,8 @@ U_NAMESPACE_BEGIN
 // data member of AdoptingModifierStore.
 // (When building DLLs for Windows this is required.)
 #if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-#if defined(_MSC_VER)
-// Ignore warning 4661 as LocalPointerBase does not use operator== or operator!=
-#pragma warning(push)
-#pragma warning(disable : 4661)
-#endif
 template class U_I18N_API LocalPointerBase<number::impl::AdoptingModifierStore>;
 template class U_I18N_API LocalPointer<number::impl::AdoptingModifierStore>;
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
 #endif
 
 namespace number::impl {

--- a/icu4c/source/i18n/number_usageprefs.h
+++ b/icu4c/source/i18n/number_usageprefs.h
@@ -70,16 +70,8 @@ class U_I18N_API UsagePrefsHandler : public MicroPropsGenerator, public UMemory 
 // Note: These need to be outside of the number::impl namespace, or Clang will
 // generate a compile error.
 #if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-#if defined(_MSC_VER)
-// Ignore warning 4661 as LocalPointerBase does not use operator== or operator!=
-#pragma warning(push)
-#pragma warning(disable: 4661)
-#endif
 template class U_I18N_API LocalPointerBase<ComplexUnitsConverter>;
 template class U_I18N_API LocalPointer<ComplexUnitsConverter>;
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
 #endif
 
 namespace number::impl {


### PR DESCRIPTION
The missing operators that used to be warned about were all deleted by commit 75eab42060d6a73b62db2bc639216eae1f8ec47e.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22721
- [x] Required: The PR title must be prefixed with a JIRA Issue number.
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number.
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
