### PR TITLE
ICU-22750 Fix Floating-point-exception in icu::Calendar::roll

### DIFF
--- a/icu4c/source/i18n/calendar.cpp
+++ b/icu4c/source/i18n/calendar.cpp
@@ -1762,6 +1762,9 @@ void Calendar::roll(UCalendarDateFields field, int32_t amount, UErrorCode& statu
         {
             int32_t min = getActualMinimum(field,status);
             int32_t max = getActualMaximum(field,status);
+            if (U_FAILURE(status)) {
+               return;
+            }
             int32_t gap = max - min + 1;
 
             int64_t value = internalGet(field);

--- a/icu4c/source/test/intltest/caltest.cpp
+++ b/icu4c/source/test/intltest/caltest.cpp
@@ -209,6 +209,7 @@ void CalendarTest::runIndexedTest( int32_t index, UBool exec, const char* &name,
 
     TESTCASE_AUTO(TestAddOverflow);
 
+    TESTCASE_AUTO(Test22750Roll);
 
     TESTCASE_AUTO(TestChineseCalendarComputeMonthStart);
 
@@ -5929,6 +5930,25 @@ void CalendarTest::TestAddOverflow() {
         }
     }
 }
+
+void CalendarTest::Test22750Roll() {
+    UErrorCode status = U_ZERO_ERROR;
+    Locale l(Locale::getRoot());
+    std::unique_ptr<icu::StringEnumeration> enumeration(
+        Calendar::getKeywordValuesForLocale("calendar", l, false, status));
+    // Test every calendar
+    for (const char* name = enumeration->next(nullptr, status);
+            U_SUCCESS(status) && name != nullptr;
+            name = enumeration->next(nullptr, status)) {
+        UErrorCode status2 = U_ZERO_ERROR;
+        l.setKeywordValue("calendar", name, status2);
+        LocalPointer<Calendar> calendar(Calendar::createInstance(l, status2));
+        if (failure(status2, "Calendar::createInstance")) return;
+        calendar->add(UCAL_DAY_OF_WEEK_IN_MONTH, 538976288, status2);
+        calendar->roll(UCAL_DATE, 538976288, status2);
+    }
+}
+
 #endif /* #if !UCONFIG_NO_FORMATTING */
 
 //eof

--- a/icu4c/source/test/intltest/caltest.h
+++ b/icu4c/source/test/intltest/caltest.h
@@ -347,6 +347,9 @@ public: // package
     void Test22633AddTwiceGetTimeOverflow();
     void Test22633RollTwiceGetTimeOverflow();
     void Test22730JapaneseOverflow();
+
+    void Test22750Roll();
+
     void RunTestOnCalendars(void(TestFunc)(Calendar*, UCalendarDateFields));
 
     void verifyFirstDayOfWeek(const char* locale, UCalendarDaysOfWeek expected);


### PR DESCRIPTION
In some calendar, the gap could be 0 and cause FPE when we % gap

<!--
Thank you for your pull request!

* General info on contributing: please see https://github.com/unicode-org/icu/blob/main/CONTRIBUTING.md
* Ticket numbers for minor changes: for minor changes (ex: docs typos), you can reuse one of the open catch-all tickets for our next release
  - ICU 76 ticket: docs minor fixes: typos/etc./version updates / User Guide & API docs: ICU-22722
  - ICU 76 ticket: code warnings/version updates: ICU-22721
* Contributors license agreement (CLA): 
  You will be automatically asked to sign the CLA before the PR is accepted.
  To sign the CLA: https://cla-assistant.io/unicode-org/icu

  For terms of use and license, see https://www.unicode.org/terms_of_use.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22750
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
