### PR TITLE
ICU-22753 Fix read-after-move in MF2

### DIFF
--- a/icu4c/source/i18n/messageformat2_errors.cpp
+++ b/icu4c/source/i18n/messageformat2_errors.cpp
@@ -189,10 +189,12 @@ namespace message2 {
     void StaticErrors::addError(StaticError&& e, UErrorCode& status) {
         CHECK_ERROR(status);
 
+        StaticErrorType type = e.type;
+
         void* errorP = static_cast<void*>(create<StaticError>(std::move(e), status));
         U_ASSERT(syntaxAndDataModelErrors.isValid());
 
-        switch (e.type) {
+        switch (type) {
         case StaticErrorType::SyntaxError: {
             syntaxError = true;
             break;
@@ -229,10 +231,12 @@ namespace message2 {
     void DynamicErrors::addError(DynamicError&& e, UErrorCode& status) {
         CHECK_ERROR(status);
 
+        DynamicErrorType type = e.type;
+
         void* errorP = static_cast<void*>(create<DynamicError>(std::move(e), status));
         U_ASSERT(resolutionAndFormattingErrors.isValid());
 
-        switch (e.type) {
+        switch (type) {
         case DynamicErrorType::UnresolvedVariable: {
             unresolvedVariableError = true;
             resolutionAndFormattingErrors->adoptElement(errorP, status);


### PR DESCRIPTION
In StaticErrors::addError() and DynamicErrors::addError(), don't read from `e` after moving out of it.

It's surprising to me that this error wasn't caught by asan or ubsan.

<!--
Thank you for your pull request!

* General info on contributing: please see https://github.com/unicode-org/icu/blob/main/CONTRIBUTING.md
* Ticket numbers for minor changes: for minor changes (ex: docs typos), you can reuse one of the open catch-all tickets for our next release
  - ICU 76 ticket: docs minor fixes: typos/etc./version updates / User Guide & API docs: ICU-22722
  - ICU 76 ticket: code warnings/version updates: ICU-22721
* Contributors license agreement (CLA): 
  You will be automatically asked to sign the CLA before the PR is accepted.
  To sign the CLA: https://cla-assistant.io/unicode-org/icu

  For terms of use and license, see https://www.unicode.org/terms_of_use.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22753
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
