### PR TITLE
ICU-21633 Fix ClangCL cross-compilation on Windows

### DIFF
--- a/icu4c/source/tools/genccode/genccode.c
+++ b/icu4c/source/tools/genccode/genccode.c
@@ -70,6 +70,7 @@ enum {
 #ifdef CAN_GENERATE_OBJECTS
   kOptObject,
   kOptMatchArch,
+  kOptCpuArch,
   kOptSkipDllExport,
 #endif
   kOptFilename,
@@ -86,6 +87,7 @@ static UOption options[]={
 #ifdef CAN_GENERATE_OBJECTS
 /*6*/UOPTION_DEF("object", 'o', UOPT_NO_ARG),
      UOPTION_DEF("match-arch", 'm', UOPT_REQUIRES_ARG),
+     UOPTION_DEF("cpu-arch", 'c', UOPT_REQUIRES_ARG),
      UOPTION_DEF("skip-dll-export", '\0', UOPT_NO_ARG),
 #endif
      UOPTION_DEF("filename", 'f', UOPT_REQUIRES_ARG),
@@ -131,6 +133,7 @@ main(int argc, char* argv[]) {
             "\t-o or --object      write a .obj file instead of .c\n"
             "\t-m or --match-arch file.o  match the architecture (CPU, 32/64 bits) of the specified .o\n"
             "\t                    ELF format defaults to i386. Windows defaults to the native platform.\n"
+            "\t-c or --cpu-arch    Specify a CPU architecture for which to write a .obj file for ClangCL on Windows\n"
             "\t--skip-dll-export   Don't export the ICU data entry point symbol (for use when statically linking)\n");
 #endif
         fprintf(stderr,
@@ -196,6 +199,7 @@ main(int argc, char* argv[]) {
                 writeObjectCode(filename, options[kOptDestDir].value,
                                 options[kOptEntryPoint].doesOccur ? options[kOptEntryPoint].value : NULL,
                                 options[kOptMatchArch].doesOccur ? options[kOptMatchArch].value : NULL,
+                                options[kOptCpuArch].doesOccur ? options[kOptCpuArch].value : NULL,
                                 options[kOptFilename].doesOccur ? options[kOptFilename].value : NULL,
                                 NULL,
                                 0,

--- a/icu4c/source/tools/pkgdata/pkgdata.cpp
+++ b/icu4c/source/tools/pkgdata/pkgdata.cpp
@@ -776,6 +776,7 @@ static int32_t pkg_executeOptions(UPKGOptions *o) {
                         o->entryName,
                         (optMatchArch[0] == 0 ? nullptr : optMatchArch),
                         nullptr,
+                        nullptr,
                         gencFilePath,
                         sizeof(gencFilePath),
                         true);

--- a/icu4c/source/tools/toolutil/pkg_genc.cpp
+++ b/icu4c/source/tools/toolutil/pkg_genc.cpp
@@ -799,7 +799,12 @@ getOutFilename(
 
 #ifdef CAN_GENERATE_OBJECTS
 static void
-getArchitecture(uint16_t *pCPU, uint16_t *pBits, UBool *pIsBigEndian, const char *optMatchArch) {
+getArchitecture(
+    uint16_t *pCPU,
+    uint16_t *pBits,
+    UBool *pIsBigEndian,
+    const char *optMatchArch,
+    [[maybe_unused]] const char *optCpuArch) {
     union {
         char        bytes[2048];
 #ifdef U_ELF
@@ -847,7 +852,24 @@ getArchitecture(uint16_t *pCPU, uint16_t *pBits, UBool *pIsBigEndian, const char
 #   if defined(_M_IX86)
         *pCPU = IMAGE_FILE_MACHINE_I386;
 #   else
-        *pCPU = IMAGE_FILE_MACHINE_UNKNOWN;
+        // Linker for ClangCL doesn't handle IMAGE_FILE_MACHINE_UNKNOWN the same as
+        // linker for MSVC. Because of this optCpuArch is used to define the CPU
+        // architecture in that case. While _M_AMD64 and _M_ARM64 could be used,
+        // this would potentially be problematic when cross-compiling as this code
+        // would most likely be ran on host machine to generate the .obj file for
+        // the target architecture.
+#       if defined(__clang__)
+            if (strcmp(optCpuArch, "x64") == 0) {
+                *pCPU = IMAGE_FILE_MACHINE_AMD64;
+            } else if (strcmp(optCpuArch, "arm64") == 0) {
+                *pCPU = IMAGE_FILE_MACHINE_ARM64;
+            } else {
+                // This should never happen.
+                *pCPU = IMAGE_FILE_MACHINE_UNKNOWN;
+            }
+#       else
+            *pCPU = IMAGE_FILE_MACHINE_UNKNOWN;
+#       endif
 #   endif
 #   if defined(_M_IA64) || defined(_M_AMD64) || defined (_M_ARM64)
         *pBits = 64; // Doesn't seem to be used for anything interesting though?
@@ -934,6 +956,7 @@ writeObjectCode(
         const char *destdir,
         const char *optEntryPoint,
         const char *optMatchArch,
+        const char *optCpuArch,
         const char *optFilename,
         char *outFilePath,
         size_t outFilePathCapacity,
@@ -1201,7 +1224,7 @@ writeObjectCode(
 #endif
 
     /* deal with options, files and the entry point name */
-    getArchitecture(&cpu, &bits, &makeBigEndian, optMatchArch);
+    getArchitecture(&cpu, &bits, &makeBigEndian, optMatchArch, optCpuArch);
     if (optMatchArch)
     {
         printf("genccode: --match-arch cpu=%hu bits=%hu big-endian=%d\n", cpu, bits, makeBigEndian);

--- a/icu4c/source/tools/toolutil/pkg_genc.h
+++ b/icu4c/source/tools/toolutil/pkg_genc.h
@@ -99,6 +99,7 @@ writeObjectCode(
     const char *destdir,
     const char *optEntryPoint,
     const char *optMatchArch,
+    const char *optCpuArch,
     const char *optFilename,
     char *outFilePath,
     size_t outFilePathCapacity,


### PR DESCRIPTION
This PR is a WIP to fix issues with cross-compilation. The current approach is focused on fixing an issue I encountered on Windows with ClangCL (MSVC had no problems).

A quick backstory to better understand my background and motivation. I'm working on supporting Node.js on Windows. There is an ongoing effort to enable Node.js to be compiled with ClangCL. While working on it I noticed an issue when creating `.obj` file in ICU because of the `*pCPU = IMAGE_FILE_MACHINE_UNKNOWN;` line, and the code I made fixes that by adding a new option. After some discussion with @srl295, I was made aware of this being a broader problem that should be fixed for multiple compilers and platforms, not only ClangCL/Windows.

The code I have is a starting point and should be built upon. Please keep in mind that my knowledge and experience with other platforms is limited and I'd appreciate any help I can get. I'm also very new to the ICU, so feel free to correct any mistakes I may start making as soon as you see them.

Refs: https://github.com/nodejs/node/pull/53003

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21633
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
