### PR TITLE
ICU-22768 Fix bidi buffer overflow

### DIFF
--- a/icu4c/source/common/ubidiwrt.cpp
+++ b/icu4c/source/common/ubidiwrt.cpp
@@ -501,7 +501,10 @@ ubidi_writeReordered(UBiDi *pBiDi,
                     destSize-=runLength;
 
                     if((pBiDi->isInverse) &&
-                       (/*run<runCount-1 &&*/ dirProps[logicalStart+runLength-1]!=L)) {
+                           (/*run<runCount-1 &&*/
+                            runLength > 0 && // doWriteForward may return 0 if src
+                                             // only include bidi control chars
+                            dirProps[logicalStart+runLength-1]!=L)) {
                         markFlag |= LRM_AFTER;
                     }
                     if (markFlag & LRM_AFTER) {
@@ -632,7 +635,10 @@ ubidi_writeReordered(UBiDi *pBiDi,
                     }
                     destSize-=runLength;
 
-                    if(/*run>0 &&*/ !(MASK_R_AL&DIRPROP_FLAG(dirProps[logicalStart+runLength-1]))) {
+                    if(/*run>0 &&*/
+                            runLength > 0 && // doWriteForward may return 0 if src
+                                             // only include bidi control chars
+                            !(MASK_R_AL&DIRPROP_FLAG(dirProps[logicalStart+runLength-1]))) {
                         if(destSize>0) {
                             *dest++=RLM_CHAR;
                         }

--- a/icu4c/source/test/cintltst/cbiditst.c
+++ b/icu4c/source/test/cintltst/cbiditst.c
@@ -92,6 +92,7 @@ static void doTailTest(void);
 
 static void testBracketOverflow(void);
 static void TestExplicitLevel0(void);
+static void testUBidiWriteReorderedBufferOverflow(void);
 
 /* new BIDI API */
 static void testReorderingMode(void);
@@ -141,6 +142,7 @@ addComplexTest(TestNode** root) {
     addTest(root, testContext, "complex/bidi/testContext");
     addTest(root, testBracketOverflow, "complex/bidi/TestBracketOverflow");
     addTest(root, TestExplicitLevel0, "complex/bidi/TestExplicitLevel0");
+    addTest(root, testUBidiWriteReorderedBufferOverflow, "complex/bidi/writeReorderedBufferOverflow");
 
     addTest(root, doArabicShapingTest, "complex/arabic-shaping/ArabicShapingTest");
     addTest(root, doLamAlefSpecialVLTRArabicShapingTest, "complex/arabic-shaping/lamalef");
@@ -4936,6 +4938,23 @@ testBracketOverflow(void) {
         log_err("setPara failed with heavily nested brackets - %s", u_errorName(status));
     }
 
+    ubidi_close(bidi);
+}
+
+/* ICU-22768 */
+static void
+testUBidiWriteReorderedBufferOverflow (void) {
+    UErrorCode status = U_ZERO_ERROR;
+    UBiDi* bidi;
+    bidi = ubidi_open();
+    ubidi_setInverse(bidi, true);
+    static const UChar text[1] = { 0x2067 };
+    ubidi_setPara(bidi, text, 1, UBIDI_DEFAULT_RTL, NULL, &status);
+    UChar dest[MAXLEN];
+    uint16_t opt = UBIDI_REMOVE_BIDI_CONTROLS |
+        UBIDI_INSERT_LRM_FOR_NUMERIC |
+        UBIDI_OUTPUT_REVERSE;
+    ubidi_writeReordered(bidi, dest, MAXLEN, opt, &status);
     ubidi_close(bidi);
 }
 

--- a/icu4c/source/test/fuzzer/ubidi_fuzzer.cpp
+++ b/icu4c/source/test/fuzzer/ubidi_fuzzer.cpp
@@ -125,7 +125,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   checkVisual = (*(fuzzData.data()) & 0x01) == 0;
   fuzzData.remove_prefix(sizeof(checkVisual));
 
-  std::memcpy(&isInverse, fuzzData.data(), sizeof(isInverse));
+  isInverse = (*(fuzzData.data()) & 0x01) != 0;
   fuzzData.remove_prefix(sizeof(isInverse));
 
   std::memcpy(&options2, fuzzData.data(), sizeof(options2));


### PR DESCRIPTION
Consider doWriteForward may return 0 if src only contains bidi control chars.

<!--
Thank you for your pull request!

* General info on contributing: please see https://github.com/unicode-org/icu/blob/main/CONTRIBUTING.md
* Ticket numbers for minor changes: for minor changes (ex: docs typos), you can reuse one of the open catch-all tickets for our next release
  - ICU 76 ticket: docs minor fixes: typos/etc./version updates / User Guide & API docs: ICU-22722
  - ICU 76 ticket: code warnings/version updates: ICU-22721
* Contributors license agreement (CLA): 
  You will be automatically asked to sign the CLA before the PR is accepted.
  To sign the CLA: https://cla-assistant.io/unicode-org/icu

  For terms of use and license, see https://www.unicode.org/terms_of_use.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22768
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
