### PR TITLE
ICU-22787 Fix ClangCL compilation on Windows

### DIFF
--- a/icu4c/source/common/unicode/platform.h
+++ b/icu4c/source/common/unicode/platform.h
@@ -235,7 +235,7 @@
 /**
  * \def U_PLATFORM_USES_ONLY_WIN32_API
  * Defines whether the platform uses only the Win32 API.
- * Set to 1 for Windows/MSVC and MinGW but not Cygwin.
+ * Set to 1 for Windows/MSVC, ClangCL and MinGW but not Cygwin.
  * @internal
  */
 #ifdef U_PLATFORM_USES_ONLY_WIN32_API
@@ -250,7 +250,7 @@
 /**
  * \def U_PLATFORM_HAS_WIN32_API
  * Defines whether the Win32 API is available on the platform.
- * Set to 1 for Windows/MSVC, MinGW and Cygwin.
+ * Set to 1 for Windows/MSVC, ClangCL, MinGW and Cygwin.
  * @internal
  */
 #ifdef U_PLATFORM_HAS_WIN32_API

--- a/icu4c/source/tools/genccode/genccode.c
+++ b/icu4c/source/tools/genccode/genccode.c
@@ -70,6 +70,7 @@ enum {
 #ifdef CAN_GENERATE_OBJECTS
   kOptObject,
   kOptMatchArch,
+  kOptCpuArch,
   kOptSkipDllExport,
 #endif
   kOptFilename,
@@ -86,6 +87,7 @@ static UOption options[]={
 #ifdef CAN_GENERATE_OBJECTS
 /*6*/UOPTION_DEF("object", 'o', UOPT_NO_ARG),
      UOPTION_DEF("match-arch", 'm', UOPT_REQUIRES_ARG),
+     UOPTION_DEF("cpu-arch", 'c', UOPT_REQUIRES_ARG),
      UOPTION_DEF("skip-dll-export", '\0', UOPT_NO_ARG),
 #endif
      UOPTION_DEF("filename", 'f', UOPT_REQUIRES_ARG),
@@ -131,6 +133,8 @@ main(int argc, char* argv[]) {
             "\t-o or --object      write a .obj file instead of .c\n"
             "\t-m or --match-arch file.o  match the architecture (CPU, 32/64 bits) of the specified .o\n"
             "\t                    ELF format defaults to i386. Windows defaults to the native platform.\n"
+            "\t-c or --cpu-arch    Specify a CPU architecture for which to write a .obj file for ClangCL on Windows\n"
+            "\t                    Valid values for this opton are x64, x86 and arm64.\n"
             "\t--skip-dll-export   Don't export the ICU data entry point symbol (for use when statically linking)\n");
 #endif
         fprintf(stderr,
@@ -193,9 +197,17 @@ main(int argc, char* argv[]) {
                 break;
 #ifdef CAN_GENERATE_OBJECTS
             case CALL_WRITEOBJECT:
+                if(options[kOptCpuArch].doesOccur) {
+                    if (!checkCpuArchitecture(options[kOptCpuArch].value)) {
+                        fprintf(stderr,
+                            "CPU architecture \"%s\" is unknown.\n", options[kOptCpuArch].value);
+                        return -1;
+                    }
+                }
                 writeObjectCode(filename, options[kOptDestDir].value,
                                 options[kOptEntryPoint].doesOccur ? options[kOptEntryPoint].value : NULL,
                                 options[kOptMatchArch].doesOccur ? options[kOptMatchArch].value : NULL,
+                                options[kOptCpuArch].doesOccur ? options[kOptCpuArch].value : NULL,
                                 options[kOptFilename].doesOccur ? options[kOptFilename].value : NULL,
                                 NULL,
                                 0,

--- a/icu4c/source/tools/pkgdata/pkgdata.cpp
+++ b/icu4c/source/tools/pkgdata/pkgdata.cpp
@@ -776,6 +776,7 @@ static int32_t pkg_executeOptions(UPKGOptions *o) {
                         o->entryName,
                         (optMatchArch[0] == 0 ? nullptr : optMatchArch),
                         nullptr,
+                        nullptr,
                         gencFilePath,
                         sizeof(gencFilePath),
                         true);

--- a/icu4c/source/tools/toolutil/pkg_genc.h
+++ b/icu4c/source/tools/toolutil/pkg_genc.h
@@ -73,6 +73,9 @@ printAssemblyHeadersToStdErr(void);
 U_CAPI UBool U_EXPORT2
 checkAssemblyHeaderName(const char* optAssembly);
 
+U_CAPI UBool U_EXPORT2
+checkCpuArchitecture(const char* optCpuArch);
+
 U_CAPI void U_EXPORT2
 writeCCode(
     const char *filename,
@@ -98,6 +101,7 @@ writeObjectCode(
     const char *destdir,
     const char *optEntryPoint,
     const char *optMatchArch,
+    const char *optCpuArch,
     const char *optFilename,
     char *outFilePath,
     size_t outFilePathCapacity,


### PR DESCRIPTION
I'm working on supporting Node.js on Windows. There is an ongoing effort to enable it to be compiled with ClangCL. While working on it I noticed an issue when creating `.obj` file in ICU because of the `*pCPU = IMAGE_FILE_MACHINE_UNKNOWN;` line, and the code I made fixes that by adding a new option. Although this is a broader problem that should be fixed for multiple compilers and platforms, my change is aimed toward ClangCL and Windows, but can be used as a good foundation to work on fixes for other platforms and compilers and make corrections in future iterations.

This issue is currently our main blocker for enabling ClangCL compilation for Node.js and it'd be greatly appreciated if it could be reviewed soon.

Refs: https://github.com/nodejs/node/pull/53003

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22787
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
