### PR TITLE
ICU-22707 bug fix hst=V: hst=NA for Kirat Rai

### DIFF
--- a/icu4c/source/common/uprops.cpp
+++ b/icu4c/source/common/uprops.cpp
@@ -590,7 +590,11 @@ static int32_t scriptGetMaxValue(const IntProperty &/*prop*/, UProperty /*which*
 
 /*
  * Map some of the Grapheme Cluster Break values to Hangul Syllable Types.
- * Hangul_Syllable_Type is fully redundant with a subset of Grapheme_Cluster_Break.
+ * Hangul_Syllable_Type is redundant with a subset of Grapheme_Cluster_Break.
+ *
+ * Starting with Unicode 16, there is an exception:
+ * Some Kirat Rai vowels are given GCB=V for proper grapheme clustering, but
+ * they are of course not related to Hangul syllables.
  */
 static const UHangulSyllableType gcbToHst[]={
     U_HST_NOT_APPLICABLE,   /* U_GCB_OTHER */
@@ -610,6 +614,11 @@ static const UHangulSyllableType gcbToHst[]={
 };
 
 static int32_t getHangulSyllableType(const IntProperty &/*prop*/, UChar32 c, UProperty /*which*/) {
+    // Ignore supplementary code points: They all have HST=NA.
+    // This is a simple way to handle the GCB!=hst cases since Unicode 16 (Kirat Rai vowels).
+    if(c>0xffff) {
+        return U_HST_NOT_APPLICABLE;
+    }
     /* see comments on gcbToHst[] above */
     int32_t gcb=(int32_t)(u_getUnicodeProperties(c, 2)&UPROPS_GCB_MASK)>>UPROPS_GCB_SHIFT;
     if(gcb<UPRV_LENGTHOF(gcbToHst)) {

--- a/icu4c/source/test/cintltst/cucdtst.c
+++ b/icu4c/source/test/cintltst/cucdtst.c
@@ -2699,6 +2699,10 @@ TestAdditionalProperties(void) {
 
         { 0xd7a4, UCHAR_HANGUL_SYLLABLE_TYPE, 0 },
 
+        // GCB=V but hst=NA (exception to GCB=hst for relevant values)
+        { 0x16D67, UCHAR_HANGUL_SYLLABLE_TYPE, U_HST_NOT_APPLICABLE },
+        { 0x16D6A, UCHAR_HANGUL_SYLLABLE_TYPE, U_HST_NOT_APPLICABLE },
+
         { -1, 0x410, 0 }, /* version break for Unicode 4.1 */
 
         { 0x00d7, UCHAR_PATTERN_SYNTAX, true },

--- a/icu4j/main/core/src/main/java/com/ibm/icu/impl/UCharacterProperty.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/impl/UCharacterProperty.java
@@ -648,7 +648,11 @@ public final class UCharacterProperty
 
     /*
      * Map some of the Grapheme Cluster Break values to Hangul Syllable Types.
-     * Hangul_Syllable_Type is fully redundant with a subset of Grapheme_Cluster_Break.
+     * Hangul_Syllable_Type is redundant with a subset of Grapheme_Cluster_Break.
+     *
+     * Starting with Unicode 16, there is an exception:
+     * Some Kirat Rai vowels are given GCB=V for proper grapheme clustering, but
+     * they are of course not related to Hangul syllables.
      */
     private static final int /* UHangulSyllableType */ gcbToHst[]={
         HangulSyllableType.NOT_APPLICABLE,   /* U_GCB_OTHER */
@@ -809,6 +813,12 @@ public final class UCharacterProperty
         new IntProperty(SRC_PROPSVEC) {  // HANGUL_SYLLABLE_TYPE
             @Override
             int getValue(int c) {
+                // Ignore supplementary code points: They all have HST=NA.
+                // This is a simple way to handle the GCB!=hst cases since Unicode 16
+                // (Kirat Rai vowels).
+                if(c>0xffff) {
+                    return HangulSyllableType.NOT_APPLICABLE;
+                }
                 /* see comments on gcbToHst[] above */
                 int gcb=(getAdditional(c, 2)&GCB_MASK)>>>GCB_SHIFT;
                 if(gcb<gcbToHst.length) {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UCharacterTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UCharacterTest.java
@@ -2109,6 +2109,10 @@ public final class UCharacterTest extends CoreTestFmwk
 
             { 0xd7a4, UProperty.HANGUL_SYLLABLE_TYPE, 0 },
 
+            // GCB=V but hst=NA (exception to GCB=hst for relevant values)
+            { 0x16D67, UProperty.HANGUL_SYLLABLE_TYPE, UCharacter.HangulSyllableType.NOT_APPLICABLE },
+            { 0x16D6A, UProperty.HANGUL_SYLLABLE_TYPE, UCharacter.HangulSyllableType.NOT_APPLICABLE },
+
             { -1, 0x410, 0 }, /* version break for Unicode 4.1 */
 
             { 0x00d7, UProperty.PATTERN_SYNTAX, 1 },


### PR DESCRIPTION
ICU does not store separate data for the Hangul_Syllable_Type property. This property has been a fully redundant subset of the Grapheme_Cluster_Break, and is therefore trivially derived at runtime.

However, starting with Unicode 16, there are a few characters (initially: some Kirat Rai vowel signs) that have nothing to do with Hangul but have GCB=V in order to make grapheme clusters work for their script.

This PR adds some spot checks and a simple derivation fix.

See the "Segmentation Issues" in https://www.unicode.org/versions/beta-16.0.0.html, and https://www.unicode.org/reports/tr29/tr29-44.html#Modifications

FYI: I thought about testing the ICU implementation against ppucd.txt, but that file does not contain hst data either: We don't currently parse HangulSyllableType.txt at all.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22707
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable