### PR TITLE
ICU-22798 Avoid stack overflow by return error.

### DIFF
--- a/icu4c/source/common/messagepattern.cpp
+++ b/icu4c/source/common/messagepattern.cpp
@@ -437,7 +437,7 @@ MessagePattern::parseMessage(int32_t index, int32_t msgStartLength,
     if(U_FAILURE(errorCode)) {
         return 0;
     }
-    if(nestingLevel>Part::MAX_VALUE) {
+    if(nestingLevel>Part::MAX_NESTED_LEVELS) {
         errorCode=U_INDEX_OUTOFBOUNDS_ERROR;
         return 0;
     }

--- a/icu4c/source/common/unicode/messagepattern.h
+++ b/icu4c/source/common/unicode/messagepattern.h
@@ -821,6 +821,7 @@ public:
 
         static const int32_t MAX_LENGTH=0xffff;
         static const int32_t MAX_VALUE=0x7fff;
+        static const int32_t MAX_NESTED_LEVELS=0x03ff;
 
         // Some fields are not final because they are modified during pattern parsing.
         // After pattern parsing, the parts are effectively immutable.

--- a/icu4c/source/test/intltest/msfmrgts.cpp
+++ b/icu4c/source/test/intltest/msfmrgts.cpp
@@ -54,6 +54,7 @@ MessageFormatRegressionTest::runIndexedTest( int32_t index, UBool exec, const ch
     TESTCASE_AUTO(TestChoicePatternQuote);
     TESTCASE_AUTO(Test4112104);
     TESTCASE_AUTO(TestICU12584);
+    TESTCASE_AUTO(TestICU22798);
     TESTCASE_AUTO(TestAPI);
     TESTCASE_AUTO_END;
 }
@@ -1012,6 +1013,23 @@ void MessageFormatRegressionTest::TestICU12584() {
     count = 0;
     inner_msg.getFormats(count);
     assertEquals("Inner placeholder match", 3, count);
+}
+void MessageFormatRegressionTest::TestICU22798() {
+    // Test deep nested choice will not cause stack overflow but return error
+    // instead.
+    UErrorCode status = U_ZERO_ERROR;
+    UnicodeString pattern;
+    constexpr static int testNestedLevel = 30000;
+    for (int i = 0; i < testNestedLevel; i++) {
+      pattern += u"A{0,choice,0#";
+    }
+    pattern += u"text";
+    for (int i = 0; i < testNestedLevel; i++) {
+      pattern += u"}a";
+    }
+    MessageFormat msg(pattern, status);
+    assertEquals("Deep nested choice should cause error but not crash",
+                 U_INDEX_OUTOFBOUNDS_ERROR, status);
 }
 
 void MessageFormatRegressionTest::TestAPI() {

--- a/icu4c/source/test/intltest/msfmrgts.h
+++ b/icu4c/source/test/intltest/msfmrgts.h
@@ -46,6 +46,7 @@ public:
     void TestChoicePatternQuote();
     void Test4112104();
     void TestICU12584();
+    void TestICU22798();
     void TestAPI();
 
 protected:


### PR DESCRIPTION
Change the nested level limit from 0x7fff to 0x0fff since the fuzzer found in some machine 6400 level deep already cause stack overflow.

<!--
Thank you for your pull request!

* General info on contributing: please see https://github.com/unicode-org/icu/blob/main/CONTRIBUTING.md
* Ticket numbers for minor changes: for minor changes (ex: docs typos), you can reuse one of the open catch-all tickets for our next release
  - ICU 76 ticket: docs minor fixes: typos/etc./version updates / User Guide & API docs: ICU-22722
  - ICU 76 ticket: code warnings/version updates: ICU-22721
* Contributors license agreement (CLA): 
  You will be automatically asked to sign the CLA before the PR is accepted.
  To sign the CLA: https://cla-assistant.io/unicode-org/icu

  For terms of use and license, see https://www.unicode.org/terms_of_use.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22798
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
