### PR TITLE
ICU-22800 Avoid inconsistent state inside Locale

### DIFF
--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -1869,11 +1869,11 @@ Locale& Locale::init(const char* localeID, UBool canonicalize)
         if(err == U_BUFFER_OVERFLOW_ERROR || length >= (int32_t)sizeof(fullNameBuffer)) {
             U_ASSERT(baseName == nullptr);
             /*Go to heap for the fullName if necessary*/
-            fullName = (char *)uprv_malloc(sizeof(char)*(length + 1));
-            if (fullName == nullptr) {
-                fullName = fullNameBuffer;
+            char* newFullName = (char *)uprv_malloc(sizeof(char)*(length + 1));
+            if (newFullName == nullptr) {
                 break; // error: out of memory
             }
+            fullName = newFullName;
             err = U_ZERO_ERROR;
             length = canonicalize ?
                 uloc_canonicalize(localeID, fullName, length+1, &err) :
@@ -1992,11 +1992,12 @@ Locale::initBaseName(UErrorCode &status) {
     if (atPtr && eqPtr && atPtr < eqPtr) {
         // Key words exist.
         int32_t baseNameLength = (int32_t)(atPtr - fullName);
-        baseName = (char *)uprv_malloc(baseNameLength + 1);
-        if (baseName == nullptr) {
+        char* newBaseName = (char *)uprv_malloc(baseNameLength + 1);
+        if (newBaseName == nullptr) {
             status = U_MEMORY_ALLOCATION_ERROR;
             return;
         }
+        baseName = newBaseName;
         uprv_strncpy(baseName, fullName, baseNameLength);
         baseName[baseNameLength] = 0;
 


### PR DESCRIPTION
There are some memory leak in Locale which is hard to figure out why. Use different variable to track memory allocation to avoid inconsistent state while malloc fail

<!--
Thank you for your pull request!

* General info on contributing: please see https://github.com/unicode-org/icu/blob/main/CONTRIBUTING.md
* Ticket numbers for minor changes: for minor changes (ex: docs typos), you can reuse one of the open catch-all tickets for our next release
  - ICU 76 ticket: docs minor fixes: typos/etc./version updates / User Guide & API docs: ICU-22722
  - ICU 76 ticket: code warnings/version updates: ICU-22721
* Contributors license agreement (CLA): 
  You will be automatically asked to sign the CLA before the PR is accepted.
  To sign the CLA: https://cla-assistant.io/unicode-org/icu

  For terms of use and license, see https://www.unicode.org/terms_of_use.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22800
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
