### PR TITLE
ICU-22721 Update filtration_test for Python 3.13

### DIFF
--- a/icu4c/source/python/icutools/databuilder/test/filtration_test.py
+++ b/icu4c/source/python/icutools/databuilder/test/filtration_test.py
@@ -418,4 +418,4 @@ class FiltrationTest(unittest.TestCase):
             self.assertEqual(is_match, expected_match, file_stem)
 
 # Export the test for the runner
-suite = unittest.makeSuite(FiltrationTest)
+suite = unittest.defaultTestLoader.loadTestsFromTestCase(FiltrationTest)


### PR DESCRIPTION
`unittest.makeSuite()` was deprecated in Python 3.11 and removed in 3.13: https://docs.python.org/3.13/whatsnew/3.13.html#unittest

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22721
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
