### PR TITLE
ICU-22716 Set smaller timeout limit for uregex_match_fuzzer

### DIFF
--- a/icu4c/source/test/fuzzer/uregex_match_fuzzer.cpp
+++ b/icu4c/source/test/fuzzer/uregex_match_fuzzer.cpp
@@ -29,7 +29,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   }
   std::unique_ptr<icu::RegexMatcher> regex_matcher(re->matcher(haystack, status));
   if (U_SUCCESS(status)) {
-    regex_matcher->setTimeLimit(3000, status);
+    regex_matcher->setTimeLimit(300, status);
     regex_matcher->find(0, status);
   }
   return 0;


### PR DESCRIPTION
3000 is still too large and cause https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=69869 set to 300 per andy's earlier suggestion

<!--
Thank you for your pull request!

* General info on contributing: please see https://github.com/unicode-org/icu/blob/main/CONTRIBUTING.md
* Ticket numbers for minor changes: for minor changes (ex: docs typos), you can reuse one of the open catch-all tickets for our next release
  - ICU 76 ticket: docs minor fixes: typos/etc./version updates / User Guide & API docs: ICU-22722
  - ICU 76 ticket: code warnings/version updates: ICU-22721
* Contributors license agreement (CLA): 
  You will be automatically asked to sign the CLA before the PR is accepted.
  To sign the CLA: https://cla-assistant.io/unicode-org/icu

  For terms of use and license, see https://www.unicode.org/terms_of_use.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22716
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
