### PR TITLE
ICU-22807 Fix for missing __STDC_FORMAT_MACROS before inttypes.h

### DIFF
--- a/icu4c/source/i18n/messageformat2_function_registry.cpp
+++ b/icu4c/source/i18n/messageformat2_function_registry.cpp
@@ -19,6 +19,13 @@
 #include "number_types.h"
 #include "uvector.h" // U_ASSERT
 
+// The C99 standard suggested that C++ implementations not define PRId64 etc. constants
+// unless this macro is defined.
+// See the Notes at https://en.cppreference.com/w/cpp/types/integer .
+// Similar to defining __STDC_LIMIT_MACROS in unicode/ptypes.h .
+#ifndef __STDC_FORMAT_MACROS
+#   define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h>
 #include <math.h>
 


### PR DESCRIPTION
This is a trivial fix for the issue which we have already addressed earlier. But now another instance of the same has to be fixed. See:
https://unicode-org.atlassian.net/browse/ICU-22807

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22807
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
