### PR TITLE
ICU-22721 Add workflow that enforces required checks

### DIFF
--- a/.github/workflows/wait-for-checks.yml
+++ b/.github/workflows/wait-for-checks.yml
@@ -1,0 +1,38 @@
+# Copyright (C) 2016 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
+#
+# GitHub Actions workflow to ensure all required checks pass when they are attempted.
+# In other words, many checks are conditionally run, so use this workflow as a workaround
+# to a limitation in Github Actions in how required checks are enforced. Instead of 
+# Github's naive behavior currently, this workflow only asserts that status=passing on
+# checks when they are run.
+
+name: Wait for Required Checks
+
+on:
+  push:
+    branches:
+      - main
+      - 'maint/maint*'
+  pull_request:
+    branches: '**'
+
+jobs:
+  enforce-all-checks:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+    steps:
+    - name: Wait for Triggered Required GH Checks
+      uses: poseidon/wait-for-status-checks@6988432d64ad3f9c2608db4ca16fded1b7d36ead # v0.5.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        # This is one large regex. The GHA parser for the YAML `>-` operator doesn't work as advertised,
+        # so instead, this next best thing is to write out the regex pattern string directly
+        match_pattern: "license.*|jira-ticket|single-commit|CI-ICU4J|CI-ICU4C|Test build of User Guide docs|copyright-scan|valid-UTF-8-and-no-BOM-check|icu4j-.*|icu4c-.*|gcc-.*|clang-.*|run-with-stubdata|u-.*|lstm-test|adaboost-test|testmap|internal-header-compilation|valid-UTF-8-and-no-BOM-check|uconfig-unit-tests.*|unicode-update-tools|lstm-icu4j.*|adaboost-icu4j.*|env-test.*"
+        # For Azure Pipelines, each pipeline displays a check that represents the complete success of the pipeline.
+        # It won't pass until all of the pipeline's checks pass.
+        # For the ICU4J and ICU4C pipelines, this is called `CI-ICU4J` and `CI-ICU4C`.
+        # These checks will return a "neutral" status, which this GH Action interprets as a failure.
+        # Since the jobs are superfluous, they can be ignored.
+        ignore: "CI-ICU4C,CI-ICU4J"

--- a/docs/userguide/dev/ci.md
+++ b/docs/userguide/dev/ci.md
@@ -52,7 +52,19 @@ Individual tests can be configured in the ICU Github repository:
 4. Choose one of the rule sets and click "Edit".  ***Note: all rule sets should be changed in the same way***
 5. Ensure that "Require status checks to pass before merging" is enabled
 6. Underneath that enabled checkbox, the table "Status checks that are required." lists the currently enabled tests ("checks") that must pass before a Pull Request can be merged to the branch
-7. If a new test (check) needs to be added, use the search box above the table and type the display name of the check, then click on it in the drop down list to add it to the table of required checks.
+7. Set the only required check to be `enforce-all-checks`.
+    - The [`wait-for-checks` Github Action](https://github.com/marketplace/actions/wait-for-checks)
+    correctly enforces that all of checks of interest are passing,
+    while only inspecting activated checks
+    (ignoring checks that are inactive or skipped due to conditional triggering).
+    - See the `enforce-all-checks` job of the `.github/workflows/wait-for-checks.yml` workflow for usage details.
+    - For background info, see [this discussion](https://github.com/orgs/community/discussions/13690) for an explanation of the shortcoming in Github Actions currently that prompts the need for this solution.
+8. If a new test (check) needs to be added, then update the regular expression in the `enforce-all-checks` job of the `.github/workflows/wait-for-checks.yml` workflow so that it will match on the name of the new check.
+    - For checks defined in Github Actions,
+    the name of the check is the name of the job.
+    In GHA workflows, if the job name is not explicitly overridden,
+    then the name falls back to the job identifier as written in the workflow file.
+
 
 
 ## Github Actions


### PR DESCRIPTION
This PR gives instructions and a workflow so that ICU can reestablish all of the CI checks as being required while still retaining the new workflow structure that optimizes time by conditionally executing workflows based on affected file paths.

Examples: I tested this in my fork and saw the new GHA workflow work as advertised. Workflow [instance 1 log](https://github.com/echeran/icu/actions/runs/9720753145/job/26832555994?pr=66), [instance 2 log](https://github.com/echeran/icu/actions/runs/9720943698/job/26833014842?pr=66).

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22721
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [X] API docs and/or User Guide docs changed or added, if applicable
