### PR TITLE
ICU-22832 Fix msan complain about use-of-uninitialized-value

### DIFF
--- a/icu4c/source/common/ustrcase.cpp
+++ b/icu4c/source/common/ustrcase.cpp
@@ -272,7 +272,7 @@ int32_t toLower(int32_t caseLocale, uint32_t options,
         } else {
             c = lead;
         }
-        const char16_t *s;
+        const char16_t *s = nullptr;
         if (caseLocale >= 0) {
             csc->cpStart = cpStart;
             csc->cpLimit = srcIndex;
@@ -369,7 +369,7 @@ int32_t toUpper(int32_t caseLocale, uint32_t options,
             c = lead;
         }
         csc->cpLimit = srcIndex;
-        const char16_t *s;
+        const char16_t *s = nullptr;
         c = ucase_toFullUpper(c, utf16_caseContextIterator, csc, &s, caseLocale);
         if (c >= 0) {
             destIndex = appendUnchanged(dest, destIndex, destCapacity,
@@ -579,8 +579,8 @@ ustrcase_internalToTitle(int32_t caseLocale, uint32_t options, BreakIterator *it
                     }
 
                     if (c == u'I' || c == u'Í') {
-                        titleLimit = maybeTitleDutchIJ(src, c, titleStart + 1, index, 
-                                                       dest, destIndex, destCapacity, options, 
+                        titleLimit = maybeTitleDutchIJ(src, c, titleStart + 1, index,
+                                                       dest, destIndex, destCapacity, options,
                                                        edits);
                     }
                 }


### PR DESCRIPTION
Detail: https://s3.amazonaws.com/clickhouse-test-reports/65761/a273def46e478e465af2078a72dd49ae3a685fb5/ast_fuzzer__msan_.html
It was found in https://github.com/ClickHouse/ClickHouse/pull/65761  


```
==27703==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x55d4727bd32e in icu_70::(anonymous namespace)::toLower(int, unsigned int, char16_t*, int, char16_t const*, UCaseContext*, int, int, icu_70::Edits*, UErrorCode&) build_gcc/./contrib/icu/icu4c/source/common/ustrcase.cpp:281:29
    #1 0x55d4727be315 in ustrcase_internalToLower_70 build_gcc/./contrib/icu/icu4c/source/common/ustrcase.cpp:1179:25
    #2 0x55d4727bf77d in icu_70::UnicodeString::caseMap(int, unsigned int, icu_70::BreakIterator*, int (*)(int, unsigned int, icu_70::BreakIterator*, char16_t*, int, char16_t const*, int, icu_70::Edits*, UErrorCode&)) build_gcc/./contrib/icu/icu4c/source/common/unistr_case.cpp:139:17
    #3 0x55d4727bbf64 in icu_70::UnicodeString::toLower() build_gcc/./contrib/icu/icu4c/source/common/unistr_case_locale.cpp:34:10
    #4 0x55d44d9a9bea in DB::LowerUpperUTF8Impl<(char)65, (char)90, false>::vector(DB::PODArray<char8_t, 4096ul, Allocator<false, false>, 63ul, 64ul> const&, DB::PODArray<unsigned long, 4096ul, Allocator<false, false>, 63ul, 64ul> const&, DB::PODArray<char8_t, 4096ul, Allocator<false, false>, 63ul, 64ul>&, DB::PODArray<unsigned long, 4096ul, Allocator<false, false>, 63ul, 64ul>&) (/data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse+0x148aabea) (BuildId: 8076648b6f8ae32721eeefa3fe7c225da1e262e9)
    #5 0x55d44d9a8765 in DB::FunctionStringToString<DB::LowerUpperUTF8Impl<(char)65, (char)90, false>, DB::(anonymous namespace)::NameLowerUTF8, false>::executeImpl(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long) const lowerUTF8.cpp
    #6 0x55d43fde8ac1 in DB::IFunction::executeImplDryRun(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long) const (/data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse+0x6ce9ac1) (BuildId: 8076648b6f8ae32721eeefa3fe7c225da1e262e9)
    #7 0x55d43fe3ca5a in DB::FunctionToExecutableFunctionAdaptor::executeDryRunImpl(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long) const (/data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse+0x6d3da5a) (BuildId: 8076648b6f8ae32721eeefa3fe7c225da1e262e9)
    #8 0x55d44310ec30 in DB::IExecutableFunction::executeWithoutLowCardinalityColumns(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const (/data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse+0xa00fc30) (BuildId: 8076648b6f8ae32721eeefa3fe7c225da1e262e9)
    #9 0x55d44310d987 in DB::IExecutableFunction::defaultImplementationForConstantArguments(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const (/data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse+0xa00e987) (BuildId: 8076648b6f8ae32721eeefa3fe7c225da1e262e9)
    #10 0x55d44310eb0e in DB::IExecutableFunction::executeWithoutLowCardinalityColumns(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const (/data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse+0xa00fb0e) (BuildId: 8076648b6f8ae32721eeefa3fe7c225da1e262e9)
    #11 0x55d443110bfe in DB::IExecutableFunction::executeWithoutSparseColumns(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const (/data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse+0xa011bfe) (BuildId: 8076648b6f8ae32721eeefa3fe7c225da1e262e9)
    #12 0x55d443116a61 in DB::IExecutableFunction::execute(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const (/data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse+0xa017a61) (BuildId: 8076648b6f8ae32721eeefa3fe7c225da1e262e9)
    #13 0x55d46a67f66e in DB::QueryAnalyzer::resolveFunction(std::__1::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&) build_gcc/./src/Analyzer/Resolve/QueryAnalyzer.cpp:3430:47
    #14 0x55d46a620499 in DB::QueryAnalyzer::resolveExpressionNode(std::__1::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&, bool, bool, bool) build_gcc/./src/Analyzer/Resolve/QueryAnalyzer.cpp:3730:46
    #15 0x55d46a61d6d0 in DB::QueryAnalyzer::resolveExpressionNodeList(std::__1::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&, bool, bool) build_gcc/./src/Analyzer/Resolve/QueryAnalyzer.cpp:3884:49
    #16 0x55d46a66c474 in DB::QueryAnalyzer::resolveFunction(std::__1::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&) build_gcc/./src/Analyzer/Resolve/QueryAnalyzer.cpp:2799:39
    #17 0x55d46a620499 in DB::QueryAnalyzer::resolveExpressionNode(std::__1::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&, bool, bool, bool) build_gcc/./src/Analyzer/Resolve/QueryAnalyzer.cpp:3730:46
    #18 0x55d46a61d6d0 in DB::QueryAnalyzer::resolveExpressionNodeList(std::__1::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&, bool, bool) build_gcc/./src/Analyzer/Resolve/QueryAnalyzer.cpp:3884:49
    #19 0x55d46a6b547f in DB::QueryAnalyzer::resolveProjectionExpressionNodeList(std::__1::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&) build_gcc/./src/Analyzer/Resolve/QueryAnalyzer.cpp:4139:40
    #20 0x55d46a608241 in DB::QueryAnalyzer::resolveQuery(std::__1::shared_ptr<DB::IQueryTreeNode> const&, DB::IdentifierResolveScope&) build_gcc/./src/Analyzer/Resolve/QueryAnalyzer.cpp:5393:30
    #21 0x55d46a604cc5 in DB::QueryAnalyzer::resolve(std::__1::shared_ptr<DB::IQueryTreeNode>&, std::__1::shared_ptr<DB::IQueryTreeNode> const&, std::__1::shared_ptr<DB::Context const>) build_gcc/./src/Analyzer/Resolve/QueryAnalyzer.cpp:135:13
    #22 0x55d46a6030ce in DB::QueryAnalysisPass::run(std::__1::shared_ptr<DB::IQueryTreeNode>&, std::__1::shared_ptr<DB::Context const>) build_gcc/./src/Analyzer/Resolve/QueryAnalysisPass.cpp:18:14
    #23 0x55d46a5f0cd8 in DB::QueryTreePassManager::run(std::__1::shared_ptr<DB::IQueryTreeNode>) build_gcc/./src/Analyzer/QueryTreePassManager.cpp:185:20
    #24 0x55d46ab4a1c3 in DB::(anonymous namespace)::buildQueryTreeAndRunPasses(std::__1::shared_ptr<DB::IAST> const&, DB::SelectQueryOptions const&, std::__1::shared_ptr<DB::Context const> const&, std::__1::shared_ptr<DB::IStorage> const&) build_gcc/./src/Interpreters/InterpreterSelectQueryAnalyzer.cpp:142:33
    #25 0x55d46ab4180d in DB::InterpreterSelectQueryAnalyzer::InterpreterSelectQueryAnalyzer(std::__1::shared_ptr<DB::IAST> const&, std::__1::shared_ptr<DB::Context const> const&, DB::SelectQueryOptions const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&) build_gcc/./src/Interpreters/InterpreterSelectQueryAnalyzer.cpp:160:18
    #26 0x55d46ab4d014 in std::__1::__unique_if<DB::InterpreterSelectQueryAnalyzer>::__unique_single std::__1::make_unique[abi:v15007]<DB::InterpreterSelectQueryAnalyzer, std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::Context> const&, DB::SelectQueryOptions const&>(std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::Context> const&, DB::SelectQueryOptions const&) build_gcc/./contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:714:32
    #27 0x55d46ab4c792 in DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0::operator()(DB::InterpreterFactory::Arguments const&) const build_gcc/./src/Interpreters/InterpreterSelectQueryAnalyzer.cpp:270:16
    #28 0x55d46ab4c792 in decltype(std::declval<DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0&>()(std::declval<DB::InterpreterFactory::Arguments const&>())) std::__1::__invoke[abi:v15007]<DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0&, DB::InterpreterFactory::Arguments const&>(DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0&, DB::InterpreterFactory::Arguments const&) build_gcc/./contrib/llvm-project/libcxx/include/__functional/invoke.h:394:23
    #29 0x55d46ab4c792 in std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>> std::__1::__invoke_void_return_wrapper<std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>>, false>::__call<DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0&, DB::InterpreterFactory::Arguments const&>(DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0&, DB::InterpreterFactory::Arguments const&) build_gcc/./contrib/llvm-project/libcxx/include/__functional/invoke.h:470:16
    #30 0x55d46ab4c792 in std::__1::__function::__default_alloc_func<DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0, std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>> (DB::InterpreterFactory::Arguments const&)>::operator()[abi:v15007](DB::InterpreterFactory::Arguments const&) build_gcc/./contrib/llvm-project/libcxx/include/__functional/function.h:235:12
    #31 0x55d46ab4c792 in std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>> std::__1::__function::__policy_invoker<std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>> (DB::InterpreterFactory::Arguments const&)>::__call_impl<std::__1::__function::__default_alloc_func<DB::registerInterpreterSelectQueryAnalyzer(DB::InterpreterFactory&)::$_0, std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>> (DB::InterpreterFactory::Arguments const&)>>(std::__1::__function::__policy_storage const*, DB::InterpreterFactory::Arguments const&) build_gcc/./contrib/llvm-project/libcxx/include/__functional/function.h:716:16
    #32 0x55d46a9b90e4 in std::__1::__function::__policy_func<std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>> (DB::InterpreterFactory::Arguments const&)>::operator()[abi:v15007](DB::InterpreterFactory::Arguments const&) const build_gcc/./contrib/llvm-project/libcxx/include/__functional/function.h:848:16
    #33 0x55d46a9b90e4 in std::__1::function<std::__1::unique_ptr<DB::IInterpreter, std::__1::default_delete<DB::IInterpreter>> (DB::InterpreterFactory::Arguments const&)>::operator()(DB::InterpreterFactory::Arguments const&) const build_gcc/./contrib/llvm-project/libcxx/include/__functional/function.h:1197:12
    #34 0x55d46a9b90e4 in DB::InterpreterFactory::get(std::__1::shared_ptr<DB::IAST>&, std::__1::shared_ptr<DB::Context>, DB::SelectQueryOptions const&) build_gcc/./src/Interpreters/InterpreterFactory.cpp:355:12
    #35 0x55d46b6b1136 in DB::executeQueryImpl(char const*, char const*, std::__1::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum, DB::ReadBuffer*) build_gcc/./src/Interpreters/executeQuery.cpp:1161:62
    #36 0x55d46b6a61bc in DB::executeQuery(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::shared_ptr<DB::Context>, DB::QueryFlags, DB::QueryProcessingStage::Enum) build_gcc/./src/Interpreters/executeQuery.cpp:1391:26
    #37 0x55d46fd2ddb7 in DB::TCPHandler::runImpl() build_gcc/./src/Server/TCPHandler.cpp:521:54
    #38 0x55d46fd79f90 in DB::TCPHandler::run() build_gcc/./src/Server/TCPHandler.cpp:2363:9
    #39 0x55d47204993f in Poco::Net::TCPServerConnection::start() build_gcc/./base/poco/Net/src/TCPServerConnection.cpp:43:3
    #40 0x55d47204a87f in Poco::Net::TCPServerDispatcher::run() build_gcc/./base/poco/Net/src/TCPServerDispatcher.cpp:115:20
    #41 0x55d471f42394 in Poco::PooledThread::run() build_gcc/./base/poco/Foundation/src/ThreadPool.cpp:205:14
    #42 0x55d471f3ed6d in Poco::(anonymous namespace)::RunnableHolder::run() build_gcc/./base/poco/Foundation/src/Thread.cpp:45:11
    #43 0x55d471f3bc30 in Poco::ThreadImpl::runnableEntry(void*) build_gcc/./base/poco/Foundation/src/Thread_POSIX.cpp:335:27
    #44 0x7f02d038b608 in start_thread /build/glibc-eX1tMB/glibc-2.31/nptl/pthread_create.c:477:8
    #45 0x7f02d02b2292 in __clone /build/glibc-eX1tMB/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95

  Uninitialized value was stored to memory at
    #0 0x55d4727bd327 in icu_70::(anonymous namespace)::toLower(int, unsigned int, char16_t*, int, char16_t const*, UCaseContext*, int, int, icu_70::Edits*, UErrorCode&) build_gcc/./contrib/icu/icu4c/source/common/ustrcase.cpp:281:76
    #1 0x55d4727be315 in ustrcase_internalToLower_70 build_gcc/./contrib/icu/icu4c/source/common/ustrcase.cpp:1179:25
    #2 0x55d4727bf77d in icu_70::UnicodeString::caseMap(int, unsigned int, icu_70::BreakIterator*, int (*)(int, unsigned int, icu_70::BreakIterator*, char16_t*, int, char16_t const*, int, icu_70::Edits*, UErrorCode&)) build_gcc/./contrib/icu/icu4c/source/common/unistr_case.cpp:139:17
    #3 0x55d4727bbf64 in icu_70::UnicodeString::toLower() build_gcc/./contrib/icu/icu4c/source/common/unistr_case_locale.cpp:34:10
    #4 0x55d44d9a9bea in DB::LowerUpperUTF8Impl<(char)65, (char)90, false>::vector(DB::PODArray<char8_t, 4096ul, Allocator<false, false>, 63ul, 64ul> const&, DB::PODArray<unsigned long, 4096ul, Allocator<false, false>, 63ul, 64ul> const&, DB::PODArray<char8_t, 4096ul, Allocator<false, false>, 63ul, 64ul>&, DB::PODArray<unsigned long, 4096ul, Allocator<false, false>, 63ul, 64ul>&) (/data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse+0x148aabea) (BuildId: 8076648b6f8ae32721eeefa3fe7c225da1e262e9)
    #5 0x55d44d9a8765 in DB::FunctionStringToString<DB::LowerUpperUTF8Impl<(char)65, (char)90, false>, DB::(anonymous namespace)::NameLowerUTF8, false>::executeImpl(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long) const lowerUTF8.cpp
    #6 0x55d43fde8ac1 in DB::IFunction::executeImplDryRun(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long) const (/data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse+0x6ce9ac1) (BuildId: 8076648b6f8ae32721eeefa3fe7c225da1e262e9)
    #7 0x55d43fe3ca5a in DB::FunctionToExecutableFunctionAdaptor::executeDryRunImpl(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long) const (/data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse+0x6d3da5a) (BuildId: 8076648b6f8ae32721eeefa3fe7c225da1e262e9)
    #8 0x55d44310ec30 in DB::IExecutableFunction::executeWithoutLowCardinalityColumns(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const (/data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse+0xa00fc30) (BuildId: 8076648b6f8ae32721eeefa3fe7c225da1e262e9)
    #9 0x55d44310d987 in DB::IExecutableFunction::defaultImplementationForConstantArguments(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const (/data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse+0xa00e987) (BuildId: 8076648b6f8ae32721eeefa3fe7c225da1e262e9)
    #10 0x55d44310eb0e in DB::IExecutableFunction::executeWithoutLowCardinalityColumns(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const (/data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse+0xa00fb0e) (BuildId: 8076648b6f8ae32721eeefa3fe7c225da1e262e9)
    #11 0x55d443110bfe in DB::IExecutableFunction::executeWithoutSparseColumns(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const (/data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse+0xa011bfe) (BuildId: 8076648b6f8ae32721eeefa3fe7c225da1e262e9)
    #12 0x55d443116a61 in DB::IExecutableFunction::execute(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const (/data1/liyang/cppproject/OfficialClickhouse/clickhouse/build_gcc/programs/clickhouse+0xa017a61) (BuildId: 8076648b6f8ae32721eeefa3fe7c225da1e262e9)
    #13 0x55d46a67f66e in DB::QueryAnalyzer::resolveFunction(std::__1::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&) build_gcc/./src/Analyzer/Resolve/QueryAnalyzer.cpp:3430:47
    #14 0x55d46a620499 in DB::QueryAnalyzer::resolveExpressionNode(std::__1::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&, bool, bool, bool) build_gcc/./src/Analyzer/Resolve/QueryAnalyzer.cpp:3730:46
    #15 0x55d46a61d6d0 in DB::QueryAnalyzer::resolveExpressionNodeList(std::__1::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&, bool, bool) build_gcc/./src/Analyzer/Resolve/QueryAnalyzer.cpp:3884:49
    #16 0x55d46a66c474 in DB::QueryAnalyzer::resolveFunction(std::__1::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&) build_gcc/./src/Analyzer/Resolve/QueryAnalyzer.cpp:2799:39
    #17 0x55d46a620499 in DB::QueryAnalyzer::resolveExpressionNode(std::__1::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&, bool, bool, bool) build_gcc/./src/Analyzer/Resolve/QueryAnalyzer.cpp:3730:46
    #18 0x55d46a61d6d0 in DB::QueryAnalyzer::resolveExpressionNodeList(std::__1::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&, bool, bool) build_gcc/./src/Analyzer/Resolve/QueryAnalyzer.cpp:3884:49
    #19 0x55d46a6b547f in DB::QueryAnalyzer::resolveProjectionExpressionNodeList(std::__1::shared_ptr<DB::IQueryTreeNode>&, DB::IdentifierResolveScope&) build_gcc/./src/Analyzer/Resolve/QueryAnalyzer.cpp:4139:40

  Uninitialized value was created by an allocation of 's' in the stack frame
    #0 0x55d4727bd022 in icu_70::(anonymous namespace)::toLower(int, unsigned int, char16_t*, int, char16_t const*, UCaseContext*, int, int, icu_70::Edits*, UErrorCode&) build_gcc/./contrib/icu/icu4c/source/common/ustrcase.cpp:269:9

SUMMARY: MemorySanitizer: use-of-uninitialized-value build_gcc/./contrib/icu/icu4c/source/common/ustrcase.cpp:281:29 in icu_70::(anonymous namespace)::toLower(int, unsigned int, char16_t*, int, char16_t const*, UCaseContext*, int, int, icu_70::Edits*, UErrorCode&)
```


