### PR TITLE
ICU-22696 Add implicit conversion from StringPiece to std::string_view

### DIFF
--- a/icu4c/source/common/unicode/stringpiece.h
+++ b/icu4c/source/common/unicode/stringpiece.h
@@ -32,6 +32,7 @@
 #if U_SHOW_CPLUSPLUS_API
 
 #include <cstddef>
+#include <string_view>
 #include <type_traits>
 
 #include "unicode/uobject.h"
@@ -175,6 +176,16 @@ class U_COMMON_API StringPiece : public UMemory {
    * @stable ICU 4.2
    */
   StringPiece(const StringPiece& x, int32_t pos, int32_t len);
+
+#ifndef U_HIDE_INTERNAL_API
+  /**
+   * Converts to a std::string_view().
+   * @internal
+   */
+  inline operator std::string_view() const {
+    return {data(), static_cast<std::string_view::size_type>(size())};
+  }
+#endif  // U_HIDE_INTERNAL_API
 
   /**
    * Returns the string pointer. May be nullptr if it is empty.

--- a/icu4c/source/test/intltest/strtest.cpp
+++ b/icu4c/source/test/intltest/strtest.cpp
@@ -516,6 +516,11 @@ StringTest::TestStringPieceStringView() {
 
     assertEquals("size()", piece.size(), view.size());
     assertEquals("data()", piece.data(), view.data());
+
+    std::string_view v2 = piece;  // Internal implicit conversion.
+
+    assertEquals("size()", piece.size(), v2.size());
+    assertEquals("data()", piece.data(), v2.data());
 }
 
 void


### PR DESCRIPTION
This will allow ICU4C to seamlessly use `std::string_view` internally while continuing to use `StringPiece` in the public API.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22696
- [x] Required: The PR title must be prefixed with a JIRA Issue number.
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number.
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
