### PR TITLE
ICU-22830 Fix memLeak in numrange_fluent.cpp

### DIFF
--- a/icu4c/source/i18n/numrange_fluent.cpp
+++ b/icu4c/source/i18n/numrange_fluent.cpp
@@ -313,9 +313,8 @@ FormattedNumberRange LocalizedNumberRangeFormatter::formatFormattableRange(
         return FormattedNumberRange(U_ILLEGAL_ARGUMENT_ERROR);
     }
 
-    auto* results = new UFormattedNumberRangeData();
-    if (results == nullptr) {
-        status = U_MEMORY_ALLOCATION_ERROR;
+    LocalPointer<UFormattedNumberRangeData> results(new UFormattedNumberRangeData(), status);
+    if (U_FAILURE(status)) {
         return FormattedNumberRange(status);
     }
 
@@ -333,9 +332,8 @@ FormattedNumberRange LocalizedNumberRangeFormatter::formatFormattableRange(
 
     // Do not save the results object if we encountered a failure.
     if (U_SUCCESS(status)) {
-        return FormattedNumberRange(results);
+        return FormattedNumberRange(results.orphan());
     } else {
-        delete results;
         return FormattedNumberRange(status);
     }
 }
@@ -373,13 +371,8 @@ LocalizedNumberRangeFormatter::getFormatter(UErrorCode& status) const {
     }
 
     // Try computing the formatter on our own
-    auto* temp = new NumberRangeFormatterImpl(fMacros, status);
+    LocalPointer<NumberRangeFormatterImpl> temp(new NumberRangeFormatterImpl(fMacros, status), status);
     if (U_FAILURE(status)) {
-        delete temp;
-        return nullptr;
-    }
-    if (temp == nullptr) {
-        status = U_MEMORY_ALLOCATION_ERROR;
         return nullptr;
     }
 
@@ -387,13 +380,12 @@ LocalizedNumberRangeFormatter::getFormatter(UErrorCode& status) const {
     // it is set to what is actually stored in the atomic
     // if another thread beat us to computing the formatter object.
     auto* nonConstThis = const_cast<LocalizedNumberRangeFormatter*>(this);
-    if (!nonConstThis->fAtomicFormatter.compare_exchange_strong(ptr, temp)) {
+    if (!nonConstThis->fAtomicFormatter.compare_exchange_strong(ptr, temp.getAlias())) {
         // Another thread beat us to computing the formatter
-        delete temp;
         return ptr;
     } else {
         // Our copy of the formatter got stored in the atomic
-        return temp;
+        return temp.orphan();
     }
 
 }


### PR DESCRIPTION
Maybe related to the leak in ICU-22800

<!--
Thank you for your pull request!

* General info on contributing: please see https://github.com/unicode-org/icu/blob/main/CONTRIBUTING.md
* Ticket numbers for minor changes: for minor changes (ex: docs typos), you can reuse one of the open catch-all tickets for our next release
  - ICU 76 ticket: docs minor fixes: typos/etc./version updates / User Guide & API docs: ICU-22722
  - ICU 76 ticket: code warnings/version updates: ICU-22721
* Contributors license agreement (CLA): 
  You will be automatically asked to sign the CLA before the PR is accepted.
  To sign the CLA: https://cla-assistant.io/unicode-org/icu

  For terms of use and license, see https://www.unicode.org/terms_of_use.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22830
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
