### PR TITLE
ICU-22855: Create combined source distribution when running `make dist` on C++ side

### DIFF
--- a/icu4c/source/config/dist.mk
+++ b/icu4c/source/config/dist.mk
@@ -18,7 +18,7 @@ include $(top_builddir)/icudefs.mk
 DISTY_DIR=dist
 DISTY_TMP=dist/tmp
 DISTY_ICU=$(DISTY_TMP)/icu
-DISTY_DATA=$(DISTY_ICU)/source/data
+DISTY_DATA=$(DISTY_ICU)/icu4c/source/data
 # The following line controls what is removed in the data/ subdirectory for the source tarball.
 DISTY_RMV=brkitr coll curr lang locales mappings rbnf region translit xml zone misc/*.txt misc/*.mk unit
 DISTY_RMDIR=$(DISTY_RMV:%=$(DISTY_DATA)/%)
@@ -65,25 +65,25 @@ $(DISTY_FILE_TGZ) $(DISTY_FILE_ZIP) $(DISTY_DATA_ZIP):  $(DISTY_DAT) $(DISTY_TMP
 	@echo Export icu4c@$(GITVER) to "$(DISTY_TMP)/icu"
 	-$(RMV) $(DISTY_FILE) $(DISTY_TMP)
 	$(MKINSTALLDIRS) $(DISTY_TMP)
-	( cd $(ICU4CTOP)/.. && git archive --format=tar --prefix=icu/ HEAD:icu4c/ ) | ( cd "$(DISTY_TMP)" && tar xf - )
+	( cd $(ICU4CTOP)/.. && git archive --format=tar --prefix=icu/ HEAD -- icu4c/ icu4j/ testdata/ ) | ( cd "$(DISTY_TMP)" && tar xf - )
     # special handling for LICENSE file. The symlinks will be included as files by tar and zip.
-	cp -fv $(ICU4CTOP)/LICENSE "$(DISTY_TMP)/LICENSE"
-    # Copy top-level testdata directory so it's a sibling of the source/ directory
+	cp -fv $(ICU4CTOP)/LICENSE "$(DISTY_ICU)/LICENSE"
+    # Copy top-level testdata directory
 	cp -R $(ICU4CTOP)/../testdata $(DISTY_TMP)/icu
-	( cd $(DISTY_TMP)/icu/source ; zip -rlq $(DISTY_DATA_ZIP) data )
+	( cd $(DISTY_TMP)/icu/icu4c/source ; zip -rlq $(DISTY_DATA_ZIP) data )
 	$(MKINSTALLDIRS) $(DISTY_IN)
 	echo DISTY_DAT=$(DISTY_DAT)
 	cp $(DISTY_DAT) $(DISTY_IN)
 	$(RMV) $(DISTY_RMDIR)
-	( cd $(DISTY_TMP)/icu ; python as_is/bomlist.py > as_is/bomlist.txt || rm -f as_is/bomlist.txt )
+	( cd $(DISTY_TMP)/icu/icu4c ; python as_is/bomlist.py > as_is/bomlist.txt || rm -f as_is/bomlist.txt )
 	( cd $(DISTY_TMP) ; tar cfpzh $(DISTY_FILE_TGZ) icu )
 	( cd $(DISTY_TMP) ; zip -rlq $(DISTY_FILE_ZIP) icu )
 	$(RMV) $(DISTY_TMP)
-	ln -sf $(shell basename $(DISTY_FILE_ZIP)) $(DISTY_FILE_DIR)/icu4c-src.zip
-	ln -sf $(shell basename $(DISTY_FILE_TGZ)) $(DISTY_FILE_DIR)/icu4c-src.tgz
+	ln -sf $(shell basename $(DISTY_FILE_ZIP)) $(DISTY_FILE_DIR)/icu-combined-src.zip
+	ln -sf $(shell basename $(DISTY_FILE_TGZ)) $(DISTY_FILE_DIR)/icu-combined-src.tgz
 	ln -sf $(shell basename $(DISTY_DATA_ZIP)) $(DISTY_FILE_DIR)/icu4c-data.zip
-	ln -f $(DISTY_FILE_ZIP) $(DISTY_FILE_DIR)/icu4c-$(DISTY_VER)-src.zip
-	ln -f $(DISTY_FILE_TGZ) $(DISTY_FILE_DIR)/icu4c-$(DISTY_VER)-src.tgz
+	ln -f $(DISTY_FILE_ZIP) $(DISTY_FILE_DIR)/icu-combined-$(DISTY_VER)-src.zip
+	ln -f $(DISTY_FILE_TGZ) $(DISTY_FILE_DIR)/icu-combined-$(DISTY_VER)-src.tgz
 	ln -f $(DISTY_DATA_ZIP) $(DISTY_FILE_DIR)/icu4c-$(DISTY_VER)-data.zip
 	ls -l $(DISTY_FILE_TGZ) $(DISTY_FILE_ZIP) $(DISTY_DATA_ZIP)
 
@@ -98,4 +98,4 @@ distcheck-tgz: $(DISTY_FILE_TGZ)
 	@echo Checking $(DISTY_FILE_TGZ)
 	@-$(RMV) $(DISTY_CHECK)
 	@$(MKINSTALLDIRS) $(DISTY_CHECK)
-	@(cd $(DISTY_CHECK) && tar xfpz $(DISTY_FILE_TGZ) && cd icu/source && $(SHELL) ./configure $(DISTCHECK_CONFIG_OPTIONS) && $(MAKE) check $(DISTCHECK_MAKE_OPTIONS) ) && (echo "!!! PASS: $(DISTY_FILE_TGZ)" )
+	@(cd $(DISTY_CHECK) && tar xfpz $(DISTY_FILE_TGZ) && cd icu/icu4c/source && $(SHELL) ./configure $(DISTCHECK_CONFIG_OPTIONS) && $(MAKE) check $(DISTCHECK_MAKE_OPTIONS) ) && (echo "!!! PASS: $(DISTY_FILE_TGZ)" )

--- a/icu4c/source/config/dist.mk
+++ b/icu4c/source/config/dist.mk
@@ -65,9 +65,7 @@ $(DISTY_FILE_TGZ) $(DISTY_FILE_ZIP) $(DISTY_DATA_ZIP):  $(DISTY_DAT) $(DISTY_TMP
 	@echo Export icu4c@$(GITVER) to "$(DISTY_TMP)/icu"
 	-$(RMV) $(DISTY_FILE) $(DISTY_TMP)
 	$(MKINSTALLDIRS) $(DISTY_TMP)
-	( cd $(ICU4CTOP)/.. && git archive --format=tar --prefix=icu/ HEAD -- icu4c/ icu4j/ testdata/ ) | ( cd "$(DISTY_TMP)" && tar xf - )
-    # special handling for LICENSE file. The symlinks will be included as files by tar and zip.
-	cp -fv $(ICU4CTOP)/LICENSE "$(DISTY_ICU)/LICENSE"
+	( cd $(ICU4CTOP)/.. && git archive --format=tar --prefix=icu/ HEAD -- LICENSE* README* icu4c/ icu4j/ testdata/ ) | ( cd "$(DISTY_TMP)" && tar xf - )
     # Copy top-level testdata directory
 	cp -R $(ICU4CTOP)/../testdata $(DISTY_TMP)/icu
 	( cd $(DISTY_TMP)/icu/icu4c/source ; zip -rlq $(DISTY_DATA_ZIP) data )

--- a/icu4c/source/test/intltest/intltest.cpp
+++ b/icu4c/source/test/intltest/intltest.cpp
@@ -1694,26 +1694,19 @@ static bool fileExists(const char* fileName) {
  * Returns the path to icu/testdata/
  */
 const char *IntlTest::getSharedTestData(UErrorCode& err) {
-#define SOURCE_TARBALL_TOP U_TOPSRCDIR U_FILE_SEP_STRING ".." U_FILE_SEP_STRING
-#define REPO_TOP SOURCE_TARBALL_TOP ".." U_FILE_SEP_STRING
+#define REPO_TOP U_TOPSRCDIR U_FILE_SEP_STRING ".." U_FILE_SEP_STRING ".." U_FILE_SEP_STRING
 #define FILE_NAME U_FILE_SEP_STRING "message2" U_FILE_SEP_STRING "valid-tests.json"
     const char *srcDataDir = nullptr;
     const char *testFile = nullptr;
     if (U_SUCCESS(err)) {
 #ifdef U_TOPSRCDIR
-        // Try U_TOPSRCDIR/../testdata (source tarball)
-        srcDataDir = SOURCE_TARBALL_TOP "testdata" U_FILE_SEP_STRING;
-        testFile = SOURCE_TARBALL_TOP "testdata" FILE_NAME;
-        if (!fileExists(testFile)) {
-            // If that doesn't exist, try U_TOPSRCDIR/../../testdata (in-repo)
-            srcDataDir = REPO_TOP "testdata" U_FILE_SEP_STRING;
-            testFile = REPO_TOP "testdata" FILE_NAME;
-            if (!fileExists(testFile)) {
-                // If neither exists, return null
-                err = U_FILE_ACCESS_ERROR;
-                srcDataDir = nullptr;
-            }
-        }
+       srcDataDir = REPO_TOP "testdata" U_FILE_SEP_STRING;
+       testFile = REPO_TOP "testdata" FILE_NAME;
+       if (!fileExists(testFile)) {
+           // If neither exists, return null
+           err = U_FILE_ACCESS_ERROR;
+           srcDataDir = nullptr;
+       }
 #else
         // Try ../../../../testdata (if we're in icu/source/test/intltest)
         // and ../../../../../../testdata (if we're in icu/source/test/intltest/Platform/(Debug|Release)


### PR DESCRIPTION
This PR changes `make dist` on the C++ side to create a single combined sources distribution, including icu4c/, icu4j/, and testdata/. It also undoes the change in `intltest.cpp` that looks for the `testdata` directory in multiple locations.

Note: I haven't changed anything on the Java side because I'm not sure what the layout of the .jar file should look like.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22855
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
