### PR TITLE
ICU-22861 std::max deduced conflicting types in unifiedcache.cpp

### DIFF
--- a/icu4c/source/common/unifiedcache.cpp
+++ b/icu4c/source/common/unifiedcache.cpp
@@ -269,7 +269,7 @@ int32_t UnifiedCache::_computeCountOfItemsToEvict() const {
 
     int32_t unusedLimitByPercentage = fNumValuesInUse * fMaxPercentageOfInUse / 100;
     int32_t unusedLimit = std::max(unusedLimitByPercentage, fMaxUnused);
-    int32_t countOfItemsToEvict = std::max(0, evictableItems - unusedLimit);
+    int32_t countOfItemsToEvict = std::max<int32_t>(0, evictableItems - unusedLimit);
     return countOfItemsToEvict;
 }
 


### PR DESCRIPTION
Declare the type 'int32_t' for std::max to fix error: no matching function for call to 'max(int, int32_t)'

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22861
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
