### PR TITLE
ICU-22843 Enable constructing UnicodeString from literal in fixed time

### DIFF
--- a/icu4c/source/common/unicode/unistr.h
+++ b/icu4c/source/common/unicode/unistr.h
@@ -105,13 +105,11 @@ class UnicodeStringAppendable;  // unicode/appendable.h
  * this macro was provided for portability and efficiency when
  * initializing UnicodeStrings from literals.
  *
- * Since C++17 and ICU 76, you can use std::u16string_view literals with compile-time
+ * Since C++17 and ICU 76, you can use UTF-16 string literals with compile-time
  * length determination:
  * \code
- * #include &lt;string_view&gt;
- * using namespace std::string_view_literals;
- * UnicodeString str(u"literal"sv);
- * if (str == u"other literal"sv) { ... }
+ * UnicodeString str(u"literal");
+ * if (str == u"other literal") { ... }
  * \endcode
  *
  * The string parameter must be a C string literal.
@@ -335,13 +333,11 @@ public:
    * which is, or which is implicitly convertible to,
    * a std::u16string_view or (if U_SIZEOF_WCHAR_T==2) std::wstring_view.
    *
-   * For performance, you can use std::u16string_view literals with compile-time
+   * For performance, you can use UTF-16 string literals with compile-time
    * length determination:
    * \code
-   * #include &lt;string_view&gt;
-   * using namespace std::string_view_literals;
    * UnicodeString str = ...;
-   * if (str == u"literal"sv) { ... }
+   * if (str == u"literal") { ... }
    * \endcode
    * @param text The string view to compare to this string.
    * @return true if `text` contains the same characters as this one, false otherwise.
@@ -3080,6 +3076,7 @@ public:
    */
   UNISTR_FROM_CHAR_EXPLICIT UnicodeString(UChar32 ch);
 
+#ifdef U_HIDE_DRAFT_API
   /**
    * char16_t* constructor.
    *
@@ -3088,20 +3085,19 @@ public:
    * on the compiler command line or similar.
    *
    * Note, for string literals:
-   * Since C++17 and ICU 76, you can use std::u16string_view literals with compile-time
+   * Since C++17 and ICU 76, you can use UTF-16 string literals with compile-time
    * length determination:
    * \code
-   * #include &lt;string_view&gt;
-   * using namespace std::string_view_literals;
-   * UnicodeString str(u"literal"sv);
-   * if (str == u"other literal"sv) { ... }
+   * UnicodeString str(u"literal");
+   * if (str == u"other literal") { ... }
    * \endcode
    *
    * @param text The characters to place in the UnicodeString.  `text`
    * must be NUL (U+0000) terminated.
    * @stable ICU 2.0
    */
-  UNISTR_FROM_STRING_EXPLICIT UnicodeString(const char16_t *text);
+  UNISTR_FROM_STRING_EXPLICIT UnicodeString(const char16_t *text) :
+      UnicodeString(text, -1) {}
 
 #if !U_CHAR16_IS_TYPEDEF
   /**
@@ -3113,20 +3109,18 @@ public:
    * on the compiler command line or similar.
    *
    * Note, for string literals:
-   * Since C++17 and ICU 76, you can use std::u16string_view literals with compile-time
+   * Since C++17 and ICU 76, you can use UTF-16 string literals with compile-time
    * length determination:
    * \code
-   * #include &lt;string_view&gt;
-   * using namespace std::string_view_literals;
-   * UnicodeString str(u"literal"sv);
-   * if (str == u"other literal"sv) { ... }
+   * UnicodeString str(u"literal");
+   * if (str == u"other literal") { ... }
    * \endcode
    *
    * @param text NUL-terminated UTF-16 string
    * @stable ICU 59
    */
   UNISTR_FROM_STRING_EXPLICIT UnicodeString(const uint16_t *text) :
-      UnicodeString(ConstChar16Ptr(text)) {}
+      UnicodeString(ConstChar16Ptr(text), -1) {}
 #endif
 
 #if U_SIZEOF_WCHAR_T==2 || defined(U_IN_DOXYGEN)
@@ -3140,21 +3134,20 @@ public:
    * on the compiler command line or similar.
    *
    * Note, for string literals:
-   * Since C++17 and ICU 76, you can use std::u16string_view literals with compile-time
+   * Since C++17 and ICU 76, you can use UTF-16 string literals with compile-time
    * length determination:
    * \code
-   * #include &lt;string_view&gt;
-   * using namespace std::string_view_literals;
-   * UnicodeString str(u"literal"sv);
-   * if (str == u"other literal"sv) { ... }
+   * UnicodeString str(u"literal");
+   * if (str == u"other literal") { ... }
    * \endcode
    *
    * @param text NUL-terminated UTF-16 string
    * @stable ICU 59
    */
   UNISTR_FROM_STRING_EXPLICIT UnicodeString(const wchar_t *text) :
-      UnicodeString(ConstChar16Ptr(text)) {}
+      UnicodeString(ConstChar16Ptr(text), -1) {}
 #endif
+#endif  // U_HIDE_DRAFT_API
 
   /**
    * nullptr_t constructor.
@@ -3172,13 +3165,11 @@ public:
    * char16_t* constructor.
    *
    * Note, for string literals:
-   * Since C++17 and ICU 76, you can use std::u16string_view literals with compile-time
+   * Since C++17 and ICU 76, you can use UTF-16 string literals with compile-time
    * length determination:
    * \code
-   * #include &lt;string_view&gt;
-   * using namespace std::string_view_literals;
-   * UnicodeString str(u"literal"sv);
-   * if (str == u"other literal"sv) { ... }
+   * UnicodeString str(u"literal");
+   * if (str == u"other literal") { ... }
    * \endcode
    *
    * @param text The characters to place in the UnicodeString.
@@ -3195,13 +3186,11 @@ public:
    * Delegates to UnicodeString(const char16_t *, int32_t).
    *
    * Note, for string literals:
-   * Since C++17 and ICU 76, you can use std::u16string_view literals with compile-time
+   * Since C++17 and ICU 76, you can use UTF-16 string literals with compile-time
    * length determination:
    * \code
-   * #include &lt;string_view&gt;
-   * using namespace std::string_view_literals;
-   * UnicodeString str(u"literal"sv);
-   * if (str == u"other literal"sv) { ... }
+   * UnicodeString str(u"literal");
+   * if (str == u"other literal") { ... }
    * \endcode
    *
    * @param text UTF-16 string
@@ -3219,13 +3208,11 @@ public:
    * Delegates to UnicodeString(const char16_t *, int32_t).
    *
    * Note, for string literals:
-   * Since C++17 and ICU 76, you can use std::u16string_view literals with compile-time
+   * Since C++17 and ICU 76, you can use UTF-16 string literals with compile-time
    * length determination:
    * \code
-   * #include &lt;string_view&gt;
-   * using namespace std::string_view_literals;
-   * UnicodeString str(u"literal"sv);
-   * if (str == u"other literal"sv) { ... }
+   * UnicodeString str(u"literal");
+   * if (str == u"other literal") { ... }
    * \endcode
    *
    * @param text UTF-16 string
@@ -3259,9 +3246,9 @@ public:
    * @draft ICU 76
    */
   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
-  explicit inline UnicodeString(const S &text) {
+  UNISTR_FROM_STRING_EXPLICIT UnicodeString(const S &text) {
     fUnion.fFields.fLengthAndFlags = kShortString;
-    doAppend(internal::toU16StringView(text));
+    doAppend(internal::toU16StringViewNullable(text));
   }
 #endif  // U_HIDE_DRAFT_API
 
@@ -3280,13 +3267,11 @@ public:
    * so that both strings then alias the same readonly-text.
    *
    * Note, for string literals:
-   * Since C++17 and ICU 76, you can use std::u16string_view literals with compile-time
+   * Since C++17 and ICU 76, you can use UTF-16 string literals with compile-time
    * length determination:
    * \code
-   * #include &lt;string_view&gt;
-   * using namespace std::string_view_literals;
-   * UnicodeString alias = UnicodeString::readOnlyAlias(u"literal"sv);
-   * if (str == u"other literal"sv) { ... }
+   * UnicodeString alias = UnicodeString::readOnlyAlias(u"literal");
+   * if (str == u"other literal") { ... }
    * \endcode
    *
    * @param isTerminated specifies if `text` is `NUL`-terminated.
@@ -3369,13 +3354,11 @@ public:
    * the constructor that takes a US_INV (for its enum EInvariant).
    *
    * Note, for string literals:
-   * Since C++17 and ICU 76, you can use std::u16string_view literals with compile-time
+   * Since C++17 and ICU 76, you can use UTF-16 string literals with compile-time
    * length determination:
    * \code
-   * #include &lt;string_view&gt;
-   * using namespace std::string_view_literals;
-   * UnicodeString str(u"literal"sv);
-   * if (str == u"other literal"sv) { ... }
+   * UnicodeString str(u"literal");
+   * if (str == u"other literal") { ... }
    * \endcode
    *
    * It is recommended to mark this constructor "explicit" by
@@ -3485,13 +3468,11 @@ public:
    * \endcode
    *
    * Note, for string literals:
-   * Since C++17 and ICU 76, you can use std::u16string_view literals with compile-time
+   * Since C++17 and ICU 76, you can use UTF-16 string literals with compile-time
    * length determination:
    * \code
-   * #include &lt;string_view&gt;
-   * using namespace std::string_view_literals;
-   * UnicodeString str(u"literal"sv);
-   * if (str == u"other literal"sv) { ... }
+   * UnicodeString str(u"literal");
+   * if (str == u"other literal") { ... }
    * \endcode
    *
    * @param src String using only invariant characters.

--- a/icu4c/source/common/unistr.cpp
+++ b/icu4c/source/common/unistr.cpp
@@ -230,11 +230,6 @@ UnicodeString::UnicodeString(UChar32 ch) {
   }
 }
 
-UnicodeString::UnicodeString(const char16_t *text) {
-  fUnion.fFields.fLengthAndFlags = kShortString;
-  doAppend(text, 0, -1);
-}
-
 UnicodeString::UnicodeString(const char16_t *text,
                              int32_t textLength) {
   fUnion.fFields.fLengthAndFlags = kShortString;


### PR DESCRIPTION
When passing a string literal to any of the legacy constructors that take just a plain pointer to a UTF-16 string it becomes necessary to iterate through the string to find its length, even though this length was known to the compiler (which just has no way of passing it on to the constructor).

But when calling the new templated string view constructor instead it becomes possible for the compiler to use the known length of a string literal to directly create a string view of the correct size and pass this on to the constructor.

By replacing the legacy constructors with the new constructor this is made the default behaviour.

Because non-templated functions take priority it's necessary to replace the legacy constructors or else the new constructor would never be called for any data type that can implicitly decay into a pointer (and this includes string literals). For the time being, this is gated on `U_HIDE_DRAFT_API` which will select either the old or the new constructors and even though the old constructors technically get deleted the new constructor is made possible to call in identical ways so that no changes to any call sites are necessary.

There is however a snag there and that's an old promise that `nullptr` is valid input and identical to the default constructor (ie. the empty string) but this is explicitly _not_ valid input for string views, so this requires a backward compatibility shim to catch any  `nullptr` before any attempt is made to use it to create a string view (which would crash most implementations of the standard library).

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22843
- [x] Required: The PR title must be prefixed with a JIRA Issue number.
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number.
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
