### PR TITLE
ICU-22606 Make the ICU4J release easier & more predictable

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,115 @@
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+
+name: Publish to Nexus Sonatype OSS
+
+# For this to run you should define the follwing GitHub Secrets in the proper Environment.
+# In Settings -- Environments -- release_env -- Environment secrets:
+# * MAVEN_CENTRAL_USERNAME & MAVEN_CENTRAL_TOKEN:
+#   * Go to https://oss.sonatype.org and login with the `icu-robot` user
+#   * Top-right select "Profile"
+#   * Open the drop-down list showing "Summary" and select "User Token"
+#   * Click the "Access User Token" button
+#   * The `username` (first, shorter part of the token) goes in the `MAVEN_CENTRAL_USERNAME` secret
+#   * The `password` (second, longer part of the token) goes in the `MAVEN_CENTRAL_TOKEN` secret
+# * MAVEN_GPG_PRIVATE_KEY: an ASCII dump of the GPG private signing key:
+#     `gpg --output icu_release_signing.asc --armor --export-secret-key <key_id>`
+# * MAVEN_GPG_PASSPHRASE: the GPG password used to protect that key
+
+on:
+  # To trigger the Env Test workflow manually, follow the instructions in
+  # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
+  workflow_dispatch:
+    inputs:
+      gitTag:
+        # TODO: make this mandatory and validate that it is in a release* branch and looks like
+        # 'release-\d+.\d+ or something like that.
+        # For now we don't do it so that we can test.
+        description: 'Git tag at which to sync for deploy and release'
+        type: string
+
+env:
+  SHARED_MVN_ARGS: '--no-transfer-progress --show-version --batch-mode'
+  RELEASE_FOLDER: 'target/release_files'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: release-env
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+
+    - name: Checkout repo files
+      uses: actions/checkout@v4.1.7
+      with:
+        lfs: true
+
+    - name: Set up JDK
+      uses: actions/setup-java@v4.2.2
+      with:
+        java-version: '8' # The custom Taglets for javadoc (tools/build) are still Java 8. They need updating to use a different JDK version.
+        distribution: 'temurin'
+        server-id: icu4j-maven-repo # Value of the distributionManagement/repository/id field of the pom.xml
+        server-username: MAVEN_USERNAME # env variable for username in deploy
+        server-password: MAVEN_CENTRAL_TOKEN # env variable for token in deploy
+        gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # Value of the GPG private key to import
+        gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    # TODO: enable tests? We don't want to release until we are 100% sure everything works.
+    - name: Build all of ICU
+      run: |
+        # Really important to do this first because we need `tools/build` for the javadoc applets
+        mvn install --file icu4j/tools/build \
+          ${SHARED_MVN_ARGS} \
+          -DskipTests -DskipITs
+
+    - name: Build and deploy to Maven Central
+      run: |
+        mvn deploy --file icu4j \
+          ${SHARED_MVN_ARGS} \
+          --settings $GITHUB_WORKSPACE/settings.xml \
+          --errors --fail-at-end -DdeployAtEnd=true \
+          -DskipTests -DskipITs \
+          -P with_sources,with_javadoc,with_signature
+      env:
+        MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+        MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
+    # These are files that will end in the "Release" section of the GitHub repo.
+    # So the jar files published in GitHub are binary identical to the ones in Maven Central.
+    - name: Prepare release folder
+      run: |
+        pushd icu4j
+        ICU_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        # Copy the artifacts (with sources and javdoc .jar files) to the release folder
+        mvn dependency:copy \
+          ${SHARED_MVN_ARGS} \
+          -DskipTests -DskipITs \
+          -Drelease.directory=${RELEASE_FOLDER} \
+          -P release_files
+        # Build the full javadoc to be posted on the public site
+        mvn site \
+          ${SHARED_MVN_ARGS} \
+          -DskipITs -DskipTests \
+          -P with_full_javadoc
+        jar -Mcf ${RELEASE_FOLDER}/icu4j-${ICU_VERSION}-fulljavadoc.jar \
+          -C target/site/apidocs/ .
+        # Create the file with MD5 checksums
+        pushd ${RELEASE_FOLDER}
+        md5sum *.jar > icu4j-${ICU_VERSION}.md5
+        popd # out of $RELEASE_FOLDER
+        popd # out of icu4j
+
+    # TODO: add them to the GitHub "Release" page automatically
+    - name: Upload build results
+      uses: actions/upload-artifact@v4.3.6
+      with:
+        path: ./icu4j/${{ env.RELEASE_FOLDER }}/*
+        retention-days: 3 # TBD if we want to keep them longer
+        overwrite: true
+

--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ pkgdata.inc
 pkgdataMakefile
 rules.mk
 .DS_Store
+.flattened-pom.xml
 
 !icu4c/source/samples/csdet/Makefile
 

--- a/icu4j/demos/pom.xml
+++ b/icu4j/demos/pom.xml
@@ -38,13 +38,6 @@
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <!-- We don't want to deploy this to Maven -->
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <executions>

--- a/icu4j/main/charset/pom.xml
+++ b/icu4j/main/charset/pom.xml
@@ -14,6 +14,7 @@
 
   <artifactId>icu4j-charset</artifactId>
   <description>icu4j-charset is a supplemental library for icu4j, implementing Java Charset SPI.</description>
+  <url>${proj.url}</url>
 
   <properties>
     <icu4j.api.doc.root.dir>${project.basedir}/../..</icu4j.api.doc.root.dir>
@@ -68,6 +69,17 @@
               <Export-Package>com.ibm.icu.charset</Export-Package>
             </manifestEntries>
           </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <!-- We want to deploy this to Maven -->
+        <configuration>
+          <skip>false</skip>
         </configuration>
       </plugin>
     </plugins>

--- a/icu4j/main/collate/pom.xml
+++ b/icu4j/main/collate/pom.xml
@@ -67,16 +67,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <!-- We don't want to deploy this to Maven -->
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/icu4j/main/common_tests/pom.xml
+++ b/icu4j/main/common_tests/pom.xml
@@ -103,13 +103,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <!-- We don't want to deploy this to Maven -->
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 

--- a/icu4j/main/core/pom.xml
+++ b/icu4j/main/core/pom.xml
@@ -90,13 +90,6 @@
           </archive>
         </configuration>
       </plugin>
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <!-- We don't want to deploy this to Maven -->
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 

--- a/icu4j/main/currdata/pom.xml
+++ b/icu4j/main/currdata/pom.xml
@@ -27,16 +27,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <!-- We don't want to deploy this to Maven -->
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/icu4j/main/framework/pom.xml
+++ b/icu4j/main/framework/pom.xml
@@ -47,13 +47,6 @@
           </archive>
         </configuration>
       </plugin>
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <!-- We don't want to deploy this to Maven -->
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 

--- a/icu4j/main/icu4j/pom.xml
+++ b/icu4j/main/icu4j/pom.xml
@@ -16,6 +16,7 @@
   <artifactId>icu4j</artifactId>
   <description>International Components for Unicode for Java (ICU4J) is a mature, widely used Java library
     providing Unicode and Globalization support</description>
+  <url>${proj.url}</url>
 
   <properties>
     <icu4j.api.doc.root.dir>${project.basedir}/../..</icu4j.api.doc.root.dir>
@@ -112,6 +113,17 @@
               <followSymlinks>false</followSymlinks>
             </fileset>
           </filesets>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <!-- We want to deploy this to Maven -->
+        <configuration>
+          <skip>false</skip>
         </configuration>
       </plugin>
     </plugins>

--- a/icu4j/main/langdata/pom.xml
+++ b/icu4j/main/langdata/pom.xml
@@ -27,16 +27,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <!-- We don't want to deploy this to Maven -->
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/icu4j/main/localespi/pom.xml
+++ b/icu4j/main/localespi/pom.xml
@@ -14,6 +14,7 @@
 
   <artifactId>icu4j-localespi</artifactId>
   <description>icu4j-localespi is a supplemental library for icu4j, implementing Java Locale SPI.</description>
+  <url>${proj.url}</url>
 
   <properties>
     <proj.displayname>JDK locale service provider</proj.displayname>
@@ -182,6 +183,19 @@
             <java.locale.providers>${localespi-tests.locale-providers}</java.locale.providers>
           </systemPropertyVariables>
 
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <!-- We want to deploy this to Maven -->
+        <configuration>
+          <skip>false</skip>
         </configuration>
       </plugin>
 

--- a/icu4j/main/regiondata/pom.xml
+++ b/icu4j/main/regiondata/pom.xml
@@ -27,16 +27,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <!-- We don't want to deploy this to Maven -->
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/icu4j/main/translit/pom.xml
+++ b/icu4j/main/translit/pom.xml
@@ -62,16 +62,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <!-- We don't want to deploy this to Maven -->
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/icu4j/perf-tests/pom.xml
+++ b/icu4j/perf-tests/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
-      <version>1.7.0</version>
+      <version>${commons-cli.version}</version>
     </dependency>
   </dependencies>
 
@@ -62,13 +62,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <!-- We don't want to deploy this to Maven -->
-        <configuration>
-          <skip>true</skip>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/icu4j/pom.xml
+++ b/icu4j/pom.xml
@@ -15,7 +15,7 @@
   <description>International Components for Unicode for Java (ICU4J) is a mature, widely used Java library
     providing Unicode and Globalization support.
     This is the base artifact with common settings, not intended to use directly.</description>
-  <url>https://icu.unicode.org/</url>
+  <url>${proj.url}</url>
   <inceptionYear>1995</inceptionYear>
 
   <organization>
@@ -56,12 +56,17 @@
     <maven-central-releases-repo-url>${maven-central-repo-url}/service/local/staging/deploy/maven2</maven-central-releases-repo-url>
     <maven-central-snapshots-repo-url>${maven-central-repo-url}/content/repositories/snapshots</maven-central-snapshots-repo-url>
 
+    <!-- This is the folder where we gather the files to be posted in the Github Release-->
+    <release.directory>${project.build.directory}/release_directory</release.directory>
+
     <junit.version>4.13.2</junit.version>
     <junitparams.version>1.1.1</junitparams.version>
-    <gson.version>2.10.1</gson.version>
+    <gson.version>2.11.0</gson.version>
+    <commons-cli.version>1.9.0</commons-cli.version>
 
     <proj-title>International Components for Unicode for Java</proj-title>
     <proj.displayname>${project.artifactId}</proj.displayname>
+    <proj.url>https://icu.unicode.org/</proj.url>
 
     <!-- Version update! -->
     <icu.major.version>76</icu.major.version>
@@ -166,12 +171,12 @@
 
   <distributionManagement>
     <repository>
-      <id>icu4j-releases</id>
+      <id>icu4j-maven-repo</id>
       <name>ICU4J Central Repository</name>
       <url>${maven-central-releases-repo-url}</url>
     </repository>
     <snapshotRepository>
-      <id>icu4j-snapshots</id>
+      <id>icu4j-maven-repo</id>
       <name>ICU4J Central Development Repository</name>
       <url>${maven-central-snapshots-repo-url}</url>
     </snapshotRepository>
@@ -182,7 +187,7 @@
       <plugins>
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>3.4.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
@@ -190,7 +195,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.11.0</version>
+          <version>3.13.0</version>
           <!-- Plugin bug, maven.compiler.* properties are not honored, see
             https://issues.apache.org/jira/browse/MCOMPILER-545
           -->
@@ -201,7 +206,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.4.0</version>
           <configuration>
             <includes>
               <!-- Some test files start with "IntlTest...". Many don't fit
@@ -218,48 +223,48 @@
         </plugin>
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.4.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.1.3</version>
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.1.3</version>
         </plugin>
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
-          <version>4.0.0-M9</version>
+          <version>4.0.0-M16</version>
         </plugin>
         <plugin>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.3.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-gpg-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.2.5</version>
         </plugin>
         <plugin>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.4.5</version>
+          <version>3.7.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.7.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.8.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>3.6.0</version>
           <executions>
             <execution>
               <!-- Workaround for Windows symlink issue:
@@ -302,11 +307,35 @@
         </plugin>
         <plugin>
           <artifactId>maven-release-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.1.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>flatten-maven-plugin</artifactId>
+          <version>1.6.0</version>
+          <configuration>
+            <flattenMode>ossrh</flattenMode>
+          </configuration>
+          <executions>
+            <execution>
+              <id>flatten</id>
+              <phase>process-resources</phase>
+              <goals>
+                <goal>flatten</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>flatten.clean</id>
+              <phase>clean</phase>
+              <goals>
+                <goal>clean</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.5.0</version>
           <executions>
             <execution>
               <id>enforce-maven</id>
@@ -316,7 +345,7 @@
               <configuration>
                 <rules>
                   <requireMavenVersion>
-                    <version>3.2.5</version>
+                    <version>3.6.3</version>
                   </requireMavenVersion>
                 </rules>
               </configuration>
@@ -325,7 +354,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.8.0</version>
           <configuration>
             <excludePackageNames>com.ibm.icu.impl,com.ibm.icu.impl.*,com.ibm.icu.dev.*,com.ibm.icu.samples,com.ibm.icu.samples.*</excludePackageNames>
             <!--
@@ -350,6 +379,8 @@
             <charset>UTF-8</charset>
             <breakiterator>true</breakiterator>
             <use>true</use>
+            <maxmemory>256m</maxmemory>
+            <minmemory>256m</minmemory>
             <!-- <verbose>true</verbose> -->
             <additionalJOptions>
               <additionalJOption>-J-Djcitesourcepath=${icu4j.api.doc.root.dir}/samples/src/main/java${path.separator}${icu4j.api.doc.root.dir}/demos/src/main/java${path.separator}${icu4j.api.doc.root.dir}/main/core/src/main/java</additionalJOption>
@@ -400,7 +431,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.2</version>
           <configuration>
             <archive>
               <manifest>
@@ -432,7 +463,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.4.1</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -685,6 +716,77 @@
       </build>
     </profile>
 
+    <profile>
+        <id>release_files</id>
+        <build>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <configuration>
+                        <outputDirectory>${release.directory}</outputDirectory>
+                        <overWriteReleases>true</overWriteReleases>
+                        <overWriteSnapshots>true</overWriteSnapshots>
+                        <artifactItems>
+                        <!-- icu4j -->
+                        <artifactItem>
+                            <groupId>com.ibm.icu</groupId>
+                            <artifactId>icu4j</artifactId>
+                            <version>${project.version}</version>
+                        </artifactItem>
+                        <artifactItem>
+                            <groupId>com.ibm.icu</groupId>
+                            <artifactId>icu4j</artifactId>
+                            <version>${project.version}</version>
+                            <classifier>sources</classifier>
+                        </artifactItem>
+                        <artifactItem>
+                            <groupId>com.ibm.icu</groupId>
+                            <artifactId>icu4j</artifactId>
+                            <version>${project.version}</version>
+                            <classifier>javadoc</classifier>
+                        </artifactItem>
+                        <!-- icu4j-charset -->
+                        <artifactItem>
+                            <groupId>com.ibm.icu</groupId>
+                            <artifactId>icu4j-charset</artifactId>
+                            <version>${project.version}</version>
+                        </artifactItem>
+                        <artifactItem>
+                            <groupId>com.ibm.icu</groupId>
+                            <artifactId>icu4j-charset</artifactId>
+                            <version>${project.version}</version>
+                            <classifier>sources</classifier>
+                        </artifactItem>
+                        <artifactItem>
+                            <groupId>com.ibm.icu</groupId>
+                            <artifactId>icu4j-charset</artifactId>
+                            <version>${project.version}</version>
+                            <classifier>javadoc</classifier>
+                        </artifactItem>
+                        <!-- icu4j-localespi -->
+                        <artifactItem>
+                            <groupId>com.ibm.icu</groupId>
+                            <artifactId>icu4j-localespi</artifactId>
+                            <version>${project.version}</version>
+                        </artifactItem>
+                        <artifactItem>
+                            <groupId>com.ibm.icu</groupId>
+                            <artifactId>icu4j-localespi</artifactId>
+                            <version>${project.version}</version>
+                            <classifier>sources</classifier>
+                        </artifactItem>
+                        <artifactItem>
+                            <groupId>com.ibm.icu</groupId>
+                            <artifactId>icu4j-localespi</artifactId>
+                            <version>${project.version}</version>
+                            <classifier>javadoc</classifier>
+                        </artifactItem>
+                        </artifactItems>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </build>
+    </profile>
   </profiles>
 
 </project>

--- a/icu4j/samples/pom.xml
+++ b/icu4j/samples/pom.xml
@@ -33,13 +33,6 @@
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <!-- We don't want to deploy this to Maven -->
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
       </plugin>

--- a/icu4j/tools/build/pom.xml
+++ b/icu4j/tools/build/pom.xml
@@ -28,16 +28,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <!-- We don't want to deploy this to Maven -->
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/icu4j/tools/misc/pom.xml
+++ b/icu4j/tools/misc/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
-      <version>1.7.0</version>
+      <version>${commons-cli.version}</version>
     </dependency>
   </dependencies>
 
@@ -46,13 +46,6 @@
               <Main-Class>com.ibm.icu.dev.tool.localeconverter.XLIFF2ICUConverter</Main-Class>
             </manifestEntries>
           </archive>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <!-- We don't want to deploy this to Maven -->
-        <configuration>
-          <skip>true</skip>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22606
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

---

This creates a GitHub workflow that builds the ICU4J artifacts using JDK 8 and publishes them to Maven Central.
It does everything that's needed: sources, javadoc, digitally signed.

The next step is to improve it and generate the javadoc ready to publish on the web, and to collect the artifacts, with md5sum for the GitHub Release.

That way the files we publish in GitHub Release / Maven Central + Javadoc site will be binary identical, and generated automatically by this GitHub action.

This will generate all ICU4J files in a GitHub Release.
