### PR TITLE
ICU-22721 Enhance #if for locdispnames.cpp

### DIFF
--- a/icu4c/source/common/locdispnames.cpp
+++ b/icu4c/source/common/locdispnames.cpp
@@ -245,7 +245,7 @@ Locale::getDisplayName(const Locale &displayLocale,
     return result;
 }
 
-#if ! UCONFIG_NO_BREAK_ITERATION
+#if !UCONFIG_NO_BREAK_ITERATION
 
 // -------------------------------------
 // Gets the objectLocale display name in the default locale language.


### PR DESCRIPTION
ICU-22721

Enhance `#if` for locdispnames.cpp from `#if ! UCONFIG_NO_BREAK_ITERATION` to `#if !UCONFIG_NO_BREAK_ITERATION` (remove spacing).