### PR TITLE
ICU-22606 Correct urls in the scm entry; fix JCite styles in javadoc

### DIFF
--- a/icu4j/main/charset/pom.xml
+++ b/icu4j/main/charset/pom.xml
@@ -15,6 +15,11 @@
   <artifactId>icu4j-charset</artifactId>
   <description>icu4j-charset is a supplemental library for icu4j, implementing Java Charset SPI.</description>
   <url>${proj.url}</url>
+  <scm>
+    <connection>${proj.scm.connection}</connection>
+    <developerConnection>${proj.scm.developerConnection}</developerConnection>
+    <url>${proj.scm.url}</url>
+  </scm>
 
   <properties>
     <icu4j.api.doc.root.dir>${project.basedir}/../..</icu4j.api.doc.root.dir>

--- a/icu4j/main/icu4j/pom.xml
+++ b/icu4j/main/icu4j/pom.xml
@@ -17,6 +17,11 @@
   <description>International Components for Unicode for Java (ICU4J) is a mature, widely used Java library
     providing Unicode and Globalization support</description>
   <url>${proj.url}</url>
+  <scm>
+    <connection>${proj.scm.connection}</connection>
+    <developerConnection>${proj.scm.developerConnection}</developerConnection>
+    <url>${proj.scm.url}</url>
+  </scm>
 
   <properties>
     <icu4j.api.doc.root.dir>${project.basedir}/../..</icu4j.api.doc.root.dir>

--- a/icu4j/main/localespi/pom.xml
+++ b/icu4j/main/localespi/pom.xml
@@ -15,6 +15,11 @@
   <artifactId>icu4j-localespi</artifactId>
   <description>icu4j-localespi is a supplemental library for icu4j, implementing Java Locale SPI.</description>
   <url>${proj.url}</url>
+  <scm>
+    <connection>${proj.scm.connection}</connection>
+    <developerConnection>${proj.scm.developerConnection}</developerConnection>
+    <url>${proj.scm.url}</url>
+  </scm>
 
   <properties>
     <proj.displayname>JDK locale service provider</proj.displayname>

--- a/icu4j/pom.xml
+++ b/icu4j/pom.xml
@@ -67,6 +67,9 @@
     <proj-title>International Components for Unicode for Java</proj-title>
     <proj.displayname>${project.artifactId}</proj.displayname>
     <proj.url>https://icu.unicode.org/</proj.url>
+    <proj.scm.connection>scm:git:git://github.com/unicode-org/icu.git</proj.scm.connection>
+    <proj.scm.developerConnection>scm:git:git@github.com:unicode-org/icu.git</proj.scm.developerConnection>
+    <proj.scm.url>https://github.com/unicode-org/icu</proj.scm.url>
 
     <!-- Version update! -->
     <icu.major.version>76</icu.major.version>
@@ -159,9 +162,9 @@
   </mailingLists>
 
   <scm>
-    <connection>scm:git:git://github.com/unicode-org/icu.git</connection>
-    <developerConnection>scm:git:git@github.com:unicode-org/icu.git</developerConnection>
-    <url>https://github.com/unicode-org/icu</url>
+    <connection>${proj.scm.connection}</connection>
+    <developerConnection>${proj.scm.developerConnection}</developerConnection>
+    <url>${proj.scm.url}</url>
   </scm>
 
   <issueManagement>
@@ -373,7 +376,7 @@
             <doctitle>${icu4j.api.doc.window.title}</doctitle>
             <header>${icu4j.api.doc.header}</header>
             <bottom>${icu4j.api.doc.copyright.footer}</bottom>
-            <stylesheetfile>stylesheet8.css</stylesheetfile>
+            <stylesheetfile>${icu4j.api.doc.root.dir}/stylesheet8.css</stylesheetfile>
             <encoding>UTF-8</encoding>
             <docencoding>UTF-8</docencoding>
             <charset>UTF-8</charset>


### PR DESCRIPTION
1. The flatten plugin appended the relative module paths to the URLs in `<scm>`. The same kind of problem solved earlier with ${proj.url}, and fixed the same way. I was unable to find any way to tell the plugin to not do that append, even after reading some of the plugin code.

2. The stylesheet containing the JCite styles was not copied in the generated javadoc. The first part of our custom stylesheet is 100% the same as the oficial one. So the only part that was visually affected was the code produced by JCite. The code still used `<pre>` and `<code>`, so it was monospaced and well indented / wrapped, but no syntax colors.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22606
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
