### PR TITLE
ICU-22716 Reduce the data size to test calendar fuzzer

### DIFF
--- a/icu4c/source/test/fuzzer/calendar_fuzzer.cpp
+++ b/icu4c/source/test/fuzzer/calendar_fuzzer.cpp
@@ -52,9 +52,9 @@ const char* GetRandomCalendarType(uint8_t rnd) {
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     uint16_t rnd;
-    // Set the limit for the test data to 1000 bytes to avoid timeout for a
+    // Set the limit for the test data to 100 bytes to avoid timeout for a
     // very long list of operations.
-    if (size > 1000) { size = 1000; }
+    if (size > 100) { size = 100; }
     if (size < 2*sizeof(rnd) + 1) return 0;
     icu::StringPiece fuzzData(reinterpret_cast<const char *>(data), size);
     // Byte 0 and 1 randomly select a TimeZone


### PR DESCRIPTION
The Calendar fuzzer tests too many operations and causes timeouts which do not surface the real issues. Limit the test data size to 100 instead of 1000 instead.

To avoid unnecessary test failure of timeout in https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=71058 
<!--
Thank you for your pull request!

* General info on contributing: please see https://github.com/unicode-org/icu/blob/main/CONTRIBUTING.md
* Ticket numbers for minor changes: for minor changes (ex: docs typos), you can reuse one of the open catch-all tickets for our next release
  - ICU 76 ticket: docs minor fixes: typos/etc./version updates / User Guide & API docs: ICU-22722
  - ICU 76 ticket: code warnings/version updates: ICU-22721
* Contributors license agreement (CLA): 
  You will be automatically asked to sign the CLA before the PR is accepted.
  To sign the CLA: https://cla-assistant.io/unicode-org/icu

  For terms of use and license, see https://www.unicode.org/terms_of_use.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22716
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
