### PR TITLE
ICU-22707 adjust UTS46 for Unicode 16

### DIFF
--- a/icu4c/source/common/uts46.cpp
+++ b/icu4c/source/common/uts46.cpp
@@ -756,7 +756,12 @@ UTS46::processLabel(UnicodeString &dest,
         if(U_FAILURE(errorCode)) {
             return labelLength;
         }
-        if(!isValid) {
+        // Unicode 15.1 UTS #46:
+        // Added an additional condition in 4.1 Validity Criteria to
+        // disallow labels such as xn--xn---epa., which do not round-trip.
+        // --> Validity Criteria new criterion 4:
+        // If not CheckHyphens, the label must not begin with “xn--”.
+        if(!isValid || fromPunycode.startsWith(UnicodeString::readOnlyAlias(u"xn--"))) {
             info.labelErrors|=UIDNA_ERROR_INVALID_ACE_LABEL;
             return markBadACELabel(dest, labelStart, labelLength, toASCII, info, errorCode);
         }

--- a/icu4j/main/core/src/main/java/com/ibm/icu/impl/UTS46.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/impl/UTS46.java
@@ -358,7 +358,12 @@ public final class UTS46 extends IDNA {
             // In the code further below, if we find non-LDH ASCII and we have UIDNA_USE_STD3_RULES
             // then we will set UIDNA_ERROR_INVALID_ACE_LABEL there too.
             boolean isValid=uts46Norm2.isNormalized(fromPunycode);
-            if(!isValid) {
+            // Unicode 15.1 UTS #46:
+            // Added an additional condition in 4.1 Validity Criteria to
+            // disallow labels such as xn--xn---epa., which do not round-trip.
+            // --> Validity Criteria new criterion 4:
+            // If not CheckHyphens, the label must not begin with “xn--”.
+            if(!isValid || startsWithXNDashDash(fromPunycode)) {
                 addLabelError(info, Error.INVALID_ACE_LABEL);
                 return markBadACELabel(dest, labelStart, labelLength, toASCII, info);
             }
@@ -488,6 +493,12 @@ public final class UTS46 extends IDNA {
         }
         return replaceLabel(dest, destLabelStart, destLabelLength, labelString, labelLength);
     }
+
+    private static boolean startsWithXNDashDash(CharSequence s) {
+        return s.length()>=4 &&
+                s.charAt(0)=='x' && s.charAt(1)=='n' && s.charAt(2)=='-' && s.charAt(3)=='-';
+    }
+
     private int
     markBadACELabel(StringBuilder dest,
                     int labelStart, int labelLength,


### PR DESCRIPTION
- I compared the ICU implementation with the UTS46 changes in Unicode [15.1](https://www.unicode.org/reports/tr46/tr46-31.html#Modifications) & [16.0](https://www.unicode.org/reports/tr46/tr46-33.html#Modifications).
  - Code & spec are not totally parallel because (a) ICU makes some optimizations and (b) where the spec has options for performing certain checks ICU always performs those but records errors in an output where callers can ignore them.
  - I checked some cases via temporary test code to make sure that the outcome was as desired.
- Added a specific check for "starts with xn--" to the code path after Punycode-decoding a label, so that we can set an invalid-ACE-label error rather than a vanilla has-hyphens-at-offsets-3-and-4 error.
  - In IDNA2008, this is checked via round-trip conversion back to Punycode. So it makes sense to me to treat this as an ACE label error.
- Added support for the new test file syntax for explicitly empty strings. (Blank fields mean "same as another field".)
- Worked around test cases where the only failure is from an empty root label. ICU always performs label length checks, but deliberately does not report the empty root label as failing that check. I filed ICU-22882 for adding a separate error flag for that.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22707
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
