### PR TITLE
ICU-22863 Remove extra line in Islamic calendar

### DIFF
--- a/icu4c/source/i18n/islamcal.cpp
+++ b/icu4c/source/i18n/islamcal.cpp
@@ -476,7 +476,6 @@ int64_t IslamicCalendar::handleComputeMonthStart(int32_t eyear, int32_t month,
     // This may be called by Calendar::handleComputeJulianDay with months out of the range
     // 0..11. Need to handle that here since monthStart requires months in the range 0.11.
     if (month > 11) {
-        eyear += (month / 12);
         if (uprv_add32_overflow(eyear, (month / 12), &eyear)) {
             status = U_ILLEGAL_ARGUMENT_ERROR;
             return 0;


### PR DESCRIPTION
Fix a regression caused by d43d216febe18d37ad840cbac3f953b989b65965
The line "        if (uprv_add32_overflow(eyear, (month / 12), &eyear)) {" was added to replace " eyear += (month / 12);" in the previous check in but I forgot to remove the line "eyear += (month / 12)" last time.

<!--
Thank you for your pull request!

* General info on contributing: please see https://github.com/unicode-org/icu/blob/main/CONTRIBUTING.md
* Ticket numbers for minor changes: for minor changes (ex: docs typos), you can reuse one of the open catch-all tickets for our next release
  - ICU 76 ticket: docs minor fixes: typos/etc./version updates / User Guide & API docs: ICU-22722
  - ICU 76 ticket: code warnings/version updates: ICU-22721
* Contributors license agreement (CLA): 
  You will be automatically asked to sign the CLA before the PR is accepted.
  To sign the CLA: https://cla-assistant.io/unicode-org/icu

  For terms of use and license, see https://www.unicode.org/terms_of_use.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22863
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
