### PR TITLE
ICU-22716 Test VTimeZone in fuzzer

### DIFF
--- a/icu4c/source/test/fuzzer/timezone_create_fuzzer.cpp
+++ b/icu4c/source/test/fuzzer/timezone_create_fuzzer.cpp
@@ -6,6 +6,7 @@
 #include "fuzzer_utils.h"
 #include "unicode/localpointer.h"
 #include "unicode/timezone.h"
+#include "unicode/vtzone.h"
 
 IcuEnvironment* env = new IcuEnvironment();
 
@@ -31,7 +32,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   UBool system;
   icu::TimeZone::getCanonicalID(fuzzstr, output, system, status);
 
-
   status = U_ZERO_ERROR;
   icu::TimeZone::getIanaID(fuzzstr, output, status);
 
@@ -40,5 +40,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
   status = U_ZERO_ERROR;
   icu::TimeZone::getRegion(fuzzstr, status);
+
+  tz.adoptInstead(icu::VTimeZone::createVTimeZoneByID(fuzzstr));
+
+  status = U_ZERO_ERROR;
+  tz.adoptInstead(icu::VTimeZone::createVTimeZone(fuzzstr, status));
   return 0;
 }


### PR DESCRIPTION
Easy way to increase the fuzzer test coverage. 
<!--
Thank you for your pull request!

* General info on contributing: please see https://github.com/unicode-org/icu/blob/main/CONTRIBUTING.md
* Ticket numbers for minor changes: for minor changes (ex: docs typos), you can reuse one of the open catch-all tickets for our next release
  - ICU 76 ticket: docs minor fixes: typos/etc./version updates / User Guide & API docs: ICU-22722
  - ICU 76 ticket: code warnings/version updates: ICU-22721
* Contributors license agreement (CLA): 
  You will be automatically asked to sign the CLA before the PR is accepted.
  To sign the CLA: https://cla-assistant.io/unicode-org/icu

  For terms of use and license, see https://www.unicode.org/terms_of_use.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22716
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
