### PR TITLE
CLDR-17930 Fix malformed hex escapes in `translit/my_my_Latn.txt` and others

### DIFF
--- a/icu4c/source/data/translit/Gurmukhi_InterIndic.txt
+++ b/icu4c/source/data/translit/Gurmukhi_InterIndic.txt
@@ -58,7 +58,7 @@
 ਲ਼→\uE033; # FALLBACK
 ਵ→\uE035;  # LETTER VA
 ਸ਼→\uE036;
-ਸ\0a3c→\uE036; # FALLBACK
+ਸ\u0a3c→\uE036; # FALLBACK
 ਸ→\uE038;  # LETTER SA
 ਹ→\uE039;  # LETTER HA
 \u0A3C→\uE03C;  # SIGN NUKTA

--- a/icu4c/source/data/translit/Zawgyi_my.txt
+++ b/icu4c/source/data/translit/Zawgyi_my.txt
@@ -22,7 +22,7 @@ $consonant = [\u1000-\u1021];
 $vowelsign = [\u102B-\u1030\u1032];  # Unicode vowel signs except E (1031)
 $vowelsAndConsonants = [\u1000-\u102a];
 $umedial = [\u103B-\u103E];    # Medial codepoints in Unicode
-$vowelmedial = [\u102B-\u1030\u1032\1u36\u1037\u103A-\u103F];  # Union of vowel signs and medials
+$vowelmedial = [\u102B-\u1030\u1032\u1036\u1037\u103A-\u103F];  # Union of vowel signs and medials
 $ukinzi = \u1004\u103A\u1039;  # Codepoints representing kinzi in Unicode
 # Zawgyi medial ra has multiple representations
 $zmedialra = [\u103B\u107E-\u1084];

--- a/icu4c/source/data/translit/el_Upper.txt
+++ b/icu4c/source/data/translit/el_Upper.txt
@@ -7,7 +7,7 @@
 #
 
 # Copyright (C) 2011-2013, Apple Inc. and others. All Rights Reserved.
-# Remove \0301 following Greek, with possible intervening 0308 marks.
+# Remove \u0301 following Greek, with possible intervening 0308 marks.
 ::NFD();
 # For uppercasing (not titlecasing!) remove all greek accents from greek letters.
 # This is done in two groups, to account for canonical ordering.

--- a/icu4c/source/data/translit/my_my_Latn.txt
+++ b/icu4c/source/data/translit/my_my_Latn.txt
@@ -127,7 +127,7 @@ $consonants = [\u1000-\u1021];
 # ျတ\u103A > yat;
 \u103B\u1010\u103A > yat;
 # ြက\u103A  > yet;
-\u103C\u1000\103A > yet;
+\u103C\u1000\u103A > yet;
 # ျက\u103A > yet;
 \u103B\u1000\u103A > yet;
 # ျင\u103A > yin;


### PR DESCRIPTION
Fix malformed hex escapes in `translit/my_my_Latn.txt` and others

`\103A` → `\u103A`
`'ြက\103A'` →  `'ြက်' `

For some reason the JIRA issue seems to have got created under "CLDR" instead of "ICU" even though I created via the "ICU" page? IDK I really hate Jira 🤷

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/CLDR-17930
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable (N/A)
- [x] API docs and/or User Guide docs changed or added, if applicable (N/A)