### PR TITLE
ICU-22843 Check libc++ version for std::basic_string_view<uint16_t>

### DIFF
--- a/icu4c/source/common/unicode/char16ptr.h
+++ b/icu4c/source/common/unicode/char16ptr.h
@@ -315,7 +315,7 @@ inline OldUChar *toOldUCharPtr(char16_t *p) {
 template<typename T>
 constexpr bool ConvertibleToU16StringView =
     std::is_convertible_v<T, std::u16string_view>
-#if !U_CHAR16_IS_TYPEDEF
+#if !U_CHAR16_IS_TYPEDEF && (!defined(_LIBCPP_VERSION) || _LIBCPP_VERSION < 180000)
     || std::is_convertible_v<T, std::basic_string_view<uint16_t>>
 #endif
 #if U_SIZEOF_WCHAR_T==2
@@ -330,7 +330,7 @@ namespace internal {
  */
 inline std::u16string_view toU16StringView(std::u16string_view sv) { return sv; }
 
-#if !U_CHAR16_IS_TYPEDEF
+#if !U_CHAR16_IS_TYPEDEF && (!defined(_LIBCPP_VERSION) || _LIBCPP_VERSION < 180000)
 /**
  * Basically undefined behavior but sometimes necessary conversion
  * from std::basic_string_view<uint16_t> to std::u16string_view.

--- a/icu4c/source/common/unicode/unistr.h
+++ b/icu4c/source/common/unicode/unistr.h
@@ -3122,8 +3122,10 @@ public:
    */
   UNISTR_FROM_STRING_EXPLICIT UnicodeString(const char16_t *text) :
       UnicodeString(text, -1) {}
+#endif  // U_HIDE_DRAFT_API
 
-#if !U_CHAR16_IS_TYPEDEF
+#if !U_CHAR16_IS_TYPEDEF && \
+    (defined(U_HIDE_DRAFT_API) || (defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 180000))
   /**
    * uint16_t * constructor.
    * Delegates to UnicodeString(const char16_t *).
@@ -3147,7 +3149,7 @@ public:
       UnicodeString(ConstChar16Ptr(text), -1) {}
 #endif
 
-#if U_SIZEOF_WCHAR_T==2 || defined(U_IN_DOXYGEN)
+#if defined(U_HIDE_DRAFT_API) && (U_SIZEOF_WCHAR_T==2 || defined(U_IN_DOXYGEN))
   /**
    * wchar_t * constructor.
    * (Only defined if U_SIZEOF_WCHAR_T==2.)
@@ -3171,7 +3173,6 @@ public:
   UNISTR_FROM_STRING_EXPLICIT UnicodeString(const wchar_t *text) :
       UnicodeString(ConstChar16Ptr(text), -1) {}
 #endif
-#endif  // U_HIDE_DRAFT_API
 
   /**
    * nullptr_t constructor.


### PR DESCRIPTION
As was pointed out in PR #3106, the standard doesn't mandate the existence of `std::char_traits<uint16_t>` and libc++ did actually deprecate it in release 18 and delete it in release 19.

As ICU4C uses this for backward compatibility for old code that still depends on setting `-DUCHAR_TYPE=uint16_t` it'd be nice to keep using it as long as possible but once it's gone from the standard library there isn't really much useful that ICU4C could do about that so conditionally compiling the code when the standard library version is old enough should suffice for keeping backward compatibility for yet some time.

https://github.com/llvm/llvm-project/commit/cce062d

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22843
- [x] Required: The PR title must be prefixed with a JIRA Issue number.
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number.
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
