### PR TITLE
ICU-22843 Disambiguate UnicodeString::readOnlyAlias() for MSVC

### DIFF
--- a/icu4c/source/common/unicode/unistr.h
+++ b/icu4c/source/common/unicode/unistr.h
@@ -3600,6 +3600,29 @@ public:
   static inline UnicodeString readOnlyAlias(const S &text) {
     return readOnlyAliasFromU16StringView(internal::toU16StringView(text));
   }
+
+  /**
+   * Readonly-aliasing factory method.
+   * Aliases the same buffer as the input `text`.
+   *
+   * The text will be used for the UnicodeString object, but
+   * it will not be released when the UnicodeString is destroyed.
+   * This has copy-on-write semantics:
+   * When the string is modified, then the buffer is first copied into
+   * newly allocated memory.
+   * The aliased buffer is never modified.
+   *
+   * In an assignment to another UnicodeString, when using the copy constructor
+   * or the assignment operator, the text will be copied.
+   * When using fastCopyFrom(), the text will be aliased again,
+   * so that both strings then alias the same readonly-text.
+   *
+   * @param text The UnicodeString to alias.
+   * @draft ICU 76
+   */
+  static inline UnicodeString readOnlyAlias(const UnicodeString &text) {
+    return readOnlyAliasFromUnicodeString(text);
+  }
 #endif  // U_HIDE_DRAFT_API
 
   /**
@@ -3730,6 +3753,7 @@ protected:
 
 private:
   static UnicodeString readOnlyAliasFromU16StringView(std::u16string_view text);
+  static UnicodeString readOnlyAliasFromUnicodeString(const UnicodeString &text);
 
   // For char* constructors. Could be made public.
   UnicodeString &setToUTF8(StringPiece utf8);

--- a/icu4c/source/common/unistr.cpp
+++ b/icu4c/source/common/unistr.cpp
@@ -308,6 +308,16 @@ UnicodeString UnicodeString::readOnlyAliasFromU16StringView(std::u16string_view 
   return result;
 }
 
+UnicodeString UnicodeString::readOnlyAliasFromUnicodeString(const UnicodeString &text) {
+  UnicodeString result;
+  if (text.isBogus()) {
+    result.setToBogus();
+  } else {
+    result.setTo(false, text.getBuffer(), text.length());
+  }
+  return result;
+}
+
 #if U_CHARSET_IS_UTF8
 
 UnicodeString::UnicodeString(const char *codepageData) {

--- a/icu4c/source/test/intltest/ustrtest.cpp
+++ b/icu4c/source/test/intltest/ustrtest.cpp
@@ -2420,6 +2420,7 @@ void UnicodeStringTest::TestU16StringView() {
     const char16_t *p16 = u"p16";
     std::u16string_view sv16 = u"sv16";
     std::u16string str16 = u"str16";
+    UnicodeString ustr = u"ustr";
 
     // These copy the string contents.
     UnicodeString fromPtr(p16);  // pointer is convertible to std::u16string_view
@@ -2443,6 +2444,10 @@ void UnicodeStringTest::TestU16StringView() {
     UnicodeString aliasFromStr = UnicodeString::readOnlyAlias(str16);
     assertTrue("aliasFromStr pointer alias", aliasFromStr.getBuffer() == str16.data());
     assertEquals("aliasFromStr length", (int32_t)str16.length(), aliasFromStr.length());
+
+    UnicodeString aliasFromUStr = UnicodeString::readOnlyAlias(ustr);
+    assertTrue("aliasFromUStr pointer alias", aliasFromUStr.getBuffer() == ustr.getBuffer());
+    assertEquals("aliasFromUStr length", ustr.length(), aliasFromUStr.length());
 
     // operator==
     UnicodeString any(true, u"any", 3);


### PR DESCRIPTION
Both `std::u16string_view` and `std::wstring_view` are possible matches for `UnicodeString` as a template parameter, but adding an explicit overload avoids both having to make that choice and taking the detour through creating any string view at all.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22843
- [x] Required: The PR title must be prefixed with a JIRA Issue number.
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number.
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

ALLOW_MANY_COMMITS=true