### PR TITLE
ICU-22716 Temp turn off message_formatter_fuzzer

### DIFF
--- a/icu4c/source/test/fuzzer/Makefile.in
+++ b/icu4c/source/test/fuzzer/Makefile.in
@@ -43,7 +43,6 @@ FUZZER_TARGETS = \
 		 dtfmtsym_fuzzer \
 		 list_format_fuzzer locale_fuzzer \
 		 locale_morph_fuzzer \
-		 message_formatter_fuzzer \
 		 normalizer2_fuzzer \
 		 number_format_fuzzer \
 		 number_formatter_fuzzer \
@@ -63,6 +62,8 @@ FUZZER_TARGETS = \
 		 uprop_fuzzer \
 		 uregex_open_fuzzer \
 		 uregex_match_fuzzer \
+# Temporary comment out the following until we fix the out-of-memory problem.
+#                message_formatter_fuzzer \
 
 
 OBJECTS = $(FUZZER_TARGETS:%=%.o)


### PR DESCRIPTION
The running of message_formatter_fuzzer cause out of memory problem. We will address that in later PR.

<!--
Thank you for your pull request!

* General info on contributing: please see https://github.com/unicode-org/icu/blob/main/CONTRIBUTING.md
* Ticket numbers for minor changes: for minor changes (ex: docs typos), you can reuse one of the open catch-all tickets for our next release
  - ICU 76 ticket: docs minor fixes: typos/etc./version updates / User Guide & API docs: ICU-22722
  - ICU 76 ticket: code warnings/version updates: ICU-22721
* Contributors license agreement (CLA): 
  You will be automatically asked to sign the CLA before the PR is accepted.
  To sign the CLA: https://cla-assistant.io/unicode-org/icu

  For terms of use and license, see https://www.unicode.org/terms_of_use.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22716
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
