### PR TITLE
ICU-22722 Prevent running PR check enforcement after merging PRs

### DIFF
--- a/.github/workflows/wait-for-checks.yml
+++ b/.github/workflows/wait-for-checks.yml
@@ -10,10 +10,6 @@
 name: Wait for Required Checks
 
 on:
-  push:
-    branches:
-      - main
-      - 'maint/maint*'
   pull_request:
     branches: '**'
 


### PR DESCRIPTION
Post-merge CI workflows run on every commit after it merges to `main`. However, we also use the setting that interrupts a workflow run when a new commit gets added to the branch. 

In order to make commits on `main` in the Github UI not look like failures, we should not run the enforce-all-checks job after merging to `main`. This is the right change to make because the sole purpose of the enforce-all-checks job is to have intelligent automated enforcement of CI jobs _before merging_ (that is: as a requirement before a PR is allowed to merge).

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22722
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
