### PR TITLE
ICU-22721 Set delay for CI enforce checks job to allow other jobs to init

### DIFF
--- a/.github/workflows/wait-for-checks.yml
+++ b/.github/workflows/wait-for-checks.yml
@@ -29,5 +29,9 @@ jobs:
         # It won't pass until all of the pipeline's checks pass.
         # For the ICU4J and ICU4C pipelines, this is called `CI-ICU4J` and `CI-ICU4C`.
         # These checks will return a "neutral" status, which this GH Action interprets as a failure.
+        # ClusterFuzzLite/CIFuzz appears to be spawned after a CIFuzz job finishes, but its status of
+        # "neutral" is interpreted by this action as a failure.
         # Since the jobs are superfluous, they can be ignored.
-        ignore: "CI-ICU4C,CI-ICU4J"
+        ignore: "CI-ICU4C,CI-ICU4J,ClusterFuzzLite/CIFuzz"
+        # Wait for 2 minutes before this action begins its work by polling Github for job/check status
+        delay: 120s


### PR DESCRIPTION
CIFuzz jobs take a while to start. Until they do, within a workflow run, their neutral status and warning about "can't find configs" was causing the enforce-all-checks jobs to falsely fail.

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22721
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
