### PR TITLE
ICU-22722 toTitle does not use UTR 21

### DIFF
--- a/icu4c/source/common/unicode/ucasemap.h
+++ b/icu4c/source/common/unicode/ucasemap.h
@@ -202,8 +202,8 @@ ucasemap_setBreakIterator(UCaseMap *csm, UBreakIterator *iterToAdopt, UErrorCode
  *
  * The titlecase break iterator can be provided to customize for arbitrary
  * styles, using rules and dictionaries beyond the standard iterators.
- * The standard titlecase iterator for the root locale implements the
- * algorithm of Unicode TR 21.
+ * If the break iterator passed in is null, the default Unicode algorithm
+ * will be used to determine the titlecase positions.
  *
  * This function uses only the setText(), first() and next() methods of the
  * provided break iterator.
@@ -312,8 +312,8 @@ ucasemap_utf8ToUpper(const UCaseMap *csm,
  *
  * The titlecase break iterator can be provided to customize for arbitrary
  * styles, using rules and dictionaries beyond the standard iterators.
- * The standard titlecase iterator for the root locale implements the
- * algorithm of Unicode TR 21.
+ * If the break iterator passed in is null, the default Unicode algorithm
+ * will be used to determine the titlecase positions.
  *
  * This function uses only the setUText(), first(), next() and close() methods of the
  * provided break iterator.

--- a/icu4c/source/common/unicode/unistr.h
+++ b/icu4c/source/common/unicode/unistr.h
@@ -2793,8 +2793,8 @@ public:
    * styles, using rules and dictionaries beyond the standard iterators.
    * It may be more efficient to always provide an iterator to avoid
    * opening and closing one for each string.
-   * The standard titlecase iterator for the root locale implements the
-   * algorithm of Unicode TR 21.
+   * If the break iterator passed in is null, the default Unicode algorithm
+   * will be used to determine the titlecase positions.
    *
    * This function uses only the setText(), first() and next() methods of the
    * provided break iterator.
@@ -2821,8 +2821,8 @@ public:
    * styles, using rules and dictionaries beyond the standard iterators.
    * It may be more efficient to always provide an iterator to avoid
    * opening and closing one for each string.
-   * The standard titlecase iterator for the root locale implements the
-   * algorithm of Unicode TR 21.
+   * If the break iterator passed in is null, the default Unicode algorithm
+   * will be used to determine the titlecase positions.
    *
    * This function uses only the setText(), first() and next() methods of the
    * provided break iterator.
@@ -2850,8 +2850,8 @@ public:
    * styles, using rules and dictionaries beyond the standard iterators.
    * It may be more efficient to always provide an iterator to avoid
    * opening and closing one for each string.
-   * The standard titlecase iterator for the root locale implements the
-   * algorithm of Unicode TR 21.
+   * If the break iterator passed in is null, the default Unicode algorithm
+   * will be used to determine the titlecase positions.
    *
    * This function uses only the setText(), first() and next() methods of the
    * provided break iterator.

--- a/icu4c/source/common/unicode/ustring.h
+++ b/icu4c/source/common/unicode/ustring.h
@@ -1107,8 +1107,8 @@ u_strToLower(UChar *dest, int32_t destCapacity,
  * styles, using rules and dictionaries beyond the standard iterators.
  * It may be more efficient to always provide an iterator to avoid
  * opening and closing one for each string.
- * The standard titlecase iterator for the root locale implements the
- * algorithm of Unicode TR 21.
+ * If the break iterator passed in is null, the default Unicode algorithm
+ * will be used to determine the titlecase positions.
  *
  * This function uses only the setText(), first() and next() methods of the
  * provided break iterator.


### PR DESCRIPTION
Fix API docs that claim that titlecasing functions use Unicode Technical Report #&zwnj;21 for the titlecase break iterator.
That was the case only for Unicode 3.2.
Use the wording from the Java API docs instead, which generically refers to the Unicode case mapping algorithms so that we need not adjust the docs every time this changes.

(Titlecasing has been using the word break iterator since Unicode 4.)

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22722
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
