### PR TITLE
ICU-22721 Fix trivial slip-up in ICU4J TimeZone.java

### DIFF
--- a/icu4j/main/core/src/main/java/com/ibm/icu/util/TimeZone.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/util/TimeZone.java
@@ -1191,7 +1191,7 @@ abstract public class TimeZone implements Serializable, Cloneable, Freezable<Tim
      */
     public static String getIanaID(String id) {
         String ianaId = TimeZone.UNKNOWN_ZONE_ID;
-        if (id == null || id.length() == 0 || id.equals(TimeZone.UNKNOWN_ZONE)) {
+        if (id == null || id.length() == 0 || id.equals(TimeZone.UNKNOWN_ZONE_ID)) {
             return ianaId;
         }
         String tmpIanaId = ZoneMeta.getIanaID(id);


### PR DESCRIPTION
The equality comparison `id.equals(TimeZone.UNKNOWN_ZONE)` causes compiler warning:

> Unlikely argument type for `equals()`: `TimeZone` seems to be unrelated to `String`

I believe `String TimeZone.UNKNOWN_ZONE_ID` was intended instead of `TimeZone TimeZone.UNKNOWN_ZONE`.

The mistake is otherwise inconsequential, the check appears to be just an optimization/reliability matter.

There already is a test for this in [`TimeZoneTest.TestGetIanaID`](https://github.com/rqu/icu/blob/lr/ICU-22721-id-equals-timezone/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timezone/TimeZoneTest.java#L2421) and it is already passing.

---

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22721 (ICU 76 code warnings catch-all)
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

