### PR TITLE
ICU-22874 sync config.guess license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -501,7 +501,7 @@ File: config.guess (only for ICU4C)
 
 This file is free software; you can redistribute it and/or modify it
 under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or
+the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
 This program is distributed in the hope that it will be useful, but


### PR DESCRIPTION
Sync the one-character change in the config.guess license from https://github.com/unicode-org/icu/pull/3169/files#diff-37c409a2bcc2b9fb4ab8a4738e28dd19a2767fedc83196ce426d67b8a56906f0 into the ICU LICENSE file.

FYI: The aclocal.m4 license text did not change.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22874
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
