### PR TITLE
ICU-22318 Fix bad spacing/formatting in utxttest.cpp

### DIFF
--- a/icu4c/source/test/intltest/utxttest.cpp
+++ b/icu4c/source/test/intltest/utxttest.cpp
@@ -1516,7 +1516,7 @@ void UTextTest::Ticket10983() {
 
 void UTextTest::Ticket12130() {
     UErrorCode status = U_ZERO_ERROR;
-    
+
     const char *text8 =
         "Fundamentally, computers just deal with numbers. They store letters and other characters "
         "by assigning a number for each one. Before Unicode was invented, there were hundreds "
@@ -1549,7 +1549,7 @@ void UTextTest::Ticket12130() {
         if (expectedni != ni) {
             errln("%s:%d utext_getNativeIndex() expected %d, got %d", __FILE__, __LINE__, expectedni, ni);
         }
-        if (0 != str.tempSubString(startIdx, 20).compare(extractBuffer)) { 
+        if (0 != str.tempSubString(startIdx, 20).compare(extractBuffer)) {
             errln("%s:%d utext_extract() failed. expected \"%s\", got \"%s\"",
                     __FILE__, __LINE__, CStr(str.tempSubString(startIdx, 20))(), CStr(UnicodeString(extractBuffer))());
         }
@@ -1558,7 +1558,7 @@ void UTextTest::Ticket12130() {
 
     // Similar utext extract, this time with the string length provided to the UText in advance,
     // and a buffer of larger than required capacity.
-   
+
     utext_openUChars(&ut, ustr, str.length(), &status);
     for (int32_t startIdx = 0; startIdx<str.length(); ++startIdx) {
         int32_t endIdx = startIdx + 20;
@@ -1576,7 +1576,7 @@ void UTextTest::Ticket12130() {
         if (expectedni != ni) {
             errln("%s:%d utext_getNativeIndex() expected %d, got %d", __FILE__, __LINE__, expectedni, ni);
         }
-        if (0 != str.tempSubString(startIdx, 20).compare(extractBuffer)) { 
+        if (0 != str.tempSubString(startIdx, 20).compare(extractBuffer)) {
             errln("%s:%d utext_extract() failed. expected \"%s\", got \"%s\"",
                     __FILE__, __LINE__, CStr(str.tempSubString(startIdx, 20))(), CStr(UnicodeString(extractBuffer))());
         }
@@ -1621,10 +1621,10 @@ static const char16_t testAccessText[] = { // text with surrogates at chunk boun
     0xE070,0xe071,0xe072,0xD83D,0xDE00,0xe075,0xe076,0xe077, 0xe078,0xe079,0xe07a,0xD83D,0xDE00,0xe07d,0xe07e,0xD802, // 112-127, unpaired lead at 127
 };
 
-static const UChar32 testAccess32Text[] = { // same as above in UTF32
+static const UChar32 testAccess32Text[] = { // same as above in UTF32, surrogate pairs coalesce...
     0xDC00,0xe001,0xe002,0x1F600,0xe005,0xe006,0xe007, 0xe008,0xe009,0xe00a,0x1F600,0xe00d,0xe00e,0xe00f, // 000-013, unpaired trail at 0
     0xE010,0xe011,0xe012,0x1F600,0xe015,0xe016,0xe017, 0xe018,0xe019,0xe01a,0x1F600,0xe01d,0xe01e,0x10001, // 014-027, nonBMP at 27, will split in chunks
-           0xe021,0xe022,0x1F600,0xe025,0xe026,0xe027, 0xe028,0xe029,0xe02a,0x1F600,0xe02d,0xe02e,0xe02f, // 028-040
+    /*---*/0xe021,0xe022,0x1F600,0xe025,0xe026,0xe027, 0xe028,0xe029,0xe02a,0x1F600,0xe02d,0xe02e,0xe02f, // 028-040
     0xe030,0xe031,0xe032,0x1F600,0xe035,0xe036,0xe037, 0xe038,0xe039,0xe03a,0x1F600,0xe03d,0xe03e,0xe03f, // 041-054
     0xDC02,0xe041,0xe042,0x1F600,0xe045,0xe046,0xe047, 0xe048,0xe049,0xe04a,0x1F600,0xe04d,0xe04e,0xe04f, // 055-068, unpaired trail at 55
     0xe050,0xe051,0xe052,0x1F600,0xe055,0xe056,0xe057, 0xe058,0xe059,0xe05a,0x1F600,0xe05d,0xe05e,0xD801, // 069-082, unpaired lead at 82
@@ -1759,7 +1759,7 @@ u32NativeLength(UText *ut) {
 
 /**
  * Map from the current char16_t offset within the current text chunk to
- *  the corresponding native index in the original source text.
+ * the corresponding native index in the original source text.
  * @return Absolute (native) index corresponding to chunkOffset in the current chunk.
  *         The returned native index should always be to a code point boundary.
  */
@@ -1779,7 +1779,7 @@ u32MapOffsetToNative(const UText *ut) {
 /**
  * Map from a native index to a char16_t offset within a text chunk.
  * Behavior is undefined if the native index does not fall within the
- *   current chunk.
+ * current chunk.
  * @param nativeIndex Absolute (native) text index, chunk->start<=index<=chunk->limit.
  * @return            Chunk-relative UTF-16 offset corresponding to the specified native
  *                    index.
@@ -1938,7 +1938,6 @@ utext_openUChar32s(UText *ut, const UChar32 *s, int64_t length, const char16_t *
 }
 
 
-
 void UTextTest::AccessChangesChunkSize() {
     UErrorCode status = U_ZERO_ERROR;
     UText ut = UTEXT_INITIALIZER;
@@ -1960,43 +1959,43 @@ void UTextTest::AccessChangesChunkSize() {
     ut.pFuncs = &textFuncs;
 
     // do test
-	const OffsetAndChar *testEntryPtr = testAccessEntries;
-	int32_t testCount = UPRV_LENGTHOF(testAccessEntries);
-	for (; testCount-- > 0; testEntryPtr++) {
-	    utext_setNativeIndex(&ut, testEntryPtr->nativeOffset);
-	    int64_t beforeOffset = utext_getNativeIndex(&ut);
-	    UChar32 uchar = utext_current32(&ut);
-	    int64_t afterOffset = utext_getNativeIndex(&ut);
-	    if (uchar != testEntryPtr->expectChar || afterOffset != beforeOffset) {
-	        errln("utext_current32 unexpected behavior for u16, test case %lld: expected char %04X at offset %lld, got %04X at %lld;\n"
-	            "chunkNativeStart %lld chunkNativeLimit %lld nativeIndexingLimit %d chunkLength %d chunkOffset %d",
-	            static_cast<int64_t>(testEntryPtr - testAccessEntries), testEntryPtr->expectChar, beforeOffset, uchar, afterOffset,
-	            ut.chunkNativeStart, ut.chunkNativeLimit, ut.nativeIndexingLimit, ut.chunkLength, ut.chunkOffset);
-	    }
-	}
-	utext_close(&ut);
-	
-	ut = UTEXT_INITIALIZER;
-	utext_openUChar32s(&ut, testAccess32Text, UPRV_LENGTHOF(testAccess32Text), testAccessText, &status);
+    const OffsetAndChar *testEntryPtr = testAccessEntries;
+    int32_t testCount = UPRV_LENGTHOF(testAccessEntries);
+    for (; testCount-- > 0; testEntryPtr++) {
+        utext_setNativeIndex(&ut, testEntryPtr->nativeOffset);
+        int64_t beforeOffset = utext_getNativeIndex(&ut);
+        UChar32 uchar = utext_current32(&ut);
+        int64_t afterOffset = utext_getNativeIndex(&ut);
+        if (uchar != testEntryPtr->expectChar || afterOffset != beforeOffset) {
+            errln("utext_current32 unexpected behavior for u16, test case %lld: expected char %04X at offset %lld, got %04X at %lld;\n"
+                "chunkNativeStart %lld chunkNativeLimit %lld nativeIndexingLimit %d chunkLength %d chunkOffset %d",
+                static_cast<int64_t>(testEntryPtr - testAccessEntries), testEntryPtr->expectChar, beforeOffset, uchar, afterOffset,
+                ut.chunkNativeStart, ut.chunkNativeLimit, ut.nativeIndexingLimit, ut.chunkLength, ut.chunkOffset);
+        }
+    }
+    utext_close(&ut);
+
+    ut = UTEXT_INITIALIZER;
+    utext_openUChar32s(&ut, testAccess32Text, UPRV_LENGTHOF(testAccess32Text), testAccessText, &status);
     if (U_FAILURE(status)) {
         errln("utext_openUChar32s failed: %s", u_errorName(status));
         return;
     }
     // do test
-	testEntryPtr = testAccess32Entries;
-	testCount = UPRV_LENGTHOF(testAccess32Entries);
-	for (; testCount-- > 0; testEntryPtr++) {
-	    utext_setNativeIndex(&ut, testEntryPtr->nativeOffset);
-	    int64_t beforeOffset = utext_getNativeIndex(&ut);
-	    UChar32 uchar = utext_current32(&ut);
-	    int64_t afterOffset = utext_getNativeIndex(&ut);
-	    if (uchar != testEntryPtr->expectChar || afterOffset != beforeOffset) {
-	        errln("utext_current32 unexpected behavior for u32, test case %lld: expected char %04X at offset %lld, got %04X at %lld;\n"
-	            "chunkNativeStart %lld chunkNativeLimit %lld nativeIndexingLimit %d chunkLength %d chunkOffset %d",
-	            static_cast<int64_t>(testEntryPtr - testAccess32Entries), testEntryPtr->expectChar, beforeOffset, uchar, afterOffset,
-	            ut.chunkNativeStart, ut.chunkNativeLimit, ut.nativeIndexingLimit, ut.chunkLength, ut.chunkOffset);
-	    }
-	}
-	utext_close(&ut);
+    testEntryPtr = testAccess32Entries;
+    testCount = UPRV_LENGTHOF(testAccess32Entries);
+    for (; testCount-- > 0; testEntryPtr++) {
+        utext_setNativeIndex(&ut, testEntryPtr->nativeOffset);
+        int64_t beforeOffset = utext_getNativeIndex(&ut);
+        UChar32 uchar = utext_current32(&ut);
+        int64_t afterOffset = utext_getNativeIndex(&ut);
+        if (uchar != testEntryPtr->expectChar || afterOffset != beforeOffset) {
+            errln("utext_current32 unexpected behavior for u32, test case %lld: expected char %04X at offset %lld, got %04X at %lld;\n"
+                "chunkNativeStart %lld chunkNativeLimit %lld nativeIndexingLimit %d chunkLength %d chunkOffset %d",
+                static_cast<int64_t>(testEntryPtr - testAccess32Entries), testEntryPtr->expectChar, beforeOffset, uchar, afterOffset,
+                ut.chunkNativeStart, ut.chunkNativeLimit, ut.nativeIndexingLimit, ut.chunkLength, ut.chunkOffset);
+        }
+    }
+    utext_close(&ut);
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

* General info on contributing: please see https://github.com/unicode-org/icu/blob/main/CONTRIBUTING.md
* Ticket numbers for minor changes: for minor changes (ex: docs typos), you can reuse one of the open catch-all tickets for our next release
  - ICU 76 ticket: docs minor fixes: typos/etc./version updates / User Guide & API docs: ICU-22722
  - ICU 76 ticket: code warnings/version updates: ICU-22721
* Contributors license agreement (CLA): 
  You will be automatically asked to sign the CLA before the PR is accepted.
  To sign the CLA: https://cla-assistant.io/unicode-org/icu

  For terms of use and license, see https://www.unicode.org/terms_of_use.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22318
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

Fix bad spacing/formatting in utxttest.cpp resulting from PR [#2382](https://github.com/unicode-org/icu/pull/2382) (was supposed to fix typos but did not notice any, maybe they already got fixed under the minor docs fix ticket. This is a separate ticket because Markus originally asked me to make it one...)