### PR TITLE
ICU-22793 Clang-Tidy: google-readability-casting

### DIFF
--- a/icu4c/source/common/propsvec.cpp
+++ b/icu4c/source/common/propsvec.cpp
@@ -194,8 +194,8 @@ upvec_setValue(UPropsVectors *pv,
      * input range (only possible for the first and last rows)
      * and if their value differs from the input value.
      */
-    splitFirstRow= (UBool)(start!=(UChar32)firstRow[0] && value!=(firstRow[column]&mask));
-    splitLastRow= (UBool)(limit!=(UChar32)lastRow[1] && value!=(lastRow[column]&mask));
+    splitFirstRow = start != static_cast<UChar32>(firstRow[0]) && value != (firstRow[column] & mask);
+    splitLastRow = limit != static_cast<UChar32>(lastRow[1]) && value != (lastRow[column] & mask);
 
     /* split first/last rows if necessary */
     if(splitFirstRow || splitLastRow) {

--- a/icu4c/source/common/punycode.cpp
+++ b/icu4c/source/common/punycode.cpp
@@ -353,10 +353,10 @@ u_strToPunycode(const char16_t *src, int32_t srcLength,
                 }
 
                 if(destLength<destCapacity) {
-                    dest[destLength]=digitToBasic(q, (UBool)(cpBuffer[j]<0));
+                    dest[destLength] = digitToBasic(q, cpBuffer[j] < 0);
                 }
                 ++destLength;
-                bias=adaptBias(delta, handledCPCount+1, (UBool)(handledCPCount==basicLength));
+                bias = adaptBias(delta, handledCPCount + 1, handledCPCount == basicLength);
                 delta=0;
                 ++handledCPCount;
             }
@@ -500,7 +500,7 @@ u_strFromPunycode(const char16_t *src, int32_t srcLength,
          * where needed instead of in for() loop tail.
          */
         ++destCPCount;
-        bias=adaptBias(i-oldi, destCPCount, (UBool)(oldi==0));
+        bias = adaptBias(i - oldi, destCPCount, oldi == 0);
 
         /*
          * i was supposed to wrap around from (incremented) destCPCount to 0,

--- a/icu4c/source/common/ubidi.cpp
+++ b/icu4c/source/common/ubidi.cpp
@@ -304,7 +304,7 @@ ubidi_setReorderingMode(UBiDi *pBiDi, UBiDiReorderingMode reorderingMode) UPRV_N
     if ((pBiDi!=nullptr) && (reorderingMode >= UBIDI_REORDER_DEFAULT)
                         && (reorderingMode < UBIDI_REORDER_COUNT)) {
         pBiDi->reorderingMode = reorderingMode;
-        pBiDi->isInverse = (UBool)(reorderingMode == UBIDI_REORDER_INVERSE_NUMBERS_AS_L);
+        pBiDi->isInverse = reorderingMode == UBIDI_REORDER_INVERSE_NUMBERS_AS_L;
     }
 }
 

--- a/icu4c/source/common/ucnv_bld.cpp
+++ b/icu4c/source/common/ucnv_bld.cpp
@@ -1440,7 +1440,7 @@ ucnv_swap(const UDataSwapper *ds,
                    MBCS_OPT_UNKNOWN_INCOMPATIBLE_MASK)==0
         ) {
             mbcsHeaderLength=mbcsHeader.options&MBCS_OPT_LENGTH_MASK;
-            noFromU=(UBool)((mbcsHeader.options&MBCS_OPT_NO_FROM_U)!=0);
+            noFromU = (mbcsHeader.options & MBCS_OPT_NO_FROM_U) != 0;
         } else {
             udata_printError(ds, "ucnv_swap(): unsupported _MBCSHeader.version %d.%d\n",
                              inMBCSHeader->version[0], inMBCSHeader->version[1]);

--- a/icu4c/source/common/ucnvhz.cpp
+++ b/icu4c/source/common/ucnvhz.cpp
@@ -389,7 +389,7 @@ UConverter_fromUnicode_HZ_OFFSETS_LOGIC (UConverterFromUnicodeArgs * args,
                 }
             }
             if (targetUniChar != missingCharMarker){
-               myConverterData->isTargetUCharDBCS = isTargetUCharDBCS = (UBool)(targetUniChar>0x00FF);     
+               myConverterData->isTargetUCharDBCS = isTargetUCharDBCS = targetUniChar > 0x00FF;
                  if(oldIsTargetUCharDBCS != isTargetUCharDBCS || !myConverterData->isEscapeAppended ){
                     /*Shifting from a double byte to single byte mode*/
                     if(!isTargetUCharDBCS){

--- a/icu4c/source/common/ucnvmbcs.cpp
+++ b/icu4c/source/common/ucnvmbcs.cpp
@@ -924,7 +924,7 @@ ucnv_MBCSGetFilteredUnicodeSetForUnicode(const UConverterSharedData *sharedData,
 
         bytes=mbcsTable->fromUnicodeBytes;
 
-        useFallback=(UBool)(which==UCNV_ROUNDTRIP_AND_FALLBACK_SET);
+        useFallback = which == UCNV_ROUNDTRIP_AND_FALLBACK_SET;
 
         switch(mbcsTable->outputType) {
         case MBCS_OUTPUT_3:
@@ -2823,7 +2823,7 @@ ucnv_MBCSToUnicodeWithOffsets(UConverterToUnicodeArgs *pArgs,
                  * - If any of the non-initial bytes could be the start of a character,
                  *   we stop the illegal sequence before the first one of those.
                  */
-                UBool isDBCSOnly=(UBool)(cnv->sharedData->mbcs.dbcsOnlyState!=0);
+                UBool isDBCSOnly = cnv->sharedData->mbcs.dbcsOnlyState != 0;
                 int8_t i;
                 for(i=1;
                     i<byteIndex && !isSingleOrLead(stateTable, state, isDBCSOnly, bytes[i]);

--- a/icu4c/source/common/unicode/unistr.h
+++ b/icu4c/source/common/unicode/unistr.h
@@ -3033,7 +3033,7 @@ public:
    * @draft ICU 76
    */
   inline operator std::u16string_view() const {
-    return { getBuffer(), (std::u16string_view::size_type)length() };
+    return {getBuffer(), static_cast<std::u16string_view::size_type>(length())};
   }
 
 #if U_SIZEOF_WCHAR_T==2 || defined(U_IN_DOXYGEN)

--- a/icu4c/source/common/unicode/uset.h
+++ b/icu4c/source/common/unicode/uset.h
@@ -1657,7 +1657,7 @@ public:
             int32_t length;
             const UChar *uchars = uset_getString(uset, index, &length);
             // assert uchars != nullptr;
-            return { ConstChar16Ptr(uchars), (uint32_t)length };
+            return {ConstChar16Ptr(uchars), static_cast<uint32_t>(length)};
         }
         return {};
     }

--- a/icu4c/source/common/unistr.cpp
+++ b/icu4c/source/common/unistr.cpp
@@ -125,7 +125,7 @@ U_COMMON_API UnicodeString U_EXPORT2
 unistr_internalConcat(const UnicodeString &s1, std::u16string_view s2) {
   int32_t sumLengths;
   if (s2.length() > INT32_MAX ||
-      uprv_add32_overflow(s1.length(), (int32_t)s2.length(), &sumLengths)) {
+      uprv_add32_overflow(s1.length(), static_cast<int32_t>(s2.length()), &sumLengths)) {
     UnicodeString bogus;
     bogus.setToBogus();
     return bogus;
@@ -301,7 +301,7 @@ UnicodeString::UnicodeString(const char *src, int32_t length, EInvariant) {
 UnicodeString UnicodeString::readOnlyAliasFromU16StringView(std::u16string_view text) {
   UnicodeString result;
   if (text.length() <= INT32_MAX) {
-    result.setTo(false, text.data(), (int32_t)text.length());
+    result.setTo(false, text.data(), static_cast<int32_t>(text.length()));
   } else {
     result.setToBogus();
   }
@@ -1622,7 +1622,7 @@ UnicodeString::doReplace(int32_t start, int32_t length, std::u16string_view src)
     setToBogus();
     return *this;
   }
-  return doReplace(start, length, src.data(), 0, (int32_t)src.length());
+  return doReplace(start, length, src.data(), 0, static_cast<int32_t>(src.length()));
 }
 
 // Versions of doReplace() only for append() variants.
@@ -1722,7 +1722,7 @@ UnicodeString::doAppend(std::u16string_view src) {
     setToBogus();
     return *this;
   }
-  return doAppend(src.data(), 0, (int32_t)src.length());
+  return doAppend(src.data(), 0, static_cast<int32_t>(src.length()));
 }
 
 /**

--- a/icu4c/source/common/ushape.cpp
+++ b/icu4c/source/common/ushape.cpp
@@ -1709,13 +1709,13 @@ u_shapeArabic(const char16_t *source, int32_t sourceLength,
         case U_SHAPE_DIGITS_ALEN2AN_INIT_LR:
             _shapeToArabicDigitsWithContext(dest, destLength,
                                             digitBase,
-                                            (UBool)((options&U_SHAPE_TEXT_DIRECTION_MASK)==U_SHAPE_TEXT_DIRECTION_LOGICAL),
+                                            (options & U_SHAPE_TEXT_DIRECTION_MASK) == U_SHAPE_TEXT_DIRECTION_LOGICAL,
                                             false);
             break;
         case U_SHAPE_DIGITS_ALEN2AN_INIT_AL:
             _shapeToArabicDigitsWithContext(dest, destLength,
                                             digitBase,
-                                            (UBool)((options&U_SHAPE_TEXT_DIRECTION_MASK)==U_SHAPE_TEXT_DIRECTION_LOGICAL),
+                                            (options & U_SHAPE_TEXT_DIRECTION_MASK) == U_SHAPE_TEXT_DIRECTION_LOGICAL,
                                             true);
             break;
         default:

--- a/icu4c/source/common/utext.cpp
+++ b/icu4c/source/common/utext.cpp
@@ -1937,7 +1937,7 @@ repTextReplace(UText *ut,
     }
 
     // Do the actual replace operation using methods of the Replaceable class
-    UnicodeString replStr((UBool)(length<0), src, length); // read-only alias
+    UnicodeString replStr(length < 0, src, length); // read-only alias
     rep->handleReplaceBetween(start32, limit32, replStr);
     int32_t newLength = rep->length();
     int32_t lengthDelta = newLength - oldLength;

--- a/icu4c/source/common/utrie.cpp
+++ b/icu4c/source/common/utrie.cpp
@@ -68,7 +68,7 @@ utrie_open(UNewTrie *fillIn,
         }
     }
     uprv_memset(trie, 0, sizeof(UNewTrie));
-    trie->isAllocated= (UBool)(fillIn==nullptr);
+    trie->isAllocated = fillIn == nullptr;
 
     if(aliasData!=nullptr) {
         trie->data=aliasData;
@@ -250,7 +250,7 @@ utrie_get32(UNewTrie *trie, UChar32 c, UBool *pInBlockZero) {
 
     block=trie->index[c>>UTRIE_SHIFT];
     if(pInBlockZero!=nullptr) {
-        *pInBlockZero= (UBool)(block==0);
+        *pInBlockZero = block == 0;
     }
 
     return trie->data[ABS(block)+(c&UTRIE_MASK)];
@@ -884,7 +884,7 @@ utrie_unserialize(UTrie *trie, const void *data, int32_t length, UErrorCode *pEr
         *pErrorCode=U_INVALID_FORMAT_ERROR;
         return -1;
     }
-    trie->isLatin1Linear= (UBool)((options&UTRIE_OPTIONS_LATIN1_IS_LINEAR)!=0);
+    trie->isLatin1Linear = (options & UTRIE_OPTIONS_LATIN1_IS_LINEAR) != 0;
 
     /* get the length values */
     trie->indexLength=header->indexLength;

--- a/icu4c/source/common/utrie_swap.cpp
+++ b/icu4c/source/common/utrie_swap.cpp
@@ -64,7 +64,7 @@ utrie_swap(const UDataSwapper *ds,
         return 0;
     }
 
-    dataIs32=(UBool)((trie.options&UTRIE_OPTIONS_DATA_IS_32_BIT)!=0);
+    dataIs32 = (trie.options & UTRIE_OPTIONS_DATA_IS_32_BIT) != 0;
     size=sizeof(UTrieHeader)+trie.indexLength*2+trie.dataLength*(dataIs32?4:2);
 
     if(length>=0) {

--- a/icu4c/source/common/uts46.cpp
+++ b/icu4c/source/common/uts46.cpp
@@ -1366,7 +1366,7 @@ uidna_labelToASCII(const UIDNA *idna,
     if(!checkArgs(label, length, dest, capacity, pInfo, pErrorCode)) {
         return 0;
     }
-    UnicodeString src((UBool)(length<0), label, length);
+    UnicodeString src(length < 0, label, length);
     UnicodeString destString(dest, 0, capacity);
     IDNAInfo info;
     reinterpret_cast<const IDNA *>(idna)->labelToASCII(src, destString, info, *pErrorCode);
@@ -1382,7 +1382,7 @@ uidna_labelToUnicode(const UIDNA *idna,
     if(!checkArgs(label, length, dest, capacity, pInfo, pErrorCode)) {
         return 0;
     }
-    UnicodeString src((UBool)(length<0), label, length);
+    UnicodeString src(length < 0, label, length);
     UnicodeString destString(dest, 0, capacity);
     IDNAInfo info;
     reinterpret_cast<const IDNA *>(idna)->labelToUnicode(src, destString, info, *pErrorCode);
@@ -1398,7 +1398,7 @@ uidna_nameToASCII(const UIDNA *idna,
     if(!checkArgs(name, length, dest, capacity, pInfo, pErrorCode)) {
         return 0;
     }
-    UnicodeString src((UBool)(length<0), name, length);
+    UnicodeString src(length < 0, name, length);
     UnicodeString destString(dest, 0, capacity);
     IDNAInfo info;
     reinterpret_cast<const IDNA *>(idna)->nameToASCII(src, destString, info, *pErrorCode);
@@ -1414,7 +1414,7 @@ uidna_nameToUnicode(const UIDNA *idna,
     if(!checkArgs(name, length, dest, capacity, pInfo, pErrorCode)) {
         return 0;
     }
-    UnicodeString src((UBool)(length<0), name, length);
+    UnicodeString src(length < 0, name, length);
     UnicodeString destString(dest, 0, capacity);
     IDNAInfo info;
     reinterpret_cast<const IDNA *>(idna)->nameToUnicode(src, destString, info, *pErrorCode);

--- a/icu4c/source/i18n/collationbuilder.cpp
+++ b/icu4c/source/i18n/collationbuilder.cpp
@@ -1675,7 +1675,7 @@ ucol_openRules(const char16_t *rules, int32_t rulesLength,
         *pErrorCode = U_MEMORY_ALLOCATION_ERROR;
         return nullptr;
     }
-    UnicodeString r((UBool)(rulesLength < 0), rules, rulesLength);
+    UnicodeString r(rulesLength < 0, rules, rulesLength);
     coll->internalBuildTailoring(r, strength, normalizationMode, parseError, nullptr, *pErrorCode);
     if(U_FAILURE(*pErrorCode)) {
         delete coll;

--- a/icu4c/source/i18n/messageformat2_parser.cpp
+++ b/icu4c/source/i18n/messageformat2_parser.cpp
@@ -460,7 +460,7 @@ void Parser::parseToken(const std::u16string_view& token, UErrorCode& errorCode)
     U_ASSERT(inBounds(source, index));
 
     int32_t tokenPos = 0;
-    while (tokenPos < (int32_t) token.length()) {
+    while (tokenPos < static_cast<int32_t>(token.length())) {
         if (source[index] != token[tokenPos]) {
             ERROR(parseError, errorCode, index);
             return;
@@ -1674,7 +1674,7 @@ void Parser::parseUnsupportedStatement(UErrorCode& status) {
 // Terrible hack to get around the ambiguity between unsupported keywords
 // and supported keywords
 bool Parser::nextIs(const std::u16string_view &keyword) const {
-    for(int32_t i = 0; i < (int32_t) keyword.length(); i++) {
+    for (int32_t i = 0; i < static_cast<int32_t>(keyword.length()); i++) {
         if (!inBounds(source, index + i) || source[index + i] != keyword[i]) {
             return false;
         }

--- a/icu4c/source/i18n/rbt_pars.cpp
+++ b/icu4c/source/i18n/rbt_pars.cpp
@@ -1693,7 +1693,7 @@ utrans_stripRules(const char16_t *source, int32_t sourceLen, char16_t *target, U
         U16_NEXT_UNSAFE(source, index, c);
         source+=index;
         if(c == QUOTE) {
-            quoted = (UBool)!quoted;
+            quoted = !quoted;
         }
         else if (!quoted) {
             if (c == RULE_COMMENT_CHAR) {
@@ -1739,7 +1739,7 @@ utrans_stripRules(const char16_t *source, int32_t sourceLen, char16_t *target, U
                 }
                 else if (c2 == QUOTE) {
                     /* \' seen. Make sure we don't do anything when we see it again. */
-                    quoted = (UBool)!quoted;
+                    quoted = !quoted;
                 }
             }
         }

--- a/icu4c/source/i18n/reldatefmt.cpp
+++ b/icu4c/source/i18n/reldatefmt.cpp
@@ -1448,8 +1448,8 @@ ureldatefmt_combineDateAndTime( const URelativeDateTimeFormatter* reldatefmt,
         *status = U_ILLEGAL_ARGUMENT_ERROR;
         return 0;
     }
-    UnicodeString relDateStr((UBool)(relativeDateStringLen == -1), relativeDateString, relativeDateStringLen);
-    UnicodeString timeStr((UBool)(timeStringLen == -1), timeString, timeStringLen);
+    UnicodeString relDateStr(relativeDateStringLen == -1, relativeDateString, relativeDateStringLen);
+    UnicodeString timeStr(timeStringLen == -1, timeString, timeStringLen);
     UnicodeString res(result, 0, resultCapacity);
     ((RelativeDateTimeFormatter*)reldatefmt)->combineDateAndTime(relDateStr, timeStr, res, *status);
     if (U_FAILURE(*status)) {

--- a/icu4c/source/i18n/ucoleitr.cpp
+++ b/icu4c/source/i18n/ucoleitr.cpp
@@ -289,7 +289,7 @@ ucol_openElements(const UCollator  *coll,
         return nullptr;
     }
 
-    UnicodeString s((UBool)(textLength < 0), text, textLength);
+    UnicodeString s(textLength < 0, text, textLength);
     CollationElementIterator *cei = rbc->createCollationElementIterator(s);
     if (cei == nullptr) {
         *status = U_MEMORY_ALLOCATION_ERROR;
@@ -488,7 +488,7 @@ ucol_setText(      UCollationElements *elems,
         *status = U_ILLEGAL_ARGUMENT_ERROR;
         return;
     }
-    UnicodeString s((UBool)(textLength < 0), text, textLength);
+    UnicodeString s(textLength < 0, text, textLength);
     return CollationElementIterator::fromUCollationElements(elems)->setText(s, *status);
 }
 

--- a/icu4c/source/i18n/udat.cpp
+++ b/icu4c/source/i18n/udat.cpp
@@ -162,7 +162,7 @@ udat_open(UDateFormatStyle  timeStyle,
         }
     }
     else {
-        UnicodeString pat((UBool)(patternLength == -1), pattern, patternLength);
+        UnicodeString pat(patternLength == -1, pattern, patternLength);
 
         if (locale == nullptr) {
             fmt = new SimpleDateFormat(pat, *status);
@@ -182,7 +182,7 @@ udat_open(UDateFormatStyle  timeStyle,
     }
 
     if (tzID != nullptr) {
-        TimeZone *zone = TimeZone::createTimeZone(UnicodeString((UBool)(tzIDLength == -1), tzID, tzIDLength));
+        TimeZone* zone = TimeZone::createTimeZone(UnicodeString(tzIDLength == -1, tzID, tzIDLength));
         if (zone == nullptr) {
             *status = U_MEMORY_ALLOCATION_ERROR;
             delete fmt;
@@ -359,7 +359,7 @@ udat_parse(    const    UDateFormat*        format,
 {
     if(U_FAILURE(*status)) return (UDate)0;
 
-    const UnicodeString src((UBool)(textLength == -1), text, textLength);
+    const UnicodeString src(textLength == -1, text, textLength);
     ParsePosition pp;
     int32_t stackParsePos = 0;
     UDate res;
@@ -392,7 +392,7 @@ udat_parseCalendar(const    UDateFormat*    format,
 {
     if(U_FAILURE(*status)) return;
 
-    const UnicodeString src((UBool)(textLength == -1), text, textLength);
+    const UnicodeString src(textLength == -1, text, textLength);
     ParsePosition pp;
     int32_t stackParsePos = 0;
 
@@ -581,7 +581,7 @@ udat_applyPattern(  UDateFormat     *format,
                     const   char16_t        *pattern,
                     int32_t         patternLength)
 {
-    const UnicodeString pat((UBool)(patternLength == -1), pattern, patternLength);
+    const UnicodeString pat(patternLength == -1, pattern, patternLength);
     UErrorCode status = U_ZERO_ERROR;
 
     verifyIsSimpleDateFormat(format, &status);
@@ -1355,8 +1355,8 @@ udat_applyPatternRelative(UDateFormat *format,
 {
     verifyIsRelativeDateFormat(format, status);
     if(U_FAILURE(*status)) return;
-    const UnicodeString datePat((UBool)(datePatternLength == -1), datePattern, datePatternLength);
-    const UnicodeString timePat((UBool)(timePatternLength == -1), timePattern, timePatternLength);
+    const UnicodeString datePat(datePatternLength == -1, datePattern, datePatternLength);
+    const UnicodeString timePat(timePatternLength == -1, timePattern, timePatternLength);
     ((RelativeDateFormat*)format)->applyPatterns(datePat, timePat, *status);
 }
 

--- a/icu4c/source/i18n/udateintervalformat.cpp
+++ b/icu4c/source/i18n/udateintervalformat.cpp
@@ -51,14 +51,14 @@ udtitvfmt_open(const char*  locale,
         *status = U_ILLEGAL_ARGUMENT_ERROR;
         return nullptr;
     }
-    UnicodeString skel((UBool)(skeletonLength == -1), skeleton, skeletonLength);
+    UnicodeString skel(skeletonLength == -1, skeleton, skeletonLength);
     LocalPointer<DateIntervalFormat> formatter(
             DateIntervalFormat::createInstance(skel, Locale(locale), *status));
     if (U_FAILURE(*status)) {
         return nullptr;
     }
     if (tzID != nullptr) {
-        TimeZone *zone = TimeZone::createTimeZone(UnicodeString((UBool)(tzIDLength == -1), tzID, tzIDLength));
+        TimeZone* zone = TimeZone::createTimeZone(UnicodeString(tzIDLength == -1, tzID, tzIDLength));
         if(zone == nullptr) {
             *status = U_MEMORY_ALLOCATION_ERROR;
             return nullptr;

--- a/icu4c/source/i18n/udatpg.cpp
+++ b/icu4c/source/i18n/udatpg.cpp
@@ -78,7 +78,7 @@ udatpg_getBestPatternWithOptions(UDateTimePatternGenerator *dtpg,
         *pErrorCode=U_ILLEGAL_ARGUMENT_ERROR;
         return 0;
     }
-    UnicodeString skeletonString((UBool)(length<0), skeleton, length);
+    UnicodeString skeletonString(length < 0, skeleton, length);
     UnicodeString result=((DateTimePatternGenerator *)dtpg)->getBestPattern(skeletonString, options, *pErrorCode);
     return result.extract(bestPattern, capacity, *pErrorCode);
 }
@@ -95,7 +95,7 @@ udatpg_getSkeleton(UDateTimePatternGenerator * /* dtpg */,
         *pErrorCode=U_ILLEGAL_ARGUMENT_ERROR;
         return 0;
     }
-    UnicodeString patternString((UBool)(length<0), pattern, length);
+    UnicodeString patternString(length < 0, pattern, length);
     UnicodeString result=DateTimePatternGenerator::staticGetSkeleton(
             patternString, *pErrorCode);
     return result.extract(skeleton, capacity, *pErrorCode);
@@ -113,7 +113,7 @@ udatpg_getBaseSkeleton(UDateTimePatternGenerator * /* dtpg */,
         *pErrorCode=U_ILLEGAL_ARGUMENT_ERROR;
         return 0;
     }
-    UnicodeString patternString((UBool)(length<0), pattern, length);
+    UnicodeString patternString(length < 0, pattern, length);
     UnicodeString result=DateTimePatternGenerator::staticGetBaseSkeleton(
             patternString, *pErrorCode);
     return result.extract(skeleton, capacity, *pErrorCode);
@@ -132,7 +132,7 @@ udatpg_addPattern(UDateTimePatternGenerator *dtpg,
         *pErrorCode=U_ILLEGAL_ARGUMENT_ERROR;
         return UDATPG_NO_CONFLICT;
     }
-    UnicodeString patternString((UBool)(patternLength<0), pattern, patternLength);
+    UnicodeString patternString(patternLength < 0, pattern, patternLength);
     UnicodeString conflictingPatternString;
     UDateTimePatternConflict result=((DateTimePatternGenerator *)dtpg)->
             addPattern(patternString, override, conflictingPatternString, *pErrorCode);
@@ -147,7 +147,7 @@ U_CAPI void U_EXPORT2
 udatpg_setAppendItemFormat(UDateTimePatternGenerator *dtpg,
                            UDateTimePatternField field,
                            const char16_t *value, int32_t length) {
-    UnicodeString valueString((UBool)(length<0), value, length);
+    UnicodeString valueString(length < 0, value, length);
     ((DateTimePatternGenerator *)dtpg)->setAppendItemFormat(field, valueString);
 }
 
@@ -166,7 +166,7 @@ U_CAPI void U_EXPORT2
 udatpg_setAppendItemName(UDateTimePatternGenerator *dtpg,
                          UDateTimePatternField field,
                          const char16_t *value, int32_t length) {
-    UnicodeString valueString((UBool)(length<0), value, length);
+    UnicodeString valueString(length < 0, value, length);
     ((DateTimePatternGenerator *)dtpg)->setAppendItemName(field, valueString);
 }
 
@@ -203,7 +203,7 @@ udatpg_getFieldDisplayName(const UDateTimePatternGenerator *dtpg,
 U_CAPI void U_EXPORT2
 udatpg_setDateTimeFormat(const UDateTimePatternGenerator *dtpg,
                          const char16_t *dtFormat, int32_t length) {
-    UnicodeString dtFormatString((UBool)(length<0), dtFormat, length);
+    UnicodeString dtFormatString(length < 0, dtFormat, length);
     ((DateTimePatternGenerator *)dtpg)->setDateTimeFormat(dtFormatString);
 }
 
@@ -226,7 +226,7 @@ udatpg_setDateTimeFormatForStyle(UDateTimePatternGenerator *udtpg,
         return;
     }
     DateTimePatternGenerator *dtpg = reinterpret_cast<DateTimePatternGenerator *>(udtpg);
-    UnicodeString dtFormatString((UBool)(length<0), dateTimeFormat, length);
+    UnicodeString dtFormatString(length < 0, dateTimeFormat, length);
     dtpg->setDateTimeFormat(style, dtFormatString, *pErrorCode);
 }
 
@@ -255,7 +255,7 @@ udatpg_getDateTimeFormatForStyle(const UDateTimePatternGenerator *udtpg,
 U_CAPI void U_EXPORT2
 udatpg_setDecimal(UDateTimePatternGenerator *dtpg,
                   const char16_t *decimal, int32_t length) {
-    UnicodeString decimalString((UBool)(length<0), decimal, length);
+    UnicodeString decimalString(length < 0, decimal, length);
     ((DateTimePatternGenerator *)dtpg)->setDecimal(decimalString);
 }
 
@@ -294,8 +294,8 @@ udatpg_replaceFieldTypesWithOptions(UDateTimePatternGenerator *dtpg,
         *pErrorCode=U_ILLEGAL_ARGUMENT_ERROR;
         return 0;
     }
-    UnicodeString patternString((UBool)(patternLength<0), pattern, patternLength);
-    UnicodeString skeletonString((UBool)(skeletonLength<0), skeleton, skeletonLength);
+    UnicodeString patternString(patternLength < 0, pattern, patternLength);
+    UnicodeString skeletonString(skeletonLength < 0, skeleton, skeletonLength);
     UnicodeString result=((DateTimePatternGenerator *)dtpg)->replaceFieldTypes(patternString, skeletonString, options, *pErrorCode);
     return result.extract(dest, destCapacity, *pErrorCode);
 }
@@ -318,7 +318,7 @@ U_CAPI const char16_t * U_EXPORT2
 udatpg_getPatternForSkeleton(const UDateTimePatternGenerator *dtpg,
                              const char16_t *skeleton, int32_t skeletonLength,
                              int32_t *pLength) {
-    UnicodeString skeletonString((UBool)(skeletonLength<0), skeleton, skeletonLength);
+    UnicodeString skeletonString(skeletonLength < 0, skeleton, skeletonLength);
     const UnicodeString &result=((const DateTimePatternGenerator *)dtpg)->getPatternForSkeleton(skeletonString);
     if(pLength!=nullptr) {
         *pLength=result.length();

--- a/icu4c/source/i18n/unum.cpp
+++ b/icu4c/source/i18n/unum.cpp
@@ -485,7 +485,7 @@ unum_parseDoubleCurrency(const UNumberFormat* fmt,
     if (U_FAILURE(*status)) {
         return doubleVal;
     }
-    const UnicodeString src((UBool)(textLength == -1), text, textLength);
+    const UnicodeString src(textLength == -1, text, textLength);
     ParsePosition pp;
     if (parsePos != nullptr) {
         pp.setIndex(*parsePos);

--- a/icu4c/source/io/ufile.cpp
+++ b/icu4c/source/io/ufile.cpp
@@ -255,7 +255,7 @@ u_feof(UFILE  *f)
     if (f == nullptr) {
         return true;
     }
-    endOfBuffer = (UBool)(f->str.fPos >= f->str.fLimit);
+    endOfBuffer = f->str.fPos >= f->str.fLimit;
     if (f->fFile != nullptr) {
         return endOfBuffer && feof(f->fFile);
     }

--- a/icu4c/source/test/cintltst/capitst.c
+++ b/icu4c/source/test/cintltst/capitst.c
@@ -1282,8 +1282,8 @@ void TestSortKey(void)
 
       for(i=0;i<sortklen;i++)
         {
-          snprintf(junk2+strlen(junk2), sizeof(junk2)-strlen(junk2), "%02X ",(int)( 0xFF & sortk2[i]));
-          snprintf(junk3+strlen(junk3), sizeof(junk3)-strlen(junk3), "%02X ",(int)( 0xFF & sortk3[i]));
+          snprintf(junk2 + strlen(junk2), sizeof(junk2) - strlen(junk2), "%02X ", (0xFF & sortk2[i]));
+          snprintf(junk3 + strlen(junk3), sizeof(junk3) - strlen(junk3), "%02X ", (0xFF & sortk3[i]));
         }
 
       log_verbose("%s\n", junk2);

--- a/icu4c/source/test/cintltst/cbiapts.c
+++ b/icu4c/source/test/cintltst/cbiapts.c
@@ -256,19 +256,19 @@ static void TestBreakIteratorCAPI(void)
     start = ubrk_first(word);
     if(start!=0)
         log_err("error ubrk_start(word) did not return 0\n");
-    log_verbose("first (word = %d\n", (int32_t)start);
+    log_verbose("first (word = %d\n", start);
        pos=ubrk_next(word);
     if(pos!=4)
         log_err("error ubrk_next(word) did not return 4\n");
-    log_verbose("next (word = %d\n", (int32_t)pos);
+    log_verbose("next (word = %d\n", pos);
     pos=ubrk_following(word, 4);
     if(pos!=5)
         log_err("error ubrl_following(word,4) did not return 6\n");
-    log_verbose("next (word = %d\n", (int32_t)pos);
+    log_verbose("next (word = %d\n", pos);
     end=ubrk_last(word);
     if(end!=49)
         log_err("error ubrk_last(word) did not return 49\n");
-    log_verbose("last (word = %d\n", (int32_t)end);
+    log_verbose("last (word = %d\n", end);
 
     pos=ubrk_previous(word);
     log_verbose("%d   %d\n", end, pos);
@@ -294,36 +294,36 @@ static void TestBreakIteratorCAPI(void)
     pos = ubrk_following(character, 5);
     if(pos!=6)
        log_err("error ubrk_following(character,5) did not return 6\n");
-    log_verbose("Following (character,5) = %d\n", (int32_t)pos);
+    log_verbose("Following (character,5) = %d\n", pos);
     pos=ubrk_following(character, 18);
     if(pos!=19)
        log_err("error ubrk_following(character,18) did not return 19\n");
-    log_verbose("Followingcharacter,18) = %d\n", (int32_t)pos);
+    log_verbose("Followingcharacter,18) = %d\n", pos);
     pos=ubrk_preceding(character, 22);
     if(pos!=21)
        log_err("error ubrk_preceding(character,22) did not return 21\n");
-    log_verbose("preceding(character,22) = %d\n", (int32_t)pos);
+    log_verbose("preceding(character,22) = %d\n", pos);
 
 
     log_verbose("\nTesting the functions for line\n");
     pos=ubrk_first(line);
     if(pos != 0)
-        log_err("error ubrk_first(line) returned %d, expected 0\n", (int32_t)pos);
+        log_err("error ubrk_first(line) returned %d, expected 0\n", pos);
     pos = ubrk_next(line);
     pos=ubrk_following(line, 18);
     if(pos!=22)
         log_err("error ubrk_following(line) did not return 22\n");
-    log_verbose("following (line) = %d\n", (int32_t)pos);
+    log_verbose("following (line) = %d\n", pos);
 
 
     log_verbose("\nTesting the functions for sentence\n");
     pos = ubrk_first(sentence);
     pos = ubrk_current(sentence);
-    log_verbose("Current(sentence) = %d\n", (int32_t)pos);
+    log_verbose("Current(sentence) = %d\n", pos);
        pos = ubrk_last(sentence);
     if(pos!=49)
         log_err("error ubrk_last for sentence did not return 49\n");
-    log_verbose("Last (sentence) = %d\n", (int32_t)pos);
+    log_verbose("Last (sentence) = %d\n", pos);
     pos = ubrk_first(sentence);
     to = ubrk_following( sentence, 0 );
     if (to == 0) log_err("ubrk_following returned 0\n");

--- a/icu4c/source/test/cintltst/ccaltst.c
+++ b/icu4c/source/test/cintltst/ccaltst.c
@@ -1379,7 +1379,7 @@ static void testZones(int32_t yr, int32_t mo, int32_t dt, int32_t hr, int32_t mn
         log_err("ucal_get() failed: %s\n", u_errorName(status));
         goto cleanup;
     }
-    temp=(double)((double)offset / 1000.0 / 60.0 / 60.0);
+    temp = (double)offset / 1000.0 / 60.0 / 60.0;
     /*printf("offset for %s %f hr\n", austrdup(myDateFormat(datfor, date1)), temp);*/
        
     utc = ((ucal_get(cal, UCAL_HOUR_OF_DAY, &status) * 60 +

--- a/icu4c/source/test/cintltst/ccapitst.c
+++ b/icu4c/source/test/cintltst/ccapitst.c
@@ -1896,10 +1896,10 @@ static void TestConvertSafeClone(void)
     }
 
     log_verbose("ucnv_safeClone(): sizeof(UConverter)=%lu  max preflighted clone size=%d (%s)  U_CNV_SAFECLONE_BUFFERSIZE=%d\n",
-        sizeof(UConverter), maxBufferSize, maxName, (int)U_CNV_SAFECLONE_BUFFERSIZE);
+        sizeof(UConverter), maxBufferSize, maxName, U_CNV_SAFECLONE_BUFFERSIZE);
     if(maxBufferSize > U_CNV_SAFECLONE_BUFFERSIZE) {
         log_err("ucnv_safeClone(): max preflighted clone size=%d (%s) is larger than U_CNV_SAFECLONE_BUFFERSIZE=%d\n",
-            maxBufferSize, maxName, (int)U_CNV_SAFECLONE_BUFFERSIZE);
+            maxBufferSize, maxName, U_CNV_SAFECLONE_BUFFERSIZE);
     }
 }
 

--- a/icu4c/source/test/cintltst/cintltst.c
+++ b/icu4c/source/test/cintltst/cintltst.c
@@ -247,10 +247,10 @@ int main(int argc, const char* const argv[])
     endTime = uprv_getRawUTCtime();
     diffTime = (int32_t)(endTime - startTime);
     printf("Elapsed Time: %02d:%02d:%02d.%03d\n",
-        (int)((diffTime%U_MILLIS_PER_DAY)/U_MILLIS_PER_HOUR),
-        (int)((diffTime%U_MILLIS_PER_HOUR)/U_MILLIS_PER_MINUTE),
-        (int)((diffTime%U_MILLIS_PER_MINUTE)/U_MILLIS_PER_SECOND),
-        (int)(diffTime%U_MILLIS_PER_SECOND));
+        (diffTime % U_MILLIS_PER_DAY) / U_MILLIS_PER_HOUR,
+        (diffTime % U_MILLIS_PER_HOUR) / U_MILLIS_PER_MINUTE,
+        (diffTime % U_MILLIS_PER_MINUTE) / U_MILLIS_PER_SECOND,
+        (diffTime % U_MILLIS_PER_SECOND));
 
     return nerrors ? 1 : 0;
 }

--- a/icu4c/source/test/cintltst/nccbtst.c
+++ b/icu4c/source/test/cintltst/nccbtst.c
@@ -2713,8 +2713,8 @@ UBool testConvertFromUnicode(const UChar *source, int sourceLen,  const uint8_t 
         status = U_ZERO_ERROR;
 
         ucnv_fromUnicode (conv,
-                  (char **)&targ,
-                  (const char *)end,
+                  &targ,
+                  end,
                   &src,
                   sourceLimit,
                   checkOffsets ? offs : NULL,
@@ -2911,8 +2911,8 @@ UBool testConvertToUnicode( const uint8_t *source, int sourcelen, const UChar *e
         ucnv_toUnicode (conv,
                 &targ,
                 end,
-                (const char **)&src,
-                (const char *)srcLimit,
+                &src,
+                srcLimit,
                 checkOffsets ? offs : NULL,
                 (UBool)(srcLimit == realSourceEnd), /* flush if we're at the end of the source data */
                 &status);
@@ -3104,8 +3104,8 @@ UBool testConvertFromUnicodeWithContext(const UChar *source, int sourceLen,  con
         status = U_ZERO_ERROR;
 
         ucnv_fromUnicode (conv,
-                  (char **)&targ,
-                  (const char *)end,
+                  &targ,
+                  end,
                   &src,
                   sourceLimit,
                   checkOffsets ? offs : NULL,
@@ -3284,8 +3284,8 @@ UBool testConvertToUnicodeWithContext( const uint8_t *source, int sourcelen, con
         ucnv_toUnicode (conv,
                 &targ,
                 end,
-                (const char **)&src,
-                (const char *)srcLimit,
+                &src,
+                srcLimit,
                 checkOffsets ? offs : NULL,
                 (UBool)(srcLimit == realSourceEnd), /* flush if we're at the end of the source data */
                 &status);

--- a/icu4c/source/test/cintltst/ncnvfbts.c
+++ b/icu4c/source/test/cintltst/ncnvfbts.c
@@ -209,8 +209,8 @@ static UBool testConvertFromUnicode(const UChar *source, int sourceLen,  const u
         status = U_ZERO_ERROR;
 
         ucnv_fromUnicode (conv,
-                  (char **)&targ,
-                  (const char *)end,
+                  &targ,
+                  end,
                   &src,
                   sourceLimit,
                   checkOffsets ? offs : NULL,
@@ -374,8 +374,8 @@ static UBool testConvertToUnicode( const uint8_t *source, int sourcelen, const U
         ucnv_toUnicode (conv,
                 &targ,
                 end,
-                (const char **)&src,
-                (const char *)srcLimit,
+                &src,
+                srcLimit,
                 checkOffsets ? offs : NULL,
                 (UBool)(srcLimit == realSourceEnd), /* flush if we're at the end of the source data */
                 &status);

--- a/icu4c/source/test/cintltst/ncnvtst.c
+++ b/icu4c/source/test/cintltst/ncnvtst.c
@@ -1027,8 +1027,8 @@ static UBool convertFromU( const UChar *source, int sourceLen,  const uint8_t *e
     targetLimit=targ+MAX_LENGTH;
     offs=offsetBuffer;
     ucnv_fromUnicode (conv,
-                  (char **)&targ,
-                  (const char *)targetLimit,
+                  &targ,
+                  targetLimit,
                   &src,
                   sourceLimit,
                   expectOffsets ? offs : NULL,
@@ -1125,7 +1125,7 @@ static UBool convertToU( const uint8_t *source, int sourceLen, const UChar *expe
     ucnv_toUnicode (conv,
                 &targ,
                 targetLimit,
-                (const char **)&src,
+                &src,
                 (const char *)sourceLimit,
                 expectOffsets ? offs : NULL,
                 doFlush,
@@ -1259,8 +1259,8 @@ static UBool testConvertFromU( const UChar *source, int sourceLen,  const uint8_
         if(gInBufferSize ==999 && gOutBufferSize==999)
             doFlush = false;
         ucnv_fromUnicode (conv,
-                  (char **)&targ,
-                  (const char *)end,
+                  &targ,
+                  end,
                   &src,
                   sourceLimit,
                   offs,
@@ -1434,8 +1434,8 @@ static UBool testConvertToU( const uint8_t *source, int sourcelen, const UChar *
         ucnv_toUnicode (conv,
                 &targ,
                 end,
-                (const char **)&src,
-                (const char *)srcLimit,
+                &src,
+                srcLimit,
                 offs,
                 doFlush, /* flush if we're at the end of the source data */
                 &status);

--- a/icu4c/source/test/cintltst/nucnvtst.c
+++ b/icu4c/source/test/cintltst/nucnvtst.c
@@ -456,12 +456,12 @@ static ETestConvertResult testConvertFromU( const UChar *source, int sourceLen, 
       junk[0] = 0;
       offset_str[0] = 0;
       for(ptr = junkout;ptr<targ;ptr++) {
-        snprintf(junk + strlen(junk), sizeof(junk)-strlen(junk), "0x%02x, ", (int)(0xFF & *ptr));
-        snprintf(offset_str + strlen(offset_str), sizeof(offset_str)-strlen(offset_str), "0x%02x, ", (int)(0xFF & junokout[ptr-junkout]));
+        snprintf(junk + strlen(junk), sizeof(junk) - strlen(junk), "0x%02x, ", (0xFF & *ptr));
+        snprintf(offset_str + strlen(offset_str), sizeof(offset_str) - strlen(offset_str), "0x%02x, ", (0xFF & junokout[ptr - junkout]));
       }
       
       log_verbose(junk);
-      printSeq((const uint8_t *)expect, expectLen);
+      printSeq(expect, expectLen);
       if ( checkOffsets ) {
         log_verbose("\nOffsets:");
         log_verbose(offset_str);
@@ -2798,7 +2798,7 @@ TestSmallTargetBuffer(const uint16_t* source, const UChar* sourceLimit,UConverte
     ucnv_reset(cnv);
     for(;--i>0; ){
         uSource = (UChar*) source;
-        uSourceLimit=(const UChar*)sourceLimit;
+        uSourceLimit = sourceLimit;
         cTarget = cBuf;
         uTarget = uBuf;
         cSource = cBuf;
@@ -2993,7 +2993,7 @@ TestGetNextUChar2022(UConverter* cnv, const char* source, const char* limit,
             }else{
                 exC = *r;
             }
-            if(c!=(uint32_t)(exC))
+            if (c != exC)
                 log_err("%s ucnv_getNextUChar() Expected:  \\u%04X Got:  \\u%04X \n",message,(uint32_t) (*r),c);
         }
         r++;
@@ -5084,7 +5084,7 @@ TestLMBCS(void) {
       pUniIn = uniString;
       ucnv_toUnicode (cnv01us,
                         &pUniIn, pUniIn + 1,
-                        &pLMBCSOut, (const char *)(pLMBCSOut + 3),
+                        &pLMBCSOut, pLMBCSOut + 3,
                         NULL, 1, &errorCode);
       if (U_FAILURE(errorCode) || pLMBCSOut != (const char *)lmbcsString+3 || pUniIn != uniString+1 || uniString[0] != 0xFF6E)
       {
@@ -5185,14 +5185,14 @@ TestLMBCS(void) {
          pUIn--;
          
          errorCode=U_ZERO_ERROR;
-         ucnv_toUnicode(cnv, &pUOut,pUOut+1,(const char **)&pLIn,(const char *)(pLIn-1),off,false, &errorCode);
+         ucnv_toUnicode(cnv, &pUOut, pUOut + 1, &pLIn, pLIn - 1, off, false, &errorCode);
          if (errorCode != U_ILLEGAL_ARGUMENT_ERROR)
          {
             log_err("Unexpected Error on negative source request to ucnv_toUnicode: %s\n", u_errorName(errorCode));
          }
          errorCode=U_ZERO_ERROR;
 
-         uniChar = ucnv_getNextUChar(cnv, (const char **)&pLIn, (const char *)(pLIn-1), &errorCode);
+         uniChar = ucnv_getNextUChar(cnv, &pLIn, pLIn - 1, &errorCode);
          if (errorCode != U_ILLEGAL_ARGUMENT_ERROR)
          {
             log_err("Unexpected Error on negative source request to ucnv_getNextUChar: %s\n", u_errorName(errorCode));
@@ -5200,7 +5200,7 @@ TestLMBCS(void) {
          errorCode=U_ZERO_ERROR;
 
          /* 0 byte source request - no error, no pointer movement */
-         ucnv_toUnicode(cnv, &pUOut,pUOut+1,(const char **)&pLIn,(const char *)pLIn,off,false, &errorCode);
+         ucnv_toUnicode(cnv, &pUOut, pUOut + 1, &pLIn, pLIn, off, false, &errorCode);
          ucnv_fromUnicode(cnv, &pLOut,pLOut+1,&pUIn,pUIn,off,false, &errorCode);
          if(U_FAILURE(errorCode)) {
             log_err("0 byte source request: unexpected error: %s\n", u_errorName(errorCode));
@@ -5210,7 +5210,7 @@ TestLMBCS(void) {
               log_err("Unexpected pointer move in 0 byte source request \n");
          }
          /*0 byte source request - GetNextUChar : error & value == fffe or ffff */
-         uniChar = ucnv_getNextUChar(cnv, (const char **)&pLIn, (const char *)pLIn, &errorCode);
+         uniChar = ucnv_getNextUChar(cnv, &pLIn, pLIn, &errorCode);
          if (errorCode != U_INDEX_OUTOFBOUNDS_ERROR)
          {
             log_err("Unexpected Error on 0-byte source request to ucnv_getnextUChar: %s\n", u_errorName(errorCode));
@@ -5252,7 +5252,7 @@ TestLMBCS(void) {
          pUOut = UOut;
 
          ucnv_setToUCallBack(cnv, UCNV_TO_U_CALLBACK_STOP, NULL, NULL, NULL, &errorCode);
-         ucnv_toUnicode(cnv, &pUOut,pUOut+UPRV_LENGTHOF(UOut),(const char **)&pLIn,(const char *)(pLIn+5),off,true, &errorCode);
+         ucnv_toUnicode(cnv, &pUOut, pUOut + UPRV_LENGTHOF(UOut), &pLIn, pLIn + 5, off, true, &errorCode);
          if (UOut[0] != 0xD801 || errorCode != U_TRUNCATED_CHAR_FOUND || pUOut != UOut + 1 || pLIn != LIn + 5)
          {
             log_err("Unexpected results on chopped low surrogate\n");
@@ -5266,7 +5266,7 @@ TestLMBCS(void) {
          errorCode = U_ZERO_ERROR;
          pUOut = UOut;
 
-         ucnv_toUnicode(cnv, &pUOut,pUOut+UPRV_LENGTHOF(UOut),(const char **)&pLIn,(const char *)(pLIn+3),off,true, &errorCode);
+         ucnv_toUnicode(cnv, &pUOut, pUOut + UPRV_LENGTHOF(UOut), &pLIn, pLIn + 3, off, true, &errorCode);
          if (UOut[0] != 0xD801 || U_FAILURE(errorCode) || pUOut != UOut + 1 || pLIn != LIn + 3)
          {
             log_err("Unexpected results on chopped at surrogate boundary \n");
@@ -5283,7 +5283,7 @@ TestLMBCS(void) {
          errorCode = U_ZERO_ERROR;
          pUOut = UOut;
 
-         ucnv_toUnicode(cnv, &pUOut,pUOut+UPRV_LENGTHOF(UOut),(const char **)&pLIn,(const char *)(pLIn+6),off,true, &errorCode);
+         ucnv_toUnicode(cnv, &pUOut, pUOut + UPRV_LENGTHOF(UOut), &pLIn, pLIn + 6, off, true, &errorCode);
          if (UOut[0] != 0xD801 || UOut[1] != 0xC9D0 || U_FAILURE(errorCode) || pUOut != UOut + 2 || pLIn != LIn + 6)
          {
             log_err("Unexpected results after unpaired surrogate plus valid Unichar \n");
@@ -5300,7 +5300,7 @@ TestLMBCS(void) {
          errorCode = U_ZERO_ERROR;
          pUOut = UOut;
 
-         ucnv_toUnicode(cnv, &pUOut,pUOut+UPRV_LENGTHOF(UOut),(const char **)&pLIn,(const char *)(pLIn+5),off,true, &errorCode);
+         ucnv_toUnicode(cnv, &pUOut, pUOut + UPRV_LENGTHOF(UOut), &pLIn, pLIn + 5, off, true, &errorCode);
          if (UOut[0] != 0xD801 || errorCode != U_TRUNCATED_CHAR_FOUND || pUOut != UOut + 1 || pLIn != LIn + 5)
          {
             log_err("Unexpected results after unpaired surrogate plus chopped Unichar \n");
@@ -5317,7 +5317,7 @@ TestLMBCS(void) {
          errorCode = U_ZERO_ERROR;
          pUOut = UOut;
 
-         ucnv_toUnicode(cnv, &pUOut,pUOut+UPRV_LENGTHOF(UOut),(const char **)&pLIn,(const char *)(pLIn+5),off,true, &errorCode);
+         ucnv_toUnicode(cnv, &pUOut, pUOut + UPRV_LENGTHOF(UOut), &pLIn, pLIn + 5, off, true, &errorCode);
          if (UOut[0] != 0xD801 || UOut[1] != 0x1B || U_FAILURE(errorCode) || pUOut != UOut + 2 || pLIn != LIn + 5)
          {
             log_err("Unexpected results after unpaired surrogate plus valid non-Unichar\n");
@@ -5333,7 +5333,7 @@ TestLMBCS(void) {
          errorCode = U_ZERO_ERROR;
          pUOut = UOut;
 
-         ucnv_toUnicode(cnv, &pUOut,pUOut+UPRV_LENGTHOF(UOut),(const char **)&pLIn,(const char *)(pLIn+4),off,true, &errorCode);
+         ucnv_toUnicode(cnv, &pUOut, pUOut + UPRV_LENGTHOF(UOut), &pLIn, pLIn + 4, off, true, &errorCode);
 
          if (UOut[0] != 0xD801 || errorCode != U_TRUNCATED_CHAR_FOUND || pUOut != UOut + 1 || pLIn != LIn + 4)
          {
@@ -5390,7 +5390,7 @@ static void TestEBCDICUS4XML(void)
         log_data_err("Failed to open the converter for EBCDIC-XML-US.\n");
         return;
     }
-    ucnv_toUnicode(cnv, &unicodes, unicodes+3, (const char**)&newLines, newLines+3, NULL, true, &status);
+    ucnv_toUnicode(cnv, &unicodes, unicodes + 3, &newLines, newLines + 3, NULL, true, &status);
     if (U_FAILURE(status) || memcmp(unicodes_x, toUnicodeMaps, sizeof(UChar)*3) != 0) {
         log_err("To Unicode conversion failed in EBCDICUS4XML test. %s\n",
             u_errorName(status));
@@ -5398,7 +5398,7 @@ static void TestEBCDICUS4XML(void)
         printUSeqErr(toUnicodeMaps, 3);
     }
     status = U_ZERO_ERROR;
-    ucnv_fromUnicode(cnv, &target, target+3, (const UChar**)&toUnicodeMaps, toUnicodeMaps+3, NULL, true, &status);
+    ucnv_fromUnicode(cnv, &target, target + 3, &toUnicodeMaps, toUnicodeMaps + 3, NULL, true, &status);
     if (U_FAILURE(status) || memcmp(target_x, fromUnicodeMaps, sizeof(char)*3) != 0) {
         log_err("From Unicode conversion failed in EBCDICUS4XML test. %s\n",
             u_errorName(status));

--- a/icu4c/source/test/cintltst/trie2test.c
+++ b/icu4c/source/test/cintltst/trie2test.c
@@ -477,7 +477,7 @@ testTrieUTF8(const char *testName,
         }
         if(i8!=(p-s)) {
             log_err("error: wrong end index from UTRIE2_U8_NEXT(%s)(from %d %lx->U+%04lx): %ld != %ld\n",
-                    testName, (int)prev8, (unsigned long)bytes, (long)c, (long)(p-s), (long)i8);
+                    testName, (int)prev8, (unsigned long)bytes, (long)c, p - s, (long)i8);
             continue;
         }
         ++i;
@@ -510,7 +510,7 @@ testTrieUTF8(const char *testName,
         }
         if(i8!=(p-s)) {
             log_err("error: wrong end index from UTRIE2_U8_PREV(%s)(from %d %lx->U+%04lx): %ld != %ld\n",
-                    testName, (int)prev8, (unsigned long)bytes, (long)c, (long)(p-s), (long)i8);
+                    testName, (int)prev8, (unsigned long)bytes, (long)c, p - s, (long)i8);
             continue;
         }
     }

--- a/icu4c/source/test/cintltst/ucptrietest.c
+++ b/icu4c/source/test/cintltst/ucptrietest.c
@@ -636,7 +636,7 @@ testTrieUTF8(const char *testName,
             log_err("error: wrong end index from UCPTRIE_FAST_U8_NEXT(%s)(from %d %lx->U+%04lx): "
                     "%ld != %ld (bytes %lx)\n",
                     testName, (int)prev8, (unsigned long)actualBytes, (long)c,
-                    (long)(p-s), (long)i8, (unsigned long)expectedBytes);
+                    p - s, (long)i8, (unsigned long)expectedBytes);
             break;
         }
         ++i;
@@ -682,7 +682,7 @@ testTrieUTF8(const char *testName,
             log_err("error: wrong end index from UCPTRIE_FAST_U8_PREV(%s)(from %d %lx->U+%04lx): "
                     "%ld != %ld (bytes %lx)\n",
                     testName, (int)prev8, (unsigned long)actualBytes, (long)c,
-                    (long)(p-s), (long)i8, (unsigned long)expectedBytes);
+                    p - s, (long)i8, (unsigned long)expectedBytes);
             break;
         }
     }

--- a/icu4c/source/test/cintltst/udatatst.c
+++ b/icu4c/source/test/cintltst/udatatst.c
@@ -1148,7 +1148,7 @@ static void TestICUDataName(void)
                 typeChar = 'l';
                 break;
           default:
-                log_err("Expected 1 or 0 for U_IS_BIG_ENDIAN, got %d!\n", (int)U_IS_BIG_ENDIAN);
+                log_err("Expected 1 or 0 for U_IS_BIG_ENDIAN, got %d!\n", U_IS_BIG_ENDIAN);
                 /* return; */
           }
           break;

--- a/icu4c/source/test/intltest/idnaref.cpp
+++ b/icu4c/source/test/intltest/idnaref.cpp
@@ -276,8 +276,8 @@ idnaref_toASCII(const char16_t* src, int32_t srcLength,
             reqLength=0;
 
     //get the options
-    UBool allowUnassigned   = (UBool)((options & IDNAREF_ALLOW_UNASSIGNED) != 0);
-    UBool useSTD3ASCIIRules = (UBool)((options & IDNAREF_USE_STD3_RULES) != 0);
+    UBool allowUnassigned = (options & IDNAREF_ALLOW_UNASSIGNED) != 0;
+    UBool useSTD3ASCIIRules = (options & IDNAREF_USE_STD3_RULES) != 0;
 
     UBool* caseFlags = nullptr;
 
@@ -455,8 +455,8 @@ idnaref_toUnicode(const char16_t* src, int32_t srcLength,
     UBool* caseFlags = nullptr;
 
     //get the options
-    UBool allowUnassigned   = (UBool)((options & IDNAREF_ALLOW_UNASSIGNED) != 0);
-    UBool useSTD3ASCIIRules = (UBool)((options & IDNAREF_USE_STD3_RULES) != 0);
+    UBool allowUnassigned = (options & IDNAREF_ALLOW_UNASSIGNED) != 0;
+    UBool useSTD3ASCIIRules = (options & IDNAREF_USE_STD3_RULES) != 0;
 
     UBool srcIsASCII = true;
     UBool srcIsLDH = true;

--- a/icu4c/source/test/intltest/usettest.cpp
+++ b/icu4c/source/test/intltest/usettest.cpp
@@ -2135,13 +2135,13 @@ UBool UnicodeSetTest::checkEqual(
     UnicodeString source; s.toPattern(source, true);
     UnicodeString result; t.toPattern(result, true);
     if (s != t) {
-        intlTest.errln((UnicodeString)"FAIL: " + message
+        intlTest.errln(UnicodeString("FAIL: ") + message
               + "\nsource = " + source
               + "\nresult = " + result
               );
         return false;
     } else {
-        intlTest.logln((UnicodeString)"Ok: " + message
+        intlTest.logln(UnicodeString("Ok: ") + message
               + "\nsource = " + source
               + "\nresult = " + result
               );

--- a/icu4c/source/test/intltest/ustrtest.cpp
+++ b/icu4c/source/test/intltest/ustrtest.cpp
@@ -2439,11 +2439,11 @@ void UnicodeStringTest::TestU16StringView() {
 
     UnicodeString aliasFromSV = UnicodeString::readOnlyAlias(sv16);
     assertTrue("aliasFromSV pointer alias", aliasFromSV.getBuffer() == sv16.data());
-    assertEquals("aliasFromSV length", (int32_t)sv16.length(), aliasFromSV.length());
+    assertEquals("aliasFromSV length", static_cast<int32_t>(sv16.length()), aliasFromSV.length());
 
     UnicodeString aliasFromStr = UnicodeString::readOnlyAlias(str16);
     assertTrue("aliasFromStr pointer alias", aliasFromStr.getBuffer() == str16.data());
-    assertEquals("aliasFromStr length", (int32_t)str16.length(), aliasFromStr.length());
+    assertEquals("aliasFromStr length", static_cast<int32_t>(str16.length()), aliasFromStr.length());
 
     UnicodeString aliasFromUStr = UnicodeString::readOnlyAlias(ustr);
     assertTrue("aliasFromUStr pointer alias", aliasFromUStr.getBuffer() == ustr.getBuffer());
@@ -2494,7 +2494,7 @@ void UnicodeStringTest::TestU16StringView() {
     // Convert UnicodeString to string view.
     std::u16string_view sv16FromUniStr(any);
     assertTrue("sv16FromUniStr buffer alias", sv16FromUniStr.data() == any.getBuffer());
-    assertEquals("sv16FromUniStr length", any.length(), (int32_t)sv16FromUniStr.length());
+    assertEquals("sv16FromUniStr length", any.length(), static_cast<int32_t>(sv16FromUniStr.length()));
 
     // Just to show convenience: Convert UnicodeString to string view, then to std string.
     std::u16string str16FromUniStr(any);

--- a/icu4c/source/tools/genrb/rle.c
+++ b/icu4c/source/tools/genrb/rle.c
@@ -162,12 +162,12 @@ usArrayToRLEString(const uint16_t* src,int32_t srcLen,uint16_t* buffer, int32_t 
                 if (s == runValue && runLength < 0xFFFF){
                     ++runLength;
                 }else {
-                    buffer = encodeRunShort(buffer,bufLimit, (uint16_t)runValue, runLength,status);
+                    buffer = encodeRunShort(buffer, bufLimit, runValue, runLength, status);
                     runValue = s;
                     runLength = 1;
                 }
             }
-            buffer= encodeRunShort(buffer,bufLimit,(uint16_t)runValue, runLength,status);
+            buffer = encodeRunShort(buffer, bufLimit, runValue, runLength, status);
         }else{
             *status = U_BUFFER_OVERFLOW_ERROR;
         }

--- a/icu4c/source/tools/makeconv/genmbcs.cpp
+++ b/icu4c/source/tools/makeconv/genmbcs.cpp
@@ -970,7 +970,7 @@ MBCSAddTable(NewConverter *cnvData, UCMTable *table, UConverterStaticData *stati
      * a sorted table, which makeconv generates when explicit precision
      * indicators are used.
      */
-    mbcsData->utf8Friendly=utf8Friendly=(UBool)((table->flagsType&UCM_FLAGS_EXPLICIT)!=0);
+    mbcsData->utf8Friendly = utf8Friendly = (table->flagsType & UCM_FLAGS_EXPLICIT) != 0;
     if(utf8Friendly) {
         mbcsData->utf8Max=MBCS_UTF8_MAX;
         if(SMALL && maxCharLength>1) {

--- a/icu4c/source/tools/toolutil/ucm.cpp
+++ b/icu4c/source/tools/toolutil/ucm.cpp
@@ -575,8 +575,8 @@ ucm_checkBaseExt(UCMStates *baseStates,
 
     /* check */
     result=
-        checkBaseExtUnicode(baseStates, base, ext, (UBool)(moveTarget!=nullptr), intersectBase)|
-        checkBaseExtBytes(baseStates, base, ext, (UBool)(moveTarget!=nullptr), intersectBase);
+        checkBaseExtUnicode(baseStates, base, ext, moveTarget != nullptr, intersectBase) |
+        checkBaseExtBytes(baseStates, base, ext, moveTarget != nullptr, intersectBase);
 
     if(result&HAS_ERRORS) {
         return false;

--- a/icu4c/source/tools/tzcode/localtime.c
+++ b/icu4c/source/tools/tzcode/localtime.c
@@ -1535,7 +1535,7 @@ timesub(const time_t *const timep, const int_fast32_t offset,
 	ip = mon_lengths[isleap(y)];
 	for (tmp->tm_mon = 0; idays >= ip[tmp->tm_mon]; ++(tmp->tm_mon))
 		idays -= ip[tmp->tm_mon];
-	tmp->tm_mday = (int) (idays + 1);
+	tmp->tm_mday = idays + 1;
 	tmp->tm_isdst = 0;
 #ifdef TM_GMTOFF
 	tmp->TM_GMTOFF = offset;


### PR DESCRIPTION
https://releases.llvm.org/19.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/google/readability-casting.html

Before running `clang-tidy` this time, I temporarily replaced `UBool` with `bool` to make it find superfluous such casts. This PR covers what was not already included in commit 0178a07a26fa7dd827a49048104b4089aa7e2b84.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22793
- [x] Required: The PR title must be prefixed with a JIRA Issue number.
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number.
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
