### PR TITLE
ICU-22730 Fix int32_t overflow in persian calendar

### DIFF
--- a/icu4c/source/i18n/persncal.cpp
+++ b/icu4c/source/i18n/persncal.cpp
@@ -217,7 +217,8 @@ int32_t PersianCalendar::handleGetExtendedYear(UErrorCode& status) {
  * method is called.
  */
 void PersianCalendar::handleComputeFields(int32_t julianDay, UErrorCode& status) {
-    int64_t daysSinceEpoch = julianDay - PERSIAN_EPOCH;
+    int64_t daysSinceEpoch = julianDay;
+    daysSinceEpoch -= PERSIAN_EPOCH;
     int64_t year = ClockMath::floorDivideInt64(
         33LL * daysSinceEpoch + 3LL, 12053LL) + 1LL;
     if (year > INT32_MAX || year < INT32_MIN) {


### PR DESCRIPTION
Fix issue found by https://g-issues.oss-fuzz.com/issues/42538607
<!--
Thank you for your pull request!

* General info on contributing: please see https://github.com/unicode-org/icu/blob/main/CONTRIBUTING.md
* Ticket numbers for minor changes: for minor changes (ex: docs typos), you can reuse one of the open catch-all tickets for our next release
  - ICU 76 ticket: docs minor fixes: typos/etc./version updates / User Guide & API docs: ICU-22722
  - ICU 76 ticket: code warnings/version updates: ICU-22721
* Contributors license agreement (CLA): 
  You will be automatically asked to sign the CLA before the PR is accepted.
  To sign the CLA: https://cla-assistant.io/unicode-org/icu

  For terms of use and license, see https://www.unicode.org/terms_of_use.html
-->

##### Checklist

- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22730
- [X] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
