### PR TITLE
ICU-22911 Fix coverity warning in numrange_fluent.cpp

### DIFF
--- a/icu4c/source/i18n/numrange_fluent.cpp
+++ b/icu4c/source/i18n/numrange_fluent.cpp
@@ -245,10 +245,10 @@ LocalizedNumberRangeFormatter::LocalizedNumberRangeFormatter(LocalizedNumberRang
         : LNF(static_cast<NFS<LNF>&&>(src)) {}
 
 LocalizedNumberRangeFormatter::LocalizedNumberRangeFormatter(NFS<LNF>&& src) noexcept
-        : NFS<LNF>(std::move(src)) {
+    : NFS<LNF>(std::move(src)) {
+    // Safely access the member from *this, which holds the moved-from state
     // Steal the compiled formatter
-    LNF&& _src = static_cast<LNF&&>(src);
-    auto* stolen = _src.fAtomicFormatter.exchange(nullptr);
+    auto* stolen = this->fAtomicFormatter.exchange(nullptr);
     delete fAtomicFormatter.exchange(stolen);
 }
 


### PR DESCRIPTION
See: https://unicode-org.atlassian.net/browse/ICU-22911

<!--
Thank you for your pull request!

* General info on contributing: please see https://github.com/unicode-org/icu/blob/main/CONTRIBUTING.md
* Ticket numbers for minor changes: for minor changes (ex: docs typos), you can reuse one of the open catch-all tickets for our next release
  - ICU 76 ticket: docs minor fixes: typos/etc./version updates / User Guide & API docs: ICU-22722
  - ICU 76 ticket: code warnings/version updates: ICU-22721
* Contributors license agreement (CLA): 
  You will be automatically asked to sign the CLA before the PR is accepted.
  To sign the CLA: https://cla-assistant.io/unicode-org/icu

  For terms of use and license, see https://www.unicode.org/terms_of_use.html
-->

##### Checklist

- [ ] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22911_____
- [ ] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
