### PR TITLE
ICU-22912 fix coverity warning in gencnval.c

### DIFF
--- a/icu4c/source/tools/gencnval/gencnval.c
+++ b/icu4c/source/tools/gencnval/gencnval.c
@@ -273,6 +273,12 @@ main(int argc, char* argv[]) {
 
     const char* sourcedir = options[SOURCEDIR].value;
     if (sourcedir != NULL && *sourcedir != 0) {
+        if (strlen(sourcedir) + strlen(path) + 2 > sizeof(pathBuf)) {
+            fprintf(stderr,
+                    "The source file name is too long, it must be less than %d in bytes.\n",
+                    (int) sizeof(pathBuf) - 1);
+            exit(U_ILLEGAL_ARGUMENT_ERROR);
+        }
         char *end;
         uprv_strcpy(pathBuf, sourcedir);
         end = uprv_strchr(pathBuf, 0);


### PR DESCRIPTION
See: https://unicode-org.atlassian.net/browse/ICU-22912

<!--
Thank you for your pull request!

* General info on contributing: please see https://github.com/unicode-org/icu/blob/main/CONTRIBUTING.md
* Ticket numbers for minor changes: for minor changes (ex: docs typos), you can reuse one of the open catch-all tickets for our next release
  - ICU 76 ticket: docs minor fixes: typos/etc./version updates / User Guide & API docs: ICU-22722
  - ICU 76 ticket: code warnings/version updates: ICU-22721
* Contributors license agreement (CLA): 
  You will be automatically asked to sign the CLA before the PR is accepted.
  To sign the CLA: https://cla-assistant.io/unicode-org/icu

  For terms of use and license, see https://www.unicode.org/terms_of_use.html
-->

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22912
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
