### PR TITLE
ICU-22919 Enable CI with JDK 21 and fix the json parsing

### DIFF
--- a/.github/workflows/icu4j.yml
+++ b/.github/workflows/icu4j.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           cd icu4j;
           mvn ${SHARED_MVN_ARGS} dependency:go-offline -P '!old_jdk_taglet'
-          
+
   # ICU4J build and unit test using Maven
   # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
   icu4j-mvn-build-and-test:
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [ '8', '11', '17' ]
+        java-version: [ '8', '11', '17', '21' ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout and setup

--- a/testdata/message2/more-functions.json
+++ b/testdata/message2/more-functions.json
@@ -102,19 +102,10 @@
     },
     {
       "src": "Default int64: {$val}!",
-      "exp": "Default int64: 1.234.567.890.123.456.800!",
+      "exp": "Default int64: 1.234.567.890.123.456.789!",
       "locale": "ro",
-      "params": [{ "name": "val", "value": 1234567890123456789 }],
-      "comment": "Rounded due to JSON not supporting full 64-bit ints",
-      "ignoreJava": "See https://unicode-org.atlassian.net/browse/ICU-22754?focusedCommentId=175932"
-    },
-    {
-      "src": "Default int64: {$val}!",
-      "exp": "Default int64: 1.234.567.890.123.456.770!",
-      "locale": "ro",
-      "params": [{ "name": "val", "value": 1234567890123456789 }],
-      "comment": "Rounded due to JSON not supporting full 64-bit ints",
-      "ignoreCpp": "See https://unicode-org.atlassian.net/browse/ICU-22754?focusedCommentId=175932"
+      "params": [{ "name": "val", "value": {"decimal": "1234567890123456789"} }],
+      "comment": "Rounded due to JSON not supporting full 64-bit ints"
     },
     {
       "src": "Default number: {$val}!",


### PR DESCRIPTION
At the code of the problem is a change in how Java parses strings to `Double`:

```
System.out.println(Double.valueOf("1234567890123456789"));
```

The results are:
jdk 17 : `1.23456789012345677E18`
jdk 21 : `1.2345678901234568E18`

The json parser was seeing a number and parsed it to a `Double`.
With the change the json parser sees a string and passes that on to our test suite, and the string is parsed / interpreted by our code.

So we just took control from the json parser.

Java supports a `long value = 1234567890123456789L`, there is no rounding, and the result from `MessageFormatter` is `"1,234,567,890,123,456,789"`, as one would expect.

So the current fix does not need to change any code in `MessageFormatter`.

It only bypasses the json parsing of numbers and informs the test code on how to parse the string value.

Before (json parser in control):
  `value: 1234567890123456789`
After (our test suite in control):
  `value: {"decimal": "1234567890123456789"}`

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22919
- [x] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
