### PR TITLE
ICU-22930 The -sources.jar files in icu4j version 76.1 are AGAIN a lot bigger than before

### DIFF
--- a/icu4j/pom.xml
+++ b/icu4j/pom.xml
@@ -503,7 +503,7 @@
             </executions>
             <configuration>
               <excludes>
-                <exclude>/com/ibm/icu/impl/data/icudt*/**</exclude>
+                <exclude>/com/ibm/icu/impl/data/icudata/**</exclude>
                 <exclude>/com/ibm/icu/impl/duration/impl/data/*.xml</exclude>
                 <exclude>/com/ibm/icu/impl/duration/impl/data/*.xml.escaped</exclude>
                 <exclude>/com/ibm/icu/impl/duration/impl/data/*.txt</exclude>


### PR DESCRIPTION
This is the same bug, and with the same root cause as [ICU-22605: The -sources.jar files in the 74.1 and 74.2 releases are (a lot) bigger than before](https://unicode-org.atlassian.net/browse/ICU-22605)
 
That was fixed in PR https://github.com/unicode-org/icu/pull/2743 by excluding the `/icudt*/` folder.

At the time that matched the name of the data folder, which included the version and endianness (for example `icudt74b`)

But we renamed that folder to be version independent.
It is now `icudata`.

And in the process we inadvertently started bypassing the filtering.

#### Checklist
- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22930
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
