### PR TITLE
ICU-22935 Add ZWG to static currency lists

### DIFF
--- a/icu4c/source/common/ucurr.cpp
+++ b/icu4c/source/common/ucurr.cpp
@@ -2024,6 +2024,7 @@ static const struct CurrencyList {
     {"ZRN", UCURR_COMMON|UCURR_DEPRECATED},
     {"ZRZ", UCURR_COMMON|UCURR_DEPRECATED},
     {"ZWD", UCURR_COMMON|UCURR_DEPRECATED},
+    {"ZWG", UCURR_COMMON|UCURR_NON_DEPRECATED},
     {"ZWL", UCURR_COMMON|UCURR_DEPRECATED},
     {"ZWR", UCURR_COMMON|UCURR_DEPRECATED},
     { nullptr, 0 } // Leave here to denote the end of the list.

--- a/icu4c/source/test/cintltst/currtest.c
+++ b/icu4c/source/test/cintltst/currtest.c
@@ -116,6 +116,9 @@ static void TestEnumList(void) {
 
     // CLDR 45 and ICU-22726
     expectInList("XCG", UCURR_ALL, true);
+
+    // CLDR 46 and ICU-22935
+    expectInList("ZWG", UCURR_ALL, true);
 }
 
 static void TestEnumListReset(void) {

--- a/icu4c/source/test/testdata/structLocale.txt
+++ b/icu4c/source/test/testdata/structLocale.txt
@@ -1545,6 +1545,10 @@ structLocale:table(nofallback){
             "",
             "",
         }
+        ZWG{
+            "",
+            "",
+        }
         ZWL{
             "",
             "",
@@ -4032,6 +4036,14 @@ structLocale:table(nofallback){
             other{""}
         }
         ZWD{
+            zero{""}
+            one{""}
+            two{""}
+            few{""}
+            many{""}
+            other{""}
+        }
+        ZWG{
             zero{""}
             one{""}
             two{""}


### PR DESCRIPTION
#### Checklist
- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22935
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

Adding ZWG to few static lists. 

Followed instructions in https://unicode-org.github.io/icu/processes/cldr-icu.html#5-generate-cldr-production-data-and-convert-for-icu (step 5f).

Also, based on discussion in https://github.com/unicode-org/icu/pull/2961, there is no lists to update in Java, so only done in C++.