### PR TITLE
ICU-22789 Add Segmenter API to conveniently wrap BreakIterator in ICU4J

### DIFF
--- a/icu4j/main/core/src/main/java/com/ibm/icu/segmenter/BoundaryIteratorOfInts.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/segmenter/BoundaryIteratorOfInts.java
@@ -1,0 +1,85 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: https://www.unicode.org/copyright.html
+
+package com.ibm.icu.segmenter;
+
+import com.ibm.icu.text.BreakIterator;
+import com.ibm.icu.segmenter.Segments.IterationDirection;
+
+/**
+ * An iterator of segmentation boundaries that can operate in either the forwards or reverse
+ * direction.
+ *
+ * <p>When constructed to operate in the forwards direction, the iterator will return all boundaries
+ * that are strictly after the input index value provided to the constructor. However, when
+ * constructed to operate in the backwards direction, if the input index is already a segmentation
+ * boundary, then it will be included as the first value that the iterator returns as it iterates
+ * backwards.
+ */
+class BoundaryIteratorOfInts {
+  private BreakIterator breakIter;
+  private IterationDirection direction;
+  private int currIdx;
+
+  BoundaryIteratorOfInts(BreakIterator breakIter, CharSequence sourceSequence, IterationDirection direction, int startIdx) {
+    this.breakIter = breakIter;
+    this.direction = direction;
+
+    if (direction == IterationDirection.FORWARDS) {
+      currIdx = breakIter.following(startIdx);
+    } else {
+      assert direction == IterationDirection.BACKWARDS;
+
+      // When iterating backwards over boundaries, adjust the initial index to be the boundary
+      // that is either startIdx or else the one right before startIdx.
+      //
+      // Note: we have to set the initial index indirectly because there is no way to statelessly
+      // query whether an index is on a boundary. Instead, BreakIterator.isBoundary() will mutate
+      // state when the input is not on a boundary, before it returns the value indicating a
+      // boundary.
+      int sourceLength = sourceSequence.length();
+      if (startIdx == 0) {
+        currIdx = breakIter.first();
+      } else if (startIdx == sourceLength) {
+        currIdx = breakIter.last();
+      } else {
+        boolean isOnBoundary =
+            0 <= startIdx
+                && startIdx <= sourceLength
+                && breakIter.isBoundary(startIdx);
+
+        // The previous call to BreakIterator.isBoundary(startIdx) will have advanced breakIter's
+        // current position forwards to the next boundary if the argument, startIdx, is not a
+        // boundary. Therefore, in that case, we have to move back to the previous boundary.
+        //
+        // BreakIterator.isBoundary(startIdx) should have cached the surrounding 2 boundaries in the
+        // BreakIterator, which means that BreakIterator.preceding(startIdx) shouldn't cost
+        // significant extra time.
+        //
+        // BreakIterator.preceding(startIdx) is used in initialization instead of a simple call to
+        // BreakIterator.previous() since BreakIterator.preceding() can accept arguments larger than
+        // the last boundary and return the last boundary, whereas .previous() would return DONE.
+        // Thus, .preceding() provides symmetrical behavior to .following(), which we use in the
+        // forwards direction.
+        currIdx = isOnBoundary ? startIdx : breakIter.preceding(startIdx);
+      }
+    }
+  }
+
+  public boolean hasNext() {
+    return currIdx != BreakIterator.DONE;
+  }
+
+  public Integer next() {
+    int result = currIdx;
+
+    if (direction == IterationDirection.FORWARDS) {
+      currIdx = breakIter.next();
+    } else {
+      assert direction == IterationDirection.BACKWARDS;
+      currIdx = breakIter.previous();
+    }
+
+    return result;
+  }
+}

--- a/icu4j/main/core/src/main/java/com/ibm/icu/segmenter/BoundarySpliterator.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/segmenter/BoundarySpliterator.java
@@ -1,0 +1,64 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: https://www.unicode.org/copyright.html
+
+package com.ibm.icu.segmenter;
+
+import com.ibm.icu.text.BreakIterator;
+import com.ibm.icu.segmenter.Segments.IterationDirection;
+import java.util.Spliterator;
+import java.util.function.IntConsumer;
+
+class BoundarySpliterator implements Spliterator.OfInt {
+
+  private final BoundaryIteratorOfInts iter;
+
+  BoundarySpliterator(BreakIterator breakIter, CharSequence sourceSequence, IterationDirection direction, int startIdx) {
+    iter = new BoundaryIteratorOfInts(breakIter, sourceSequence, direction, startIdx);
+  }
+
+  @Override
+  public OfInt trySplit() {
+    // The elements of the Stream represent an iteration through a string, and is thus inherently
+    // stateful. Therefore, splitting this Stream does not make sense. Ex: splitting the Stream
+    // is tantamount to discarding the segment subtended by the end value (index into the input
+    // string) of one substream and the beginning value of the next substream.
+    return null;
+  }
+
+  @Override
+  public long estimateSize() {
+    // The number of segments per input size depends on language, script, and
+    // the content of the input string, and thus is hard to estimate without
+    // sacrificing performance. Thus, returning `Long.MAX_VALUE`, according
+    // to the API, to mean "unknown, or too expensive to compute".
+    return Long.MAX_VALUE;
+  }
+
+  @Override
+  public int characteristics() {
+    return
+        // BreakIterator always advances
+        Spliterator.DISTINCT
+        // The design of the Segmenter API is to provide an immutable view of
+        // segmentation by preventing the input string from mutating
+        // in the underlying BreakIterator.
+        | Spliterator.IMMUTABLE
+        // primitive int is non-null
+        | Spliterator.NONNULL
+        // BreakIterator always advances, and in a single direction.
+        | Spliterator.ORDERED;
+  }
+
+  @Override
+  public boolean tryAdvance(IntConsumer action) {
+    if (action == null) {
+      throw new NullPointerException();
+    }
+    if (iter.hasNext()) {
+      action.accept(iter.next());
+      return true;
+    } else {
+      return false;
+    }
+  }
+}

--- a/icu4j/main/core/src/main/java/com/ibm/icu/segmenter/LocalizedSegmenter.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/segmenter/LocalizedSegmenter.java
@@ -1,0 +1,137 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: https://www.unicode.org/copyright.html
+
+package com.ibm.icu.segmenter;
+
+import com.ibm.icu.text.BreakIterator;
+import com.ibm.icu.util.ULocale;
+import java.util.Locale;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Performs segmentation according to the rules defined for the locale.
+ */
+public class LocalizedSegmenter implements Segmenter {
+
+  private BreakIterator breakIterPrototype;
+
+  /**
+   * Returns a {@link Segments} object that encapsulates the segmentation of the input
+   * {@code CharSequence}. The {@code Segments} object, in turn, provides the main APIs to support
+   * traversal over the resulting segments and boundaries via the Java {@code Stream} abstraction.
+   * @param s input {@code CharSequence} on which segmentation is performed. The input must not be
+   *     modified while using the resulting {@code Segments} object.
+   * @return A {@code Segments} object with APIs to access the results of segmentation, including
+   *     APIs that return {@code Stream}s of the segments and boundaries.
+   * @draft ICU 78
+   */
+  @Override
+  public Segments segment(CharSequence s) {
+    return new SegmentsImpl(breakIterPrototype, s);
+  }
+
+  /**
+   * @return a builder for constructing {@code LocalizedSegmenter}
+   * @draft ICU 78
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  private LocalizedSegmenter(ULocale locale, SegmentationType segmentationType) {
+    switch (segmentationType) {
+      case LINE:
+        breakIterPrototype = BreakIterator.getLineInstance(locale);
+        break;
+      case SENTENCE:
+        breakIterPrototype = BreakIterator.getSentenceInstance(locale);
+        break;
+      case WORD:
+        breakIterPrototype = BreakIterator.getWordInstance(locale);
+        break;
+      case GRAPHEME_CLUSTER:
+        breakIterPrototype = BreakIterator.getCharacterInstance(locale);
+        break;
+    }
+  }
+
+  /**
+   * The type of segmentation to be performed. See the ICU User Guide page
+   * <a
+   * href="https://unicode-org.github.io/icu/userguide/boundaryanalysis/#four-types-of-breakiterator">Boundary Analysis</a>
+   * for further details.
+   * @draft ICU 78
+   */
+  public enum SegmentationType {
+    GRAPHEME_CLUSTER,
+    WORD,
+    LINE,
+    SENTENCE,
+  }
+
+  /**
+   * Builder for {@link LocalizedSegmenter}
+   * @draft ICU 78
+   */
+  public static class Builder {
+
+    private ULocale locale = ULocale.ROOT;
+
+    private SegmentationType segmentationType = null;
+
+    private Builder() { }
+
+    /**
+     * Set the locale for which segmentation rules will be loaded
+     * @param locale an ICU locale object
+     * @draft ICU 78
+     */
+    public Builder setLocale(ULocale locale) {
+      if (locale == null) {
+        throw new IllegalArgumentException("locale cannot be set to null.");
+      }
+      this.locale = locale;
+      return this;
+    }
+
+    /**
+     * Set the locale for which segmentation rules will be loaded
+     * @param locale a Java locale object
+     * @draft ICU 78
+     */
+    public Builder setLocale(Locale locale) {
+      if (locale == null) {
+        throw new IllegalArgumentException("locale cannot be set to null.");
+      }
+      this.locale = ULocale.forLocale(locale);
+      return this;
+    }
+
+    /**
+     * Set the segmentation type to be performed.
+     * @param segmentationType
+     * @draft ICU 78
+     */
+    public Builder setSegmentationType(SegmentationType segmentationType) {
+      if (segmentationType == null) {
+        throw new IllegalArgumentException("segmentationType cannot be set to null.");
+      }
+      this.segmentationType = segmentationType;
+      return this;
+    }
+
+    /**
+     * Builds the {@code Segmenter}
+     * @return the constructed {@code Segmenter} instance
+     * @draft ICU 78
+     */
+    public Segmenter build() {
+      if (segmentationType == null) {
+        throw new IllegalArgumentException("segmentationType is null and must be set to a specific value.");
+      }
+      return new LocalizedSegmenter(locale, segmentationType);
+    }
+
+  }
+}

--- a/icu4j/main/core/src/main/java/com/ibm/icu/segmenter/RuleBasedSegmenter.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/segmenter/RuleBasedSegmenter.java
@@ -1,0 +1,90 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: https://www.unicode.org/copyright.html
+
+package com.ibm.icu.segmenter;
+
+import com.ibm.icu.text.BreakIterator;
+import com.ibm.icu.text.RuleBasedBreakIterator;
+import java.io.InputStream;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Performs segmentation according to the provided rule string. The rule string must follow the
+ * same guidelines as for {@link RuleBasedBreakIterator#RuleBasedBreakIterator(String)}.
+ * @draft ICU 78
+ */
+public class RuleBasedSegmenter implements Segmenter {
+
+  private final BreakIterator breakIterPrototype;
+
+  /**
+   * Returns a {@link Segments} object that encapsulates the segmentation of the input
+   * {@code CharSequence}. The {@code Segments} object, in turn, provides the main APIs to support
+   * traversal over the resulting segments and boundaries via the Java {@code Stream} abstraction.
+   * @param s input {@code CharSequence} on which segmentation is performed. The input must not be
+   *     modified while using the resulting {@code Segments} object.
+   * @return A {@code Segments} object with APIs to access the results of segmentation, including
+   *     APIs that return {@code Stream}s of the segments and boundaries.
+   * @draft ICU 78
+   */
+  @Override
+  public Segments segment(CharSequence s) {
+    return new SegmentsImpl(breakIterPrototype, s);
+  }
+
+  /**
+   * @return a builder for constructing {@code RuleBasedSegmenter}
+   * @draft ICU 78
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  private RuleBasedSegmenter(BreakIterator breakIter) {
+    breakIterPrototype = breakIter;
+  }
+
+  /**
+   * Builder for {@link RuleBasedSegmenter}
+   * @draft ICU 78
+   */
+  public static class Builder {
+
+    private BreakIterator breakIter = null;
+
+    private Builder() { }
+
+    /**
+     * Sets the rule string for segmentation.
+     * @param rules rule string.  The rule string must follow the same guidelines as for
+     *     {@link RuleBasedBreakIterator#getInstanceFromCompiledRules(InputStream)}.
+     * @draft ICU 78
+     */
+    public Builder setRules(String rules) {
+      if (rules == null) {
+        throw new IllegalArgumentException("rules cannot be set to null.");
+      }
+      try {
+        breakIter = new RuleBasedBreakIterator(rules);
+        return this;
+      } catch (RuntimeException rte) {
+        throw new IllegalArgumentException("The provided rule string is invalid"
+            + " or there was an error in creating the RuleBasedSegmenter.", rte);
+      }
+    }
+
+    /**
+     * Builds the {@code Segmenter}
+     * @return the constructed {@code Segmenter} instance
+     * @draft ICU 78
+     */
+    public Segmenter build() {
+      if (breakIter == null) {
+        throw new IllegalArgumentException("A rule string must be set.");
+      } else {
+        return new RuleBasedSegmenter(breakIter);
+      }
+    }
+  }
+}

--- a/icu4j/main/core/src/main/java/com/ibm/icu/segmenter/Segment.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/segmenter/Segment.java
@@ -1,0 +1,34 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: https://www.unicode.org/copyright.html
+
+package com.ibm.icu.segmenter;
+
+/**
+ * A simple struct to represent an element of the segmentation result. The {@code start} and
+ * {@code limit} indices correspond to {@code source}, the input {@code CharSequence} that was
+ * originally passed to the {@code Segmenter}. {@code start} and {@code limit} are inclusive and
+ * exclusive boundaries, respectively.
+ * @draft ICU 78
+ */
+public class Segment {
+  public final int start;
+  public final int limit;
+  public final int ruleStatus = 0;
+  private final CharSequence source;
+
+  Segment(int start, int limit, CharSequence source) {
+    this.start = start;
+    this.limit = limit;
+    this.source = source;
+  }
+
+  /**
+   * Returns the subsequence represented by this {@code Segment}
+   * @return a new {@code CharSequence} object that is the subsequence represented by this
+   * {@code Segment}.
+   * @draft ICU 78
+   */
+  public CharSequence getSubSequence() {
+    return source.subSequence(start, limit);
+  }
+}

--- a/icu4j/main/core/src/main/java/com/ibm/icu/segmenter/SegmentIterable.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/segmenter/SegmentIterable.java
@@ -1,0 +1,32 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: https://www.unicode.org/copyright.html
+
+package com.ibm.icu.segmenter;
+
+import com.ibm.icu.text.BreakIterator;
+import com.ibm.icu.segmenter.Segments.IterationDirection;
+import java.util.Iterator;
+
+/**
+ * This {@code Iterable} exists to enable the creation of a {@code Spliterator} that in turn
+ * enables the creation of a lazy {@code Stream}.
+ */
+class SegmentIterable implements Iterable<Segment> {
+  private BreakIterator breakIter;
+  private final IterationDirection direction;
+  private int startIdx;
+  private final CharSequence source;
+
+  SegmentIterable(BreakIterator breakIter, IterationDirection direction, int startIdx, CharSequence source) {
+    this.breakIter = breakIter;
+    this.direction = direction;
+    this.startIdx = startIdx;
+    this.source = source;
+  }
+
+  @Override
+  public Iterator<Segment> iterator() {
+    return new SegmentIterator(breakIter, direction, startIdx, source);
+  }
+}
+

--- a/icu4j/main/core/src/main/java/com/ibm/icu/segmenter/SegmentIterator.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/segmenter/SegmentIterator.java
@@ -1,0 +1,77 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: https://www.unicode.org/copyright.html
+
+package com.ibm.icu.segmenter;
+
+import com.ibm.icu.text.BreakIterator;
+import com.ibm.icu.segmenter.Segments.IterationDirection;
+import java.util.Iterator;
+
+class SegmentIterator implements Iterator<Segment> {
+  private BreakIterator breakIter;
+  private final IterationDirection direction;
+  private int start;
+  private int limit;
+  private final CharSequence source;
+
+  SegmentIterator(BreakIterator breakIter, IterationDirection direction, int startIdx, CharSequence source) {
+    this.breakIter = breakIter;
+    this.direction = direction;
+    this.source = source;
+
+    // Note: BreakIterator.isBoundary() is a stateful operation. It resets the position in the
+    // BreakIterator, and thus doesn't just return whether the input is on a boundary.
+    boolean startIdxIsBoundary = breakIter.isBoundary(startIdx);
+
+    if (direction == IterationDirection.FORWARDS) {
+      if (startIdxIsBoundary) {
+        start = startIdx;
+        limit = breakIter.next();
+      } else {
+        // if startIdx wasn't on a boundary, then the call to isBoundary will have advanced it to
+        // the next boundary, which is the limit of the segment
+        limit = breakIter.current();
+        // go back to get the start of the segment
+        start = breakIter.previous();
+        // reset current position of BreakIterator to be limit of segment
+        breakIter.isBoundary(limit);
+      }
+    } else {
+      assert direction == IterationDirection.BACKWARDS;
+      if (startIdxIsBoundary) {
+        limit = breakIter.current();
+      } else {
+        // if startIdx was not on boundary, then the breakIter state moved forward past startIdx
+        // after the call to BreakIterator.current(), so we need to move to the previous boundary
+        // before startIdx to start the iteration
+        limit = breakIter.previous();
+      }
+      start = breakIter.previous();
+    }
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (direction == IterationDirection.FORWARDS) {
+      return limit != BreakIterator.DONE;
+    } else {
+      return start != BreakIterator.DONE;
+    }
+  }
+
+  @Override
+  public Segment next() {
+    Segment result = new Segment(start, limit, source);
+
+    if (direction == IterationDirection.FORWARDS) {
+      start = limit;
+      limit = breakIter.next();
+    } else {
+      assert direction == IterationDirection.BACKWARDS;
+      limit = start;
+      start = breakIter.previous();
+    }
+
+    return result;
+  }
+}

--- a/icu4j/main/core/src/main/java/com/ibm/icu/segmenter/Segmenter.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/segmenter/Segmenter.java
@@ -1,0 +1,43 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: https://www.unicode.org/copyright.html
+
+package com.ibm.icu.segmenter;
+
+import com.ibm.icu.text.BreakIterator;
+
+/**
+ * An interface that defines APIs for segmentation in terms of segments and boundaries, and
+ * enforces immutable stateless iteration over the segmentation result yielded from an input
+ * {@code CharSequence}.
+ *
+ * <p>{@code Segmenter} is designed to be a followup to the {@code BreakIterator} in providing
+ * segmentation functionality. {@code Segmenter} provides immutable iteration, higher level
+ * constructs like {@code Segment}s and {@code CharSequence}s as return types, and Java programmer
+ * conveniences like {@code Stream}s in its APIs.
+ *
+ * <p>Iteration over the input sequences is made immutable by separating the design into two parts,
+ * each represented by an interface. The {@code Segmenter} interface represents the construction of
+ * the object that encapsulates the segmentation logic. The {@link Segments} interface represents
+ * the result of segmentation being performed for a specific given input {@code CharSequence}.
+ * {@code Segments} APIs also provide {@code Stream}s to support iteration over the segmentation
+ * results in a stateless manner.
+ *
+ * @see Segments
+ * @see BreakIterator
+ * @draft ICU 78
+ */
+public interface Segmenter {
+
+  /**
+   * Returns a {@link Segments} object that encapsulates the segmentation of the input
+   * {@code CharSequence}. The {@code Segments} object, in turn, provides the main APIs to support
+   * traversal over the resulting segments and boundaries via the Java {@code Stream} abstraction.
+   * @param s input {@code CharSequence} on which segmentation is performed. The input must not be
+   *     modified while using the resulting {@code Segments} object.
+   * @return A {@code Segments} object with APIs to access the results of segmentation, including
+   *     APIs that return {@code Stream}s of the segments and boundaries.
+   * @draft ICU 78
+   */
+  Segments segment(CharSequence s);
+
+}

--- a/icu4j/main/core/src/main/java/com/ibm/icu/segmenter/Segments.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/segmenter/Segments.java
@@ -1,0 +1,165 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: https://www.unicode.org/copyright.html
+
+package com.ibm.icu.segmenter;
+
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * An interface that represents the segmentation results, including the APIs for iteration therein,
+ * that are yielded from passing an input {@code CharSequence} to a {@code Segmenter}.
+ *
+ * <p>The segmentation results can be provided either as the segmentation boundary indices
+ * ({code int}s) or as segments, which are represented by the {@link Segment} class. In turn, the
+ * {@code Segment} object can also provide the subsequence of the original input that it
+ * represents.
+ *
+ * <p>Example:
+ *
+ * <blockquote><pre>
+ * Segmenter wordSeg =
+ *     LocalizedSegmenter.builder()
+ *         .setLocale(ULocale.forLanguageTag("de"))
+ *         .setSegmentationType(SegmentationType.WORD)
+ *         .build();
+ *
+ * Segments segments = wordSeg.segment("Das 21ste Jahrh. ist das beste.");
+ *
+ * List<CharSequence> words = segments.subSequences().collect(Collectors.toList());
+ * </pre></blockquote>
+ *
+ * @see Segmenter
+ * @see Segment
+ * @draft ICU 78
+ */
+public interface Segments {
+
+  /**
+   * Returns a {@code Stream} of the {@code CharSequence}s for all of the segments in the source
+   * sequence. Start from the beginning of the sequence and iterate forwards until the end.
+   * @return a {@code Stream} of all {@code Segments} in the source sequence.
+   * @draft ICU 78
+   */
+  default Stream<CharSequence> subSequences() {
+    return segments().map(Segment::getSubSequence);
+  }
+
+  /**
+   * Returns the segment that contains index {@code i}. Containment is inclusive of the start index
+   * and exclusive of the limit index.
+   *
+   * <p>Specifically, the containing segment is defined as the segment with start {@code s} and
+   * limit {@code  l} such that {@code  s ≤ i < l}.</p>
+   * @param i index in the input {@code CharSequence} to the {@code Segmenter}
+   * @throws IndexOutOfBoundsException if {@code i} is less than 0 or greater than or equal to the
+   *     length of the input {@code CharSequence} to the {@code Segmenter}
+   * @return A segment that either starts at or contains index {@code i}
+   * @draft ICU 78
+   */
+  Segment segmentAt(int i);
+
+  /**
+   * Returns a {@code Stream} of all {@code Segment}s in the source sequence. Start with the first
+   * and iterate forwards until the end of the sequence.
+   *
+   * <p>This is equivalent to {@code segmentsFrom(0)}.</p>
+   * @return a {@code Stream} of all {@code Segments} in the source sequence.
+   * @draft ICU 78
+   */
+  default Stream<Segment> segments() {
+    return segmentsFrom(0);
+  }
+
+  /**
+   * Returns a {@code Stream} of all {@code Segment}s in the source sequence where all segment limits
+   * {@code  l} satisfy {@code i < l}.  Iteration moves forwards.
+   *
+   * <p>This means that the first segment in the stream is the same
+   * as what is returned by {@code segmentAt(i)}.</p>
+   *
+   * <p>The word "from" is used here to mean "at or after", with the semantics of "at" for a
+   * {@code Segment} defined by {@link #segmentAt(int)}}. We cannot describe the segments all as
+   * being "after" since the first segment might contain {@code i} in the middle, meaning that
+   * in the forward direction, its start position precedes {@code i}.</p>
+   *
+   * <p>{@code segmentsFrom} and {@link #segmentsBefore(int)} create a partitioning of the space of
+   * all {@code Segment}s.</p>
+   * @param i index in the input {@code CharSequence} to the {@code Segmenter}
+   * @return a {@code Stream} of all {@code Segment}s at or after {@code i}
+   * @draft ICU 78
+   */
+  Stream<Segment> segmentsFrom(int i);
+
+  /**
+   * Returns a {@code Stream} of all {@code Segment}s in the source sequence where all segment
+   * limits {@code  l} satisfy {@code l ≤ i}. Iteration moves backwards.
+   *
+   * <p>This means that the all segments in the stream come before the one that
+   * is returned by {@code segmentAt(i)}. A segment is not considered to contain index {@code i} if
+   * {code i} is equal to limit {@code l}. Thus, "before" encapsulates the invariant
+   * {@code l ≤ i}.</p>
+   * @param i index in the input {@code CharSequence} to the {@code Segmenter}
+   * @return a {@code Stream} of all {@code Segment}s before {@code i}
+   * @draft ICU 78
+   */
+  Stream<Segment> segmentsBefore(int i);
+
+  /**
+   * Returns whether offset {@code i} is a segmentation boundary. Throws an exception when
+   * {@code i} is not a valid index position for the source sequence.
+   * @param i index in the input {@code CharSequence} to the {@code Segmenter}
+   * @throws IllegalArgumentException if {@code i} is less than 0 or greater than the length of the
+   *     input {@code CharSequence} to the {@code Segmenter}
+   * @return Returns whether offset {@code i} is a segmentation boundary.
+   * @draft ICU 78
+   */
+  boolean isBoundary(int i);
+
+  /**
+   * Returns all segmentation boundaries, starting from the beginning and moving forwards.
+   *
+   * <p><b>Note:</b> {@code boundaries() != boundariesAfter(0)}.
+   * This difference naturally results from the strict inequality condition in boundariesAfter,
+   * and the fact that 0 is the first boundary returned from the start of an input sequence.</p>
+   * @return An {@code IntStream} of all segmentation boundaries, starting at the first
+   * boundary with index 0, and moving forwards in the input sequence.
+   * @draft ICU 78
+   */
+  default IntStream boundaries() {
+    return boundariesAfter(-1);
+  }
+
+  /**
+   * Returns all segmentation boundaries after the provided index.  Iteration moves forwards.
+   * @param i index in the input {@code CharSequence} to the {@code Segmenter}
+   * @return An {@code IntStream} of all boundaries {@code b} such that {@code b > i}
+   * @draft ICU 78
+   */
+  IntStream boundariesAfter(int i);
+
+  /**
+   * Returns all segmentation boundaries on or before the provided index. Iteration moves backwards.
+   *
+   * <p>The phrase "back from" is used to indicate both that: 1) boundaries are "on or before" the
+   * input index; 2) the direction of iteration is backwards (towards the beginning).
+   * "on or before" indicates that the result set is {@code b} where {@code b ≤ i}, which is a weak
+   * inequality, while "before" might suggest the strict inequality {@code b < i}.</p>
+   *
+   * <p>{@code boundariesBackFrom} and {@link #boundariesAfter(int)} create a partitioning of the
+   *     space of all boundaries.</p>
+   * @param i index in the input {@code CharSequence} to the {@code Segmenter}
+   * @return An {@code IntStream} of all boundaries {@code b} such that {@code b ≤ i}
+   * @draft ICU 78
+   */
+  IntStream boundariesBackFrom(int i);
+
+  //
+  // Inner enums/classes in common for other inner classes
+  //
+
+  enum IterationDirection {
+    FORWARDS,
+    BACKWARDS,
+  }
+}

--- a/icu4j/main/core/src/main/java/com/ibm/icu/segmenter/SegmentsImpl.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/segmenter/SegmentsImpl.java
@@ -1,0 +1,106 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: https://www.unicode.org/copyright.html
+
+package com.ibm.icu.segmenter;
+
+import com.ibm.icu.text.BreakIterator;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+class SegmentsImpl implements Segments {
+
+  private CharSequence source;
+
+  private BreakIterator breakIterPrototype;
+
+  SegmentsImpl(BreakIterator breakIter, CharSequence source) {
+    this.source = source;
+
+    // We are creating a clone of the Segmenter's prototype BreakIterator field so that this
+    // concrete Segments object can avoid sharing state with the other Segments object instances
+    // that get spawned from the Segmenter. This allows difference source CharSequences to be used
+    // in each Segments object.
+    //
+    // In turn, the cloned BreakIterator becomes a prototype to be stored in the Segments object,
+    // which then gets cloned and used in each of the Segments APIs' implementations. The second
+    // level of cloning that happens when the Segments object's local BreakIterator prototype
+    // gets cloned allows the iteration state to be separate whenever an Segments API is called.
+    // Otherwise, there is a chance that multiple API calls on the same Segments object might
+    // mutate the same position/index, if done concurrently.
+    breakIterPrototype = (BreakIterator) breakIter.clone();
+    // It's okay to perform .setText on the object that we want to clone later because we should
+    // then not have to call .setText on the clones.
+    breakIterPrototype.setText(source);
+  }
+
+  @Override
+  public Segment segmentAt(int i) {
+    BreakIterator breakIter = (BreakIterator) breakIterPrototype.clone();
+    int start;
+    int limit;
+
+    if (i < 0 || i >= source.length()) {
+      throw new IndexOutOfBoundsException(i);
+    }
+
+    boolean isBoundary = breakIter.isBoundary(i);
+
+    if (isBoundary) {
+      start = i;
+      limit = breakIter.next();
+    } else {
+      // BreakIterator.isBoundary(i) will advance forwards to the next boundary if the argument
+      // is not a boundary.
+      limit = breakIter.current();
+      start = breakIter.previous();
+    }
+
+    assert start != BreakIterator.DONE && limit != BreakIterator.DONE;
+
+    return new Segment(start, limit, source);
+  }
+
+  @Override
+  public boolean isBoundary(int i) {
+    return ((BreakIterator) breakIterPrototype.clone()).isBoundary(i);
+  }
+
+  @Override
+  public Stream<Segment> segmentsFrom(int i) {
+    BreakIterator breakIter = (BreakIterator) breakIterPrototype.clone();
+
+    // create a Stream from a Spliterator of an Iterable so that the Stream can be lazy, not eager
+    SegmentIterable iterable = new SegmentIterable(breakIter, IterationDirection.FORWARDS, i,
+        source);
+    return StreamSupport.stream(iterable.spliterator(), false);
+  }
+
+  @Override
+  public Stream<Segment> segmentsBefore(int i) {
+    BreakIterator breakIter = (BreakIterator) breakIterPrototype.clone();
+
+    // create a Stream from a Spliterator of an Iterable so that the Stream can be lazy, not eager
+    SegmentIterable iterable = new SegmentIterable(breakIter, IterationDirection.BACKWARDS, i,
+        source);
+    return StreamSupport.stream(iterable.spliterator(), false);
+  }
+
+  @Override
+  public IntStream boundariesAfter(int i) {
+    BreakIterator breakIter = (BreakIterator) breakIterPrototype.clone();
+
+    // create a Stream from a Spliterator of an Iterable so that the Stream can be lazy, not eager
+    return StreamSupport.intStream(new BoundarySpliterator(breakIter, source, IterationDirection.FORWARDS,
+        i), false);
+  }
+
+  @Override
+  public IntStream boundariesBackFrom(int i) {
+    BreakIterator breakIter = (BreakIterator) breakIterPrototype.clone();
+    // create a Stream from a Spliterator of an Iterable so that the Stream can be lazy, not eager
+    return StreamSupport.intStream(new BoundarySpliterator(breakIter, source, IterationDirection.BACKWARDS,
+        i), false);
+  }
+
+}

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/RuleBasedBreakIterator.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/RuleBasedBreakIterator.java
@@ -529,7 +529,7 @@ public class RuleBasedBreakIterator extends BreakIterator {
      */
     protected static final void checkOffset(int offset, CharacterIterator text) {
         if (offset < text.getBeginIndex() || offset > text.getEndIndex()) {
-            throw new IndexOutOfBoundsException("offset out of bounds");
+            throw new IndexOutOfBoundsException(offset);
         }
     }
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/BreakIteratorRules_en_US_TEST.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/BreakIteratorRules_en_US_TEST.java
@@ -46,7 +46,7 @@ public class BreakIteratorRules_en_US_TEST extends ListResourceBundle {
                 // all of which should not influence the algorithm
                 "$_ignore_=[[:Mn:][:Me:][:Cf:]];"
 
-                // lower and upper case Roman letters, apostrophy and dash are
+                // lower and upper case Roman letters, apostrophe and dash are
                 // in the English dictionary
                 +"$_dictionary_=[a-zA-Z\\'\\-];"
 
@@ -64,7 +64,7 @@ public class BreakIteratorRules_en_US_TEST extends ListResourceBundle {
                 +"$mid_word=[[:Pd:]\u00ad\u2027\\\"\\\'];"
 
                 // punctuation that can occur in the middle of a number: currently
-                // apostrophes, qoutation marks, periods, commas, and the Arabic
+                // apostrophes, quotation marks, periods, commas, and the Arabic
                 // decimal point
                 +"$mid_num=[\\\"\\\'\\,\u066b\\.];"
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/segmenter/LocalizedSegmenterTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/segmenter/LocalizedSegmenterTest.java
@@ -1,0 +1,64 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: https://www.unicode.org/copyright.html
+
+package com.ibm.icu.dev.test.segmenter;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.ibm.icu.dev.test.CoreTestFmwk;
+import com.ibm.icu.segmenter.LocalizedSegmenter;
+import com.ibm.icu.segmenter.LocalizedSegmenter.SegmentationType;
+import com.ibm.icu.segmenter.Segmenter;
+import com.ibm.icu.segmenter.Segments;
+import com.ibm.icu.util.ULocale;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class LocalizedSegmenterTest extends CoreTestFmwk {
+
+  @Test
+  public void testLocaleInLocalizedSegmenter() {
+
+    Object[][] casesData = {
+        {"de",
+            "Das 21ste Jahrh. ist das beste.",
+            Arrays.asList("Das", " ", "21ste", " ", "Jahrh", ".", " ", "ist", " ", "das", " ", "beste", ".")},
+    };
+
+    for (Object[] caseDatum : casesData) {
+      String localeTag = (String) caseDatum[0];
+      String source = (String) caseDatum[1];
+      List<CharSequence> expWords = (List<CharSequence>) caseDatum[2];
+
+      // create functions that abstract over the different types of locales so that, later on,
+      // we can test using both in the same way
+      Function<LocalizedSegmenter.Builder, LocalizedSegmenter.Builder> setJLocaleFn =
+          builder -> builder.setLocale(Locale.forLanguageTag(localeTag));
+      Function<LocalizedSegmenter.Builder, LocalizedSegmenter.Builder> setULocaleFn =
+          builder -> builder.setLocale(ULocale.forLanguageTag(localeTag));
+
+      // Loop/iterate over both Java Locale and ICU ULocale such that we always test with both
+      // types of locale objects.
+      for (Function<LocalizedSegmenter.Builder, LocalizedSegmenter.Builder> setLocIntoBuilder : Arrays.asList(setJLocaleFn, setULocaleFn)) {
+
+        LocalizedSegmenter.Builder builder = LocalizedSegmenter.builder()
+            .setSegmentationType(SegmentationType.WORD);
+        LocalizedSegmenter.Builder builderWithLocale = setLocIntoBuilder.apply(builder);
+        Segmenter wordSeg = builderWithLocale.build();
+        Segments segments = wordSeg.segment(source);
+
+        List<CharSequence> actWords = segments.subSequences().collect(Collectors.toList());
+
+        assertThat(actWords, is(expWords));
+      }
+    }
+  }
+}

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/segmenter/RuleBasedSegmenterTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/segmenter/RuleBasedSegmenterTest.java
@@ -1,0 +1,58 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: https://www.unicode.org/copyright.html
+
+package com.ibm.icu.dev.test.segmenter;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.ibm.icu.dev.test.CoreTestFmwk;
+import com.ibm.icu.segmenter.RuleBasedSegmenter;
+import com.ibm.icu.segmenter.Segmenter;
+import com.ibm.icu.segmenter.Segments;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class RuleBasedSegmenterTest extends CoreTestFmwk {
+
+  @Test
+  public void testRules() {
+    Object[][] casesData = {
+        {"ASCII lowercase a-z only",
+            "Kühlschränke kühlen Getränke",
+            "[a-z]+;",
+            Arrays.asList("K", "ü", "hlschr", "ä", "nke", " ", "k", "ü", "hlen", " ", "G", "etr", "ä", "nke")},
+        {"ASCII upper- and lowercase a-z",
+            "Kühlschränke kühlen Getränke",
+            "[A-Za-z]+;",
+            Arrays.asList("K", "ü", "hlschr", "ä", "nke", " ", "k", "ü", "hlen", " ", "Getr", "ä", "nke")},
+        {"ASCII upper- and lowercase a-z and some letters with diaeresis",
+            "Kühlschränke kühlen Getränke",
+            "[A-Za-züä]+;",
+            Arrays.asList("Kühlschränke", " ", "kühlen", " ", "Getränke")},
+    };
+
+    for (Object[] caseDatum : casesData) {
+      String desc = (String) caseDatum[0];
+      String source = (String) caseDatum[1];
+      String rule = (String) caseDatum[2];
+      List<CharSequence> expWords = (List<CharSequence>) caseDatum[3];
+
+      Segmenter seg = RuleBasedSegmenter.builder()
+          .setRules(rule)
+          .build();
+      Segments segments = seg.segment(source);
+
+      List<CharSequence> actWords = segments.subSequences().collect(Collectors.toList());
+
+      assertThat(desc, actWords, is(expWords));
+    }
+
+  }
+
+}

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/segmenter/SegmentsTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/segmenter/SegmentsTest.java
@@ -1,0 +1,371 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: https://www.unicode.org/copyright.html
+
+package com.ibm.icu.dev.test.segmenter;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.ibm.icu.dev.test.CoreTestFmwk;
+import com.ibm.icu.segmenter.LocalizedSegmenter;
+import com.ibm.icu.segmenter.LocalizedSegmenter.SegmentationType;
+import com.ibm.icu.segmenter.Segment;
+import com.ibm.icu.segmenter.Segmenter;
+import com.ibm.icu.segmenter.Segments;
+import com.ibm.icu.util.ULocale;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SegmentsTest extends CoreTestFmwk {
+
+  @Test
+  public void testSegments() {
+    Segmenter enWordSegmenter =
+        LocalizedSegmenter.builder()
+            .setLocale(ULocale.ENGLISH)
+            .setSegmentationType(SegmentationType.WORD)
+            .build();
+
+    String source1 = "The quick brown fox jumped over the lazy dog.";
+
+    // Create new Segments for source1
+    Segments segments1 = enWordSegmenter.segment(source1);
+
+    List<Segment> segments = segments1.segments().collect(Collectors.toList());
+
+    assertEquals("first segment start", 0, segments.get(0).start);
+    assertEquals("first segment limit", 3, segments.get(0).limit);
+
+    assertEquals("second segment start", 3, segments.get(1).start);
+    assertEquals("second segment limit", 4, segments.get(1).limit);
+  }
+
+  @Test
+  public void testMultipleSegmentObjectsFromSegmenter() {
+    Segmenter enWordSegmenter =
+        LocalizedSegmenter.builder()
+            .setLocale(ULocale.ENGLISH)
+            .setSegmentationType(SegmentationType.WORD)
+            .build();
+
+    String source1 = "The quick brown fox jumped over the lazy dog.";
+    String source2 = "Sphinx of black quartz, judge my vow.";
+    String source3 = "How vexingly quick daft zebras jump!";
+
+    List<CharSequence> exp1 = Arrays.asList("The", " ", "quick", " ", "brown", " ", "fox", " ",
+        "jumped", " ", "over", " ", "the", " ", "lazy", " ", "dog", ".");
+    List<CharSequence> exp2 = Arrays.asList("Sphinx", " ", "of", " ", "black", " ", "quartz", ",",
+        " ", "judge", " ", "my", " ", "vow", ".");
+    List<CharSequence> exp3 = Arrays.asList("How", " ", "vexingly", " ", "quick", " ", "daft", " ",
+        "zebras", " ", "jump", "!");
+
+    // Create new Segments for source1
+    Segments segments1 = enWordSegmenter.segment(source1);
+    List<CharSequence> act1 = segments1.subSequences().collect(Collectors.toList());
+    assertThat(act1, is(exp1));
+
+    // Create new Segments for source2
+    Segments segments2 = enWordSegmenter.segment(source2);
+    List<CharSequence> act2 = segments2.subSequences().collect(Collectors.toList());
+    assertThat(act2, is(exp2));
+
+    // Check that Segments for source1 is unaffected
+    act1 = segments1.subSequences().collect(Collectors.toList());
+    assertThat(act1, is(exp1));
+
+    // Create new Segments for source3
+    Segments segments3 = enWordSegmenter.segment(source3);
+    List<CharSequence> act3 = segments3.subSequences().collect(Collectors.toList());
+    assertThat(act3, is(exp3));
+
+    // Check that Segments for source1 is unaffected
+    act1 = segments1.subSequences().collect(Collectors.toList());
+    assertThat(act1, is(exp1));
+
+    // Check that Segments for source2 is unaffected
+    act2 = segments2.subSequences().collect(Collectors.toList());
+    assertThat(act2, is(exp2));
+  }
+
+  @Test
+  public void testIsBoundary() {
+    Segmenter enWordSegmenter =
+        LocalizedSegmenter.builder()
+            .setLocale(ULocale.ENGLISH)
+            .setSegmentationType(LocalizedSegmenter.SegmentationType.WORD)
+            .build();
+
+    String source1 = "The quick brown fox jumped over the lazy dog.";
+
+    // Create new Segments for source1
+    Segments segments1 = enWordSegmenter.segment(source1);
+    List<Segment> segments = segments1.segments().collect(Collectors.toList());
+
+    // Make space for n+1 possible boundary positions for an input of length n
+    BitSet actBoundaries = new BitSet(source1.length() + 1);
+    for (Segment seg : segments) {
+      actBoundaries.set(seg.start);
+      actBoundaries.set(seg.limit);
+    }
+
+    // since we are iterating over boundaries (not chars), we go from 0..n (not 0..n-1)
+    IntStream.rangeClosed(0, source1.length()).forEach(
+        i -> {
+          if (actBoundaries.get(i)) {
+            assertTrue("Detected " + i + " as boundary", segments1.isBoundary(i));
+          } else {
+            assertFalse("Detected " + i + " as not a boundary", segments1.isBoundary(i));
+          }
+        }
+    );
+  }
+
+  @Test
+  public void testSegmentsFrom_middleOfSegment() {
+    Segmenter enWordSegmenter =
+        LocalizedSegmenter.builder()
+            .setLocale(ULocale.ENGLISH)
+            .setSegmentationType(LocalizedSegmenter.SegmentationType.WORD)
+            .build();
+
+    String source1 = "The quick brown fox jumped over the lazy dog.";
+    int startIdx = 1;
+
+    // Create new Segments for source1
+    Segments segments1 = enWordSegmenter.segment(source1);
+
+    List<Segment> segments = segments1.segmentsFrom(startIdx).collect(Collectors.toList());
+
+    assertEquals("first segment start", 0, segments.get(0).start);
+    assertEquals("first segment limit", 3, segments.get(0).limit);
+
+    assertEquals("second segment start", 3, segments.get(1).start);
+    assertEquals("second segment limit", 4, segments.get(1).limit);
+  }
+
+  @Test
+  public void testSegmentsFrom_onBoundary() {
+    Segmenter enWordSegmenter =
+        LocalizedSegmenter.builder()
+            .setLocale(ULocale.ENGLISH)
+            .setSegmentationType(LocalizedSegmenter.SegmentationType.WORD)
+            .build();
+
+    String source1 = "The quick brown fox jumped over the lazy dog.";
+    int startIdx = 3;
+
+    // Create new Segments for source1
+    Segments segments1 = enWordSegmenter.segment(source1);
+
+    List<Segment> segments = segments1.segmentsFrom(startIdx).collect(Collectors.toList());
+
+    assertEquals("first segment start", 3, segments.get(0).start);
+    assertEquals("first segment limit", 4, segments.get(0).limit);
+
+    assertEquals("second segment start", 4, segments.get(1).start);
+    assertEquals("second segment limit", 9, segments.get(1).limit);
+  }
+
+  @Test
+  public void testSegmentsBefore_middleOfSegment() {
+    Segmenter enWordSegmenter =
+        LocalizedSegmenter.builder()
+            .setLocale(ULocale.ENGLISH)
+            .setSegmentationType(LocalizedSegmenter.SegmentationType.WORD)
+            .build();
+
+    String source1 = "The quick brown fox jumped over the lazy dog.";
+    int startIdx = 8;
+
+    // Create new Segments for source1
+    Segments segments1 = enWordSegmenter.segment(source1);
+
+    List<Segment> segments = segments1.segmentsBefore(startIdx).collect(Collectors.toList());
+
+    assertEquals("first segment start", 3, segments.get(0).start);
+    assertEquals("first segment limit", 4, segments.get(0).limit);
+
+    assertEquals("second segment start", 0, segments.get(1).start);
+    assertEquals("second segment limit", 3, segments.get(1).limit);
+  }
+
+  @Test
+  public void testSegmentsBefore_onBoundary() {
+    Segmenter enWordSegmenter =
+        LocalizedSegmenter.builder()
+            .setLocale(ULocale.ENGLISH)
+            .setSegmentationType(LocalizedSegmenter.SegmentationType.WORD)
+            .build();
+
+    String source1 = "The quick brown fox jumped over the lazy dog.";
+    int startIdx = 9;
+
+    // Create new Segments for source1
+    Segments segments1 = enWordSegmenter.segment(source1);
+
+    List<Segment> segments = segments1.segmentsBefore(startIdx).collect(Collectors.toList());
+
+    assertEquals("first segment start", 4, segments.get(0).start);
+    assertEquals("first segment limit", 9, segments.get(0).limit);
+
+    assertEquals("second segment start", 3, segments.get(1).start);
+    assertEquals("second segment limit", 4, segments.get(1).limit);
+  }
+
+  @Test
+  public void testBoundaries() {
+    Segmenter enWordSegmenter =
+        LocalizedSegmenter.builder()
+            .setLocale(ULocale.ENGLISH)
+            .setSegmentationType(SegmentationType.WORD)
+            .build();
+
+    String source = "The quick brown fox jumped over the lazy dog.";
+
+    // Create new Segments for source
+    Segments segments = enWordSegmenter.segment(source);
+
+    int[] exp = {0, 3, 4, 9, 10, 15, 16, 19, 20, 26, 27, 31, 32, 35, 36, 40, 41, 44, 45};
+
+    int[] act = segments.boundaries().toArray();
+
+    assertThat(act, is(exp));
+  }
+
+  @Test
+  public void testBoundariesAfter() {
+    Segmenter enWordSegmenter =
+        LocalizedSegmenter.builder()
+            .setLocale(ULocale.ENGLISH)
+            .setSegmentationType(SegmentationType.WORD)
+            .build();
+
+    String source = "The quick brown fox jumped over the lazy dog.";
+    int TAKE_LIMIT = 5;
+
+    // Create new Segments for source
+    Segments segments = enWordSegmenter.segment(source);
+
+    Object[][] casesData = {
+        {"first " + TAKE_LIMIT + " before beginning",                       -2,                 new int[]{0, 3, 4, 9, 10}},
+        {"first " + TAKE_LIMIT + " in the middle of the third segment",     5,                  new int[]{9, 10, 15, 16, 19}},
+        {"first " + TAKE_LIMIT + " on the limit of the third segment",      9,                  new int[]{10, 15, 16, 19, 20}},
+        {"first " + TAKE_LIMIT + " at the end",                             source.length(),    new int[0]},
+        {"first " + TAKE_LIMIT + " after the end",                          source.length()+1,  new int[0]},
+    };
+
+    for (Object[] caseDatum : casesData) {
+      String desc = (String) caseDatum[0];
+      int startIdx = (int) caseDatum[1];
+      int[] exp = (int[]) caseDatum[2];
+
+      int[] act = segments.boundariesAfter(startIdx).limit(TAKE_LIMIT).toArray();
+
+      assertThat(desc, act, is(exp));
+    }
+  }
+
+  @Test
+  public void testBoundariesBackFrom() {
+    Segmenter enWordSegmenter =
+        LocalizedSegmenter.builder()
+            .setLocale(ULocale.ENGLISH)
+            .setSegmentationType(SegmentationType.WORD)
+            .build();
+
+    String source = "The quick brown fox jumped over the lazy dog.";
+    int TAKE_LIMIT = 5;
+
+    // Create new Segments for source
+    Segments segments = enWordSegmenter.segment(source);
+
+    Object[][] casesData = {
+        {"first " + TAKE_LIMIT + " before beginning",                          -2,                 new int[0]},
+        {"first " + TAKE_LIMIT + " at the beginning",                          0,                  new int[]{0}},
+        {"first " + TAKE_LIMIT + " from the start of the 2nd to last segment", 41,                 new int[]{41, 40, 36, 35, 32}},
+        {"first " + TAKE_LIMIT + " in the middle of the 2nd to last segment",  42,                 new int[]{41, 40, 36, 35, 32}},
+        {"first " + TAKE_LIMIT + " at the end",                                source.length(),    new int[]{45, 44, 41, 40, 36}},
+        {"first " + TAKE_LIMIT + " after the end",                             source.length()+1,  new int[]{45, 44, 41, 40, 36}},
+    };
+
+    for (Object[] caseDatum : casesData) {
+      String desc = (String) caseDatum[0];
+      int startIdx = (int) caseDatum[1];
+      int[] exp = (int[]) caseDatum[2];
+
+      int[] act = segments.boundariesBackFrom(startIdx).limit(TAKE_LIMIT).toArray();
+
+      assertThat(desc, act, is(exp));
+    }
+  }
+
+  @Test
+  public void testSegmentAt() {
+    Segmenter enWordSegmenter =
+        LocalizedSegmenter.builder()
+            .setLocale(ULocale.ENGLISH)
+            .setSegmentationType(SegmentationType.WORD)
+            .build();
+
+    String source = "The quick brown fox jumped over the lazy dog.";
+
+    // Create new Segments for source
+    Segments segments1 = enWordSegmenter.segment(source);
+
+    Object[][] casesData = {
+        {"index before beginning",                       -2,                 null,              null},
+        {"index at beginning",                           0,                  0,                 3},
+        {"index in the middle of the first segment",     2,                  0,                 3},
+        {"index in the middle of the third segment",     5,                  4,                 9},
+        {"index right before the end",                   source.length()-1,  44,                45},
+        {"index at the end",                             source.length(),    null,              null},
+        {"index after the end",                          source.length()+1,  null,              null},
+    };
+
+    for (Object[] caseDatum : casesData) {
+      String desc = (String) caseDatum[0];
+      int startIdx = (int) caseDatum[1];
+      Integer expStart = (Integer) caseDatum[2];
+      Integer expLimit = (Integer) caseDatum[3];
+
+      if (expStart == null) {
+        try {
+          // this should throw an exception because the index is out of bounds
+          Segment segment = segments1.segmentAt(startIdx);
+          // if an exception isn't thrown, then we have a test failure
+          fail("segmentAt should throw for an out of bounds index");
+        } catch (IndexOutOfBoundsException ioobe) {
+          // test throws expected exception, so continue
+        }
+      } else {
+        Segment segment = segments1.segmentAt(startIdx);
+
+        assertEquals(desc + ", start", (long) expStart.intValue(), (long) segment.start);
+        assertEquals(desc + ", limit", (long) expLimit.intValue(), (long) segment.limit);
+      }
+    }
+  }
+
+  @Test(expected = IndexOutOfBoundsException.class)
+  public void testSegmentAt_throwsIndexOutOfBoundsException() {
+    Segmenter enWordSegmenter =
+        LocalizedSegmenter.builder()
+            .setLocale(ULocale.ENGLISH)
+            .setSegmentationType(SegmentationType.WORD)
+            .build();
+
+    String source = "The quick brown fox jumped over the lazy dog.";
+
+    Segments segments = enWordSegmenter.segment(source);
+
+    segments.segmentAt(-1);
+  }
+
+}


### PR DESCRIPTION
In order to "modernize" the `BreakIterator` API, this PR introduces a new  wrapper using a more convenient, modern API design around a `Segmenter` interface.

A few of the goals that motivate the new `Segmenter` API:

* Use newer Java features from Java 8 that support the `Stream` API which underlies a functional programming style
* Create instances that are immutable (reduces complexity borne of statefulness; allows user code to be more referentially transparent)
* Create a wrapper class around the iteration. This allows the decoupling of the iteration of a source string from the construction of the BreakIterator such that we can perform iteration over one string in isolation from other strings
* Use interfaces to properly decouple and abstract. APIs built on top of interfaces can allow user-created implementations to participate in such higher level APIs.

More details in the [design doc](https://docs.google.com/document/d/17C02RNdwD41e-sKTHcwyM8uPJhYNvo0oNI7LBs8un58/edit?pli=1).

This PR will focus on the ICU4J side of the work.

#### Checklist
- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22789
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
