### PR TITLE
ICU-22765 fix uloc_addLikelySubtags on "und@x=private"

### DIFF
--- a/icu4c/source/common/loclikelysubtags.cpp
+++ b/icu4c/source/common/loclikelysubtags.cpp
@@ -527,7 +527,7 @@ LSR LikelySubtags::makeMaximizedLsrFrom(const Locale &locale,
         return {};
     }
     const char *name = locale.getName();
-    if (uprv_isAtSign(name[0]) && name[1] == 'x' && name[2] == '=') {  // name.startsWith("@x=")
+    if (!returnInputIfUnmatch && uprv_isAtSign(name[0]) && name[1] == 'x' && name[2] == '=') {  // name.startsWith("@x=")
         // Private use language tag x-subtag-subtag... which CLDR changes to
         // und-x-subtag-subtag...
         return LSR(name, "", "", LSR::EXPLICIT_LSR);

--- a/icu4c/source/test/cintltst/cloctst.c
+++ b/icu4c/source/test/cintltst/cloctst.c
@@ -3924,6 +3924,13 @@ const char* const basic_maximize_data[][2] = {
     // ICU-22545 & ICU-22742
     "ru_XC",
     "ru_Cyrl_XC"
+  }, {
+    // ICU-22765
+    "und@x=private",
+    "en_Latn_US@x=private",
+  }, {
+    "th@x=private",
+    "th_Thai_TH@x=private",
   }
 };
 

--- a/icu4c/source/test/intltest/loctest.cpp
+++ b/icu4c/source/test/intltest/loctest.cpp
@@ -4124,6 +4124,15 @@ LocaleTest::TestAddLikelyAndMinimizeSubtags() {
             "en_PSCRACK",
             "en_Latn_US_PSCRACK",
             "en__PSCRACK"
+        }, {
+            // ICU-22765
+            "th@x=private",
+            "th_Thai_TH@x=private",
+            "th@x=private",
+        }, {
+            "und@x=private",
+            "en_Latn_US@x=private",
+            "en@x=private",
         }
     };
 

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/util/ULocaleTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/util/ULocaleTest.java
@@ -4162,7 +4162,15 @@ public class ULocaleTest extends CoreTestFmwk {
                     "und_US",
                     "en_Latn_US",
                     "en"
-                }
+                }, {
+                    "th@x=private",
+                    "th_Thai_TH@x=private",
+                    "th@x=private",
+                }, {
+                    "und@x=private",
+                    "en_Latn_US@x=private",
+                    "en@x=private",
+               }
         };
 
         for (int i = 0; i < full_data.length; i++) {


### PR DESCRIPTION
Fix Locale addLikelySubtags when input is "und@x=private"
Since the code are shared by matcher and addLikelySubtags the behavior for this special case need to check an additional condition. 
For Java, just add the test case. 

#### Checklist
- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22765
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
