### PR TITLE
ICU-22950 Do not initialize currency for NumberPropertyMapper when useCurrency is false

### DIFF
--- a/icu4c/source/i18n/number_mapper.cpp
+++ b/icu4c/source/i18n/number_mapper.cpp
@@ -74,9 +74,11 @@ MacroProps NumberPropertyMapper::oldToNew(const DecimalFormatProperties& propert
             !properties.currencyPluralInfo.fPtr.isNull() ||
             !properties.currencyUsage.isNull() ||
             warehouse.affixProvider.get().hasCurrencySign());
-    CurrencyUnit currency = resolveCurrency(properties, locale, status);
-    UCurrencyUsage currencyUsage = properties.currencyUsage.getOrDefault(UCURR_USAGE_STANDARD);
+    CurrencyUnit currency;
+    UCurrencyUsage currencyUsage;
     if (useCurrency) {
+        currency = resolveCurrency(properties, locale, status);
+        currencyUsage = properties.currencyUsage.getOrDefault(UCURR_USAGE_STANDARD);
         // NOTE: Slicing is OK.
         macros.unit = currency; // NOLINT
     }
@@ -129,6 +131,7 @@ MacroProps NumberPropertyMapper::oldToNew(const DecimalFormatProperties& propert
     }
     Precision precision;
     if (!properties.currencyUsage.isNull()) {
+        U_ASSERT(useCurrency);
         precision = Precision::constructCurrency(currencyUsage).withCurrency(currency);
     } else if (roundingIncrement != 0.0) {
         if (PatternStringUtils::ignoreRoundingIncrement(roundingIncrement, maxFrac)) {
@@ -276,7 +279,7 @@ MacroProps NumberPropertyMapper::oldToNew(const DecimalFormatProperties& propert
         exportedProperties->maximumIntegerDigits = maxInt == -1 ? INT32_MAX : maxInt;
 
         Precision rounding_;
-        if (precision.fType == Precision::PrecisionType::RND_CURRENCY) {
+        if (useCurrency && precision.fType == Precision::PrecisionType::RND_CURRENCY) {
             rounding_ = precision.withCurrency(currency, status);
         } else {
             rounding_ = precision;


### PR DESCRIPTION
resolveCurrency() slows down simple number formatting requests like:
```
for (int i = 0; i < 9999; i++)
  u_snprintf_u(buff, 100, u"%d", i);
```
Since icu4c doesn't use currency there, we can skip its initialization.

#### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22950
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
