### PR TITLE
ICU-22953 MF2: Allow unpaired surrogates in text and quoted literals

### DIFF
--- a/icu4c/source/i18n/messageformat2_parser.cpp
+++ b/icu4c/source/i18n/messageformat2_parser.cpp
@@ -121,8 +121,8 @@ static bool isContentChar(UChar32 c) {
            || inRange(c, 0x002F, 0x003F) // Omit '@'
            || inRange(c, 0x0041, 0x005B) // Omit '\'
            || inRange(c, 0x005D, 0x007A) // Omit { | }
-           || inRange(c, 0x007E, 0xD7FF) // Omit surrogates
-           || inRange(c, 0xE000, 0x10FFFF);
+           || inRange(c, 0x007E, 0x2FFF) // Omit IDEOGRAPHIC_SPACE
+           || inRange(c, 0x3001, 0x10FFFF); // Allowing surrogates is intentional
 }
 
 // See `s` in the MessageFormat 2 grammar

--- a/icu4c/source/test/intltest/messageformat2test.cpp
+++ b/icu4c/source/test/intltest/messageformat2test.cpp
@@ -33,6 +33,7 @@ TestMessageFormat2::runIndexedTest(int32_t index, UBool exec,
     TESTCASE_AUTO(testFormatterAPI);
     TESTCASE_AUTO(testHighLoneSurrogate);
     TESTCASE_AUTO(testLowLoneSurrogate);
+    TESTCASE_AUTO(testLoneSurrogateInQuotedLiteral);
     TESTCASE_AUTO(dataDrivenTests);
     TESTCASE_AUTO_END;
 }
@@ -350,7 +351,8 @@ void TestMessageFormat2::testHighLoneSurrogate() {
       .setPattern(loneSurrogate, pe, errorCode)
       .build(errorCode);
     UnicodeString result = msgfmt1.formatToString({}, errorCode);
-    errorCode.expectErrorAndReset(U_MF_SYNTAX_ERROR, "testHighLoneSurrogate");
+    assertEquals("testHighLoneSurrogate", loneSurrogate, result);
+    errorCode.errIfFailureAndReset("testHighLoneSurrogate");
 }
 
 // ICU-22890 lone surrogate cause infinity loop
@@ -364,7 +366,25 @@ void TestMessageFormat2::testLowLoneSurrogate() {
       .setPattern(loneSurrogate, pe, errorCode)
       .build(errorCode);
     UnicodeString result = msgfmt2.formatToString({}, errorCode);
-    errorCode.expectErrorAndReset(U_MF_SYNTAX_ERROR, "testLowLoneSurrogate");
+    assertEquals("testLowLoneSurrogate", loneSurrogate, result);
+    errorCode.errIfFailureAndReset("testLowLoneSurrogate");
+}
+
+void TestMessageFormat2::testLoneSurrogateInQuotedLiteral() {
+    IcuTestErrorCode errorCode(*this, "testLoneSurrogateInQuotedLiteral");
+    UParseError pe = { 0, 0, {0}, {0} };
+    // |\udc02|
+    UnicodeString literal("{|");
+    literal += 0xdc02;
+    literal += "|}";
+    UnicodeString expectedResult({0xdc02, 0});
+    icu::message2::MessageFormatter msgfmt2 =
+      icu::message2::MessageFormatter::Builder(errorCode)
+      .setPattern(literal, pe, errorCode)
+      .build(errorCode);
+    UnicodeString result = msgfmt2.formatToString({}, errorCode);
+    assertEquals("testLoneSurrogateInQuotedLiteral", expectedResult, result);
+    errorCode.errIfFailureAndReset("testLoneSurrogateInQuotedLiteral");
 }
 
 void TestMessageFormat2::dataDrivenTests() {

--- a/icu4c/source/test/intltest/messageformat2test.h
+++ b/icu4c/source/test/intltest/messageformat2test.h
@@ -91,6 +91,7 @@ private:
 
     void testHighLoneSurrogate(void);
     void testLowLoneSurrogate(void);
+    void testLoneSurrogateInQuotedLiteral(void);
 }; // class TestMessageFormat2
 
 U_NAMESPACE_BEGIN


### PR DESCRIPTION
In a previous version of the spec, unpaired surrogates in text or quoted literals were an error. 
A recent PR, https://github.com/unicode-org/message-format-wg/pull/906/ , made them allowable. This PR changes ICU4C to be consistent with the spec.


#### Checklist
- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22953
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
