### PR TITLE
ICU-22965 Fix the problems we had with the maven deploy for ICU 76.1

### DIFF
--- a/icu4j/main/charset/pom.xml
+++ b/icu4j/main/charset/pom.xml
@@ -13,6 +13,7 @@
   </parent>
 
   <artifactId>icu4j-charset</artifactId>
+  <name>ICU4J Charset Provider</name>
   <description>icu4j-charset is a supplemental library for icu4j, implementing Java Charset SPI.</description>
   <url>${proj.url}</url>
   <scm>

--- a/icu4j/main/icu4j/pom.xml
+++ b/icu4j/main/icu4j/pom.xml
@@ -14,6 +14,7 @@
   </parent>
 
   <artifactId>icu4j</artifactId>
+  <name>ICU4J</name>
   <description>International Components for Unicode for Java (ICU4J) is a mature, widely used Java library
     providing Unicode and Globalization support</description>
   <url>${proj.url}</url>

--- a/icu4j/main/localespi/pom.xml
+++ b/icu4j/main/localespi/pom.xml
@@ -13,6 +13,7 @@
   </parent>
 
   <artifactId>icu4j-localespi</artifactId>
+  <name>ICU4J Locale Service Provider</name>
   <description>icu4j-localespi is a supplemental library for icu4j, implementing Java Locale SPI.</description>
   <url>${proj.url}</url>
   <scm>

--- a/icu4j/pom.xml
+++ b/icu4j/pom.xml
@@ -235,6 +235,9 @@
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>3.1.3</version>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-site-plugin</artifactId>


### PR DESCRIPTION
The blocker was the missing `<name>` element, which is mandatory.
See https://central.sonatype.org/publish/requirements/#project-name-description-and-url

The second problem was that all modules were staged, not just the three we normally publish.

#### Checklist
- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22965
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
