### PR TITLE
ICU-22127 Remove obsolete WordBreakTest.txt known issues

### DIFF
--- a/icu4c/source/test/intltest/rbbitst.cpp
+++ b/icu4c/source/test/intltest/rbbitst.cpp
@@ -1267,11 +1267,6 @@ UBool RBBITest::testCaseIsKnownIssue(const UnicodeString &testCase, const char *
         const char16_t *fString;
     } badTestCases[] = {
         {"10666", "GraphemeBreakTest.txt", u"\u0020\u0020\u0033"},    // Fake example, for illustration.
-
-        // ICU-22127 until UAX #29 wordbreak is update for the colon changes in ICU-22112,
-        // need to skip some tests in WordBreakTest.txt
-        {"22127", "WordBreakTest.txt", u"a:"},
-        {"22127", "WordBreakTest.txt", u"A:"},
     };
 
     for (int n=0; n<UPRV_LENGTHOF(badTestCases); n++) {


### PR DESCRIPTION
Made obsolete by #3249.

#### Checklist
- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22127
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
