### PR TITLE
ICU-22960 Use `ICUBinary.getRequiredData()` to load BreakIterator data

### DIFF
--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/BreakIteratorFactory.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/BreakIteratorFactory.java
@@ -150,7 +150,7 @@ final class BreakIteratorFactory extends BreakIterator.BreakIteratorServiceShim 
             String         typeKey       = typeKeyExt.isEmpty() ? KIND_NAMES[kind] : KIND_NAMES[kind] + typeKeyExt;
                            brkfname      = rb.getStringWithFallback("boundaries/" + typeKey);
             String         rulesFileName = ICUData.ICU_BRKITR_NAME+ '/' + brkfname;
-                           bytes         = ICUBinary.getData(rulesFileName);
+                           bytes         = ICUBinary.getRequiredData(rulesFileName);
         }
         catch (Exception e) {
             throw new MissingResourceException(e.toString(),"","");


### PR DESCRIPTION
Propagate the `MissingResourceException` when the data files for BreakIterator are not found

#### Checklist
- [X] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22960
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
