### PR TITLE
ICU-21396 Fix incorrect result shown in the userguide example

### DIFF
--- a/docs/userguide/transforms/general/rules.md
+++ b/docs/userguide/transforms/general/rules.md
@@ -503,7 +503,7 @@ the position, for those cases:
 The first rule will convert "x", when preceded by a vowel, into "ks". The
 transform will then backup to the position before the vowel and continue. In the
 next pass, the "ak" will match and be invoked. Thus, if the source text is "ax",
-the result will be "ack".
+the result will be "acks".
 
 > :point_right: **Note**: *Although you can move the cursor forward or backward, it is limited in two
 ways: (a) to the text that is matched, (b) within the original substring that is


### PR DESCRIPTION
To check I did a `RuleBasedTransliterator.createFromRules` with the rules in the userguide.
The result is indeed `"acks"`.

#### Checklist
- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-21396
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
