### PR TITLE
ICU-22870 Remove ja_JP_TRADITIONAL pattern generator tests

### DIFF
--- a/docs/userguide/datetime/calendar/index.md
+++ b/docs/userguide/datetime/calendar/index.md
@@ -66,8 +66,7 @@ classes.*
 When a calendar object is created, via either `Calendar::create()`, or
 `ucal_open()`, or indirectly within a date formatter, ICU looks up the 'default'
 calendar type for that locale. At present, all locales default to a Gregorian
-calendar, except for the compatibility locales th_TH_TRADITIONAL and
-ja_JP_TRADITIONAL. If the "calendar" keyword is supplied, this value will
+calendar. If the "calendar" keyword is supplied, this value will
 override the default for that locale.
 
 For instance, `Calendar::createInstance("fr_FR", status)` will create a Gregorian calendar,

--- a/docs/userguide/locale/index.md
+++ b/docs/userguide/locale/index.md
@@ -391,11 +391,7 @@ and `Locale::createCanonical`. The latter API exists in both C++ and Java.
     es@collation=traditional, hi__DIRECT => hi@collation=direct, zh_TW_STROKE =>
     zh_TW@collation=stroke, zh__PINYIN => zh@collation=pinyin.
 
-9.  Variants specifying a calendar are remapped to calendar keyword specifiers,
-    as follows: ja_JP_TRADITIONAL => ja_JP@calendar=japanese, th_TH_TRADITIONAL
-    => th_TH@calendar=buddhist.
-
-10. Special case: C => en_US_POSIX.
+9.  Special case: C => en_US_POSIX.
 
 Certain other operations are not performed by either level 1 or level 2
 canonicalization. These are listed here for completeness.

--- a/icu4c/source/test/intltest/dtptngts.cpp
+++ b/icu4c/source/test/intltest/dtptngts.cpp
@@ -53,7 +53,7 @@ void IntlTestDateTimePatternGeneratorAPI::runIndexedTest( int32_t index, UBool e
     }
 }
 
-#define MAX_LOCALE   12
+#define MAX_LOCALE   11
 
 /**
  * Test various generic API methods of DateTimePatternGenerator for API coverage.
@@ -93,7 +93,6 @@ void IntlTestDateTimePatternGeneratorAPI::testAPI(/*char *par*/)
         {"zh", "TW", "", "calendar=roc"},       // 8
         {"ru", "", "", ""},                     // 9
         {"zh", "", "", "calendar=chinese"},     // 10
-        {"ja", "JP", "TRADITIONAL", ""},        // 11
      };
 
     // For Weds, Jan 13, 1999, 23:58:59
@@ -328,28 +327,7 @@ void IntlTestDateTimePatternGeneratorAPI::testAPI(/*char *par*/)
         UnicodeString("23:58"),                                                 // 16: JJmm
     };
 
-    UnicodeString patternResults_ja_jp_traditional[] = {
-        // ja_JP_TRADITIONAL                 // 11 ja_JP_TRADITIONAL
-        u"AD1999/1",                         // 00: yM
-        u"西暦1999年1月",                     // 01: yMMM
-        u"1999年1月13日",                     // 02: yMd
-        u"西暦1999年1月13日",                  // 03: yMMMd
-        u"1/13",                             // 04: Md
-        u"1月13日",                           // 05: MMMd
-        u"1月13日",                           // 06: MMMMd
-        u"西暦1999/Q1",                       // 07: yQQQ
-        u"午後11:58",                         // 08: hhmm
-        u"23:58",                            // 09: HHmm
-        u"23:58",                            // 10: jjmm
-        u"58:59",                            // 11: mmss
-        u"西暦1999年1月",                     // 12: yyyyMMMM
-        u"1月13日(水)",                       // 13: MMMEd
-        u"13日(水)",                          // 14: Ed
-        u"23:58:59.123",                     // 15: jmmssSSS
-        u"23:58",                            // 16: JJmm
-    };
-
-    UnicodeString* patternResults[] = {
+    UnicodeString* patternResults[MAX_LOCALE] = {
         patternResults_en_US, // 0
         patternResults_en_US_japanese, // 1
         patternResults_de_DE, // 2
@@ -361,7 +339,6 @@ void IntlTestDateTimePatternGeneratorAPI::testAPI(/*char *par*/)
         patternResults_zh_TW_roc, // 8
         patternResults_ru, // 9
         patternResults_zh_chinese, // 10
-        patternResults_ja_jp_traditional, // 11
     };
 
     UnicodeString patternTests2[] = {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DateTimeGeneratorTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DateTimeGeneratorTest.java
@@ -576,26 +576,6 @@ public class DateTimeGeneratorTest extends CoreTestFmwk {
         new String[] {"Ed", "26\u65E5\u5468\u4E09"},
         new String[] {"jmmssSSS", "23:58:59.123"},
         new String[] {"JJmm", "23:58"},
-
-        new ULocale("ja_JP_TRADITIONAL"),
-        // TODO: This is different in C++ and Java.
-        new String[] {"yM", "1999/1",},
-        new String[] {"yMMM", "1999年1月"},
-        new String[] {"yMd", "1999/1/13"},
-        new String[] {"yMMMd", "1999年1月13日"},
-        new String[] {"Md", "1/13"},
-        new String[] {"MMMd", "1月13日"},
-        new String[] {"MMMMd", "1月13日"},
-        new String[] {"yQQQ", "1999/Q1"},
-        new String[] {"hhmm", "午後11:58"},
-        new String[] {"HHmm", "23:58"},
-        new String[] {"jjmm", "23:58"},
-        new String[] {"mmss", "58:59"},
-        new String[] {"yyyyMMMM", "1999年1月"},
-        new String[] {"MMMEd", "1月13日(水)"},
-        new String[] {"Ed", "13日(水)"},
-        new String[] {"jmmssSSS", "23:58:59.123"},
-        new String[] {"JJmm", "23:58"}
     };
 
     @Test


### PR DESCRIPTION
Support for obsolete locale ID variants was removed 5 years ago, see ICU-20187.

#### Checklist
- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22870
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
