### PR TITLE
ICU-22920 fix exhaustive tests for likely subtags failure ICU-22976

### DIFF
--- a/icu4c/source/test/intltest/loctest.cpp
+++ b/icu4c/source/test/intltest/loctest.cpp
@@ -5923,6 +5923,11 @@ testLikelySubtagsLineFn(void *context,
         return;
     }
 
+    if ((uprv_strcmp(source.c_str(), "und-Latn-RS") == 0 )
+        && THIS->logKnownIssue("ICU-22976", "unexpected likely subtags for und-Latn-RS")) {
+      return;
+    }
+
     Locale actualMax(l);
     actualMax.addLikelySubtags(*pErrorCode);
     if (addLikely == "FAIL") {


### PR DESCRIPTION
Restore known issue check for 'und-Latn-RS', addressing issue https://unicode-org.atlassian.net/browse/ICU-22976

#### Checklist
- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22920
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
