### PR TITLE
ICU-22977 Rollback to windows-2019 temporarily to unblock CI

### DIFF
--- a/.github/workflows/icu4c.yml
+++ b/.github/workflows/icu4c.yml
@@ -362,7 +362,7 @@ jobs:
 
   # Windows MSVC builds
   windows-msvc:
-    runs-on: windows-2022  # Updated in BRS
+    runs-on: windows-2019  # Updated in BRS TODO: Update back to windows-2022 ASAP
     strategy:
       fail-fast: false
       matrix:
@@ -410,7 +410,7 @@ jobs:
 
   # Windows MSVC distribution release
   windows-msvc-dist-release:
-    runs-on: windows-2022  # Updated in BRS
+    runs-on: windows-2019  # Updated in BRS TODO: Update back to windows-2022 ASAP
     permissions:
       contents: write # So that we can upload to release
     timeout-minutes: 30

--- a/.github/workflows/icu_merge_ci.yml
+++ b/.github/workflows/icu_merge_ci.yml
@@ -827,7 +827,7 @@ jobs:
 
   # Build ICU and tests sample on some windows configurations
   icu4c-windows-msvc-postmerge:
-    runs-on: windows-2022  # Updated in BRS
+    runs-on: windows-2019  # Updated in BRS TODO: Update back to windows-2022 ASAP
     timeout-minutes: 30
     strategy:
       matrix:


### PR DESCRIPTION
This change rollbacks to previous version of windows VM runner temporarily to unblock devs from https://github.com/actions/runner-images/issues/11016


#### Checklist
- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22977
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
