### PR TITLE
ICU-23055 Fix broken links in docs

### DIFF
--- a/docs/userguide/icu/design.md
+++ b/docs/userguide/icu/design.md
@@ -373,7 +373,7 @@ There are 3 major extensibility elements in ICU:
    There are mechanisms available to enhance the built-in error handling when
    it is necessary. For example, you can design and create your own conversion
    callback functions when an error occurs. Refer to the
-   [Conversion](conversion/index.md) chapter callback section for more
+   [Conversion](../conversion/index.md) chapter callback section for more
    information.
 
 ### Resource Bundle Inheritance Model

--- a/docs/userguide/icu/howtouseicu.md
+++ b/docs/userguide/icu/howtouseicu.md
@@ -35,8 +35,7 @@ Options](../icu4c/build#recommended-build-options)
 default simply for compatibility with older ICU-using code.
 
 Starting with ICU 49, the ICU4C Readme has a short section about
-[User-Configurable
-Settings](../icu4c/build#user-configurable-settings).
+[User-Configurable Settings](../icu4c/build#user-configurable-settings).
 
 ## C++ Makefiles
 
@@ -52,7 +51,7 @@ This table shows the package names used within pkg-config.
 |icu-uc|Common (uc) and Data (dt/data) libraries|
 |icu-i18n|Internationalization (in/i18n) library|icu-le [Layout Engine](../layoutengine/index.md)|
 |icu-lx|Paragraph Layout|
-|icu-io|[Ustdio](io/ustdio.md)/[iostream](io/ustream.md) library (icuio)
+|icu-io|[Ustdio](../io/ustdio.md)/[iostream](../io/ustream.md) library (icuio)
 
 For example, to compile a simple application, you could run the following
 command. See the [pkg-config](http://pkg-config.freedesktop.org/) manpage for
@@ -159,8 +158,7 @@ libraries.](../icu4c/build#recommended-build-options))
 By default, and only for backward compatibility, the ICU headers contain a line
 `using namespace icu_50;` which makes all ICU APIs visible in/with the global
 namespace (and potentially collide with non-ICU APIs there). One of the
-[Recommended Build
-Options](../icu4c/build#recommended-build-options)
+[Recommended Build Options](../icu4c/build#recommended-build-options)
 is to turn this off.
 
 To write forward declarations, use
@@ -189,7 +187,7 @@ samples. Their paths are given in the installed `Makefile.inc` (see above).
 
 ### Data Packaging Settings
 
-The `pkgdata` tool (see [Packaging ICU4C](../icu4c/packaging/index.md) ) makes use of the
+The `pkgdata` tool (see [Packaging ICU4C](../icu4c/packaging.md)) makes use of the
 installed file `**$(prefix)/lib/icu/pkgdata.inc**` to set parameters for data
 packaging operations that require use of platform compilers and linkers ( in
 `static` or `dll` mode). `pkgdata` uses the icu-config script in order to locate

--- a/docs/userguide/icu/i18n.md
+++ b/docs/userguide/icu/i18n.md
@@ -180,8 +180,8 @@ assumptions components. See a list of topics below:
 Numbers and dates are represented in different languages. Do not implement
 routines for converting numbers into strings, and do not call low-level system
 interfaces like `sprintf()` that do not produce language-sensitive results.
-Instead, see how ICU's [NumberFormat](format_parse/numbers/index.md) and
-[DateFormat](format_parse/datetime/index.md) services can be used more
+Instead, see how ICU's [NumberFormat](../format_parse/numbers/index.md) and
+[DateFormat](../format_parse/datetime/index.md) services can be used more
 effectively.
 
 #### Messages
@@ -190,8 +190,8 @@ Be careful when formulating assumptions about how individual pieces of text are
 used together to create a complete sentence (for example, when error messages
 are generated). The elements might go together in a different order if the
 message is translated into a new language. ICU provides
-[MessageFormat](format_parse/messages/index.md) (§) and
-[ChoiceFormat](format_parse/messages/index.md) (§) to help with these
+[MessageFormat](../format_parse/messages/index.md) (§) and
+[ChoiceFormat](../format_parse/messages/index.md) (§) to help with these
 occurrences.
 
 > :point_right: **Note**: There also might be situations where parts of the sentence change when other
@@ -206,7 +206,7 @@ the representation of $1,000 dollars. This amount can represent either U.S. or
 Canadian dollar values. US dollars can be displayed as USD while Canadian
 dollars can be displayed as CAD, depending on the locale. In this case, the
 displayed numerical quantity might change, and the number itself might also
-change. [NumberFormat](format_parse/numbers/index.md) provides some support for
+change. [NumberFormat](../format_parse/numbers/index.md) provides some support for
 this.
 
 #### Alphabetical Order of Characters
@@ -222,7 +222,7 @@ Not all languages interpret the same characters as equivalent. If a character's
 case is changed it is not always a one-to-one mapping. Accent differences, the
 presence or absence of certain characters, and even spelling differences might
 be insignificant when determining whether two strings are equal. The
-[Collator](collation/index.md) services provide significant help in this area.
+[Collator](../collation/index.md) services provide significant help in this area.
 
 #### Characters
 
@@ -230,7 +230,7 @@ A character does not necessarily correspond to a single code-point position in
 the backing store. All languages might not have the same definition of a word,
 and might not find that any group of characters separated by a white space is an
 acceptable approximation for the definition of a word. ICU provides the
-[BreakIterator](boundaryanalysis/index.md) services to help locate boundaries or
+[BreakIterator](../boundaryanalysis/index.md) services to help locate boundaries or
 when counting units of text.
 
 When checking characters for membership in a particular class, do not list the

--- a/docs/userguide/icu/posix.md
+++ b/docs/userguide/icu/posix.md
@@ -97,7 +97,7 @@ character and string literals.
 ICU always processes Unicode text. Unicode covers all languages and allows safe
 hard coding of character codes, in addition to providing many standard or
 recommended algorithms and a lot of useful character property data. See the
-chapters about [Unicode Basics](unicode.md) and [Strings](strings/index.md) and others.
+chapters about [Unicode Basics](unicode.md) and [Strings](../strings/index.md) and others.
 
 ICU uses the 16-bit encoding form of Unicode (UTF-16) for processing, making it
 fully interoperable with most Unicode-aware software. See [UTF-16 for
@@ -105,7 +105,7 @@ Processing](http://www.unicode.org/notes/tn12/). In the case of ICU4J, this is
 naturally the case because the Java language and the JDK use UTF-16.
 
 ICU uses and/or provides direct access to all of the [Unicode
-properties](strings/properties.md) which provide a much finer-grained
+properties](../strings/properties.md) which provide a much finer-grained
 classification of characters than [C/POSIX character
 classes](https://htmlpreview.github.io/?https://github.com/unicode-org/icu-docs/blob/main/design/posix_classes.html).
 
@@ -208,7 +208,7 @@ locale's respective character class.
 #### ICU
 
 ICU provides locale-independent access to all [Unicode
-properties](strings/properties.md) (except Unihan.txt properties), as well as to
+properties](../strings/properties.md) (except Unihan.txt properties), as well as to
 the POSIX character classes, via functions defined in `uchar.h` and in ICU4J's
 `UCharacter` class (see API references) as well as via `UnicodeSet`. The POSIX
 character classes are implemented according to the recommendations in UTS #18.
@@ -255,4 +255,4 @@ resembling what `printf()` uses.
 ICU number formatting APIs have separate, orthogonal settings for the number
 format, which can be selected with a locale ID, and the currency, which is
 specified with an ISO code. See the [Formatting
-Numbers](format_parse/numbers/index.md) chapter for details.
+Numbers](../format_parse/numbers/index.md) chapter for details.

--- a/docs/userguide/icu/services.md
+++ b/docs/userguide/icu/services.md
@@ -32,18 +32,18 @@ for a broad range of languages.
 
 ICU provides basic Unicode support for the following:
 
-*   [Unicode strings](../strings/index)
+*   [Unicode strings](../strings/index.md)
 
     ICU includes type definitions for UTF-16 strings and code points. It also
     contains many C `u_string` functions and the C++ `UnicodeString` class with many
     additional string functions.
 
-*   [Unicode properties](../strings/properties)
+*   [Unicode properties](../strings/properties.md)
 
     ICU includes the C definitions and functions found in `uchar.h` as well as
     some macros found in `utf.h`. It also includes the C++ Unicode class.
 
-*   [Unicode string iteration](../strings/characteriterator)
+*   [Unicode string iteration](../strings/characteriterator.md)
 
     In C, ICU uses the macros in `utf.h` for the iteration of strings. In C++, ICU
     uses the characterIterator and its subclasses.
@@ -91,7 +91,7 @@ separate file instead of being embedded in the lines of the program.*
 ### Locales and Services
 
 The interaction between locales and services is fundamental to ICU. Please refer
-to [Locales and Services](./locale/index#locales-and-services).
+to [Locales and Services](../locale/index#locales-and-services).
 
 ### Transliteration
 
@@ -116,22 +116,22 @@ Date and time routines manage independent date and time functions in
 milliseconds since January 1, 1970 (0:00:00.000 UTC). Points in time before then
 are represented as negative numbers.
 
-ICU provides the following [classes](../datetime/index) to support calendars and
+ICU provides the following [classes](../datetime/index.md) to support calendars and
 time zones:
 
-*   [`Calendar`](../datetime/calendar/index#calendar)
+*   [`Calendar`](../datetime/calendar/index.md#calendar)
     
     The abstract superclass for extracting calendar-related attributes from a `Date` value.
 
-*   [`GregorianCalendar`](../datetime/calendar/index#gregoriancalendar)
+*   [`GregorianCalendar`](../datetime/calendar/index.md#gregoriancalendar)
     
     A concrete class for representing a Gregorian calendar.
 
-*   [`TimeZone`](../datetime/timezone/index)
+*   [`TimeZone`](../datetime/timezone/index.md)
     
     An abstract superclass for representing a time zone.
 
-*   [`SimpleTimeZone`](../datetime/timezone/index)
+*   [`SimpleTimeZone`](../datetime/timezone/index.md)
     
     A concrete class for representing a time zone for use with a Gregorian calendar.
 
@@ -156,7 +156,7 @@ numbers, formatting dates and times, and formatting messages:
 
 #### General Formatting
 
-See [Formatting and Parsing Classes](format_parse/index#formatting-and-parsing-classes) for an introduction to the following:
+See [Formatting and Parsing Classes](../format_parse/index.md#formatting-and-parsing-classes) for an introduction to the following:
 
 * `Format`
 * `FieldPosition`
@@ -165,35 +165,35 @@ See [Formatting and Parsing Classes](format_parse/index#formatting-and-parsing-c
 
 #### Formatting Numbers
 
-*   [`NumberFormat`](../format_parse/numbers/index#formatting-numbers)
+*   [`NumberFormat`](../format_parse/numbers/index.md#formatting-numbers)
     NumberFormat provides the basic fields and methods to format number objects
     and number primitives into localized strings and parse localized strings to
     number objects.
 
-*   [`DecimalFormat`](../format_parse/numbers/index#decimalformat)
+*   [`DecimalFormat`](../format_parse/numbers/index.md#decimalformat)
     DecimalFormat provides the methods used to format number objects and number
     primitives into localized strings and parse localized strings into number
     objects in base 10.
 
-*   [`DecimalFormatSymbols`](../format_parse/numbers/index#decimalformatsymbols)
+*   [`DecimalFormatSymbols`](../format_parse/numbers/index.md#decimalformatsymbols)
     DecimalFormatSymbols is a concrete class used by DecimalFormat to access
     localized number strings such as the grouping separators, the decimal
     separator, and the percent sign.
 
 #### Formatting Dates and Times
 
-*   [`DateFormat`](../format_parse/datetime/index)
+*   [`DateFormat`](../format_parse/datetime/index.md#dateformat)
     
     `DateFormat` provides the basic fields and methods for formatting date objects
     to localized strings and parsing date and time strings to date objects.
 
-*   [`SimpleDateFormat`](../format_parse/datetime/index)
+*   [`SimpleDateFormat`](../format_parse/datetime/index.md#simpledateformat)
     
     `SimpleDateFormat` is a concrete class used to format date objects to
     localized strings and to parse date and time strings to date objects using a
     `GregorianCalendar`.
 
-*   [`DateFormatSymbols`](../format_parse/datetime/index)
+*   [`DateFormatSymbols`](../format_parse/datetime/index.md#dateformatsymbols)
     
     `DateFormatSymbols` is a concrete class used to access localized date and time
     formatting strings, such as names of the months, days of the week, and the
@@ -201,13 +201,13 @@ See [Formatting and Parsing Classes](format_parse/index#formatting-and-parsing-c
 
 #### Formatting Messages
 
-*   [`MessageFormat`](../format_parse/messages/index)
+*   [`MessageFormat`](../format_parse/messages/index.md#messageformat)
     
     `MessageFormat` is a concrete class used to produce a language-specific user
     message that contains numbers, currency, percentages, date, time, and string
     variables.
 
-*   [`ChoiceFormat`](../format_parse/messages/index)
+*   [`ChoiceFormat`](../format_parse/messages/index.md)
     
     `ChoiceFormat` is a concrete class used to map strings to ranges of numbers
     and to handle plural words and name series in user messages.
@@ -247,19 +247,19 @@ associated with base characters (such as 'a' and 'b'), accent marks (such as
 ICU provides the following collation classes for sorting and searching natural
 language text according to locale-specific rules:
 
-*   [`Collator`](../collation/architecture) is the abstract base class of all classes that compare strings.
+*   [`Collator`](../collation/architecture.md#collator) is the abstract base class of all classes that compare strings.
 
-*   [`CollationElementIterator`](../collation/architecture) is a concrete iterator class that provides an
+*   [`CollationElementIterator`](../collation/architecture.md#collation-element-iterator) is a concrete iterator class that provides an
     iterator for stepping through each character of a locale-specific string
     according to the rules of a specific collator object.
 
-*   [`RuleBasedCollator`](../collation/architecture) is the only built-in 
+*   [`RuleBasedCollator`](../collation/architecture.md) is the only built-in 
     implementation of the collator. It
     provides a sophisticated mechanism for comparing strings in a
     language-specific manner, and an interface that allows the user to
     specifically customize the sorting order.
 
-*   [`CollationKey`](../collation/architecture)  is an object that enables the fast sorting of strings by
+*   [`CollationKey`](../collation/architecture.md)  is an object that enables the fast sorting of strings by
     representing a string as a sort key under the rules of a specific collator
     object.
 
@@ -307,18 +307,18 @@ that it recognizes text boundaries according to the particular locale ID.
 
 ICU provides the following classes for iterating over locale-specific text:
 
-*   [`BreakIterator`](../boundaryanalysis/index)
+*   [`BreakIterator`](../boundaryanalysis/index.md)
     
     The abstract base class that defines the operations for finding and getting
     the positions of logical breaks in a string of text: characters, words,
     sentences, and potential line breaks.
 
-*   [`CharacterIterator`](../strings/characteriterator)
+*   [`CharacterIterator`](../strings/characteriterator.md)
     
     The abstract base class for forward and backward iteration over a string of
     Unicode characters.
 
-*   [`StringCharacterIterator`](../strings/index)
+*   [`StringCharacterIterator`](../strings/index.md)
     
     A concrete class for forward and backward iteration over a string of Unicode
     characters. `StringCharacterIterator` inherits from `CharacterIterator`.


### PR DESCRIPTION
Fixed broken links in the docs. Also fixed links like `https://unicode-org.github.io/icu/userguide/strings/index` because it makes sidebar closed and erase current position.

#### Checklist
- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-23055
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
