### PR TITLE
ICU-22974 Fix broken links pointing to "ICU Architectural Design"

### DIFF
--- a/docs/userguide/collation/architecture.md
+++ b/docs/userguide/collation/architecture.md
@@ -58,7 +58,7 @@ when opening collators:
 
 2.  The empty locale name ("") means the root locale.
     The Collation Service adheres to the ICU conventions described in the
-    "[ICU Architectural Design](../design.md) " section of the users guide.
+    "[ICU Architectural Design](../icu/design.md)" section of the users guide.
     In particular:
 
 3.  The standard error code convention is usually followed. (Functions that do

--- a/docs/userguide/conversion/converters.md
+++ b/docs/userguide/conversion/converters.md
@@ -264,7 +264,7 @@ There are four ways to create a converter:
 > define the default codepage to something that supports Hindi.
 > The default converter is used in expressions such as: `UnicodeString text("abc");`
 > to convert 'abc', and in the `u_uastrcpy()` C functions.
-> Code operating at the [OS level](../design.md) MAY choose to
+> Code operating at the [OS level](../icu/design.md) MAY choose to
 > change the default converter with `ucnv_setDefaultName()`.
 > However, be aware that this change has inconsistent results if it is done after
 > ICU components are initialized.
@@ -274,7 +274,7 @@ There are four ways to create a converter:
 Closing a converter frees memory occupied by that instance of the converter.
 However it does not release the larger shared data tables the converter might
 use. OS-level code may call `ucnv_flushCache()` to explicitly free memory occupied
-by [unused tables](../design.md).
+by [unused tables](../icu/design.md).
 
 ```c
 ucnv_close(conv)
@@ -283,7 +283,7 @@ ucnv_close(conv)
 ### Converter Life Cycle
 
 Note that a Converter is created with a certain type (for instance, ISO-8859-3)
-which does not change over the life of that [object](../design.md). Converters
+which does not change over the life of that [object](../icu/design.md). Converters
 should be allocated one per thread. They are cheap to create, as the shared data
 doesn't need to be reallocated.
 

--- a/docs/userguide/dev/codingguidelines.md
+++ b/docs/userguide/dev/codingguidelines.md
@@ -177,7 +177,7 @@ also mark every API with whether it is `@draft`, `@stable`, `@deprecated` or
 `@internal`. (Where `@internal` is used when something is not actually supported
 API but needs to be physically public anyway.) A new API is usually marked with
 "`@draft ICU 4.8`". For details of how we mark APIs see the "ICU API
-compatibility" section of the [ICU Architectural Design](../design.md) page. In
+compatibility" section of the [ICU Architectural Design](../icu/design.md) page. In
 Java, also see existing @draft APIs for complete examples.
 
 Functions that override a base class or interface definition take the API status

--- a/docs/userguide/dev/sync/index.md
+++ b/docs/userguide/dev/sync/index.md
@@ -22,7 +22,7 @@ License & terms of use: http://www.unicode.org/copyright.html
 ## Overview
 
 ICU is designed for use in multi-threaded environments. Guidelines for
-developers using ICU are in the [ICU Design](../../design.md) section of the
+developers using ICU are in the [ICU Design](../../icu/design.md) section of the
 user guide.
 
 Within the ICU implementation, access to shared or global data sometimes must be

--- a/docs/userguide/icu4c/faq.md
+++ b/docs/userguide/icu4c/faq.md
@@ -88,8 +88,8 @@ your topic.
 #### What is the ICU binary compatibility policy?
 
 Please see the section on
-[binary compatibility](../design#icu-binary-compatibility)
-in the [design chapter](../design.md).
+[binary compatibility](../icu/design#icu-binary-compatibility)
+in the [design chapter](../icu/design.md).
 
 #### How is ICU licensed?
 
@@ -120,8 +120,8 @@ upgrade-friendly.
 
 *   **API:** ensure that you are not using draft APIs which may have changed in
     a future release. See the section on
-    [API compatibility](../design#icu-api-compatibility) in the
-    [design chapter](../design.md).
+    [API compatibility](../icu/design#icu-api-compatibility) in the
+    [design chapter](../icu/design.md).
 *   **Unicode:** See the release notes for particular versions of Unicode to
     ensure that your code is not affected by property changes or other
     specification changes.
@@ -133,8 +133,8 @@ upgrade-friendly.
     currencies, types of calendars
 *   **Building/Deploying your Application (ICU4C):** ICU4C usually builds with
     symbol renaming (See:
-    [binary compatibility](../design#icu-binary-compatibility)
-    in the [design chapter](../design.md)). Be sure that you build your
+    [binary compatibility](../icu/design#icu-binary-compatibility)
+    in the [design chapter](../icu/design.md)). Be sure that you build your
     application with the updated ICU header files, so that it will link against
     the current ICU. Also, don't hard-code the names of ICU libraries in your
     build scripts and projects. Where possible, link against just the
@@ -268,8 +268,8 @@ ICU4C (ICU) is written in C and C++, and ICU4J is written in Java™.
 
 #### How are the APIs documented for deprecation?
 
-Please read the [ICU API compatibility](../design#icu-api-compatibility)
-section in the [ICU Design](../design.md) chapter.
+Please read the [ICU API compatibility](../icu/design#icu-api-compatibility)
+section in the [ICU Design](../icu/design.md) chapter.
 
 #### What version of Unicode standard does ICU support?
 
@@ -409,7 +409,7 @@ Chapter](../locale/index.md) of this User's Guide.
 
 #### How is ICU versioned?
 
-Please read the [ICU Design](../design.md) chapter of the User's Guide.
+Please read the [ICU Design](../icu/design.md) chapter of the User's Guide.
 
 #### What is the relationship between ICU locale data and system locale data?
 
@@ -445,7 +445,7 @@ puts("callMyFunction() Failed!");
 }
 ```
 
-Please see the [ICU Design](../design.md) chapter for details.
+Please see the [ICU Design](../icu/design.md) chapter for details.
 
 #### With calendar classes, why are months 0-based?
 

--- a/docs/userguide/icu4c/packaging.md
+++ b/docs/userguide/icu4c/packaging.md
@@ -75,7 +75,7 @@ with -DU_STATIC_IMPLEMENTATION. Also see [How To Use ICU](../icu/howtouseicu.md)
 
 ### Reduce the number of libraries used
 
-ICU consists of a number of different libraries. The library dependency chart in the [Design](../design#library-dependencies-c)
+ICU consists of a number of different libraries. The library dependency chart in the [Design](../icu/design#library-dependencies-c)
 chapter can be used to understand and
 determine the exact set of libraries needed.
 
@@ -149,8 +149,8 @@ data to be installed and removed without rebuilding ICU. For details, see the
 
 ## ICU Versions
 
-(This section assumes the reader is familiar with [ICU version numbers](../design#version-numbers-in-icu) as
-covered in the [Design](../design.md) chapter, and filename conventions for
+(This section assumes the reader is familiar with [ICU version numbers](../icu/design#version-numbers-in-icu) as
+covered in the [Design](../icu/design.md) chapter, and filename conventions for
 libraries as described above.)
 
 ### POSIX Library Names
@@ -237,5 +237,5 @@ DLLs will be copied with names such as 'icuuc55.dll'.
 The services which are now known as ICU were written to provide operating
 system-level and application environment-level services. Several operating
 systems include ICU as a standard or optional package.
-See [ICU Binary Compatibility](../design#icu-binary-compatibility) for
+See [ICU Binary Compatibility](../icu/design#icu-binary-compatibility) for
 more details.

--- a/docs/userguide/icu4j/faq.md
+++ b/docs/userguide/icu4j/faq.md
@@ -62,7 +62,7 @@ Time Zone Data Version: 2011g
 #### I'm using ICU4J X, but planning to upgrade ICU4J version to X+1 soon. What should I do for the migration?
 
 See the user guide section
-[Version Numbers in ICU](../design#version-numbers-in-icu)
+[Version Numbers in ICU](../icu/design#version-numbers-in-icu)
 for the details about the meaning of the version number parts and how the ICU
 version number changes.
 
@@ -70,7 +70,7 @@ In general, two different reference releases are not binary compatible (i.e.
 drop-in jar file replacement would not work). To use a new reference version of
 ICU4J, you should rebuild your application with the new ICU4J library. ICU
 project has the
-[API compatibility policy](../design#icu-api-compatibility)
+[API compatibility policy](../icu/design#icu-api-compatibility)
 long as you're using ICU APIs marked as @stable in the API reference
 documentation, your application should successfully compile with the new
 reference version of ICU4J library without any source code modifications. (Note:


### PR DESCRIPTION
This fixes several broken links that were pointing to `../design.md` instead of `../icu/design.md`.

#### Checklist
- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-22974
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
