### PR TITLE
ICU-22921 fix link from gitdev to ci exhaustive tests

### DIFF
--- a/docs/userguide/dev/gitdev.md
+++ b/docs/userguide/dev/gitdev.md
@@ -596,4 +596,4 @@ every Saturday (at 4:00 AM UTC) and post merging on the maintenance branches.
 They do not run on pull-requests by default as they take 1-2 hours to run.
 
 However, you can manually request the CI builds to run the exhaustive tests.
-See [Continuous Integration / Exhaustive Tests](../userguide/dev/ci.md#exhaustive-tests).
+See [Continuous Integration / Exhaustive Tests](../ci.md#exhaustive-tests).


### PR DESCRIPTION
https://unicode-org.github.io/icu/userguide/dev/gitdev.html#requesting-an-exhaustive-test-run-on-a-pull-request-pr points to Continuous Integration / Exhaustive Tests but has a bad indirection. It should just go sideways to its sibling page.

#### Checklist
- [x] Required: Issue filed: ICU-22921
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
