### PR TITLE
ICU-22954 USet C++ iterator return std::u16string; header-only LocalPointer

### DIFF
--- a/icu4c/source/common/characterproperties.cpp
+++ b/icu4c/source/common/characterproperties.cpp
@@ -24,7 +24,7 @@
 #include "umutex.h"
 #include "uprops.h"
 
-using icu::LocalPointer;
+using U_ICU_NAMESPACE_OR_INTERNAL::LocalPointer;
 #if !UCONFIG_NO_NORMALIZATION
 using icu::Normalizer2Factory;
 using icu::Normalizer2Impl;
@@ -340,7 +340,7 @@ UnicodeSet *makeSet(UProperty property, UErrorCode &errorCode) {
 UCPMap *makeMap(UProperty property, UErrorCode &errorCode) {
     if (U_FAILURE(errorCode)) { return nullptr; }
     uint32_t nullValue = property == UCHAR_SCRIPT ? USCRIPT_UNKNOWN : 0;
-    icu::LocalUMutableCPTriePointer mutableTrie(
+    U_ICU_NAMESPACE_OR_INTERNAL::LocalUMutableCPTriePointer mutableTrie(
         umutablecptrie_open(nullValue, nullValue, &errorCode));
     const UnicodeSet *inclusions =
         icu::CharacterProperties::getInclusionsForProperty(property, errorCode);

--- a/icu4c/source/common/locavailable.cpp
+++ b/icu4c/source/common/locavailable.cpp
@@ -208,7 +208,8 @@ UBool U_CALLCONV uloc_cleanup() {
 void U_CALLCONV loadInstalledLocales(UErrorCode& status) {
     ucln_common_registerCleanup(UCLN_COMMON_ULOC, uloc_cleanup);
 
-    icu::LocalUResourceBundlePointer rb(ures_openDirect(nullptr, "res_index", &status));
+    U_ICU_NAMESPACE_OR_INTERNAL::LocalUResourceBundlePointer rb(
+        ures_openDirect(nullptr, "res_index", &status));
     AvailableLocalesSink sink;
     ures_getAllItemsWithFallback(rb.getAlias(), "", sink, status);
 }

--- a/icu4c/source/common/locdispnames.cpp
+++ b/icu4c/source/common/locdispnames.cpp
@@ -37,6 +37,9 @@
 #include "ureslocs.h"
 #include "ustr_imp.h"
 
+using U_ICU_NAMESPACE_OR_INTERNAL::LocalUEnumerationPointer;
+using U_ICU_NAMESPACE_OR_INTERNAL::LocalUResourceBundlePointer;
+
 // C++ API ----------------------------------------------------------------- ***
 
 U_NAMESPACE_BEGIN
@@ -313,7 +316,7 @@ _getStringOrCopyKey(const char *path, const char *locale,
 
     if(itemKey==nullptr) {
         /* top-level item: normal resource bundle access */
-        icu::LocalUResourceBundlePointer rb(ures_open(path, locale, &errorCode));
+        LocalUResourceBundlePointer rb(ures_open(path, locale, &errorCode));
 
         if(U_SUCCESS(errorCode)) {
             s=ures_getStringByKey(rb.getAlias(), tableKey, &length, &errorCode);
@@ -539,9 +542,9 @@ uloc_getDisplayName(const char *locale,
     {
         UErrorCode status = U_ZERO_ERROR;
 
-        icu::LocalUResourceBundlePointer locbundle(
+        LocalUResourceBundlePointer locbundle(
                 ures_open(U_ICUDATA_LANG, displayLocale, &status));
-        icu::LocalUResourceBundlePointer dspbundle(
+        LocalUResourceBundlePointer dspbundle(
                 ures_getByKeyWithFallback(locbundle.getAlias(), _kLocaleDisplayPattern, nullptr, &status));
 
         separator=ures_getStringByKeyWithFallback(dspbundle.getAlias(), _kSeparator, &sepLen, &status);
@@ -613,7 +616,7 @@ uloc_getDisplayName(const char *locale,
         int32_t langPos=0; /* position in output of language substitution */
         int32_t restLen=0; /* length of 'everything else' substitution */
         int32_t restPos=0; /* position in output of 'everything else' substitution */
-        icu::LocalUEnumerationPointer kenum; /* keyword enumeration */
+        LocalUEnumerationPointer kenum; /* keyword enumeration */
 
         /* prefix of pattern, extremely likely to be empty */
         if(sub0Pos) {
@@ -855,11 +858,11 @@ uloc_getDisplayKeywordValue(   const char* locale,
         int32_t dispNameLen = 0;
         const char16_t *dispName = nullptr;
 
-        icu::LocalUResourceBundlePointer bundle(
+        LocalUResourceBundlePointer bundle(
                 ures_open(U_ICUDATA_CURR, displayLocale, status));
-        icu::LocalUResourceBundlePointer currencies(
+        LocalUResourceBundlePointer currencies(
                 ures_getByKey(bundle.getAlias(), _kCurrencies, nullptr, status));
-        icu::LocalUResourceBundlePointer currency(
+        LocalUResourceBundlePointer currency(
                 ures_getByKeyWithFallback(currencies.getAlias(), keywordValue.data(), nullptr, status));
 
         dispName = ures_getStringByIndex(currency.getAlias(), UCURRENCY_DISPLAY_NAME_INDEX, &dispNameLen, status);

--- a/icu4c/source/common/locresdata.cpp
+++ b/icu4c/source/common/locresdata.cpp
@@ -59,7 +59,8 @@ uloc_getTableStringWithFallback(const char *path, const char *locale,
      * this falls back through the locale's chain to root
      */
     errorCode=U_ZERO_ERROR;
-    icu::LocalUResourceBundlePointer rb(ures_open(path, locale, &errorCode));
+    U_ICU_NAMESPACE_OR_INTERNAL::LocalUResourceBundlePointer rb(
+        ures_open(path, locale, &errorCode));
 
     if(U_FAILURE(errorCode)) {
         /* total failure, not even root could be opened */

--- a/icu4c/source/common/locutil.cpp
+++ b/icu4c/source/common/locutil.cpp
@@ -233,7 +233,8 @@ LocaleUtility::getAvailableLocaleNames(const UnicodeString& bundleID)
             CharString cbundleID;
             cbundleID.appendInvariantChars(bundleID, status);
             const char* path = cbundleID.isEmpty() ? nullptr : cbundleID.data();
-            icu::LocalUEnumerationPointer uenum(ures_openAvailableLocales(path, &status));
+            U_ICU_NAMESPACE_OR_INTERNAL::LocalUEnumerationPointer uenum(
+                ures_openAvailableLocales(path, &status));
             for (;;) {
                 const char16_t* id = uenum_unext(uenum.getAlias(), nullptr, &status);
                 if (id == nullptr) {

--- a/icu4c/source/common/uloc_tag.cpp
+++ b/icu4c/source/common/uloc_tag.cpp
@@ -27,6 +27,9 @@
 #include "ulocimp.h"
 #include "uassert.h"
 
+using U_ICU_NAMESPACE_OR_INTERNAL::LocalPointer;
+using U_ICU_NAMESPACE_OR_INTERNAL::LocalUEnumerationPointer;
+
 namespace {
 
 /* struct holding a single variant */
@@ -354,10 +357,6 @@ const char*
 ultag_getLegacy(const ULanguageTag* langtag);
 #endif
 
-}  // namespace
-
-U_NAMESPACE_BEGIN
-
 /**
  * \class LocalULanguageTagPointer
  * "Smart pointer" class, closes a ULanguageTag via ultag_close().
@@ -369,7 +368,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalULanguageTagPointer, ULanguageTag, ultag_close);
 
-U_NAMESPACE_END
+}  // namespace
 
 /*
 * -------------------------------------------------
@@ -869,7 +868,7 @@ namespace {
 */
 
 bool
-_addVariantToList(VariantListEntry **first, icu::LocalPointer<VariantListEntry> var) {
+_addVariantToList(VariantListEntry **first, LocalPointer<VariantListEntry> var) {
     if (*first == nullptr) {
         var->next = nullptr;
         *first = var.orphan();
@@ -1212,7 +1211,7 @@ _appendVariantsToLanguageTag(std::string_view localeID, icu::ByteSink& sink, boo
                     if (_isVariantSubtag(pVar, -1)) {
                         if (uprv_strcmp(pVar, POSIX_VALUE) || buf.length() != static_cast<int32_t>(uprv_strlen(POSIX_VALUE))) {
                             /* emit the variant to the list */
-                            icu::LocalPointer<VariantListEntry> var(new VariantListEntry, status);
+                            LocalPointer<VariantListEntry> var(new VariantListEntry, status);
                             if (U_FAILURE(status)) {
                                 break;
                             }
@@ -1284,7 +1283,7 @@ _appendKeywordsToLanguageTag(const char* localeID, icu::ByteSink& sink, bool str
     icu::MemoryPool<ExtensionListEntry> extPool;
     icu::MemoryPool<icu::CharString> strPool;
 
-    icu::LocalUEnumerationPointer keywordEnum(uloc_openKeywords(localeID, &status));
+    LocalUEnumerationPointer keywordEnum(uloc_openKeywords(localeID, &status));
     if (U_FAILURE(status) && !hadPosix) {
         return;
     }
@@ -1984,7 +1983,7 @@ ultag_parse(const char* tag, int32_t tagLen, int32_t* parsedLen, UErrorCode& sta
     char *pSubtag, *pNext, *pLastGoodPosition;
     int32_t subtagLen;
     int32_t extlangIdx;
-    icu::LocalPointer<ExtensionListEntry> pExtension;
+    LocalPointer<ExtensionListEntry> pExtension;
     char *pExtValueSubtag, *pExtValueSubtagEnd;
     int32_t i;
     bool privateuseVar = false;
@@ -2011,7 +2010,7 @@ ultag_parse(const char* tag, int32_t tagLen, int32_t* parsedLen, UErrorCode& sta
     *(tagBuf + tagLen) = 0;
 
     /* create a ULanguageTag */
-    icu::LocalULanguageTagPointer t(
+    LocalULanguageTagPointer t(
             static_cast<ULanguageTag*>(uprv_malloc(sizeof(ULanguageTag))));
     if (t.isNull()) {
         uprv_free(tagBuf);
@@ -2197,7 +2196,7 @@ ultag_parse(const char* tag, int32_t tagLen, int32_t* parsedLen, UErrorCode& sta
         if (next & VART) {
             if (_isVariantSubtag(pSubtag, subtagLen) ||
                (privateuseVar && _isPrivateuseVariantSubtag(pSubtag, subtagLen))) {
-                icu::LocalPointer<VariantListEntry> var(new VariantListEntry, status);
+                LocalPointer<VariantListEntry> var(new VariantListEntry, status);
                 if (U_FAILURE(status)) {
                     return nullptr;
                 }
@@ -2609,7 +2608,7 @@ ulocimp_toLanguageTag(const char* localeID,
         int kwdCnt = 0;
         bool done = false;
 
-        icu::LocalUEnumerationPointer kwdEnum(uloc_openKeywords(canonical.data(), &tmpStatus));
+        LocalUEnumerationPointer kwdEnum(uloc_openKeywords(canonical.data(), &tmpStatus));
         if (U_SUCCESS(tmpStatus)) {
             kwdCnt = uenum_count(kwdEnum.getAlias(), &tmpStatus);
             if (kwdCnt == 1) {
@@ -2691,7 +2690,7 @@ ulocimp_forLanguageTag(const char* langtag,
     int32_t i, n;
     bool noRegion = true;
 
-    icu::LocalULanguageTagPointer lt(ultag_parse(langtag, tagLen, parsedLength, status));
+    LocalULanguageTagPointer lt(ultag_parse(langtag, tagLen, parsedLength, status));
     if (U_FAILURE(status)) {
         return;
     }

--- a/icu4c/source/common/unicode/char16ptr.h
+++ b/icu4c/source/common/unicode/char16ptr.h
@@ -9,10 +9,13 @@
 
 #include "unicode/utypes.h"
 
-#if U_SHOW_CPLUSPLUS_API
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
 
 #include <cstddef>
 #include <string_view>
+#include <type_traits>
+
+#endif
 
 /**
  * \file
@@ -20,8 +23,6 @@
  *        implicit conversion from bit-compatible raw pointer types.
  *        Also conversion functions from char16_t * to UChar * and OldUChar *.
  */
-
-U_NAMESPACE_BEGIN
 
 /**
  * \def U_ALIASING_BARRIER
@@ -35,6 +36,11 @@ U_NAMESPACE_BEGIN
 #elif defined(U_IN_DOXYGEN)
 #   define U_ALIASING_BARRIER(ptr)
 #endif
+
+// ICU DLL-exported
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * char16_t * wrapper with implicit conversion from distinct but bit-compatible pointer types.
@@ -251,6 +257,34 @@ const char16_t *ConstChar16Ptr::get() const { return u_.cp; }
 #endif
 /// \endcond
 
+U_NAMESPACE_END
+
+#endif  // U_SHOW_CPLUSPLUS_API
+
+// Usable in header-only definitions
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
+
+#ifndef U_FORCE_HIDE_INTERNAL_API
+/** @internal */
+template<typename T, typename = std::enable_if_t<std::is_same_v<T, UChar>>>
+inline const char16_t *uprv_char16PtrFromUChar(const T *p) {
+    if constexpr (std::is_same_v<UChar, char16_t>) {
+        return p;
+    } else {
+#if U_SHOW_CPLUSPLUS_API
+        return ConstChar16Ptr(p).get();
+#else
+#ifdef U_ALIASING_BARRIER
+        U_ALIASING_BARRIER(p);
+#endif
+        return reinterpret_cast<const char16_t *>(p);
+#endif
+    }
+}
+#endif
+
 /**
  * Converts from const char16_t * to const UChar *.
  * Includes an aliasing barrier if available.
@@ -306,6 +340,15 @@ inline OldUChar *toOldUCharPtr(char16_t *p) {
 #endif
     return reinterpret_cast<OldUChar *>(p);
 }
+
+}  // U_ICU_NAMESPACE_OR_INTERNAL
+
+#endif  // U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+
+// ICU DLL-exported
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 #ifndef U_FORCE_HIDE_INTERNAL_API
 /**
@@ -379,6 +422,6 @@ inline std::u16string_view toU16StringViewNullable(const T& text) {
 
 U_NAMESPACE_END
 
-#endif /* U_SHOW_CPLUSPLUS_API */
+#endif  // U_SHOW_CPLUSPLUS_API
 
 #endif  // __CHAR16PTR_H__

--- a/icu4c/source/common/unicode/localpointer.h
+++ b/icu4c/source/common/unicode/localpointer.h
@@ -21,7 +21,7 @@
 
 /**
  * \file
- * \brief C++ API: "Smart pointers" for use with and in ICU4C C++ code.
+ * \brief C++ header-only API: "Smart pointers" for use with and in ICU4C C++ code.
  *
  * These classes are inspired by
  * - std::auto_ptr
@@ -40,11 +40,11 @@
 
 #include "unicode/utypes.h"
 
-#if U_SHOW_CPLUSPLUS_API
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
 
 #include <memory>
 
-U_NAMESPACE_BEGIN
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * "Smart pointer" base class; do not use directly: use LocalPointer etc.
@@ -603,7 +603,7 @@ public:
 }  // namespace internal
 #endif
 
-U_NAMESPACE_END
+}  // U_ICU_NAMESPACE_OR_INTERNAL
 
-#endif  /* U_SHOW_CPLUSPLUS_API */
+#endif  // U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
 #endif  /* __LOCALPOINTER_H__ */

--- a/icu4c/source/common/unicode/localpointer.h
+++ b/icu4c/source/common/unicode/localpointer.h
@@ -548,7 +548,8 @@ public:
  * @stable ICU 4.4
  */
 #define U_DEFINE_LOCAL_OPEN_POINTER(LocalPointerClassName, Type, closeFunction) \
-    using LocalPointerClassName = internal::LocalOpenPointer<Type, closeFunction>
+    using LocalPointerClassName = \
+        U_ICU_NAMESPACE_OR_INTERNAL::internal::LocalOpenPointer<Type, closeFunction>
 
 #ifndef U_IN_DOXYGEN
 namespace internal {

--- a/icu4c/source/common/unicode/normlzr.h
+++ b/icu4c/source/common/unicode/normlzr.h
@@ -801,8 +801,8 @@ Normalizer::compare(const UnicodeString &s1, const UnicodeString &s2,
                     uint32_t options,
                     UErrorCode &errorCode) {
   // all argument checking is done in unorm_compare
-  return unorm_compare(toUCharPtr(s1.getBuffer()), s1.length(),
-                       toUCharPtr(s2.getBuffer()), s2.length(),
+  return unorm_compare(U_ICU_NAMESPACE_OR_INTERNAL::toUCharPtr(s1.getBuffer()), s1.length(),
+                       U_ICU_NAMESPACE_OR_INTERNAL::toUCharPtr(s2.getBuffer()), s2.length(),
                        options,
                        &errorCode);
 }

--- a/icu4c/source/common/unicode/ubidi.h
+++ b/icu4c/source/common/unicode/ubidi.h
@@ -563,9 +563,8 @@ ubidi_openSized(int32_t maxLength, int32_t maxRunCount, UErrorCode *pErrorCode);
 U_CAPI void U_EXPORT2
 ubidi_close(UBiDi *pBiDi);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUBiDiPointer
@@ -578,8 +577,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUBiDiPointer, UBiDi, ubidi_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/common/unicode/ubiditransform.h
+++ b/icu4c/source/common/unicode/ubiditransform.h
@@ -304,9 +304,8 @@ ubiditransform_open(UErrorCode *pErrorCode);
 U_CAPI void U_EXPORT2
 ubiditransform_close(UBiDiTransform *pBidiTransform);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUBiDiTransformPointer
@@ -319,8 +318,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUBiDiTransformPointer, UBiDiTransform, ubiditransform_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 #endif

--- a/icu4c/source/common/unicode/ubrk.h
+++ b/icu4c/source/common/unicode/ubrk.h
@@ -356,9 +356,8 @@ ubrk_clone(const UBreakIterator *bi,
 U_CAPI void U_EXPORT2
 ubrk_close(UBreakIterator *bi);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUBreakIteratorPointer
@@ -371,8 +370,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUBreakIteratorPointer, UBreakIterator, ubrk_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/common/unicode/ucasemap.h
+++ b/icu4c/source/common/unicode/ucasemap.h
@@ -83,9 +83,8 @@ ucasemap_open(const char *locale, uint32_t options, UErrorCode *pErrorCode);
 U_CAPI void U_EXPORT2
 ucasemap_close(UCaseMap *csm);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUCaseMapPointer
@@ -98,8 +97,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUCaseMapPointer, UCaseMap, ucasemap_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/common/unicode/ucnv.h
+++ b/icu4c/source/common/unicode/ucnv.h
@@ -581,9 +581,8 @@ ucnv_safeClone(const UConverter *cnv,
 U_CAPI void  U_EXPORT2
 ucnv_close(UConverter * converter);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUConverterPointer
@@ -596,8 +595,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUConverterPointer, UConverter, ucnv_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/common/unicode/ucnvsel.h
+++ b/icu4c/source/common/unicode/ucnvsel.h
@@ -97,9 +97,8 @@ ucnvsel_open(const char* const*  converterList, int32_t converterListSize,
 U_CAPI void U_EXPORT2
 ucnvsel_close(UConverterSelector *sel);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUConverterSelectorPointer
@@ -112,8 +111,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUConverterSelectorPointer, UConverterSelector, ucnvsel_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/common/unicode/ucptrie.h
+++ b/icu4c/source/common/unicode/ucptrie.h
@@ -623,9 +623,8 @@ U_CDECL_END
 
 #endif  // U_IN_DOXYGEN
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUCPTriePointer
@@ -638,8 +637,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUCPTriePointer, UCPTrie, ucptrie_close);
 
-U_NAMESPACE_END
-
-#endif  // U_SHOW_CPLUSPLUS_API
+}
+#endif
 
 #endif

--- a/icu4c/source/common/unicode/udata.h
+++ b/icu4c/source/common/unicode/udata.h
@@ -418,9 +418,8 @@ udata_setFileAccess(UDataFileAccess access, UErrorCode *status);
 
 U_CDECL_END
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUDataMemoryPointer
@@ -433,8 +432,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUDataMemoryPointer, UDataMemory, udata_close);
 
-U_NAMESPACE_END
-
-#endif  // U_SHOW_CPLUSPLUS_API
+}
+#endif
 
 #endif

--- a/icu4c/source/common/unicode/uenum.h
+++ b/icu4c/source/common/unicode/uenum.h
@@ -53,9 +53,8 @@ typedef struct UEnumeration UEnumeration;
 U_CAPI void U_EXPORT2
 uenum_close(UEnumeration* en);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUEnumerationPointer
@@ -68,8 +67,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUEnumerationPointer, UEnumeration, uenum_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/common/unicode/uidna.h
+++ b/icu4c/source/common/unicode/uidna.h
@@ -171,9 +171,8 @@ uidna_openUTS46(uint32_t options, UErrorCode *pErrorCode);
 U_CAPI void U_EXPORT2
 uidna_close(UIDNA *idna);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUIDNAPointer
@@ -186,8 +185,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUIDNAPointer, UIDNA, uidna_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/common/unicode/uldnames.h
+++ b/icu4c/source/common/unicode/uldnames.h
@@ -81,9 +81,8 @@ uldn_open(const char * locale,
 U_CAPI void U_EXPORT2
 uldn_close(ULocaleDisplayNames *ldn);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalULocaleDisplayNamesPointer
@@ -96,8 +95,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalULocaleDisplayNamesPointer, ULocaleDisplayNames, uldn_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /* getters for state */

--- a/icu4c/source/common/unicode/ulocale.h
+++ b/icu4c/source/common/unicode/ulocale.h
@@ -204,9 +204,8 @@ ulocale_getUnicodeKeywordValue(
     const ULocale* locale, const char* keyword, int32_t keywordLength,
     char* valueBuffer, int32_t valueBufferCapacity, UErrorCode *err);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalULocalePointer
@@ -219,8 +218,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalULocalePointer, ULocale, ulocale_close);
 
-U_NAMESPACE_END
-
-#endif  /* U_SHOW_CPLUSPLUS_API */
+}
+#endif
 
 #endif /*_ULOCALE */

--- a/icu4c/source/common/unicode/ulocbuilder.h
+++ b/icu4c/source/common/unicode/ulocbuilder.h
@@ -415,9 +415,8 @@ ulocbld_buildLanguageTag(ULocaleBuilder* builder, char* language,
 U_CAPI UBool U_EXPORT2
 ulocbld_copyErrorTo(const ULocaleBuilder* builder, UErrorCode *outErrorCode);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalULocaleBuilderPointer
@@ -430,8 +429,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalULocaleBuilderPointer, ULocaleBuilder, ulocbld_close);
 
-U_NAMESPACE_END
-
-#endif  /* U_SHOW_CPLUSPLUS_API */
+}
+#endif
 
 #endif  // __ULOCBUILDER_H__

--- a/icu4c/source/common/unicode/umutablecptrie.h
+++ b/icu4c/source/common/unicode/umutablecptrie.h
@@ -218,9 +218,8 @@ umutablecptrie_buildImmutable(UMutableCPTrie *trie, UCPTrieType type, UCPTrieVal
 
 U_CDECL_END
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUMutableCPTriePointer
@@ -233,8 +232,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUMutableCPTriePointer, UMutableCPTrie, umutablecptrie_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 #endif

--- a/icu4c/source/common/unicode/uniset.h
+++ b/icu4c/source/common/unicode/uniset.h
@@ -1173,10 +1173,12 @@ public:
     inline U_HEADER_NESTED_NAMESPACE::USetStrings strings() const {
         return U_HEADER_NESTED_NAMESPACE::USetStrings(toUSet());
     }
+#endif  // U_HIDE_DRAFT_API
 
+#ifndef U_HIDE_DRAFT_API
     /**
      * Returns a C++ iterator for iterating over all of the elements of this set.
-     * Convenient all-in one iteration, but creates a UnicodeString for each
+     * Convenient all-in one iteration, but creates a std::u16string for each
      * code point or string.
      * (Similar to how Java UnicodeSet *is an* Iterable&lt;String&gt;.)
      *
@@ -1185,13 +1187,14 @@ public:
      * \code
      * UnicodeSet set(u"[abcçカ🚴{}{abc}{de}]", errorCode);
      * for (auto el : set) {
+     *     UnicodeString us(el);
      *     std::string u8;
-     *     printf("set.string length %ld \"%s\"\n", (long)el.length(), el.toUTF8String(u8).c_str());
+     *     printf("set.string length %ld \"%s\"\n", (long)us.length(), us.toUTF8String(u8).c_str());
      * }
      * \endcode
      *
      * @return an all-elements iterator.
-     * @draft ICU 76
+     * @draft ICU 77
      * @see end
      * @see codePoints
      * @see ranges
@@ -1203,7 +1206,7 @@ public:
 
     /**
      * @return an exclusive-end sentinel for iterating over all of the elements of this set.
-     * @draft ICU 76
+     * @draft ICU 77
      * @see begin
      * @see codePoints
      * @see ranges

--- a/icu4c/source/common/unicode/unistr.h
+++ b/icu4c/source/common/unicode/unistr.h
@@ -4676,7 +4676,7 @@ UnicodeString::startsWith(const UnicodeString& srcText,
 inline UBool
 UnicodeString::startsWith(ConstChar16Ptr srcChars, int32_t srcLength) const {
   if(srcLength < 0) {
-    srcLength = u_strlen(toUCharPtr(srcChars));
+    srcLength = u_strlen(U_ICU_NAMESPACE_OR_INTERNAL::toUCharPtr(srcChars));
   }
   return doEqualsSubstring(0, srcLength, srcChars, 0, srcLength);
 }
@@ -4684,7 +4684,7 @@ UnicodeString::startsWith(ConstChar16Ptr srcChars, int32_t srcLength) const {
 inline UBool
 UnicodeString::startsWith(const char16_t *srcChars, int32_t srcStart, int32_t srcLength) const {
   if(srcLength < 0) {
-    srcLength = u_strlen(toUCharPtr(srcChars));
+    srcLength = u_strlen(U_ICU_NAMESPACE_OR_INTERNAL::toUCharPtr(srcChars));
   }
   return doEqualsSubstring(0, srcLength, srcChars, srcStart, srcLength);
 }
@@ -4707,7 +4707,7 @@ inline UBool
 UnicodeString::endsWith(ConstChar16Ptr srcChars,
             int32_t srcLength) const {
   if(srcLength < 0) {
-    srcLength = u_strlen(toUCharPtr(srcChars));
+    srcLength = u_strlen(U_ICU_NAMESPACE_OR_INTERNAL::toUCharPtr(srcChars));
   }
   return doEqualsSubstring(length() - srcLength, srcLength, srcChars, 0, srcLength);
 }
@@ -4717,7 +4717,7 @@ UnicodeString::endsWith(const char16_t *srcChars,
             int32_t srcStart,
             int32_t srcLength) const {
   if(srcLength < 0) {
-    srcLength = u_strlen(toUCharPtr(srcChars + srcStart));
+    srcLength = u_strlen(U_ICU_NAMESPACE_OR_INTERNAL::toUCharPtr(srcChars + srcStart));
   }
   return doEqualsSubstring(length() - srcLength, srcLength,
                    srcChars, srcStart, srcLength);

--- a/icu4c/source/common/unicode/unorm2.h
+++ b/icu4c/source/common/unicode/unorm2.h
@@ -268,9 +268,8 @@ unorm2_openFiltered(const UNormalizer2 *norm2, const USet *filterSet, UErrorCode
 U_CAPI void U_EXPORT2
 unorm2_close(UNormalizer2 *norm2);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUNormalizer2Pointer
@@ -283,8 +282,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUNormalizer2Pointer, UNormalizer2, unorm2_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/common/unicode/ures.h
+++ b/icu4c/source/common/unicode/ures.h
@@ -252,9 +252,8 @@ ures_countArrayItems(const UResourceBundle* resourceBundle,
 U_CAPI void U_EXPORT2
 ures_close(UResourceBundle* resourceBundle);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUResourceBundlePointer
@@ -267,8 +266,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUResourceBundlePointer, UResourceBundle, ures_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 #ifndef U_HIDE_DEPRECATED_API

--- a/icu4c/source/common/unicode/uset.h
+++ b/icu4c/source/common/unicode/uset.h
@@ -347,7 +347,6 @@ U_CAPI void U_EXPORT2
 uset_close(USet* set);
 
 #if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-
 namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
@@ -361,8 +360,7 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUSetPointer, USet, uset_close);
 
-}  // U_ICU_NAMESPACE_OR_INTERNAL
-
+}
 #endif
 
 /**

--- a/icu4c/source/common/unicode/uset.h
+++ b/icu4c/source/common/unicode/uset.h
@@ -32,13 +32,13 @@
 #include "unicode/utypes.h"
 #include "unicode/uchar.h"
 
-#if U_SHOW_CPLUSPLUS_API
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
 #include <string>
 #include <string_view>
 #include "unicode/char16ptr.h"
 #include "unicode/localpointer.h"
 #include "unicode/utf16.h"
-#endif   // U_SHOW_CPLUSPLUS_API
+#endif
 
 #ifndef USET_DEFINED
 
@@ -346,9 +346,9 @@ uset_openPatternOptions(const UChar* pattern, int32_t patternLength,
 U_CAPI void U_EXPORT2
 uset_close(USet* set);
 
-#if U_SHOW_CPLUSPLUS_API
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
 
-U_NAMESPACE_BEGIN
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUSetPointer
@@ -361,7 +361,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUSetPointer, USet, uset_close);
 
-U_NAMESPACE_END
+}  // U_ICU_NAMESPACE_OR_INTERNAL
 
 #endif
 
@@ -1658,7 +1658,7 @@ public:
             int32_t length;
             const UChar *uchars = uset_getString(uset, index, &length);
             // assert uchars != nullptr;
-            return {ConstChar16Ptr(uchars), static_cast<uint32_t>(length)};
+            return {uprv_char16PtrFromUChar(uchars), static_cast<size_t>(length)};
         }
         return {};
     }
@@ -1772,7 +1772,7 @@ public:
             int32_t length;
             const UChar *uchars = uset_getString(uset, index - rangeCount, &length);
             // assert uchars != nullptr;
-            return {ConstChar16Ptr(uchars), static_cast<uint32_t>(length)};
+            return {uprv_char16PtrFromUChar(uchars), static_cast<size_t>(length)};
         } else {
             return {};
         }

--- a/icu4c/source/common/unicode/usprep.h
+++ b/icu4c/source/common/unicode/usprep.h
@@ -212,9 +212,8 @@ usprep_openByType(UStringPrepProfileType type,
 U_CAPI void U_EXPORT2
 usprep_close(UStringPrepProfile* profile);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUStringPrepProfilePointer
@@ -227,8 +226,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUStringPrepProfilePointer, UStringPrepProfile, usprep_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/common/unicode/utext.h
+++ b/icu4c/source/common/unicode/utext.h
@@ -1580,9 +1580,8 @@ enum {
 U_CDECL_END
 
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUTextPointer
@@ -1595,8 +1594,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUTextPointer, UText, utext_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 

--- a/icu4c/source/common/unicode/uversion.h
+++ b/icu4c/source/common/unicode/uversion.h
@@ -125,7 +125,7 @@ typedef uint8_t UVersionInfo[U_MAX_VERSION_LENGTH];
         U_NAMESPACE_USE
 #   endif
 
-#ifndef U_HIDE_DRAFT_API
+#ifndef U_FORCE_HIDE_DRAFT_API
 /**
  * \def U_HEADER_NESTED_NAMESPACE
  * Nested namespace used inside U_ICU_NAMESPACE for header-only APIs.
@@ -150,22 +150,37 @@ typedef uint8_t UVersionInfo[U_MAX_VERSION_LENGTH];
  * @draft ICU 76
  */
 
+/**
+ * \def U_ICU_NAMESPACE_OR_INTERNAL
+ * Namespace used for header-only APIs that used to be regular C++ APIs.
+ * Different when used inside ICU to prevent public use of internal instantiations.
+ * Similar to U_HEADER_ONLY_NAMESPACE, but the public definition is the same as U_ICU_NAMESPACE.
+ * "U_ICU_NAMESPACE" or "U_ICU_NAMESPACE::internal".
+ *
+ * @draft ICU 77
+ */
+
 // The first test is the same as for defining U_EXPORT for Windows.
 #if defined(_MSC_VER) || (UPRV_HAS_DECLSPEC_ATTRIBUTE(__dllexport__) && \
                           UPRV_HAS_DECLSPEC_ATTRIBUTE(__dllimport__))
 #   define U_HEADER_NESTED_NAMESPACE header
+#   define U_ICU_NAMESPACE_OR_INTERNAL U_ICU_NAMESPACE
 #elif defined(U_COMBINED_IMPLEMENTATION) || defined(U_COMMON_IMPLEMENTATION) || \
         defined(U_I18N_IMPLEMENTATION) || defined(U_IO_IMPLEMENTATION) || \
         defined(U_LAYOUTEX_IMPLEMENTATION) || defined(U_TOOLUTIL_IMPLEMENTATION)
 #   define U_HEADER_NESTED_NAMESPACE internal
+#   define U_ICU_NAMESPACE_OR_INTERNAL U_ICU_NAMESPACE::internal
+    namespace U_ICU_NAMESPACE_OR_INTERNAL {}
+    using namespace U_ICU_NAMESPACE_OR_INTERNAL;
 #else
 #   define U_HEADER_NESTED_NAMESPACE header
+#   define U_ICU_NAMESPACE_OR_INTERNAL U_ICU_NAMESPACE
 #endif
 
 #define U_HEADER_ONLY_NAMESPACE U_ICU_NAMESPACE::U_HEADER_NESTED_NAMESPACE
 
 namespace U_HEADER_ONLY_NAMESPACE {}
-#endif  // U_HIDE_DRAFT_API
+#endif  // U_FORCE_HIDE_DRAFT_API
 
 #endif /* __cplusplus */
 

--- a/icu4c/source/i18n/unicode/ucal.h
+++ b/icu4c/source/i18n/unicode/ucal.h
@@ -787,9 +787,8 @@ ucal_open(const UChar*   zoneID,
 U_CAPI void U_EXPORT2 
 ucal_close(UCalendar *cal);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUCalendarPointer
@@ -802,8 +801,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUCalendarPointer, UCalendar, ucal_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/ucol.h
+++ b/icu4c/source/i18n/unicode/ucol.h
@@ -537,9 +537,8 @@ ucol_getContractionsAndExpansions( const UCollator *coll,
 U_CAPI void U_EXPORT2 
 ucol_close(UCollator *coll);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUCollatorPointer
@@ -552,8 +551,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUCollatorPointer, UCollator, ucol_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/ucol.h
+++ b/icu4c/source/i18n/unicode/ucol.h
@@ -1572,8 +1572,8 @@ class Predicate {
         return compare(
             ucol_strcoll(
                 collator,
-                toUCharPtr(lhs.getBuffer()), lhs.length(),
-                toUCharPtr(rhs.getBuffer()), rhs.length()),
+                U_ICU_NAMESPACE_OR_INTERNAL::toUCharPtr(lhs.getBuffer()), lhs.length(),
+                U_ICU_NAMESPACE_OR_INTERNAL::toUCharPtr(rhs.getBuffer()), rhs.length()),
             result);
     }
 

--- a/icu4c/source/i18n/unicode/ucsdet.h
+++ b/icu4c/source/i18n/unicode/ucsdet.h
@@ -93,9 +93,8 @@ ucsdet_open(UErrorCode   *status);
 U_CAPI void U_EXPORT2
 ucsdet_close(UCharsetDetector *ucsd);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUCharsetDetectorPointer
@@ -108,8 +107,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUCharsetDetectorPointer, UCharsetDetector, ucsdet_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/udat.h
+++ b/icu4c/source/i18n/unicode/udat.h
@@ -1006,9 +1006,8 @@ typedef enum UDateFormatHourCycle {
     UDAT_HOUR_CYCLE_24
 } UDateFormatHourCycle;
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUDateFormatPointer
@@ -1021,8 +1020,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUDateFormatPointer, UDateFormat, udat_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/udateintervalformat.h
+++ b/icu4c/source/i18n/unicode/udateintervalformat.h
@@ -182,9 +182,8 @@ U_CAPI void U_EXPORT2
 udtitvfmt_closeResult(UFormattedDateInterval* uresult);
 
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUDateIntervalFormatPointer
@@ -208,8 +207,7 @@ U_DEFINE_LOCAL_OPEN_POINTER(LocalUDateIntervalFormatPointer, UDateIntervalFormat
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUFormattedDateIntervalPointer, UFormattedDateInterval, udtitvfmt_closeResult);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 

--- a/icu4c/source/i18n/unicode/udatpg.h
+++ b/icu4c/source/i18n/unicode/udatpg.h
@@ -185,9 +185,8 @@ udatpg_openEmpty(UErrorCode *pErrorCode);
 U_CAPI void U_EXPORT2
 udatpg_close(UDateTimePatternGenerator *dtpg);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUDateTimePatternGeneratorPointer
@@ -200,8 +199,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUDateTimePatternGeneratorPointer, UDateTimePatternGenerator, udatpg_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/ufieldpositer.h
+++ b/icu4c/source/i18n/unicode/ufieldpositer.h
@@ -67,9 +67,8 @@ U_CAPI void U_EXPORT2
 ufieldpositer_close(UFieldPositionIterator *fpositer);
 
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUFieldPositionIteratorPointer
@@ -82,8 +81,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUFieldPositionIteratorPointer, UFieldPositionIterator, ufieldpositer_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/uformattable.h
+++ b/icu4c/source/i18n/unicode/uformattable.h
@@ -93,9 +93,8 @@ ufmt_open(UErrorCode* status);
 U_CAPI void U_EXPORT2
 ufmt_close(UFormattable* fmt);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUFormattablePointer
@@ -108,8 +107,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUFormattablePointer, UFormattable, ufmt_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/uformattednumber.h
+++ b/icu4c/source/i18n/unicode/uformattednumber.h
@@ -196,8 +196,8 @@ U_CAPI void U_EXPORT2
 unumf_closeResult(UFormattedNumber* uresult);
 
 
-#if U_SHOW_CPLUSPLUS_API
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUFormattedNumberPointer
@@ -216,8 +216,8 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUFormattedNumberPointer, UFormattedNumber, unumf_closeResult);
 
-U_NAMESPACE_END
-#endif // U_SHOW_CPLUSPLUS_API
+}
+#endif
 
 
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/i18n/unicode/uformattedvalue.h
+++ b/icu4c/source/i18n/unicode/uformattedvalue.h
@@ -418,8 +418,8 @@ ufmtval_nextPosition(
     UErrorCode* ec);
 
 
-#if U_SHOW_CPLUSPLUS_API
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUConstrainedFieldPositionPointer
@@ -437,8 +437,8 @@ U_DEFINE_LOCAL_OPEN_POINTER(LocalUConstrainedFieldPositionPointer,
     UConstrainedFieldPosition,
     ucfpos_close);
 
-U_NAMESPACE_END
-#endif // U_SHOW_CPLUSPLUS_API
+}
+#endif
 
 
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/i18n/unicode/ulistformatter.h
+++ b/icu4c/source/i18n/unicode/ulistformatter.h
@@ -220,9 +220,8 @@ U_CAPI void U_EXPORT2
 ulistfmt_closeResult(UFormattedList* uresult);
 
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUListFormatterPointer
@@ -246,8 +245,7 @@ U_DEFINE_LOCAL_OPEN_POINTER(LocalUListFormatterPointer, UListFormatter, ulistfmt
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUFormattedListPointer, UFormattedList, ulistfmt_closeResult);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/ulocdata.h
+++ b/icu4c/source/i18n/unicode/ulocdata.h
@@ -102,9 +102,8 @@ ulocdata_open(const char *localeID, UErrorCode *status);
 U_CAPI void U_EXPORT2
 ulocdata_close(ULocaleData *uld);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalULocaleDataPointer
@@ -117,8 +116,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalULocaleDataPointer, ULocaleData, ulocdata_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/umsg.h
+++ b/icu4c/source/i18n/unicode/umsg.h
@@ -415,9 +415,8 @@ umsg_open(  const UChar     *pattern,
 U_CAPI void U_EXPORT2 
 umsg_close(UMessageFormat* format);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUMessageFormatPointer
@@ -430,8 +429,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUMessageFormatPointer, UMessageFormat, umsg_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/unum.h
+++ b/icu4c/source/i18n/unicode/unum.h
@@ -444,9 +444,8 @@ unum_open(  UNumberFormatStyle    style,
 U_CAPI void U_EXPORT2 
 unum_close(UNumberFormat* fmt);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUNumberFormatPointer
@@ -459,8 +458,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUNumberFormatPointer, UNumberFormat, unum_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/unumberformatter.h
+++ b/icu4c/source/i18n/unicode/unumberformatter.h
@@ -549,8 +549,8 @@ unumf_close(UNumberFormatter* uformatter);
 
 
 
-#if U_SHOW_CPLUSPLUS_API
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUNumberFormatterPointer
@@ -569,8 +569,8 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUNumberFormatterPointer, UNumberFormatter, unumf_close);
 
-U_NAMESPACE_END
-#endif // U_SHOW_CPLUSPLUS_API
+}
+#endif
 
 #endif /* #if !UCONFIG_NO_FORMATTING */
 #endif //__UNUMBERFORMATTER_H__

--- a/icu4c/source/i18n/unicode/unumberrangeformatter.h
+++ b/icu4c/source/i18n/unicode/unumberrangeformatter.h
@@ -426,8 +426,8 @@ U_CAPI void U_EXPORT2
 unumrf_closeResult(UFormattedNumberRange* uresult);
 
 
-#if U_SHOW_CPLUSPLUS_API
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUNumberRangeFormatterPointer
@@ -464,8 +464,8 @@ U_DEFINE_LOCAL_OPEN_POINTER(LocalUNumberRangeFormatterPointer, UNumberRangeForma
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUFormattedNumberRangePointer, UFormattedNumberRange, unumrf_closeResult);
 
-U_NAMESPACE_END
-#endif // U_SHOW_CPLUSPLUS_API
+}
+#endif
 
 #endif /* #if !UCONFIG_NO_FORMATTING */
 #endif //__UNUMBERRANGEFORMATTER_H__

--- a/icu4c/source/i18n/unicode/unumsys.h
+++ b/icu4c/source/i18n/unicode/unumsys.h
@@ -89,8 +89,8 @@ unumsys_openByName(const char *name, UErrorCode *status);
 U_CAPI void U_EXPORT2
 unumsys_close(UNumberingSystem *unumsys);
 
-#if U_SHOW_CPLUSPLUS_API
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUNumberingSystemPointer
@@ -102,7 +102,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUNumberingSystemPointer, UNumberingSystem, unumsys_close);
 
-U_NAMESPACE_END
+}
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/upluralrules.h
+++ b/icu4c/source/i18n/unicode/upluralrules.h
@@ -120,9 +120,8 @@ U_CAPI void U_EXPORT2
 uplrules_close(UPluralRules *uplrules);
 
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUPluralRulesPointer
@@ -135,8 +134,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUPluralRulesPointer, UPluralRules, uplrules_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 

--- a/icu4c/source/i18n/unicode/uregex.h
+++ b/icu4c/source/i18n/unicode/uregex.h
@@ -213,9 +213,8 @@ uregex_openC( const char           *pattern,
 U_CAPI void U_EXPORT2 
 uregex_close(URegularExpression *regexp);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalURegularExpressionPointer
@@ -228,8 +227,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalURegularExpressionPointer, URegularExpression, uregex_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/ureldatefmt.h
+++ b/icu4c/source/i18n/unicode/ureldatefmt.h
@@ -299,9 +299,8 @@ U_CAPI void U_EXPORT2
 ureldatefmt_closeResult(UFormattedRelativeDateTime* ufrdt);
 
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalURelativeDateTimeFormatterPointer
@@ -325,8 +324,7 @@ U_DEFINE_LOCAL_OPEN_POINTER(LocalURelativeDateTimeFormatterPointer, URelativeDat
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUFormattedRelativeDateTimePointer, UFormattedRelativeDateTime, ureldatefmt_closeResult);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/usearch.h
+++ b/icu4c/source/i18n/unicode/usearch.h
@@ -360,9 +360,8 @@ U_CAPI UStringSearch * U_EXPORT2 usearch_openFromCollator(
  */
 U_CAPI void U_EXPORT2 usearch_close(UStringSearch *searchiter);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUStringSearchPointer
@@ -375,8 +374,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUStringSearchPointer, UStringSearch, usearch_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /* get and set methods -------------------------------------------------- */

--- a/icu4c/source/i18n/unicode/usimplenumberformatter.h
+++ b/icu4c/source/i18n/unicode/usimplenumberformatter.h
@@ -250,8 +250,8 @@ U_CAPI void U_EXPORT2
 usnumf_close(USimpleNumberFormatter* uformatter);
 
 
-#if U_SHOW_CPLUSPLUS_API
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUSimpleNumberPointer
@@ -290,7 +290,7 @@ U_DEFINE_LOCAL_OPEN_POINTER(LocalUSimpleNumberPointer, USimpleNumber, usnum_clos
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUSimpleNumberFormatterPointer, USimpleNumberFormatter, usnumf_close);
 
-U_NAMESPACE_END
+}
 #endif // U_SHOW_CPLUSPLUS_API
 
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/i18n/unicode/uspoof.h
+++ b/icu4c/source/i18n/unicode/uspoof.h
@@ -1550,9 +1550,8 @@ uspoof_serialize(USpoofChecker *sc,
 
 U_CDECL_END
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUSpoofCheckerPointer
@@ -1589,7 +1588,10 @@ U_DEFINE_LOCAL_OPEN_POINTER(LocalUSpoofCheckerPointer, USpoofChecker, uspoof_clo
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUSpoofCheckResultPointer, USpoofCheckResult, uspoof_closeCheckResult);
 /** \endcond */
 
-U_NAMESPACE_END
+}
+#endif
+
+#if U_SHOW_CPLUSPLUS_API
 
 /**
  * Limit the acceptable characters to those specified by a Unicode Set.

--- a/icu4c/source/i18n/unicode/utrans.h
+++ b/icu4c/source/i18n/unicode/utrans.h
@@ -242,9 +242,8 @@ utrans_clone(const UTransliterator* trans,
 U_CAPI void U_EXPORT2 
 utrans_close(UTransliterator* trans);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUTransliteratorPointer
@@ -257,8 +256,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUTransliteratorPointer, UTransliterator, utrans_close);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/io/unicode/ustdio.h
+++ b/icu4c/source/io/unicode/ustdio.h
@@ -341,9 +341,8 @@ u_fstropen(UChar      *stringBuf,
 U_CAPI void U_EXPORT2
 u_fclose(UFILE *file);
 
-#if U_SHOW_CPLUSPLUS_API
-
-U_NAMESPACE_BEGIN
+#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
  * \class LocalUFILEPointer
@@ -356,8 +355,7 @@ U_NAMESPACE_BEGIN
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUFILEPointer, UFILE, u_fclose);
 
-U_NAMESPACE_END
-
+}
 #endif
 
 /**

--- a/icu4c/source/test/intltest/Makefile.in
+++ b/icu4c/source/test/intltest/Makefile.in
@@ -75,7 +75,7 @@ numbertest_parse.o numbertest_doubleconversion.o numbertest_skeletons.o \
 static_unisets_test.o numfmtdatadriventest.o numbertest_range.o erarulestest.o \
 formattedvaluetest.o formatted_string_builder_test.o numbertest_permutation.o \
 units_data_test.o units_router_test.o units_test.o displayoptions_test.o \
-numbertest_simple.o uchar_type_build_test.o
+numbertest_simple.o uchar_type_build_test.o usetheaderonlytest.o
 
 DEPS = $(OBJECTS:.o=.d)
 

--- a/icu4c/source/test/intltest/intltest.cpp
+++ b/icu4c/source/test/intltest/intltest.cpp
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <cmath>
 #include <math.h>
+#include <string_view>
 
 #include "unicode/ctest.h" // for str_timeDelta
 #include "unicode/curramt.h"
@@ -501,13 +502,13 @@ IntlTest* IntlTest::gTest = nullptr;
 
 static int32_t execCount = 0;
 
-void it_log( UnicodeString message )
+void it_log(std::u16string_view message)
 {
     if (IntlTest::gTest)
         IntlTest::gTest->log( message );
 }
 
-void it_logln( UnicodeString message )
+void it_logln(std::u16string_view message)
 {
     if (IntlTest::gTest)
         IntlTest::gTest->logln( message );
@@ -519,13 +520,13 @@ void it_logln()
         IntlTest::gTest->logln();
 }
 
-void it_info( UnicodeString message )
+void it_info(std::u16string_view message)
 {
     if (IntlTest::gTest)
         IntlTest::gTest->info( message );
 }
 
-void it_infoln( UnicodeString message )
+void it_infoln(std::u16string_view message)
 {
     if (IntlTest::gTest)
         IntlTest::gTest->infoln( message );
@@ -543,29 +544,46 @@ void it_err()
         IntlTest::gTest->err();
 }
 
-void it_err( UnicodeString message )
+void it_err(std::u16string_view message)
 {
     if (IntlTest::gTest)
         IntlTest::gTest->err( message );
 }
 
-void it_errln( UnicodeString message )
+void it_errln(std::u16string_view message)
 {
     if (IntlTest::gTest)
         IntlTest::gTest->errln( message );
 }
 
-void it_dataerr( UnicodeString message )
+void it_dataerr(std::u16string_view message)
 {
     if (IntlTest::gTest)
         IntlTest::gTest->dataerr( message );
 }
 
-void it_dataerrln( UnicodeString message )
+void it_dataerrln(std::u16string_view message)
 {
     if (IntlTest::gTest)
         IntlTest::gTest->dataerrln( message );
 }
+
+void it_logln(const char* message) {
+    it_logln(UnicodeString(message));
+}
+
+void it_err(const char* message) {
+    it_err(UnicodeString(message));
+}
+
+void it_errln(const char* message) {
+    it_errln(UnicodeString(message));
+}
+
+void it_dataerrln(const char* message) {
+    it_dataerrln(UnicodeString(message));
+}
+
 
 IntlTest::IntlTest()
 {
@@ -784,7 +802,7 @@ UBool IntlTest::runTestLoop( char* testname, char* par, char *baseName )
             execCount++;
             char msg[256];
             snprintf(msg, sizeof(msg), "%s {", name);
-            LL_message(msg, true);
+            LL_message(UnicodeString(msg), true);
             UDate timeStart = uprv_getRawUTCtime();
             strcpy(saveBaseLoc,name);
             strcat(saveBaseLoc,"/");
@@ -828,11 +846,11 @@ UBool IntlTest::runTestLoop( char* testname, char* par, char *baseName )
             }
             LL_indentlevel -= 3;
             if (lastTestFailed) {
-                LL_message( "", true);
+                LL_message({}, true);
             }
-            LL_message( msg, true);
+            LL_message(UnicodeString(msg), true);
             if (lastTestFailed) {
-                LL_message( "", true);
+                LL_message({}, true);
             }
             LL_indentlevel += 3;
         }
@@ -849,7 +867,7 @@ UBool IntlTest::runTestLoop( char* testname, char* par, char *baseName )
 /**
 * Adds given string to the log if we are in verbose mode.
 */
-void IntlTest::log( const UnicodeString &message )
+void IntlTest::log(std::u16string_view message)
 {
     if( verbose ) {
         LL_message( message, false );
@@ -860,7 +878,7 @@ void IntlTest::log( const UnicodeString &message )
 * Adds given string to the log if we are in verbose mode. Adds a new line to
 * the given message.
 */
-void IntlTest::logln( const UnicodeString &message )
+void IntlTest::logln(std::u16string_view message)
 {
     if( verbose ) {
         LL_message( message, true );
@@ -870,14 +888,14 @@ void IntlTest::logln( const UnicodeString &message )
 void IntlTest::logln()
 {
     if( verbose ) {
-        LL_message( "", true );
+        LL_message({}, true );
     }
 }
 
 /**
 * Unconditionally adds given string to the log.
 */
-void IntlTest::info( const UnicodeString &message )
+void IntlTest::info(std::u16string_view message)
 {
   LL_message( message, false );
 }
@@ -886,14 +904,14 @@ void IntlTest::info( const UnicodeString &message )
 * Unconditionally adds given string to the log. Adds a new line to
 * the given message.
 */
-void IntlTest::infoln( const UnicodeString &message )
+void IntlTest::infoln(std::u16string_view message)
 {
   LL_message( message, true );
 }
 
 void IntlTest::infoln()
 {
-  LL_message( "", true );
+  LL_message({}, true );
 }
 
 int32_t IntlTest::IncErrorCount()
@@ -915,19 +933,19 @@ void IntlTest::err()
     IncErrorCount();
 }
 
-void IntlTest::err( const UnicodeString &message )
+void IntlTest::err(std::u16string_view message)
 {
     IncErrorCount();
     if (!no_err_msg) LL_message( message, false );
 }
 
-void IntlTest::errln( const UnicodeString &message )
+void IntlTest::errln(std::u16string_view message)
 {
     IncErrorCount();
     if (!no_err_msg) LL_message( message, true );
 }
 
-void IntlTest::dataerr( const UnicodeString &message )
+void IntlTest::dataerr(std::u16string_view message)
 {
     IncDataErrorCount();
 
@@ -938,7 +956,7 @@ void IntlTest::dataerr( const UnicodeString &message )
     if (!no_err_msg) LL_message( message, false );
 }
 
-void IntlTest::dataerrln( const UnicodeString &message )
+void IntlTest::dataerrln(std::u16string_view message)
 {
     int32_t errCount = IncDataErrorCount();
     UnicodeString msg;
@@ -958,7 +976,7 @@ void IntlTest::dataerrln( const UnicodeString &message )
     }
 }
 
-void IntlTest::errcheckln(UErrorCode status, const UnicodeString &message ) {
+void IntlTest::errcheckln(UErrorCode status, std::u16string_view message) {
     if (status == U_FILE_ACCESS_ERROR || status == U_MISSING_RESOURCE_ERROR) {
         dataerrln(message);
     } else {
@@ -1011,7 +1029,7 @@ UBool IntlTest::logKnownIssue(const char *ticket) {
   return logKnownIssue(ticket, UnicodeString());
 }
 
-UBool IntlTest::logKnownIssue(const char *ticket, const UnicodeString &msg) {
+UBool IntlTest::logKnownIssue(const char *ticket, std::u16string_view msg) {
   if(noKnownIssues) return false;
 
   char fullpath[2048];
@@ -1123,7 +1141,7 @@ UBool IntlTest::printKnownIssues()
 }
 
 
-void IntlTest::LL_message( UnicodeString message, UBool newline )
+void IntlTest::LL_message(std::u16string_view message, UBool newline)
 {
     // Synchronize this function.
     // All error messages generated by tests funnel through here.
@@ -1160,10 +1178,11 @@ void IntlTest::LL_message( UnicodeString message, UBool newline )
     }
 
     // replace each LineFeed by the indentation string
-    message.findAndReplace(UnicodeString(static_cast<char16_t>('\n')), indent);
+    UnicodeString us(message);
+    us.findAndReplace(UnicodeString(static_cast<char16_t>('\n')), indent);
 
     // stream out the message
-    length = message.extract(0, message.length(), buffer, sizeof(buffer));
+    length = us.extract(0, us.length(), buffer, sizeof(buffer));
     if (length > 0) {
         length = length > 30000 ? 30000 : length;
         fwrite(buffer, sizeof(*buffer), length, static_cast<FILE*>(testoutfp));
@@ -1938,8 +1957,8 @@ static inline char16_t toHex(int32_t i) {
     return static_cast<char16_t>(i + (i < 10 ? 0x30 : (0x41 - 10)));
 }
 
-static UnicodeString& escape(const UnicodeString& s, UnicodeString& result) {
-    for (int32_t i=0; i<s.length(); ++i) {
+static UnicodeString& escape(std::u16string_view s, UnicodeString& result) {
+    for (int32_t i=0; i<static_cast<int32_t>(s.length()); ++i) {
         char16_t c = s[i];
         if (c <= static_cast<char16_t>(0x7F)) {
             result += c;
@@ -2014,8 +2033,8 @@ UBool IntlTest::assertSuccess(const char* message, UErrorCode ec, UBool possible
 }
 
 UBool IntlTest::assertEquals(const char* message,
-                             const UnicodeString& expected,
-                             const UnicodeString& actual,
+                             std::u16string_view expected,
+                             std::u16string_view actual,
                              UBool possibleDataError) {
     if (expected != actual) {
         if (possibleDataError) {
@@ -2054,6 +2073,22 @@ UBool IntlTest::assertEquals(const char* message,
     }
 #endif
     return true;
+}
+
+UBool IntlTest::assertEquals(const char* message, const char* expected,
+                             std::u16string_view actual, UBool possibleDataError) {
+    return assertEquals(
+        message,
+        UnicodeString(expected), actual,
+        possibleDataError);
+}
+
+UBool IntlTest::assertEquals(const char* message, std::u16string_view expected,
+                             const char* actual, UBool possibleDataError) {
+    return assertEquals(
+        message,
+        expected, UnicodeString(actual),
+        possibleDataError);
 }
 
 UBool IntlTest::assertEquals(const char* message,
@@ -2163,10 +2198,10 @@ UBool IntlTest::assertEquals(const char* message,
 
 
 #if !UCONFIG_NO_FORMATTING
-UBool IntlTest::assertEquals(const char* message,
-                             const Formattable& expected,
-                             const Formattable& actual,
-                             UBool possibleDataError) {
+UBool IntlTest::assertEqualFormattables(const char* message,
+                                        const Formattable& expected,
+                                        const Formattable& actual,
+                                        UBool possibleDataError) {
     if (expected != actual) {
         if (possibleDataError) {
             dataerrln(UnicodeString("FAIL: ") + message + "; got " +
@@ -2273,7 +2308,7 @@ UBool IntlTest::assertEqualsNear(const char* message,
 
 static char ASSERT_BUF[256];
 
-static const char* extractToAssertBuf(const UnicodeString& message) {
+static const char* extractToAssertBuf(std::u16string_view message) {
     UnicodeString buf;
     escape(message, buf);
     buf.extract(0, 0x7FFFFFFF, ASSERT_BUF, sizeof(ASSERT_BUF) - 1, nullptr);
@@ -2281,82 +2316,87 @@ static const char* extractToAssertBuf(const UnicodeString& message) {
     return ASSERT_BUF;
 }
 
-UBool IntlTest::assertTrue(const UnicodeString& message, UBool condition, UBool quiet, UBool possibleDataError) {
+UBool IntlTest::assertTrue(std::u16string_view message, UBool condition, UBool quiet, UBool possibleDataError) {
     return assertTrue(extractToAssertBuf(message), condition, quiet, possibleDataError);
 }
 
-UBool IntlTest::assertFalse(const UnicodeString& message, UBool condition, UBool quiet, UBool possibleDataError) {
+UBool IntlTest::assertFalse(std::u16string_view message, UBool condition, UBool quiet, UBool possibleDataError) {
     return assertFalse(extractToAssertBuf(message), condition, quiet, possibleDataError);
 }
 
-UBool IntlTest::assertSuccess(const UnicodeString& message, UErrorCode ec) {
+UBool IntlTest::assertSuccess(std::u16string_view message, UErrorCode ec) {
     return assertSuccess(extractToAssertBuf(message), ec);
 }
 
-UBool IntlTest::assertEquals(const UnicodeString& message,
-                             const UnicodeString& expected,
-                             const UnicodeString& actual,
+UBool IntlTest::assertEquals(std::u16string_view message,
+                             std::u16string_view expected,
+                             std::u16string_view actual,
                              UBool possibleDataError) {
     return assertEquals(extractToAssertBuf(message), expected, actual, possibleDataError);
 }
 
-UBool IntlTest::assertEquals(const UnicodeString& message,
+UBool IntlTest::assertEquals(std::u16string_view message,
                              const char* expected,
                              const char* actual) {
     return assertEquals(extractToAssertBuf(message), expected, actual);
 }
-UBool IntlTest::assertEquals(const UnicodeString& message,
+UBool IntlTest::assertEquals(std::u16string_view message,
                              UBool expected,
                              UBool actual) {
     return assertEquals(extractToAssertBuf(message), expected, actual);
 }
-UBool IntlTest::assertEquals(const UnicodeString& message,
+UBool IntlTest::assertEquals(std::u16string_view message,
                              int32_t expected,
                              int32_t actual) {
     return assertEquals(extractToAssertBuf(message), expected, actual);
 }
-UBool IntlTest::assertEquals(const UnicodeString& message,
+UBool IntlTest::assertEquals(std::u16string_view message,
                              int64_t expected,
                              int64_t actual) {
     return assertEquals(extractToAssertBuf(message), expected, actual);
 }
-UBool IntlTest::assertEquals(const UnicodeString& message,
+UBool IntlTest::assertEquals(std::u16string_view message,
                              double expected,
                              double actual) {
     return assertEquals(extractToAssertBuf(message), expected, actual);
 }
-UBool IntlTest::assertEquals(const UnicodeString& message,
+UBool IntlTest::assertEquals(std::u16string_view message,
                              UErrorCode expected,
                              UErrorCode actual) {
     return assertEquals(extractToAssertBuf(message), expected, actual);
 }
-UBool IntlTest::assertEquals(const UnicodeString& message,
+UBool IntlTest::assertEquals(std::u16string_view message,
                              const UnicodeSet& expected,
                              const UnicodeSet& actual) {
     return assertEquals(extractToAssertBuf(message), expected, actual);
 }
-UBool IntlTest::assertEquals(const UnicodeString& message,
+UBool IntlTest::assertEquals(std::u16string_view message,
                              const std::vector<std::string>& expected,
                              const std::vector<std::string>& actual) {
     return assertEquals(extractToAssertBuf(message), expected, actual);
 }
-UBool IntlTest::assertNotEquals(const UnicodeString &message,
+UBool IntlTest::assertNotEquals(std::u16string_view message,
                                 int32_t expectedNot,
                                 int32_t actual) {
     return assertNotEquals(extractToAssertBuf(message), expectedNot, actual);
 }
-UBool IntlTest::assertEqualsNear(const UnicodeString& message,
+UBool IntlTest::assertEqualsNear(std::u16string_view message,
                                  double expected,
                                  double actual,
                                  double delta) {
     return assertEqualsNear(extractToAssertBuf(message), expected, actual, delta);
 }
 
+UBool IntlTest::assertEquals(std::u16string_view message, const char* expected,
+                             std::u16string_view actual, UBool possibleDataError) {
+    return assertEquals(message, UnicodeString(expected), actual, possibleDataError);
+}
+
 #if !UCONFIG_NO_FORMATTING
-UBool IntlTest::assertEquals(const UnicodeString& message,
-                             const Formattable& expected,
-                             const Formattable& actual) {
-    return assertEquals(extractToAssertBuf(message), expected, actual);
+UBool IntlTest::assertEqualFormattables(std::u16string_view message,
+                                        const Formattable& expected,
+                                        const Formattable& actual) {
+    return assertEqualFormattables(extractToAssertBuf(message), expected, actual);
 }
 #endif
 

--- a/icu4c/source/test/intltest/intltest.h
+++ b/icu4c/source/test/intltest/intltest.h
@@ -13,16 +13,22 @@
 #ifndef _INTLTEST
 #define _INTLTEST
 
-// The following includes utypes.h, uobject.h and unistr.h
-#include "unicode/fmtable.h"
-#include "unicode/testlog.h"
-#include "unicode/uniset.h"
-
 #include <vector>
 #include <string>
+#include <string_view>
+
+#include "unicode/utypes.h"
+#include "unicode/testlog.h"
+
+#if U_SHOW_CPLUSPLUS_API
+#include "unicode/fmtable.h"
+#include "unicode/uniset.h"
+#include "unicode/unistr.h"
+#endif
 
 U_NAMESPACE_USE
 
+#if U_SHOW_CPLUSPLUS_API
 
 //-----------------------------------------------------------------------------
 //convenience classes to ease porting code that uses the Java
@@ -46,6 +52,8 @@ UnicodeString toString(const Formattable& f); // liu
 UnicodeString toString(int32_t n);
 #endif
 UnicodeString toString(UBool b);
+
+#endif  // U_SHOW_CPLUSPLUS_API
 
 //-----------------------------------------------------------------------------
 
@@ -154,9 +162,9 @@ public:
     virtual void setCaller( IntlTest* callingTest ); // for internal use only
     virtual void setPath( char* path ); // for internal use only
 
-    virtual void log( const UnicodeString &message );
+    virtual void log(std::u16string_view message);
 
-    virtual void logln( const UnicodeString &message ) override;
+    virtual void logln(std::u16string_view message) override;
 
     virtual void logln();
 
@@ -168,7 +176,7 @@ public:
      * @param message optional message string
      * @return true if test should be skipped
      */
-    UBool logKnownIssue( const char *ticket, const UnicodeString &message );
+    UBool logKnownIssue( const char *ticket, std::u16string_view message);
     /**
      * Logs that an issue is known. Can be called multiple times.
      * Usually used this way:
@@ -192,23 +200,23 @@ public:
     UBool skipLSTMTest();
 #endif /* #if !UCONFIG_NO_BREAK_ITERATION */
 
-    virtual void info( const UnicodeString &message );
+    virtual void info(std::u16string_view message);
 
-    virtual void infoln( const UnicodeString &message );
+    virtual void infoln(std::u16string_view message);
 
     virtual void infoln();
 
     virtual void err();
 
-    virtual void err( const UnicodeString &message );
+    virtual void err(std::u16string_view message);
 
-    virtual void errln( const UnicodeString &message ) override;
+    virtual void errln(std::u16string_view message) override;
 
-    virtual void dataerr( const UnicodeString &message );
+    virtual void dataerr(std::u16string_view message);
 
-    virtual void dataerrln( const UnicodeString &message ) override;
+    virtual void dataerrln(std::u16string_view message) override;
 
-    void errcheckln(UErrorCode status, const UnicodeString &message );
+    void errcheckln(UErrorCode status, std::u16string_view message);
 
     // convenience functions: sprintf() + errln() etc.
     void log(const char *fmt, ...);
@@ -289,13 +297,20 @@ public:
      * @return true on success, false on failure.
      */
     UBool assertSuccess(const char* message, UErrorCode ec, UBool possibleDataError=false, const char *file=nullptr, int line=0);
-    UBool assertEquals(const char* message, const UnicodeString& expected,
-                       const UnicodeString& actual, UBool possibleDataError=false);
+    UBool assertEquals(const char* message, std::u16string_view expected,
+                       std::u16string_view actual, UBool possibleDataError=false);
     UBool assertEquals(const char* message, const char* expected, const char* actual);
     UBool assertEquals(const char* message, UBool expected, UBool actual);
     UBool assertEquals(const char* message, int32_t expected, int32_t actual);
     UBool assertEquals(const char* message, int64_t expected, int64_t actual);
     UBool assertEquals(const char* message, double expected, double actual);
+
+    // for disambiguation
+    UBool assertEquals(const char* message, const char* expected,
+                       std::u16string_view actual, UBool possibleDataError=false);
+    UBool assertEquals(const char* message, std::u16string_view expected,
+                       const char* actual, UBool possibleDataError=false);
+
     /**
      * Asserts that two doubles are equal to within a positive delta. Returns
      * false if they are not.
@@ -311,27 +326,36 @@ public:
      */
     UBool assertEqualsNear(const char* message, double expected, double actual, double delta);
     UBool assertEquals(const char* message, UErrorCode expected, UErrorCode actual);
+#if U_SHOW_CPLUSPLUS_API
     UBool assertEquals(const char* message, const UnicodeSet& expected, const UnicodeSet& actual);
+#endif
     UBool assertEquals(const char* message,
         const std::vector<std::string>& expected, const std::vector<std::string>& actual);
 
+#if U_SHOW_CPLUSPLUS_API
 #if !UCONFIG_NO_FORMATTING
-    UBool assertEquals(const char* message, const Formattable& expected,
-                       const Formattable& actual, UBool possibleDataError=false);
-    UBool assertEquals(const UnicodeString& message, const Formattable& expected,
-                       const Formattable& actual);
+    UBool assertEqualFormattables(const char* message, const Formattable& expected,
+                                  const Formattable& actual, UBool possibleDataError=false);
+    UBool assertEqualFormattables(std::u16string_view message, const Formattable& expected,
+                                  const Formattable& actual);
+#endif
 #endif
     UBool assertNotEquals(const char* message, int32_t expectedNot, int32_t actual);
-    UBool assertTrue(const UnicodeString& message, UBool condition, UBool quiet=false, UBool possibleDataError=false);
-    UBool assertFalse(const UnicodeString& message, UBool condition, UBool quiet=false, UBool possibleDataError=false);
-    UBool assertSuccess(const UnicodeString& message, UErrorCode ec);
-    UBool assertEquals(const UnicodeString& message, const UnicodeString& expected,
-                       const UnicodeString& actual, UBool possibleDataError=false);
-    UBool assertEquals(const UnicodeString& message, const char* expected, const char* actual);
-    UBool assertEquals(const UnicodeString& message, UBool expected, UBool actual);
-    UBool assertEquals(const UnicodeString& message, int32_t expected, int32_t actual);
-    UBool assertEquals(const UnicodeString& message, int64_t expected, int64_t actual);
-    UBool assertEquals(const UnicodeString& message, double expected, double actual);
+    UBool assertTrue(std::u16string_view message, UBool condition, UBool quiet=false, UBool possibleDataError=false);
+    UBool assertFalse(std::u16string_view message, UBool condition, UBool quiet=false, UBool possibleDataError=false);
+    UBool assertSuccess(std::u16string_view message, UErrorCode ec);
+    UBool assertEquals(std::u16string_view message, std::u16string_view expected,
+                       std::u16string_view actual, UBool possibleDataError=false);
+    UBool assertEquals(std::u16string_view message, const char* expected, const char* actual);
+    UBool assertEquals(std::u16string_view message, UBool expected, UBool actual);
+    UBool assertEquals(std::u16string_view message, int32_t expected, int32_t actual);
+    UBool assertEquals(std::u16string_view message, int64_t expected, int64_t actual);
+    UBool assertEquals(std::u16string_view message, double expected, double actual);
+
+    // for disambiguation
+    UBool assertEquals(std::u16string_view message, const char* expected,
+                       std::u16string_view actual, UBool possibleDataError=false);
+
     /**
      * Asserts that two doubles are equal to within a positive delta. Returns
      * false if they are not.
@@ -345,12 +369,14 @@ public:
      * @param delta - the maximum delta between expected and actual for which
      * both numbers are still considered equal.
      */
-    UBool assertEqualsNear(const UnicodeString& message, double expected, double actual, double delta);
-    UBool assertEquals(const UnicodeString& message, UErrorCode expected, UErrorCode actual);
-    UBool assertEquals(const UnicodeString& message, const UnicodeSet& expected, const UnicodeSet& actual);
-    UBool assertEquals(const UnicodeString& message,
+    UBool assertEqualsNear(std::u16string_view message, double expected, double actual, double delta);
+    UBool assertEquals(std::u16string_view message, UErrorCode expected, UErrorCode actual);
+#if U_SHOW_CPLUSPLUS_API
+    UBool assertEquals(std::u16string_view message, const UnicodeSet& expected, const UnicodeSet& actual);
+#endif
+    UBool assertEquals(std::u16string_view message,
         const std::vector<std::string>& expected, const std::vector<std::string>& actual);
-    UBool assertNotEquals(const UnicodeString& message, int32_t expectedNot, int32_t actual);
+    UBool assertNotEquals(std::u16string_view message, int32_t expectedNot, int32_t actual);
 
     virtual void runIndexedTest( int32_t index, UBool exec, const char* &name, char* par = nullptr ); // override !
 
@@ -392,8 +418,9 @@ private:
 
 protected:
 
-    virtual void LL_message( UnicodeString message, UBool newline );
+    virtual void LL_message(std::u16string_view message, UBool newline);
 
+#if U_SHOW_CPLUSPLUS_API
     // used for collation result reporting, defined here for convenience
 
     static UnicodeString &prettify(const UnicodeString &source, UnicodeString &target);
@@ -404,6 +431,7 @@ protected:
     static inline UnicodeString toHex(int32_t number, int32_t digits=-1) {
         return toHex(static_cast<uint32_t>(number), digits);
     }
+#endif
 
 public:
     static void setICU_DATA();       // Set up ICU_DATA if necessary.
@@ -428,17 +456,24 @@ public:
 
 };
 
-void it_log( UnicodeString message );
-void it_logln( UnicodeString message );
+void it_log(std::u16string_view message);
+void it_logln(std::u16string_view message);
 void it_logln();
-void it_info( UnicodeString message );
-void it_infoln( UnicodeString message );
+void it_info(std::u16string_view message);
+void it_infoln(std::u16string_view message);
 void it_infoln();
 void it_err();
-void it_err( UnicodeString message );
-void it_errln( UnicodeString message );
-void it_dataerr( UnicodeString message );
-void it_dataerrln( UnicodeString message );
+void it_err(std::u16string_view message);
+void it_errln(std::u16string_view message);
+void it_dataerr(std::u16string_view message);
+void it_dataerrln(std::u16string_view message);
+
+void it_logln(const char* message);
+void it_err(const char* message);
+void it_errln(const char* message);
+void it_dataerrln(const char* message);
+
+#if U_SHOW_CPLUSPLUS_API
 
 /**
  * This is a variant of cintltst/ccolltst.c:CharsToUChars().
@@ -449,5 +484,7 @@ extern UnicodeString CharsToUnicodeString(const char* chars);
 
 /* alias for CharsToUnicodeString */
 extern UnicodeString ctou(const char* chars);
+
+#endif
 
 #endif // _INTLTEST

--- a/icu4c/source/test/intltest/intltest.vcxproj
+++ b/icu4c/source/test/intltest/intltest.vcxproj
@@ -242,6 +242,7 @@
     <ClCompile Include="units_router_test.cpp" />
     <ClCompile Include="units_test.cpp" />
     <ClCompile Include="uchar_type_build_test.cpp" />
+    <ClCompile Include="usetheaderonlytest.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="colldata.h" />

--- a/icu4c/source/test/intltest/intltest.vcxproj.filters
+++ b/icu4c/source/test/intltest/intltest.vcxproj.filters
@@ -571,9 +571,18 @@
     <ClCompile Include="uchar_type_build_test.cpp">
       <Filter>configuration</Filter>
     </ClCompile>
-    <ClCompile Include="messageformat2test.cpp" />
-    <ClCompile Include="messageformat2test_custom.cpp" />
-    <ClCompile Include="messageformat2test_read_json.cpp" />
+    <ClCompile Include="messageformat2test.cpp">
+      <Filter>formatting</Filter>
+    </ClCompile>
+    <ClCompile Include="messageformat2test_custom.cpp">
+      <Filter>formatting</Filter>
+    </ClCompile>
+    <ClCompile Include="messageformat2test_read_json.cpp">
+      <Filter>formatting</Filter>
+    </ClCompile>
+    <ClCompile Include="usetheaderonlytest.cpp">
+      <Filter>misc</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="itrbbi.h">

--- a/icu4c/source/test/intltest/itutil.cpp
+++ b/icu4c/source/test/intltest/itutil.cpp
@@ -204,19 +204,19 @@ void ErrorCodeTest::TestSubclass() {
 
 class IcuTestErrorCodeTestHelper : public IntlTest {
   public:
-    void errln( const UnicodeString &message ) override {
+    void errln(std::u16string_view message) override {
         test->assertFalse("Already saw an error", seenError);
         seenError = true;
-        test->assertEquals("Message for Error", expectedErrln, message);
+        test->assertEquals("Message for Error", std::u16string_view{expectedErrln}, message);
         if (expectedDataErr) {
             test->errln("Got non-data error, but expected data error");
         }
     }
 
-    void dataerrln( const UnicodeString &message ) override {
+    void dataerrln(std::u16string_view message) override {
         test->assertFalse("Already saw an error", seenError);
         seenError = true;
-        test->assertEquals("Message for Error", expectedErrln, message);
+        test->assertEquals("Message for Error", std::u16string_view{expectedErrln}, message);
         if (!expectedDataErr) {
             test->errln("Got data error, but expected non-data error");
         }

--- a/icu4c/source/test/intltest/itutil.cpp
+++ b/icu4c/source/test/intltest/itutil.cpp
@@ -35,6 +35,7 @@
 #include "usettest.h"
 
 extern IntlTest *createBytesTrieTest();
+extern IntlTest *createUSetHeaderOnlyTest();
 extern IntlTest *createLocaleMatcherTest();
 static IntlTest *createLocalPointerTest();
 extern IntlTest *createUCharsTrieTest();
@@ -82,6 +83,7 @@ void IntlTestUtilities::runIndexedTest( int32_t index, UBool exec, const char* &
     TESTCASE_AUTO_CLASS(LocaleBuilderTest);
     TESTCASE_AUTO_CREATE_CLASS(LocaleMatcherTest);
     TESTCASE_AUTO_CREATE_CLASS(UHashTest);
+    TESTCASE_AUTO_CREATE_CLASS(USetHeaderOnlyTest);
     TESTCASE_AUTO_END;
 }
 

--- a/icu4c/source/test/intltest/localematchertest.cpp
+++ b/icu4c/source/test/intltest/localematchertest.cpp
@@ -457,7 +457,7 @@ void LocaleMatcherTest::testResolvedLocale() {
 
 namespace {
 
-bool toInvariant(const UnicodeString &s, CharString &inv, ErrorCode &errorCode) {
+bool toInvariant(const UnicodeString &s, CharString &inv, IcuTestErrorCode &errorCode) {
     if (errorCode.isSuccess()) {
         inv.clear().appendInvariantChars(s, errorCode);
         return errorCode.isSuccess();
@@ -477,7 +477,7 @@ bool getSuffixAfterPrefix(const UnicodeString &s, int32_t limit,
 
 bool getInvariantSuffixAfterPrefix(const UnicodeString &s, int32_t limit,
                                    const UnicodeString &prefix, CharString &suffix,
-                                   ErrorCode &errorCode) {
+                                   IcuTestErrorCode &errorCode) {
     UnicodeString u_suffix;
     return getSuffixAfterPrefix(s, limit, prefix, u_suffix) &&
         toInvariant(u_suffix, suffix, errorCode);

--- a/icu4c/source/test/intltest/numfmtst.cpp
+++ b/icu4c/source/test/intltest/numfmtst.cpp
@@ -2516,7 +2516,7 @@ void NumberFormatTest::TestPerMill() {
     if (!assertSuccess("setup", ec)) return;
     str.truncate(0);
     assertEquals("0.4857 x ###.###m",
-                 "485.7m", fmt2.format(0.4857, str));
+                 u"485.7m", fmt2.format(0.4857, str));
 }
 
 /**
@@ -2677,8 +2677,8 @@ void NumberFormatTest::TestCases() {
                     Formattable m;
                     fmt->parse(str, m, ec);
                     assertSuccess("parse", ec);
-                    assertEquals(where + "\"" + pat + "\".parse(\"" + str + "\")",
-                                 n, m);
+                    assertEqualFormattables(
+                        where + "\"" + pat + "\".parse(\"" + str + "\")", n, m);
                 }
             }
             // p: <pattern or '-'> <string to parse> <exp. number>
@@ -2691,8 +2691,7 @@ void NumberFormatTest::TestCases() {
                 assertSuccess("parse", ec);
                 fmt->parse(str, n, ec);
                 assertSuccess("parse", ec);
-                assertEquals(where + "\"" + pat + "\".parse(\"" + str + "\")",
-                             exp, n);
+                assertEqualFormattables(where + "\"" + pat + "\".parse(\"" + str + "\")", exp, n);
             }
             break;
         case 8: // fpc:
@@ -2734,8 +2733,8 @@ void NumberFormatTest::TestCases() {
 
                 mfmt->parseObject(str, m, ec);
                 if (assertSuccess("parseCurrency", ec)) {
-                    assertEquals(where + "getCurrencyFormat(" + mloc + ").parse(\"" + str + "\")",
-                                 n, m);
+                    assertEqualFormattables(
+                        where + "getCurrencyFormat(" + mloc + ").parse(\"" + str + "\")", n, m);
                 } else {
                     errln("FAIL: source " + str);
                 }
@@ -3767,7 +3766,7 @@ void NumberFormatTest::TestMismatchedCurrencyFormatFail() {
     df->setLenient(false);
     {
         Formattable result;
-        ErrorCode failStatus;
+        UErrorCode failStatus = U_ZERO_ERROR;
         df->parse(u"1.23\u20AC", result, failStatus);
         assertEquals("Should fail to parse", U_INVALID_FORMAT_ERROR, failStatus);
     }
@@ -6900,7 +6899,7 @@ void NumberFormatTest::TestDecimal() {
             StringPiece num("244444444444444444444444444444444444446.4");
             fmtr->format(num, formattedResult, nullptr, status);
             ASSERT_SUCCESS(status);
-            ASSERT_EQUALS("244,444,444,444,444,444,444,444,444,444,444,444,446.4", formattedResult);
+            ASSERT_EQUALS(u"244,444,444,444,444,444,444,444,444,444,444,444,446.4", formattedResult);
             //std::string ss; std::cout << formattedResult.toUTF8String(ss);
             delete fmtr;
         }
@@ -6921,7 +6920,7 @@ void NumberFormatTest::TestDecimal() {
             ASSERT_SUCCESS(status);
             fmtr->format(dl, formattedResult, nullptr, status);
             ASSERT_SUCCESS(status);
-            ASSERT_EQUALS("1,234,566,666,666,666,666,666,666,666,666,666,666,621,000", formattedResult);
+            ASSERT_EQUALS(u"1,234,566,666,666,666,666,666,666,666,666,666,666,621,000", formattedResult);
 
             status = U_ZERO_ERROR;
             num.set("666.666");
@@ -6931,7 +6930,7 @@ void NumberFormatTest::TestDecimal() {
             formattedResult.remove();
             fmtr->format(dl, formattedResult, pos, status);
             ASSERT_SUCCESS(status);
-            ASSERT_EQUALS("666.666", formattedResult);
+            ASSERT_EQUALS(u"666.666", formattedResult);
             ASSERT_EQUALS(4, pos.getBeginIndex());
             ASSERT_EQUALS(7, pos.getEndIndex());
             delete fmtr;
@@ -8788,7 +8787,7 @@ void NumberFormatTest::Test13391_chakmaParsing() {
     Formattable result;
     df->parse(expected, result, status);
     assertSuccess("Should not fail when parsing in ccp", status);
-    assertEquals("Should parse to 12345 in ccp", 12345, result);
+    assertEqualFormattables("Should parse to 12345 in ccp", 12345, result);
 
     const char16_t* expectedScientific = u"\U00011137.\U00011139E\U00011138";
     UnicodeString actualScientific;
@@ -8802,7 +8801,7 @@ void NumberFormatTest::Test13391_chakmaParsing() {
     Formattable resultScientific;
     df->parse(expectedScientific, resultScientific, status);
     assertSuccess("Should not fail when parsing scientific in ccp", status);
-    assertEquals("Should parse scientific to 130 in ccp", 130, resultScientific);
+    assertEqualFormattables("Should parse scientific to 130 in ccp", 130, resultScientific);
 }
 
 
@@ -9592,7 +9591,7 @@ void NumberFormatTest::Test20037_ScientificIntegerOverflow() {
     StringPiece sp = result.getDecimalNumber(status);
     assertEquals(u"Should snap to zero",
                  u"0",
-                 {sp.data(), sp.length(), US_INV});
+                 UnicodeString(sp.data(), sp.length(), US_INV));
 
     // Test edge case overflow of exponent
     result = Formattable();
@@ -9600,7 +9599,7 @@ void NumberFormatTest::Test20037_ScientificIntegerOverflow() {
     sp = result.getDecimalNumber(status);
     assertEquals(u"Should not overflow and should parse only the first exponent",
                  u"1E-2147483647",
-                 {sp.data(), sp.length(), US_INV});
+                 UnicodeString(sp.data(), sp.length(), US_INV));
 
     // Test edge case overflow of exponent
     result = Formattable();
@@ -9608,7 +9607,7 @@ void NumberFormatTest::Test20037_ScientificIntegerOverflow() {
     sp = result.getDecimalNumber(status);
     assertEquals(u"Should not overflow",
                  u"3E-2147483648",
-                 {sp.data(), sp.length(), US_INV});
+                 UnicodeString(sp.data(), sp.length(), US_INV));
 
     // Test largest parseable exponent
     result = Formattable();
@@ -9616,7 +9615,7 @@ void NumberFormatTest::Test20037_ScientificIntegerOverflow() {
     sp = result.getDecimalNumber(status);
     assertEquals(u"Should not overflow",
                  u"9.876E+2147483646",
-                 {sp.data(), sp.length(), US_INV});
+                 UnicodeString(sp.data(), sp.length(), US_INV));
 
     // Test max value as well
     const char16_t* infinityInputs[] = {
@@ -9632,8 +9631,8 @@ void NumberFormatTest::Test20037_ScientificIntegerOverflow() {
         nf->parse(input, result, status);
         sp = result.getDecimalNumber(status);
         assertEquals(UnicodeString("Should become Infinity: ") + input,
-                    u"Infinity",
-                    {sp.data(), sp.length(), US_INV});
+                     u"Infinity",
+                     UnicodeString(sp.data(), sp.length(), US_INV));
     }
 }
 

--- a/icu4c/source/test/intltest/usetheaderonlytest.cpp
+++ b/icu4c/source/test/intltest/usetheaderonlytest.cpp
@@ -1,0 +1,219 @@
+// © 2024 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+
+// usetheaderonlytest.cpp
+// created: 2024dec11 Markus W. Scherer
+
+#include <string>
+
+// Test header-only ICU C++ APIs. Do not use other ICU C++ APIs.
+// Non-default configuration:
+#define U_SHOW_CPLUSPLUS_API 0
+// Default configuration:
+// #define U_SHOW_CPLUSPLUS_HEADER_API 1
+
+#include "unicode/utypes.h"
+#include "unicode/uset.h"
+#include "unicode/utf.h"
+#include "unicode/utf16.h"
+#include "intltest.h"
+
+class USetHeaderOnlyTest : public IntlTest {
+public:
+    USetHeaderOnlyTest() = default;
+
+    void runIndexedTest(int32_t index, UBool exec, const char *&name, char *par=nullptr) override;
+
+    void TestUSetCodePointIterator();
+    void TestUSetRangeIterator();
+    void TestUSetStringIterator();
+    void TestUSetElementIterator();
+};
+
+extern IntlTest *createUSetHeaderOnlyTest() {
+    return new USetHeaderOnlyTest();
+}
+
+void USetHeaderOnlyTest::runIndexedTest(int32_t index, UBool exec, const char *&name, char * /*par*/) {
+    if(exec) {
+        logln("TestSuite USetHeaderOnlyTest: ");
+    }
+    TESTCASE_AUTO_BEGIN;
+    TESTCASE_AUTO(TestUSetCodePointIterator);
+    TESTCASE_AUTO(TestUSetRangeIterator);
+    TESTCASE_AUTO(TestUSetStringIterator);
+    TESTCASE_AUTO(TestUSetElementIterator);
+    TESTCASE_AUTO_END;
+}
+
+std::u16string cpString(UChar32 c) {
+    if (U_IS_BMP(c)) {
+        return {static_cast<char16_t>(c)};
+    } else {
+        return {U16_LEAD(c), U16_TRAIL(c)};
+    }
+}
+
+void USetHeaderOnlyTest::TestUSetCodePointIterator() {
+    IcuTestErrorCode errorCode(*this, "TestUSetCodePointIterator");
+    using U_HEADER_NESTED_NAMESPACE::USetCodePoints;
+    LocalUSetPointer uset(uset_openPattern(u"[abcçカ🚴]", -1, errorCode));
+    std::u16string result;
+    for (UChar32 c : USetCodePoints(uset.getAlias())) {
+        // Commented-out sample code for pasting into the API docs.
+        // printf("uset.codePoint U+%04lx\n", (long)c);
+        result.append(u" ").append(cpString(c));
+    }
+    assertEquals(WHERE, u" a b c ç カ 🚴", result);
+
+    USetCodePoints range1(uset.getAlias());
+    auto range2(range1);  // copy constructor
+    auto iter = range1.begin();
+    auto limit = range2.end();
+    // operator* with pre- and post-increment
+    assertEquals(WHERE, u'a', *iter);
+    ++iter;
+    assertEquals(WHERE, u'b', *iter);
+    assertEquals(WHERE, u'c', *++iter);
+    auto iter2(iter);  // copy constructor
+    assertEquals(WHERE, u'c', *iter2++);
+    assertEquals(WHERE, u'ç', *iter2++);
+    assertEquals(WHERE, u'カ', *iter2);
+    assertTrue(WHERE, ++iter2 != limit);
+    auto iter3(iter2++);
+    assertEquals(WHERE, U'🚴', *iter3);
+    assertTrue(WHERE, iter2 == limit);
+}
+
+void USetHeaderOnlyTest::TestUSetRangeIterator() {
+    IcuTestErrorCode errorCode(*this, "TestUSetRangeIterator");
+    using U_HEADER_NESTED_NAMESPACE::USetRanges;
+    using U_HEADER_NESTED_NAMESPACE::CodePointRange;
+    LocalUSetPointer uset(uset_openPattern(u"[abcçカ🚴]", -1, errorCode));
+    std::u16string result;
+    for (auto [start, end] : USetRanges(uset.getAlias())) {
+        // Commented-out sample code for pasting into the API docs.
+        // printf("uset.range U+%04lx..U+%04lx\n", (long)start, (long)end);
+        result.append(u" ").append(cpString(start)).append(u"-").append(cpString(end));
+    }
+    assertEquals(WHERE, u" a-c ç-ç カ-カ 🚴-🚴", result);
+    result.clear();
+    for (auto range : USetRanges(uset.getAlias())) {
+        for (UChar32 c : range) {
+            // Commented-out sample code for pasting into the API docs.
+            // printf("uset.range.c U+%04lx\n", (long)c);
+            result.append(u" ").append(cpString(c));
+        }
+        result.append(u" |");
+    }
+    assertEquals(WHERE, u" a b c | ç | カ | 🚴 |", result);
+
+    USetRanges range1(uset.getAlias());
+    auto range2(range1);  // copy constructor
+    auto iter = range1.begin();
+    auto limit = range2.end();
+    // operator* with pre- and post-increment
+    {
+        auto cpRange = *iter;
+        assertEquals(WHERE, u'a', cpRange.rangeStart);
+        assertEquals(WHERE, u'c', cpRange.rangeEnd);
+        assertEquals(WHERE, 3, cpRange.size());
+        auto cpRange2(cpRange);
+        auto cpIter = cpRange.begin();
+        auto cpLimit = cpRange2.end();
+        assertEquals(WHERE, u'a', *cpIter++);
+        assertEquals(WHERE, u'b', *cpIter);
+        assertTrue(WHERE, cpIter != cpLimit);
+        CodePointRange::iterator cpIter2(u'b');  // public constructor
+        assertTrue(WHERE, cpIter == cpIter2);
+        assertEquals(WHERE, u'c', *++cpIter);
+        assertTrue(WHERE, cpIter != cpIter2);
+        assertTrue(WHERE, ++cpIter == cpLimit);
+    }
+    ++iter;
+    auto iter2(iter);  // copy constructor
+    assertEquals(WHERE, u'ç', (*iter2).rangeStart);
+    assertEquals(WHERE, u'ç', (*iter2).rangeEnd);
+    assertEquals(WHERE, 1, (*iter2).size());
+    assertEquals(WHERE, u'ç', (*iter2++).rangeStart);
+    assertEquals(WHERE, u'カ', (*iter2).rangeStart);
+    assertTrue(WHERE, ++iter2 != limit);
+    auto iter3(iter2++);
+    assertEquals(WHERE, U'🚴', (*iter3).rangeStart);
+    assertTrue(WHERE, iter2 == limit);
+
+    {
+        CodePointRange cpRange(u'h', u'k');  // public constructor
+        // FYI: currently no operator==
+        assertEquals(WHERE, u'h', cpRange.rangeStart);
+        assertEquals(WHERE, u'k', cpRange.rangeEnd);
+        assertEquals(WHERE, 4, cpRange.size());
+        assertEquals(WHERE, u'i', *++(cpRange.begin()));
+    }
+}
+
+void USetHeaderOnlyTest::TestUSetStringIterator() {
+    IcuTestErrorCode errorCode(*this, "TestUSetStringIterator");
+    using U_HEADER_NESTED_NAMESPACE::USetStrings;
+    LocalUSetPointer uset(uset_openPattern(u"[abcçカ🚴{}{abc}{de}]", -1, errorCode));
+    std::u16string result;
+    for (auto s : USetStrings(uset.getAlias())) {
+        // Commented-out sample code for pasting into the API docs.
+        // Needs U_SHOW_CPLUSPLUS_API=1 for UnicodeString.
+        // UnicodeString us(s);
+        // std::string u8;
+        // printf("uset.string length %ld \"%s\"\n", (long)s.length(), us.toUTF8String(u8).c_str());
+        result.append(u" \"").append(s).append(u"\"");
+    }
+    assertEquals(WHERE, uR"( "" "abc" "de")", result);
+
+    USetStrings range1(uset.getAlias());
+    auto range2(range1);  // copy constructor
+    auto iter = range1.begin();
+    auto limit = range2.end();
+    // operator* with pre- and post-increment
+    assertEquals(WHERE, u"", *iter);
+    assertEquals(WHERE, u"abc", *++iter);
+    auto iter2(iter);  // copy constructor
+    assertEquals(WHERE, u"abc", *iter2++);
+    assertTrue(WHERE, iter2 != limit);
+    auto iter3(iter2++);
+    assertEquals(WHERE, u"de", *iter3);
+    assertTrue(WHERE, iter2 == limit);
+}
+
+void USetHeaderOnlyTest::TestUSetElementIterator() {
+    IcuTestErrorCode errorCode(*this, "TestUSetElementIterator");
+    using U_HEADER_NESTED_NAMESPACE::USetElements;
+    LocalUSetPointer uset(uset_openPattern(u"[abcçカ🚴{}{abc}{de}]", -1, errorCode));
+    std::u16string result;
+    for (auto el : USetElements(uset.getAlias())) {
+        // Commented-out sample code for pasting into the API docs.
+        // Needs U_SHOW_CPLUSPLUS_API=1 for UnicodeString.
+        // UnicodeString us(el);
+        // std::string u8;
+        // printf("uset.string length %ld \"%s\"\n", (long)us.length(), us.toUTF8String(u8).c_str());
+        result.append(u" \"").append(el).append(u"\"");
+    }
+    assertEquals(WHERE, uR"( "a" "b" "c" "ç" "カ" "🚴" "" "abc" "de")", result);
+
+    USetElements range1(uset.getAlias());
+    auto range2(range1);  // copy constructor
+    auto iter = range1.begin();
+    auto limit = range2.end();
+    // operator* with pre- and post-increment
+    assertEquals(WHERE, u"a", *iter);
+    ++iter;
+    assertEquals(WHERE, u"b", *iter);
+    assertEquals(WHERE, u"c", *++iter);
+    auto iter2(iter);  // copy constructor
+    assertEquals(WHERE, u"c", *iter2++);
+    // skip çカ🚴
+    ++++++iter2;
+    assertEquals(WHERE, u"", *iter2++);
+    assertEquals(WHERE, u"abc", *iter2);
+    assertTrue(WHERE, ++iter2 != limit);
+    auto iter3(iter2++);
+    assertEquals(WHERE, u"de", *iter3);
+    assertTrue(WHERE, iter2 == limit);
+}

--- a/icu4c/source/test/intltest/usettest.cpp
+++ b/icu4c/source/test/intltest/usettest.cpp
@@ -4448,8 +4448,9 @@ void UnicodeSetTest::TestElementIterator() {
     UnicodeSet set(u"[abcçカ🚴{}{abc}{de}]", errorCode);
     UnicodeString result;
     for (auto el : set) {
+        // UnicodeString us(el);
         // std::string u8;
-        // printf("set.string length %ld \"%s\"\n", (long)el.length(), el.toUTF8String(u8).c_str());
+        // printf("set.string length %ld \"%s\"\n", (long)us.length(), us.toUTF8String(u8).c_str());
         result.append(u" \"").append(el).append(u'"');
     }
     assertEquals(WHERE, uR"( "a" "b" "c" "ç" "カ" "🚴" "" "abc" "de")", result);
@@ -4463,8 +4464,9 @@ void UnicodeSetTest::TestUSetElementIterator() {
     LocalUSetPointer uset(uset_openPattern(u"[abcçカ🚴{}{abc}{de}]", -1, errorCode));
     UnicodeString result;
     for (auto el : USetElements(uset.getAlias())) {
+        // UnicodeString us(el);
         // std::string u8;
-        // printf("uset.string length %ld \"%s\"\n", (long)el.length(), el.toUTF8String(u8).c_str());
+        // printf("uset.string length %ld \"%s\"\n", (long)us.length(), us.toUTF8String(u8).c_str());
         result.append(u" \"").append(el).append(u'"');
     }
     assertEquals(WHERE, uR"( "a" "b" "c" "ç" "カ" "🚴" "" "abc" "de")", result);

--- a/icu4c/source/test/intltest/usettest.cpp
+++ b/icu4c/source/test/intltest/usettest.cpp
@@ -107,13 +107,9 @@ UnicodeSetTest::runIndexedTest(int32_t index, UBool exec,
     TESTCASE_AUTO(TestSkipToStrings);
     TESTCASE_AUTO(TestPatternCodePointComplement);
     TESTCASE_AUTO(TestCodePointIterator);
-    TESTCASE_AUTO(TestUSetCodePointIterator);
     TESTCASE_AUTO(TestRangeIterator);
-    TESTCASE_AUTO(TestUSetRangeIterator);
     TESTCASE_AUTO(TestStringIterator);
-    TESTCASE_AUTO(TestUSetStringIterator);
     TESTCASE_AUTO(TestElementIterator);
-    TESTCASE_AUTO(TestUSetElementIterator);
     TESTCASE_AUTO_END;
 }
 
@@ -4280,37 +4276,8 @@ void UnicodeSetTest::TestCodePointIterator() {
     }
     assertEquals(WHERE, u" a b c ç カ 🚴", result);
 
-    // codePoints() returns USetCodePoints for which explicit APIs are tested via USet.
-}
-
-void UnicodeSetTest::TestUSetCodePointIterator() {
-    IcuTestErrorCode errorCode(*this, "TestUSetCodePointIterator");
-    using U_HEADER_NESTED_NAMESPACE::USetCodePoints;
-    LocalUSetPointer uset(uset_openPattern(u"[abcçカ🚴]", -1, errorCode));
-    UnicodeString result;
-    for (UChar32 c : USetCodePoints(uset.getAlias())) {
-        // printf("uset.codePoint U+%04lx\n", (long)c);
-        result.append(u' ').append(c);
-    }
-    assertEquals(WHERE, u" a b c ç カ 🚴", result);
-
-    USetCodePoints range1(uset.getAlias());
-    auto range2(range1);  // copy constructor
-    auto iter = range1.begin();
-    auto limit = range2.end();
-    // operator* with pre- and post-increment
-    assertEquals(WHERE, u'a', *iter);
-    ++iter;
-    assertEquals(WHERE, u'b', *iter);
-    assertEquals(WHERE, u'c', *++iter);
-    auto iter2(iter);  // copy constructor
-    assertEquals(WHERE, u'c', *iter2++);
-    assertEquals(WHERE, u'ç', *iter2++);
-    assertEquals(WHERE, u'カ', *iter2);
-    assertTrue(WHERE, ++iter2 != limit);
-    auto iter3(iter2++);
-    assertEquals(WHERE, U'🚴', *iter3);
-    assertTrue(WHERE, iter2 == limit);
+    // codePoints() returns USetCodePoints for which explicit APIs are tested via USet
+    // in a header-only unit test file.
 }
 
 void UnicodeSetTest::TestRangeIterator() {
@@ -4332,72 +4299,8 @@ void UnicodeSetTest::TestRangeIterator() {
     }
     assertEquals(WHERE, u" a b c | ç | カ | 🚴 |", result);
 
-    // ranges() returns USetRanges for which explicit APIs are tested via USet.
-}
-
-void UnicodeSetTest::TestUSetRangeIterator() {
-    IcuTestErrorCode errorCode(*this, "TestUSetRangeIterator");
-    using U_HEADER_NESTED_NAMESPACE::USetRanges;
-    using U_HEADER_NESTED_NAMESPACE::CodePointRange;
-    LocalUSetPointer uset(uset_openPattern(u"[abcçカ🚴]", -1, errorCode));
-    UnicodeString result;
-    for (auto [start, end] : USetRanges(uset.getAlias())) {
-        // printf("uset.range U+%04lx..U+%04lx\n", (long)start, (long)end);
-        result.append(u' ').append(start).append(u'-').append(end);
-    }
-    assertEquals(WHERE, u" a-c ç-ç カ-カ 🚴-🚴", result);
-    result.remove();
-    for (auto range : USetRanges(uset.getAlias())) {
-        for (UChar32 c : range) {
-            // printf("uset.range.c U+%04lx\n", (long)c);
-            result.append(u' ').append(c);
-        }
-        result.append(u" |");
-    }
-    assertEquals(WHERE, u" a b c | ç | カ | 🚴 |", result);
-
-    USetRanges range1(uset.getAlias());
-    auto range2(range1);  // copy constructor
-    auto iter = range1.begin();
-    auto limit = range2.end();
-    // operator* with pre- and post-increment
-    {
-        auto cpRange = *iter;
-        assertEquals(WHERE, u'a', cpRange.rangeStart);
-        assertEquals(WHERE, u'c', cpRange.rangeEnd);
-        assertEquals(WHERE, 3, cpRange.size());
-        auto cpRange2(cpRange);
-        auto cpIter = cpRange.begin();
-        auto cpLimit = cpRange2.end();
-        assertEquals(WHERE, u'a', *cpIter++);
-        assertEquals(WHERE, u'b', *cpIter);
-        assertTrue(WHERE, cpIter != cpLimit);
-        CodePointRange::iterator cpIter2(u'b');  // public constructor
-        assertTrue(WHERE, cpIter == cpIter2);
-        assertEquals(WHERE, u'c', *++cpIter);
-        assertTrue(WHERE, cpIter != cpIter2);
-        assertTrue(WHERE, ++cpIter == cpLimit);
-    }
-    ++iter;
-    auto iter2(iter);  // copy constructor
-    assertEquals(WHERE, u'ç', (*iter2).rangeStart);
-    assertEquals(WHERE, u'ç', (*iter2).rangeEnd);
-    assertEquals(WHERE, 1, (*iter2).size());
-    assertEquals(WHERE, u'ç', (*iter2++).rangeStart);
-    assertEquals(WHERE, u'カ', (*iter2).rangeStart);
-    assertTrue(WHERE, ++iter2 != limit);
-    auto iter3(iter2++);
-    assertEquals(WHERE, U'🚴', (*iter3).rangeStart);
-    assertTrue(WHERE, iter2 == limit);
-
-    {
-        CodePointRange cpRange(u'h', u'k');  // public constructor
-        // FYI: currently no operator==
-        assertEquals(WHERE, u'h', cpRange.rangeStart);
-        assertEquals(WHERE, u'k', cpRange.rangeEnd);
-        assertEquals(WHERE, 4, cpRange.size());
-        assertEquals(WHERE, u'i', *++(cpRange.begin()));
-    }
+    // ranges() returns USetRanges for which explicit APIs are tested via USet
+    // in a header-only unit test file.
 }
 
 void UnicodeSetTest::TestStringIterator() {
@@ -4412,35 +4315,8 @@ void UnicodeSetTest::TestStringIterator() {
     }
     assertEquals(WHERE, uR"( "" "abc" "de")", result);
 
-    // strings() returns USetStrins for which explicit APIs are tested via USet.
-}
-
-void UnicodeSetTest::TestUSetStringIterator() {
-    IcuTestErrorCode errorCode(*this, "TestUSetStringIterator");
-    using U_HEADER_NESTED_NAMESPACE::USetStrings;
-    LocalUSetPointer uset(uset_openPattern(u"[abcçカ🚴{}{abc}{de}]", -1, errorCode));
-    UnicodeString result;
-    for (auto s : USetStrings(uset.getAlias())) {
-        // UnicodeString us(s);
-        // std::string u8;
-        // printf("uset.string length %ld \"%s\"\n", (long)s.length(), us.toUTF8String(u8).c_str());
-        result.append(u" \"").append(s).append(u'"');
-    }
-    assertEquals(WHERE, uR"( "" "abc" "de")", result);
-
-    USetStrings range1(uset.getAlias());
-    auto range2(range1);  // copy constructor
-    auto iter = range1.begin();
-    auto limit = range2.end();
-    // operator* with pre- and post-increment
-    assertEquals(WHERE, UnicodeString(), UnicodeString(*iter));
-    assertEquals(WHERE, u"abc", UnicodeString(*++iter));
-    auto iter2(iter);  // copy constructor
-    assertEquals(WHERE, u"abc", UnicodeString(*iter2++));
-    assertTrue(WHERE, iter2 != limit);
-    auto iter3(iter2++);
-    assertEquals(WHERE, u"de", UnicodeString(*iter3));
-    assertTrue(WHERE, iter2 == limit);
+    // strings() returns USetStrins for which explicit APIs are tested via USet
+    // in a header-only unit test file.
 }
 
 void UnicodeSetTest::TestElementIterator() {
@@ -4455,39 +4331,6 @@ void UnicodeSetTest::TestElementIterator() {
     }
     assertEquals(WHERE, uR"( "a" "b" "c" "ç" "カ" "🚴" "" "abc" "de")", result);
 
-    // begin() & end() return USetElementIterator for which explicit APIs are tested via USet.
-}
-
-void UnicodeSetTest::TestUSetElementIterator() {
-    IcuTestErrorCode errorCode(*this, "TestUSetElementIterator");
-    using U_HEADER_NESTED_NAMESPACE::USetElements;
-    LocalUSetPointer uset(uset_openPattern(u"[abcçカ🚴{}{abc}{de}]", -1, errorCode));
-    UnicodeString result;
-    for (auto el : USetElements(uset.getAlias())) {
-        // UnicodeString us(el);
-        // std::string u8;
-        // printf("uset.string length %ld \"%s\"\n", (long)us.length(), us.toUTF8String(u8).c_str());
-        result.append(u" \"").append(el).append(u'"');
-    }
-    assertEquals(WHERE, uR"( "a" "b" "c" "ç" "カ" "🚴" "" "abc" "de")", result);
-
-    USetElements range1(uset.getAlias());
-    auto range2(range1);  // copy constructor
-    auto iter = range1.begin();
-    auto limit = range2.end();
-    // operator* with pre- and post-increment
-    assertEquals(WHERE, u"a", *iter);
-    ++iter;
-    assertEquals(WHERE, u"b", *iter);
-    assertEquals(WHERE, u"c", *++iter);
-    auto iter2(iter);  // copy constructor
-    assertEquals(WHERE, u"c", *iter2++);
-    // skip çカ🚴
-    ++++++iter2;
-    assertEquals(WHERE, UnicodeString(), *iter2++);
-    assertEquals(WHERE, u"abc", *iter2);
-    assertTrue(WHERE, ++iter2 != limit);
-    auto iter3(iter2++);
-    assertEquals(WHERE, u"de", *iter3);
-    assertTrue(WHERE, iter2 == limit);
+    // begin() & end() return USetElementIterator for which explicit APIs are tested via USet
+    // in a header-only unit test file.
 }

--- a/icu4c/source/test/intltest/usettest.h
+++ b/icu4c/source/test/intltest/usettest.h
@@ -106,13 +106,9 @@ private:
     void TestPatternCodePointComplement();
 
     void TestCodePointIterator();
-    void TestUSetCodePointIterator();
     void TestRangeIterator();
-    void TestUSetRangeIterator();
     void TestStringIterator();
-    void TestUSetStringIterator();
     void TestElementIterator();
-    void TestUSetElementIterator();
 
 private:
 

--- a/icu4c/source/test/iotest/iotest.cpp
+++ b/icu4c/source/test/iotest/iotest.cpp
@@ -14,6 +14,9 @@
 *   created by: George Rhoten
 */
 
+#include <string.h>
+#include <stdlib.h>
+#include <string_view>
 
 #include "unicode/ustdio.h"
 #include "unicode/uclean.h"
@@ -28,9 +31,6 @@
 #include "unicode/tstdtmod.h"
 #include "putilimp.h"
 
-#include <string.h>
-#include <stdlib.h>
-
 class DataDrivenLogger : public TestLog {
     static const char* fgDataDir;
     static char *fgTestDataPath;
@@ -42,23 +42,26 @@ public:
             fgTestDataPath = nullptr;
         }
     }
-    virtual void errln( const UnicodeString &message ) override {
+    virtual void errln(std::u16string_view message) override {
         char buffer[4000];
-        message.extract(0, message.length(), buffer, sizeof(buffer));
+        UnicodeString us(message);
+        us.extract(0, us.length(), buffer, sizeof(buffer));
         buffer[3999] = 0; /* NUL terminate */
         log_err(buffer);
     }
 
-    virtual void logln( const UnicodeString &message ) override {
+    virtual void logln(std::u16string_view message) override {
         char buffer[4000];
-        message.extract(0, message.length(), buffer, sizeof(buffer));
+        UnicodeString us(message);
+        us.extract(0, us.length(), buffer, sizeof(buffer));
         buffer[3999] = 0; /* NUL terminate */
         log_info(buffer);
     }
 
-    virtual void dataerrln( const UnicodeString &message ) override {
+    virtual void dataerrln(std::u16string_view message) override {
         char buffer[4000];
-        message.extract(0, message.length(), buffer, sizeof(buffer));
+        UnicodeString us(message);
+        us.extract(0, us.length(), buffer, sizeof(buffer));
         buffer[3999] = 0; /* NUL terminate */
         log_data_err(buffer);
     }

--- a/icu4c/source/tools/ctestfw/tstdtmod.cpp
+++ b/icu4c/source/tools/ctestfw/tstdtmod.cpp
@@ -25,6 +25,22 @@ IcuTestErrorCode::~IcuTestErrorCode() {
     }
 }
 
+UErrorCode IcuTestErrorCode::reset() {
+    UErrorCode code = errorCode;
+    errorCode = U_ZERO_ERROR;
+    return code;
+}
+
+void IcuTestErrorCode::assertSuccess() const {
+    if(isFailure()) {
+        handleFailure();
+    }
+}
+
+const char* IcuTestErrorCode::errorName() const {
+    return u_errorName(errorCode);
+}
+
 UBool IcuTestErrorCode::errIfFailureAndReset() {
     if(isFailure()) {
         errlog(false, u"expected success", nullptr);
@@ -103,10 +119,11 @@ UBool IcuTestErrorCode::expectErrorAndReset(UErrorCode expectedError, const char
 }
 
 void IcuTestErrorCode::setScope(const char* message) {
-    scopeMessage.remove().append({ message, -1, US_INV });
+    UnicodeString us(message, -1, US_INV);
+    scopeMessage = us;
 }
 
-void IcuTestErrorCode::setScope(const UnicodeString& message) {
+void IcuTestErrorCode::setScope(std::u16string_view message) {
     scopeMessage = message;
 }
 
@@ -114,12 +131,12 @@ void IcuTestErrorCode::handleFailure() const {
     errlog(false, u"(handleFailure)", nullptr);
 }
 
-void IcuTestErrorCode::errlog(UBool dataErr, const UnicodeString& mainMessage, const char* extraMessage) const {
+void IcuTestErrorCode::errlog(UBool dataErr, std::u16string_view mainMessage, const char* extraMessage) const {
     UnicodeString msg(testName, -1, US_INV);
     msg.append(u' ').append(mainMessage);
     msg.append(u" but got error: ").append(UnicodeString(errorName(), -1, US_INV));
 
-    if (!scopeMessage.isEmpty()) {
+    if (!scopeMessage.empty()) {
         msg.append(u" scope: ").append(scopeMessage);
     }
 

--- a/icu4c/source/tools/ctestfw/unicode/testlog.h
+++ b/icu4c/source/tools/ctestfw/unicode/testlog.h
@@ -13,8 +13,9 @@
 #ifndef U_TESTFW_TESTLOG
 #define U_TESTFW_TESTLOG
 
-#include "unicode/errorcode.h"
-#include "unicode/unistr.h"
+#include <string>
+#include <string_view>
+#include "unicode/utypes.h"
 #include "unicode/testtype.h"
 
 /** Facilitates internal logging of data driven test service 
@@ -24,17 +25,33 @@
 class T_CTEST_EXPORT_API TestLog {
 public:
     virtual ~TestLog();
-    virtual void errln( const UnicodeString &message ) = 0;
-    virtual void logln( const UnicodeString &message ) = 0;
-    virtual void dataerrln( const UnicodeString &message ) = 0;
+    virtual void errln(std::u16string_view message) = 0;
+    virtual void logln(std::u16string_view message) = 0;
+    virtual void dataerrln(std::u16string_view message) = 0;
     virtual const char* getTestDataPath(UErrorCode& err) = 0;
 };
 
-class T_CTEST_EXPORT_API IcuTestErrorCode : public ErrorCode {
+// Note: The IcuTestErrorCode used to be a subclass of ErrorCode, but that made it not usable for
+// unit tests that work without U_SHOW_CPLUSPLUS_API.
+// So instead we *copy* the ErrorCode API.
+
+class T_CTEST_EXPORT_API IcuTestErrorCode {
 public:
     IcuTestErrorCode(TestLog &callingTestClass, const char *callingTestName)
-            : testClass(callingTestClass), testName(callingTestName), scopeMessage() {}
+            : errorCode(U_ZERO_ERROR),
+              testClass(callingTestClass), testName(callingTestName), scopeMessage() {}
     virtual ~IcuTestErrorCode();
+
+    // ErrorCode API
+    operator UErrorCode & () { return errorCode; }
+    operator UErrorCode * () { return &errorCode; }
+    UBool isSuccess() const { return U_SUCCESS(errorCode); }
+    UBool isFailure() const { return U_FAILURE(errorCode); }
+    UErrorCode get() const { return errorCode; }
+    void set(UErrorCode value) { errorCode=value; }
+    UErrorCode reset();
+    void assertSuccess() const;
+    const char* errorName() const;
 
     // Returns true if isFailure().
     UBool errIfFailureAndReset();
@@ -46,17 +63,18 @@ public:
 
     /** Sets an additional message string to be appended to failure output. */
     void setScope(const char* message);
-    void setScope(const UnicodeString& message);
+    void setScope(std::u16string_view message);
 
 protected:
-    virtual void handleFailure() const override;
+    virtual void handleFailure() const;
 
 private:
+    UErrorCode errorCode;
     TestLog &testClass;
     const char *const testName;
-    UnicodeString scopeMessage;
+    std::u16string scopeMessage;
 
-    void errlog(UBool dataErr, const UnicodeString& mainMessage, const char* extraMessage) const;
+    void errlog(UBool dataErr, std::u16string_view mainMessage, const char* extraMessage) const;
 };
 
 #endif


### PR DESCRIPTION
- ICU-22954 Build error in uset.h when `U_SHOW_CPLUSPLUS_HEADER_API` is true but `U_SHOW_CPLUSPLUS_API` is false
    - USet C++ iterator return std::u16string instead of a not-header-only icu::UnicodeString
    - Change USetElements to draft ICU 77 because of this change
    - Make the intltest C++ test framework work without U_SHOW_CPLUSPLUS_API by
        - switching from UnicodeString arguments to std::u16string_view
        - decoupling IcuTestErrorCode from the DLL-exported class ErrorCode
    - Test header-only USet C++ iterators in an intltest file with U_SHOW_CPLUSPLUS_API=0
- ICU-22980 make localpointer.h header-only compatible, and parts of char16ptr.h
    - Add U_ICU_NAMESPACE_OR_INTERNAL = icu or icu::internal
    - Change localpointer.h to be header-only and work with just U_SHOW_CPLUSPLUS_HEADER_API
    - (Const)Char16Ptr need to remain DLL-exported because they are baked into DLL-exported APIs in UnicodeString member function signatures

Best to review one commit at a time.

#### Checklist
- [x] Required: Issue filed: ICU-22954
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable

ALLOW_MANY_COMMITS=true