### PR TITLE
ICU-22920 Fix raw type warnings in icu4j core tests

### DIFF
--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/ModuleTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/ModuleTest.java
@@ -70,7 +70,7 @@ public class ModuleTest {
         Iterator<TestData> tIter = m.getTestDataIterator();
         while (tIter.hasNext()) {
             TestData t = tIter.next();
-            for (Iterator siter = t.getSettingsIterator(); siter.hasNext();) {
+            for (Iterator<DataMap> siter = t.getSettingsIterator(); siter.hasNext();) {
                 DataMap settings = (DataMap) siter.next();
                 list.add(new TestDataPair(t, settings));
             }

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/ResourceModule.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/ResourceModule.java
@@ -103,9 +103,9 @@ class ResourceModule implements TestDataModule {
         return new UResourceTestData(defaultHeader, testData.get(testName));
     }
 
-    public Iterator getTestDataIterator() {
-        return new IteratorAdapter(testData){
-            protected Object prepareNext(UResourceBundle nextRes) throws DataModuleFormatError {
+    public Iterator<TestData> getTestDataIterator() {
+        return new IteratorAdapter<TestData>(testData){
+            protected TestData prepareNext(UResourceBundle nextRes) throws DataModuleFormatError {
                 return new UResourceTestData(defaultHeader, nextRes);
             }
         };
@@ -116,11 +116,12 @@ class ResourceModule implements TestDataModule {
      * and return various data-driven test object for next() call
      * 
      * @author Raymond Yang
+     * @param <T>
      */
-    private abstract static class IteratorAdapter implements Iterator{
+    private abstract static class IteratorAdapter<T> implements Iterator<T>{
         private UResourceBundle res;
         private UResourceBundleIterator itr;
-        private Object preparedNextElement = null;
+        private T preparedNextElement = null;
         // fix a strange behavior for UResourceBundleIterator for 
         // UResourceBundle.STRING. It support hasNext(), but does 
         // not support next() now. 
@@ -178,9 +179,9 @@ class ResourceModule implements TestDataModule {
             }
         }
 
-        public Object next(){
+        public T next(){
             if (hasNext()) {
-                Object t = preparedNextElement;
+                T t = preparedNextElement;
                 preparedNextElement = null;
                 return t;
             } else {
@@ -190,7 +191,7 @@ class ResourceModule implements TestDataModule {
         /**
          * To prepare data-driven test object for next() call, should not return null
          */
-        abstract protected Object prepareNext(UResourceBundle nextRes) throws DataModuleFormatError;
+        abstract protected T prepareNext(UResourceBundle nextRes) throws DataModuleFormatError;
     }
     
     
@@ -327,21 +328,21 @@ class ResourceModule implements TestDataModule {
             return info == null ? null : new UTableResource(info);
         }
 
-        public Iterator getSettingsIterator() {
+        public Iterator<DataMap> getSettingsIterator() {
             assert_is (settings.getType() == UResourceBundle.ARRAY);
-            return new IteratorAdapter(settings){
-                protected Object prepareNext(UResourceBundle nextRes) throws DataModuleFormatError {
+            return new IteratorAdapter<DataMap>(settings){
+                protected DataMap prepareNext(UResourceBundle nextRes) throws DataModuleFormatError {
                     return new UTableResource(nextRes);
                 }
             };
         }
 
-        public Iterator getDataIterator() {
+        public Iterator<DataMap> getDataIterator() {
             // unfortunately,
             assert_is (data.getType() == UResourceBundle.ARRAY 
                  || data.getType() == UResourceBundle.STRING);
-            return new IteratorAdapter(data){
-                protected Object prepareNext(UResourceBundle nextRes) throws DataModuleFormatError {
+            return new IteratorAdapter<DataMap>(data){
+                protected DataMap prepareNext(UResourceBundle nextRes) throws DataModuleFormatError {
                     return new UArrayResource(header, nextRes);
                 }
             };
@@ -370,7 +371,7 @@ class ResourceModule implements TestDataModule {
     }
     
     private static class UArrayResource implements DataMap{
-        private Map theMap; 
+        private Map<String, Object> theMap; 
         UArrayResource(UResourceBundle theHeader, UResourceBundle theData) throws DataModuleFormatError{
             assert_is (theHeader != null && theData != null);
             String[] header;
@@ -378,7 +379,7 @@ class ResourceModule implements TestDataModule {
             header = getStringArrayHelper(theHeader);
             if (theData.getSize() != header.length) 
                 throw new DataModuleFormatError("The count of Header and Data is mismatch.");
-            theMap = new HashMap();
+            theMap = new HashMap<>();
             for (int i = 0; i < header.length; i++) {
                 if(theData.getType()==UResourceBundle.ARRAY){
                     theMap.put(header[i], theData.get(i));

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/TestBoilerplate.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/TestBoilerplate.java
@@ -129,12 +129,12 @@ public abstract class TestBoilerplate<T> extends TestFmwk {
      * @return clone
      */
     protected T _clone(T a) throws Exception {
-        Class aClass = a.getClass();
+        Class<?> aClass = a.getClass();
         try {
             Method cloner = aClass.getMethod("clone", (Class[])null);
             return (T) cloner.invoke(a,(Object[])null);
         } catch (NoSuchMethodException e) {
-            Constructor constructor = aClass.getConstructor(new Class[] {aClass});
+            Constructor<?> constructor = aClass.getConstructor(new Class[] {aClass});
             return (T) constructor.newInstance(new Object[]{a});
         }
     }
@@ -150,26 +150,25 @@ public abstract class TestBoilerplate<T> extends TestFmwk {
         return false;
     }
 
-    public static boolean verifySetsIdentical(AbstractTestLog here, Set values1, Set values2) {
+    public static <T> boolean verifySetsIdentical(AbstractTestLog here, Set<T> values1, Set<T> values2) {
         if (values1.equals(values2)) return true;
-        Set temp;
+        Set<T> temp;
         TestFmwk.errln("Values differ:");
         TestFmwk.errln("UnicodeMap - HashMap");
-        temp = new TreeSet(values1);
+        temp = new TreeSet<>(values1);
         temp.removeAll(values2);
         TestFmwk.errln(show(temp));
         TestFmwk.errln("HashMap - UnicodeMap");
-        temp = new TreeSet(values2);
+        temp = new TreeSet<>(values2);
         temp.removeAll(values1);
         TestFmwk.errln(show(temp));
         return false;
     }
-    
-    public static String show(Map m) {
+
+    public static <K, V> String show(Map<K, V> m) {
         StringBuilder buffer = new StringBuilder();
-        for (Iterator it = m.keySet().iterator(); it.hasNext();) {
-            Object key = it.next();
-            buffer.append(key + "=>" + m.get(key) + "\r\n");
+        for (Map.Entry<K, V> e : m.entrySet()) {
+            buffer.append(e.getKey() + "=>" + e.getValue() + "\r\n");
         }
         return buffer.toString();
     }
@@ -184,11 +183,11 @@ public abstract class TestBoilerplate<T> extends TestFmwk {
         }
         return result;
     }
-    
-    public static String show(Collection c) {
+
+    public static <T> String show(Collection<T> c) {
         StringBuilder buffer = new StringBuilder();
-        for (Iterator it = c.iterator(); it.hasNext();) {
-            buffer.append(it.next() + "\r\n");
+        for (T item : c) {
+            buffer.append(item + "\r\n");
         }
         return buffer.toString();
     }

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/TestDataModule.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/TestDataModule.java
@@ -36,7 +36,7 @@ public interface TestDataModule {
     /**
      * @return Iterator<TestData>
      */
-    public Iterator getTestDataIterator();
+    public Iterator<TestData> getTestDataIterator();
 
     public static class Factory{
 
@@ -74,11 +74,11 @@ public interface TestDataModule {
         /**
          * @return Iterator<DataMap>
          */
-        public Iterator getSettingsIterator();
+        public Iterator<DataMap> getSettingsIterator();
         /**
          * @return Iterator<DataMap>
          */
-        public Iterator getDataIterator();
+        public Iterator<DataMap> getDataIterator();
     }
 
     /**

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/UnicodeMapBoilerplateTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/UnicodeMapBoilerplateTest.java
@@ -17,7 +17,7 @@ import com.ibm.icu.impl.UnicodeMap;
 /**
  * Moved from UnicodeMapTest
  */
-public class UnicodeMapBoilerplateTest extends TestBoilerplate<UnicodeMap> {
+public class UnicodeMapBoilerplateTest extends TestBoilerplate<UnicodeMap<String>> {
 
     private static String[] TEST_VALUES = {"A", "B", "C", "D", "E", "F"};
 
@@ -32,7 +32,7 @@ public class UnicodeMapBoilerplateTest extends TestBoilerplate<UnicodeMap> {
     /* (non-Javadoc)
      * @see com.ibm.icu.dev.test.TestBoilerplate#_hasSameBehavior(java.lang.Object, java.lang.Object)
      */
-    protected boolean _hasSameBehavior(UnicodeMap a, UnicodeMap b) {
+    protected boolean _hasSameBehavior(UnicodeMap<String> a, UnicodeMap<String> b) {
         // we are pretty confident in the equals method, so won't bother with this right now.
         return true;
     }
@@ -40,9 +40,9 @@ public class UnicodeMapBoilerplateTest extends TestBoilerplate<UnicodeMap> {
     /* (non-Javadoc)
      * @see com.ibm.icu.dev.test.TestBoilerplate#_addTestObject(java.util.List)
      */
-    protected boolean _addTestObject(List<UnicodeMap> list) {
+    protected boolean _addTestObject(List<UnicodeMap<String>> list) {
         if (list.size() > 30) return false;
-        UnicodeMap result = new UnicodeMap();
+        UnicodeMap<String> result = new UnicodeMap<>();
         for (int i = 0; i < 50; ++i) {
             int start = random.nextInt(25);
             String value = TEST_VALUES[random.nextInt(TEST_VALUES.length)];

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/UnicodeMapTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/UnicodeMapTest.java
@@ -13,7 +13,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
@@ -46,7 +45,7 @@ public class UnicodeMapTest extends TestFmwk {
 
     @Test
     public void TestIterations() {
-        UnicodeMap<Double> foo = new UnicodeMap();
+        UnicodeMap<Double> foo = new UnicodeMap<>();
         checkToString(foo, "");
         foo.put(3, 6d).put(5, 10d);
         checkToString(foo, "0003=6.0\n0005=10.0\n");
@@ -64,7 +63,7 @@ public class UnicodeMapTest extends TestFmwk {
 
     public void checkToString(UnicodeMap<Double> foo, String expected) {
         StringJoiner joiner = new StringJoiner("\n");
-        for (UnicodeMap.EntryRange range : foo.entryRanges()) {
+        for (UnicodeMap.EntryRange<Double> range : foo.entryRanges()) {
             joiner.add(range.toString());
         }
         assertEquals("EntryRange<T>", expected, joiner.toString() + (foo.size() == 0 ? "" : "\n"));
@@ -73,30 +72,30 @@ public class UnicodeMapTest extends TestFmwk {
 
     @Test
     public void TestRemove() {
-        UnicodeMap<Double> foo = new UnicodeMap()
-        .putAll(0x20, 0x29, -2d)
-        .put("abc", 3d)
-        .put("xy", 2d)
-        .put("mark", 4d)
-        .freeze();
-        UnicodeMap<Double> fii = new UnicodeMap()
-        .putAll(0x21, 0x25, -2d)
-        .putAll(0x26, 0x28, -3d)
-        .put("abc", 3d)
-        .put("mark", 999d)
-        .freeze();
+        UnicodeMap<Double> foo = new UnicodeMap<Double>()
+                .putAll(0x20, 0x29, -2d)
+                .put("abc", 3d)
+                .put("xy", 2d)
+                .put("mark", 4d)
+                .freeze();
+        UnicodeMap<Double> fii = new UnicodeMap<Double>()
+                .putAll(0x21, 0x25, -2d)
+                .putAll(0x26, 0x28, -3d)
+                .put("abc", 3d)
+                .put("mark", 999d)
+                .freeze();
 
-        UnicodeMap<Double> afterFiiRemoval = new UnicodeMap()
-        .put(0x20, -2d)
-        .putAll(0x26, 0x29, -2d)
-        .put("xy", 2d)
-        .put("mark", 4d)
-        .freeze();
+        UnicodeMap<Double> afterFiiRemoval = new UnicodeMap<Double>()
+                .put(0x20, -2d)
+                .putAll(0x26, 0x29, -2d)
+                .put("xy", 2d)
+                .put("mark", 4d)
+                .freeze();
 
-        UnicodeMap<Double> afterFiiRetained = new UnicodeMap()
-        .putAll(0x21, 0x25, -2d)
-        .put("abc", 3d)
-        .freeze();
+        UnicodeMap<Double> afterFiiRetained = new UnicodeMap<Double>()
+                .putAll(0x21, 0x25, -2d)
+                .put("abc", 3d)
+                .freeze();
 
         UnicodeMap<Double> test = new UnicodeMap<Double>().putAll(foo)
                 .removeAll(fii);
@@ -117,7 +116,7 @@ public class UnicodeMapTest extends TestFmwk {
         me.remove(0x10FFFF);
 
         int iterations = 100000;
-        SortedMap<String,Integer> test = new TreeMap();
+        SortedMap<String,Integer> test = new TreeMap<>();
 
         Random rand = new Random(0);
         String other;
@@ -178,17 +177,16 @@ public class UnicodeMapTest extends TestFmwk {
         return test;
     }
 
-    Set temp = new HashSet();
     /**
      * @param me
      * @param stayWithMe
      */
     private void checkEquals(UnicodeMap<Integer> me, SortedMap<String, Integer> stayWithMe) {
-        temp.clear();
-        for (Entry<String, Integer> e : me.entrySet()) {
+        Set<Map.Entry<String, Integer>> temp = new HashSet<>();
+        for (Map.Entry<String, Integer> e : me.entrySet()) {
             temp.add(e);
         }
-        Set<Entry<String, Integer>> entrySet = stayWithMe.entrySet();
+        Set<Map.Entry<String, Integer>> entrySet = stayWithMe.entrySet();
         if (!entrySet.equals(temp)) {
             logln(me.entrySet().toString());
             logln(me.toString());
@@ -260,8 +258,8 @@ public class UnicodeMapTest extends TestFmwk {
     @Test
     public void TestModify() {
         Random random = new Random(0);
-        UnicodeMap unicodeMap = new UnicodeMap();
-        HashMap hashMap = new HashMap();
+        UnicodeMap<String> unicodeMap = new UnicodeMap<>();
+        HashMap<Integer, String> hashMap = new HashMap<>();
         String[] values = {null, "the", "quick", "brown", "fox"};
         for (int count = 1; count <= MODIFY_TEST_ITERATIONS; ++count) {
             String value = values[random.nextInt(values.length)];
@@ -291,10 +289,10 @@ public class UnicodeMapTest extends TestFmwk {
         }
     }
 
-    private boolean hasSameValues(UnicodeMap unicodeMap, HashMap hashMap) {
+    private boolean hasSameValues(UnicodeMap<String> unicodeMap, HashMap<Integer, String> hashMap) {
         for (int i = 0; i < MODIFY_TEST_LIMIT; ++i) {
-            Object unicodeMapValue = unicodeMap.getValue(i);
-            Object hashMapValue = hashMap.get(i);
+            String unicodeMapValue = unicodeMap.getValue(i);
+            String hashMapValue = hashMap.get(i);
             if (unicodeMapValue != hashMapValue) {
                 return false;
             }
@@ -304,7 +302,7 @@ public class UnicodeMapTest extends TestFmwk {
 
     @Test
     public void TestCloneAsThawed11721 () {
-        UnicodeMap<Integer> test = new UnicodeMap().put("abc", 3).freeze();
+        UnicodeMap<Integer> test = new UnicodeMap<Integer>().put("abc", 3).freeze();
         UnicodeMap<Integer> copy = test.cloneAsThawed();
         copy.put("def", 4);
         assertEquals("original-abc", (Integer) 3, test.get("abc"));
@@ -326,7 +324,7 @@ public class UnicodeMapTest extends TestFmwk {
         // do random change to both, then compare
         random.setSeed(12345); // reproducible results
         logln("Comparing against HashMap");
-        UnicodeMap<String> map1 = new UnicodeMap();
+        UnicodeMap<String> map1 = new UnicodeMap<>();
         Map<Integer, String> map2 = new HashMap<Integer, String>();
         for (int counter = 0; counter < ITERATIONS; ++counter) {
             int start = random.nextInt(LIMIT);
@@ -349,7 +347,7 @@ public class UnicodeMapTest extends TestFmwk {
     @Test
     public void TestUnicodeMapGeneralCategory() {
         logln("Setting General Category");
-        UnicodeMap<String> map1 = new UnicodeMap();
+        UnicodeMap<String> map1 = new UnicodeMap<>();
         Map<Integer, String> map2 = new HashMap<Integer, String>();
         //Map<Integer, String> map3 = new TreeMap<Integer, String>();
         map1 = new UnicodeMap<String>();
@@ -396,11 +394,11 @@ public class UnicodeMapTest extends TestFmwk {
 
     @Test
     public void TestAUnicodeMap2() {
-        UnicodeMap foo = new UnicodeMap();
+        UnicodeMap<String> foo = new UnicodeMap<>();
         @SuppressWarnings("unused")
         int hash = foo.hashCode(); // make sure doesn't NPE
         @SuppressWarnings("unused")
-        Set fii = foo.stringKeys(); // make sure doesn't NPE
+        Set<String> fii = foo.stringKeys(); // make sure doesn't NPE
     }
 
     @Test
@@ -413,13 +411,13 @@ public class UnicodeMapTest extends TestFmwk {
                 ;
         Map<Character, UnicodeSet> target = new HashMap<Character, UnicodeSet>();
         foo1.addInverseTo(target);
-        UnicodeMap<Character> reverse = new UnicodeMap().putAllInverse(target);
+        UnicodeMap<Character> reverse = new UnicodeMap<Character>().putAllInverse(target);
         assertEquals("", foo1, reverse);
     }
 
     private void checkNext(UnicodeMap<String> map1, Map<Integer,String> map2, int limit) {
         logln("Comparing nextRange");
-        Map localMap = new TreeMap();
+        Map<Integer, String> localMap = new TreeMap<>();
         UnicodeMapIterator<String> mi = new UnicodeMapIterator<String>(map1);
         while (mi.nextRange()) {
             logln(Utility.hex(mi.codepoint) + ".." + Utility.hex(mi.codepointEnd) + " => " + mi.value);
@@ -432,7 +430,7 @@ public class UnicodeMapTest extends TestFmwk {
 
         logln("Comparing next");
         mi.reset();
-        localMap = new TreeMap();
+        localMap = new TreeMap<>();
 //        String lastValue = null;
         while (mi.next()) {
 //            if (!UnicodeMap.areEqual(lastValue, mi.value)) {
@@ -460,11 +458,11 @@ public class UnicodeMapTest extends TestFmwk {
         }
     }
 
-    void checkMap(Map m1, Map m2) {
+    void checkMap(Map<Integer, String> m1, Map<Integer, String> m2) {
         if (m1.equals(m2)) return;
         StringBuilder buffer = new StringBuilder();
-        Set m1entries = m1.entrySet();
-        Set m2entries = m2.entrySet();
+        Set<Map.Entry<Integer, String>> m1entries = m1.entrySet();
+        Set<Map.Entry<Integer, String>> m2entries = m2.entrySet();
         getEntries("\r\nIn First, and not Second", m1entries, m2entries, buffer, 20);
         getEntries("\r\nIn Second, and not First", m2entries, m1entries, buffer, 20);
         errln(buffer.toString());
@@ -482,7 +480,7 @@ public class UnicodeMapTest extends TestFmwk {
             if (result != 0) return result;
             return compare2(a.getValue(), b.getValue());
         }
-        private <T extends Comparable> int compare2(T o1, T o2) {
+        private <T extends Comparable<T>> int compare2(T o1, T o2) {
             if (o1 == o2) return 0;
             if (o1 == null) return -1;
             if (o2 == null) return 1;
@@ -495,7 +493,7 @@ public class UnicodeMapTest extends TestFmwk {
         m1_m2.addAll(m1entries);
         m1_m2.removeAll(m2entries);
         buffer.append(title + ": " + m1_m2.size() + "\r\n");
-        for (Entry<Integer, String> entry : m1_m2) {
+        for (Map.Entry<Integer, String> entry : m1_m2) {
             if (limit-- < 0) return;
             buffer.append(entry.getKey()).append(" => ")
              .append(entry.getValue()).append("\r\n");

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/CalendarRegressionTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/CalendarRegressionTest.java
@@ -2193,7 +2193,7 @@ public class CalendarRegressionTest extends CoreTestFmwk {
         };
 
         String[] ALL = Calendar.getKeywordValuesForLocale("calendar", ULocale.getDefault(), false);
-        HashSet ALLSET = new HashSet();
+        HashSet<String> ALLSET = new HashSet<>();
         for (int i = 0; i < ALL.length; i++) {
             if (ALL[i] == "unknown") {
                 errln("Calendar.getKeywordValuesForLocale should not return \"unknown\"");

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/CalendarTestFmwk.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/CalendarTestFmwk.java
@@ -241,7 +241,7 @@ public class CalendarTestFmwk extends CoreTestFmwk {
 
         // Keep a record of minima and maxima that we actually see.
         // These are kept in an array of arrays of hashes.
-        Map[][] limits = new Map[fieldsToTest.length][2];
+        Map<Integer, Object>[][] limits = new Map[fieldsToTest.length][2];
         Object nub = new Object(); // Meaningless placeholder
 
         // This test can run for a long time; show progress.
@@ -273,10 +273,10 @@ public class CalendarTestFmwk extends CoreTestFmwk {
 
                 // Fetch the hash for this field and keep track of the
                 // minima and maxima.
-                Map[] h = limits[j];
+                Map<Integer, Object>[] h = limits[j];
                 if (h[0] == null) {
-                    h[0] = new HashMap();
-                    h[1] = new HashMap();
+                    h[0] = new HashMap<>();
+                    h[1] = new HashMap<>();
                 }
                 h[0].put(minActual, nub);
                 h[1].put(maxActual, nub);
@@ -311,7 +311,7 @@ public class CalendarTestFmwk extends CoreTestFmwk {
             int f = fieldsToTest[j];
             buf.setLength(0);
             buf.append(FIELD_NAME[f]);
-            Map[] h = limits[j];
+            Map<Integer, Object>[] h = limits[j];
             boolean fullRangeSeen = true;
             for (int k=0; k<2; ++k) {
                 int rangeLow = (k==0) ?

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/duration/LanguageTestFmwk.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/duration/LanguageTestFmwk.java
@@ -63,7 +63,7 @@ public abstract class LanguageTestFmwk extends CoreTestFmwk implements TimeUnitC
 
     private PrintWriter pw;
 
-    private static final Map datacache = new HashMap(); // String->TestData
+    private static final Map<String, TestData> datacache = new HashMap<>(); // String->TestData
 
     private static final long[] approxDurations = {
         36525L*24*60*60*10, 3045*24*60*60*10L, 7*24*60*60*1000L, 24*60*60*1000L,
@@ -79,7 +79,7 @@ public abstract class LanguageTestFmwk extends CoreTestFmwk implements TimeUnitC
         if (locale.equals("testFullPluralizedForms")) {
             Thread.dumpStack();
         }
-        TestData data = (TestData) datacache.get(locale);
+        TestData data = datacache.get(locale);
         if (data == null) {
             try {
                 InputStream is = LanguageTestFmwk.class
@@ -604,14 +604,13 @@ class FileTestData extends LanguageTestFmwk.TestData {
 
             String[] stringArray;
 
-            void wrapup(List /* of String */list, Element element) {
+            void wrapup(List<String> list, Element element) {
                 if (list == null)
                     return;
 
                 switch (element.mode) {
                 case EMode.mString:
-                    stringArray = (String[]) list.toArray(new String[list
-                            .size()]);
+                    stringArray = list.toArray(new String[list.size()]);
                     break;
 
                 case EMode.mInt:
@@ -668,7 +667,7 @@ class FileTestData extends LanguageTestFmwk.TestData {
         }
         Wrapup w = new Wrapup();
 
-        List /* of String */list = null;
+        List<String> list = null;
         Element element = null;
         String line = null;
         while (null != (line = br.readLine())) {
@@ -678,7 +677,7 @@ class FileTestData extends LanguageTestFmwk.TestData {
             if (line.charAt(0) == '=') {
                 w.wrapup(list, element);
 
-                list = new ArrayList();
+                list = new ArrayList<>();
                 element = Element.forString(line.substring(1));
             } else if (line.equals("null")) {
                 list.add(null);

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/duration/ResourceBasedPeriodFormatterDataServiceTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/duration/ResourceBasedPeriodFormatterDataServiceTest.java
@@ -11,9 +11,6 @@
 
 package com.ibm.icu.dev.test.duration;
 
-import java.util.Collection;
-import java.util.Iterator;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -28,9 +25,7 @@ public class ResourceBasedPeriodFormatterDataServiceTest extends CoreTestFmwk {
   public void testAvailable() {
     ResourceBasedPeriodFormatterDataService service =
         ResourceBasedPeriodFormatterDataService.getInstance();
-    Collection locales = service.getAvailableLocales();
-    for (Iterator i = locales.iterator(); i.hasNext();) {
-      String locale = (String)i.next();
+    for (String locale : service.getAvailableLocales()) {
       PeriodFormatterData pfd = service.get(locale);
       assertFalse(locale + ": " + pfd.pluralization(), -1 == pfd.pluralization());
     }

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DateTimeGeneratorTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DateTimeGeneratorTest.java
@@ -13,7 +13,6 @@ import java.text.ParsePosition;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -777,7 +776,7 @@ public class DateTimeGeneratorTest extends CoreTestFmwk {
      * @return
      */
     public String replaceZoneString(String pattern, String newZone) {
-        final List itemList = formatParser.set(pattern).getItems();
+        final List<Object> itemList = formatParser.set(pattern).getItems();
         boolean changed = false;
         for (int i = 0; i < itemList.size(); ++i) {
             Object item = itemList.get(i);
@@ -795,8 +794,7 @@ public class DateTimeGeneratorTest extends CoreTestFmwk {
     }
 
     public boolean containsZone(String pattern) {
-        for (Iterator it = formatParser.set(pattern).getItems().iterator(); it.hasNext();) {
-            Object item = it.next();
+        for (Object item : formatParser.set(pattern).getItems()) {
             if (item instanceof VariableField) {
                 VariableField variableField = (VariableField) item;
                 if (variableField.getType() == DateTimePatternGenerator.ZONE) {
@@ -829,8 +827,7 @@ public class DateTimeGeneratorTest extends CoreTestFmwk {
         int count = 0;
         DateOrder result = new DateOrder();
 
-        for (Iterator it = formatParser.set(pattern).getItems().iterator(); it.hasNext();) {
-            Object item = it.next();
+        for (Object item : formatParser.set(pattern).getItems()) {
             if (!(item instanceof String)) {
                 // the first character of the variable field determines the type,
                 // according to CLDR.

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/ListFormatterTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/ListFormatterTest.java
@@ -418,7 +418,7 @@ public class ListFormatterTest extends CoreTestFmwk {
                 String expected = (String) cas[2];
                 for (String locale : locales) {
                     ULocale uloc = new ULocale(locale);
-                    List inputs = Arrays.asList(cas).subList(3, cas.length);
+                    List<Object> inputs = Arrays.asList(cas).subList(3, cas.length);
                     ListFormatter fmt = ListFormatter.getInstance(uloc, type, width);
                     String message = "TestContextual uloc="
                         + uloc + " type="

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/MessageRegressionTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/MessageRegressionTest.java
@@ -677,19 +677,17 @@ public class MessageRegressionTest extends CoreTestFmwk {
         try {
             logln("Apply with pattern : " + pattern1);
             messageFormatter.applyPattern(pattern1);
-            HashMap paramsMap = new HashMap();
+            HashMap<String, Object> paramsMap = new HashMap<>();
             paramsMap.put("arg0", 7);
             String tempBuffer = messageFormatter.format(paramsMap);
             if (!tempBuffer.equals("Impossible {arg1} has occurred -- status code is 7 and message is {arg2}."))
                 errln("Tests arguments < substitution failed");
             logln("Formatted with 7 : " + tempBuffer);
             ParsePosition status = new ParsePosition(0);
-            Map objs = messageFormatter.parseToMap(tempBuffer, status);
+            Map<String, Object> objs = messageFormatter.parseToMap(tempBuffer, status);
             if (objs.get("arg1") != null || objs.get("arg2") != null)
                 errln("Parse failed with more than expected arguments");
-            for (Iterator keyIter = objs.keySet().iterator();
-                 keyIter.hasNext();) {
-                String key = (String) keyIter.next();
+            for (String key : objs.keySet()) {
                 if (objs.get(key) != null && !objs.get(key).toString().equals(paramsMap.get(key).toString())) {
                     errln("Parse failed on object " + objs.get(key) + " with argument name : " + key );
                 }
@@ -721,7 +719,7 @@ public class MessageRegressionTest extends CoreTestFmwk {
         }
         MessageFormat fmt = new MessageFormat("There are {numberOfApples} apples growing on the {whatKindOfTree} tree.");
         String str = new String("There is one apple growing on the peach tree.");
-        Map objs = fmt.parseToMap(str, pos);
+        Map<String, Object> objs = fmt.parseToMap(str, pos);
         logln("unparsable string , should fail at " + pos.getErrorIndex());
         if (pos.getErrorIndex() == -1)
             errln("Bug 4052223 failed : parsing string " + str);
@@ -773,14 +771,14 @@ public class MessageRegressionTest extends CoreTestFmwk {
             String pattern = patterns[i];
             mf.applyPattern(pattern);
             try {
-                Map objs = mf.parseToMap(null, new ParsePosition(0));
+                Map<String, Object> objs = mf.parseToMap(null, new ParsePosition(0));
                 logln("pattern: \"" + pattern + "\"");
                 log(" parsedObjects: ");
                 if (objs != null) {
                     log("{");
-                    for (Iterator keyIter = objs.keySet().iterator();
+                    for (Iterator<String> keyIter = objs.keySet().iterator();
                          keyIter.hasNext();) {
-                        String key = (String)keyIter.next();
+                        String key = keyIter.next();
                         if (objs.get(key) != null) {
                             err("\"" + objs.get(key).toString() + "\"");
                         } else {
@@ -802,9 +800,9 @@ public class MessageRegressionTest extends CoreTestFmwk {
         }
     }{ // Taken from Test4114739().
         MessageFormat mf = new MessageFormat("<{arg}>");
-        Map objs1 = null;
-        Map objs2 = new HashMap();
-        Map objs3 = new HashMap();
+        Map<String, Object> objs1 = null;
+        Map<String, Object> objs2 = new HashMap<>();
+        Map<String, Object> objs3 = new HashMap<>();
         objs3.put("arg", null);
         try {
             logln("pattern: \"" + mf.toPattern() + "\"");
@@ -821,14 +819,14 @@ public class MessageRegressionTest extends CoreTestFmwk {
         String argName = "something_stupid";
         MessageFormat mf = new MessageFormat("{"+ argName + "}, {" + argName + "}, {" + argName + "}");
         String forParsing = "x, y, z";
-        Map objs = mf.parseToMap(forParsing, new ParsePosition(0));
+        Map<String, Object> objs = mf.parseToMap(forParsing, new ParsePosition(0));
         logln("pattern: \"" + mf.toPattern() + "\"");
         logln("text for parsing: \"" + forParsing + "\"");
         if (!objs.get(argName).toString().equals("z"))
             errln("argument0: \"" + objs.get(argName) + "\"");
         mf.setLocale(Locale.US);
         mf.applyPattern("{" + argName + ",number,#.##}, {" + argName + ",number,#.#}");
-        Map oldobjs = new HashMap();
+        Map<String, Object> oldobjs = new HashMap<>();
         oldobjs.put(argName, 3.1415d);
         String result = mf.format( oldobjs );
         logln("pattern: \"" + mf.toPattern() + "\"");
@@ -836,7 +834,7 @@ public class MessageRegressionTest extends CoreTestFmwk {
         // result now equals "3.14, 3.1"
         if (!result.equals("3.14, 3.1"))
             errln("result = " + result);
-        Map newobjs = mf.parseToMap(result, new ParsePosition(0));
+        Map<String, Object> newobjs = mf.parseToMap(result, new ParsePosition(0));
         // newobjs now equals {Double.valueOf(3.1)}
         if (((Number)newobjs.get(argName)).doubleValue() != 3.1) // was (Double) [alan]
             errln( "newobjs.get(argName) = " + newobjs.get(argName));
@@ -850,14 +848,14 @@ public class MessageRegressionTest extends CoreTestFmwk {
         ChoiceFormat fileform = new ChoiceFormat(filelimits, filepart);
         form1.setFormat(1, fileform);
         form2.setFormat(0, fileform);
-        Map testArgs = new HashMap();
+        Map<String, Object> testArgs = new HashMap<>();
         testArgs.put("diskName", "MyDisk");
         testArgs.put("numberOfFiles", 12373L);
         logln(form1.format(testArgs));
         logln(form2.format(testArgs));
     }{ // Taken from test4293229().
         MessageFormat format = new MessageFormat("'''{'myNamedArgument}'' '''{myNamedArgument}'''");
-        Map args = new HashMap();
+        Map<String, Object> args = new HashMap<>();
         String expected = "'{myNamedArgument}' '{myNamedArgument}'";
         String result = format.format(args);
         if (!result.equals(expected)) {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/PluralFormatUnitTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/PluralFormatUnitTest.java
@@ -215,11 +215,11 @@ public class PluralFormatUnitTest extends CoreTestFmwk {
 
     @Test
     public void TestSamples() {
-        Map<ULocale,Set<ULocale>> same = new LinkedHashMap();
+        Map<ULocale,Set<ULocale>> same = new LinkedHashMap<>();
         for (ULocale locale : PluralRules.getAvailableULocales()) {
             ULocale otherLocale = PluralRules.getFunctionalEquivalent(locale, null);
             Set<ULocale> others = same.get(otherLocale);
-            if (others == null) same.put(otherLocale, others = new LinkedHashSet());
+            if (others == null) same.put(otherLocale, others = new LinkedHashSet<>());
             others.add(locale);
             continue;
         }

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/DataDrivenUScriptTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/DataDrivenUScriptTest.java
@@ -48,7 +48,7 @@ public class DataDrivenUScriptTest extends CoreTestFmwk {
         }
 
         @Parameterized.Parameters
-        public static Collection testData() {
+        public static Collection<Object[]> testData() {
             return Arrays.asList(new Object[][] { { new ULocale("en"), UScript.LATIN },
                     { new ULocale("en_US"), UScript.LATIN },
                     { new ULocale("sr"), UScript.CYRILLIC },
@@ -126,7 +126,7 @@ public class DataDrivenUScriptTest extends CoreTestFmwk {
         }
 
         @Parameterized.Parameters
-        public static Collection testData() {
+        public static Collection<Object[]> testData() {
             return Arrays.asList(new Object[][] {
                     { "ja", new int[] { UScript.KATAKANA, UScript.HIRAGANA, UScript.HAN }, Locale.JAPANESE },
                     { "ko_KR", new int[] { UScript.HANGUL, UScript.HAN }, Locale.KOREA },
@@ -175,7 +175,7 @@ public class DataDrivenUScriptTest extends CoreTestFmwk {
         }
 
         @Parameterized.Parameters
-        public static Collection testData() {
+        public static Collection<Object[]> testData() {
             return Arrays.asList(new Object[][] {
                     /* test locale */
                     { "en", UScript.LATIN },
@@ -269,7 +269,7 @@ public class DataDrivenUScriptTest extends CoreTestFmwk {
         }
 
         @Parameterized.Parameters
-        public static Collection testData() {
+        public static Collection<Object[]> testData() {
             return Arrays.asList(new Object[][] {
                     { UScript.CYRILLIC, "Cyrillic" },
                     { UScript.DESERET, "Deseret" },
@@ -302,7 +302,7 @@ public class DataDrivenUScriptTest extends CoreTestFmwk {
         }
 
         @Parameterized.Parameters
-        public static Collection testData() {
+        public static Collection<Object[]> testData() {
             return Arrays.asList(new Object[][] {
                     { UScript.HAN, "Hani" },
                     { UScript.HANGUL, "Hang" },
@@ -338,7 +338,7 @@ public class DataDrivenUScriptTest extends CoreTestFmwk {
         }
 
         @Parameterized.Parameters
-        public static Collection testData() {
+        public static Collection<int[]> testData() {
             return Arrays.asList(new int[][] {
                     { 0x0000FF9D, UScript.KATAKANA },
                     { 0x0000FFBE, UScript.HANGUL },

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UCharacterSurrogateTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UCharacterSurrogateTest.java
@@ -263,7 +263,7 @@ public final class UCharacterSurrogateTest extends CoreTestFmwk {
                 }
             }
 
-            void fail(String s, int start, int limit, Class exc) {
+            void fail(String s, int start, int limit, Class<? extends RuntimeException> exc) {
                 try {
                     UCharacter.codePointCount(s, start, limit);
                     errln("unexpected success " + str(s, start, limit));
@@ -350,7 +350,7 @@ public final class UCharacterSurrogateTest extends CoreTestFmwk {
             }
 
             void fail(char[] text, int start, int count, int index, int offset,
-                    Class exc) {
+                    Class<? extends RuntimeException> exc) {
                 try {
                     UCharacter.offsetByCodePoints(text, start, count, index,
                             offset);
@@ -365,7 +365,7 @@ public final class UCharacterSurrogateTest extends CoreTestFmwk {
                 }
             }
 
-            void fail(String text, int index, int offset, Class exc) {
+            void fail(String text, int index, int offset, Class<? extends RuntimeException> exc) {
                 try {
                     UCharacter.offsetByCodePoints(text, index, offset);
                     errln("unexpected success "

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UCharacterTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UCharacterTest.java
@@ -2988,7 +2988,7 @@ public final class UCharacterTest extends CoreTestFmwk
     @Test
     public void TestBlockData()
     {
-        Class ubc = UCharacter.UnicodeBlock.class;
+        Class<UCharacter.UnicodeBlock> ubc = UCharacter.UnicodeBlock.class;
 
         for (int b = 1; b < UCharacter.UnicodeBlock.COUNT; b += 1) {
             UCharacter.UnicodeBlock blk = UCharacter.UnicodeBlock.getInstance(b);

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UCharacterThreadTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UCharacterThreadTest.java
@@ -8,9 +8,8 @@
  */
 package com.ibm.icu.dev.test.lang;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.ListIterator;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,7 +41,7 @@ public class UCharacterThreadTest extends CoreTestFmwk {
     //
     @Test
     public void TestUCharactersGetName() throws InterruptedException {
-        List threads = new LinkedList();
+        List<GetNameThread> threads = new ArrayList<>();
         for(int t=0; t<20; t++) {
           int codePoint = 47 + t;
           String correctName = UCharacter.getName(codePoint);
@@ -50,9 +49,7 @@ public class UCharacterThreadTest extends CoreTestFmwk {
           thread.start();
           threads.add(thread);
         }
-        ListIterator i = threads.listIterator();
-        while (i.hasNext()) {
-            GetNameThread thread = (GetNameThread)i.next();
+        for (GetNameThread thread : threads) {
             thread.join();
             if (!thread.correctName.equals(thread.actualName)) {
                 errln("FAIL, expected \"" + thread.correctName + "\", got \"" + thread.actualName + "\"");

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UnicodeSetTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UnicodeSetTest.java
@@ -781,8 +781,8 @@ public class UnicodeSetTest extends CoreTestFmwk {
             //    Ram also add a similar test to UtilityTest.java
             logln("Testing addAll(Collection) ... ");
             String[] array = {"a", "b", "c", "de"};
-            List list = Arrays.asList(array);
-            Set aset = new HashSet(list);
+            List<String> list = Arrays.asList(array);
+            Set<String> aset = new HashSet<>(list);
             logln(" *** The source set's size is: " + aset.size());
 
             set.clear();
@@ -794,16 +794,16 @@ public class UnicodeSetTest extends CoreTestFmwk {
                 logln("OK: After addAll, the UnicodeSet size got " + set.size());
             }
 
-            List list2 = new ArrayList();
+            List<String> list2 = new ArrayList<>();
             set.addAllTo(list2);
 
             //verify the result
             log(" *** The elements are: ");
             String s = set.toPattern(true);
             logln(s);
-            Iterator myiter = list2.iterator();
+            Iterator<String> myiter = list2.iterator();
             while(myiter.hasNext()) {
-                log(myiter.next().toString() + "  ");
+                log(myiter.next() + "  ");
             }
             logln("");  // a new line
         }
@@ -859,8 +859,8 @@ public class UnicodeSetTest extends CoreTestFmwk {
         String[] choices = {"a", "b", "cd", "ef"};
         int limit = 1 << choices.length;
 
-        SortedSet iset = new TreeSet();
-        SortedSet jset = new TreeSet();
+        SortedSet<String> iset = new TreeSet<>();
+        SortedSet<String> jset = new TreeSet<>();
 
         for (int i = 0; i < limit; ++i) {
             pick(i, choices, iset);
@@ -882,8 +882,8 @@ public class UnicodeSetTest extends CoreTestFmwk {
 
     public void SetSpeed2(int size) {
 
-        SortedSet iset = new TreeSet();
-        SortedSet jset = new TreeSet();
+        SortedSet<Integer> iset = new TreeSet<>();
+        SortedSet<Integer> jset = new TreeSet<>();
 
         for (int i = 0; i < size*2; i += 2) { // only even values
             iset.add(i);
@@ -907,12 +907,12 @@ public class UnicodeSetTest extends CoreTestFmwk {
         CheckSpeed(jset, iset, "when a, b are disjoint", iterations);
     }
 
-    void CheckSpeed(SortedSet iset, SortedSet jset, String message, int iterations) {
+    void CheckSpeed(SortedSet<Integer> iset, SortedSet<Integer> jset, String message, int iterations) {
         CheckSpeed2(iset, jset, message, iterations);
         CheckSpeed3(iset, jset, message, iterations);
     }
 
-    void CheckSpeed2(SortedSet iset, SortedSet jset, String message, int iterations) {
+    void CheckSpeed2(SortedSet<Integer> iset, SortedSet<Integer> jset, String message, int iterations) {
         boolean x;
         boolean y;
 
@@ -939,7 +939,7 @@ public class UnicodeSetTest extends CoreTestFmwk {
                 + ", Utility: " + utime + ", u:j: " + nf.format(utime/jtime));
     }
 
-    void CheckSpeed3(SortedSet iset, SortedSet jset, String message, int iterations) {
+    void CheckSpeed3(SortedSet<Integer> iset, SortedSet<Integer> jset, String message, int iterations) {
         boolean x;
         boolean y;
 
@@ -967,7 +967,7 @@ public class UnicodeSetTest extends CoreTestFmwk {
                 + ", Utility: " + utime + ", u:j: " + nf.format(utime/jtime));
     }
 
-    void pick(int bits, Object[] examples, SortedSet output) {
+    void pick(int bits, String[] examples, SortedSet<String> output) {
         output.clear();
         for (int k = 0; k < 32; ++k) {
             if (((1<<k) & bits) != 0) output.add(examples[k]);
@@ -984,8 +984,8 @@ public class UnicodeSetTest extends CoreTestFmwk {
         "contains",
         "any", };
 
-    boolean dumbHasRelation(Collection A, int filter, Collection B) {
-        Collection ab = new TreeSet(A);
+    boolean dumbHasRelation(Collection<String> A, int filter, Collection<String> B) {
+        Collection<String> ab = new TreeSet<>(A);
         ab.retainAll(B);
         if (ab.size() > 0 && (filter & SortedSetRelation.A_AND_B) == 0) return false;
 
@@ -999,7 +999,7 @@ public class UnicodeSetTest extends CoreTestFmwk {
         return true;
     }
 
-    void checkSetRelation(SortedSet a, SortedSet b, String message) {
+    void checkSetRelation(SortedSet<String> a, SortedSet<String> b, String message) {
         for (int i = 0; i < 8; ++i) {
 
             boolean hasRelation = SortedSetRelation.hasRelation(a, i, b);
@@ -1768,16 +1768,16 @@ public class UnicodeSetTest extends CoreTestFmwk {
         set1.addAllTo(list1);
         assertEquals("iteration test", oldList, list1);
 
-        list1 = set1.addAllTo(new ArrayList<String>());
+        list1 = set1.addAllTo(new ArrayList<>());
         assertEquals("addAllTo", oldList, list1);
 
-        ArrayList<String> list2 = set2.addAllTo(new ArrayList<String>());
-        ArrayList<String> list3 = set3.addAllTo(new ArrayList<String>());
+        ArrayList<String> list2 = set2.addAllTo(new ArrayList<>());
+        ArrayList<String> list3 = set3.addAllTo(new ArrayList<>());
 
         // put them into different order, to check that order doesn't matter
-        TreeSet sorted1 = set1.addAllTo(new TreeSet<String>());
-        TreeSet sorted2 = set2.addAllTo(new TreeSet<String>());
-        TreeSet sorted3 = set3.addAllTo(new TreeSet<String>());
+        TreeSet<String> sorted1 = set1.addAllTo(new TreeSet<>());
+        TreeSet<String> sorted2 = set2.addAllTo(new TreeSet<>());
+        TreeSet<String> sorted3 = set3.addAllTo(new TreeSet<>());
 
         //containsAll(Collection<String> collection)
         assertTrue("containsAll", set1.containsAll(list1));
@@ -1837,7 +1837,7 @@ public class UnicodeSetTest extends CoreTestFmwk {
         List<UnicodeSet> goalLongest = Arrays.asList(set1, set3, set2);
         List<UnicodeSet> goalLex = Arrays.asList(set1, set2, set3);
 
-        List<UnicodeSet> sorted = new ArrayList(new TreeSet<>(unsorted));
+        List<UnicodeSet> sorted = new ArrayList<>(new TreeSet<>(unsorted));
         assertNotEquals("compareTo-shorter-first", unsorted, sorted);
         assertEquals("compareTo-shorter-first", goalShortest, sorted);
 
@@ -1848,7 +1848,7 @@ public class UnicodeSetTest extends CoreTestFmwk {
                 return o1.compareTo(o2, ComparisonStyle.LONGER_FIRST);
             }});
         sorted1.addAll(unsorted);
-        sorted = new ArrayList(sorted1);
+        sorted = new ArrayList<>(sorted1);
         assertNotEquals("compareTo-longer-first", unsorted, sorted);
         assertEquals("compareTo-longer-first", goalLongest, sorted);
 
@@ -1859,7 +1859,7 @@ public class UnicodeSetTest extends CoreTestFmwk {
                 return o1.compareTo(o2, ComparisonStyle.LEXICOGRAPHIC);
             }});
         sorted1.addAll(unsorted);
-        sorted = new ArrayList(sorted1);
+        sorted = new ArrayList<>(sorted1);
         assertNotEquals("compareTo-lex", unsorted, sorted);
         assertEquals("compareTo-lex", goalLex, sorted);
 
@@ -1931,8 +1931,8 @@ public class UnicodeSetTest extends CoreTestFmwk {
         UnicodeSet t = new UnicodeSet(3,5, 7,7);
         assertEquals("new constructor", w, t);
         // check to make sure right exceptions are thrown
-        Class expected = IllegalArgumentException.class;
-        Class actual;
+        Class<? extends RuntimeException> expected = IllegalArgumentException.class;
+        Class<? extends RuntimeException> actual;
 
         try {
             actual = null;
@@ -2022,7 +2022,7 @@ public class UnicodeSetTest extends CoreTestFmwk {
                     case 0: test.add(0); break;
                     case 1: test.add(0,1); break;
                     case 2: test.add("a"); break;
-                    case 3: List a = new ArrayList(); a.add("a"); test.addAll(a); break;
+                    case 3: List<String> a = new ArrayList<>(); a.add("a"); test.addAll(a); break;
                     case 4: test.addAll("ab"); break;
                     case 5: test.addAll(new UnicodeSet("[ab]")); break;
                     case 6: test.applyIntPropertyValue(0,0); break;
@@ -2135,7 +2135,7 @@ public class UnicodeSetTest extends CoreTestFmwk {
     //    }
 
     public class TokenSymbolTable implements SymbolTable {
-        HashMap contents = new HashMap();
+        HashMap<String, char[]> contents = new HashMap<>();
 
         /**
          * (Non-SymbolTable API) Add the given variable and value to
@@ -2163,8 +2163,8 @@ public class UnicodeSetTest extends CoreTestFmwk {
         @Override
         public char[] lookup(String s) {
             logln("TokenSymbolTable: lookup \"" + s + "\" => \"" +
-                    new String((char[]) contents.get(s)) + "\"");
-            return (char[])contents.get(s);
+                    new String(contents.get(s)) + "\"");
+            return contents.get(s);
         }
 
         /* (non-Javadoc)

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/normalizer/TestCanonicalIterator.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/normalizer/TestCanonicalIterator.java
@@ -9,9 +9,9 @@
 package com.ibm.icu.dev.test.normalizer;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.StringJoiner;
 import java.util.TreeSet;
 
 import org.junit.Test;
@@ -135,12 +135,12 @@ public class TestCanonicalIterator extends CoreTestFmwk {
         // check permute
         // NOTE: we use a TreeSet below to sort the output, which is not guaranteed to be sorted!
 
-        Set results = new TreeSet();
+        Set<String> results = new TreeSet<>();
         CanonicalIterator.permute("ABC", false, results);
         expectEqual("Simple permutation ", "", collectionToString(results), "ABC, ACB, BAC, BCA, CAB, CBA");
 
         // try samples
-        SortedSet set = new TreeSet();
+        SortedSet<String> set = new TreeSet<>();
         for (int i = 0; i < testArray.length; ++i) {
             //logln("Results for: " + name.transliterate(testArray[i]));
             CanonicalIterator it = new CanonicalIterator(testArray[i][0]);
@@ -263,12 +263,10 @@ public class TestCanonicalIterator extends CoreTestFmwk {
         }
     }
 
-    static String collectionToString(Collection col) {
-        StringBuffer result = new StringBuffer();
-        Iterator it = col.iterator();
-        while (it.hasNext()) {
-            if (result.length() != 0) result.append(", ");
-            result.append(it.next().toString());
+    static String collectionToString(Collection<String> col) {
+        StringJoiner result = new StringJoiner(", ");
+        for (String item : col) {
+            result.add(item);
         }
         return result.toString();
     }

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBITest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBITest.java
@@ -499,8 +499,8 @@ public class RBBITest extends CoreTestFmwk {
 
     static class T13512Thread extends Thread {
         private String fText;
-        public List fBoundaries;
-        public List fExpectedBoundaries;
+        public List<Integer> fBoundaries;
+        public List<Integer> fExpectedBoundaries;
 
         T13512Thread(String text) {
             fText = text;

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBITestMonkey.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBITestMonkey.java
@@ -55,14 +55,14 @@ public class RBBITestMonkey extends CoreTestFmwk {
     //
     abstract static class RBBIMonkeyKind {
         RBBIMonkeyKind() {
-            fSets = new  ArrayList();
-            fClassNames = new ArrayList();
-            fAppliedRules = new ArrayList();
+            fSets = new  ArrayList<>();
+            fClassNames = new ArrayList<>();
+            fAppliedRules = new ArrayList<>();
         }
 
         // Return a List of UnicodeSets, representing the character classes used
         //   for this type of iterator.
-        abstract  List  charClasses();
+        abstract  List<UnicodeSet>  charClasses();
 
         // Set the test text on which subsequent calls to next() will operate
         abstract  void   setText(StringBuffer text);
@@ -207,7 +207,7 @@ public class RBBITestMonkey extends CoreTestFmwk {
         }
 
         @Override
-        List charClasses() {
+        List<UnicodeSet> charClasses() {
             return fSets;
         }
 
@@ -476,7 +476,7 @@ public class RBBITestMonkey extends CoreTestFmwk {
 
 
         @Override
-        List  charClasses() {
+        List<UnicodeSet> charClasses() {
             return fSets;
         }
 
@@ -1762,7 +1762,7 @@ public class RBBITestMonkey extends CoreTestFmwk {
 
 
         @Override
-        List  charClasses() {
+        List<UnicodeSet> charClasses() {
             return fSets;
         }
     }
@@ -1845,7 +1845,7 @@ public class RBBITestMonkey extends CoreTestFmwk {
 
 
         @Override
-        List  charClasses() {
+        List<UnicodeSet> charClasses() {
             return fSets;
         }
 
@@ -2203,7 +2203,7 @@ public class RBBITestMonkey extends CoreTestFmwk {
         int              TESTSTRINGLEN = 500;
         StringBuffer     testText         = new StringBuffer();
         int              numCharClasses;
-        List             chClasses;
+        List<UnicodeSet> chClasses;
         @SuppressWarnings("unused")
         int              expectedCount    = 0;
         boolean[]        expectedBreaks   = new boolean[TESTSTRINGLEN*2 + 1];

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/shaping/DataDrivenArabicShapingRegTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/shaping/DataDrivenArabicShapingRegTest.java
@@ -60,7 +60,7 @@ public class DataDrivenArabicShapingRegTest extends CoreTestFmwk {
         }
 
         @Parameterized.Parameters
-        public static Collection testData() {
+        public static Collection<Object[]> testData() {
             String lamAlefSpecialVLTR =
                 "\u0020\u0646\u0622\u0644\u0627\u0020\u0646\u0623\u064E\u0644\u0627\u0020" +
                 "\u0646\u0627\u0670\u0644\u0627\u0020\u0646\u0622\u0653\u0644\u0627\u0020" +
@@ -390,7 +390,7 @@ public class DataDrivenArabicShapingRegTest extends CoreTestFmwk {
         }
 
         @Parameterized.Parameters
-        public static Collection testData() {
+        public static Collection<Object[]> testData() {
             return Arrays.asList(new Object[][] {
                     {"\u0644\u0627", LETTERS_SHAPE | LENGTH_GROW_SHRINK, 1},
                     {"\u0644\u0627\u0031",
@@ -432,16 +432,16 @@ public class DataDrivenArabicShapingRegTest extends CoreTestFmwk {
     public static class ErrorDataTest extends CoreTestFmwk {
         private String source;
         private int flags;
-        private Class error;
+        private Class<? extends Exception> error;
 
-        public ErrorDataTest(String source, int flags, Class error) {
+        public ErrorDataTest(String source, int flags, Class<? extends Exception> error) {
             this.source = source;
             this.flags = flags;
             this.error = error;
         }
 
         @Parameterized.Parameters
-        public static Collection testData() {
+        public static Collection<Object[]> testData() {
             return Arrays.asList(new Object[][] {
                     /* bad data */
                     {"\u0020\ufef7\u0644\u0020", LETTERS_UNSHAPE | LENGTH_FIXED_SPACES_NEAR,

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/stringprep/IDNAConformanceTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/stringprep/IDNAConformanceTest.java
@@ -15,7 +15,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
-import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -38,7 +38,7 @@ public class IDNAConformanceTest extends CoreTestFmwk {
     @Test
     public void TestConformance() {
 
-        TreeMap inputData = null;
+        TreeMap<Integer, Map<String, String>> inputData = null;
 
         try {
             inputData = ReadInput.getInputData();
@@ -50,11 +50,8 @@ public class IDNAConformanceTest extends CoreTestFmwk {
             return;
         }
 
-        Set keyMap = inputData.keySet();
-        for (Iterator iter = keyMap.iterator(); iter.hasNext();) {
-            Long element = (Long) iter.next();
-            HashMap tempHash = (HashMap) inputData.get(element);
-
+        Set<Integer> keyMap = inputData.keySet();
+        for (Map<String, String> tempHash : inputData.values()) {
             //get all attributes from input data
             String passfail = (String) tempHash.get("passfail");
             String desc = (String) tempHash.get("desc");
@@ -244,16 +241,16 @@ public class IDNAConformanceTest extends CoreTestFmwk {
      */
     public static class ReadInput {
 
-        public static TreeMap getInputData() throws IOException,
+        public static TreeMap<Integer, Map<String, String>> getInputData() throws IOException,
                 UnsupportedEncodingException {
 
-            TreeMap result = new TreeMap();
+            TreeMap<Integer, Map<String, String>> result = new TreeMap<>();
             BufferedReader in = TestUtil.getDataReader("IDNATestInput.txt", "utf-8");
             try {
                 String tempStr = null;
                 int records = 0;
                 boolean firstLine = true;
-                HashMap hashItem = new HashMap();
+                HashMap<String, String> hashItem = new HashMap<>();
 
                 while ((tempStr = in.readLine()) != null) {
                     //ignore the first line if it's "====="
@@ -292,9 +289,9 @@ public class IDNAConformanceTest extends CoreTestFmwk {
                     //if met "=====", it means this item is finished
                     if ("=====".equals(tempStr)) {
                         //set them into result, using records number as key
-                        result.put((long)records, hashItem);
+                        result.put(records, hashItem);
                         //create another hash item and continue
-                        hashItem = new HashMap();
+                        hashItem = new HashMap<>();
                         records++;
                         continue;
                     }

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/stringprep/NamePrepTransform.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/stringprep/NamePrepTransform.java
@@ -185,7 +185,7 @@ public class NamePrepTransform {
 
         boolean initialize(String id, String rule, int direction) {
             try {
-                Class cls = Class.forName("com.ibm.icu.text.Transliterator");
+                Class<?> cls = Class.forName("com.ibm.icu.text.Transliterator");
                 Method createMethod = cls.getMethod("createFromRules", String.class, String.class, Integer.TYPE);
                 translitInstance = createMethod.invoke(null, id, rule, direction);
                 translitMethod = cls.getMethod("transliterate", String.class);

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/text/SpoofCheckerTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/text/SpoofCheckerTest.java
@@ -849,8 +849,8 @@ public class SpoofCheckerTest extends CoreTestFmwk {
     @Test
     public void testScriptSet() {
         try {
-            Class ScriptSet = Class.forName("com.ibm.icu.text.SpoofChecker$ScriptSet");
-            Constructor ctor = ScriptSet.getDeclaredConstructor();
+            Class<?> ScriptSet = Class.forName("com.ibm.icu.text.SpoofChecker$ScriptSet");
+            Constructor<?> ctor = ScriptSet.getDeclaredConstructor();
             ctor.setAccessible(true);
             BitSet ss = (BitSet) ctor.newInstance();
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timezone/TimeZoneTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/timezone/TimeZoneTest.java
@@ -1390,7 +1390,7 @@ public class TimeZoneTest extends CoreTestFmwk
         TimeZone tz = TimeZone.getTimeZone(tzid);
         int offset = tz.getOffset(new Date().getTime());
         logln(tzid + ":\t" + offset);
-        List list = Arrays.asList(TimeZone.getAvailableIDs());
+        List<String> list = Arrays.asList(TimeZone.getAvailableIDs());
         if(!list.contains(tzid)){
             errln("Could create the time zone but it is not in getAvailableIDs");
         }

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/DisplayNameTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/DisplayNameTest.java
@@ -42,9 +42,9 @@ public class DisplayNameTest extends CoreTestFmwk {
         public String get(ULocale locale, String code, Object context);
     }
 
-    Map[] codeToName = new Map[10];
+    Map<String, String>[] codeToName = new Map[10];
     {
-        for (int k = 0; k < codeToName.length; ++k) codeToName[k] = new HashMap();
+        for (int k = 0; k < codeToName.length; ++k) codeToName[k] = new HashMap<>();
     }
 
     static final Object[] zoneFormats = {0, 1, 2, 3, 4, 5, 6, 7};
@@ -82,9 +82,9 @@ public class DisplayNameTest extends CoreTestFmwk {
      * @return
      */
     private String[] getRealZoneIDs() {
-        Set temp = new TreeSet(Arrays.asList(TimeZone.getAvailableIDs()));
+        Set<String> temp = new TreeSet<>(Arrays.asList(TimeZone.getAvailableIDs()));
         temp.removeAll(getAliasMap().keySet());
-        return (String[])temp.toArray(new String[temp.size()]);
+        return temp.toArray(new String[temp.size()]);
     }
 
     @Ignore
@@ -141,12 +141,12 @@ public class DisplayNameTest extends CoreTestFmwk {
 
     }
 
-    Map zoneData = new HashMap();
+    Map<ULocale, Map<String, String[]>> zoneData = new HashMap<>();
 
     private String getZoneString(ULocale locale, String olsonID, int item) {
-        Map data = (Map)zoneData.get(locale);
+        Map<String, String[]> data = zoneData.get(locale);
         if (data == null) {
-            data = new HashMap();
+            data = new HashMap<>();
             if (SHOW_ALL) System.out.println();
             if (SHOW_ALL) System.out.println("zones for " + locale);
             ICUResourceBundle bundle = (ICUResourceBundle)UResourceBundle.getBundleInstance(locale);
@@ -156,7 +156,7 @@ public class DisplayNameTest extends CoreTestFmwk {
                 //ICUResourceBundle stringSet = table.getWithFallback(String.valueOf(i));
                 String key = stringSet.getString(0);
                 if (SHOW_ALL) System.out.println("key: " + key);
-                ArrayList list = new ArrayList();
+                ArrayList<String> list = new ArrayList<>();
                 for (int j = 1; j < stringSet.getSize(); ++j) {
                     String entry = stringSet.getString(j);
                     if (SHOW_ALL) System.out.println("  entry: " + entry);
@@ -337,8 +337,8 @@ public class DisplayNameTest extends CoreTestFmwk {
         ICUResourceBundle bundle = (ICUResourceBundle)UResourceBundle.getBundleInstance(locale);
         ICUResourceBundle table = bundle.getWithFallback(tableName);
         // copy into array
-        ArrayList stuff = new ArrayList();
-        for (Enumeration keys = table.getKeys(); keys.hasMoreElements();) {
+        ArrayList<String> stuff = new ArrayList<>();
+        for (Enumeration<String> keys = table.getKeys(); keys.hasMoreElements();) {
             stuff.add(keys.nextElement());
         }
         String[] result = new String[stuff.size()];
@@ -359,18 +359,13 @@ public class DisplayNameTest extends CoreTestFmwk {
         return result;
     }
 
-    Map bogusZones = null;
-
-    private Map getAliasMap() {
-        if (bogusZones == null) {
-            bogusZones = new TreeMap();
-            for (int i = 0; i < zonesAliases.length; ++i) {
-                bogusZones.put(zonesAliases[i][0], zonesAliases[i][1]);
-            }
+    private Map<String, String> getAliasMap() {
+        Map<String, String> bogusZones = new TreeMap<>();
+        for (int i = 0; i < zonesAliases.length; ++i) {
+            bogusZones.put(zonesAliases[i][0], zonesAliases[i][1]);
         }
         return bogusZones;
     }
-
 
     private void check(String type, ULocale locale,
       String[] codes, Object[] contextList, DisplayNameGetter getter) {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/ICUServiceTestSample.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/ICUServiceTestSample.java
@@ -10,9 +10,7 @@ package com.ibm.icu.dev.test.util;
 
 import java.text.Collator;
 import java.util.EventListener;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
 
@@ -60,13 +58,11 @@ public class ICUServiceTestSample {
         }
 
         private void display() {
-            Map names = HelloService.getDisplayNames(ULocale.US);
+            Map<String, String> names = HelloService.getDisplayNames(ULocale.US);
             System.out.println("displaying " + names.size() + " names.");
-            Iterator iter = names.entrySet().iterator();
-            while (iter.hasNext()) {
-                Entry entry = (Entry)iter.next();
-                String displayName = (String)entry.getKey();
-                HelloService service = HelloService.get((String)entry.getValue());
+            for (Map.Entry<String, String> entry : names.entrySet()) {
+                String displayName = entry.getKey();
+                HelloService service = HelloService.get(entry.getValue());
                 System.out.println(displayName + " says " + service.hello());
                 try {
                     Thread.sleep(50);
@@ -184,11 +180,11 @@ public class ICUServiceTestSample {
             return (HelloService)registry().get(id);
         }
     
-        public static Set getVisibleIDs() {
+        public static Set<String> getVisibleIDs() {
             return registry().getVisibleIDs();
         }
     
-        public static Map getDisplayNames(ULocale locale) {
+        public static Map<String, String> getDisplayNames(ULocale locale) {
             return getDisplayNames(registry(), locale);
         }
     
@@ -210,7 +206,7 @@ public class ICUServiceTestSample {
          * uses the default collator for the locale as the comparator to
          * sort the display names, and null for the matchID.
          */
-        public static SortedMap getDisplayNames(ICUService service, ULocale locale) {
+        public static SortedMap<String, String> getDisplayNames(ICUService service, ULocale locale) {
             Collator col = Collator.getInstance(locale.toLocale());
             return service.getDisplayNames(locale, col, null);
         }

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/RegionTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/RegionTest.java
@@ -13,6 +13,7 @@
 
 package com.ibm.icu.dev.test.util;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -611,7 +612,7 @@ public class RegionTest extends CoreTestFmwk {
             try {
                 Region grouping = Region.getInstance(groupingCode);
                 Set<Region> actualChildren = grouping.getContainedRegions();
-                List<String> actualChildIDs = new java.util.ArrayList();
+                List<String> actualChildIDs = new ArrayList<>();
                 for (Region childRegion : actualChildren) {
                     actualChildIDs.add(childRegion.toString());
                 }

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/TestLocaleValidity.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/TestLocaleValidity.java
@@ -12,7 +12,6 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 
 import org.junit.Test;
@@ -187,7 +186,7 @@ public class TestLocaleValidity extends CoreTestFmwk {
         final LinkedHashSet<String> foundKeys = new LinkedHashSet<String>();
         check(tests, foundKeys, Datasubtype.regular, Datasubtype.unknown);
 
-        LinkedHashSet<String> missing = new LinkedHashSet(KeyTypeData.getBcp47Keys());
+        LinkedHashSet<String> missing = new LinkedHashSet<>(KeyTypeData.getBcp47Keys());
         missing.removeAll(foundKeys);
         if (!assertEquals("Missing keys", Collections.EMPTY_SET, missing)) {
             // print out template for missing cases for adding
@@ -313,9 +312,9 @@ public class TestLocaleValidity extends CoreTestFmwk {
 
     private static void showAll() {
         Map<Datatype, Map<Datasubtype, ValiditySet>> data = ValidIdentifiers.getData();
-        for (Entry<Datatype, Map<Datasubtype, ValiditySet>> e1 : data.entrySet()) {
+        for (Map.Entry<Datatype, Map<Datasubtype, ValiditySet>> e1 : data.entrySet()) {
             System.out.println(e1.getKey());
-            for (Entry<Datasubtype, ValiditySet> e2 : e1.getValue().entrySet()) {
+            for (Map.Entry<Datasubtype, ValiditySet> e2 : e1.getValue().entrySet()) {
                 System.out.println("\t" + e2.getKey());
                 System.out.println("\t\t" + e2.getValue());
             }

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/TextTrieMapTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/TextTrieMapTest.java
@@ -87,8 +87,8 @@ public class TextTrieMapTest extends CoreTestFmwk {
 
     @Test
     public void TestCaseSensitive() {
-        Iterator itr = null;
-        TextTrieMap map = new TextTrieMap(false);
+        Iterator<Object> itr = null;
+        TextTrieMap<Object> map = new TextTrieMap<>(false);
         for (int i = 0; i < TESTDATA.length; i++) {
             map.put((String)TESTDATA[i][0], TESTDATA[i][1]);
         }
@@ -147,8 +147,8 @@ public class TextTrieMapTest extends CoreTestFmwk {
 
     @Test
     public void TestCaseInsensitive() {
-        Iterator itr = null;
-        TextTrieMap map = new TextTrieMap(true);
+        Iterator<Object> itr = null;
+        TextTrieMap<Object> map = new TextTrieMap<>(true);
         for (int i = 0; i < TESTDATA.length; i++) {
             map.put((String)TESTDATA[i][0], TESTDATA[i][1]);
         }
@@ -214,7 +214,7 @@ public class TextTrieMapTest extends CoreTestFmwk {
         return o1.equals(o2);
     }
 
-    private void checkResult(String memo, Iterator itr, Object expected) {
+    private void checkResult(String memo, Iterator<Object> itr, Object expected) {
         if (itr == null) {
             if (expected != null) {
                 String expectedStr = (expected instanceof Object[])

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/UtilityTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/UtilityTest.java
@@ -195,8 +195,8 @@ public class UtilityTest extends CoreTestFmwk {
     @Test
     public void TestUnicodeSet(){
         String[] array = new String[]{"a", "b", "c", "{de}"};
-        List list = Arrays.asList(array);
-        Set aset = new HashSet(list);
+        List<String> list = Arrays.asList(array);
+        Set<String> aset = new HashSet<>(list);
         logln(" *** The source set's size is: " + aset.size());
     //The size reads 4
         UnicodeSet set = new UnicodeSet();


### PR DESCRIPTION
To make the review easier this only fixes one kind of warning:
`XYZ is a raw type. References to generic type XYZ should be parameterized.`

This PR removes about 440 warnings.

Only fixed the warnings in tests, leaving the main code untouched.

The non-test code might needs a bit more care.
Some might be implementation details, private methods / members, easy to change.
But some might affect public APIs

---

There is also a leftover class in tests that need fixing.

`LocaleAliasTest` fails if I fix it, because it is already broken, but no tests run.

There is a generic (typeless) `Map`, initialized with some `String` (key) =>  `Strings` (value).

Later on there are `get(ULocale)` calls, which return `null`, and that test case if skipped.
So no test is executed, because in fact all test cases are skipped.

If I fix the type of the map to `<ULocale, ULocale>` (as it should be), then the real tests are executed and some are failing.

#### Checklist
- [x] Required: Issue filed: ICU-22920
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
