### PR TITLE
ICU-22954 revert making LocalPointer & Co. header-only

### DIFF
--- a/icu4c/source/common/characterproperties.cpp
+++ b/icu4c/source/common/characterproperties.cpp
@@ -24,7 +24,7 @@
 #include "umutex.h"
 #include "uprops.h"
 
-using U_ICU_NAMESPACE_OR_INTERNAL::LocalPointer;
+using icu::LocalPointer;
 #if !UCONFIG_NO_NORMALIZATION
 using icu::Normalizer2Factory;
 using icu::Normalizer2Impl;
@@ -340,7 +340,7 @@ UnicodeSet *makeSet(UProperty property, UErrorCode &errorCode) {
 UCPMap *makeMap(UProperty property, UErrorCode &errorCode) {
     if (U_FAILURE(errorCode)) { return nullptr; }
     uint32_t nullValue = property == UCHAR_SCRIPT ? USCRIPT_UNKNOWN : 0;
-    U_ICU_NAMESPACE_OR_INTERNAL::LocalUMutableCPTriePointer mutableTrie(
+    icu::LocalUMutableCPTriePointer mutableTrie(
         umutablecptrie_open(nullValue, nullValue, &errorCode));
     const UnicodeSet *inclusions =
         icu::CharacterProperties::getInclusionsForProperty(property, errorCode);

--- a/icu4c/source/common/locavailable.cpp
+++ b/icu4c/source/common/locavailable.cpp
@@ -208,8 +208,7 @@ UBool U_CALLCONV uloc_cleanup() {
 void U_CALLCONV loadInstalledLocales(UErrorCode& status) {
     ucln_common_registerCleanup(UCLN_COMMON_ULOC, uloc_cleanup);
 
-    U_ICU_NAMESPACE_OR_INTERNAL::LocalUResourceBundlePointer rb(
-        ures_openDirect(nullptr, "res_index", &status));
+    icu::LocalUResourceBundlePointer rb(ures_openDirect(nullptr, "res_index", &status));
     AvailableLocalesSink sink;
     ures_getAllItemsWithFallback(rb.getAlias(), "", sink, status);
 }

--- a/icu4c/source/common/locdispnames.cpp
+++ b/icu4c/source/common/locdispnames.cpp
@@ -37,9 +37,6 @@
 #include "ureslocs.h"
 #include "ustr_imp.h"
 
-using U_ICU_NAMESPACE_OR_INTERNAL::LocalUEnumerationPointer;
-using U_ICU_NAMESPACE_OR_INTERNAL::LocalUResourceBundlePointer;
-
 // C++ API ----------------------------------------------------------------- ***
 
 U_NAMESPACE_BEGIN
@@ -316,7 +313,7 @@ _getStringOrCopyKey(const char *path, const char *locale,
 
     if(itemKey==nullptr) {
         /* top-level item: normal resource bundle access */
-        LocalUResourceBundlePointer rb(ures_open(path, locale, &errorCode));
+        icu::LocalUResourceBundlePointer rb(ures_open(path, locale, &errorCode));
 
         if(U_SUCCESS(errorCode)) {
             s=ures_getStringByKey(rb.getAlias(), tableKey, &length, &errorCode);
@@ -542,9 +539,9 @@ uloc_getDisplayName(const char *locale,
     {
         UErrorCode status = U_ZERO_ERROR;
 
-        LocalUResourceBundlePointer locbundle(
+        icu::LocalUResourceBundlePointer locbundle(
                 ures_open(U_ICUDATA_LANG, displayLocale, &status));
-        LocalUResourceBundlePointer dspbundle(
+        icu::LocalUResourceBundlePointer dspbundle(
                 ures_getByKeyWithFallback(locbundle.getAlias(), _kLocaleDisplayPattern, nullptr, &status));
 
         separator=ures_getStringByKeyWithFallback(dspbundle.getAlias(), _kSeparator, &sepLen, &status);
@@ -616,7 +613,7 @@ uloc_getDisplayName(const char *locale,
         int32_t langPos=0; /* position in output of language substitution */
         int32_t restLen=0; /* length of 'everything else' substitution */
         int32_t restPos=0; /* position in output of 'everything else' substitution */
-        LocalUEnumerationPointer kenum; /* keyword enumeration */
+        icu::LocalUEnumerationPointer kenum; /* keyword enumeration */
 
         /* prefix of pattern, extremely likely to be empty */
         if(sub0Pos) {
@@ -858,11 +855,11 @@ uloc_getDisplayKeywordValue(   const char* locale,
         int32_t dispNameLen = 0;
         const char16_t *dispName = nullptr;
 
-        LocalUResourceBundlePointer bundle(
+        icu::LocalUResourceBundlePointer bundle(
                 ures_open(U_ICUDATA_CURR, displayLocale, status));
-        LocalUResourceBundlePointer currencies(
+        icu::LocalUResourceBundlePointer currencies(
                 ures_getByKey(bundle.getAlias(), _kCurrencies, nullptr, status));
-        LocalUResourceBundlePointer currency(
+        icu::LocalUResourceBundlePointer currency(
                 ures_getByKeyWithFallback(currencies.getAlias(), keywordValue.data(), nullptr, status));
 
         dispName = ures_getStringByIndex(currency.getAlias(), UCURRENCY_DISPLAY_NAME_INDEX, &dispNameLen, status);

--- a/icu4c/source/common/locresdata.cpp
+++ b/icu4c/source/common/locresdata.cpp
@@ -59,8 +59,7 @@ uloc_getTableStringWithFallback(const char *path, const char *locale,
      * this falls back through the locale's chain to root
      */
     errorCode=U_ZERO_ERROR;
-    U_ICU_NAMESPACE_OR_INTERNAL::LocalUResourceBundlePointer rb(
-        ures_open(path, locale, &errorCode));
+    icu::LocalUResourceBundlePointer rb(ures_open(path, locale, &errorCode));
 
     if(U_FAILURE(errorCode)) {
         /* total failure, not even root could be opened */

--- a/icu4c/source/common/locutil.cpp
+++ b/icu4c/source/common/locutil.cpp
@@ -233,8 +233,7 @@ LocaleUtility::getAvailableLocaleNames(const UnicodeString& bundleID)
             CharString cbundleID;
             cbundleID.appendInvariantChars(bundleID, status);
             const char* path = cbundleID.isEmpty() ? nullptr : cbundleID.data();
-            U_ICU_NAMESPACE_OR_INTERNAL::LocalUEnumerationPointer uenum(
-                ures_openAvailableLocales(path, &status));
+            icu::LocalUEnumerationPointer uenum(ures_openAvailableLocales(path, &status));
             for (;;) {
                 const char16_t* id = uenum_unext(uenum.getAlias(), nullptr, &status);
                 if (id == nullptr) {

--- a/icu4c/source/common/uloc_tag.cpp
+++ b/icu4c/source/common/uloc_tag.cpp
@@ -27,9 +27,6 @@
 #include "ulocimp.h"
 #include "uassert.h"
 
-using U_ICU_NAMESPACE_OR_INTERNAL::LocalPointer;
-using U_ICU_NAMESPACE_OR_INTERNAL::LocalUEnumerationPointer;
-
 namespace {
 
 /* struct holding a single variant */
@@ -357,6 +354,10 @@ const char*
 ultag_getLegacy(const ULanguageTag* langtag);
 #endif
 
+}  // namespace
+
+U_NAMESPACE_BEGIN
+
 /**
  * \class LocalULanguageTagPointer
  * "Smart pointer" class, closes a ULanguageTag via ultag_close().
@@ -368,7 +369,7 @@ ultag_getLegacy(const ULanguageTag* langtag);
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalULanguageTagPointer, ULanguageTag, ultag_close);
 
-}  // namespace
+U_NAMESPACE_END
 
 /*
 * -------------------------------------------------
@@ -868,7 +869,7 @@ namespace {
 */
 
 bool
-_addVariantToList(VariantListEntry **first, LocalPointer<VariantListEntry> var) {
+_addVariantToList(VariantListEntry **first, icu::LocalPointer<VariantListEntry> var) {
     if (*first == nullptr) {
         var->next = nullptr;
         *first = var.orphan();
@@ -1211,7 +1212,7 @@ _appendVariantsToLanguageTag(std::string_view localeID, icu::ByteSink& sink, boo
                     if (_isVariantSubtag(pVar, -1)) {
                         if (uprv_strcmp(pVar, POSIX_VALUE) || buf.length() != static_cast<int32_t>(uprv_strlen(POSIX_VALUE))) {
                             /* emit the variant to the list */
-                            LocalPointer<VariantListEntry> var(new VariantListEntry, status);
+                            icu::LocalPointer<VariantListEntry> var(new VariantListEntry, status);
                             if (U_FAILURE(status)) {
                                 break;
                             }
@@ -1283,7 +1284,7 @@ _appendKeywordsToLanguageTag(const char* localeID, icu::ByteSink& sink, bool str
     icu::MemoryPool<ExtensionListEntry> extPool;
     icu::MemoryPool<icu::CharString> strPool;
 
-    LocalUEnumerationPointer keywordEnum(uloc_openKeywords(localeID, &status));
+    icu::LocalUEnumerationPointer keywordEnum(uloc_openKeywords(localeID, &status));
     if (U_FAILURE(status) && !hadPosix) {
         return;
     }
@@ -1983,7 +1984,7 @@ ultag_parse(const char* tag, int32_t tagLen, int32_t* parsedLen, UErrorCode& sta
     char *pSubtag, *pNext, *pLastGoodPosition;
     int32_t subtagLen;
     int32_t extlangIdx;
-    LocalPointer<ExtensionListEntry> pExtension;
+    icu::LocalPointer<ExtensionListEntry> pExtension;
     char *pExtValueSubtag, *pExtValueSubtagEnd;
     int32_t i;
     bool privateuseVar = false;
@@ -2010,7 +2011,7 @@ ultag_parse(const char* tag, int32_t tagLen, int32_t* parsedLen, UErrorCode& sta
     *(tagBuf + tagLen) = 0;
 
     /* create a ULanguageTag */
-    LocalULanguageTagPointer t(
+    icu::LocalULanguageTagPointer t(
             static_cast<ULanguageTag*>(uprv_malloc(sizeof(ULanguageTag))));
     if (t.isNull()) {
         uprv_free(tagBuf);
@@ -2196,7 +2197,7 @@ ultag_parse(const char* tag, int32_t tagLen, int32_t* parsedLen, UErrorCode& sta
         if (next & VART) {
             if (_isVariantSubtag(pSubtag, subtagLen) ||
                (privateuseVar && _isPrivateuseVariantSubtag(pSubtag, subtagLen))) {
-                LocalPointer<VariantListEntry> var(new VariantListEntry, status);
+                icu::LocalPointer<VariantListEntry> var(new VariantListEntry, status);
                 if (U_FAILURE(status)) {
                     return nullptr;
                 }
@@ -2608,7 +2609,7 @@ ulocimp_toLanguageTag(const char* localeID,
         int kwdCnt = 0;
         bool done = false;
 
-        LocalUEnumerationPointer kwdEnum(uloc_openKeywords(canonical.data(), &tmpStatus));
+        icu::LocalUEnumerationPointer kwdEnum(uloc_openKeywords(canonical.data(), &tmpStatus));
         if (U_SUCCESS(tmpStatus)) {
             kwdCnt = uenum_count(kwdEnum.getAlias(), &tmpStatus);
             if (kwdCnt == 1) {
@@ -2690,7 +2691,7 @@ ulocimp_forLanguageTag(const char* langtag,
     int32_t i, n;
     bool noRegion = true;
 
-    LocalULanguageTagPointer lt(ultag_parse(langtag, tagLen, parsedLength, status));
+    icu::LocalULanguageTagPointer lt(ultag_parse(langtag, tagLen, parsedLength, status));
     if (U_FAILURE(status)) {
         return;
     }

--- a/icu4c/source/common/unicode/localpointer.h
+++ b/icu4c/source/common/unicode/localpointer.h
@@ -548,8 +548,7 @@ public:
  * @stable ICU 4.4
  */
 #define U_DEFINE_LOCAL_OPEN_POINTER(LocalPointerClassName, Type, closeFunction) \
-    using LocalPointerClassName = \
-        U_ICU_NAMESPACE_OR_INTERNAL::internal::LocalOpenPointer<Type, closeFunction>
+    using LocalPointerClassName = internal::LocalOpenPointer<Type, closeFunction>
 
 #ifndef U_IN_DOXYGEN
 namespace internal {

--- a/icu4c/source/common/unicode/localpointer.h
+++ b/icu4c/source/common/unicode/localpointer.h
@@ -21,7 +21,7 @@
 
 /**
  * \file
- * \brief C++ header-only API: "Smart pointers" for use with and in ICU4C C++ code.
+ * \brief C++ API: "Smart pointers" for use with and in ICU4C C++ code.
  *
  * These classes are inspired by
  * - std::auto_ptr
@@ -40,11 +40,11 @@
 
 #include "unicode/utypes.h"
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+#if U_SHOW_CPLUSPLUS_API
 
 #include <memory>
 
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+U_NAMESPACE_BEGIN
 
 /**
  * "Smart pointer" base class; do not use directly: use LocalPointer etc.
@@ -603,7 +603,7 @@ public:
 }  // namespace internal
 #endif
 
-}  // U_ICU_NAMESPACE_OR_INTERNAL
+U_NAMESPACE_END
 
-#endif  // U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+#endif  /* U_SHOW_CPLUSPLUS_API */
 #endif  /* __LOCALPOINTER_H__ */

--- a/icu4c/source/common/unicode/normlzr.h
+++ b/icu4c/source/common/unicode/normlzr.h
@@ -801,8 +801,8 @@ Normalizer::compare(const UnicodeString &s1, const UnicodeString &s2,
                     uint32_t options,
                     UErrorCode &errorCode) {
   // all argument checking is done in unorm_compare
-  return unorm_compare(U_ICU_NAMESPACE_OR_INTERNAL::toUCharPtr(s1.getBuffer()), s1.length(),
-                       U_ICU_NAMESPACE_OR_INTERNAL::toUCharPtr(s2.getBuffer()), s2.length(),
+  return unorm_compare(toUCharPtr(s1.getBuffer()), s1.length(),
+                       toUCharPtr(s2.getBuffer()), s2.length(),
                        options,
                        &errorCode);
 }

--- a/icu4c/source/common/unicode/ubidi.h
+++ b/icu4c/source/common/unicode/ubidi.h
@@ -563,8 +563,9 @@ ubidi_openSized(int32_t maxLength, int32_t maxRunCount, UErrorCode *pErrorCode);
 U_CAPI void U_EXPORT2
 ubidi_close(UBiDi *pBiDi);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUBiDiPointer
@@ -577,7 +578,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUBiDiPointer, UBiDi, ubidi_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/common/unicode/ubiditransform.h
+++ b/icu4c/source/common/unicode/ubiditransform.h
@@ -304,8 +304,9 @@ ubiditransform_open(UErrorCode *pErrorCode);
 U_CAPI void U_EXPORT2
 ubiditransform_close(UBiDiTransform *pBidiTransform);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUBiDiTransformPointer
@@ -318,7 +319,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUBiDiTransformPointer, UBiDiTransform, ubiditransform_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 #endif

--- a/icu4c/source/common/unicode/ubrk.h
+++ b/icu4c/source/common/unicode/ubrk.h
@@ -356,8 +356,9 @@ ubrk_clone(const UBreakIterator *bi,
 U_CAPI void U_EXPORT2
 ubrk_close(UBreakIterator *bi);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUBreakIteratorPointer
@@ -370,7 +371,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUBreakIteratorPointer, UBreakIterator, ubrk_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/common/unicode/ucasemap.h
+++ b/icu4c/source/common/unicode/ucasemap.h
@@ -83,8 +83,9 @@ ucasemap_open(const char *locale, uint32_t options, UErrorCode *pErrorCode);
 U_CAPI void U_EXPORT2
 ucasemap_close(UCaseMap *csm);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUCaseMapPointer
@@ -97,7 +98,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUCaseMapPointer, UCaseMap, ucasemap_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/common/unicode/ucnv.h
+++ b/icu4c/source/common/unicode/ucnv.h
@@ -581,8 +581,9 @@ ucnv_safeClone(const UConverter *cnv,
 U_CAPI void  U_EXPORT2
 ucnv_close(UConverter * converter);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUConverterPointer
@@ -595,7 +596,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUConverterPointer, UConverter, ucnv_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/common/unicode/ucnvsel.h
+++ b/icu4c/source/common/unicode/ucnvsel.h
@@ -97,8 +97,9 @@ ucnvsel_open(const char* const*  converterList, int32_t converterListSize,
 U_CAPI void U_EXPORT2
 ucnvsel_close(UConverterSelector *sel);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUConverterSelectorPointer
@@ -111,7 +112,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUConverterSelectorPointer, UConverterSelector, ucnvsel_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/common/unicode/ucptrie.h
+++ b/icu4c/source/common/unicode/ucptrie.h
@@ -623,8 +623,9 @@ U_CDECL_END
 
 #endif  // U_IN_DOXYGEN
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUCPTriePointer
@@ -637,7 +638,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUCPTriePointer, UCPTrie, ucptrie_close);
 
-}
-#endif
+U_NAMESPACE_END
+
+#endif  // U_SHOW_CPLUSPLUS_API
 
 #endif

--- a/icu4c/source/common/unicode/udata.h
+++ b/icu4c/source/common/unicode/udata.h
@@ -418,8 +418,9 @@ udata_setFileAccess(UDataFileAccess access, UErrorCode *status);
 
 U_CDECL_END
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUDataMemoryPointer
@@ -432,7 +433,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUDataMemoryPointer, UDataMemory, udata_close);
 
-}
-#endif
+U_NAMESPACE_END
+
+#endif  // U_SHOW_CPLUSPLUS_API
 
 #endif

--- a/icu4c/source/common/unicode/uenum.h
+++ b/icu4c/source/common/unicode/uenum.h
@@ -53,8 +53,9 @@ typedef struct UEnumeration UEnumeration;
 U_CAPI void U_EXPORT2
 uenum_close(UEnumeration* en);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUEnumerationPointer
@@ -67,7 +68,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUEnumerationPointer, UEnumeration, uenum_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/common/unicode/uidna.h
+++ b/icu4c/source/common/unicode/uidna.h
@@ -171,8 +171,9 @@ uidna_openUTS46(uint32_t options, UErrorCode *pErrorCode);
 U_CAPI void U_EXPORT2
 uidna_close(UIDNA *idna);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUIDNAPointer
@@ -185,7 +186,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUIDNAPointer, UIDNA, uidna_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/common/unicode/uldnames.h
+++ b/icu4c/source/common/unicode/uldnames.h
@@ -81,8 +81,9 @@ uldn_open(const char * locale,
 U_CAPI void U_EXPORT2
 uldn_close(ULocaleDisplayNames *ldn);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalULocaleDisplayNamesPointer
@@ -95,7 +96,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalULocaleDisplayNamesPointer, ULocaleDisplayNames, uldn_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /* getters for state */

--- a/icu4c/source/common/unicode/ulocale.h
+++ b/icu4c/source/common/unicode/ulocale.h
@@ -204,8 +204,9 @@ ulocale_getUnicodeKeywordValue(
     const ULocale* locale, const char* keyword, int32_t keywordLength,
     char* valueBuffer, int32_t valueBufferCapacity, UErrorCode *err);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalULocalePointer
@@ -218,7 +219,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalULocalePointer, ULocale, ulocale_close);
 
-}
-#endif
+U_NAMESPACE_END
+
+#endif  /* U_SHOW_CPLUSPLUS_API */
 
 #endif /*_ULOCALE */

--- a/icu4c/source/common/unicode/ulocbuilder.h
+++ b/icu4c/source/common/unicode/ulocbuilder.h
@@ -415,8 +415,9 @@ ulocbld_buildLanguageTag(ULocaleBuilder* builder, char* language,
 U_CAPI UBool U_EXPORT2
 ulocbld_copyErrorTo(const ULocaleBuilder* builder, UErrorCode *outErrorCode);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalULocaleBuilderPointer
@@ -429,7 +430,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalULocaleBuilderPointer, ULocaleBuilder, ulocbld_close);
 
-}
-#endif
+U_NAMESPACE_END
+
+#endif  /* U_SHOW_CPLUSPLUS_API */
 
 #endif  // __ULOCBUILDER_H__

--- a/icu4c/source/common/unicode/umutablecptrie.h
+++ b/icu4c/source/common/unicode/umutablecptrie.h
@@ -218,8 +218,9 @@ umutablecptrie_buildImmutable(UMutableCPTrie *trie, UCPTrieType type, UCPTrieVal
 
 U_CDECL_END
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUMutableCPTriePointer
@@ -232,7 +233,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUMutableCPTriePointer, UMutableCPTrie, umutablecptrie_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 #endif

--- a/icu4c/source/common/unicode/unistr.h
+++ b/icu4c/source/common/unicode/unistr.h
@@ -4676,7 +4676,7 @@ UnicodeString::startsWith(const UnicodeString& srcText,
 inline UBool
 UnicodeString::startsWith(ConstChar16Ptr srcChars, int32_t srcLength) const {
   if(srcLength < 0) {
-    srcLength = u_strlen(U_ICU_NAMESPACE_OR_INTERNAL::toUCharPtr(srcChars));
+    srcLength = u_strlen(toUCharPtr(srcChars));
   }
   return doEqualsSubstring(0, srcLength, srcChars, 0, srcLength);
 }
@@ -4684,7 +4684,7 @@ UnicodeString::startsWith(ConstChar16Ptr srcChars, int32_t srcLength) const {
 inline UBool
 UnicodeString::startsWith(const char16_t *srcChars, int32_t srcStart, int32_t srcLength) const {
   if(srcLength < 0) {
-    srcLength = u_strlen(U_ICU_NAMESPACE_OR_INTERNAL::toUCharPtr(srcChars));
+    srcLength = u_strlen(toUCharPtr(srcChars));
   }
   return doEqualsSubstring(0, srcLength, srcChars, srcStart, srcLength);
 }
@@ -4707,7 +4707,7 @@ inline UBool
 UnicodeString::endsWith(ConstChar16Ptr srcChars,
             int32_t srcLength) const {
   if(srcLength < 0) {
-    srcLength = u_strlen(U_ICU_NAMESPACE_OR_INTERNAL::toUCharPtr(srcChars));
+    srcLength = u_strlen(toUCharPtr(srcChars));
   }
   return doEqualsSubstring(length() - srcLength, srcLength, srcChars, 0, srcLength);
 }
@@ -4717,7 +4717,7 @@ UnicodeString::endsWith(const char16_t *srcChars,
             int32_t srcStart,
             int32_t srcLength) const {
   if(srcLength < 0) {
-    srcLength = u_strlen(U_ICU_NAMESPACE_OR_INTERNAL::toUCharPtr(srcChars + srcStart));
+    srcLength = u_strlen(toUCharPtr(srcChars + srcStart));
   }
   return doEqualsSubstring(length() - srcLength, srcLength,
                    srcChars, srcStart, srcLength);

--- a/icu4c/source/common/unicode/unorm2.h
+++ b/icu4c/source/common/unicode/unorm2.h
@@ -268,8 +268,9 @@ unorm2_openFiltered(const UNormalizer2 *norm2, const USet *filterSet, UErrorCode
 U_CAPI void U_EXPORT2
 unorm2_close(UNormalizer2 *norm2);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUNormalizer2Pointer
@@ -282,7 +283,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUNormalizer2Pointer, UNormalizer2, unorm2_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/common/unicode/ures.h
+++ b/icu4c/source/common/unicode/ures.h
@@ -252,8 +252,9 @@ ures_countArrayItems(const UResourceBundle* resourceBundle,
 U_CAPI void U_EXPORT2
 ures_close(UResourceBundle* resourceBundle);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUResourceBundlePointer
@@ -266,7 +267,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUResourceBundlePointer, UResourceBundle, ures_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 #ifndef U_HIDE_DEPRECATED_API

--- a/icu4c/source/common/unicode/uset.h
+++ b/icu4c/source/common/unicode/uset.h
@@ -346,9 +346,9 @@ uset_openPatternOptions(const UChar* pattern, int32_t patternLength,
 U_CAPI void U_EXPORT2
 uset_close(USet* set);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+#if U_SHOW_CPLUSPLUS_API
 
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUSetPointer
@@ -361,7 +361,7 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUSetPointer, USet, uset_close);
 
-}  // U_ICU_NAMESPACE_OR_INTERNAL
+U_NAMESPACE_END
 
 #endif
 

--- a/icu4c/source/common/unicode/uset.h
+++ b/icu4c/source/common/unicode/uset.h
@@ -347,6 +347,7 @@ U_CAPI void U_EXPORT2
 uset_close(USet* set);
 
 #if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
+
 namespace U_ICU_NAMESPACE_OR_INTERNAL {
 
 /**
@@ -360,7 +361,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUSetPointer, USet, uset_close);
 
-}
+}  // U_ICU_NAMESPACE_OR_INTERNAL
+
 #endif
 
 /**

--- a/icu4c/source/common/unicode/usprep.h
+++ b/icu4c/source/common/unicode/usprep.h
@@ -212,8 +212,9 @@ usprep_openByType(UStringPrepProfileType type,
 U_CAPI void U_EXPORT2
 usprep_close(UStringPrepProfile* profile);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUStringPrepProfilePointer
@@ -226,7 +227,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUStringPrepProfilePointer, UStringPrepProfile, usprep_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/common/unicode/utext.h
+++ b/icu4c/source/common/unicode/utext.h
@@ -1580,8 +1580,9 @@ enum {
 U_CDECL_END
 
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUTextPointer
@@ -1594,7 +1595,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUTextPointer, UText, utext_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 

--- a/icu4c/source/i18n/unicode/ucal.h
+++ b/icu4c/source/i18n/unicode/ucal.h
@@ -787,8 +787,9 @@ ucal_open(const UChar*   zoneID,
 U_CAPI void U_EXPORT2 
 ucal_close(UCalendar *cal);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUCalendarPointer
@@ -801,7 +802,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUCalendarPointer, UCalendar, ucal_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/ucol.h
+++ b/icu4c/source/i18n/unicode/ucol.h
@@ -1572,8 +1572,8 @@ class Predicate {
         return compare(
             ucol_strcoll(
                 collator,
-                U_ICU_NAMESPACE_OR_INTERNAL::toUCharPtr(lhs.getBuffer()), lhs.length(),
-                U_ICU_NAMESPACE_OR_INTERNAL::toUCharPtr(rhs.getBuffer()), rhs.length()),
+                toUCharPtr(lhs.getBuffer()), lhs.length(),
+                toUCharPtr(rhs.getBuffer()), rhs.length()),
             result);
     }
 

--- a/icu4c/source/i18n/unicode/ucol.h
+++ b/icu4c/source/i18n/unicode/ucol.h
@@ -537,8 +537,9 @@ ucol_getContractionsAndExpansions( const UCollator *coll,
 U_CAPI void U_EXPORT2 
 ucol_close(UCollator *coll);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUCollatorPointer
@@ -551,7 +552,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUCollatorPointer, UCollator, ucol_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/ucsdet.h
+++ b/icu4c/source/i18n/unicode/ucsdet.h
@@ -93,8 +93,9 @@ ucsdet_open(UErrorCode   *status);
 U_CAPI void U_EXPORT2
 ucsdet_close(UCharsetDetector *ucsd);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUCharsetDetectorPointer
@@ -107,7 +108,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUCharsetDetectorPointer, UCharsetDetector, ucsdet_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/udat.h
+++ b/icu4c/source/i18n/unicode/udat.h
@@ -1006,8 +1006,9 @@ typedef enum UDateFormatHourCycle {
     UDAT_HOUR_CYCLE_24
 } UDateFormatHourCycle;
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUDateFormatPointer
@@ -1020,7 +1021,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUDateFormatPointer, UDateFormat, udat_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/udateintervalformat.h
+++ b/icu4c/source/i18n/unicode/udateintervalformat.h
@@ -182,8 +182,9 @@ U_CAPI void U_EXPORT2
 udtitvfmt_closeResult(UFormattedDateInterval* uresult);
 
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUDateIntervalFormatPointer
@@ -207,7 +208,8 @@ U_DEFINE_LOCAL_OPEN_POINTER(LocalUDateIntervalFormatPointer, UDateIntervalFormat
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUFormattedDateIntervalPointer, UFormattedDateInterval, udtitvfmt_closeResult);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 

--- a/icu4c/source/i18n/unicode/udatpg.h
+++ b/icu4c/source/i18n/unicode/udatpg.h
@@ -185,8 +185,9 @@ udatpg_openEmpty(UErrorCode *pErrorCode);
 U_CAPI void U_EXPORT2
 udatpg_close(UDateTimePatternGenerator *dtpg);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUDateTimePatternGeneratorPointer
@@ -199,7 +200,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUDateTimePatternGeneratorPointer, UDateTimePatternGenerator, udatpg_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/ufieldpositer.h
+++ b/icu4c/source/i18n/unicode/ufieldpositer.h
@@ -67,8 +67,9 @@ U_CAPI void U_EXPORT2
 ufieldpositer_close(UFieldPositionIterator *fpositer);
 
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUFieldPositionIteratorPointer
@@ -81,7 +82,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUFieldPositionIteratorPointer, UFieldPositionIterator, ufieldpositer_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/uformattable.h
+++ b/icu4c/source/i18n/unicode/uformattable.h
@@ -93,8 +93,9 @@ ufmt_open(UErrorCode* status);
 U_CAPI void U_EXPORT2
 ufmt_close(UFormattable* fmt);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUFormattablePointer
@@ -107,7 +108,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUFormattablePointer, UFormattable, ufmt_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/uformattednumber.h
+++ b/icu4c/source/i18n/unicode/uformattednumber.h
@@ -196,8 +196,8 @@ U_CAPI void U_EXPORT2
 unumf_closeResult(UFormattedNumber* uresult);
 
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUFormattedNumberPointer
@@ -216,8 +216,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUFormattedNumberPointer, UFormattedNumber, unumf_closeResult);
 
-}
-#endif
+U_NAMESPACE_END
+#endif // U_SHOW_CPLUSPLUS_API
 
 
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/i18n/unicode/uformattedvalue.h
+++ b/icu4c/source/i18n/unicode/uformattedvalue.h
@@ -418,8 +418,8 @@ ufmtval_nextPosition(
     UErrorCode* ec);
 
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUConstrainedFieldPositionPointer
@@ -437,8 +437,8 @@ U_DEFINE_LOCAL_OPEN_POINTER(LocalUConstrainedFieldPositionPointer,
     UConstrainedFieldPosition,
     ucfpos_close);
 
-}
-#endif
+U_NAMESPACE_END
+#endif // U_SHOW_CPLUSPLUS_API
 
 
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/i18n/unicode/ulistformatter.h
+++ b/icu4c/source/i18n/unicode/ulistformatter.h
@@ -220,8 +220,9 @@ U_CAPI void U_EXPORT2
 ulistfmt_closeResult(UFormattedList* uresult);
 
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUListFormatterPointer
@@ -245,7 +246,8 @@ U_DEFINE_LOCAL_OPEN_POINTER(LocalUListFormatterPointer, UListFormatter, ulistfmt
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUFormattedListPointer, UFormattedList, ulistfmt_closeResult);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/ulocdata.h
+++ b/icu4c/source/i18n/unicode/ulocdata.h
@@ -102,8 +102,9 @@ ulocdata_open(const char *localeID, UErrorCode *status);
 U_CAPI void U_EXPORT2
 ulocdata_close(ULocaleData *uld);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalULocaleDataPointer
@@ -116,7 +117,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalULocaleDataPointer, ULocaleData, ulocdata_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/umsg.h
+++ b/icu4c/source/i18n/unicode/umsg.h
@@ -415,8 +415,9 @@ umsg_open(  const UChar     *pattern,
 U_CAPI void U_EXPORT2 
 umsg_close(UMessageFormat* format);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUMessageFormatPointer
@@ -429,7 +430,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUMessageFormatPointer, UMessageFormat, umsg_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/unum.h
+++ b/icu4c/source/i18n/unicode/unum.h
@@ -444,8 +444,9 @@ unum_open(  UNumberFormatStyle    style,
 U_CAPI void U_EXPORT2 
 unum_close(UNumberFormat* fmt);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUNumberFormatPointer
@@ -458,7 +459,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUNumberFormatPointer, UNumberFormat, unum_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/unumberformatter.h
+++ b/icu4c/source/i18n/unicode/unumberformatter.h
@@ -549,8 +549,8 @@ unumf_close(UNumberFormatter* uformatter);
 
 
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUNumberFormatterPointer
@@ -569,8 +569,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUNumberFormatterPointer, UNumberFormatter, unumf_close);
 
-}
-#endif
+U_NAMESPACE_END
+#endif // U_SHOW_CPLUSPLUS_API
 
 #endif /* #if !UCONFIG_NO_FORMATTING */
 #endif //__UNUMBERFORMATTER_H__

--- a/icu4c/source/i18n/unicode/unumberrangeformatter.h
+++ b/icu4c/source/i18n/unicode/unumberrangeformatter.h
@@ -426,8 +426,8 @@ U_CAPI void U_EXPORT2
 unumrf_closeResult(UFormattedNumberRange* uresult);
 
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUNumberRangeFormatterPointer
@@ -464,8 +464,8 @@ U_DEFINE_LOCAL_OPEN_POINTER(LocalUNumberRangeFormatterPointer, UNumberRangeForma
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUFormattedNumberRangePointer, UFormattedNumberRange, unumrf_closeResult);
 
-}
-#endif
+U_NAMESPACE_END
+#endif // U_SHOW_CPLUSPLUS_API
 
 #endif /* #if !UCONFIG_NO_FORMATTING */
 #endif //__UNUMBERRANGEFORMATTER_H__

--- a/icu4c/source/i18n/unicode/unumsys.h
+++ b/icu4c/source/i18n/unicode/unumsys.h
@@ -89,8 +89,8 @@ unumsys_openByName(const char *name, UErrorCode *status);
 U_CAPI void U_EXPORT2
 unumsys_close(UNumberingSystem *unumsys);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUNumberingSystemPointer
@@ -102,7 +102,7 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUNumberingSystemPointer, UNumberingSystem, unumsys_close);
 
-}
+U_NAMESPACE_END
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/upluralrules.h
+++ b/icu4c/source/i18n/unicode/upluralrules.h
@@ -120,8 +120,9 @@ U_CAPI void U_EXPORT2
 uplrules_close(UPluralRules *uplrules);
 
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUPluralRulesPointer
@@ -134,7 +135,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUPluralRulesPointer, UPluralRules, uplrules_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 

--- a/icu4c/source/i18n/unicode/uregex.h
+++ b/icu4c/source/i18n/unicode/uregex.h
@@ -213,8 +213,9 @@ uregex_openC( const char           *pattern,
 U_CAPI void U_EXPORT2 
 uregex_close(URegularExpression *regexp);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalURegularExpressionPointer
@@ -227,7 +228,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalURegularExpressionPointer, URegularExpression, uregex_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/ureldatefmt.h
+++ b/icu4c/source/i18n/unicode/ureldatefmt.h
@@ -299,8 +299,9 @@ U_CAPI void U_EXPORT2
 ureldatefmt_closeResult(UFormattedRelativeDateTime* ufrdt);
 
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalURelativeDateTimeFormatterPointer
@@ -324,7 +325,8 @@ U_DEFINE_LOCAL_OPEN_POINTER(LocalURelativeDateTimeFormatterPointer, URelativeDat
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUFormattedRelativeDateTimePointer, UFormattedRelativeDateTime, ureldatefmt_closeResult);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/i18n/unicode/usearch.h
+++ b/icu4c/source/i18n/unicode/usearch.h
@@ -360,8 +360,9 @@ U_CAPI UStringSearch * U_EXPORT2 usearch_openFromCollator(
  */
 U_CAPI void U_EXPORT2 usearch_close(UStringSearch *searchiter);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUStringSearchPointer
@@ -374,7 +375,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUStringSearchPointer, UStringSearch, usearch_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /* get and set methods -------------------------------------------------- */

--- a/icu4c/source/i18n/unicode/usimplenumberformatter.h
+++ b/icu4c/source/i18n/unicode/usimplenumberformatter.h
@@ -250,8 +250,8 @@ U_CAPI void U_EXPORT2
 usnumf_close(USimpleNumberFormatter* uformatter);
 
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUSimpleNumberPointer
@@ -290,7 +290,7 @@ U_DEFINE_LOCAL_OPEN_POINTER(LocalUSimpleNumberPointer, USimpleNumber, usnum_clos
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUSimpleNumberFormatterPointer, USimpleNumberFormatter, usnumf_close);
 
-}
+U_NAMESPACE_END
 #endif // U_SHOW_CPLUSPLUS_API
 
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/i18n/unicode/uspoof.h
+++ b/icu4c/source/i18n/unicode/uspoof.h
@@ -1550,8 +1550,9 @@ uspoof_serialize(USpoofChecker *sc,
 
 U_CDECL_END
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUSpoofCheckerPointer
@@ -1588,10 +1589,7 @@ U_DEFINE_LOCAL_OPEN_POINTER(LocalUSpoofCheckerPointer, USpoofChecker, uspoof_clo
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUSpoofCheckResultPointer, USpoofCheckResult, uspoof_closeCheckResult);
 /** \endcond */
 
-}
-#endif
-
-#if U_SHOW_CPLUSPLUS_API
+U_NAMESPACE_END
 
 /**
  * Limit the acceptable characters to those specified by a Unicode Set.

--- a/icu4c/source/i18n/unicode/utrans.h
+++ b/icu4c/source/i18n/unicode/utrans.h
@@ -242,8 +242,9 @@ utrans_clone(const UTransliterator* trans,
 U_CAPI void U_EXPORT2 
 utrans_close(UTransliterator* trans);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUTransliteratorPointer
@@ -256,7 +257,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUTransliteratorPointer, UTransliterator, utrans_close);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/io/unicode/ustdio.h
+++ b/icu4c/source/io/unicode/ustdio.h
@@ -341,8 +341,9 @@ u_fstropen(UChar      *stringBuf,
 U_CAPI void U_EXPORT2
 u_fclose(UFILE *file);
 
-#if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API
-namespace U_ICU_NAMESPACE_OR_INTERNAL {
+#if U_SHOW_CPLUSPLUS_API
+
+U_NAMESPACE_BEGIN
 
 /**
  * \class LocalUFILEPointer
@@ -355,7 +356,8 @@ namespace U_ICU_NAMESPACE_OR_INTERNAL {
  */
 U_DEFINE_LOCAL_OPEN_POINTER(LocalUFILEPointer, UFILE, u_fclose);
 
-}
+U_NAMESPACE_END
+
 #endif
 
 /**

--- a/icu4c/source/test/intltest/usetheaderonlytest.cpp
+++ b/icu4c/source/test/intltest/usetheaderonlytest.cpp
@@ -4,6 +4,7 @@
 // usetheaderonlytest.cpp
 // created: 2024dec11 Markus W. Scherer
 
+#include <memory>
 #include <string>
 
 // Test header-only ICU C++ APIs. Do not use other ICU C++ APIs.
@@ -57,16 +58,17 @@ std::u16string cpString(UChar32 c) {
 void USetHeaderOnlyTest::TestUSetCodePointIterator() {
     IcuTestErrorCode errorCode(*this, "TestUSetCodePointIterator");
     using U_HEADER_NESTED_NAMESPACE::USetCodePoints;
-    LocalUSetPointer uset(uset_openPattern(u"[abcçカ🚴]", -1, errorCode));
+    std::unique_ptr<USet, decltype(&uset_close)> uset(
+        uset_openPattern(u"[abcçカ🚴]", -1, errorCode), &uset_close);
     std::u16string result;
-    for (UChar32 c : USetCodePoints(uset.getAlias())) {
+    for (UChar32 c : USetCodePoints(uset.get())) {
         // Commented-out sample code for pasting into the API docs.
         // printf("uset.codePoint U+%04lx\n", (long)c);
         result.append(u" ").append(cpString(c));
     }
     assertEquals(WHERE, u" a b c ç カ 🚴", result);
 
-    USetCodePoints range1(uset.getAlias());
+    USetCodePoints range1(uset.get());
     auto range2(range1);  // copy constructor
     auto iter = range1.begin();
     auto limit = range2.end();
@@ -89,16 +91,17 @@ void USetHeaderOnlyTest::TestUSetRangeIterator() {
     IcuTestErrorCode errorCode(*this, "TestUSetRangeIterator");
     using U_HEADER_NESTED_NAMESPACE::USetRanges;
     using U_HEADER_NESTED_NAMESPACE::CodePointRange;
-    LocalUSetPointer uset(uset_openPattern(u"[abcçカ🚴]", -1, errorCode));
+    std::unique_ptr<USet, decltype(&uset_close)> uset(
+        uset_openPattern(u"[abcçカ🚴]", -1, errorCode), &uset_close);
     std::u16string result;
-    for (auto [start, end] : USetRanges(uset.getAlias())) {
+    for (auto [start, end] : USetRanges(uset.get())) {
         // Commented-out sample code for pasting into the API docs.
         // printf("uset.range U+%04lx..U+%04lx\n", (long)start, (long)end);
         result.append(u" ").append(cpString(start)).append(u"-").append(cpString(end));
     }
     assertEquals(WHERE, u" a-c ç-ç カ-カ 🚴-🚴", result);
     result.clear();
-    for (auto range : USetRanges(uset.getAlias())) {
+    for (auto range : USetRanges(uset.get())) {
         for (UChar32 c : range) {
             // Commented-out sample code for pasting into the API docs.
             // printf("uset.range.c U+%04lx\n", (long)c);
@@ -108,7 +111,7 @@ void USetHeaderOnlyTest::TestUSetRangeIterator() {
     }
     assertEquals(WHERE, u" a b c | ç | カ | 🚴 |", result);
 
-    USetRanges range1(uset.getAlias());
+    USetRanges range1(uset.get());
     auto range2(range1);  // copy constructor
     auto iter = range1.begin();
     auto limit = range2.end();
@@ -155,9 +158,10 @@ void USetHeaderOnlyTest::TestUSetRangeIterator() {
 void USetHeaderOnlyTest::TestUSetStringIterator() {
     IcuTestErrorCode errorCode(*this, "TestUSetStringIterator");
     using U_HEADER_NESTED_NAMESPACE::USetStrings;
-    LocalUSetPointer uset(uset_openPattern(u"[abcçカ🚴{}{abc}{de}]", -1, errorCode));
+    std::unique_ptr<USet, decltype(&uset_close)> uset(
+        uset_openPattern(u"[abcçカ🚴{}{abc}{de}]", -1, errorCode), &uset_close);
     std::u16string result;
-    for (auto s : USetStrings(uset.getAlias())) {
+    for (auto s : USetStrings(uset.get())) {
         // Commented-out sample code for pasting into the API docs.
         // Needs U_SHOW_CPLUSPLUS_API=1 for UnicodeString.
         // UnicodeString us(s);
@@ -167,7 +171,7 @@ void USetHeaderOnlyTest::TestUSetStringIterator() {
     }
     assertEquals(WHERE, uR"( "" "abc" "de")", result);
 
-    USetStrings range1(uset.getAlias());
+    USetStrings range1(uset.get());
     auto range2(range1);  // copy constructor
     auto iter = range1.begin();
     auto limit = range2.end();
@@ -185,9 +189,10 @@ void USetHeaderOnlyTest::TestUSetStringIterator() {
 void USetHeaderOnlyTest::TestUSetElementIterator() {
     IcuTestErrorCode errorCode(*this, "TestUSetElementIterator");
     using U_HEADER_NESTED_NAMESPACE::USetElements;
-    LocalUSetPointer uset(uset_openPattern(u"[abcçカ🚴{}{abc}{de}]", -1, errorCode));
+    std::unique_ptr<USet, decltype(&uset_close)> uset(
+        uset_openPattern(u"[abcçカ🚴{}{abc}{de}]", -1, errorCode), &uset_close);
     std::u16string result;
-    for (auto el : USetElements(uset.getAlias())) {
+    for (auto el : USetElements(uset.get())) {
         // Commented-out sample code for pasting into the API docs.
         // Needs U_SHOW_CPLUSPLUS_API=1 for UnicodeString.
         // UnicodeString us(el);
@@ -197,7 +202,7 @@ void USetHeaderOnlyTest::TestUSetElementIterator() {
     }
     assertEquals(WHERE, uR"( "a" "b" "c" "ç" "カ" "🚴" "" "abc" "de")", result);
 
-    USetElements range1(uset.getAlias());
+    USetElements range1(uset.get());
     auto range2(range1);  // copy constructor
     auto iter = range1.begin();
     auto limit = range2.end();


### PR DESCRIPTION
Making LocalPointer header-only, with a different namespace when compiling internally, turned out to be problematic.
In particular, there are DLL-exported ICU classes that have LocalPointer members, and while the LocalPointer functions are usually inlined, there is a chance that they need to be DLL-exported.

Therefore, I am reverting those parts of PR #3295 “USet C++ iterator return std::u16string; header-only LocalPointer”.
One commit here is a clean revert. One is a partial revert.

I also had to fix the USet header-only iterator unit test because it can no longer use a LocalUSetPointer. It is now using a std::unique_ptr.

Best to review one commit at a time.

#### Checklist
- [x] Required: Issue filed: ICU-22954
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable

ALLOW_MANY_COMMITS=true