### PR TITLE
ICU-22954 USet C++ iter samples no UnicodeString

### DIFF
--- a/icu4c/source/common/unicode/uniset.h
+++ b/icu4c/source/common/unicode/uniset.h
@@ -1189,7 +1189,7 @@ public:
      * for (auto el : set) {
      *     UnicodeString us(el);
      *     std::string u8;
-     *     printf("set.string length %ld \"%s\"\n", (long)us.length(), us.toUTF8String(u8).c_str());
+     *     printf("set.element length %ld \"%s\"\n", (long)us.length(), us.toUTF8String(u8).c_str());
      * }
      * \endcode
      *

--- a/icu4c/source/common/unicode/uset.h
+++ b/icu4c/source/common/unicode/uset.h
@@ -1700,9 +1700,11 @@ private:
  * using U_HEADER_NESTED_NAMESPACE::USetStrings;
  * LocalUSetPointer uset(uset_openPattern(u"[abcçカ🚴{}{abc}{de}]", -1, &errorCode));
  * for (auto s : USetStrings(uset.getAlias())) {
- *     UnicodeString us(s);
- *     std::string u8;
- *     printf("uset.string length %ld \"%s\"\n", (long)s.length(), us.toUTF8String(u8).c_str());
+ *     int32_t len32 = s.length();
+ *     char utf8[200];
+ *     u_strToUTF8WithSub(utf8, int32_t{sizeof(utf8) - 1}, nullptr,
+ *                        s.data(), len32, 0xFFFD, nullptr, errorCode);
+ *     printf("uset.string length %ld \"%s\"\n", long{len32}, utf8);
  * }
  * \endcode
  *
@@ -1854,9 +1856,11 @@ private:
  * using U_HEADER_NESTED_NAMESPACE::USetElements;
  * LocalUSetPointer uset(uset_openPattern(u"[abcçカ🚴{}{abc}{de}]", -1, &errorCode));
  * for (auto el : USetElements(uset.getAlias())) {
- *     UnicodeString us(el);
- *     std::string u8;
- *     printf("uset.string length %ld \"%s\"\n", (long)us.length(), us.toUTF8String(u8).c_str());
+ *     int32_t len32 = el.length();
+ *     char utf8[200];
+ *     u_strToUTF8WithSub(utf8, int32_t{sizeof(utf8) - 1}, nullptr,
+ *                        el.data(), len32, 0xFFFD, nullptr, errorCode);
+ *     printf("uset.element length %ld \"%s\"\n", long{len32}, utf8);
  * }
  * \endcode
  *

--- a/icu4c/source/test/intltest/usetheaderonlytest.cpp
+++ b/icu4c/source/test/intltest/usetheaderonlytest.cpp
@@ -15,6 +15,7 @@
 
 #include "unicode/utypes.h"
 #include "unicode/uset.h"
+// for commented-out sample code: #include "unicode/ustring.h"
 #include "unicode/utf.h"
 #include "unicode/utf16.h"
 #include "intltest.h"
@@ -62,9 +63,9 @@ void USetHeaderOnlyTest::TestUSetCodePointIterator() {
         uset_openPattern(u"[abcçカ🚴]", -1, errorCode), &uset_close);
     std::u16string result;
     for (UChar32 c : USetCodePoints(uset.get())) {
+        result.append(u" ").append(cpString(c));
         // Commented-out sample code for pasting into the API docs.
         // printf("uset.codePoint U+%04lx\n", (long)c);
-        result.append(u" ").append(cpString(c));
     }
     assertEquals(WHERE, u" a b c ç カ 🚴", result);
 
@@ -95,17 +96,17 @@ void USetHeaderOnlyTest::TestUSetRangeIterator() {
         uset_openPattern(u"[abcçカ🚴]", -1, errorCode), &uset_close);
     std::u16string result;
     for (auto [start, end] : USetRanges(uset.get())) {
+        result.append(u" ").append(cpString(start)).append(u"-").append(cpString(end));
         // Commented-out sample code for pasting into the API docs.
         // printf("uset.range U+%04lx..U+%04lx\n", (long)start, (long)end);
-        result.append(u" ").append(cpString(start)).append(u"-").append(cpString(end));
     }
     assertEquals(WHERE, u" a-c ç-ç カ-カ 🚴-🚴", result);
     result.clear();
     for (auto range : USetRanges(uset.get())) {
         for (UChar32 c : range) {
+            result.append(u" ").append(cpString(c));
             // Commented-out sample code for pasting into the API docs.
             // printf("uset.range.c U+%04lx\n", (long)c);
-            result.append(u" ").append(cpString(c));
         }
         result.append(u" |");
     }
@@ -162,12 +163,13 @@ void USetHeaderOnlyTest::TestUSetStringIterator() {
         uset_openPattern(u"[abcçカ🚴{}{abc}{de}]", -1, errorCode), &uset_close);
     std::u16string result;
     for (auto s : USetStrings(uset.get())) {
-        // Commented-out sample code for pasting into the API docs.
-        // Needs U_SHOW_CPLUSPLUS_API=1 for UnicodeString.
-        // UnicodeString us(s);
-        // std::string u8;
-        // printf("uset.string length %ld \"%s\"\n", (long)s.length(), us.toUTF8String(u8).c_str());
         result.append(u" \"").append(s).append(u"\"");
+        // Commented-out sample code for pasting into the API docs.
+        // int32_t len32 = s.length();
+        // char utf8[200];
+        // u_strToUTF8WithSub(utf8, int32_t{sizeof(utf8) - 1}, nullptr,
+        //                    s.data(), len32, 0xFFFD, nullptr, errorCode);
+        // printf("uset.string length %ld \"%s\"\n", long{len32}, utf8);
     }
     assertEquals(WHERE, uR"( "" "abc" "de")", result);
 
@@ -193,12 +195,13 @@ void USetHeaderOnlyTest::TestUSetElementIterator() {
         uset_openPattern(u"[abcçカ🚴{}{abc}{de}]", -1, errorCode), &uset_close);
     std::u16string result;
     for (auto el : USetElements(uset.get())) {
-        // Commented-out sample code for pasting into the API docs.
-        // Needs U_SHOW_CPLUSPLUS_API=1 for UnicodeString.
-        // UnicodeString us(el);
-        // std::string u8;
-        // printf("uset.string length %ld \"%s\"\n", (long)us.length(), us.toUTF8String(u8).c_str());
         result.append(u" \"").append(el).append(u"\"");
+        // Commented-out sample code for pasting into the API docs.
+        // int32_t len32 = el.length();
+        // char utf8[200];
+        // u_strToUTF8WithSub(utf8, int32_t{sizeof(utf8) - 1}, nullptr,
+        //                    el.data(), len32, 0xFFFD, nullptr, errorCode);
+        // printf("uset.element length %ld \"%s\"\n", long{len32}, utf8);
     }
     assertEquals(WHERE, uR"( "a" "b" "c" "ç" "カ" "🚴" "" "abc" "de")", result);
 

--- a/icu4c/source/test/intltest/usettest.cpp
+++ b/icu4c/source/test/intltest/usettest.cpp
@@ -4326,7 +4326,7 @@ void UnicodeSetTest::TestElementIterator() {
     for (auto el : set) {
         // UnicodeString us(el);
         // std::string u8;
-        // printf("set.string length %ld \"%s\"\n", (long)us.length(), us.toUTF8String(u8).c_str());
+        // printf("set.element length %ld \"%s\"\n", (long)us.length(), us.toUTF8String(u8).c_str());
         result.append(u" \"").append(el).append(u'"');
     }
     assertEquals(WHERE, uR"( "a" "b" "c" "ç" "カ" "🚴" "" "abc" "de")", result);


### PR DESCRIPTION
... to make the sample code work without U_SHOW_CPLUSPLUS_API as discussed in https://github.com/unicode-org/icu/pull/3295#discussion_r1892174805

I am also moving the non-sample code above the commented-out sample code, for clarity.

#### Checklist
- [x] Required: Issue filed: ICU-22954
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
