### PR TITLE
ICU-22991 Remove unnecessary overload in Calendar

### DIFF
--- a/icu4c/source/i18n/buddhcal.cpp
+++ b/icu4c/source/i18n/buddhcal.cpp
@@ -36,7 +36,6 @@ static const int32_t kGregorianEpoch = 1970;    // used as the default value of 
 BuddhistCalendar::BuddhistCalendar(const Locale& aLocale, UErrorCode& success)
 :   GregorianCalendar(aLocale, success)
 {
-    setTimeInMillis(getNow(), success); // Call this again now that the vtable is set up properly.
 }
 
 BuddhistCalendar::~BuddhistCalendar()
@@ -46,12 +45,6 @@ BuddhistCalendar::~BuddhistCalendar()
 BuddhistCalendar::BuddhistCalendar(const BuddhistCalendar& source)
 : GregorianCalendar(source)
 {
-}
-
-BuddhistCalendar& BuddhistCalendar::operator= ( const BuddhistCalendar& right)
-{
-    GregorianCalendar::operator=(right);
-    return *this;
 }
 
 BuddhistCalendar* BuddhistCalendar::clone() const

--- a/icu4c/source/i18n/buddhcal.h
+++ b/icu4c/source/i18n/buddhcal.h
@@ -83,13 +83,6 @@ public:
     BuddhistCalendar(const BuddhistCalendar& source);
 
     /**
-     * Default assignment operator
-     * @param right    the object to be copied.
-     * @internal
-     */
-    BuddhistCalendar& operator=(const BuddhistCalendar& right);
-
-    /**
      * Create and return a polymorphic copy of this calendar.
      * @return    return a polymorphic copy of this calendar.
      * @internal

--- a/icu4c/source/i18n/cecal.cpp
+++ b/icu4c/source/i18n/cecal.cpp
@@ -53,7 +53,6 @@ static const int32_t LIMITS[UCAL_FIELD_COUNT][4] = {
 CECalendar::CECalendar(const Locale& aLocale, UErrorCode& success)
 :   Calendar(TimeZone::forLocaleOrDefault(aLocale), aLocale, success)
 {
-    setTimeInMillis(getNow(), success);
 }
 
 CECalendar::CECalendar (const CECalendar& other) 
@@ -63,13 +62,6 @@ CECalendar::CECalendar (const CECalendar& other)
 
 CECalendar::~CECalendar()
 {
-}
-
-CECalendar&
-CECalendar::operator=(const CECalendar& right)
-{
-    Calendar::operator=(right);
-    return *this;
 }
 
 //-------------------------------------------------------------------------

--- a/icu4c/source/i18n/cecal.h
+++ b/icu4c/source/i18n/cecal.h
@@ -82,13 +82,6 @@ protected:
      */
     virtual ~CECalendar();
 
-    /**
-     * Default assignment operator
-     * @param right    Calendar object to be copied
-     * @internal
-     */
-    CECalendar& operator=(const CECalendar& right);
-
 protected:
     //-------------------------------------------------------------------------
     // Calendar framework

--- a/icu4c/source/i18n/chnsecal.cpp
+++ b/icu4c/source/i18n/chnsecal.cpp
@@ -130,7 +130,6 @@ ChineseCalendar::ChineseCalendar(const Locale& aLocale, UErrorCode& success)
 :   Calendar(TimeZone::forLocaleOrDefault(aLocale), aLocale, success),
     hasLeapMonthBetweenWinterSolstices(false)
 {
-    setTimeInMillis(getNow(), success); // Call this again now that the vtable is set up properly.
 }
 
 ChineseCalendar::ChineseCalendar(const ChineseCalendar& other) : Calendar(other) {

--- a/icu4c/source/i18n/gregocal.cpp
+++ b/icu4c/source/i18n/gregocal.cpp
@@ -147,6 +147,7 @@ UOBJECT_DEFINE_RTTI_IMPLEMENTATION(GregorianCalendar)
 // in Java, -12219292800000L
 //const UDate GregorianCalendar::kPapalCutover = -12219292800000L;
 static const uint32_t kCutoverJulianDay = 2299161;
+static const int32_t kDefaultCutoverYear = 1582;
 static const UDate kPapalCutover = (2299161.0 - kEpochStartAsJulianDay) * U_MILLIS_PER_DAY;
 //static const UDate kPapalCutoverJulian = (2299161.0 - kEpochStartAsJulianDay);
 
@@ -155,7 +156,7 @@ static const UDate kPapalCutover = (2299161.0 - kEpochStartAsJulianDay) * U_MILL
 GregorianCalendar::GregorianCalendar(UErrorCode& status)
 :   Calendar(status),
 fGregorianCutover(kPapalCutover),
-fCutoverJulianDay(kCutoverJulianDay), fNormalizedGregorianCutover(fGregorianCutover), fGregorianCutoverYear(1582),
+fCutoverJulianDay(kCutoverJulianDay), fNormalizedGregorianCutover(fGregorianCutover), fGregorianCutoverYear(kDefaultCutoverYear),
 fIsGregorian(true), fInvertGregorian(false)
 {
     setTimeInMillis(getNow(), status);
@@ -164,34 +165,22 @@ fIsGregorian(true), fInvertGregorian(false)
 // -------------------------------------
 
 GregorianCalendar::GregorianCalendar(TimeZone* zone, UErrorCode& status)
-:   Calendar(zone, Locale::getDefault(), status),
-fGregorianCutover(kPapalCutover),
-fCutoverJulianDay(kCutoverJulianDay), fNormalizedGregorianCutover(fGregorianCutover), fGregorianCutoverYear(1582),
-fIsGregorian(true), fInvertGregorian(false)
+:   GregorianCalendar(zone, Locale::getDefault(), status)
 {
-    setTimeInMillis(getNow(), status);
 }
 
 // -------------------------------------
 
 GregorianCalendar::GregorianCalendar(const TimeZone& zone, UErrorCode& status)
-:   Calendar(zone, Locale::getDefault(), status),
-fGregorianCutover(kPapalCutover),
-fCutoverJulianDay(kCutoverJulianDay), fNormalizedGregorianCutover(fGregorianCutover), fGregorianCutoverYear(1582),
-fIsGregorian(true), fInvertGregorian(false)
+:   GregorianCalendar(zone, Locale::getDefault(), status)
 {
-    setTimeInMillis(getNow(), status);
 }
 
 // -------------------------------------
 
 GregorianCalendar::GregorianCalendar(const Locale& aLocale, UErrorCode& status)
-:   Calendar(TimeZone::forLocaleOrDefault(aLocale), aLocale, status),
-fGregorianCutover(kPapalCutover),
-fCutoverJulianDay(kCutoverJulianDay), fNormalizedGregorianCutover(fGregorianCutover), fGregorianCutoverYear(1582),
-fIsGregorian(true), fInvertGregorian(false)
+:   GregorianCalendar(TimeZone::forLocaleOrDefault(aLocale), aLocale, status)
 {
-    setTimeInMillis(getNow(), status);
 }
 
 // -------------------------------------
@@ -200,7 +189,7 @@ GregorianCalendar::GregorianCalendar(TimeZone* zone, const Locale& aLocale,
                                      UErrorCode& status)
                                      :   Calendar(zone, aLocale, status),
                                      fGregorianCutover(kPapalCutover),
-                                     fCutoverJulianDay(kCutoverJulianDay), fNormalizedGregorianCutover(fGregorianCutover), fGregorianCutoverYear(1582),
+                                     fCutoverJulianDay(kCutoverJulianDay), fNormalizedGregorianCutover(fGregorianCutover), fGregorianCutoverYear(kDefaultCutoverYear),
                                      fIsGregorian(true), fInvertGregorian(false)
 {
     setTimeInMillis(getNow(), status);
@@ -212,7 +201,7 @@ GregorianCalendar::GregorianCalendar(const TimeZone& zone, const Locale& aLocale
                                      UErrorCode& status)
                                      :   Calendar(zone, aLocale, status),
                                      fGregorianCutover(kPapalCutover),
-                                     fCutoverJulianDay(kCutoverJulianDay), fNormalizedGregorianCutover(fGregorianCutover), fGregorianCutoverYear(1582),
+                                     fCutoverJulianDay(kCutoverJulianDay), fNormalizedGregorianCutover(fGregorianCutover), fGregorianCutoverYear(kDefaultCutoverYear),
                                      fIsGregorian(true), fInvertGregorian(false)
 {
     setTimeInMillis(getNow(), status);
@@ -224,7 +213,7 @@ GregorianCalendar::GregorianCalendar(int32_t year, int32_t month, int32_t date,
                                      UErrorCode& status)
                                      :   Calendar(TimeZone::createDefault(), Locale::getDefault(), status),
                                      fGregorianCutover(kPapalCutover),
-                                     fCutoverJulianDay(kCutoverJulianDay), fNormalizedGregorianCutover(fGregorianCutover), fGregorianCutoverYear(1582),
+                                     fCutoverJulianDay(kCutoverJulianDay), fNormalizedGregorianCutover(fGregorianCutover), fGregorianCutoverYear(kDefaultCutoverYear),
                                      fIsGregorian(true), fInvertGregorian(false)
 {
     set(UCAL_ERA, AD);
@@ -237,15 +226,8 @@ GregorianCalendar::GregorianCalendar(int32_t year, int32_t month, int32_t date,
 
 GregorianCalendar::GregorianCalendar(int32_t year, int32_t month, int32_t date,
                                      int32_t hour, int32_t minute, UErrorCode& status)
-                                     :   Calendar(TimeZone::createDefault(), Locale::getDefault(), status),
-                                     fGregorianCutover(kPapalCutover),
-                                     fCutoverJulianDay(kCutoverJulianDay), fNormalizedGregorianCutover(fGregorianCutover), fGregorianCutoverYear(1582),
-                                     fIsGregorian(true), fInvertGregorian(false)
+                                     :   GregorianCalendar(year, month, date, status)
 {
-    set(UCAL_ERA, AD);
-    set(UCAL_YEAR, year);
-    set(UCAL_MONTH, month);
-    set(UCAL_DATE, date);
     set(UCAL_HOUR_OF_DAY, hour);
     set(UCAL_MINUTE, minute);
 }
@@ -255,17 +237,8 @@ GregorianCalendar::GregorianCalendar(int32_t year, int32_t month, int32_t date,
 GregorianCalendar::GregorianCalendar(int32_t year, int32_t month, int32_t date,
                                      int32_t hour, int32_t minute, int32_t second,
                                      UErrorCode& status)
-                                     :   Calendar(TimeZone::createDefault(), Locale::getDefault(), status),
-                                     fGregorianCutover(kPapalCutover),
-                                     fCutoverJulianDay(kCutoverJulianDay), fNormalizedGregorianCutover(fGregorianCutover), fGregorianCutoverYear(1582),
-                                     fIsGregorian(true), fInvertGregorian(false)
+                                     :   GregorianCalendar(year, month, date, hour, minute, status)
 {
-    set(UCAL_ERA, AD);
-    set(UCAL_YEAR, year);
-    set(UCAL_MONTH, month);
-    set(UCAL_DATE, date);
-    set(UCAL_HOUR_OF_DAY, hour);
-    set(UCAL_MINUTE, minute);
     set(UCAL_SECOND, second);
 }
 

--- a/icu4c/source/i18n/hebrwcal.cpp
+++ b/icu4c/source/i18n/hebrwcal.cpp
@@ -164,7 +164,6 @@ HebrewCalendar::HebrewCalendar(const Locale& aLocale, UErrorCode& success)
 :   Calendar(TimeZone::forLocaleOrDefault(aLocale), aLocale, success)
 
 {
-    setTimeInMillis(getNow(), success); // Call this again now that the vtable is set up properly.
 }
 
 

--- a/icu4c/source/i18n/indiancal.cpp
+++ b/icu4c/source/i18n/indiancal.cpp
@@ -41,7 +41,6 @@ IndianCalendar* IndianCalendar::clone() const {
 IndianCalendar::IndianCalendar(const Locale& aLocale, UErrorCode& success)
   :   Calendar(TimeZone::forLocaleOrDefault(aLocale), aLocale, success)
 {
-  setTimeInMillis(getNow(), success); // Call this again now that the vtable is set up properly.
 }
 
 IndianCalendar::IndianCalendar(const IndianCalendar& other) : Calendar(other) {

--- a/icu4c/source/i18n/islamcal.cpp
+++ b/icu4c/source/i18n/islamcal.cpp
@@ -202,7 +202,6 @@ IslamicCalendar* IslamicCalendar::clone() const {
 IslamicCalendar::IslamicCalendar(const Locale& aLocale, UErrorCode& success)
 :   Calendar(TimeZone::forLocaleOrDefault(aLocale), aLocale, success)
 {
-    setTimeInMillis(getNow(), success); // Call this again now that the vtable is set up properly.
 }
 
 IslamicCalendar::~IslamicCalendar()

--- a/icu4c/source/i18n/japancal.cpp
+++ b/icu4c/source/i18n/japancal.cpp
@@ -115,7 +115,6 @@ JapaneseCalendar::JapaneseCalendar(const Locale& aLocale, UErrorCode& success)
 :   GregorianCalendar(aLocale, success)
 {
     init(success);
-    setTimeInMillis(getNow(), success); // Call this again now that the vtable is set up properly.
 }
 
 JapaneseCalendar::~JapaneseCalendar()
@@ -128,12 +127,6 @@ JapaneseCalendar::JapaneseCalendar(const JapaneseCalendar& source)
     UErrorCode status = U_ZERO_ERROR;
     init(status);
     U_ASSERT(U_SUCCESS(status));
-}
-
-JapaneseCalendar& JapaneseCalendar::operator= ( const JapaneseCalendar& right)
-{
-    GregorianCalendar::operator=(right);
-    return *this;
 }
 
 JapaneseCalendar* JapaneseCalendar::clone() const

--- a/icu4c/source/i18n/japancal.h
+++ b/icu4c/source/i18n/japancal.h
@@ -105,13 +105,6 @@ public:
     JapaneseCalendar(const JapaneseCalendar& source);
 
     /**
-     * Default assignment operator
-     * @param right    the object to be copied.
-     * @internal
-     */
-    JapaneseCalendar& operator=(const JapaneseCalendar& right);
-
-    /**
      * Create and return a polymorphic copy of this calendar.
      * @return    return a polymorphic copy of this calendar.
      * @internal

--- a/icu4c/source/i18n/persncal.cpp
+++ b/icu4c/source/i18n/persncal.cpp
@@ -125,7 +125,6 @@ PersianCalendar* PersianCalendar::clone() const {
 PersianCalendar::PersianCalendar(const Locale& aLocale, UErrorCode& success)
   :   Calendar(TimeZone::forLocaleOrDefault(aLocale), aLocale, success)
 {
-    setTimeInMillis(getNow(), success); // Call this again now that the vtable is set up properly.
 }
 
 PersianCalendar::PersianCalendar(const PersianCalendar& other) : Calendar(other) {

--- a/icu4c/source/i18n/taiwncal.cpp
+++ b/icu4c/source/i18n/taiwncal.cpp
@@ -36,7 +36,6 @@ static const int32_t kGregorianEpoch = 1970;
 TaiwanCalendar::TaiwanCalendar(const Locale& aLocale, UErrorCode& success)
 :   GregorianCalendar(aLocale, success)
 {
-    setTimeInMillis(getNow(), success); // Call this again now that the vtable is set up properly.
 }
 
 TaiwanCalendar::~TaiwanCalendar()
@@ -46,12 +45,6 @@ TaiwanCalendar::~TaiwanCalendar()
 TaiwanCalendar::TaiwanCalendar(const TaiwanCalendar& source)
 : GregorianCalendar(source)
 {
-}
-
-TaiwanCalendar& TaiwanCalendar::operator= ( const TaiwanCalendar& right)
-{
-    GregorianCalendar::operator=(right);
-    return *this;
 }
 
 TaiwanCalendar* TaiwanCalendar::clone() const

--- a/icu4c/source/i18n/taiwncal.h
+++ b/icu4c/source/i18n/taiwncal.h
@@ -80,13 +80,6 @@ public:
     TaiwanCalendar(const TaiwanCalendar& source);
 
     /**
-     * Default assignment operator
-     * @param right    the object to be copied.
-     * @internal
-     */
-    TaiwanCalendar& operator=(const TaiwanCalendar& right);
-
-    /**
      * Create and return a polymorphic copy of this calendar.
      * @return    return a polymorphic copy of this calendar.
      * @internal


### PR DESCRIPTION
1. Remove unnecessary call to setTimeInMillis(getNow(), success);  in constructor except in GregorianCalendar because allother calendar are not public class and are created through the Calendar::createInstance() method and code in that  method already call setTimeInMillis(getNow(), success);

Notice the Calendar API documentation states

"Like other locale-sensitive classes, Calendar provides a static method, createInstance, for getting a generally useful object of this type. Calendar's createInstance method returns the appropriate Calendar subclass whose time fields have been initialized with the current date and time:

Calendar *rightNow = Calendar::createInstance(errCode);
"

and this is guaranteed in the code
```
Calendar* U_EXPORT2
Calendar::createInstance(TimeZone* zone, const Locale& aLocale, UErrorCode& success)
{
...
    // Now, reset calendar to default state:
    c->adoptTimeZone(zonePtr.orphan()); //  Set the correct time zone
    c->setTimeInMillis(getNow(), success); // let the new calendar have the current time.
    return c;
}
```

https://github.com/unicode-org/icu/blob/b0ae845e4760a26719b2285fca3fc464cf213aee/icu4c/source/i18n/calendar.cpp#L985

And there are no need for all the setTimeInMillis(getNow(), success);   inside each constructor

2.  Remove overloading of operator= in Calendar since these implementation currently are the same as compiler generated assignment operator
3. Simplified the GregorianCalendar constructor by chaining the calls
4. add "static const int32_t kDefaultCutoverYear = 1582;" inside GregorianCalendar to make it clear

#### Checklist
- [X] Required: Issue filed: ICU-22991
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
