### PR TITLE
ICU-22991 Remove unused private fIsSet

### DIFF
--- a/icu4c/source/i18n/calendar.cpp
+++ b/icu4c/source/i18n/calendar.cpp
@@ -806,7 +806,6 @@ Calendar::operator=(const Calendar &right)
 {
     if (this != &right) {
         uprv_arrayCopy(right.fFields, fFields, UCAL_FIELD_COUNT);
-        uprv_arrayCopy(right.fIsSet, fIsSet, UCAL_FIELD_COUNT);
         uprv_arrayCopy(right.fStamp, fStamp, UCAL_FIELD_COUNT);
         fTime                    = right.fTime;
         fIsTimeSet               = right.fIsTimeSet;
@@ -1170,7 +1169,6 @@ Calendar::setTimeInMillis( double millis, UErrorCode& status ) {
     for (int32_t i=0; i<UCAL_FIELD_COUNT; ++i) {
         fFields[i]     = 0;
         fStamp[i]     = kUnset;
-        fIsSet[i]     = false;
     }
 
 
@@ -1213,7 +1211,6 @@ Calendar::set(UCalendarDateFields field, int32_t value)
         recalculateStamp();
     }
     fStamp[field]     = fNextStamp++;
-    fIsSet[field]     = true; // Remove later
     fIsTimeSet = fAreFieldsSet = fAreFieldsVirtuallySet = false;
 }
 
@@ -1273,7 +1270,6 @@ Calendar::clear()
     for (int32_t i=0; i<UCAL_FIELD_COUNT; ++i) {
         fFields[i]     = 0; // Must do this; other code depends on it
         fStamp[i]     = kUnset;
-        fIsSet[i]     = false; // Remove later
     }
     fIsTimeSet = fAreFieldsSet = fAreAllFieldsSet = fAreFieldsVirtuallySet = false;
     // fTime is not 'cleared' - may be used if no fields are set.
@@ -1296,12 +1292,10 @@ Calendar::clear(UCalendarDateFields field)
     if (field == UCAL_MONTH) {
         fFields[UCAL_ORDINAL_MONTH]         = 0;
         fStamp[UCAL_ORDINAL_MONTH]         = kUnset;
-        fIsSet[UCAL_ORDINAL_MONTH]         = false; // Remove later
     }
     if (field == UCAL_ORDINAL_MONTH) {
         fFields[UCAL_MONTH]         = 0;
         fStamp[UCAL_MONTH]         = kUnset;
-        fIsSet[UCAL_MONTH]         = false; // Remove later
     }
     fIsTimeSet = fAreFieldsSet = fAreAllFieldsSet = fAreFieldsVirtuallySet = false;
 }
@@ -1434,10 +1428,8 @@ void Calendar::computeFields(UErrorCode &ec)
     for (int32_t i=0; i<UCAL_FIELD_COUNT; ++i) {
         if ((mask & 1) == 0) {
             fStamp[i] = kInternallySet;
-            fIsSet[i] = true; // Remove later
         } else {
             fStamp[i] = kUnset;
-            fIsSet[i] = false; // Remove later
         }
         mask >>= 1;
     }

--- a/icu4c/source/i18n/unicode/calendar.h
+++ b/icu4c/source/i18n/unicode/calendar.h
@@ -1937,12 +1937,6 @@ protected:
      */
     int32_t     fFields[UCAL_FIELD_COUNT];
 
-private:
-    /**
-     * The flags which tell if a specified time field for the calendar is set.
-     */
-    UBool      fIsSet[UCAL_FIELD_COUNT];
-
 protected:
     /** Special values of stamp[]
      * @stable ICU 2.0
@@ -2552,7 +2546,6 @@ Calendar::internalSet(UCalendarDateFields field, int32_t value)
 {
     fFields[field] = value;
     fStamp[field] = kInternallySet;
-    fIsSet[field]     = true; // Remove later
 }
 
 /**


### PR DESCRIPTION
Remove unused private fIsSet from Calendar to save 24 bytes per Calendar object.

Java removed the isSet field at least 24 years ago.

#### Checklist
- [X] Required: Issue filed: ICU-22991
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
