### PR TITLE
ICU-22921 remove redundant PR checklist item

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,6 @@ TODO: Fill out the checklist below.
 #### Checklist
 - [ ] Required: Issue filed: ICU-NNNNN
 - [ ] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
-- [ ] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
 - [ ] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
 - [ ] Issue accepted (done by Technical Committee after discussion)
 - [ ] Tests included, if applicable


### PR DESCRIPTION
Remove this checklist item from the PR template:
- Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item

... because
- it is no longer a link or URL
- it is redundant with the first checklist item “Required: Issue filed: ICU-NNNNN”

#### Checklist
- [x] Required: Issue filed: ICU-22921
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
