### PR TITLE
ICU-22954 Workaround to make the icu4c-windows-cygwin-gcc CI job work

### DIFF
--- a/icu4c/source/test/intltest/listformattertest.cpp
+++ b/icu4c/source/test/intltest/listformattertest.cpp
@@ -618,7 +618,7 @@ void ListFormatterTest::DoTheRealListStyleTesting(
         UListFormatterType type,
         UListFormatterWidth width,
         const char* expected,
-        IcuTestErrorCode status) {
+        IcuTestErrorCode& status) {
 
     LocalPointer<ListFormatter> formatter(
             ListFormatter::createInstance(locale, type, width, status));

--- a/icu4c/source/test/intltest/listformattertest.h
+++ b/icu4c/source/test/intltest/listformattertest.h
@@ -115,7 +115,7 @@ class ListFormatterTest : public IntlTestWithFieldPosition {
         UListFormatterType type,
         UListFormatterWidth width,
         const char* expected,
-        IcuTestErrorCode status);
+        IcuTestErrorCode& status);
 
   private:
     // Reused test data.

--- a/icu4c/source/tools/ctestfw/unicode/testlog.h
+++ b/icu4c/source/tools/ctestfw/unicode/testlog.h
@@ -37,6 +37,9 @@ public:
 
 class T_CTEST_EXPORT_API IcuTestErrorCode {
 public:
+    IcuTestErrorCode(const IcuTestErrorCode&) = delete;
+    IcuTestErrorCode& operator=(const IcuTestErrorCode&) = delete;
+
     IcuTestErrorCode(TestLog &callingTestClass, const char *callingTestName)
             : errorCode(U_ZERO_ERROR),
               testClass(callingTestClass), testName(callingTestName), scopeMessage() {}

--- a/icu4c/source/tools/ctestfw/unicode/testlog.h
+++ b/icu4c/source/tools/ctestfw/unicode/testlog.h
@@ -13,7 +13,6 @@
 #ifndef U_TESTFW_TESTLOG
 #define U_TESTFW_TESTLOG
 
-#include <string>
 #include <string_view>
 #include "unicode/utypes.h"
 #include "unicode/testtype.h"
@@ -35,14 +34,16 @@ public:
 // unit tests that work without U_SHOW_CPLUSPLUS_API.
 // So instead we *copy* the ErrorCode API.
 
+U_NAMESPACE_BEGIN
+class UnicodeString;
+U_NAMESPACE_END
+
 class T_CTEST_EXPORT_API IcuTestErrorCode {
 public:
     IcuTestErrorCode(const IcuTestErrorCode&) = delete;
     IcuTestErrorCode& operator=(const IcuTestErrorCode&) = delete;
 
-    IcuTestErrorCode(TestLog &callingTestClass, const char *callingTestName)
-            : errorCode(U_ZERO_ERROR),
-              testClass(callingTestClass), testName(callingTestName), scopeMessage() {}
+    IcuTestErrorCode(TestLog &callingTestClass, const char *callingTestName);
     virtual ~IcuTestErrorCode();
 
     // ErrorCode API
@@ -75,7 +76,14 @@ private:
     UErrorCode errorCode;
     TestLog &testClass;
     const char *const testName;
-    std::u16string scopeMessage;
+
+    // It's not possible to use a UnicodeString member directly here because
+    // that won't work without U_SHOW_CPLUSPLUS_API, but it's also not possible
+    // to use a std::u16string member because for unknown reasons that leads to
+    // a crash in the icu4c-windows-cygwin-gcc CI job. As a workaround, the
+    // UnicodeString class is forward declared to make it possible to use a
+    // reference here and then heap allocate the object in the constructor.
+    UnicodeString& scopeMessage;
 
     void errlog(UBool dataErr, std::u16string_view mainMessage, const char* extraMessage) const;
 };


### PR DESCRIPTION
For some unknown reason the use of `std::u16string` in `class IcuTestErrorCode` since commit 5dff777fe045acfafba79ec1e9cb953dac6c068f causes the icu4c-windows-cygwin-gcc CI job to fail.

#### Checklist
- [x] Required: Issue filed: ICU-22954
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

ALLOW_MANY_COMMITS=true