### PR TITLE
ICU-22991 Reduce fStamp to 8 bits

### DIFF
--- a/icu4c/source/i18n/unicode/calendar.h
+++ b/icu4c/source/i18n/unicode/calendar.h
@@ -1881,38 +1881,6 @@ private:
      */
     int32_t getActualHelper(UCalendarDateFields field, int32_t startValue, int32_t endValue, UErrorCode &status) const;
 
-
-private:
-    /**
-     * The flag which indicates if the current time is set in the calendar.
-     */
-    UBool      fIsTimeSet;
-
-    /**
-     * True if the fields are in sync with the currently set time of this Calendar.
-     * If false, then the next attempt to get the value of a field will
-     * force a recomputation of all fields from the current value of the time
-     * field.
-     * <P>
-     * This should really be named areFieldsInSync, but the old name is retained
-     * for backward compatibility.
-     */
-    UBool      fAreFieldsSet;
-
-    /**
-     * True if all of the fields have been set.  This is initially false, and set to
-     * true by computeFields().
-     */
-    UBool      fAreAllFieldsSet;
-
-    /**
-     * True if all fields have been virtually set, but have not yet been
-     * computed.  This occurs only in setTimeInMillis().  A calendar set
-     * to this state will compute all fields from the time if it becomes
-     * necessary, but otherwise will delay such computation.
-     */
-    UBool fAreFieldsVirtuallySet;
-
 protected:
     /**
      * Get the current time without recomputing.
@@ -1951,9 +1919,9 @@ private:
     /**
      * Pseudo-time-stamps which specify when each field was set. There
      * are two special values, UNSET and INTERNALLY_SET. Values from
-     * MINIMUM_USER_SET to Integer.MAX_VALUE are legal user set values.
+     * MINIMUM_USER_SET to STAMP_MAX are legal user set values.
      */
-    int32_t        fStamp[UCAL_FIELD_COUNT];
+    int8_t        fStamp[UCAL_FIELD_COUNT];
 
 protected:
     /**
@@ -2169,7 +2137,7 @@ private:
     /**
      * The next available value for fStamp[]
      */
-    int32_t fNextStamp;// = MINIMUM_USER_STAMP;
+    int8_t fNextStamp = kMinimumUserStamp;
 
     /**
      * Recalculates the time stamp array (fStamp).
@@ -2180,30 +2148,60 @@ private:
     /**
      * The current time set for the calendar.
      */
-    UDate        fTime;
-
-    /**
-     * @see   #setLenient
-     */
-    UBool      fLenient;
+    UDate        fTime = 0;
 
     /**
      * Time zone affects the time calculation done by Calendar. Calendar subclasses use
      * the time zone data to produce the local time. Always set; never nullptr.
      */
-    TimeZone*   fZone;
+    TimeZone*   fZone = nullptr;
+
+    /**
+     * The flag which indicates if the current time is set in the calendar.
+     */
+    bool      fIsTimeSet:1;
+
+    /**
+     * True if the fields are in sync with the currently set time of this Calendar.
+     * If false, then the next attempt to get the value of a field will
+     * force a recomputation of all fields from the current value of the time
+     * field.
+     * <P>
+     * This should really be named areFieldsInSync, but the old name is retained
+     * for backward compatibility.
+     */
+    bool      fAreFieldsSet:1;
+
+    /**
+     * True if all of the fields have been set.  This is initially false, and set to
+     * true by computeFields().
+     */
+    bool      fAreAllFieldsSet:1;
+
+    /**
+     * True if all fields have been virtually set, but have not yet been
+     * computed.  This occurs only in setTimeInMillis().  A calendar set
+     * to this state will compute all fields from the time if it becomes
+     * necessary, but otherwise will delay such computation.
+     */
+    bool      fAreFieldsVirtuallySet:1;
+
+    /**
+     * @see   #setLenient
+     */
+    bool      fLenient:1;
 
     /**
      * Option for repeated wall time
      * @see #setRepeatedWallTimeOption
      */
-    UCalendarWallTimeOption fRepeatedWallTime;
+    UCalendarWallTimeOption fRepeatedWallTime:3; // Somehow MSVC need 3 bits for UCalendarWallTimeOption
 
     /**
      * Option for skipped wall time
      * @see #setSkippedWallTimeOption
      */
-    UCalendarWallTimeOption fSkippedWallTime;
+    UCalendarWallTimeOption fSkippedWallTime:3; // Somehow MSVC need 3 bits for UCalendarWallTimeOption
 
     /**
      * Both firstDayOfWeek and minimalDaysInFirstWeek are locale-dependent. They are
@@ -2213,11 +2211,14 @@ private:
      * out the week count for a specific date for a given locale. These must be set when
      * a Calendar is constructed.
      */
-    UCalendarDaysOfWeek fFirstDayOfWeek;
-    uint8_t     fMinimalDaysInFirstWeek;
-    UCalendarDaysOfWeek fWeekendOnset;
+    UCalendarDaysOfWeek fFirstDayOfWeek:4; // Somehow MSVC need 4 bits for
+                                           // UCalendarDaysOfWeek
+    UCalendarDaysOfWeek fWeekendOnset:4; // Somehow MSVC need 4 bits for
+                                         // UCalendarDaysOfWeek
+    UCalendarDaysOfWeek fWeekendCease:4; // Somehow MSVC need 4 bits for
+                                         // UCalendarDaysOfWeek
+    uint8_t fMinimalDaysInFirstWeek;
     int32_t fWeekendOnsetMillis;
-    UCalendarDaysOfWeek fWeekendCease;
     int32_t fWeekendCeaseMillis;
 
     /**

--- a/icu4j/main/core/src/main/java/com/ibm/icu/util/Calendar.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/util/Calendar.java
@@ -13,6 +13,7 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.text.StringCharacterIterator;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Locale;
 import java.util.MissingResourceException;
@@ -1355,9 +1356,9 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
     /**
      * Pseudo-time-stamps which specify when each field was set. There
      * are two special values, UNSET and INTERNALLY_SET. Values from
-     * MINIMUM_USER_SET to Integer.MAX_VALUE are legal user set values.
+     * MINIMUM_USER_SET to STAMP_MAX are legal user set values.
      */
-    private transient int           stamp[];
+    private transient byte           stamp[];
 
     /**
      * The currently set time for this calendar, expressed in milliseconds after
@@ -1507,10 +1508,10 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
      * The next available value for <code>stamp[]</code>, an internal array.
      * @serial
      */
-    private transient int             nextStamp = MINIMUM_USER_STAMP;
+    private transient byte             nextStamp = MINIMUM_USER_STAMP;
 
     /* Max value for stamp allowable before recalculation */
-    private static int STAMP_MAX = 10000;
+    private static byte STAMP_MAX = Byte.MAX_VALUE;
 
     // the internal serial version which says which version was written
     // - 0 (default) for version up to JDK 1.1.5
@@ -1684,7 +1685,7 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
 
     private void recalculateStamp() {
         int index;
-        int currentValue;
+        byte currentValue;
         int j, i;
 
         nextStamp = 1;
@@ -1721,7 +1722,7 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
             throw new IllegalStateException("Invalid fields[]");
         }
         ///CLOVER:ON
-        stamp = new int[fields.length];
+        stamp = new byte[fields.length];
         int mask = (1 << ERA) |
                 (1 << YEAR) |
                 (1 << MONTH) |
@@ -2054,9 +2055,9 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
         areFieldsSet = areAllFieldsSet = false;
         isTimeSet = areFieldsVirtuallySet = true;
 
-        for (int i=0; i<fields.length; ++i) {
-            fields[i] = stamp[i] = 0; // UNSET == 0
-        }
+        Arrays.fill(fields, 0);
+        Arrays.fill(stamp, (byte)0);
+        nextStamp = MINIMUM_USER_STAMP;
 
     }
 
@@ -2455,9 +2456,9 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
      */
     public final void clear()
     {
-        for (int i=0; i<fields.length; ++i) {
-            fields[i] = stamp[i] = 0; // UNSET == 0
-        }
+        Arrays.fill(fields, 0);
+        Arrays.fill(stamp, (byte)0);
+        nextStamp = MINIMUM_USER_STAMP;
         isTimeSet = areFieldsSet = areAllFieldsSet = areFieldsVirtuallySet = false;
     }
 
@@ -4904,7 +4905,7 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
             Calendar other = (Calendar) super.clone();
 
             other.fields = new int[fields.length];
-            other.stamp = new int[fields.length];
+            other.stamp = new byte[fields.length];
             System.arraycopy(this.fields, 0, other.fields, 0, fields.length);
             System.arraycopy(this.stamp, 0, other.stamp, 0, fields.length);
 


### PR DESCRIPTION
Reduce 24x3=72 bytes per Calendar object by changing from 32 bits integer to 8 bits integer for the stamp array.
Reset the fNextStamp whenever we clear the fStamp. There are at most 24 different stamp values stored inside fStamp so using 7 bits to store up to 127 different one should be enough.

Also change to use bit fields for:
fIsTimeSet, fAreFieldsSet, fAreAllFieldsSet, fAreFieldsVirtuallySet, fLenient, fRepeatedWallTime, fSkippedWallTime, fFirstDayOfWeek, fWeekendOnset, fWeekendCease to save more space

#### Checklist
- [X] Required: Issue filed: ICU-22991
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
