### PR TITLE
ICU-22929 Improve fuzzer to find leak from udat_open

### DIFF
--- a/icu4c/source/test/fuzzer/date_format_fuzzer.cpp
+++ b/icu4c/source/test/fuzzer/date_format_fuzzer.cpp
@@ -90,5 +90,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
         icu::DateFormat::createDateTimeInstance(dateStyle, timeStyle, locale2));
     df.reset(
         icu::DateFormat::createDateTimeInstance(dateStyle2, timeStyle2, locale2));
+
+    UDateFormat* udf = udat_open(UDAT_PATTERN, UDAT_PATTERN, str.c_str(), nullptr, 0,
+                                 skeleton.getBuffer(), skeleton.length(), &status);
+    if (udf && U_SUCCESS(status)) {
+        udat_close(udf);
+    }
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Try to find out what cause ICU-23008. Use ICU-22929 as bug number to improve fuzzer to find the problem.
According to ICU-23008 bug report, the leak of DecimalFormatSymbols can be reach by udat_open when the style is UDAT_PATTERN


#### Checklist
- [X] Required: Issue filed: ICU-22929
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
