### PR TITLE
ICU-22920 Avoid "return by const value" antipattern

### DIFF
--- a/icu4c/source/common/resbund.cpp
+++ b/icu4c/source/common/resbund.cpp
@@ -388,7 +388,7 @@ const Locale &ResourceBundle::getLocale() const {
     return ncThis->fLocale != nullptr ? *ncThis->fLocale : Locale::getDefault();
 }
 
-const Locale ResourceBundle::getLocale(ULocDataLocaleType type, UErrorCode &status) const
+Locale ResourceBundle::getLocale(ULocDataLocaleType type, UErrorCode &status) const
 {
   return ures_getLocaleByType(fResource, type, &status);
 }

--- a/icu4c/source/common/unicode/resbund.h
+++ b/icu4c/source/common/unicode/resbund.h
@@ -450,7 +450,7 @@ public:
      * @return a Locale object
      * @stable ICU 2.8
      */
-    const Locale
+    Locale
       getLocale(ULocDataLocaleType type, UErrorCode &status) const;
 #ifndef U_HIDE_INTERNAL_API
     /**

--- a/icu4c/source/i18n/timezone.cpp
+++ b/icu4c/source/i18n/timezone.cpp
@@ -1058,7 +1058,7 @@ TimeZone::countEquivalentIDs(const UnicodeString& id) {
 
 // ---------------------------------------
 
-const UnicodeString U_EXPORT2
+UnicodeString U_EXPORT2
 TimeZone::getEquivalentID(const UnicodeString& id, int32_t index) {
     U_DEBUG_TZ_MSG(("gEI(%d)\n", index));
     UnicodeString result;

--- a/icu4c/source/i18n/unicode/messageformat2_data_model.h
+++ b/icu4c/source/i18n/unicode/messageformat2_data_model.h
@@ -2330,7 +2330,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        const std::vector<VariableName> getSelectors() const {
+        std::vector<VariableName> getSelectors() const {
             if (std::holds_alternative<Pattern>(body)) {
                 return {};
             }

--- a/icu4c/source/i18n/unicode/timezone.h
+++ b/icu4c/source/i18n/unicode/timezone.h
@@ -323,7 +323,7 @@ public:
      * @see #countEquivalentIDs
      * @stable ICU 2.0
      */
-    static const UnicodeString U_EXPORT2 getEquivalentID(const UnicodeString& id,
+    static UnicodeString U_EXPORT2 getEquivalentID(const UnicodeString& id,
                                                int32_t index);
 
     /**

--- a/icu4c/source/tools/ctestfw/datamap.cpp
+++ b/icu4c/source/tools/ctestfw/datamap.cpp
@@ -116,7 +116,7 @@ const ResourceBundle *RBDataMap::getItem(const char* key, UErrorCode &status) co
   }
 }
 
-const UnicodeString RBDataMap::getString(const char* key, UErrorCode &status) const
+UnicodeString RBDataMap::getString(const char* key, UErrorCode &status) const
 {
   const ResourceBundle *r = getItem(key, status);
   if(U_SUCCESS(status)) {

--- a/icu4c/source/tools/ctestfw/unicode/datamap.h
+++ b/icu4c/source/tools/ctestfw/unicode/datamap.h
@@ -40,7 +40,7 @@ public:
    *  @param key name of the data field.
    *  @return a string containing the data
    */
-  virtual const UnicodeString getString(const char* key, UErrorCode &status) const = 0;
+  virtual UnicodeString getString(const char* key, UErrorCode &status) const = 0;
 
   /** get the string from the DataMap. Addressed by name
    *  parses a bundle string into an integer
@@ -121,7 +121,7 @@ public:
 
   virtual const ResourceBundle *getItem(const char* key, UErrorCode &status) const;
 
-  virtual const UnicodeString getString(const char* key, UErrorCode &status) const override;
+  virtual UnicodeString getString(const char* key, UErrorCode &status) const override;
   virtual int32_t getInt28(const char* key, UErrorCode &status) const override;
   virtual uint32_t getUInt28(const char* key, UErrorCode &status) const override;
   virtual const int32_t *getIntVector(int32_t &length, const char *key, UErrorCode &status) const override;


### PR DESCRIPTION
Returning a const-qualified prvalue doesn't do anything useful, but it does turn an assignment such as `v = rb.getLocale();` from a move-assignment into a copy-assignment (because it's forbidden to move-from a const value, even if it's a const prvalue). Each affected site was diagnosed mechanically by my fork of Clang. E.g.:

    warning: 'const' type qualifier on return type is a bad idea [-Wqual-class-return-type]
      391 | const Locale ResourceBundle::getLocale(ULocDataLocaleType type, UErrorCode &status) const
          | ^~~~~

#### Checklist
- [x] Required: Issue filed: ICU-22920
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
