### PR TITLE
ICU-22920 Avoid CTAD in Formattable's constructor. NFC

### DIFF
--- a/icu4c/source/i18n/unicode/messageformat2_formattable.h
+++ b/icu4c/source/i18n/unicode/messageformat2_formattable.h
@@ -389,7 +389,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        Formattable(const Formattable* arr, int32_t len) : contents(std::pair(arr, len)) {}
+        Formattable(const Formattable* arr, int32_t len) : contents(std::make_pair(arr, len)) {}
         /**
          * Object constructor.
          *


### PR DESCRIPTION
This line uses CTAD on `pair`, when every other place in the codebase uses a function call to `make_pair` (and no other place uses CTAD on any class template at all). Assume this was unintentional, and fix it.

    warning: class template argument deduction is incompatible with
    C++ standards before C++17; for compatibility, use explicit type
    name 'std::pair<const Formattable *, int>'
    (aka 'pair<const icu_77::message2::Formattable *, int>') [-Wctad]
          Formattable(const Formattable* arr, int32_t len) : contents(std::pair(arr, len)) {}
                                                                      ^~~~~~~~~

#### Checklist
- [ ] Required: Issue filed: ICU-NNNNN
- [ ] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable