### PR TITLE
ICU-23006 Fix Chinese Calendar getActualMaximize

### DIFF
--- a/icu4c/source/i18n/chnsecal.cpp
+++ b/icu4c/source/i18n/chnsecal.cpp
@@ -253,11 +253,16 @@ int32_t ChineseCalendar::handleGetExtendedYear(UErrorCode& status) {
  * @stable ICU 2.8
  */
 int32_t ChineseCalendar::handleGetMonthLength(int32_t extendedYear, int32_t month, UErrorCode& status) const {
+    bool isLeapMonth = internalGet(UCAL_IS_LEAP_MONTH) == 1;
+    return handleGetMonthLengthWithLeap(extendedYear, month, isLeapMonth, status);
+}
+
+int32_t ChineseCalendar::handleGetMonthLengthWithLeap(int32_t extendedYear, int32_t month, bool leap, UErrorCode& status) const {
     const Setting setting = getSetting(status);
     if (U_FAILURE(status)) {
         return 0;
     }
-    int32_t thisStart = handleComputeMonthStart(extendedYear, month, true, status);
+    int32_t thisStart = handleComputeMonthStartWithLeap(extendedYear, month, leap, status);
     if (U_FAILURE(status)) {
         return 0;
     }
@@ -333,6 +338,14 @@ struct MonthInfo computeMonthInfo(
  * @stable ICU 2.8
  */
 int64_t ChineseCalendar::handleComputeMonthStart(int32_t eyear, int32_t month, UBool useMonth, UErrorCode& status) const {
+    bool isLeapMonth = false;
+    if (useMonth) {
+        isLeapMonth = internalGet(UCAL_IS_LEAP_MONTH) != 0;
+    }
+    return handleComputeMonthStartWithLeap(eyear, month, isLeapMonth, status);
+}
+
+int64_t ChineseCalendar::handleComputeMonthStartWithLeap(int32_t eyear, int32_t month, bool isLeapMonth, UErrorCode& status) const {
     if (U_FAILURE(status)) {
        return 0;
     }
@@ -361,12 +374,6 @@ int64_t ChineseCalendar::handleComputeMonthStart(int32_t eyear, int32_t month, U
     int32_t newMoon = newMoonNear(setting.zoneAstroCalc, theNewYear + month * 29, true, status);
     if (U_FAILURE(status)) {
        return 0;
-    }
-
-    // Ignore IS_LEAP_MONTH field if useMonth is false
-    bool isLeapMonth = false;
-    if (useMonth) {
-        isLeapMonth = internalGet(UCAL_IS_LEAP_MONTH) != 0;
     }
 
     int32_t newMonthYear = Grego::dayToYear(newMoon, status);
@@ -1182,6 +1189,27 @@ ChineseCalendar::Setting ChineseCalendar::getSetting(UErrorCode&) const {
         &gWinterSolsticeCache,
         &gNewYearCache
   };
+}
+
+int32_t
+ChineseCalendar::getActualMaximum(UCalendarDateFields field, UErrorCode& status) const
+{
+    if (U_FAILURE(status)) {
+       return 0;
+    }
+    if (field == UCAL_DATE) {
+        LocalPointer<ChineseCalendar> cal(clone(), status);
+        if(U_FAILURE(status)) {
+            return 0;
+        }
+        cal->setLenient(true);
+        cal->prepareGetActual(field,false,status);
+        int32_t year = cal->get(UCAL_EXTENDED_YEAR, status);
+        int32_t month = cal->get(UCAL_MONTH, status);
+        bool leap = cal->get(UCAL_IS_LEAP_MONTH, status) != 0;
+        return handleGetMonthLengthWithLeap(year, month, leap, status);
+    }
+    return Calendar::getActualMaximum(field, status);
 }
 
 U_NAMESPACE_END

--- a/icu4c/source/i18n/chnsecal.h
+++ b/icu4c/source/i18n/chnsecal.h
@@ -194,6 +194,10 @@ class U_I18N_API ChineseCalendar : public Calendar {
   virtual void handleComputeFields(int32_t julianDay, UErrorCode &status) override;
   virtual const UFieldResolutionTable* getFieldResolutionTable() const override;
 
+ private:
+  int32_t handleGetMonthLengthWithLeap(int32_t extendedYear, int32_t month, bool isLeap, UErrorCode& status) const;
+  int64_t handleComputeMonthStartWithLeap(int32_t eyear, int32_t month, bool isLeap, UErrorCode& status) const;
+
  public:
   virtual void add(UCalendarDateFields field, int32_t amount, UErrorCode &status) override;
   virtual void add(EDateFields field, int32_t amount, UErrorCode &status) override;
@@ -253,6 +257,8 @@ class U_I18N_API ChineseCalendar : public Calendar {
    * @internal
    */
   virtual const char * getType() const override;
+
+  virtual int32_t getActualMaximum(UCalendarDateFields field, UErrorCode& status) const override;
 
   struct Setting {
       int32_t epochYear;

--- a/icu4c/source/test/intltest/calregts.cpp
+++ b/icu4c/source/test/intltest/calregts.cpp
@@ -2433,7 +2433,7 @@ void CalendarRegressionTest::TestT5555()
 
     // Should be set to Wednesday, February 24, 2010
     if (U_FAILURE(ec) || yy != 2010 || mm != UCAL_FEBRUARY || dd != 24 || ee != UCAL_WEDNESDAY) {
-        errln("FAIL: got date %4d/%02d/%02d, expected 210/02/24: ", yy, mm + 1, dd);
+        errln("FAIL: got date %4d/%02d/%02d (wd=%d), expected 2010/02/24: ", yy, mm + 1, dd, ee);
     }
     delete cal;
 }

--- a/icu4c/source/test/intltest/caltest.cpp
+++ b/icu4c/source/test/intltest/caltest.cpp
@@ -183,6 +183,7 @@ void CalendarTest::runIndexedTest( int32_t index, UBool exec, const char* &name,
     TESTCASE_AUTO(TestCalendarRollOrdinalMonth);
     TESTCASE_AUTO(TestLimitsOrdinalMonth);
     TESTCASE_AUTO(TestActualLimitsOrdinalMonth);
+    TESTCASE_AUTO(TestMaxActualLimitsWithoutGet23006);
     TESTCASE_AUTO(TestChineseCalendarMonthInSpecialYear);
     TESTCASE_AUTO(TestClearMonth);
 
@@ -5354,6 +5355,30 @@ void CalendarTest::TestLimitsOrdinalMonth() {
     }
 }
 
+void CalendarTest::TestMaxActualLimitsWithoutGet23006() {
+    UErrorCode status = U_ZERO_ERROR;
+    GregorianCalendar gc(status);
+    gc.set(2025, UCAL_AUGUST, 8);
+    LocalPointer<Calendar> cal(Calendar::createInstance(Locale("en@calendar=chinese"), status), status);
+    cal->setTime(gc.getTime(status), status);
+    int32_t beforeCallingGet = cal->getActualMaximum(UCAL_DAY_OF_MONTH, status);
+    cal->get(UCAL_DAY_OF_MONTH, status);
+    int32_t afterCallingGet = cal->getActualMaximum(UCAL_DAY_OF_MONTH, status);
+    assertEquals("getActualMaximum() should return same value before/after calling get()",
+                 beforeCallingGet, afterCallingGet);
+    assertEquals("getActualMaximum() should return 29 before calling get()",
+                 29, beforeCallingGet);
+
+    gc.set(2026, UCAL_AUGUST, 8);
+    cal->setTime(gc.getTime(status), status);
+    beforeCallingGet = cal->getActualMaximum(UCAL_DAY_OF_MONTH, status);
+    cal->get(UCAL_DAY_OF_MONTH, status);
+    afterCallingGet = cal->getActualMaximum(UCAL_DAY_OF_MONTH, status);
+    assertEquals("getActualMaximum() should return same value before/after calling get()",
+                 beforeCallingGet, afterCallingGet);
+    assertEquals("getActualMaximum() should return 29 before calling get()",
+                 30, beforeCallingGet);
+}
 void CalendarTest::TestActualLimitsOrdinalMonth() {
     UErrorCode status = U_ZERO_ERROR;
     GregorianCalendar gc(status);

--- a/icu4c/source/test/intltest/caltest.h
+++ b/icu4c/source/test/intltest/caltest.h
@@ -329,6 +329,7 @@ public: // package
     void TestCalendarRollOrdinalMonth();
     void TestLimitsOrdinalMonth();
     void TestActualLimitsOrdinalMonth();
+    void TestMaxActualLimitsWithoutGet23006();
     void TestDangiOverflowIsLeapMonthBetween22507();
 
     void TestFWWithISO8601();

--- a/icu4j/main/core/src/main/java/com/ibm/icu/util/Calendar.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/util/Calendar.java
@@ -6157,6 +6157,7 @@ public abstract class Calendar implements Serializable, Cloneable, Comparable<Ca
      * @stable ICU 2.0
      */
     protected int handleGetMonthLength(int extendedYear, int month) {
+      System.out.printf("handleGetMonthLength(ey=%d, m=%d)",  extendedYear, month);
         return handleComputeMonthStart(extendedYear, month+1, true) -
                 handleComputeMonthStart(extendedYear, month, true);
     }

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/CalendarRegressionTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/CalendarRegressionTest.java
@@ -2718,5 +2718,33 @@ public class CalendarRegressionTest extends CoreTestFmwk {
 
     }
 
+    @Test
+    public void TestMaxActualLimitsWithoutGet23006() {
+        Calendar calendar = Calendar.getInstance(new Locale("zh_zh@calendar=chinese"));
+        // set day equal to 8th August 2025 in Gregorian calendar
+        // this is a leap month in Chinese calendar
+        GregorianCalendar gc = new GregorianCalendar(TimeZone.GMT_ZONE);
+        gc.clear();
+        gc.set(2025, Calendar.AUGUST, 8);
+        calendar.setTimeInMillis(gc.getTimeInMillis());
+        int actualMaximumBeforeCallingGet = calendar.getActualMaximum(Calendar.DAY_OF_MONTH);
+        assertTrue("get(ERA)", calendar.get(Calendar.ERA) > 0); // calling get will cause to compute fields
+        int actualMaximumAfterCallingGet = calendar.getActualMaximum(Calendar.DAY_OF_MONTH);
+        assertEquals("calling getActualMaximum before/after calling get should be the same",
+            actualMaximumBeforeCallingGet, actualMaximumAfterCallingGet);
+        assertEquals("calling getActualMaximum before should return 29",
+            29, actualMaximumBeforeCallingGet);
+
+        gc.set(2026, Calendar.AUGUST, 8);
+        calendar.setTimeInMillis(gc.getTimeInMillis());
+        actualMaximumBeforeCallingGet = calendar.getActualMaximum(Calendar.DAY_OF_MONTH);
+        assertTrue("get(ERA)", calendar.get(Calendar.ERA) > 0); // calling get will cause to compute fields
+        actualMaximumAfterCallingGet = calendar.getActualMaximum(Calendar.DAY_OF_MONTH);
+        assertEquals("calling getActualMaximum before/after calling get should be the same",
+            actualMaximumBeforeCallingGet, actualMaximumAfterCallingGet);
+        assertEquals("calling getActualMaximum before should return 30",
+            30, actualMaximumBeforeCallingGet);
+
+    }
 }
 //eof


### PR DESCRIPTION
Read the IS_LEAP_MONTH field correctly while calling getActualMaximize.

Chinese Calendar need to read additional IS_LEAP_MONTH field while calculate the start and length of month, make the value read from the out most calls and passed into function parameter. 

#### Checklist
- [X] Required: Issue filed: ICU-23006
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
