### PR TITLE
ICU-23026 Add support to QNX 8.0 and fix test

### DIFF
--- a/icu4c/source/test/cintltst/cmsgtst.c
+++ b/icu4c/source/test/cintltst/cmsgtst.c
@@ -231,7 +231,7 @@ static void MessageFormatTest( void )
                         austrdup(result), austrdup(testResultStrings[i]) );
                 }
 
-#if (U_PLATFORM == U_PF_LINUX) /* add platforms here .. */
+#if (U_PLATFORM == U_PF_LINUX || U_PLATFORM == U_PF_QNX) /* add platforms here .. */
                 log_verbose("Skipping potentially crashing test for mismatched varargs.\n");
 #else
                 log_verbose("Note: the next is a platform dependent test. If it crashes, add an exclusion for your platform near %s:%d\n", __FILE__, __LINE__); 


### PR DESCRIPTION
https://unicode-org.atlassian.net/browse/ICU-23026: This change disable part of `cmsgtst/MessageFormatTest` for QNX 8.0 since it will crash the test.

Test instructions will be provided in the near future.

#### Checklist
- [x] Required: Issue filed: [ICU-23026](https://unicode-org.atlassian.net/browse/ICU-23026)
- [x] Required: The PR title must be prefixed with a JIRA Issue number.
- [x] Required: Each commit message must be prefixed with a JIRA Issue number.
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable


[ICU-23026]: https://unicode-org.atlassian.net/browse/ICU-23026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ