### PR TITLE
ICU-22781 Fix &Improve MeasureUnit identifier generation for constant denominators (C++)

### DIFF
--- a/icu4c/source/common/charstr.cpp
+++ b/icu4c/source/common/charstr.cpp
@@ -152,7 +152,7 @@ CharString &CharString::append(const char *s, int32_t sLength, UErrorCode &error
     return *this;
 }
 
-CharString &CharString::appendNumber(int32_t number, UErrorCode &status) {
+CharString &CharString::appendNumber(int64_t number, UErrorCode &status) {
     if (number < 0) {
         this->append('-', status);
         if (U_FAILURE(status)) {

--- a/icu4c/source/common/charstr.h
+++ b/icu4c/source/common/charstr.h
@@ -136,7 +136,7 @@ public:
     }
     CharString &append(const char *s, int32_t sLength, UErrorCode &status);
 
-    CharString &appendNumber(int32_t number, UErrorCode &status);
+    CharString &appendNumber(int64_t number, UErrorCode &status);
 
     /**
      * Returns a writable buffer for appending and writes the buffer's capacity to

--- a/icu4c/source/test/intltest/units_test.cpp
+++ b/icu4c/source/test/intltest/units_test.cpp
@@ -53,6 +53,7 @@ class UnitsTest : public IntlTest {
     void testUnitPreferencesWithCLDRTests();
     void testUnitsConstantsDenomenator();
     void testMeasureUnit_withConstantDenominator();
+    void testUnitsConstantsDenomenator_getIdentifier();
     void testConverter();
 };
 
@@ -72,6 +73,7 @@ void UnitsTest::runIndexedTest(int32_t index, UBool exec, const char *&name, cha
     TESTCASE_AUTO(testUnitPreferencesWithCLDRTests);
     TESTCASE_AUTO(testUnitsConstantsDenomenator);
     TESTCASE_AUTO(testMeasureUnit_withConstantDenominator);
+    TESTCASE_AUTO(testUnitsConstantsDenomenator_getIdentifier);
     TESTCASE_AUTO(testConverter);
     TESTCASE_AUTO_END;
 }
@@ -1340,6 +1342,41 @@ void UnitsTest::testMeasureUnit_withConstantDenominator() {
     unit = unit.withConstantDenominator(denominator, status);
     assertTrue("There is a failure caused by withConstantDenominator(\"portion\")", status.isFailure());
     status.reset();
+}
+
+void UnitsTest::testUnitsConstantsDenomenator_getIdentifier() {
+    IcuTestErrorCode status(*this, "UnitTests::testUnitsConstantsDenomenator_getIdentifier");
+
+    // Test Cases
+    struct TestCase {
+        const char *source;
+        const char *expectedIdentifier;
+    } testCases[]{
+        {"meter-per-1000", "meter-per-1000"},
+        {"meter-per-1000-kilometer", "meter-per-1000-kilometer"},
+        {"meter-per-1000000", "meter-per-1e6"},
+        {"meter-per-1000000-kilometer", "meter-per-1e6-kilometer"},
+        {"meter-per-1000000000", "meter-per-1e9"},
+        {"meter-per-1000000000-kilometer", "meter-per-1e9-kilometer"},
+        {"meter-per-1000000000000", "meter-per-1e12"},
+        {"meter-per-1000000000000-kilometer", "meter-per-1e12-kilometer"},
+        {"meter-per-1000000000000000", "meter-per-1e15"},
+        {"meter-per-1e15-kilometer", "meter-per-1e15-kilometer"},
+        {"meter-per-1000000000000000000", "meter-per-1e18"},
+        {"meter-per-1e18-kilometer", "meter-per-1e18-kilometer"},
+        {"meter-per-1000000000000001", "meter-per-1000000000000001"},
+        {"meter-per-1000000000000001-kilometer", "meter-per-1000000000000001-kilometer"},
+    };
+
+    for (const auto &testCase : testCases) {
+        MeasureUnit unit = MeasureUnit::forIdentifier(testCase.source, status);
+        if (status.errIfFailureAndReset("forIdentifier(\"%s\")", testCase.source)) {
+            continue;
+        }
+
+        auto actualIdentifier = unit.getIdentifier();
+        assertEquals(" getIdentifier(\"%s\")", testCase.expectedIdentifier, actualIdentifier);
+    }
 }
 
 #endif /* #if !UCONFIG_NO_FORMATTING */


### PR DESCRIPTION
# Description

- Add support for generating more compact identifiers for constant denominators
- Introduce methods to convert large constant denominators to scientific notation
- Update MeasureUnitImpl to use new constant denominator string generation
- Add test cases to verify identifier generation for various constant denominator scenarios

#### Checklist
- [x] Required: Issue filed: ICU-22781
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
