### PR TITLE
ICU-23035 Fix bound check at `u_strToPunycode`

### DIFF
--- a/icu4c/source/common/punycode.cpp
+++ b/icu4c/source/common/punycode.cpp
@@ -193,7 +193,7 @@ u_strToPunycode(const char16_t *src, int32_t srcLength,
         return 0;
     }
 
-    if(src==nullptr || srcLength<-1 || (dest==nullptr && destCapacity!=0)) {
+    if(src==nullptr || srcLength<-1 || destCapacity<0 || (dest==nullptr && destCapacity!=0)) {
         *pErrorCode=U_ILLEGAL_ARGUMENT_ERROR;
         return 0;
     }


### PR DESCRIPTION
I checked a lot source code, and think we should use this type of check to avoid possible CWE-476 or CWE-190/CWE-369

#### Checklist
- [x] Required: Issue filed: ICU-23035
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
