### PR TITLE
ICU-22954 Make UCollator predicates usable without U_SHOW_CPLUSPLUS_API

### DIFF
--- a/icu4c/source/common/unicode/char16ptr.h
+++ b/icu4c/source/common/unicode/char16ptr.h
@@ -283,6 +283,32 @@ inline const char16_t *uprv_char16PtrFromUChar(const T *p) {
 #endif
     }
 }
+#if !U_CHAR16_IS_TYPEDEF && (!defined(_LIBCPP_VERSION) || _LIBCPP_VERSION < 180000)
+/** @internal */
+inline const char16_t *uprv_char16PtrFromUint16(const uint16_t *p) {
+#if U_SHOW_CPLUSPLUS_API
+    return ConstChar16Ptr(p).get();
+#else
+#ifdef U_ALIASING_BARRIER
+    U_ALIASING_BARRIER(p);
+#endif
+    return reinterpret_cast<const char16_t *>(p);
+#endif
+}
+#endif
+#if U_SIZEOF_WCHAR_T==2
+/** @internal */
+inline const char16_t *uprv_char16PtrFromWchar(const wchar_t *p) {
+#if U_SHOW_CPLUSPLUS_API
+    return ConstChar16Ptr(p).get();
+#else
+#ifdef U_ALIASING_BARRIER
+    U_ALIASING_BARRIER(p);
+#endif
+    return reinterpret_cast<const char16_t *>(p);
+#endif
+}
+#endif
 #endif
 
 /**

--- a/icu4c/source/test/intltest/Makefile.in
+++ b/icu4c/source/test/intltest/Makefile.in
@@ -75,7 +75,7 @@ numbertest_parse.o numbertest_doubleconversion.o numbertest_skeletons.o \
 static_unisets_test.o numfmtdatadriventest.o numbertest_range.o erarulestest.o \
 formattedvaluetest.o formatted_string_builder_test.o numbertest_permutation.o \
 units_data_test.o units_router_test.o units_test.o displayoptions_test.o \
-numbertest_simple.o uchar_type_build_test.o usetheaderonlytest.o
+numbertest_simple.o uchar_type_build_test.o ucolheaderonlytest.o usetheaderonlytest.o
 
 DEPS = $(OBJECTS:.o=.d)
 

--- a/icu4c/source/test/intltest/Makefile.in
+++ b/icu4c/source/test/intltest/Makefile.in
@@ -75,7 +75,7 @@ numbertest_parse.o numbertest_doubleconversion.o numbertest_skeletons.o \
 static_unisets_test.o numfmtdatadriventest.o numbertest_range.o erarulestest.o \
 formattedvaluetest.o formatted_string_builder_test.o numbertest_permutation.o \
 units_data_test.o units_router_test.o units_test.o displayoptions_test.o \
-numbertest_simple.o uchar_type_build_test.o ucolheaderonlytest.o usetheaderonlytest.o
+numbertest_simple.o cplusplus_header_api_build_test.o uchar_type_build_test.o ucolheaderonlytest.o usetheaderonlytest.o
 
 DEPS = $(OBJECTS:.o=.d)
 

--- a/icu4c/source/test/intltest/cplusplus_header_api_build_test.cpp
+++ b/icu4c/source/test/intltest/cplusplus_header_api_build_test.cpp
@@ -1,0 +1,11 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html#License
+
+// ICU-22954 Test that client code can be built with U_SHOW_CPLUSPLUS_API=0.
+#undef U_ALL_IMPLEMENTATION
+#undef U_SHOW_CPLUSPLUS_API
+#define U_SHOW_CPLUSPLUS_API 0
+#include "unicode/char16ptr.h"
+#include "unicode/ucol.h"
+#include "unicode/uset.h"
+#include "unicode/utypes.h"

--- a/icu4c/source/test/intltest/intltest.vcxproj
+++ b/icu4c/source/test/intltest/intltest.vcxproj
@@ -242,6 +242,7 @@
     <ClCompile Include="units_router_test.cpp" />
     <ClCompile Include="units_test.cpp" />
     <ClCompile Include="uchar_type_build_test.cpp" />
+    <ClCompile Include="ucolheaderonlytest.cpp" />
     <ClCompile Include="usetheaderonlytest.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/icu4c/source/test/intltest/intltest.vcxproj
+++ b/icu4c/source/test/intltest/intltest.vcxproj
@@ -241,6 +241,7 @@
     <ClCompile Include="units_data_test.cpp" />
     <ClCompile Include="units_router_test.cpp" />
     <ClCompile Include="units_test.cpp" />
+    <ClCompile Include="cplusplus_header_api_build_test.cpp" />
     <ClCompile Include="uchar_type_build_test.cpp" />
     <ClCompile Include="ucolheaderonlytest.cpp" />
     <ClCompile Include="usetheaderonlytest.cpp" />

--- a/icu4c/source/test/intltest/intltest.vcxproj.filters
+++ b/icu4c/source/test/intltest/intltest.vcxproj.filters
@@ -580,6 +580,9 @@
     <ClCompile Include="messageformat2test_read_json.cpp">
       <Filter>formatting</Filter>
     </ClCompile>
+    <ClCompile Include="ucolheaderonlytest.cpp">
+      <Filter>misc</Filter>
+    </ClCompile>
     <ClCompile Include="usetheaderonlytest.cpp">
       <Filter>misc</Filter>
     </ClCompile>

--- a/icu4c/source/test/intltest/intltest.vcxproj.filters
+++ b/icu4c/source/test/intltest/intltest.vcxproj.filters
@@ -568,6 +568,9 @@
     <ClCompile Include="units_test.cpp">
       <Filter>formatting</Filter>
     </ClCompile>
+    <ClCompile Include="cplusplus_header_api_build_test.cpp">
+      <Filter>configuration</Filter>
+    </ClCompile>
     <ClCompile Include="uchar_type_build_test.cpp">
       <Filter>configuration</Filter>
     </ClCompile>

--- a/icu4c/source/test/intltest/itutil.cpp
+++ b/icu4c/source/test/intltest/itutil.cpp
@@ -35,6 +35,9 @@
 #include "usettest.h"
 
 extern IntlTest *createBytesTrieTest();
+#if !UCONFIG_NO_COLLATION
+extern IntlTest *createUColHeaderOnlyTest();
+#endif
 extern IntlTest *createUSetHeaderOnlyTest();
 extern IntlTest *createLocaleMatcherTest();
 static IntlTest *createLocalPointerTest();
@@ -83,6 +86,9 @@ void IntlTestUtilities::runIndexedTest( int32_t index, UBool exec, const char* &
     TESTCASE_AUTO_CLASS(LocaleBuilderTest);
     TESTCASE_AUTO_CREATE_CLASS(LocaleMatcherTest);
     TESTCASE_AUTO_CREATE_CLASS(UHashTest);
+#if !UCONFIG_NO_COLLATION
+    TESTCASE_AUTO_CREATE_CLASS(UColHeaderOnlyTest);
+#endif
     TESTCASE_AUTO_CREATE_CLASS(USetHeaderOnlyTest);
     TESTCASE_AUTO_END;
 }

--- a/icu4c/source/test/intltest/ucolheaderonlytest.cpp
+++ b/icu4c/source/test/intltest/ucolheaderonlytest.cpp
@@ -1,0 +1,96 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+
+// Test header-only ICU C++ APIs. Do not use other ICU C++ APIs.
+// Non-default configuration:
+#define U_SHOW_CPLUSPLUS_API 0
+
+#include "unicode/utypes.h"
+
+#if !UCONFIG_NO_COLLATION
+
+#include <string_view>
+
+#include "unicode/ucol.h"
+
+#include "intltest.h"
+
+namespace {
+
+class UColHeaderOnlyTest : public IntlTest {
+public:
+    UColHeaderOnlyTest() = default;
+    void runIndexedTest(int32_t index, UBool exec, const char*& name, char* par = nullptr) override;
+    void TestPredicateTypes();
+};
+
+void UColHeaderOnlyTest::runIndexedTest(int32_t index, UBool exec, const char*& name, char* /*par*/) {
+    if (exec) {
+        logln("TestSuite UColHeaderOnlyTest: ");
+    }
+    TESTCASE_AUTO_BEGIN;
+    TESTCASE_AUTO(TestPredicateTypes);
+    TESTCASE_AUTO_END;
+}
+
+class UCollatorWrapper {
+public:
+    UCollatorWrapper(const char* loc, UErrorCode* status) : ucol(ucol_open(loc, status)) {}
+    ~UCollatorWrapper() { ucol_close(ucol); }
+    operator UCollator*() { return ucol; }
+
+private:
+    UCollator* ucol;
+};
+
+constexpr char16_t TEXT_CHAR16[] = u"char16";
+#if !U_CHAR16_IS_TYPEDEF && (!defined(_LIBCPP_VERSION) || _LIBCPP_VERSION < 180000)
+constexpr uint16_t TEXT_UINT16[] = {0x75, 0x69, 0x6e, 0x74, 0x31, 0x36, 0x00};
+#endif
+#if U_SIZEOF_WCHAR_T == 2
+constexpr wchar_t TEXT_WCHAR[] = L"wchar";
+#endif
+
+constexpr char TEXT_CHAR[] = "char";
+#if defined(__cpp_char8_t)
+constexpr char8_t TEXT_CHAR8[] = u8"char8";
+#endif
+
+// Verify that the UCollator predicates handle all string types.
+void UColHeaderOnlyTest::TestPredicateTypes() {
+    using namespace U_HEADER_NESTED_NAMESPACE;
+    IcuTestErrorCode status(*this, "TestPredicateTypes");
+    UCollatorWrapper ucol("", status);
+    status.assertSuccess();
+    const auto equal_to = collator::equal_to(ucol);
+
+    assertTrue("char16_t", equal_to(TEXT_CHAR16, TEXT_CHAR16));
+    assertTrue("u16string_view", equal_to(std::u16string_view{TEXT_CHAR16}, TEXT_CHAR16));
+
+#if !U_CHAR16_IS_TYPEDEF && (!defined(_LIBCPP_VERSION) || _LIBCPP_VERSION < 180000)
+    assertTrue("uint16_t", equal_to(TEXT_UINT16, TEXT_UINT16));
+    assertTrue("basic_string_view<uint16_t>",
+               equal_to(std::basic_string_view<uint16_t>{TEXT_UINT16}, TEXT_UINT16));
+#endif
+
+#if U_SIZEOF_WCHAR_T == 2
+    assertTrue("wchar_t", equal_to(TEXT_WCHAR, TEXT_WCHAR));
+    assertTrue("wstring_view", equal_to(std::wstring_view{TEXT_WCHAR}, TEXT_WCHAR));
+#endif
+
+    assertTrue("char", equal_to(TEXT_CHAR, TEXT_CHAR));
+    assertTrue("string_view", equal_to(std::string_view{TEXT_CHAR}, TEXT_CHAR));
+
+#if defined(__cpp_char8_t)
+    assertTrue("char8_t", equal_to(TEXT_CHAR8, TEXT_CHAR8));
+    assertTrue("u8string_view", equal_to(std::u8string_view{TEXT_CHAR8}, TEXT_CHAR8));
+#endif
+}
+
+} // namespace
+
+IntlTest* createUColHeaderOnlyTest() {
+    return new UColHeaderOnlyTest();
+}
+
+#endif  // !UCONFIG_NO_COLLATION


### PR DESCRIPTION
Until now, the implementation of the `UCollator` predicates has been using `UnicodeString` and `StringPiece` as convenient wrappers for converting from standard C++ data types to ICU4C data types.

But as that doesn't work when the client uses ICU4C built without `U_SHOW_CPLUSPLUS_API` this is now changed to instead perform these conversions directly.

(It's a bit more code, but does just the same thing in the end.)

Then add a build test for all header files that use `U_SHOW_CPLUSPLUS_HEADER_API` to verify that they now all can be built without `U_SHOW_CPLUSPLUS_API`.

With this all done, ICU-22954 should be resolved.

#### Checklist
- [x] Required: Issue filed: ICU-22954
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

ALLOW_MANY_COMMITS=true