### PR TITLE
ICU-22967 Remove explicit manipultaion of old-xmls.tar.bz2 in workflows

### DIFF
--- a/.github/workflows/icu_merge_ci.yml
+++ b/.github/workflows/icu_merge_ci.yml
@@ -349,11 +349,6 @@ jobs:
 
       - name: Build and run unicodesetperf test
         run: |
-          # This file needs to be restored  otherwise GHA cannot
-          # check-out the perfdata branch. Setting up this task with GH lfs
-          # modifies the file but the details of why and how are unknown.
-          git restore --staged tools/multi/proj/icu4cscan/old-xmls.tar.bz2;
-          git restore tools/multi/proj/icu4cscan/old-xmls.tar.bz2;
           cd icu4j;
           mvn ${SHARED_MVN_ARGS} verify -DskipITs -DskipTests;
           git status
@@ -411,11 +406,6 @@ jobs:
 
       - name: Build and run ucharacterperf test
         run: |
-          # This file needs to be restored  otherwise GHA cannot
-          # check-out the perfdata branch. Setting up this task with GH lfs
-          # modifies the file but the details of why and how are unknown.
-          git restore --staged tools/multi/proj/icu4cscan/old-xmls.tar.bz2;
-          git restore tools/multi/proj/icu4cscan/old-xmls.tar.bz2;
           cd icu4j;
           mvn ${SHARED_MVN_ARGS} verify -DskipITs -DskipTests;
           cd perf-tests;
@@ -475,11 +465,6 @@ jobs:
 
       - name: Build and run decimalformatperf
         run: |
-          # This file needs to be restored  otherwise GHA cannot
-          # check-out the perfdata branch. Setting up this task with GH lfs
-          # modifies the file but the details of why and how are unknown.
-          git restore --staged tools/multi/proj/icu4cscan/old-xmls.tar.bz2;
-          git restore tools/multi/proj/icu4cscan/old-xmls.tar.bz2;
           cd icu4j;
           mvn ${SHARED_MVN_ARGS} verify -DskipITs -DskipTests;
           cd perf-tests;
@@ -546,11 +531,6 @@ jobs:
         env:
           DATA_FILE_PATH: data/collation
         run: |
-          # This file needs to be restored  otherwise GHA cannot
-          # check-out the perfdata branch. Setting up this task with GH lfs
-          # modifies the file but the details of why and how are unknown.
-          git restore --staged tools/multi/proj/icu4cscan/old-xmls.tar.bz2;
-          git restore tools/multi/proj/icu4cscan/old-xmls.tar.bz2;
           cd icu4j;
           mvn ${SHARED_MVN_ARGS} verify -DskipITs -DskipTests;
           cd perf-tests;
@@ -685,11 +665,6 @@ jobs:
         env:
           DATA_FILE_PATH: data/conversion
         run: |
-          # This file needs to be restored  otherwise GHA cannot
-          # check-out the perfdata branch. Setting up this task with GH lfs
-          # modifies the file but the details of why and how are unknown.
-          git restore --staged tools/multi/proj/icu4cscan/old-xmls.tar.bz2;
-          git restore tools/multi/proj/icu4cscan/old-xmls.tar.bz2;
           cd icu4j;
           mvn ${SHARED_MVN_ARGS} verify -DskipITs -DskipTests;
           cd perf-tests;
@@ -771,11 +746,6 @@ jobs:
           echo "DDIR=${ddir: -1}" >> $GITHUB_ENV
       - name: Build and run dateformatperf
         run: |
-          # This file needs to be restored  otherwise GHA cannot
-          # check-out the perfdata branch. Setting up this task with GH lfs
-          # modifies the file but the details of why and how are unknown.
-          git restore --staged tools/multi/proj/icu4cscan/old-xmls.tar.bz2
-          git restore tools/multi/proj/icu4cscan/old-xmls.tar.bz2
           cd icu4j;
           mvn ${SHARED_MVN_ARGS} verify -DskipITs -DskipTests;
           cd perf-tests;


### PR DESCRIPTION
The workflow was trying to repair old-xmls.tar.bz2

Which was broken (the first commit in my pull request https://github.com/unicode-org/icu/pull/3375)
Although the right fix would have been to restore the file for good.
But this "fix" does not work now, on a removed file :-) (the second commit in the mentioned PR)
Anyway... the whole folder 'tools/multi' is not needed, so it should be good now.

#### Checklist
- [x] Required: Issue filed: ICU-22967
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
