### PR TITLE
ICU-23031 Reinstate special case for "-u-va-posix" lost by ICU-22520

### DIFF
--- a/icu4c/source/test/cintltst/cloctst.c
+++ b/icu4c/source/test/cintltst/cloctst.c
@@ -288,6 +288,9 @@ void addLocaleTest(TestNode** root)
     TESTCASE(TestBug20321UnicodeLocaleKey);
     TESTCASE(TestUsingDefaultWarning);
     TESTCASE(TestBug21449InfiniteLoop);
+    TESTCASE(TestBug23031VaPosix);
+    TESTCASE(TestBug23031VaPosixManyExtensions);
+    TESTCASE(TestBug23031VaPosixManyVariants);
     TESTCASE(TestExcessivelyLongIDs);
 #if !UCONFIG_NO_FORMATTING
     TESTCASE(TestUldnNameVariants);
@@ -7445,6 +7448,63 @@ static void TestBug21449InfiniteLoop(void) {
     // The issue causes an infinite loop to occur when looking up a non-existent resource for the invalid locale ID,
     // so the test is considered passed if the call to the API below returns anything at all.
     uloc_getDisplayLanguage(invalidLocaleId, invalidLocaleId, NULL, 0, &status);
+}
+
+// Test case for ICU-23031
+static void TestBug23031VaPosix(void) {
+    static const char tag[] = "en-US-u-va-posIX";
+    static const char expected[] = "POSIX";
+
+    UErrorCode status = U_ZERO_ERROR;
+    char actual[32];
+    int32_t len = uloc_getVariant(tag, actual, UPRV_LENGTHOF(actual), &status);
+    if (U_FAILURE(status)) {
+        log_err("ERROR: in uloc_getVariant  %s\n", myErrorName(status));
+    }
+    if (len < 1) {
+        log_err("FAIL: uloc_getVariant() returned %d\n", len);
+    }
+    if (uprv_strcmp(actual, expected) != 0) {
+        log_err("FAIL: uloc_getVariant() Wanted %s, got %s\n", expected, actual);
+    }
+}
+
+// Test case for ICU-23031
+static void TestBug23031VaPosixManyExtensions(void) {
+    static const char tag[] = "en-US-u-co-search-va-posIX-kc";
+    static const char expected[] = "POSIX";
+
+    UErrorCode status = U_ZERO_ERROR;
+    char actual[32];
+    int32_t len = uloc_getVariant(tag, actual, UPRV_LENGTHOF(actual), &status);
+    if (U_FAILURE(status)) {
+        log_err("ERROR: in uloc_getVariant  %s\n", myErrorName(status));
+    }
+    if (len < 1) {
+        log_err("FAIL: uloc_getVariant() returned %d\n", len);
+    }
+    if (uprv_strcmp(actual, expected) != 0) {
+        log_err("FAIL: uloc_getVariant() Wanted %s, got %s\n", expected, actual);
+    }
+}
+
+// Test case for ICU-23031
+static void TestBug23031VaPosixManyVariants(void) {
+    static const char tag[] = "en-US-fonIPA-u-va-posIX";
+    static const char expected[] = "FONIPA_POSIX";
+
+    UErrorCode status = U_ZERO_ERROR;
+    char actual[32];
+    int32_t len = uloc_getVariant(tag, actual, UPRV_LENGTHOF(actual), &status);
+    if (U_FAILURE(status)) {
+        log_err("ERROR: in uloc_getVariant  %s\n", myErrorName(status));
+    }
+    if (len < 1) {
+        log_err("FAIL: uloc_getVariant() returned %d\n", len);
+    }
+    if (uprv_strcmp(actual, expected) != 0) {
+        log_err("FAIL: uloc_getVariant() Wanted %s, got %s\n", expected, actual);
+    }
 }
 
 // rdar://79296849 and https://unicode-org.atlassian.net/browse/ICU-21639

--- a/icu4c/source/test/cintltst/cloctst.h
+++ b/icu4c/source/test/cintltst/cloctst.h
@@ -146,6 +146,9 @@ static void TestToLegacyType(void);
 static void TestBug20149(void);
 static void TestCDefaultLocale(void);
 static void TestBug21449InfiniteLoop(void);
+static void TestBug23031VaPosix(void);
+static void TestBug23031VaPosixManyExtensions(void);
+static void TestBug23031VaPosixManyVariants(void);
 
 
 /**


### PR DESCRIPTION
Inside of `locimp_forLanguageTag()` in `_appendKeywords()` in `uloc_tag.cpp` there's a hardcoded special case for `-u-va-posix` which appends the `_POSIX` variant but this was missed during the refactoring made for ICU-22520 (there isn't any test case that covers this).

So the call to `locimp_forLanguageTag()` did more than previously understood, but we still don't want to have to call that for every language tag that has BCP-47 extensions just in order to get to this special case. Instead, add a special case also to `ulocimp_getSubtags().`

For this to work nicely, the loop in `_getVariant()` that copies variants needs to be refactored so that it easily can break when encountering the start of any BCP-47 extension (which also has the welcome side-effect of making it more efficient, being able to append an entire variant at once to the output sink).

This was broken by commit 678d5c127373d699ac4f1be55f8c017aeb0493d5.

#### Checklist
- [x] Required: Issue filed: ICU-23031
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
