### PR TITLE
ICU-22781 Support Arbitrary Constant Unit Formatting

### DIFF
--- a/icu4c/source/test/intltest/numbertest.h
+++ b/icu4c/source/test/intltest/numbertest.h
@@ -103,6 +103,7 @@ class NumberFormatterApiTest : public IntlTestWithFieldPosition {
     void toDecimalNumber();
     void microPropsInternals();
     void formatUnitsAliases();
+    void formatArbitraryConstant();
     void TestPortionFormat();
     void testIssue22378();
 

--- a/icu4j/main/core/src/main/java/com/ibm/icu/util/MeasureUnit.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/util/MeasureUnit.java
@@ -716,12 +716,22 @@ public class MeasureUnit implements Serializable {
             implCopy.appendSingleUnit(singleUnit);
         }
 
-        if (this.getConstantDenominator() != 0 && other.getConstantDenominator() != 0) {
+        long thisConstantDenominator = this.getConstantDenominator();
+        long otherConstantDenominator = other.getConstantDenominator();
+
+        // TODO: we can also multiply the constant denominators instead of throwing an
+        // exception.
+        if (thisConstantDenominator != 0 && otherConstantDenominator != 0) {
+            // There is only `one` constant denominator in a compound unit.
+            // Therefore, we cannot multiply units that both of them have a constant
+            // denominator.
             throw new UnsupportedOperationException(
                     "Cannot multiply units that both of them have a constant denominator");
         }
 
-        implCopy.setConstantDenominator(this.getConstantDenominator() + other.getConstantDenominator());
+        // Because either one of the constant denominators is zero, we can use the
+        // maximum of them.
+        implCopy.setConstantDenominator(Math.max(thisConstantDenominator, otherConstantDenominator));
 
         return implCopy.build();
     }


### PR DESCRIPTION
# Description: 
- Added support for constant denominators in MeasureUnit and LongNameHandler
- Updated MeasureUnit serialization and product methods to handle constant denominators
- Added test cases for formatting units with arbitrary constant denominators
- Added comprehensive test coverage for complex unit formatting scenarios

Related ticket that needs to be addressed: https://unicode-org.atlassian.net/browse/ICU-23039

#### Checklist
- [x] Required: Issue filed: ICU-22781
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
