### PR TITLE
ICU-23032 Optimize complexity caching of MeasureUnit (Java)

### DIFF
--- a/icu4j/main/core/src/main/java/com/ibm/icu/util/MeasureUnit.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/util/MeasureUnit.java
@@ -49,6 +49,8 @@ public class MeasureUnit implements Serializable {
     // i.e. from synchronized static methods. Beware of non-static methods.
     private static final Map<String, Map<String, MeasureUnit>> cache = new HashMap<>();
     private static boolean cacheIsPopulated = false;
+    private Complexity complexity;
+    private boolean isComplexitySet = false;
 
     /**
      * If type set to null, measureUnitImpl is in use instead of type and subType.
@@ -448,6 +450,8 @@ public class MeasureUnit implements Serializable {
         String identifier = measureUnitImpl.getIdentifier();
         MeasureUnit result = MeasureUnit.findBySubType(identifier);
         if (result != null) {
+            result.complexity = measureUnitImpl.getComplexity();
+            result.isComplexitySet = true;
             return result;
         }
 
@@ -458,6 +462,8 @@ public class MeasureUnit implements Serializable {
         type = null;
         subType = null;
         this.measureUnitImpl = measureUnitImpl.copy();
+        this.complexity = measureUnitImpl.getComplexity();
+        this.isComplexitySet = true;
     }
 
     /**
@@ -496,8 +502,14 @@ public class MeasureUnit implements Serializable {
      * @stable ICU 68
      */
     public Complexity getComplexity() {
+        if (isComplexitySet) {
+            return complexity;
+        }
+
         if (measureUnitImpl == null) {
-            return MeasureUnitImpl.forIdentifier(getIdentifier()).getComplexity();
+            complexity = MeasureUnitImpl.forIdentifier(getIdentifier()).getComplexity();
+            isComplexitySet = true;
+            return complexity;
         }
 
         return measureUnitImpl.getComplexity();


### PR DESCRIPTION
# Description: 
Optimize MeasureUnit complexity retrieval by:
- Adding complexity and isComplexitySet fields
- Caching complexity value after first retrieval
- Reducing redundant complexity calculations

#### Checklist
- [x] Required: Issue filed: ICU-23032
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
