### PR TITLE
ICU-23042 Optimize MeasureUnit complexity retrieval

### DIFF
--- a/icu4c/source/i18n/measunit_extra.cpp
+++ b/icu4c/source/i18n/measunit_extra.cpp
@@ -1399,8 +1399,15 @@ MeasureUnit MeasureUnit::forIdentifier(StringPiece identifier, UErrorCode &statu
 }
 
 UMeasureUnitComplexity MeasureUnit::getComplexity(UErrorCode &status) const {
+    if (isComplexitySet) {
+        return fComplexity;
+    }
     MeasureUnitImpl temp;
-    return MeasureUnitImpl::forMeasureUnit(*this, temp, status).complexity;
+    MeasureUnitImpl::forMeasureUnit(*this, temp, status);
+
+    fComplexity = temp.complexity;
+    isComplexitySet = true;
+    return fComplexity;
 }
 
 UMeasurePrefix MeasureUnit::getPrefix(UErrorCode &status) const {

--- a/icu4c/source/i18n/unicode/measunit.h
+++ b/icu4c/source/i18n/unicode/measunit.h
@@ -3895,6 +3895,9 @@ private:
     // is in use instead of fTypeId and fSubTypeId.
     int8_t fTypeId;
 
+    bool isComplexitySet = false;
+    UMeasureUnitComplexity fComplexity;
+
     MeasureUnit(int32_t typeId, int32_t subTypeId);
     MeasureUnit(MeasureUnitImpl&& impl);
     void setTo(int32_t typeId, int32_t subTypeId);


### PR DESCRIPTION
Cache the complexity of a MeasureUnit to improve performance by avoiding redundant computations. Added a flag and member variable to store the complexity result after the first calculation.

TODO: Please describe your changes here.

TODO: Please read the following on ICU Contributing, and then delete these instructions.

Thank you for your pull request! 

* For general info on contributing: https://github.com/unicode-org/icu/blob/main/CONTRIBUTING.md
* Associating PRs with Jira issues
  - We require each pull request to be associated with a [Jira issue](https://icu.unicode.org/bugs).
  - Reuse existing issues for minor changes:
    * ICU 77 docs minor fixes: ICU-22921 — User Guide & API docs typos etc., and version updates (e.g., dependabot for User Guide)
    * ICU 77 code warnings/version updates: ICU-22920 — Fix compiler warnings. Update versions of code-related dependencies (e.g., dependabot).
* Contributors license agreement (CLA):
  - You will be automatically asked to sign the CLA before the PR is accepted.
  - To sign the CLA: https://cla-assistant.io/unicode-org/icu
  - For terms of use and license, see https://www.unicode.org/terms_of_use.html

TODO: Fill out the checklist below.

#### Checklist
- [ ] Required: Issue filed: ICU-NNNNN
- [ ] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
