### PR TITLE
ICU-22781 Add test for portion format with parts per billion (C++)

### DIFF
--- a/icu4c/source/test/intltest/numbertest.h
+++ b/icu4c/source/test/intltest/numbertest.h
@@ -103,6 +103,7 @@ class NumberFormatterApiTest : public IntlTestWithFieldPosition {
     void toDecimalNumber();
     void microPropsInternals();
     void formatUnitsAliases();
+    void TestPortionFormat();
     void testIssue22378();
 
     void runIndexedTest(int32_t index, UBool exec, const char*& name, char* par = nullptr) override;


### PR DESCRIPTION
# Description:
- Added a new test method `TestPortionFormat()` in `numbertest_api.cpp`
- Updated `numbertest.h` to declare the new test method
- Test covers formatting of "portion-per-1e9" unit in different locales
- Includes test cases for singular and plural forms
- Handles known issue for other portion units with a log message

java code : https://github.com/unicode-org/icu/pull/3390

#### Checklist
- [x] Required: Issue filed: ICU-22781
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
