### PR TITLE
ICU-22922 Scrubbing closed issues

### DIFF
--- a/icu4c/source/test/intltest/tzfmttst.cpp
+++ b/icu4c/source/test/intltest/tzfmttst.cpp
@@ -338,10 +338,6 @@ TimeZoneFormatTest::TestTimeZoneRoundTrip() {
                         } else {
                             // Specific or generic: raw offset must be preserved.
                             if (inRaw != outRaw) {
-                            	if ((strcmp(LOCALES[locidx].getName(), "tg") == 0 || strcmp(LOCALES[locidx].getName(), "tg_TJ") == 0) 
-                            		&& logKnownIssue("ICU-22857", "Time zone round test fails for tg/tg_TJ")) {
-                            		continue;
-                            	}
                                 errln(UnicodeString("Raw offset round trip failed; tz=") + *tzid
                                     + ", locale=" + LOCALES[locidx].getName() + ", pattern=" + PATTERNS[patidx]
                                     + ", time=" + DATES[datidx] + ", str=" + tzstr
@@ -533,9 +529,9 @@ TimeZoneFormatTest::TestTimeRoundTrip() {
 
 // TimeZoneFormatTest::RunTimeRoundTripTests()
 //    This function loops, running time zone format round trip test cases until there are no more, then returns.
-//    Threading: multiple invocations of this function are started in parallel 
+//    Threading: multiple invocations of this function are started in parallel
 //               by TimeZoneFormatTest::TestTimeRoundTrip()
-//    
+//
 void TimeZoneFormatTest::RunTimeRoundTripTests(int32_t threadNumber) {
     UErrorCode status = U_ZERO_ERROR;
     UBool REALLY_VERBOSE = false;
@@ -577,7 +573,7 @@ void TimeZoneFormatTest::RunTimeRoundTripTests(int32_t threadNumber) {
 
         UnicodeString pattern(BASEPATTERN);
         pattern.append(" ").append(PATTERNS[patidx]);
-        logln("    Thread %d, Locale %s, Pattern %s", 
+        logln("    Thread %d, Locale %s, Pattern %s",
                 threadNumber, gLocaleData->locales[locidx].getName(), CStr(pattern)());
 
         SimpleDateFormat *sdf = new SimpleDateFormat(pattern, gLocaleData->locales[locidx], status);
@@ -1088,7 +1084,7 @@ TimeZoneFormatTest::TestFormat() {
     const FormatTestData DATA[] = {
         {
             "en",
-            "America/Los_Angeles", 
+            "America/Los_Angeles",
             dateJan,
             UTZFMT_STYLE_GENERIC_LOCATION,
             "Los Angeles Time",
@@ -1187,7 +1183,7 @@ TimeZoneFormatTest::TestFormatTZDBNames() {
     const FormatTestData DATA[] = {
         {
             "en",
-            "America/Chicago", 
+            "America/Chicago",
             dateJan,
             UTZFMT_STYLE_SPECIFIC_SHORT,
             "CST",
@@ -1195,7 +1191,7 @@ TimeZoneFormatTest::TestFormatTZDBNames() {
         },
         {
             "en",
-            "Asia/Shanghai", 
+            "Asia/Shanghai",
             dateJan,
             UTZFMT_STYLE_SPECIFIC_SHORT,
             "CST",
@@ -1203,7 +1199,7 @@ TimeZoneFormatTest::TestFormatTZDBNames() {
         },
         {
             "zh_Hans",
-            "Asia/Shanghai", 
+            "Asia/Shanghai",
             dateJan,
             UTZFMT_STYLE_SPECIFIC_SHORT,
             "CST",

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/TimeZoneFormatTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/TimeZoneFormatTest.java
@@ -275,10 +275,6 @@ public class TimeZoneFormatTest extends CoreTestFmwk {
                             } else {
                                 // Specific or generic: raw offset must be preserved.
                                 if (inOffsets[0] != outOffsets[0] ) {
-                                    if ((LOCALES[locidx].toString().equals("tg") || LOCALES[locidx].toString().equals("tg_TJ"))
-                                            && logKnownIssue("ICU-22857", "Time zone round test fails for tg/tg_TJ")) {
-                                        continue;
-                                    }
                                     if (JDKTZ && tzids[tzidx].startsWith("SystemV/")) {
                                         // JDK uses rule SystemV for these zones while
                                         // ICU handles these zones as aliases of existing time zones

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/util/ULocaleTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/util/ULocaleTest.java
@@ -5723,10 +5723,9 @@ public class ULocaleTest extends CoreTestFmwk {
             assertEquals("addLikelySubtags(" + test.source + ") should be unchanged",
                 l, ULocale.addLikelySubtags(l));
         } else {
-            if ( ( test.source.equals("und-Latn-MU") || test.source.equals("und-Latn-RS") || test.source.equals("und-Latn-SL")
-                || test.source.equals("und-Latn-TK") || test.source.equals("und-Latn-ZM") )
-                && logKnownIssue("CLDR-18002", "Incorrect Likely Subtags for some entries modified in CLDR 46") ) {
-                    return;
+            if (test.source.equals("und-Latn-RS")
+                && logKnownIssue("ICU-23052", "addLikelySubtags(und-Latn-RS) bug") ) {
+              return;
                 }
               assertEquals("addLikelySubtags(" + test.source + ")",
                   test.addLikely, ULocale.addLikelySubtags(l).toLanguageTag());


### PR DESCRIPTION
Updating code for 3 Closed JIRA ids: ['CLDR-18002', 'ICU-22857', 'ICU-22984']
 
Changed logKnownIssue for 'CLDR-18002' to logKnownIssue for 'ICU-23052' in main/common_tests/src/test/java/com/ibm/icu/dev/test/util/ULocaleTest.java
  This now triggers only on locale "und-Latn-RS".

 Resolved ICU-22857: ['ICU-22857', 'logKnownIssue', 'main/common_tests/src/test/java/com/ibm/icu/dev/test/format/TimeZoneFormatTest.java', 279]
  Resolved ICU-22857: ['ICU-22857', 'logKnownIssue', 'test/intltest/tzfmttst.cpp', 342]

#### Checklist
- [x] Required: Issue filed: ICU-22922
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
