### PR TITLE
ICU-23056 Add workflow to generate commit checker report

### DIFF
--- a/.github/workflows/brs-commit-checker.yml
+++ b/.github/workflows/brs-commit-checker.yml
@@ -1,0 +1,93 @@
+name: BRS Commit Checker Report
+on:
+      workflow_dispatch:
+        inputs:
+            fix_version:
+                type: string
+                required: true
+                description: The ICU Jira "Fix Version" semver
+            from_git_ref:
+                type: string
+                required: true
+                description: The git ref start of comparison range. Prefix branches with `origin/`.
+            end_git_ref:
+                type: string
+                required: true
+                description: The git ref end of comparison range. Must be descendant of `from_git_ref`. Prefix branches with `origin/`.
+            # Jira user name & API token is used for processing sensitive tickets
+            jira_user_email:
+                type: string
+                required: false
+                description: (optional to include sensitive tickets) Email address of Jira user
+            # Jira user name & API token is used for processing sensitive tickets
+            # We protect the API token as a secret by preventing its value from pasted at the command line
+            # by using add-mask to obfuscate secret values in the jobs
+            # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions
+            jira_user_api_token:
+                type: string
+                required: false
+                description: (optional to include sensitive tickets) API token of Jira user
+
+jobs:
+    commit-report:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                fetch-tags: true
+                fetch-depth: 0
+            # workaround for bug in checkout action. this step should be redundant.
+            # https://github.com/actions/checkout/issues/1471
+            # https://github.com/actions/checkout/issues/1781
+            # https://github.com/actions/checkout/issues/701#issuecomment-1133937950
+            - name: Fetch all tags
+              run: |
+                git fetch --tags origin
+            - name: Fetch all branches
+              run: |
+                git fetch origin
+            - name: Setup Python
+              uses: actions/setup-python@v5
+              with:
+                python-version: '3.12.8'
+                cache: 'pipenv'
+                cache-dependency-path: |
+                    tools/commit-checker/Pipfile
+                    tools/commit-checker/Pipfile.lock
+            - name: Install pipenv
+              run: |
+                sudo pip3 install pipenv
+              # Use add-mask to obfuscate secret values in the jobs
+              # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions
+              # https://stackoverflow.com/a/71698374/2077918
+            - name: Store Jira credentials if provided
+              run: |
+                JIRA_USERNAME=$(cat $GITHUB_EVENT_PATH | jq -r '.inputs.jira_user_email' )
+                echo "::add-mask::${JIRA_USERNAME}"
+                JIRA_PASSWORD=$(cat $GITHUB_EVENT_PATH | jq -r '.inputs.jira_user_api_token' )
+                echo "::add-mask::${JIRA_PASSWORD}"
+                if [ ! -z "${JIRA_USERNAME}" ] && [ ! -z "${JIRA_PASSWORD}" ]
+                then
+                    echo "::add-mask::${JIRA_USERNAME}"
+                    echo "::add-mask::${JIRA_PASSWORD}"
+                    pushd ./tools/commit-checker
+                    echo "appending username and password to .env file"
+                    echo "JIRA_USERNAME=${JIRA_USERNAME}" >> ./.env
+                    echo "JIRA_PASSWORD=${JIRA_PASSWORD}" >> ./.env
+                    popd
+                else
+                    echo "Either jira_user_email or jira_user_api_token is empty. Not storing credentials file to enable access to sensitive tickets."
+                fi
+            - name: Generate report
+              run: |
+                pushd ./tools/commit-checker
+                pipenv install
+                pipenv run python3 check.py \
+                    --jira-query "project=ICU AND fixVersion=${{ inputs.fix_version }}" \
+                    --rev-range "${{ inputs.from_git_ref }}..${{ inputs.end_git_ref }}" > REPORT.md
+                popd
+            # https://github.blog/news-insights/product-news/supercharging-github-actions-with-job-summaries/
+            - name: Reproduce report as workflow job summary
+              run: |
+                cat ./tools/commit-checker/REPORT.md >> $GITHUB_STEP_SUMMARY
+                echo "View the Summary page of this GHA Workflow instance to view the rendered Markdown of this report."

--- a/docs/processes/release/tasks/miscellaneous.md
+++ b/docs/processes/release/tasks/miscellaneous.md
@@ -57,12 +57,33 @@ merging post RC fixes from trunk and others.
 Every commit being shipped in the next ICU release should be labeled with a Jira
 ticket that is marked as fixed with the correct fix version. Further, there
 should be no Jira tickets marked as fixed with the current fixVersion that do
-not have commits. To check this, run the following tool:
+not have commits. 
+
+### Run locally
+
+To check this, run the following tool:
 
 <https://github.com/unicode-org/icu/tree/main/tools/commit-checker>
 
-Follow the instructions in the README file to generate the report and send it
+Follow the instructions in the README file to generate the report locally and send it
 for review.
+
+### Run via CI
+
+Alternatively, you can run the "BRS Commit Checker Report" workflow directly from the project page CI
+by:
+
+1. Go to the [Actions tab](https://github.com/unicode-org/icu/actions)
+1. Click on the "BRS Commit Checker Report" workflow name on the left hand list of workflows
+1. Click the "Run workflow" dropdown.
+
+    The dropdown should reveal an input form in which to provide inputs
+
+1. Provide the same inputs in the form as you would for a local run of the tool,
+as described in the tool's Readme in the instructions above.
+
+    The only difference from the local run instructions is that git branch names in the 
+Actions workflow input form should be prefixed with `origin/`.
 
 ---
 


### PR DESCRIPTION
Adds a CI workflow that is manually invoked that automates the instructions for the BRS task to generate the commit checker report.

Details:
* Output: After the workflow completes, the summary page for that workflow instance will render the markdown of the report at the bottom, like so:
https://github.com/echeran/icu/actions/runs/13466516414
* Authentication: When the commit range includes a sensitive ticket, the tool will fail unless the user provides the optional  needed for this purpose. Otherwise, the credentials are optional.
* Privacy: The workflow avoids needing to print the user email & API token. In addition, the workflow will mask the user email & API token in the future hypothetical scenario that they are needed in some way that gets captured by the log. (This is a feature after invoking the `add-mask` directive in Github Actions). 

Note: The instructions for running the commit checker tool locally are in the BRS tasks section of the User Guide here: https://unicode-org.github.io/icu/processes/release/tasks/miscellaneous.html#check-integrity-of-jira-issues-in-commit-messages

#### Checklist
- [X] Required: Issue filed: ICU-23056
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [X] API docs and/or User Guide docs changed or added, if applicable
