### PR TITLE
ICU-23061 LowercaseTransliterator has poor scalability due to synchronized state

### DIFF
--- a/icu4j/main/translit/src/main/java/com/ibm/icu/text/CaseFoldTransliterator.java
+++ b/icu4j/main/translit/src/main/java/com/ibm/icu/text/CaseFoldTransliterator.java
@@ -39,8 +39,6 @@ class CaseFoldTransliterator extends Transliterator{
     }
 
     private final UCaseProps csp;
-    private ReplaceableContextIterator iter;
-    private StringBuilder result;
 
     /**
      * Constructs a transliterator.
@@ -49,15 +47,13 @@ class CaseFoldTransliterator extends Transliterator{
     public CaseFoldTransliterator() {
         super(_ID, null);
         csp=UCaseProps.INSTANCE;
-        iter=new ReplaceableContextIterator();
-        result = new StringBuilder();
     }
 
     /**
      * Implements {@link Transliterator#handleTransliterate}.
      */
     @Override
-    protected synchronized void handleTransliterate(Replaceable text,
+    protected void handleTransliterate(Replaceable text,
                                        Position offsets, boolean isIncremental) {
         if(csp==null) {
             return;
@@ -67,8 +63,10 @@ class CaseFoldTransliterator extends Transliterator{
             return;
         }
 
+        ReplaceableContextIterator iter = new ReplaceableContextIterator();
+        StringBuilder result = new StringBuilder();
+
         iter.setText(text);
-        result.setLength(0);
         int c, delta;
 
         // Walk through original string

--- a/icu4j/main/translit/src/main/java/com/ibm/icu/text/LowercaseTransliterator.java
+++ b/icu4j/main/translit/src/main/java/com/ibm/icu/text/LowercaseTransliterator.java
@@ -42,8 +42,6 @@ class LowercaseTransliterator extends Transliterator{
     private final ULocale locale;
 
     private final UCaseProps csp;
-    private ReplaceableContextIterator iter;
-    private StringBuilder result;
     private int caseLocale;
 
     /**
@@ -54,8 +52,6 @@ class LowercaseTransliterator extends Transliterator{
         super(_ID, null);
         locale = loc;
         csp=UCaseProps.INSTANCE;
-        iter=new ReplaceableContextIterator();
-        result = new StringBuilder();
         caseLocale = UCaseProps.getCaseLocale(locale);
     }
 
@@ -63,7 +59,7 @@ class LowercaseTransliterator extends Transliterator{
      * Implements {@link Transliterator#handleTransliterate}.
      */
     @Override
-    protected synchronized void handleTransliterate(Replaceable text,
+    protected void handleTransliterate(Replaceable text,
                                        Position offsets, boolean isIncremental) {
         if(csp==null) {
             return;
@@ -73,8 +69,10 @@ class LowercaseTransliterator extends Transliterator{
             return;
         }
 
+        ReplaceableContextIterator iter = new ReplaceableContextIterator();
+        StringBuilder result = new StringBuilder();
+
         iter.setText(text);
-        result.setLength(0);
         int c, delta;
 
         // Walk through original string

--- a/icu4j/main/translit/src/main/java/com/ibm/icu/text/TitlecaseTransliterator.java
+++ b/icu4j/main/translit/src/main/java/com/ibm/icu/text/TitlecaseTransliterator.java
@@ -40,8 +40,6 @@ class TitlecaseTransliterator extends Transliterator {
     private final ULocale locale;
 
     private final UCaseProps csp;
-    private ReplaceableContextIterator iter;
-    private StringBuilder result;
     private int caseLocale;
 
    /**
@@ -53,8 +51,6 @@ class TitlecaseTransliterator extends Transliterator {
         // Need to look back 2 characters in the case of "can't"
         setMaximumContextLength(2);
         csp=UCaseProps.INSTANCE;
-        iter=new ReplaceableContextIterator();
-        result = new StringBuilder();
         caseLocale = UCaseProps.getCaseLocale(locale);
     }
 
@@ -62,7 +58,7 @@ class TitlecaseTransliterator extends Transliterator {
      * Implements {@link Transliterator#handleTransliterate}.
      */
     @Override
-    protected synchronized void handleTransliterate(Replaceable text,
+    protected void handleTransliterate(Replaceable text,
                                        Position offsets, boolean isIncremental) {
         // TODO reimplement, see ustrcase.c
         // using a real word break iterator
@@ -74,6 +70,9 @@ class TitlecaseTransliterator extends Transliterator {
         if (offsets.start >= offsets.limit) {
             return;
         }
+
+        ReplaceableContextIterator iter = new ReplaceableContextIterator();
+        StringBuilder result = new StringBuilder();
 
         // case type: >0 cased (UCaseProps.LOWER etc.)  ==0 uncased  <0 case-ignorable
         int type;
@@ -107,8 +106,6 @@ class TitlecaseTransliterator extends Transliterator {
         iter.setIndex(offsets.start);
         iter.setLimit(offsets.limit);
         iter.setContextLimits(offsets.contextStart, offsets.contextLimit);
-
-        result.setLength(0);
 
         // Walk through original string
         // If there is a case change, modify corresponding position in replaceable

--- a/icu4j/main/translit/src/main/java/com/ibm/icu/text/UppercaseTransliterator.java
+++ b/icu4j/main/translit/src/main/java/com/ibm/icu/text/UppercaseTransliterator.java
@@ -39,8 +39,6 @@ class UppercaseTransliterator extends Transliterator {
     private final ULocale locale;
 
     private final UCaseProps csp;
-    private ReplaceableContextIterator iter;
-    private StringBuilder result;
     private int caseLocale;
 
     /**
@@ -50,8 +48,6 @@ class UppercaseTransliterator extends Transliterator {
         super(_ID, null);
         locale = loc;
         csp=UCaseProps.INSTANCE;
-        iter=new ReplaceableContextIterator();
-        result = new StringBuilder();
         caseLocale = UCaseProps.getCaseLocale(locale);
     }
 
@@ -59,7 +55,7 @@ class UppercaseTransliterator extends Transliterator {
      * Implements {@link Transliterator#handleTransliterate}.
      */
     @Override
-    protected synchronized void handleTransliterate(Replaceable text,
+    protected void handleTransliterate(Replaceable text,
                 Position offsets, boolean isIncremental) {
         if(csp==null) {
             return;
@@ -69,8 +65,10 @@ class UppercaseTransliterator extends Transliterator {
             return;
         }
 
+        ReplaceableContextIterator iter = new ReplaceableContextIterator();
+        StringBuilder result = new StringBuilder();
+
         iter.setText(text);
-        result.setLength(0);
         int c, delta;
 
         // Walk through original string

--- a/icu4j/perf-tests/README.txt
+++ b/icu4j/perf-tests/README.txt
@@ -43,6 +43,9 @@ COLLATION TESTS
     The collation tests run only on the command line with tabular output:
     perl collationperf.pl |& tee collation_output.txt
 
+JMH
+Some performance tests run using OpenJDK JMH. Example invocation:
+    mvn clean package exec:java -pl perf-tests -Pjmh_benchmark
 
 OTHER COMMAND LINE TESTS
 Additional tests are run from the command line, each producing an HTML

--- a/icu4j/perf-tests/pom.xml
+++ b/icu4j/perf-tests/pom.xml
@@ -43,6 +43,73 @@
       <artifactId>commons-cli</artifactId>
       <version>${commons-cli.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>${jmh.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>${jmh.version}</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>jmh_benchmark</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <annotationProcessors>
+                <annotationProcessor>org.openjdk.jmh.generators.BenchmarkProcessor</annotationProcessor>
+              </annotationProcessors>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-jmh-classpath</id>
+                <goals>
+                  <goal>build-classpath</goal>
+                </goals>
+                <configuration>
+                  <includeScope>runtime</includeScope>
+                  <outputProperty>jmhClasspath</outputProperty>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <configuration>
+              <mainClass>org.openjdk.jmh.Main</mainClass>
+              <arguments>
+                <argument>-f</argument>
+                <argument>1</argument>
+                <argument>-wi</argument>
+                <argument>5</argument>
+                <argument>-i</argument>
+                <argument>10</argument>
+              </arguments>
+              <systemProperties>
+                <property>
+                  <key>java.class.path</key>
+                  <value>${project.build.outputDirectory}${path.separator}${jmhClasspath}</value>
+                </property>
+              </systemProperties>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/icu4j/perf-tests/src/main/java/com/ibm/icu/dev/test/perf/BreakTransliteratorPerfTest.java
+++ b/icu4j/perf-tests/src/main/java/com/ibm/icu/dev/test/perf/BreakTransliteratorPerfTest.java
@@ -1,0 +1,30 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+package com.ibm.icu.dev.test.perf;
+
+import java.util.concurrent.TimeUnit;
+
+import com.ibm.icu.text.BreakTransliteratorAccess;
+import com.ibm.icu.text.Transliterator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class BreakTransliteratorPerfTest {
+
+    static final Transliterator TITLE = BreakTransliteratorAccess.newInstance();
+
+    @Benchmark
+    public String testShort() {
+        return TITLE.transliterate("Cat");
+    }
+
+    @Benchmark
+    public String testSentence() {
+        return TITLE.transliterate("The Quick Brown Fox jumped over the Lazy Dog");
+    }
+
+}

--- a/icu4j/perf-tests/src/main/java/com/ibm/icu/dev/test/perf/CaseFoldTransliteratorPerfTest.java
+++ b/icu4j/perf-tests/src/main/java/com/ibm/icu/dev/test/perf/CaseFoldTransliteratorPerfTest.java
@@ -1,0 +1,29 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+package com.ibm.icu.dev.test.perf;
+
+import java.util.concurrent.TimeUnit;
+
+import com.ibm.icu.text.Transliterator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class CaseFoldTransliteratorPerfTest {
+
+    static final Transliterator CASE = Transliterator.getInstance("CaseFold");
+
+    @Benchmark
+    public String testShort() {
+        return CASE.transliterate("Cat");
+    }
+
+    @Benchmark
+    public String testSentence() {
+        return CASE.transliterate("The Quick Brown Fox Jumped Over The Lazy Dog");
+    }
+
+}

--- a/icu4j/perf-tests/src/main/java/com/ibm/icu/dev/test/perf/LowercaseTransliteratorPerfTest.java
+++ b/icu4j/perf-tests/src/main/java/com/ibm/icu/dev/test/perf/LowercaseTransliteratorPerfTest.java
@@ -1,0 +1,29 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+package com.ibm.icu.dev.test.perf;
+
+import java.util.concurrent.TimeUnit;
+
+import com.ibm.icu.text.Transliterator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class LowercaseTransliteratorPerfTest {
+
+    static final Transliterator LOWER = Transliterator.getInstance("Lower");
+
+    @Benchmark
+    public String testShort() {
+        return LOWER.transliterate("Cat");
+    }
+
+    @Benchmark
+    public String testSentence() {
+        return LOWER.transliterate("The Quick Brown Fox Jumped Over The Lazy Dog");
+    }
+
+}

--- a/icu4j/perf-tests/src/main/java/com/ibm/icu/dev/test/perf/TitlecaseTransliteratorPerfTest.java
+++ b/icu4j/perf-tests/src/main/java/com/ibm/icu/dev/test/perf/TitlecaseTransliteratorPerfTest.java
@@ -1,0 +1,29 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+package com.ibm.icu.dev.test.perf;
+
+import java.util.concurrent.TimeUnit;
+
+import com.ibm.icu.text.Transliterator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class TitlecaseTransliteratorPerfTest {
+
+    static final Transliterator TITLE = Transliterator.getInstance("Title");
+
+    @Benchmark
+    public String testShort() {
+        return TITLE.transliterate("CAT");
+    }
+
+    @Benchmark
+    public String testSentence() {
+        return TITLE.transliterate("the quick brown fox jumped over the lazy dog");
+    }
+
+}

--- a/icu4j/perf-tests/src/main/java/com/ibm/icu/dev/test/perf/UppercaseTransliteratorPerfTest.java
+++ b/icu4j/perf-tests/src/main/java/com/ibm/icu/dev/test/perf/UppercaseTransliteratorPerfTest.java
@@ -1,0 +1,29 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+package com.ibm.icu.dev.test.perf;
+
+import java.util.concurrent.TimeUnit;
+
+import com.ibm.icu.text.Transliterator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class UppercaseTransliteratorPerfTest {
+
+    static final Transliterator UPPER = Transliterator.getInstance("Upper");
+
+    @Benchmark
+    public String testShort() {
+        return UPPER.transliterate("Cat");
+    }
+
+    @Benchmark
+    public String testSentence() {
+        return UPPER.transliterate("The Quick Brown Fox Jumped Over The Lazy Dog");
+    }
+
+}

--- a/icu4j/perf-tests/src/main/java/com/ibm/icu/text/BreakTransliteratorAccess.java
+++ b/icu4j/perf-tests/src/main/java/com/ibm/icu/text/BreakTransliteratorAccess.java
@@ -1,0 +1,10 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+package com.ibm.icu.text;
+
+public class BreakTransliteratorAccess {
+    // Non-public access
+    public static Transliterator newInstance() {
+        return new BreakTransliterator("Any-Break", UnicodeSet.ALL_CODE_POINTS);
+    }
+}

--- a/icu4j/pom.xml
+++ b/icu4j/pom.xml
@@ -61,6 +61,7 @@
     <!-- This is the folder where we gather the files to be posted in the Github Release-->
     <release.directory>${project.build.directory}/release_directory</release.directory>
 
+    <jmh.version>1.37</jmh.version>
     <junit.version>4.13.2</junit.version>
     <junitparams.version>1.1.1</junitparams.version>
     <gson.version>2.11.0</gson.version>


### PR DESCRIPTION
LowercaseTransliterator tries to reuse buffers to avoid allocation. Historically, this may have been an important optimization.
However on modern machines you are much more likely to use multiple CPUs, and modern JVMs are very efficient at GC, especially for local temporary data. Contending on a monitor is a big deal nowadays, especially for something so low level and hidden.

I've prepared a benchmark using [JMH](https://github.com/openjdk/jmh) to show the change in scalability:

```
Linux 6.12.13-200.fc41.x86_64 AMD Ryzen 7 3700X 8-Core Processor
JMH version: 1.37
JDK 23.0.2, OpenJDK 64-Bit Server VM, 23.0.2+7

Original `synchronized`:

1 Thread Benchmark                         Mode  Cnt     Score    Error   Units
LowercaseTransliteratorPerf.testSentence  thrpt    5   789.169 ±  2.779  ops/ms
LowercaseTransliteratorPerf.testShort     thrpt    5  5217.250 ± 35.501  ops/ms

8 Thread Benchmark                         Mode  Cnt     Score    Error   Units
LowercaseTransliteratorPerf.testSentence  thrpt    5   759.934 ±  4.880  ops/ms
LowercaseTransliteratorPerf.testShort     thrpt    5  3916.430 ± 70.545  ops/ms

New `stateless`:

1 Thread Benchmark                         Mode  Cnt     Score    Error   Units
LowercaseTransliteratorPerf.testSentence  thrpt    5   779.504 ±  6.507  ops/ms
LowercaseTransliteratorPerf.testShort     thrpt    5  5641.104 ± 29.747  ops/ms

8 Thread Benchmark                         Mode  Cnt      Score      Error   Units
LowercaseTransliteratorPerf.testSentence  thrpt    5   6340.495 ±  240.436  ops/ms
LowercaseTransliteratorPerf.testShort     thrpt    5  39132.015 ± 7102.311  ops/ms

```

The current implementation exhibits negative scalability: adding more threads hurts throughput (~5% loss going from 1T to 8T)
By removing the `synchronized` state, the implementation now scales perfectly (~8x increase going from 1T to 8T for the longer test case)
There is a very minor (~1%) penalty for pure single-threaded throughput since we no longer reuse state.
I believe this is acceptable in the context of allowing multiple threads to work without coordination.

#### Checklist
- [x] Required: Issue filed: ICU-23061
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
