### PR TITLE
ICU-23062 Added null check in one spot in genrb where we know we've s…

### DIFF
--- a/icu4c/source/tools/genrb/parse.cpp
+++ b/icu4c/source/tools/genrb/parse.cpp
@@ -297,7 +297,7 @@ static char *getInvariantString(ParseState* state, uint32_t *line, struct UStrin
 
     if(!uprv_isInvariantUString(tokenValue->fChars, tokenValue->fLength)) {
         *status = U_INVALID_FORMAT_ERROR;
-        error(*line, "invariant characters required for table keys, binary data, etc.");
+        error((line == nullptr) ? 0 : *line, "invariant characters required for table keys, binary data, etc.");
         return nullptr;
     }
 


### PR DESCRIPTION
…een crashes.

The ticket describes a null-pointer dereference on line 300 in `parse.cpp` (in the `genrb` tool).  Turns out we already had a fix for that in the Apple branch of ICU, but it never got applied back to open-source ICU.  This PR does that.  (No new unit tests are added, because this is an internal tool that runs all the time as part of the build process, and because the problem is intermittent.)

#### Checklist
- [x] Required: Issue filed: ICU-23062
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
