### PR TITLE
ICU-23055 Update buildtool.md to point to hjson.github.io

### DIFF
--- a/docs/userguide/icu_data/buildtool.md
+++ b/docs/userguide/icu_data/buildtool.md
@@ -55,7 +55,7 @@ The ICU Data Build Tool enables you to write a configuration file that
 specifies what features and locales to include in a custom data bundle.
 
 The configuration file may be written in either [JSON](http://json.org/) or
-[Hjson](https://hjson.org/).  To build ICU4C with custom data, set the
+[Hjson](https://hjson.github.io/).  To build ICU4C with custom data, set the
 `ICU_DATA_FILTER_FILE` environment variable when running `runConfigureICU` on
 Unix or when building the data package on Windows.  For example:
 


### PR DESCRIPTION
The pre-existing link to https://hjson.org goes to some sort of gambling/gaming site. It looks like the new authoritative link is https://hjson.github.io/

#### Checklist
- [X] Required: Issue filed: ICU-23055
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [X] API docs and/or User Guide docs changed or added, if applicable
