### PR TITLE
ICU-23086 Fix Eclipse errors on imported projects

### DIFF
--- a/icu4j/main/localespi/pom.xml
+++ b/icu4j/main/localespi/pom.xml
@@ -90,48 +90,6 @@
         </configuration>
       </plugin>
 
-      <!--
-        Mainly for running localespi tests in Java 8:
-        The easiest way to get the integration tests to pass (in particular, to get the JVM that is
-        spawned with the `-Djava.ext.dirs` system property value to be interpreted properly in order
-        for the extensions jars therein to be loaded correctly) was to copy the jars needed to a
-        separate directory. (The alternative of pointing to the build directories of the respective
-        submodules didn't seem to work.)
-
-        This isn't of much use for Java 9+, in which extensions are deprecated and the regular
-        classpath is to be used instead.
-      -->
-      <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>it-test-copy-localespi-extension-jars</id>
-            <phase>integration-test</phase>
-            <goals>
-              <goal>copy</goal>
-            </goals>
-            <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>${project.groupId}</groupId>
-                  <artifactId>icu4j</artifactId>
-                  <version>${project.version}</version>
-                  <type>${project.packaging}</type>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>${project.groupId}</groupId>
-                  <artifactId>icu4j-localespi</artifactId>
-                  <version>${project.version}</version>
-                  <type>${project.packaging}</type>
-                </artifactItem>
-              </artifactItems>
-              <!-- https://stackoverflow.com/questions/36181371/how-can-i-get-the-temp-folder-of-a-machine-running-maven -->
-              <outputDirectory>${java.io.tmpdir}/ext-test-jars</outputDirectory>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
         <executions>
@@ -209,6 +167,7 @@
   </build>
 
   <profiles>
+
     <!--
       For testing localespi using the Java extensions feature, which last existed in Java 8.
       ICU4J currently has a minimum supported version of 8.
@@ -222,7 +181,53 @@
         <localespi-tests.jvm.args>-Djava.ext.dirs="${java.io.tmpdir}/ext-test-jars"</localespi-tests.jvm.args>
         <localespi-tests.locale-providers></localespi-tests.locale-providers>
       </properties>
+      <build>
+        <plugins>
+          <!--
+            Mainly for running localespi tests in Java 8:
+            The easiest way to get the integration tests to pass (in particular, to get the JVM that is
+            spawned with the `-Djava.ext.dirs` system property value to be interpreted properly in order
+            for the extensions jars therein to be loaded correctly) was to copy the jars needed to a
+            separate directory. (The alternative of pointing to the build directories of the respective
+            submodules didn't seem to work.)
+
+            This isn't of much use for Java 9+, in which extensions are deprecated and the regular
+            classpath is to be used instead.
+          -->
+          <plugin>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>it-test-copy-localespi-extension-jars</id>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>copy</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>${project.groupId}</groupId>
+                      <artifactId>icu4j</artifactId>
+                      <version>${project.version}</version>
+                      <type>${project.packaging}</type>
+                    </artifactItem>
+                    <artifactItem>
+                      <groupId>${project.groupId}</groupId>
+                      <artifactId>icu4j-localespi</artifactId>
+                      <version>${project.version}</version>
+                      <type>${project.packaging}</type>
+                    </artifactItem>
+                  </artifactItems>
+                  <!-- https://stackoverflow.com/questions/36181371/how-can-i-get-the-temp-folder-of-a-machine-running-maven -->
+                  <outputDirectory>${java.io.tmpdir}/ext-test-jars</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
+
     <!--
       For testing localespi using the classpath for Java 9+, since Java extensions were
       deprecated after Java 8.
@@ -237,6 +242,7 @@
         <localespi-tests.locale-providers>CLDR,COMPAT,SPI</localespi-tests.locale-providers>
       </properties>
     </profile>
+
     <profile>
       <id>with_javadoc</id>
       <build>

--- a/icu4j/perf-tests/pom.xml
+++ b/icu4j/perf-tests/pom.xml
@@ -45,25 +45,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <!-- Copy dependencies by default, so that everythign is easier to run
-          without having to explicitly list all kind of folders in classpath.
-          Just use `./target/*` and `./target/dependency/*`
-        -->
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>copy-dependencies</id>
-            <phase>package</phase>
-            <goals>
-              <goal>copy-dependencies</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/icu4j/pom.xml
+++ b/icu4j/pom.xml
@@ -273,36 +273,6 @@
           <version>3.6.0</version>
           <executions>
             <execution>
-              <!-- Workaround for Windows symlink issue:
-                 https://issues.apache.org/jira/browse/MRESOURCES-237
-                 Note: The recommended fix there is to filter out the symlink files, which
-                 would result in no license files in the .jar. That is not what we want.
-                 Instead, this `<execution>` config copies the LICENSE file to `target` at build time.
-              -->
-              <id>add-resource</id>
-              <goals>
-                <goal>add-resource</goal>
-              </goals>
-              <configuration>
-                <resources>
-                  <resource>
-                    <directory>${rootlocation}/../testdata/</directory>
-                    <includes>
-                      <!-- Do not "repair" this to use ${rootlocation}/../ and LICENSE.
-                        This is a workaround for Eclipse, which fails to import the projects because
-                        ${rootlocation}/../ overlaps with the location of the sub-projects (for example main/core).
-                        True, because {rootlocation} is resolved to $icu_root/icu4j.
-                        So ${rootlocation}/../ points to $icu_root, which overlaps with $icu_root/icu4j/main/core.
-                        But $icu_root/testdata/ does not overlap with $icu_root/icu4j/ so all is good.
-                        We then go up one step for the LICENSE, because Eclipse does not validate for files overlapping, only folders.
-                      -->
-                      <include>../LICENSE</include>
-                    </includes>
-                  </resource>
-                </resources>
-              </configuration>
-            </execution>
-            <execution>
               <id>root-location</id>
               <phase>initialize</phase>
               <goals>


### PR DESCRIPTION
- perf-tests: the copy was a convenience (as the comment said)
- icu4j-localespi: the copy was only needed for JDK 8. Moving it into a self-activating profile (based on jdk version) means that the copy still happens when building with maven under jdk 8, but will not get activated in Eclipse (so no error)
- The use of ../testdata (the warning) is an incorrect way to share resources they should have their own (resource only) Maven artifact. And nothing in the folder is not used by icu4j right now. \
  ICU-23050 (_"Deduplicate C & Java testdata to a common directory"_) is still open.

#### Checklist
- [x] Required: Issue filed: ICU-23086
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
