### PR TITLE
ICU-23087 Pass null to applyPropertyAlias for a unary property query

### DIFF
--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/UnicodeSet.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/UnicodeSet.java
@@ -3601,7 +3601,7 @@ public class UnicodeSet extends UnicodeFilter implements Iterable<String>, Compa
             }
         }
 
-        if (valueAlias.length() > 0) {
+        if (valueAlias != null && !valueAlias.isEmpty()) {
             p = UCharacter.getPropertyEnum(propertyAlias);
 
             // Treat gc as gcm
@@ -3835,7 +3835,7 @@ public class UnicodeSet extends UnicodeFilter implements Iterable<String>, Compa
         else {
             // Handle case where no '=' is seen, and \N{}
             propName = pattern.substring(pos, close);
-            valueName = "";
+            valueName = null;
 
             // Handle \N{name}
             if (isName) {


### PR DESCRIPTION
This only affects users of the internal perpetually-`@draft` XSymbolTable (in particular, unicode-org/unicodetools). It makes it possible to distinguish \p{X} (the characters that have binary property X, or that have gc X or script X) from \p{X=} (the characters for which property X is the empty string).

Note that ICU allows \p{Whitespace=} for \p{Whitespace}, or \p{L=} for \p{L}. This remains the case with this change, so the public API is unaffected.

#### Checklist
- [x] Required: Issue filed: ICU-23087
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
