### PR TITLE
ICU-22142 Deprecate ICU4C createMetricTon/getMetricTon, ICU4J METRIC_TON

### DIFF
--- a/icu4c/source/i18n/unicode/measunit.h
+++ b/icu4c/source/i18n/unicode/measunit.h
@@ -2847,29 +2847,25 @@ class U_I18N_API MeasureUnit: public UObject {
      */
     static MeasureUnit getTonne();
 
+#ifndef U_HIDE_DEPRECATED_API
     /**
      * Returns by pointer, unit of mass: metric-ton
      * (renamed to tonne in CLDR 42 / ICU 72).
      * Caller owns returned value and must free it.
-     * Note: In ICU 74 this will be deprecated in favor of
-     * createTonne(), which is currently draft but will
-     * become stable in ICU 74, and which uses the preferred naming.
      * Also see {@link #getMetricTon()} and {@link #createTonne()}.
      * @param status ICU error code.
-     * @stable ICU 54
+     * @deprecated ICU 78 use createTonne(UErrorCode &status)
      */
     static MeasureUnit *createMetricTon(UErrorCode &status);
 
     /**
      * Returns by value, unit of mass: metric-ton
      * (renamed to tonne in CLDR 42 / ICU 72).
-     * Note: In ICU 74 this will be deprecated in favor of
-     * getTonne(), which is currently draft but will
-     * become stable in ICU 74, and which uses the preferred naming.
      * Also see {@link #createMetricTon()} and {@link #getTonne()}.
-     * @stable ICU 64
+     * @deprecated ICU 78 use getTonne()
      */
     static MeasureUnit getMetricTon();
+#endif  /* U_HIDE_DEPRECATED_API */
 
     /**
      * Returns by pointer, unit of power: gigawatt.

--- a/icu4j/main/core/src/main/java/com/ibm/icu/util/MeasureUnit.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/util/MeasureUnit.java
@@ -1776,10 +1776,10 @@ public class MeasureUnit implements Serializable {
 
     /**
      * Constant for unit of mass: metric-ton (renamed to tonne in CLDR 42 / ICU 72).
-     * Note: In ICU 74 this will be deprecated in favor of TONNE, which is currently
-     * draft but will become stable in ICU 74, and which uses the preferred naming.
-     * @stable ICU 54
+     * @internal
+     * @deprecated This API is ICU internal only.
      */
+    @Deprecated
     public static final MeasureUnit METRIC_TON = MeasureUnit.internalGetInstance("mass", "tonne");
 
     /**


### PR DESCRIPTION
Deprecate ICU4C createMetricTon/getMetricTon, ICU4J METRIC_TON per [API proposal approved 2025-03-27](https://docs.google.com/document/d/19vv8vxCJiaWZEsR56Ospyr_UbJvl0AW86IZCoMM4bxs/edit?tab=t.0#heading=h.js0nkbazwftv).

#### Checklist
- [x] Required: Issue filed: ICU-22142
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
