### PR TITLE
ICU-23099 uposixdefs.h: define _DARWIN_C_SOURCE on macOS

### DIFF
--- a/icu4c/source/common/uposixdefs.h
+++ b/icu4c/source/common/uposixdefs.h
@@ -74,4 +74,9 @@
 #define _POSIX_C_SOURCE 200809L
 #endif
 
+/* Prevent _XOPEN_SOURCE from breaking build on macOS when aligned_alloc exists. */
+#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)
+#   define _DARWIN_C_SOURCE
+#endif
+
 #endif  /* __UPOSIXDEFS_H__ */


### PR DESCRIPTION
Fixes: https://unicode-org.atlassian.net/browse/ICU-23099

```
/opt/local/bin/g++-mp-14 -DU_ALL_IMPLEMENTATION -DU_ATTRIBUTE_DEPRECATED= -DU_COMMON_IMPLEMENTATION -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -DU_HAVE_STRTOD_L=1 -DU_HAVE_XLOCALE_H=1 -I. "-DDEFAULT_ICU_PLUGINS=\"/opt/local/lib/icu\" " -pipe -Os -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -arch x86_64 -W -Wall -pedantic -Wpointer-arith -Wwrite-strings -Wno-long-long -std=c++17 -fvisibility=hidden -fno-common -c -MMD -MT "putil.d putil.o putil.ao" -o putil.ao putil.cpp
In file included from /opt/local/include/gcc14/c++/stdlib.h:36,
                 from uassert.h:23,
                 from putil.cpp:62:
/opt/local/include/gcc14/c++/cstdlib:136:11: error: 'aligned_alloc' has not been declared in '::'
  136 |   using ::aligned_alloc;
      |           ^~~~~~~~~~~~~
/opt/local/bin/g++-mp-14 -DU_ALL_IMPLEMENTATION -DU_ATTRIBUTE_DEPRECATED= -DU_COMMON_IMPLEMENTATION -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -DU_HAVE_STRTOD_L=1 -DU_HAVE_XLOCALE_H=1 -I. "-DDEFAULT_ICU_PLUGINS=\"/opt/local/lib/icu\" " -pipe -Os -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -arch x86_64 -W -Wall -pedantic -Wpointer-arith -Wwrite-strings -Wno-long-long -std=c++17 -fvisibility=hidden -fno-common -c -MMD -MT "rbbi.d rbbi.o rbbi.ao" -o rbbi.ao rbbi.cpp
In file included from /opt/local/include/gcc14/c++/bits/chrono.h:40,
                 from /opt/local/include/gcc14/c++/condition_variable:40,
                 from umutex.h:24,
                 from putil.cpp:63:
/opt/local/include/gcc14/c++/ctime:80:11: error: 'timespec_get' has not been declared in '::'
   80 |   using ::timespec_get;
      |           ^~~~~~~~~~~~
/opt/local/bin/g++-mp-14 -DU_ALL_IMPLEMENTATION -DU_ATTRIBUTE_DEPRECATED= -DU_COMMON_IMPLEMENTATION -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -DU_HAVE_STRTOD_L=1 -DU_HAVE_XLOCALE_H=1 -I. "-DDEFAULT_ICU_PLUGINS=\"/opt/local/lib/icu\" " -pipe -Os -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -arch x86_64 -W -Wall -pedantic -Wpointer-arith -Wwrite-strings -Wno-long-long -std=c++17 -fvisibility=hidden -fno-common -c -MMD -MT "rbbi_cache.d rbbi_cache.o rbbi_cache.ao" -o rbbi_cache.ao rbbi_cache.cpp
/opt/local/bin/g++-mp-14 -DU_ALL_IMPLEMENTATION -DU_ATTRIBUTE_DEPRECATED= -DU_COMMON_IMPLEMENTATION -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -DU_HAVE_STRTOD_L=1 -DU_HAVE_XLOCALE_H=1 -I. "-DDEFAULT_ICU_PLUGINS=\"/opt/local/lib/icu\" " -pipe -Os -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -arch x86_64 -W -Wall -pedantic -Wpointer-arith -Wwrite-strings -Wno-long-long -std=c++17 -fvisibility=hidden -fno-common -c -MMD -MT "rbbidata.d rbbidata.o rbbidata.ao" -o rbbidata.ao rbbidata.cpp
/opt/local/bin/g++-mp-14 -DU_ALL_IMPLEMENTATION -DU_ATTRIBUTE_DEPRECATED= -DU_COMMON_IMPLEMENTATION -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -DU_HAVE_STRTOD_L=1 -DU_HAVE_XLOCALE_H=1 -I. "-DDEFAULT_ICU_PLUGINS=\"/opt/local/lib/icu\" " -pipe -Os -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -arch x86_64 -W -Wall -pedantic -Wpointer-arith -Wwrite-strings -Wno-long-long -std=c++17 -fvisibility=hidden -fno-common -c -MMD -MT "rbbinode.d rbbinode.o rbbinode.ao" -o rbbinode.ao rbbinode.cpp
gnumake[1]: *** [putil.ao] Error 1
gnumake[1]: *** Waiting for unfinished jobs....
gnumake[1]: Leaving directory `/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_devel_icu/icu/work/icu/source/common'
gnumake: *** [all-recursive] Error 2
```

See also: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=93469
https://trac.macports.org/ticket/72297

#### Checklist
- [x] Required: Issue filed: ICU-NNNNN
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
