### PR TITLE
ICU-20072 Move `modified = true` before `return` to fix `hasMappings()`

### DIFF
--- a/icu4c/source/i18n/collationdatabuilder.cpp
+++ b/icu4c/source/i18n/collationdatabuilder.cpp
@@ -413,9 +413,8 @@ CollationDataBuilder::setPrimaryRangeAndReturnNext(UChar32 start, UChar32 end,
             utrie2_set32(trie, start, Collation::makeLongPrimaryCE32(primary), &errorCode);
             ++start;
             primary = Collation::incThreeBytePrimaryByOffset(primary, isCompressible, step);
-            if(start > end) { return primary; }
+            if(start > end) { modified = true; return primary; }
         }
-        modified = true;
     }
 }
 


### PR DESCRIPTION


This resolves a compiler warning:  
`collationdatabuilder.cpp:418:20: warning: code will never be executed [-Wunreachable-code]`.  
The `modified = true;` line after the [loop](https://github.com/unicode-org/icu/blob/89fe16ef3b77a6b98f7664f52338c8ff80e28096/icu4c/source/i18n/collationdatabuilder.cpp#L410-L419) in `setPrimaryRangeAndReturnNext()` is unreachable due to the `return` within the `for` loop and lack of any `break`s. Unlike other methods in this file (e.g., `maybeSetPrimaryRange()`), where `modified` is [set](https://github.com/unicode-org/icu/blob/89fe16ef3b77a6b98f7664f52338c8ff80e28096/icu4c/source/i18n/collationdatabuilder.cpp#L394) before returning, this leaves `modified` unset despite trie updates. This could lead to `hasMappings()` incorrectly returning `false` when mappings have been added, potentially affecting downstream logic that depends on this flag. Moving `modified = true;` before the `return primary;` ensures consistency with the class’s pattern and proper state tracking.




#### Checklist
- [x] Required: Issue filed: ICU-20072
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
