### PR TITLE
ICU-23098 Allow tests to pass with parallel building

### DIFF
--- a/icu4c/source/Makefile.in
+++ b/icu4c/source/Makefile.in
@@ -240,7 +240,7 @@ xcheck-local: $(top_builddir)/config/icu-config $(top_builddir)/config/Makefile.
 	@echo verifying that icu-config --selfcheck can operate
 	@test "passed" = "$(shell $(top_builddir)/config/icu-config --selfcheck 2>&1)" || (echo "FAIL: icu-config could not run properly." ; exit 1)
 	@echo verifying that $(MAKE) -f Makefile.inc selfcheck can operate
-	@test "passed" = "$(shell $(MAKE) --no-print-directory -f $(top_builddir)/config/Makefile.inc SELFCHECK=1 selfcheck)" || (echo "FAIL: Makefile.inc could not run properly." ; exit 1 )
+	@test "passed" = "$(shell MAKEFLAGS= $(MAKE) --no-print-directory -f $(top_builddir)/config/Makefile.inc SELFCHECK=1 selfcheck)" || (echo "FAIL: Makefile.inc could not run properly." ; exit 1 )
 	@echo "PASS: config selfcheck OK"
 
 #$(srcdir)/configure : $(srcdir)/configure.ac $(top_srcdir)/aclocal.m4


### PR DESCRIPTION
ICU-23098

This change allows `make -j 2 check` to pass. This allows faster testing of ICU, and I like fast builds. It was failing because `config/Makefile.inc` is using `ifeq (selfcheck,$(MAKECMDGOALS)) #M#` to check if a self check is run, and the variable can include the other arguments, like the parallels building option. These self check lines are removed when the file is installed.

I confirmed that this change allows testing to fully succeed. It's run right after running intltest, iotest, and cintltst. The rest of the ICU build seems to work when specifying `-j32`.

#### Checklist
- [x] Required: Issue filed: ICU-23098
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
