### PR TITLE
ICU-23109 Fix float point exception cased by "% 0"

### DIFF
--- a/icu4c/source/i18n/nfrule.cpp
+++ b/icu4c/source/i18n/nfrule.cpp
@@ -153,6 +153,7 @@ NFRule::makeRules(UnicodeString& description,
         // base value is an even multiple of its divisor (or it's one
         // of the special rules)
         if ((rule1->baseValue > 0
+            && (rule1->radix != 0) // ICU-23109 Ensure next line won't "% 0"
             && (rule1->baseValue % util64_pow(rule1->radix, rule1->exponent)) == 0)
             || rule1->getType() == kImproperFractionRule
             || rule1->getType() == kDefaultRule) {


### PR DESCRIPTION
Fix fuzzer found Floating-point-exception in icu_78::NFRule::makeRules. The bug is found by fuzzer at https://g-issues.oss-fuzz.com/issues/410114671?pli=1&authuser=0

#### Checklist
- [X] Required: Issue filed: ICU-23109
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
