### PR TITLE
ICU-23102 Simplify GregorianCalendar

### DIFF
--- a/icu4c/source/i18n/gregocal.cpp
+++ b/icu4c/source/i18n/gregocal.cpp
@@ -156,7 +156,7 @@ static const UDate kPapalCutover = (2299161.0 - kEpochStartAsJulianDay) * U_MILL
 GregorianCalendar::GregorianCalendar(UErrorCode& status)
 :   Calendar(status),
 fGregorianCutover(kPapalCutover),
-fCutoverJulianDay(kCutoverJulianDay), fNormalizedGregorianCutover(fGregorianCutover), fGregorianCutoverYear(kDefaultCutoverYear),
+fCutoverJulianDay(kCutoverJulianDay), fGregorianCutoverYear(kDefaultCutoverYear),
 fIsGregorian(true), fInvertGregorian(false)
 {
     setTimeInMillis(getNow(), status);
@@ -189,7 +189,7 @@ GregorianCalendar::GregorianCalendar(TimeZone* zone, const Locale& aLocale,
                                      UErrorCode& status)
                                      :   Calendar(zone, aLocale, status),
                                      fGregorianCutover(kPapalCutover),
-                                     fCutoverJulianDay(kCutoverJulianDay), fNormalizedGregorianCutover(fGregorianCutover), fGregorianCutoverYear(kDefaultCutoverYear),
+                                     fCutoverJulianDay(kCutoverJulianDay), fGregorianCutoverYear(kDefaultCutoverYear),
                                      fIsGregorian(true), fInvertGregorian(false)
 {
     setTimeInMillis(getNow(), status);
@@ -201,7 +201,7 @@ GregorianCalendar::GregorianCalendar(const TimeZone& zone, const Locale& aLocale
                                      UErrorCode& status)
                                      :   Calendar(zone, aLocale, status),
                                      fGregorianCutover(kPapalCutover),
-                                     fCutoverJulianDay(kCutoverJulianDay), fNormalizedGregorianCutover(fGregorianCutover), fGregorianCutoverYear(kDefaultCutoverYear),
+                                     fCutoverJulianDay(kCutoverJulianDay), fGregorianCutoverYear(kDefaultCutoverYear),
                                      fIsGregorian(true), fInvertGregorian(false)
 {
     setTimeInMillis(getNow(), status);
@@ -213,7 +213,7 @@ GregorianCalendar::GregorianCalendar(int32_t year, int32_t month, int32_t date,
                                      UErrorCode& status)
                                      :   Calendar(TimeZone::createDefault(), Locale::getDefault(), status),
                                      fGregorianCutover(kPapalCutover),
-                                     fCutoverJulianDay(kCutoverJulianDay), fNormalizedGregorianCutover(fGregorianCutover), fGregorianCutoverYear(kDefaultCutoverYear),
+                                     fCutoverJulianDay(kCutoverJulianDay), fGregorianCutoverYear(kDefaultCutoverYear),
                                      fIsGregorian(true), fInvertGregorian(false)
 {
     set(UCAL_ERA, AD);
@@ -253,7 +253,7 @@ GregorianCalendar::~GregorianCalendar()
 GregorianCalendar::GregorianCalendar(const GregorianCalendar &source)
 :   Calendar(source),
 fGregorianCutover(source.fGregorianCutover),
-fCutoverJulianDay(source.fCutoverJulianDay), fNormalizedGregorianCutover(source.fNormalizedGregorianCutover), fGregorianCutoverYear(source.fGregorianCutoverYear),
+fCutoverJulianDay(source.fCutoverJulianDay), fGregorianCutoverYear(source.fGregorianCutoverYear),
 fIsGregorian(source.fIsGregorian), fInvertGregorian(source.fInvertGregorian)
 {
 }
@@ -274,7 +274,6 @@ GregorianCalendar::operator=(const GregorianCalendar &right)
     {
         Calendar::operator=(right);
         fGregorianCutover = right.fGregorianCutover;
-        fNormalizedGregorianCutover = right.fNormalizedGregorianCutover;
         fGregorianCutoverYear = right.fGregorianCutoverYear;
         fCutoverJulianDay = right.fCutoverJulianDay;
     }
@@ -311,12 +310,11 @@ GregorianCalendar::setGregorianChange(UDate date, UErrorCode& status)
     
     if (cutoverDay <= INT32_MIN) {
         cutoverDay = INT32_MIN;
-        fGregorianCutover = fNormalizedGregorianCutover = cutoverDay * kOneDay;
+        fGregorianCutover = cutoverDay * kOneDay;
     } else if (cutoverDay >= INT32_MAX) {
         cutoverDay = INT32_MAX;
-        fGregorianCutover = fNormalizedGregorianCutover = cutoverDay * kOneDay;
+        fGregorianCutover = cutoverDay * kOneDay;
     } else {
-        fNormalizedGregorianCutover = cutoverDay * kOneDay;
         fGregorianCutover = date;
     }
 

--- a/icu4c/source/i18n/unicode/gregocal.h
+++ b/icu4c/source/i18n/unicode/gregocal.h
@@ -676,13 +676,6 @@ public:
     int32_t             fCutoverJulianDay;
 
     /**
-     * Midnight, local time (using this Calendar's TimeZone) at or before the
-     * gregorianCutover. This is a pure date value with no time of day or
-     * timezone component.
-     */
-    UDate                 fNormalizedGregorianCutover;// = gregorianCutover;
-
-    /**
      * The year of the gregorianCutover, with 0 representing
      * 1 BC, -1 representing 2 BC, etc.
      */


### PR DESCRIPTION
Remove unnecessary fNormalizedGregorianCutover which is not read for any decision making nor in ICU4J.



#### Checklist
- [X] Required: Issue filed: ICU-23102
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
