### PR TITLE
ICU-11533 limited Myanmar calendar support

### DIFF
--- a/icu4c/source/i18n/calendar.cpp
+++ b/icu4c/source/i18n/calendar.cpp
@@ -50,6 +50,7 @@
 #include "coptccal.h"
 #include "dangical.h"
 #include "ethpccal.h"
+#include "myancal.h"
 #include "unicode/calendar.h"
 #include "cpputils.h"
 #include "servloc.h"
@@ -162,6 +163,7 @@ static const char * const gCalTypes[] = {
     "gregorian",
     "japanese",
     "buddhist",
+    "myanmar",
     "roc",
     "persian",
     "islamic-civil",
@@ -186,6 +188,7 @@ typedef enum ECalType {
     CALTYPE_GREGORIAN = 0,
     CALTYPE_JAPANESE,
     CALTYPE_BUDDHIST,
+    CALTYPE_MYANMAR,
     CALTYPE_ROC,
     CALTYPE_PERSIAN,
     CALTYPE_ISLAMIC_CIVIL,
@@ -322,6 +325,9 @@ static Calendar *createStandardCalendar(ECalType calType, const Locale &loc, UEr
             break;
         case CALTYPE_BUDDHIST:
             cal.adoptInsteadAndCheckErrorCode(new BuddhistCalendar(loc, status), status);
+            break;
+        case CALTYPE_MYANMAR:
+            cal.adoptInsteadAndCheckErrorCode(new MyanmarCalendar(loc, status), status);
             break;
         case CALTYPE_ROC:
             cal.adoptInsteadAndCheckErrorCode(new TaiwanCalendar(loc, status), status);

--- a/icu4c/source/i18n/i18n.vcxproj
+++ b/icu4c/source/i18n/i18n.vcxproj
@@ -185,6 +185,7 @@
     <ClCompile Include="messageformat2_parser.cpp" />
     <ClCompile Include="messageformat2_serializer.cpp" />
     <ClCompile Include="msgfmt.cpp" />
+    <ClCompile Include="myancal.cpp" />
     <ClCompile Include="nfrs.cpp" />
     <ClCompile Include="nfrule.cpp" />
     <ClCompile Include="nfsubs.cpp" />
@@ -400,6 +401,7 @@
     <ClInclude Include="japancal.h" />
     <ClInclude Include="measunit_impl.h" />
     <ClInclude Include="msgfmt_impl.h" />
+    <ClInclude Include="myancal.h" />
     <ClInclude Include="nfrlist.h" />
     <ClInclude Include="nfrs.h" />
     <ClInclude Include="nfrule.h" />

--- a/icu4c/source/i18n/i18n.vcxproj.filters
+++ b/icu4c/source/i18n/i18n.vcxproj.filters
@@ -252,6 +252,9 @@
     <ClCompile Include="msgfmt.cpp">
       <Filter>formatting</Filter>
     </ClCompile>
+    <ClCompile Include="myancal.cpp">
+      <Filter>formatting</Filter>
+    </ClCompile>
     <ClCompile Include="nfrs.cpp">
       <Filter>formatting</Filter>
     </ClCompile>
@@ -906,6 +909,9 @@
       <Filter>formatting</Filter>
     </ClInclude>
     <ClInclude Include="msgfmt_impl.h">
+      <Filter>formatting</Filter>
+    </ClInclude>
+    <ClInclude Include="myancal.h">
       <Filter>formatting</Filter>
     </ClInclude>
     <ClInclude Include="nfrlist.h">

--- a/icu4c/source/i18n/i18n_uwp.vcxproj
+++ b/icu4c/source/i18n/i18n_uwp.vcxproj
@@ -418,6 +418,7 @@
     <ClCompile Include="messageformat2_parser.cpp" />
     <ClCompile Include="messageformat2_serializer.cpp" />
     <ClCompile Include="msgfmt.cpp" />
+    <ClCompile Include="myancal.cpp" />
     <ClCompile Include="nfrs.cpp" />
     <ClCompile Include="nfrule.cpp" />
     <ClCompile Include="nfsubs.cpp" />
@@ -631,6 +632,7 @@
     <ClInclude Include="japancal.h" />
     <ClInclude Include="measunit_impl.h" />
     <ClInclude Include="msgfmt_impl.h" />
+    <ClInclude Include="myancal.h" />
     <ClInclude Include="nfrlist.h" />
     <ClInclude Include="nfrs.h" />
     <ClInclude Include="nfrule.h" />

--- a/icu4c/source/i18n/myancal.cpp
+++ b/icu4c/source/i18n/myancal.cpp
@@ -1,0 +1,107 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+/*
+*
+* File MYANCAL.CPP
+*
+* Modification History:
+* 04/18/2025  srl          copied from buddhcal.h
+*
+*/
+
+#include "unicode/ucal.h"
+#include "unicode/utypes.h"
+
+#if !UCONFIG_NO_FORMATTING
+
+#include "myancal.h"
+#include "gregoimp.h"
+#include "unicode/gregocal.h"
+#include "umutex.h"
+#include <float.h>
+
+U_NAMESPACE_BEGIN
+
+UOBJECT_DEFINE_RTTI_IMPLEMENTATION(MyanmarCalendar)
+
+//static const int32_t kMaxEra = 0; // only 1 era
+
+static const int32_t kMEEraStart = 639;  // 639 AD (Gregorian)
+
+static const int32_t kGregorianEpoch = 1970;    // used as the default value of EXTENDED_YEAR
+
+MyanmarCalendar::MyanmarCalendar(const Locale& aLocale, UErrorCode& success)
+:   GregorianCalendar(aLocale, success)
+{
+}
+
+MyanmarCalendar::~MyanmarCalendar()
+{
+}
+
+MyanmarCalendar::MyanmarCalendar(const MyanmarCalendar& source)
+: GregorianCalendar(source)
+{
+}
+
+MyanmarCalendar* MyanmarCalendar::clone() const
+{
+    return new MyanmarCalendar(*this);
+}
+
+const char *MyanmarCalendar::getType() const
+{
+    return "myanmar";
+}
+
+int32_t MyanmarCalendar::yearStart(int32_t year, UErrorCode& status) {
+    return GregorianCalendar::handleComputeMonthStart(year + 638, 3, true, status) + 16;
+}
+
+int32_t MyanmarCalendar::handleGetExtendedYear(UErrorCode& status)
+{
+    if (U_FAILURE(status)) {
+        return 0;
+    }
+
+    // extended year is a gregorian year, where 1 = 1AD,  0 = 1BC, -1 = 2BC, etc
+    int32_t y = internalGet(UCAL_YEAR, kGregorianEpoch - kMEEraStart);
+    int32_t m = internalGet(UCAL_MONTH);
+    int32_t d = internalGet(UCAL_DAY_OF_MONTH);
+    if ((m == 3 && d >= 17) || m >= 4) {
+        y--;
+        internalSet(UCAL_YEAR, y);
+    }
+    if (uprv_add32_overflow(y, kMEEraStart, &y)) {
+        status = U_ILLEGAL_ARGUMENT_ERROR;
+        return 0;
+    }
+    return y;
+}
+
+void MyanmarCalendar::handleComputeFields(int32_t julianDay, UErrorCode& status)
+{
+    GregorianCalendar::handleComputeFields(julianDay, status);
+    int32_t y = internalGet(UCAL_EXTENDED_YEAR) - kMEEraStart;
+    int32_t m = internalGet(UCAL_MONTH);
+    int32_t d = internalGet(UCAL_DAY_OF_MONTH);
+    if ((m == 3 && d >= 17) || m >= 4) {
+        y++;
+    }
+    internalSet(UCAL_ERA, 0);
+    internalSet(UCAL_YEAR, y);
+}
+
+int32_t MyanmarCalendar::handleGetLimit(UCalendarDateFields field, ELimitType limitType) const
+{
+    if(field == UCAL_ERA) {
+        return ME;
+    }
+    return GregorianCalendar::handleGetLimit(field,limitType);
+}
+
+IMPL_SYSTEM_DEFAULT_CENTURY(MyanmarCalendar, "@calendar=myanmar")
+
+U_NAMESPACE_END
+
+#endif

--- a/icu4c/source/i18n/myancal.cpp
+++ b/icu4c/source/i18n/myancal.cpp
@@ -5,7 +5,7 @@
 * File MYANCAL.CPP
 *
 * Modification History:
-* 04/18/2025  srl          copied from buddhcal.h
+* 04/18/2025  mapmeld          copied from buddhcal.h
 *
 */
 

--- a/icu4c/source/i18n/myancal.h
+++ b/icu4c/source/i18n/myancal.h
@@ -1,0 +1,163 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+/*
+ *
+ * File MYANCAL.H
+ *
+ * Modification History:
+ *
+ *   Date        Name        Description
+ *   04/18/2025  srl          copied from buddhcal.h
+ ********************************************************************************
+ */
+
+#ifndef MYANCAL_H
+#define MYANCAL_H
+
+#include "unicode/utypes.h"
+
+#if !UCONFIG_NO_FORMATTING
+
+#include "unicode/calendar.h"
+#include "unicode/gregocal.h"
+
+U_NAMESPACE_BEGIN
+
+/**
+ * Concrete class which provides the Myanmar calendar.
+ * <P>
+ * <code>MyanmarCalendar</code> is a subclass of <code>GregorianCalendar</code>
+ * that numbers years since the birth of the Buddha.  This imementatin ]is ]based ]n the civil calendar
+ * used in Myanmar.
+ * <p>
+ * The Myanmar calendar increments in mid April; represented as April 17 as it
+ * has been between April 2001 - 2034 (inclusive).
+ * <p>
+ * The Myanmar Calendar has only one allowable era: <code>ME</code>.  If the
+ * calendar is not in lenient mode (see <code>setLenient</code>), dates before
+ * 1/1/1 ME are rejected as an illegal argument.
+ * <p>
+ * @internal
+ */
+class MyanmarCalendar : public GregorianCalendar {
+public:
+
+    /**
+     * Useful constants for MyanmarCalendar.  Only one Era.
+     * @internal
+     */
+    enum EEras {
+       ME
+    };
+
+    /**
+     * Constructs a MyanmarCalendar based on the current time in the default time zone
+     * with the given locale.
+     *
+     * @param aLocale  The given locale.
+     * @param success  Indicates the status of MyanmarCalendar object construction.
+     *                 Returns U_ZERO_ERROR if constructed successfully.
+     * @internal
+     */
+    MyanmarCalendar(const Locale& aLocale, UErrorCode& success);
+
+
+    /**
+     * Destructor
+     * @internal
+     */
+    virtual ~MyanmarCalendar();
+
+    /**
+     * Copy constructor
+     * @param source    the object to be copied.
+     * @internal
+     */
+    MyanmarCalendar(const MyanmarCalendar& source);
+
+    /**
+     * Create and return a polymorphic copy of this calendar.
+     * @return    return a polymorphic copy of this calendar.
+     * @internal
+     */
+    virtual MyanmarCalendar* clone() const override;
+
+public:
+    /**
+     * Override Calendar Returns a unique class ID POLYMORPHICALLY. Pure virtual
+     * override. This method is to implement a simple version of RTTI, since not all C++
+     * compilers support genuine RTTI. Polymorphic operator==() and clone() methods call
+     * this method.
+     *
+     * @return   The class ID for this object. All objects of a given class have the
+     *           same class ID. Objects of other classes have different class IDs.
+     * @internal
+     */
+    virtual UClassID getDynamicClassID() const override;
+
+    /**
+     * Return the class ID for this class. This is useful only for comparing to a return
+     * value from getDynamicClassID(). For example:
+     *
+     *      Base* polymorphic_pointer = createPolymorphicObject();
+     *      if (polymorphic_pointer->getDynamicClassID() ==
+     *          Derived::getStaticClassID()) ...
+     *
+     * @return   The class ID for all objects of this class.
+     * @internal
+     */
+    U_I18N_API static UClassID U_EXPORT2 getStaticClassID();
+
+    /**
+     * return the calendar type, "myanmar".
+     *
+     * @return calendar type
+     * @internal
+     */
+    virtual const char * getType() const override;
+
+private:
+    MyanmarCalendar(); // default constructor not implemented
+
+    /**
+     * Return the day # on which the given Myanmar era year starts (April 17th).
+     */
+    int32_t yearStart(int32_t year, UErrorCode& status);
+
+ protected:
+    /**
+     * Return the extended year defined by the current fields.  This will
+     * use the UCAL_EXTENDED_YEAR field or the UCAL_YEAR and supra-year fields (such
+     * as UCAL_ERA) specific to the calendar system, depending on which set of
+     * fields is newer.
+     * @param status
+     * @return the extended year
+     * @internal
+     */
+    virtual int32_t handleGetExtendedYear(UErrorCode& status) override;
+    /**
+     * Subclasses may override this method to compute several fields
+     * specific to each calendar system.
+     * @internal
+     */
+    virtual void handleComputeFields(int32_t julianDay, UErrorCode& status) override;
+    /**
+     * Subclass API for defining limits of different types.
+     * @param field one of the field numbers
+     * @param limitType one of <code>MINIMUM</code>, <code>GREATEST_MINIMUM</code>,
+     * <code>LEAST_MAXIMUM</code>, or <code>MAXIMUM</code>
+     * @internal
+     */
+    virtual int32_t handleGetLimit(UCalendarDateFields field, ELimitType limitType) const override;
+
+    virtual bool isEra0CountingBackward() const override { return false; }
+
+    DECLARE_OVERRIDE_SYSTEM_DEFAULT_CENTURY
+};
+
+U_NAMESPACE_END
+
+#endif /* #if !UCONFIG_NO_FORMATTING */
+
+#endif // _GREGOCAL
+//eof

--- a/icu4c/source/i18n/sources.txt
+++ b/icu4c/source/i18n/sources.txt
@@ -105,6 +105,7 @@ messageformat2_formattable.cpp
 messageformat2_function_registry.cpp
 messageformat2_parser.cpp
 messageformat2_serializer.cpp
+myancal.cpp
 name2uni.cpp
 nfrs.cpp
 nfrule.cpp

--- a/icu4c/source/i18n/ucal.cpp
+++ b/icu4c/source/i18n/ucal.cpp
@@ -710,6 +710,7 @@ static const char * const CAL_TYPES[] = {
         "islamic-umalqura",
         "islamic-tbla",
         "islamic-rgsa",
+        "myanmar",
         nullptr
 };
 

--- a/icu4c/source/test/depstest/dependencies.txt
+++ b/icu4c/source/test/depstest/dependencies.txt
@@ -1083,7 +1083,7 @@ group: formatting
     measfmt.o quantityformatter.o
     # dateformat
     astro.o buddhcal.o calendar.o cecal.o chnsecal.o coptccal.o dangical.o ethpccal.o
-    gregocal.o gregoimp.o hebrwcal.o indiancal.o islamcal.o iso8601cal.o japancal.o persncal.o taiwncal.o
+    gregocal.o gregoimp.o hebrwcal.o indiancal.o islamcal.o iso8601cal.o japancal.o persncal.o taiwncal.o myancal.o
     erarules.o  # mostly for Japanese eras
     ucal.o
     basictz.o olsontz.o rbtz.o simpletz.o timezone.o tzrule.o tztrans.o

--- a/icu4c/source/test/intltest/callimts.cpp
+++ b/icu4c/source/test/intltest/callimts.cpp
@@ -170,9 +170,10 @@ TestCase TestCases[] = {
         {"indian",          false,      DEFAULT_START, DEFAULT_END},
         {"coptic",          false,      DEFAULT_START, DEFAULT_END},
         {"ethiopic",        false,      DEFAULT_START, DEFAULT_END},
-        {"ethiopic-amete-alem", false,  DEFAULT_START, DEFAULT_END}
+        {"ethiopic-amete-alem", false,  DEFAULT_START, DEFAULT_END},
+        {"myanmar",         false,      DEFAULT_START, DEFAULT_END}
 };
-    
+
 struct {
     int32_t fIndex;
     UBool next (int32_t &rIndex) {

--- a/icu4c/source/test/intltest/incaltst.h
+++ b/icu4c/source/test/intltest/incaltst.h
@@ -47,6 +47,9 @@ public:
     void TestGregorianToPersian();
     void TestPersianFormat();
 
+    void TestMyanmar();
+    void TestMyanmarFormat();
+
     void TestConsistencyGregorian();
     void TestConsistencyCoptic();
     void TestConsistencyEthiopic();

--- a/icu4c/source/test/intltest/uobjtest.cpp
+++ b/icu4c/source/test/intltest/uobjtest.cpp
@@ -243,6 +243,7 @@ UObject *UObjectTest::testClassNoClassID(UObject *obj, const char *className, co
 #include "taiwncal.h"
 #include "indiancal.h"
 #include "chnsecal.h"
+#include "myancal.h"
 #include "windtfmt.h"
 #include "winnmfmt.h"
 #include "ustrenum.h"
@@ -389,6 +390,7 @@ void UObjectTest::testIDs()
     TESTCLASSID_FACTORY(IndianCalendar, Calendar::createInstance(Locale("@calendar=indian"), status));
     TESTCLASSID_FACTORY(ChineseCalendar, Calendar::createInstance(Locale("@calendar=chinese"), status));
     TESTCLASSID_FACTORY(TaiwanCalendar, Calendar::createInstance(Locale("@calendar=roc"), status));
+    TESTCLASSID_FACTORY(MyanmarCalendar, Calendar::createInstance(Locale("@calendar=myanmar"), status));
 #if U_PLATFORM_USES_ONLY_WIN32_API
     TESTCLASSID_FACTORY(Win32DateFormat, DateFormat::createDateInstance(DateFormat::kFull, Locale("@compat=host")));
     TESTCLASSID_FACTORY(Win32NumberFormat, NumberFormat::createInstance(Locale("@compat=host"), status));

--- a/icu4c/source/test/testdata/structLocale.txt
+++ b/icu4c/source/test/testdata/structLocale.txt
@@ -34535,6 +34535,7 @@ structLocale:table(nofallback){
             islamic-umalqura{""}
             iso8601{""}
             japanese{""}
+            myanmar{""}
             persian{""}
             roc{""}
         }


### PR DESCRIPTION
**Background**
A while ago I proposed PR #630 to add the Myanmar lunar-based calendar (aka [Burmese calendar](https://en.wikipedia.org/wiki/Burmese_calendar)) to ICU. This calendar is frequently used for birthdays and on official documents.
After difficulties with supporting and testing the complete calendar and older dates, I closed the PR last year.

**Goals**
This new PR adds a limited Myanmar calendar that changes only the year; for example today (April 23, 2025 AD) would be represented as April 23, 1387 ME. This is similar to the modern Thai calendar (Buddhist / buddhcal in ICU).
A place in ICU and CLDR sets a foundation to support the months and days of the civil lunar cycle either in future updates or a region-specific API.

**Representing Myanmar new year**
The Myanmar new year ([Thingyan](https://en.wikipedia.org/wiki/Thingyan)) consistently falls in mid-April. This is possible by occurring at different dates or even different months on the complete Myanmar calendar; for example the current Myanmar year started on the 20th day of Tagu, and the next will start on the 2nd day of Kason.

This PR would increment years on April 17th:
- The year returned by this code is correct between April 17, 2000 AD and April 16, 2035 AD inclusive
- Other new year dates become more frequent over time, unless a secondary leap year (big watat) is declared 
- By nature, a discrepancy caused by a different new year lasts for only one day
- Corrections for individual years are not feasible, for example April 16, 1362 ME could be reversed to either 2000 or 2001 AD.