### PR TITLE
ICU-23107 Remove unnecessary virtual specifiers

### DIFF
--- a/icu4c/source/common/unicode/uniset.h
+++ b/icu4c/source/common/unicode/uniset.h
@@ -495,7 +495,7 @@ public:
      * @return <tt>true</tt> if the specified set is equal to this set.
      * @stable ICU 2.0
      */
-    virtual bool operator==(const UnicodeSet& o) const;
+    bool operator==(const UnicodeSet& o) const;
 
     /**
      * Compares the specified object with this set for equality.  Returns
@@ -522,7 +522,7 @@ public:
      * @see Object#hashCode()
      * @stable ICU 2.0
      */
-    virtual int32_t hashCode() const;
+    int32_t hashCode() const;
 
     /**
      * Get a UnicodeSet pointer from a USet
@@ -792,7 +792,7 @@ public:
      * @stable ICU 2.0
      * @see getRangeCount
      */
-    virtual int32_t size() const;
+    int32_t size() const;
 
     /**
      * Returns <tt>true</tt> if this set contains no elements.
@@ -800,7 +800,7 @@ public:
      * @return <tt>true</tt> if this set contains no elements.
      * @stable ICU 2.0
      */
-    virtual UBool isEmpty() const;
+    UBool isEmpty() const;
 
     /**
      * @return true if this set contains multi-character strings or the empty string.
@@ -825,7 +825,7 @@ public:
      * @return true if the test condition is met
      * @stable ICU 2.0
      */
-    virtual UBool contains(UChar32 start, UChar32 end) const;
+    UBool contains(UChar32 start, UChar32 end) const;
 
     /**
      * Returns <tt>true</tt> if this set contains the given
@@ -843,7 +843,7 @@ public:
      * @return true if the test condition is met
      * @stable ICU 2.4
      */
-    virtual UBool containsAll(const UnicodeSet& c) const;
+    UBool containsAll(const UnicodeSet& c) const;
 
     /**
      * Returns true if this set contains all the characters
@@ -1021,7 +1021,7 @@ public:
      * Implement UnicodeMatcher::matches()
      * @stable ICU 2.4
      */
-    virtual UMatchDegree matches(const Replaceable& text,
+    UMatchDegree matches(const Replaceable& text,
                          int32_t& offset,
                          int32_t limit,
                          UBool incremental) override;
@@ -1231,7 +1231,7 @@ public:
      * to this set.
      * @stable ICU 2.0
      */
-    virtual UnicodeSet& add(UChar32 start, UChar32 end);
+    UnicodeSet& add(UChar32 start, UChar32 end);
 
     /**
      * Adds the specified character to this set if it is not already
@@ -1337,7 +1337,7 @@ public:
      * @param end last character, inclusive, of range
      * @stable ICU 2.0
      */
-    virtual UnicodeSet& retain(UChar32 start, UChar32 end);
+    UnicodeSet& retain(UChar32 start, UChar32 end);
 
 
     /**
@@ -1375,7 +1375,7 @@ public:
      * from this set.
      * @stable ICU 2.0
      */
-    virtual UnicodeSet& remove(UChar32 start, UChar32 end);
+    UnicodeSet& remove(UChar32 start, UChar32 end);
 
     /**
      * Removes the specified character from this set if it is present.
@@ -1412,7 +1412,7 @@ public:
      * A frozen set will not be modified.
      * @stable ICU 2.0
      */
-    virtual UnicodeSet& complement();
+    UnicodeSet& complement();
 
     /**
      * Complements the specified range in this set.  Any character in
@@ -1426,7 +1426,7 @@ public:
      * @param end last character, inclusive, of range
      * @stable ICU 2.0
      */
-    virtual UnicodeSet& complement(UChar32 start, UChar32 end);
+    UnicodeSet& complement(UChar32 start, UChar32 end);
 
     /**
      * Complements the specified character in this set.  The character
@@ -1463,7 +1463,7 @@ public:
      * @see #add(UChar32, UChar32)
      * @stable ICU 2.0
      */
-    virtual UnicodeSet& addAll(const UnicodeSet& c);
+    UnicodeSet& addAll(const UnicodeSet& c);
 
     /**
      * Retains only the elements in this set that are contained in the
@@ -1476,7 +1476,7 @@ public:
      * @param c set that defines which elements this set will retain.
      * @stable ICU 2.0
      */
-    virtual UnicodeSet& retainAll(const UnicodeSet& c);
+    UnicodeSet& retainAll(const UnicodeSet& c);
 
     /**
      * Removes from this set all of its elements that are contained in the
@@ -1489,7 +1489,7 @@ public:
      *          this set.
      * @stable ICU 2.0
      */
-    virtual UnicodeSet& removeAll(const UnicodeSet& c);
+    UnicodeSet& removeAll(const UnicodeSet& c);
 
     /**
      * Complements in this set all elements contained in the specified
@@ -1501,7 +1501,7 @@ public:
      *          this set.
      * @stable ICU 2.4
      */
-    virtual UnicodeSet& complementAll(const UnicodeSet& c);
+    UnicodeSet& complementAll(const UnicodeSet& c);
 
     /**
      * Removes all of the elements from this set.  This set will be
@@ -1509,7 +1509,7 @@ public:
      * A frozen set will not be modified.
      * @stable ICU 2.0
      */
-    virtual UnicodeSet& clear();
+    UnicodeSet& clear();
 
     /**
      * Close this set over the given attribute.  For the attribute
@@ -1546,7 +1546,7 @@ public:
      * @return a reference to this set.
      * @stable ICU 4.2
      */
-    virtual UnicodeSet &removeAllStrings();
+    UnicodeSet &removeAllStrings();
 
     /**
      * Iteration method that returns the number of ranges contained in
@@ -1555,7 +1555,7 @@ public:
      * @see #getRangeEnd
      * @stable ICU 2.4
      */
-    virtual int32_t getRangeCount() const;
+    int32_t getRangeCount() const;
 
     /**
      * Iteration method that returns the first character in the
@@ -1564,7 +1564,7 @@ public:
      * @see #getRangeEnd
      * @stable ICU 2.4
      */
-    virtual UChar32 getRangeStart(int32_t index) const;
+    UChar32 getRangeStart(int32_t index) const;
 
     /**
      * Iteration method that returns the last character in the
@@ -1573,7 +1573,7 @@ public:
      * @see #getRangeEnd
      * @stable ICU 2.4
      */
-    virtual UChar32 getRangeEnd(int32_t index) const;
+    UChar32 getRangeEnd(int32_t index) const;
 
     /**
      * Serializes this set into an array of 16-bit integers.  Serialization
@@ -1631,7 +1631,7 @@ public:
      * A frozen set will not be modified.
      * @stable ICU 2.4
      */
-    virtual UnicodeSet& compact();
+    UnicodeSet& compact();
 
     /**
      * Return the class ID for this class.  This is useful only for

--- a/icu4c/source/i18n/unicode/dtitvinf.h
+++ b/icu4c/source/i18n/unicode/dtitvinf.h
@@ -197,14 +197,13 @@ public:
      * @return   a copy of the object
      * @stable ICU 4.0
      */
-    virtual DateIntervalInfo* clone() const;
+    DateIntervalInfo* clone() const;
 
     /**
      * Destructor.
-     * It is virtual to be safe, but it is not designed to be subclassed.
      * @stable ICU 4.0
      */
-    virtual ~DateIntervalInfo();
+    ~DateIntervalInfo();
 
 
     /**
@@ -214,7 +213,7 @@ public:
      * @return         true if other is semantically equal to this.
      * @stable ICU 4.0
      */
-    virtual bool operator==(const DateIntervalInfo& other) const;
+    bool operator==(const DateIntervalInfo& other) const;
 
     /**
      * Return true if another object is semantically unequal to this one.

--- a/icu4c/source/i18n/unicode/regex.h
+++ b/icu4c/source/i18n/unicode/regex.h
@@ -145,7 +145,7 @@ public:
      * @return the copy of this RegexPattern
      * @stable ICU 2.4
      */
-    virtual RegexPattern  *clone() const;
+    RegexPattern  *clone() const;
 
 
    /**
@@ -325,7 +325,7 @@ public:
     * @return  the #URegexpFlag match mode flags
     * @stable ICU 2.4
     */
-    virtual uint32_t flags() const;
+    uint32_t flags() const;
 
    /**
     * Creates a RegexMatcher that will match the given input against this pattern.  The
@@ -344,7 +344,7 @@ public:
     *
     * @stable ICU 2.4
     */
-    virtual RegexMatcher *matcher(const UnicodeString &input,
+    RegexMatcher *matcher(const UnicodeString &input,
         UErrorCode          &status) const;
         
 private:
@@ -376,7 +376,7 @@ public:
     *
     * @stable ICU 2.6
     */
-    virtual RegexMatcher *matcher(UErrorCode  &status) const;
+    RegexMatcher *matcher(UErrorCode  &status) const;
 
 
    /**
@@ -425,7 +425,7 @@ public:
     * the returned string may no longer reflect the RegexPattern object.
     * @stable ICU 2.4
     */
-    virtual UnicodeString pattern() const;
+    UnicodeString pattern() const;
     
     
    /**
@@ -438,7 +438,7 @@ public:
     *
     * @stable ICU 4.6
     */
-    virtual UText *patternText(UErrorCode      &status) const;
+    UText *patternText(UErrorCode      &status) const;
 
 
     /**
@@ -454,7 +454,7 @@ public:
      *
      * @stable ICU 55
      */
-    virtual int32_t groupNumberFromName(const UnicodeString &groupName, UErrorCode &status) const;
+    int32_t groupNumberFromName(const UnicodeString &groupName, UErrorCode &status) const;
 
 
     /**
@@ -473,7 +473,7 @@ public:
      *
      * @stable ICU 55
      */
-    virtual int32_t groupNumberFromName(const char *groupName, int32_t nameLength, UErrorCode &status) const;
+    int32_t groupNumberFromName(const char *groupName, int32_t nameLength, UErrorCode &status) const;
 
 
     /**
@@ -514,7 +514,7 @@ public:
      * @return        The number of fields into which the input string was split.
      * @stable ICU 2.4
      */
-    virtual int32_t  split(const UnicodeString &input,
+    int32_t  split(const UnicodeString &input,
         UnicodeString    dest[],
         int32_t          destCapacity,
         UErrorCode       &status) const;
@@ -558,7 +558,7 @@ public:
      *
      * @stable ICU 4.6
      */
-    virtual int32_t  split(UText *input,
+    int32_t  split(UText *input,
         UText            *dest[],
         int32_t          destCapacity,
         UErrorCode       &status) const;
@@ -767,7 +767,7 @@ public:
     *    @return true if there is a match
     *    @stable ICU 2.4
     */
-    virtual UBool matches(UErrorCode &status);
+    UBool matches(UErrorCode &status);
 
 
    /**
@@ -780,7 +780,7 @@ public:
     *    @return true if there is a match
     *    @stable ICU 2.8
     */
-    virtual UBool matches(int64_t startIndex, UErrorCode &status);
+    UBool matches(int64_t startIndex, UErrorCode &status);
 
 
    /**
@@ -796,7 +796,7 @@ public:
     *    @return  true if there is a match at the start of the input string.
     *    @stable ICU 2.4
     */
-    virtual UBool lookingAt(UErrorCode &status);
+    UBool lookingAt(UErrorCode &status);
 
 
   /**
@@ -812,7 +812,7 @@ public:
     *    @return  true if there is a match.
     *    @stable ICU 2.8
     */
-    virtual UBool lookingAt(int64_t startIndex, UErrorCode &status);
+    UBool lookingAt(int64_t startIndex, UErrorCode &status);
 
 
    /**
@@ -827,7 +827,7 @@ public:
     *  @return  true if a match is found.
     *  @stable ICU 2.4
     */
-    virtual UBool find();
+    UBool find();
 
 
    /**
@@ -844,7 +844,7 @@ public:
     *  @return  true if a match is found.
     * @stable ICU 55
     */
-    virtual UBool find(UErrorCode &status);
+    UBool find(UErrorCode &status);
 
    /**
     *   Resets this RegexMatcher and then attempts to find the next substring of the
@@ -855,7 +855,7 @@ public:
     *   @return  true if a match is found.
     *   @stable ICU 2.4
     */
-    virtual UBool find(int64_t start, UErrorCode &status);
+    UBool find(int64_t start, UErrorCode &status);
 
 
    /**
@@ -867,7 +867,7 @@ public:
     *   @return  a string containing the matched input text.
     *   @stable ICU 2.4
     */
-    virtual UnicodeString group(UErrorCode &status) const;
+    UnicodeString group(UErrorCode &status) const;
 
 
    /**
@@ -887,14 +887,14 @@ public:
     *    @return the captured text
     *    @stable ICU 2.4
     */
-    virtual UnicodeString group(int32_t groupNum, UErrorCode &status) const;
+    UnicodeString group(int32_t groupNum, UErrorCode &status) const;
 
    /**
     *   Returns the number of capturing groups in this matcher's pattern.
     *   @return the number of capture groups
     *   @stable ICU 2.4
     */
-    virtual int32_t groupCount() const;
+    int32_t groupCount() const;
 
 
    /**
@@ -911,7 +911,7 @@ public:
     *
     *   @stable ICU 4.6
     */
-    virtual UText *group(UText *dest, int64_t &group_len, UErrorCode &status) const; 
+    UText *group(UText *dest, int64_t &group_len, UErrorCode &status) const; 
 
    /**
     *   Returns a shallow clone of the entire live input string with the UText current native index
@@ -933,7 +933,7 @@ public:
     *
     *   @stable ICU 4.6
     */
-    virtual UText *group(int32_t groupNum, UText *dest, int64_t &group_len, UErrorCode &status) const;
+    UText *group(int32_t groupNum, UText *dest, int64_t &group_len, UErrorCode &status) const;
 
    /**
     *   Returns the index in the input string of the start of the text matched
@@ -942,7 +942,7 @@ public:
     *    @return              The (native) position in the input string of the start of the last match.
     *    @stable ICU 2.4
     */
-    virtual int32_t start(UErrorCode &status) const;
+    int32_t start(UErrorCode &status) const;
 
    /**
     *   Returns the index in the input string of the start of the text matched
@@ -951,7 +951,7 @@ public:
     *    @return              The (native) position in the input string of the start of the last match.
     *   @stable ICU 4.6
     */
-    virtual int64_t start64(UErrorCode &status) const;
+    int64_t start64(UErrorCode &status) const;
 
 
    /**
@@ -967,7 +967,7 @@ public:
     *    @return the (native) start position of substring matched by the specified group.
     *    @stable ICU 2.4
     */
-    virtual int32_t start(int32_t group, UErrorCode &status) const;
+    int32_t start(int32_t group, UErrorCode &status) const;
 
    /**
     *   Returns the index in the input string of the start of the text matched by the
@@ -982,7 +982,7 @@ public:
     *    @return the (native) start position of substring matched by the specified group.
     *    @stable ICU 4.6
     */
-    virtual int64_t start64(int32_t group, UErrorCode &status) const;
+    int64_t start64(int32_t group, UErrorCode &status) const;
 
    /**
     *    Returns the index in the input string of the first character following the
@@ -997,7 +997,7 @@ public:
     *                        a byte index for UTF-8.
     *   @stable ICU 2.4
     */
-    virtual int32_t end(UErrorCode &status) const;
+    int32_t end(UErrorCode &status) const;
 
    /**
     *    Returns the index in the input string of the first character following the
@@ -1012,7 +1012,7 @@ public:
     *                        a byte index for UTF-8.
     *   @stable ICU 4.6
     */
-    virtual int64_t end64(UErrorCode &status) const;
+    int64_t end64(UErrorCode &status) const;
 
 
    /**
@@ -1032,7 +1032,7 @@ public:
     *              a byte index for UTF8.
     *    @stable ICU 2.4
     */
-    virtual int32_t end(int32_t group, UErrorCode &status) const;
+    int32_t end(int32_t group, UErrorCode &status) const;
 
    /**
     *    Returns the index in the input string of the character following the
@@ -1051,7 +1051,7 @@ public:
     *              a byte index for UTF8.
     *   @stable ICU 4.6
     */
-    virtual int64_t end64(int32_t group, UErrorCode &status) const;
+    int64_t end64(int32_t group, UErrorCode &status) const;
 
    /**
     *   Resets this matcher.  The effect is to remove any memory of previous matches,
@@ -1061,7 +1061,7 @@ public:
     *   @return this RegexMatcher.
     *   @stable ICU 2.4
     */
-    virtual RegexMatcher &reset();
+    RegexMatcher &reset();
 
 
    /**
@@ -1079,7 +1079,7 @@ public:
     *   @return this RegexMatcher.
     *   @stable ICU 2.8
     */
-    virtual RegexMatcher &reset(int64_t index, UErrorCode &status);
+    RegexMatcher &reset(int64_t index, UErrorCode &status);
 
 
    /**
@@ -1099,7 +1099,7 @@ public:
     *   @return this RegexMatcher.
     *   @stable ICU 2.4
     */
-    virtual RegexMatcher &reset(const UnicodeString &input);
+    RegexMatcher &reset(const UnicodeString &input);
 
 
    /**
@@ -1115,7 +1115,7 @@ public:
     *
     *   @stable ICU 4.6
     */
-    virtual RegexMatcher &reset(UText *input);
+    RegexMatcher &reset(UText *input);
 
 
   /**
@@ -1142,7 +1142,7 @@ public:
     *
     * @stable ICU 4.8 
     */
-    virtual RegexMatcher &refreshInputText(UText *input, UErrorCode &status);
+    RegexMatcher &refreshInputText(UText *input, UErrorCode &status);
 
 private:
     /**
@@ -1167,7 +1167,7 @@ public:
     *   @return the input string
     *   @stable ICU 2.4
     */
-    virtual const UnicodeString &input() const;
+    const UnicodeString &input() const;
     
    /**
     *   Returns the input string being matched.  This is the live input text; it should not be
@@ -1177,7 +1177,7 @@ public:
     *
     *   @stable ICU 4.6
     */
-    virtual UText *inputText() const;
+    UText *inputText() const;
     
    /**
     *   Returns the input string being matched, either by copying it into the provided
@@ -1189,7 +1189,7 @@ public:
     *
     *   @stable ICU 4.6
     */
-    virtual UText *getInput(UText *dest, UErrorCode &status) const;
+    UText *getInput(UText *dest, UErrorCode &status) const;
     
 
    /** Sets the limits of this matcher's region.
@@ -1210,7 +1210,7 @@ public:
      * @param status A reference to a UErrorCode to receive any errors.
      * @stable ICU 4.0
      */
-     virtual RegexMatcher &region(int64_t start, int64_t limit, UErrorCode &status);
+     RegexMatcher &region(int64_t start, int64_t limit, UErrorCode &status);
 
    /** 
      * Identical to region(start, limit, status) but also allows a start position without
@@ -1223,7 +1223,7 @@ public:
      *                U_INDEX_OUTOFBOUNDS_ERROR is returned.
      * @stable ICU 4.6
      */
-     virtual RegexMatcher &region(int64_t regionStart, int64_t regionLimit, int64_t startIndex, UErrorCode &status);
+     RegexMatcher &region(int64_t regionStart, int64_t regionLimit, int64_t startIndex, UErrorCode &status);
 
    /**
      * Reports the start index of this matcher's region. The searches this matcher
@@ -1233,7 +1233,7 @@ public:
      * @return The starting (native) index of this matcher's region.
      * @stable ICU 4.0
      */
-     virtual int32_t regionStart() const;
+     int32_t regionStart() const;
 
    /**
      * Reports the start index of this matcher's region. The searches this matcher
@@ -1243,7 +1243,7 @@ public:
      * @return The starting (native) index of this matcher's region.
      * @stable ICU 4.6
      */
-     virtual int64_t regionStart64() const;
+     int64_t regionStart64() const;
 
 
     /**
@@ -1254,7 +1254,7 @@ public:
       * @return The ending point (native) of this matcher's region.
       * @stable ICU 4.0
       */
-      virtual int32_t regionEnd() const;
+      int32_t regionEnd() const;
 
    /**
      * Reports the end (limit) index (exclusive) of this matcher's region. The searches
@@ -1264,7 +1264,7 @@ public:
      * @return The ending point (native) of this matcher's region.
      * @stable ICU 4.6
      */
-      virtual int64_t regionEnd64() const;
+      int64_t regionEnd64() const;
 
     /**
       * Queries the transparency of region bounds for this matcher.
@@ -1274,7 +1274,7 @@ public:
       * @return true if this matcher is using opaque bounds, false if it is not.
       * @stable ICU 4.0
       */
-      virtual UBool hasTransparentBounds() const;
+      UBool hasTransparentBounds() const;
 
     /**
       * Sets the transparency of region bounds for this matcher.
@@ -1294,7 +1294,7 @@ public:
       * @return  This Matcher;
       * @stable ICU 4.0
       **/
-      virtual RegexMatcher &useTransparentBounds(UBool b);
+      RegexMatcher &useTransparentBounds(UBool b);
 
      
     /**
@@ -1304,7 +1304,7 @@ public:
       * @return true if this matcher is using anchoring bounds.
       * @stable ICU 4.0
       */    
-      virtual UBool hasAnchoringBounds() const;
+      UBool hasAnchoringBounds() const;
 
 
     /**
@@ -1319,7 +1319,7 @@ public:
       * @return  This Matcher
       * @stable ICU 4.0
       */
-      virtual RegexMatcher &useAnchoringBounds(UBool b);
+      RegexMatcher &useAnchoringBounds(UBool b);
 
 
     /**
@@ -1334,7 +1334,7 @@ public:
       *  @return  true if the most recent match hit the end of input
       *  @stable ICU 4.0
       */
-      virtual UBool hitEnd() const;
+      UBool hitEnd() const;
 
     /**
       * Return true the most recent match succeeded and additional input could cause
@@ -1345,7 +1345,7 @@ public:
       * @return true if more input could cause the most recent match to no longer match.
       * @stable ICU 4.0
       */
-      virtual UBool requireEnd() const;
+      UBool requireEnd() const;
 
 
    /**
@@ -1353,7 +1353,7 @@ public:
     *    @return  the RegexPattern for this RegexMatcher
     *    @stable ICU 2.4
     */
-    virtual const RegexPattern &pattern() const;
+    const RegexPattern &pattern() const;
 
 
    /**
@@ -1372,7 +1372,7 @@ public:
     *    @return              a string containing the results of the find and replace.
     *    @stable ICU 2.4
     */
-    virtual UnicodeString replaceAll(const UnicodeString &replacement, UErrorCode &status);
+    UnicodeString replaceAll(const UnicodeString &replacement, UErrorCode &status);
 
 
    /**
@@ -1395,7 +1395,7 @@ public:
     *
     *    @stable ICU 4.6
     */
-    virtual UText *replaceAll(UText *replacement, UText *dest, UErrorCode &status);
+    UText *replaceAll(UText *replacement, UText *dest, UErrorCode &status);
     
 
    /**
@@ -1418,7 +1418,7 @@ public:
     *    @return              a string containing the results of the find and replace.
     *    @stable ICU 2.4
     */
-    virtual UnicodeString replaceFirst(const UnicodeString &replacement, UErrorCode &status);
+    UnicodeString replaceFirst(const UnicodeString &replacement, UErrorCode &status);
     
 
    /**
@@ -1445,7 +1445,7 @@ public:
     *
     *    @stable ICU 4.6
     */
-    virtual UText *replaceFirst(UText *replacement, UText *dest, UErrorCode &status);
+    UText *replaceFirst(UText *replacement, UText *dest, UErrorCode &status);
     
     
    /**
@@ -1475,7 +1475,7 @@ public:
     *   @stable ICU 2.4
     *
     */
-    virtual RegexMatcher &appendReplacement(UnicodeString &dest,
+    RegexMatcher &appendReplacement(UnicodeString &dest,
         const UnicodeString &replacement, UErrorCode &status);
     
     
@@ -1506,7 +1506,7 @@ public:
     *
     *   @stable ICU 4.6
     */
-    virtual RegexMatcher &appendReplacement(UText *dest,
+    RegexMatcher &appendReplacement(UText *dest,
         UText *replacement, UErrorCode &status);
 
 
@@ -1520,7 +1520,7 @@ public:
     *  @return  the destination string.
     *  @stable ICU 2.4
     */
-    virtual UnicodeString &appendTail(UnicodeString &dest);
+    UnicodeString &appendTail(UnicodeString &dest);
 
 
    /**
@@ -1536,7 +1536,7 @@ public:
     *
     *  @stable ICU 4.6
     */
-    virtual UText *appendTail(UText *dest, UErrorCode &status);
+    UText *appendTail(UText *dest, UErrorCode &status);
 
 
     /**
@@ -1562,7 +1562,7 @@ public:
      * @return        The number of fields into which the input string was split.
      * @stable ICU 2.6
      */
-    virtual int32_t  split(const UnicodeString &input,
+     int32_t  split(const UnicodeString &input,
         UnicodeString    dest[],
         int32_t          destCapacity,
         UErrorCode       &status);
@@ -1591,7 +1591,7 @@ public:
      *
      * @stable ICU 4.6
      */
-    virtual int32_t  split(UText *input,
+     int32_t  split(UText *input,
         UText           *dest[],
         int32_t          destCapacity,
         UErrorCode       &status);
@@ -1617,7 +1617,7 @@ public:
     *   @param   status      A reference to a UErrorCode to receive any errors.
     *   @stable ICU 4.0
     */
-    virtual void setTimeLimit(int32_t limit, UErrorCode &status);
+    void setTimeLimit(int32_t limit, UErrorCode &status);
 
   /**
     * Get the time limit, if any, for match operations made with this Matcher.
@@ -1625,7 +1625,7 @@ public:
     *   @return the maximum allowed time for a match, in units of processing steps.
     *   @stable ICU 4.0
     */
-    virtual int32_t getTimeLimit() const;
+    int32_t getTimeLimit() const;
 
   /**
     *  Set the amount of heap storage available for use by the match backtracking stack.
@@ -1648,7 +1648,7 @@ public:
     *
     *  @stable ICU 4.0
     */
-    virtual void setStackLimit(int32_t  limit, UErrorCode &status);
+    void setStackLimit(int32_t  limit, UErrorCode &status);
     
   /**
     *  Get the size of the heap storage available for use by the back tracking stack.
@@ -1657,7 +1657,7 @@ public:
     *           stack size is unlimited.
     *  @stable ICU 4.0
     */
-    virtual int32_t  getStackLimit() const;
+    int32_t  getStackLimit() const;
 
 
   /**
@@ -1673,9 +1673,9 @@ public:
     *    @param   status      A reference to a UErrorCode to receive any errors.
     *  @stable ICU 4.0
     */
-    virtual void setMatchCallback(URegexMatchCallback     *callback,
-                                  const void              *context,
-                                  UErrorCode              &status);
+    void setMatchCallback(URegexMatchCallback     *callback,
+                          const void              *context,
+                          UErrorCode              &status);
 
 
   /**
@@ -1688,9 +1688,9 @@ public:
     *    @param   status      A reference to a UErrorCode to receive any errors.
     *    @stable ICU 4.0
     */
-    virtual void getMatchCallback(URegexMatchCallback     *&callback,
-                                  const void              *&context,
-                                  UErrorCode              &status);
+    void getMatchCallback(URegexMatchCallback     *&callback,
+                          const void              *&context,
+                          UErrorCode              &status);
 
 
   /**
@@ -1706,9 +1706,9 @@ public:
     *    @param   status      A reference to a UErrorCode to receive any errors.
     *    @stable ICU 4.6
     */
-    virtual void setFindProgressCallback(URegexFindProgressCallback      *callback,
-                                              const void                              *context,
-                                              UErrorCode                              &status);
+    void setFindProgressCallback(URegexFindProgressCallback      *callback,
+                                 const void                              *context,
+                                 UErrorCode                              &status);
 
 
   /**
@@ -1721,9 +1721,9 @@ public:
     *    @param   status      A reference to a UErrorCode to receive any errors.
     *    @stable ICU 4.6
     */
-    virtual void getFindProgressCallback(URegexFindProgressCallback      *&callback,
-                                              const void                      *&context,
-                                              UErrorCode                      &status);
+    void getFindProgressCallback(URegexFindProgressCallback      *&callback,
+                                 const void                      *&context,
+                                 UErrorCode                      &status);
 
 #ifndef U_HIDE_INTERNAL_API
    /**

--- a/icu4c/source/i18n/unicode/tblcoll.h
+++ b/icu4c/source/i18n/unicode/tblcoll.h
@@ -242,7 +242,7 @@ public:
      *         the based Collator.
      * @stable ICU 2.2
      */
-    virtual CollationElementIterator* createCollationElementIterator(
+    CollationElementIterator* createCollationElementIterator(
                                            const UnicodeString& source) const;
 
     /**
@@ -254,7 +254,7 @@ public:
      *         based Collator.
      * @stable ICU 2.2
      */
-    virtual CollationElementIterator* createCollationElementIterator(
+    CollationElementIterator* createCollationElementIterator(
                                          const CharacterIterator& source) const;
 
     // Make deprecated versions of Collator::compare() visible.


### PR DESCRIPTION
Clang has recently added a warning for code with the `virtual` keyword on methods of `final` classes that don't override anything. Such classes can never be subclassed, so the keyword is meaningless. This fixes instances of that warning in ICU.

#### Checklist
- [X] Required: Issue filed: ICU-23107
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable (N/A)
- [ ] API docs and/or User Guide docs changed or added, if applicable (N/A)
