### PR TITLE
ICU-23054 Fix Eclipse warning, leftover from un-sharing test data

### DIFF
--- a/icu4j/main/core/pom.xml
+++ b/icu4j/main/core/pom.xml
@@ -56,29 +56,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <!-- Test files shared between ICU4C and ICU4J -->
-            <id>add-test-resource</id>
-            <goals>
-              <goal>add-test-resource</goal>
-            </goals>
-            <configuration>
-              <resources>
-                <resource>
-                  <directory>${rootlocation}/../testdata/</directory>
-                  <includes>
-                    <include>message2/**</include>
-                  </includes>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>


### PR DESCRIPTION
Left over from PR ##3450.
This only a warning, not an error, but still "unclean".

#### Checklist
- [x] Required: Issue filed: ICU-23054
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
