### PR TITLE
ICU-23120 Fix malloc request larger than PTRDIFF_MAX bytes

### DIFF
--- a/icu4c/source/test/intltest/ustrtest.cpp
+++ b/icu4c/source/test/intltest/ustrtest.cpp
@@ -2356,7 +2356,7 @@ void UnicodeStringTest::TestLargeMemory() {
 #if U_PLATFORM_IS_LINUX_BASED || U_PLATFORM_IS_DARWIN_BASED
     if(quick) { return; }
     IcuTestErrorCode status(*this, "TestLargeMemory");
-    constexpr uint32_t len = 2147483643;
+    constexpr uint32_t len = (PTRDIFF_MAX - 10) / sizeof(char16_t);
     char16_t *buf = new char16_t[len];
     if (buf == nullptr) { return; }
     uprv_memset(buf, 0x4e, len * 2);


### PR DESCRIPTION
* glibc does not allow allocations that exceed PTRDIFF_MAX bytes: https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=9bf8e29ca136094f73f69f725f15c51facc97206
* Without this, we get compile failures on 32-bit platforms:

```
    work/icu/source/test/intltest/ustrtest.cpp: In member function ‘void UnicodeStringTest::TestLargeMemory()’:
    work/icu/source/test/intltest/ustrtest.cpp:2360:37: error: size ‘4294967286’ of array exceeds maximum object size ‘2147483647’
     2360 |     char16_t *buf = new char16_t[len];
          |                                     ^
```

#### Checklist
- [x] Required: Issue filed: ICU-NNNNN
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
