### PR TITLE
ICU-23121 Export compressibleBytes as bools instead of packed u8

### DIFF
--- a/icu4c/source/tools/genrb/parse.cpp
+++ b/icu4c/source/tools/genrb/parse.cpp
@@ -1026,15 +1026,6 @@ writeCollationSpecialPrimariesTOML(const char* outputdir, const char* name, cons
         lastPrimaries[i] = static_cast<uint16_t>((data->getLastPrimaryForGroup(UCOL_REORDER_CODE_FIRST + i) + 1) >> 16);
     }
 
-    uint8_t compressibleBytes[32] = {};
-    for (int32_t i = 0; i < 256; ++i) {
-        if (data->compressibleBytes[i]) {
-            int32_t arrIndex = i >> 3;
-            uint8_t mask = (1 << (i & 7));
-            compressibleBytes[arrIndex] |= mask;
-        }
-    }
-
     uint32_t numericPrimary = data->numericPrimary;
     if (numericPrimary & 0xFFFFFF) {
         printf("Lower 24 bits set in numeric primary");
@@ -1043,7 +1034,7 @@ writeCollationSpecialPrimariesTOML(const char* outputdir, const char* name, cons
     }
 
     usrc_writeArray(f, "last_primaries = [\n  ", lastPrimaries, 16, 4, "  ", "\n]\n");
-    usrc_writeArray(f, "compressible_bytes = [\n  ", compressibleBytes, 8, 32, "  ", "\n]\n");
+    usrc_writeArray(f, "compressible_bytes = [\n  ", data->compressibleBytes, 1, 256, "  ", "\n]\n");
     fprintf(f, "numeric_primary = 0x%X\n", numericPrimary >> 24);
     fclose(f);
 }

--- a/icu4c/source/tools/toolutil/writesrc.cpp
+++ b/icu4c/source/tools/toolutil/writesrc.cpp
@@ -162,6 +162,7 @@ usrc_writeArray(FILE *f,
     p32=nullptr;
     p64=nullptr;
     switch(width) {
+    case 1:
     case 8:
         p8=(const uint8_t *)p;
         break;
@@ -192,6 +193,7 @@ usrc_writeArray(FILE *f,
             }
         }
         switch(width) {
+        case 1:
         case 8:
             value=p8[i];
             break;
@@ -208,7 +210,11 @@ usrc_writeArray(FILE *f,
             value=0; /* unreachable */
             break;
         }
-        fprintf(f, value<=9 ? "%" PRId64 : "0x%" PRIx64, value);
+        if (width == 1) {
+            fprintf(f, value ? "true" : "false");
+        } else {
+            fprintf(f, value<=9 ? "%" PRId64 : "0x%" PRIx64, value);
+        }
     }
     if(postfix!=nullptr) {
         fputs(postfix, f);


### PR DESCRIPTION
Old (from @hsivonen):

```toml
#
# file name: root_standard_prim
#
# machine-generated by: genrb -X

last_primaries = [
  0x506,0xc00,0xda0,0xf00
]
compressible_bytes = [
  0,0,0,0,0,0,0,0,0,0,0,0,0xfe,0xff,0xff,0xff,
  1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x40
]
numeric_primary = 0x10
```

New:

```toml
#
# file name: root_standard_prim
#
# machine-generated by: genrb -X

last_primaries = [
  0x506,0xc00,0xda0,0xf00
]
compressible_bytes = [
  false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,
  false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,
  false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,
  false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,
  false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,
  false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,
  false,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,
  true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,
  true,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,
  false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,
  false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,
  false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,
  false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,
  false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,
  false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,
  false,false,false,false,false,false,false,false,false,false,false,false,false,false,true,false
]
numeric_primary = 0x10
```

#### Checklist
- [x] Required: Issue filed: ICU-23121
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
