### PR TITLE
ICU-23054 Fix several types of errorprone warnings

### DIFF
--- a/icu4j/main/core/src/main/java/com/ibm/icu/impl/JavaTimeConverters.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/impl/JavaTimeConverters.java
@@ -91,6 +91,7 @@ public class JavaTimeConverters {
      * @deprecated This API is ICU internal only.
      */
     @Deprecated
+    @SuppressWarnings("JavaTimeDefaultTimeZone")
     public static Calendar temporalToCalendar(OffsetTime time) {
         return temporalToCalendar(time.atDate(LocalDate.now()));
     }

--- a/icu4j/main/core/src/main/java/com/ibm/icu/impl/RBBIDataWrapper.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/impl/RBBIDataWrapper.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Objects;
 
 import com.ibm.icu.impl.ICUBinary.Authenticate;
 import com.ibm.icu.text.RuleBasedBreakIterator;
@@ -142,6 +143,19 @@ public final class RBBIDataWrapper {
             if (fFlags     != otherST.fFlags)     return false;
             return Arrays.equals(fTable, otherST.fTable);
         }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + Arrays.hashCode(fTable);
+            result = prime * result
+                    + Objects.hash(fDictCategoriesStart, fFlags, fLookAheadResultsSize, fNumStates, fRowLen);
+            return result;
+        }
     }
 
     /**
@@ -170,14 +184,14 @@ public final class RBBIDataWrapper {
 
     public CodePointTrie    fTrie;
     public String  fRuleSource;
-    public int     fStatusTable[];
+    public int []  fStatusTable;
 
     public static final int DATA_FORMAT = 0x42726b20;     // "Brk "
     public static final int FORMAT_VERSION = 0x06000000;  // 6.0.0.0
 
     private static final class IsAcceptable implements Authenticate {
         @Override
-        public boolean isDataVersionAcceptable(byte version[]) {
+        public boolean isDataVersionAcceptable(byte[] version) {
             int intVersion = (version[0] << 24) + (version[1] << 16) + (version[2] << 8) + version[3];
             return intVersion == FORMAT_VERSION;
         }
@@ -397,7 +411,6 @@ public final class RBBIDataWrapper {
             throw new IOException("Break iterator Rule data corrupt");
         }
         ICUBinary.skipBytes(bytes, This.fHeader.fRuleSource - pos);
-        pos = This.fHeader.fRuleSource;
         This.fRuleSource = new String(
             ICUBinary.getBytes(bytes, This.fHeader.fRuleSourceLen, 0), StandardCharsets.UTF_8);
 
@@ -507,13 +520,13 @@ public final class RBBIDataWrapper {
 
     private void dumpCharCategories(java.io.PrintStream out) {
         int n = fHeader.fCatCount;
-        String   catStrings[] = new  String[n+1];
+        String[] catStrings = new  String[n+1];
         int      rangeStart = 0;
         int      rangeEnd = 0;
         int      lastCat = -1;
         int      char32;
         int      category;
-        int      lastNewline[] = new int[n+1];
+        int[]    lastNewline = new int[n+1];
 
         for (category = 0; category <= fHeader.fCatCount; category ++) {
             catStrings[category] = "";

--- a/icu4j/main/core/src/main/java/com/ibm/icu/impl/number/DecimalQuantity_AbstractBCD.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/impl/number/DecimalQuantity_AbstractBCD.java
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.MathContext;
 import java.text.FieldPosition;
+import java.util.Objects;
 
 import com.ibm.icu.impl.StandardPlural;
 import com.ibm.icu.impl.Utility;
@@ -1199,6 +1200,23 @@ public abstract class DecimalQuantity_AbstractBCD implements DecimalQuantity {
             }
             return true;
         }
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(scale, precision, flags, lReqPos, rReqPos, isApproximate);
+
+        if (precision == 0) {
+            return result;
+        }
+        if (isApproximate) {
+            return Objects.hash(result, origDouble, origDelta);
+        } else {
+            for (int m = getUpperDisplayMagnitude(); m >= getLowerDisplayMagnitude(); m--) {
+                return Objects.hash(result, getDigit(m));
+            }
+        }
+        return result;
     }
 
     /**

--- a/icu4j/main/core/src/main/java/com/ibm/icu/impl/personname/PersonNameFormatterImpl.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/impl/personname/PersonNameFormatterImpl.java
@@ -363,7 +363,7 @@ public class PersonNameFormatterImpl {
         Locale.Builder builder = new Locale.Builder();
         if (oldLocale != null) {
             workingLocale = oldLocale;
-            builder.setLocale(oldLocale);
+            var unused = builder.setLocale(oldLocale);
             localeScript = ULocale.addLikelySubtags(ULocale.forLocale(oldLocale)).getScript();
         } else {
             ULocale tmpLocale = ULocale.addLikelySubtags(new ULocale("und_" + scriptCode));
@@ -372,7 +372,7 @@ public class PersonNameFormatterImpl {
             localeScript = workingLocale.getScript();
 
             if (regionCode != null) {
-                builder.setRegion(regionCode);
+                var unused = builder.setRegion(regionCode);
             }
         }
 

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/NFSubstitution.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/NFSubstitution.java
@@ -1651,11 +1651,10 @@ class NumeratorSubstitution extends NFSubstitution {
         if (withZeros) {
             String workText = text;
             ParsePosition workPos = new ParsePosition(1);
-            //int digit;
 
             while (workText.length() > 0 && workPos.getIndex() != 0) {
                 workPos.setIndex(0);
-                /*digit = */ruleSet.parse(workText, workPos, 1, nonNumericalExecutedRuleMask, recursionCount).intValue(); // parse zero or nothing at all
+                var unused = ruleSet.parse(workText, workPos, 1, nonNumericalExecutedRuleMask, recursionCount).intValue(); // parse zero or nothing at all
                 if (workPos.getIndex() == 0) {
                     // we failed, either there were no more zeros, or the number was formatted with digits
                     // either way, we're done

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/number/NumberSkeletonTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/number/NumberSkeletonTest.java
@@ -2,10 +2,6 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 package com.ibm.icu.dev.test.number;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.math.RoundingMode;
 import java.util.Locale;
 

--- a/icu4j/perf-tests/src/main/java/com/ibm/icu/dev/test/perf/CollationPerformanceTest.java
+++ b/icu4j/perf-tests/src/main/java/com/ibm/icu/dev/test/perf/CollationPerformanceTest.java
@@ -13,6 +13,9 @@ import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Comparator;
 
@@ -831,7 +834,7 @@ public class CollationPerformanceTest {
             opt_icu = false;
         }
         
-        if (opt_rules.length() != 0) {
+        if (!opt_rules.isEmpty()) {
             try {
                 icuCol = new com.ibm.icu.text.RuleBasedCollator(getCollationRules(opt_rules));
             } catch (Exception e) {
@@ -1119,37 +1122,20 @@ public class CollationPerformanceTest {
      * 3. File encoding is ISO-8859-1
      */
     String getCollationRules(String ruleFileName) {
-        FileInputStream fis = null;
-        InputStreamReader isr = null;
-        BufferedReader br = null;
-        try {
-            fis = new FileInputStream(opt_rules);
-            isr = new InputStreamReader(fis,"ISO-8859-1");
-            br= new BufferedReader(isr);
-        } catch (Exception e) {
+        StringBuilder rules = new StringBuilder();
+        try (BufferedReader br = Files.newBufferedReader(Paths.get(ruleFileName), StandardCharsets.ISO_8859_1)) {
+            br.lines().forEach(line -> {
+                int commentPos = line.indexOf('#');
+                if (commentPos >= 0) line = line.substring(0, commentPos);
+                rules.append(line.trim());
+            });
+        } catch (IOException e) {
             System.err.println("Error: File access exception: " + e.getMessage() + "!");
             System.exit(2);
         }
-        String rules = "";
-        String line = "";
-        while (true) {
-            try {
-                line = br.readLine();
-            } catch (IOException e) {
-                System.err.println("Read File Error" + e.getMessage() + "!");
-                System.exit(1);
-            }
-            if (line == null) {
-                break;
-            }
-            int commentPos = line.indexOf('#');
-            if (commentPos >= 0) line = line.substring(0, commentPos);
-            line = line.trim();
-            rules = rules + line;
-        }
-        return rules;
+        return rules.toString();
     }
-    
+
     //Implementing qsort
     void qSortImpl_java_usekeys(String src[], int fromIndex, int toIndex, java.text.Collator c) {
         int low = fromIndex;

--- a/icu4j/perf-tests/src/main/java/com/ibm/icu/dev/test/perf/RBBIPerf.java
+++ b/icu4j/perf-tests/src/main/java/com/ibm/icu/dev/test/perf/RBBIPerf.java
@@ -7,14 +7,13 @@
 **********************************************************************
 */
 package com.ibm.icu.dev.test.perf;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.text.BreakIterator;
 
 import com.ibm.icu.text.RuleBasedBreakIterator;
-import com.ibm.icu.text.UTF16;
 
 /**
  * A class for testing UnicodeSet performance.
@@ -24,7 +23,6 @@ import com.ibm.icu.text.UTF16;
  */
 public class RBBIPerf extends PerfTest {
 
-    String                  dataFileName;
     RuleBasedBreakIterator  bi;
     BreakIterator           jdkbi;
     String                  testString;
@@ -40,19 +38,7 @@ public class RBBIPerf extends PerfTest {
         }
 
         try {
-            dataFileName = args[0];
-            StringBuffer  testFileBuf = new StringBuffer();
-            InputStream is = new FileInputStream(dataFileName);
-            InputStreamReader isr = new InputStreamReader(is, "UTF-8");           
-            int c;
-            for (;;) {
-                c = isr.read();
-                if (c < 0) {
-                    break;
-                }
-                UTF16.append(testFileBuf, c);
-            }
-            testString = testFileBuf.toString();
+            testString = Files.readString(Paths.get(args[0]), StandardCharsets.UTF_8);
         }
         catch (IOException e) {
             throw new RuntimeException(e.toString());   


### PR DESCRIPTION
Fixed: `CheckReturnValue`, `EqualsHashCode`, `JavaTimeDefaultTimeZone`
And a couple of resource leaks (streams opened and not closed)

#### Checklist
- [x] Required: Issue filed: ICU-23054
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
