### PR TITLE
ICU-22987 Return DONE for BreakIterator.preceding on negative index

### DIFF
--- a/icu4c/source/test/intltest/rbbitst.cpp
+++ b/icu4c/source/test/intltest/rbbitst.cpp
@@ -107,6 +107,7 @@ void RBBITest::runIndexedTest( int32_t index, UBool exec, const char* &name, cha
     TESTCASE_AUTO(TestGetDisplayName);
 #if !UCONFIG_NO_FILE_IO
     TESTCASE_AUTO(TestEndBehaviour);
+    TESTCASE_AUTO(TestPreceding_NegativeIndex);
     TESTCASE_AUTO(TestWordBreaks);
     TESTCASE_AUTO(TestWordBoundary);
     TESTCASE_AUTO(TestLineBreaks);
@@ -737,6 +738,34 @@ void RBBITest::executeTest(TestParams *t, UErrorCode &status) {
                   "        Expected, Actual= %d, %d",
                   i, t->getSrcLine(i), t->getSrcCol(i), expectedBreak, actualBreak);
         }
+    }
+}
+
+void RBBITest::TestPreceding_NegativeIndex() {
+    UErrorCode status = U_ZERO_ERROR;
+    Locale loc = Locale::getRoot();
+    LocalPointer<BreakIterator> bi(BreakIterator::createWordInstance(loc, status));
+    UnicodeString source(u"The quick brown fox jumped over the lazy dog.");
+    bi->setText(source);
+
+    assertEquals("length of source string", 45, source.length());
+
+    struct TestCase {
+        const UnicodeString description;
+        const int32_t startIdx;
+        const int32_t expected;
+    } cases[] = {
+        {"negative index",                 -2, BreakIterator::DONE},
+        {"zero",                            0, BreakIterator::DONE},
+        {"one",                             1, 0},
+        {"middle",                         41, 40},
+        {"end",                            45, 44},
+        {"after the end", source.length() + 2, source.length()}
+    };
+
+    for (const auto& cas : cases) {
+        int32_t actual = bi->preceding(cas.startIdx);
+        assertEquals(cas.description, cas.expected, actual);
     }
 }
 

--- a/icu4c/source/test/intltest/rbbitst.h
+++ b/icu4c/source/test/intltest/rbbitst.h
@@ -58,6 +58,7 @@ public:
 
     void TestExtended();
     void executeTest(TestParams *, UErrorCode &status);
+    void TestPreceding_NegativeIndex();
 
     void TestWordBreaks();
     void TestWordBoundary();

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/BreakIterator.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/BreakIterator.java
@@ -347,6 +347,10 @@ public abstract class BreakIterator implements Cloneable
         // NOTE:  This implementation is here solely because we can't add new
         // abstract methods to an existing class.  There is almost ALWAYS a
         // better, faster way to do this.
+
+        if (offset < 0) {
+            return DONE;
+        }
         int pos = following(offset);
         while (pos >= offset && pos != DONE)
             pos = previous();

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/RuleBasedBreakIterator.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/RuleBasedBreakIterator.java
@@ -511,7 +511,7 @@ public class RuleBasedBreakIterator extends BreakIterator {
         if (fText == null || offset > fText.getEndIndex()) {
             return last();
         } else if (offset < fText.getBeginIndex()) {
-            return first();
+            return DONE;
         }
 
         // Move requested offset to a code point start. It might be between a lead and trail surrogate.

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/BreakIteratorTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/BreakIteratorTest.java
@@ -8,6 +8,9 @@
  */
 package com.ibm.icu.dev.test.rbbi;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import java.text.StringCharacterIterator;
 import java.util.Locale;
 
@@ -107,6 +110,33 @@ public class BreakIteratorTest extends CoreTestFmwk
     // tests
     //=========================================================================
 
+    @Test
+    public void TestPreceding_NegativeIndex() {
+        String source = "The quick brown fox jumped over the lazy dog.";
+        BreakIterator iter = BreakIterator.getWordInstance();
+        iter.setText(source);
+
+        assertEquals("length of source string", 45, source.length());
+
+        Object[][] casesData = {
+            {"negative index",                 -2, BreakIterator.DONE},
+            {"zero",                            0, BreakIterator.DONE},
+            {"one",                             1, 0},
+            {"middle",                         41, 40},
+            {"end",                            45, 44},
+            {"after the end", source.length() + 2, source.length()}
+        };
+
+        for (Object[] caseDatum : casesData) {
+            String desc = (String) caseDatum[0];
+            int startIdx = (int) caseDatum[1];
+            int expected = (int) caseDatum[2];
+
+            int actual = iter.preceding(startIdx);
+
+            assertThat(desc, actual, is(expected));
+        }
+    }
 
     /*
      * @bug 4153072

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBITest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBITest.java
@@ -324,14 +324,14 @@ public class RBBITest extends CoreTestFmwk {
         rbbi.setText((CharacterIterator)null);
         if (rbbi.preceding(-1) != BreakIterator.DONE) {
             errln("RuleBasedBreakIterator.preceding(-1) was suppose to return "
-                    + "0 when the object has a fText of null.");
+                    + "DONE when the object has a fText of null.");
         }
 
         // Tests when "else if (offset < fText.getBeginIndex())" is true
         rbbi.setText("dummy");
-        if (rbbi.preceding(-1) != 0) {
+        if (rbbi.preceding(-1) != BreakIterator.DONE) {
             errln("RuleBasedBreakIterator.preceding(-1) was suppose to return "
-                    + "0 when the object has a fText of dummy.");
+                    + "DONE when the object has a fText of dummy.");
         }
     }
 


### PR DESCRIPTION
Make `BreakIterator.preceding()` return `DONE` when given a negative index for the input string. A negative index is already out of bounds and comes before the start of the string. The current behavior is to return 0, which doesn't make sense and is misleading. By contrast, the current behavior also returns 0 for an index of 1, which does make sense.

#### Checklist
- [X] Required: Issue filed: ICU-22987
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
