### PR TITLE
ICU-23124 Fix exception type in BreakIterator for OOB index values

### DIFF
--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/RuleBasedBreakIterator.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/RuleBasedBreakIterator.java
@@ -524,12 +524,12 @@ public class RuleBasedBreakIterator extends BreakIterator {
 
 
     /**
-     * Throw IllegalArgumentException unless begin &lt;= offset &lt; end.
+     * Throw IndexOutOfBoundsException unless begin &lt;= offset &lt; end.
      * @stable ICU 2.0
      */
     protected static final void checkOffset(int offset, CharacterIterator text) {
         if (offset < text.getBeginIndex() || offset > text.getEndIndex()) {
-            throw new IllegalArgumentException("offset out of bounds");
+            throw new IndexOutOfBoundsException("offset out of bounds");
         }
     }
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/BreakIteratorTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/BreakIteratorTest.java
@@ -128,7 +128,7 @@ public class BreakIteratorTest extends CoreTestFmwk
                     errln("Didn't get exception with offset = " + index +
                                     " and begin index = " + begin);
             }
-            catch (IllegalArgumentException e) {
+            catch (IndexOutOfBoundsException e) {
                 if (index >= begin)
                     errln("Got exception with offset = " + index +
                                     " and begin index = " + begin);


### PR DESCRIPTION
In `BreakIterator`, change `IllegalArgumentException` to `IndexOutOfBoundsException` when the index is out of bounds.

#### Checklist
- [X] Required: Issue filed: ICU-23124
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
