### PR TITLE
ICU-23128 Don't clobber UErrorCode on expected U_BUFFER_OVERFLOW_ERROR

### DIFF
--- a/icu4c/source/common/rbbisetb.cpp
+++ b/icu4c/source/common/rbbisetb.cpp
@@ -328,9 +328,10 @@ int32_t RBBISetBuilder::getTrieSize()  {
             UCPTRIE_TYPE_FAST,
             use8Bits ? UCPTRIE_VALUE_BITS_8 : UCPTRIE_VALUE_BITS_16,
             fStatus);
-        fTrieSize = ucptrie_toBinary(fTrie, nullptr, 0, fStatus);
-        if (*fStatus == U_BUFFER_OVERFLOW_ERROR) {
-            *fStatus = U_ZERO_ERROR;
+        UErrorCode bufferStatus = *fStatus;
+        fTrieSize = ucptrie_toBinary(fTrie, nullptr, 0, &bufferStatus);
+        if (bufferStatus != U_BUFFER_OVERFLOW_ERROR && U_FAILURE(bufferStatus)) {
+            *fStatus = bufferStatus;
         }
     }
     return fTrieSize;

--- a/icu4c/source/common/ucasemap.cpp
+++ b/icu4c/source/common/ucasemap.cpp
@@ -102,9 +102,9 @@ ucasemap_setLocale(UCaseMap *csm, const char *locale, UErrorCode *pErrorCode) {
         return;
     }
 
-    int32_t length=uloc_getName(locale, csm->locale, (int32_t)sizeof(csm->locale), pErrorCode);
-    if(*pErrorCode==U_BUFFER_OVERFLOW_ERROR || length==sizeof(csm->locale)) {
-        *pErrorCode=U_ZERO_ERROR;
+    UErrorCode bufferStatus = U_ZERO_ERROR;
+    int32_t length=uloc_getName(locale, csm->locale, (int32_t)sizeof(csm->locale), &bufferStatus);
+    if(bufferStatus==U_BUFFER_OVERFLOW_ERROR || length==sizeof(csm->locale)) {
         /* we only really need the language code for case mappings */
         length=uloc_getLanguage(locale, csm->locale, (int32_t)sizeof(csm->locale), pErrorCode);
     }

--- a/icu4c/source/common/ucnv.cpp
+++ b/icu4c/source/common/ucnv.cpp
@@ -1752,20 +1752,24 @@ ucnv_fromUChars(UConverter *cnv,
         destLimit=dest+destCapacity;
 
         /* perform the conversion */
-        ucnv_fromUnicode(cnv, &dest, destLimit, &src, srcLimit, nullptr, true, pErrorCode);
+        UErrorCode bufferStatus = U_ZERO_ERROR;
+        ucnv_fromUnicode(cnv, &dest, destLimit, &src, srcLimit, nullptr, true, &bufferStatus);
         destLength=(int32_t)(dest-originalDest);
 
         /* if an overflow occurs, then get the preflighting length */
-        if(*pErrorCode==U_BUFFER_OVERFLOW_ERROR) {
+        if(bufferStatus==U_BUFFER_OVERFLOW_ERROR) {
             char buffer[1024];
 
             destLimit=buffer+sizeof(buffer);
             do {
                 dest=buffer;
-                *pErrorCode=U_ZERO_ERROR;
-                ucnv_fromUnicode(cnv, &dest, destLimit, &src, srcLimit, nullptr, true, pErrorCode);
+                bufferStatus=U_ZERO_ERROR;
+                ucnv_fromUnicode(cnv, &dest, destLimit, &src, srcLimit, nullptr, true, &bufferStatus);
                 destLength+=(int32_t)(dest-buffer);
-            } while(*pErrorCode==U_BUFFER_OVERFLOW_ERROR);
+            } while(bufferStatus==U_BUFFER_OVERFLOW_ERROR);
+        }
+        if (U_FAILURE(bufferStatus)) {
+            *pErrorCode = bufferStatus;
         }
     } else {
         destLength=0;
@@ -1808,22 +1812,26 @@ ucnv_toUChars(UConverter *cnv,
         destLimit=dest+destCapacity;
 
         /* perform the conversion */
-        ucnv_toUnicode(cnv, &dest, destLimit, &src, srcLimit, nullptr, true, pErrorCode);
+        UErrorCode bufferStatus = U_ZERO_ERROR;
+        ucnv_toUnicode(cnv, &dest, destLimit, &src, srcLimit, nullptr, true, &bufferStatus);
         destLength=(int32_t)(dest-originalDest);
 
         /* if an overflow occurs, then get the preflighting length */
-        if(*pErrorCode==U_BUFFER_OVERFLOW_ERROR)
+        if(bufferStatus==U_BUFFER_OVERFLOW_ERROR)
         {
             char16_t buffer[1024];
 
             destLimit=buffer+UPRV_LENGTHOF(buffer);
             do {
                 dest=buffer;
-                *pErrorCode=U_ZERO_ERROR;
-                ucnv_toUnicode(cnv, &dest, destLimit, &src, srcLimit, nullptr, true, pErrorCode);
+                bufferStatus=U_ZERO_ERROR;
+                ucnv_toUnicode(cnv, &dest, destLimit, &src, srcLimit, nullptr, true, &bufferStatus);
                 destLength+=(int32_t)(dest-buffer);
             }
-            while(*pErrorCode==U_BUFFER_OVERFLOW_ERROR);
+            while(bufferStatus==U_BUFFER_OVERFLOW_ERROR);
+        }
+        if (U_FAILURE(bufferStatus)) {
+            *pErrorCode = bufferStatus;
         }
     } else {
         destLength=0;

--- a/icu4c/source/common/usprep.cpp
+++ b/icu4c/source/common/usprep.cpp
@@ -666,11 +666,12 @@ usprep_prepare(   const UStringPrepProfile* profile,
         *status = U_MEMORY_ALLOCATION_ERROR;
         return 0;
     }
+    UErrorCode bufferStatus = U_ZERO_ERROR;
     int32_t b1Len = usprep_map(profile, src, srcLength,
-                               b1, s1.getCapacity(), options, parseError, status);
-    s1.releaseBuffer(U_SUCCESS(*status) ? b1Len : 0);
+                               b1, s1.getCapacity(), options, parseError, &bufferStatus);
+    s1.releaseBuffer(U_SUCCESS(bufferStatus) ? b1Len : 0);
 
-    if(*status == U_BUFFER_OVERFLOW_ERROR){
+    if(bufferStatus == U_BUFFER_OVERFLOW_ERROR){
         // redo processing of string
         /* we do not have enough room so grow the buffer*/
         b1 = s1.getBuffer(b1Len);
@@ -679,12 +680,13 @@ usprep_prepare(   const UStringPrepProfile* profile,
             return 0;
         }
 
-        *status = U_ZERO_ERROR; // reset error
+        bufferStatus = U_ZERO_ERROR; // reset error
         b1Len = usprep_map(profile, src, srcLength,
-                           b1, s1.getCapacity(), options, parseError, status);
-        s1.releaseBuffer(U_SUCCESS(*status) ? b1Len : 0);
+                           b1, s1.getCapacity(), options, parseError, &bufferStatus);
+        s1.releaseBuffer(U_SUCCESS(bufferStatus) ? b1Len : 0);
     }
-    if(U_FAILURE(*status)){
+    if(U_FAILURE(bufferStatus)){
+        *status = bufferStatus;
         return 0;
     }
 

--- a/icu4c/source/common/uts46.cpp
+++ b/icu4c/source/common/uts46.cpp
@@ -872,11 +872,12 @@ UTS46::processLabel(UnicodeString &dest,
                 buffer[1]=0x6e;
                 buffer[2]=0x2d;
                 buffer[3]=0x2d;
+                UErrorCode punycodeErrorCode=U_ZERO_ERROR;
                 int32_t punycodeLength=u_strToPunycode(label, labelLength,
                                                       buffer+4, punycode.getCapacity()-4,
-                                                      nullptr, &errorCode);
-                if(errorCode==U_BUFFER_OVERFLOW_ERROR) {
-                    errorCode=U_ZERO_ERROR;
+                                                      nullptr, &punycodeErrorCode);
+                if(punycodeErrorCode==U_BUFFER_OVERFLOW_ERROR) {
+                    punycodeErrorCode=U_ZERO_ERROR;
                     punycode.releaseBuffer(4);
                     buffer=punycode.getBuffer(4+punycodeLength);
                     if(buffer==nullptr) {
@@ -885,11 +886,12 @@ UTS46::processLabel(UnicodeString &dest,
                     }
                     punycodeLength=u_strToPunycode(label, labelLength,
                                                   buffer+4, punycode.getCapacity()-4,
-                                                  nullptr, &errorCode);
+                                                  nullptr, &punycodeErrorCode);
                 }
                 punycodeLength+=4;
                 punycode.releaseBuffer(punycodeLength);
-                if(U_FAILURE(errorCode)) {
+                if(U_FAILURE(punycodeErrorCode)) {
+                    errorCode = punycodeErrorCode;
                     return destLabelLength;
                 }
                 if(punycodeLength>63) {

--- a/icu4c/source/extra/uconv/uwmsg.c
+++ b/icu4c/source/extra/uconv/uwmsg.c
@@ -46,6 +46,7 @@ uprint(const UChar *s,
     const UChar *mySourceEnd;
     char *myTarget;
     int32_t arraySize;
+    UErrorCode bufferStatus;
 
     if(s == 0) return;
 
@@ -54,6 +55,7 @@ uprint(const UChar *s,
     mySourceEnd  = mySource + sourceLen;
     myTarget     = buf;
     arraySize    = BUF_SIZE;
+    bufferStatus = U_ZERO_ERROR;
 
     /* open a default converter */
     converter = ucnv_open(0, status);
@@ -64,12 +66,12 @@ uprint(const UChar *s,
     /* perform the conversion */
     do {
         /* reset the error code */
-        *status = U_ZERO_ERROR;
+        bufferStatus = U_ZERO_ERROR;
 
         /* perform the conversion */
         ucnv_fromUnicode(converter, &myTarget,  myTarget + arraySize,
             &mySource, mySourceEnd, NULL,
-            true, status);
+            true, &bufferStatus);
 
         /* Write the converted data to the FILE* */
         fwrite(buf, sizeof(char), myTarget - buf, f);
@@ -78,7 +80,10 @@ uprint(const UChar *s,
         myTarget     = buf;
         arraySize    = BUF_SIZE;
     }
-    while(*status == U_BUFFER_OVERFLOW_ERROR); 
+    while(bufferStatus == U_BUFFER_OVERFLOW_ERROR);
+    if (U_FAILURE(bufferStatus)) {
+        *status = bufferStatus;
+    }
 
 finish:
 

--- a/icu4c/source/i18n/collationdatawriter.cpp
+++ b/icu4c/source/i18n/collationdatawriter.cpp
@@ -39,16 +39,20 @@ RuleBasedCollator::cloneRuleData(int32_t &length, UErrorCode &errorCode) const {
         errorCode = U_MEMORY_ALLOCATION_ERROR;
         return nullptr;
     }
-    length = cloneBinary(buffer.getAlias(), 20000, errorCode);
-    if(errorCode == U_BUFFER_OVERFLOW_ERROR) {
+    UErrorCode bufferStatus = U_ZERO_ERROR;
+    length = cloneBinary(buffer.getAlias(), 20000, bufferStatus);
+    if(bufferStatus == U_BUFFER_OVERFLOW_ERROR) {
         if(buffer.allocateInsteadAndCopy(length, 0) == nullptr) {
             errorCode = U_MEMORY_ALLOCATION_ERROR;
             return nullptr;
         }
-        errorCode = U_ZERO_ERROR;
-        length = cloneBinary(buffer.getAlias(), length, errorCode);
+        bufferStatus = U_ZERO_ERROR;
+        length = cloneBinary(buffer.getAlias(), length, bufferStatus);
     }
-    if(U_FAILURE(errorCode)) { return nullptr; }
+    if(U_FAILURE(bufferStatus)) {
+        errorCode = bufferStatus;
+        return nullptr;
+    }
     return buffer.orphan();
 }
 

--- a/icu4c/source/i18n/rematch.cpp
+++ b/icu4c/source/i18n/rematch.cpp
@@ -1218,12 +1218,15 @@ UnicodeString RegexMatcher::group(int32_t groupNum, UErrorCode &status) const {
 
     // Get the group length using a utext_extract preflight.
     //    UText is actually pretty efficient at this when underlying encoding is UTF-16.
-    int32_t length = utext_extract(fInputText, groupStart, groupEnd, nullptr, 0, &status);
-    if (status != U_BUFFER_OVERFLOW_ERROR) {
+    UErrorCode bufferStatus = U_ZERO_ERROR;
+    int32_t length = utext_extract(fInputText, groupStart, groupEnd, nullptr, 0, &bufferStatus);
+    if (bufferStatus != U_BUFFER_OVERFLOW_ERROR) {
+        if (U_FAILURE(bufferStatus)) {
+            status = bufferStatus;
+        }
         return result;
     }
 
-    status = U_ZERO_ERROR;
     char16_t *buf = result.getBuffer(length);
     if (buf == nullptr) {
         status = U_MEMORY_ALLOCATION_ERROR;
@@ -1995,11 +1998,12 @@ static UText *utext_extract_replace(UText *src, UText *dest, int64_t start, int6
             return utext_openUChars(nullptr, nullptr, 0, status);
         }
     }
-    int32_t length = utext_extract(src, start, limit, nullptr, 0, status);
-    if (*status != U_BUFFER_OVERFLOW_ERROR && U_FAILURE(*status)) {
+    UErrorCode bufferStatus = U_ZERO_ERROR;
+    int32_t length = utext_extract(src, start, limit, nullptr, 0, &bufferStatus);
+    if (bufferStatus != U_BUFFER_OVERFLOW_ERROR && U_FAILURE(bufferStatus)) {
+        *status = bufferStatus;
         return dest;
     }
-    *status = U_ZERO_ERROR;
     MaybeStackArray<char16_t, 40> buffer;
     if (length >= buffer.getCapacity()) {
         char16_t *newBuf = buffer.resize(length+1);   // Leave space for terminating Nul.

--- a/icu4c/source/i18n/uspoof_conf.cpp
+++ b/icu4c/source/i18n/uspoof_conf.cpp
@@ -232,11 +232,14 @@ void ConfusabledataBuilder::build(const char * confusables, int32_t confusablesL
     if (U_FAILURE(status)) {
         return;
     }
-    u_strFromUTF8(nullptr, 0, &inputLen, confusables, confusablesLen, &status);
-    if (status != U_BUFFER_OVERFLOW_ERROR) {
+    UErrorCode bufferStatus = U_ZERO_ERROR;
+    u_strFromUTF8(nullptr, 0, &inputLen, confusables, confusablesLen, &bufferStatus);
+    if (bufferStatus != U_BUFFER_OVERFLOW_ERROR) {
+        if (U_FAILURE(bufferStatus)) {
+            status = bufferStatus;
+        }
         return;
     }
-    status = U_ZERO_ERROR;
     fInput = static_cast<char16_t *>(uprv_malloc((inputLen+1) * sizeof(char16_t)));
     if (fInput == nullptr) {
         status = U_MEMORY_ALLOCATION_ERROR;

--- a/icu4c/source/tools/ctestfw/uperf.cpp
+++ b/icu4c/source/tools/ctestfw/uperf.cpp
@@ -189,16 +189,20 @@ void UPerfTest::init(UOption addOptions[], int32_t addOptionsCount,
     int32_t len = 0;
     if(fileName!=nullptr){
         //pre-flight
-        ucbuf_resolveFileName(sourceDir, fileName, nullptr, &len, &status);
+        UErrorCode bufferStatus = U_ZERO_ERROR;
+        ucbuf_resolveFileName(sourceDir, fileName, nullptr, &len, &bufferStatus);
         resolvedFileName = static_cast<char*>(uprv_malloc(len));
         if(resolvedFileName==nullptr){
             status= U_MEMORY_ALLOCATION_ERROR;
             return;
         }
-        if(status == U_BUFFER_OVERFLOW_ERROR){
-            status = U_ZERO_ERROR;
+        if(bufferStatus == U_BUFFER_OVERFLOW_ERROR){
+            bufferStatus = U_ZERO_ERROR;
         }
-        ucbuf_resolveFileName(sourceDir, fileName, resolvedFileName, &len, &status);
+        ucbuf_resolveFileName(sourceDir, fileName, resolvedFileName, &len, &bufferStatus);
+        if (U_FAILURE(bufferStatus)) {
+            status = bufferStatus;
+        }
         ucharBuf = ucbuf_open(resolvedFileName,&encoding,true,false,&status);
 
         if(U_FAILURE(status)){


### PR DESCRIPTION
When it's expected that a function call might result in setting `U_BUFFER_OVERFLOW_ERROR` upon which a new buffer is allocated and the function call is retried, this should upon success not overwrite any already set value of `UErrorCode`, as this could accidentally overwrite some valid and meaningful value when this was other than `U_ZERO_ERROR`.

#### Checklist
- [X] Required: Issue filed: ICU-23128
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
