### PR TITLE
ICU-22763 MF2: Bump API version number for DateInfo struct

### DIFF
--- a/icu4c/source/i18n/unicode/messageformat2_formattable.h
+++ b/icu4c/source/i18n/unicode/messageformat2_formattable.h
@@ -72,14 +72,14 @@ namespace message2 {
      * format a date with a time zone. It includes an absolute date and a time zone name,
      * as well as a calendar name. The calendar name is not currently used.
      *
-     * @internal ICU 76 technology preview
+     * @internal ICU 78 technology preview
      * @deprecated This API is for technology preview only.
      */
     struct U_I18N_API DateInfo {
         /**
          * Date in UTC
          *
-         * @internal ICU 76 technology preview
+         * @internal ICU 78 technology preview
          * @deprecated This API is for technology preview only.
          */
         UDate date;
@@ -89,7 +89,7 @@ namespace message2 {
          * (its offset is added to/subtracted from the datestamp in order to
          * produce the formatted date).
          *
-         * @internal ICU 76 technology preview
+         * @internal ICU 78 technology preview
          * @deprecated This API is for technology preview only.
          */
         UnicodeString zoneId;


### PR DESCRIPTION
After landing https://github.com/unicode-org/icu/pull/3012 , I realized I'd forgotten to bump the version number in the newly added struct.

#### Checklist
- [ ] Required: Issue filed: ICU-22763 
- [ ] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
