### PR TITLE
ICU-23054 Make the MSVC stdcpplatest build work as intended

### DIFF
--- a/.github/workflows/icu4c.yml
+++ b/.github/workflows/icu4c.yml
@@ -376,10 +376,10 @@ jobs:
             build_flags: '/p:Configuration=Debug /p:Platform=Win32'
           - test_flags: 'arm Release'
             build_flags: '/p:Configuration=Release /p:Platform=ARM'
+          - test_flags: 'x64 Release cpplatest'
+            build_flags: '/p:OverrideLanguageStandard=stdcpplatest /p:Configuration=Release /p:Platform=x64'
           - test_flags: 'x64 Release'
-            build_flags: '/p:LanguageStandard=stdcpplatest /p:Configuration=Release /p:Platform=x64'
-          - test_flags: 'x64 Release'
-            build_flags: '/p:_HAS_EXCEPTIONS=0 /p:Configuration=Release /p:Platform=x64'
+            build_flags: '/p:Configuration=Release /p:Platform=x64'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set up MSBuild

--- a/icu4c/source/allinone/Build.Windows.ProjectConfiguration.props
+++ b/icu4c/source/allinone/Build.Windows.ProjectConfiguration.props
@@ -97,7 +97,8 @@
       <!-- Enable parallel compilation for faster builds. -->
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <!-- Set the C/C++ versions supported. -->
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard Condition="'$(OverrideLanguageStandard)'==''">stdcpp17</LanguageStandard>
+      <LanguageStandard Condition="'$(OverrideLanguageStandard)'!=''">$(OverrideLanguageStandard)</LanguageStandard>
       <LanguageStandard_C>stdc11</LanguageStandard_C>
     </ClCompile>
     <ResourceCompile>

--- a/icu4c/source/allinone/Build.Windows.UWP.ProjectConfiguration.props
+++ b/icu4c/source/allinone/Build.Windows.UWP.ProjectConfiguration.props
@@ -46,7 +46,8 @@
         U_PLATFORM_HAS_WINUWP_API=1;
       </PreprocessorDefinitions>
       <!-- Set the C/C++ versions supported. -->
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard Condition="'$(OverrideLanguageStandard)'==''">stdcpp17</LanguageStandard>
+      <LanguageStandard Condition="'$(OverrideLanguageStandard)'!=''">$(OverrideLanguageStandard)</LanguageStandard>
       <LanguageStandard_C>stdc11</LanguageStandard_C>
     </ClCompile>
     <ResourceCompile>


### PR DESCRIPTION
LanguageStandard is not a property, so setting a property by that name via /p doesn’t actually do anything: the stdcpplatest build is currently C++17.

Note that we want an stdcpplatest build, as that is currently C++23 (preview), and we are using some C++23 features (if available) in #3499.

See also discussion in ICU-TC [2025-06-05](https://docs.google.com/document/d/11yJUWedBIpmq-YNSqqDfgUxcREmlvV0NskYganXkQHA/edit?tab=t.0#heading=h.hqdumez95ye3).

#### Checklist
- [x] Required: Issue filed: ICU-23054
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
