### PR TITLE
package.cpp: fix ILP32 build with -Wformat.

### DIFF
--- a/icu4c/source/tools/toolutil/package.cpp
+++ b/icu4c/source/tools/toolutil/package.cpp
@@ -1289,7 +1289,7 @@ void Package::setItemCapacity(int32_t max)
   Item* newItems = static_cast<Item*>(uprv_malloc(max * sizeof(items[0])));
   Item *oldItems = items;
   if(newItems == nullptr) {
-    fprintf(stderr, "icupkg: Out of memory trying to allocate %lu bytes for %d items\n",
+    fprintf(stderr, "icupkg: Out of memory trying to allocate %zu bytes for %d items\n",
         max * sizeof(items[0]), max);
     exit(U_MEMORY_ALLOCATION_ERROR);
   }


### PR DESCRIPTION
Android uses -Wformat, and although %lu works on LP64 where size_t is unsigned long, on ILP32 where size_t is unsigned int it fails with "format specifies type 'unsigned long' but the argument has type 'unsigned int'".

The fix is to just use %zu, which is the specifier for size_t.