### PR TITLE
ICU-23142 Fix tiny header guarder in `icu4c/source/i18n/regexcxt.h`

### DIFF
--- a/icu4c/source/i18n/regexcmp.h
+++ b/icu4c/source/i18n/regexcmp.h
@@ -13,8 +13,8 @@
 //
 
 
-#ifndef RBBISCAN_H
-#define RBBISCAN_H
+#ifndef REGEXCMP_H
+#define REGEXCMP_H
 
 #include "unicode/utypes.h"
 #if !UCONFIG_NO_REGULAR_EXPRESSIONS

--- a/icu4c/source/i18n/regexcst.h
+++ b/icu4c/source/i18n/regexcst.h
@@ -11,8 +11,8 @@
 //   and others. All rights reserved.  
 //
 //---------------------------------------------------------------------------------
-#ifndef RBBIRPT_H
-#define RBBIRPT_H
+#ifndef REGEXCST_H
+#define REGEXCST_H
 
 #include "unicode/utypes.h"
 

--- a/icu4c/source/i18n/regexcst.pl
+++ b/icu4c/source/i18n/regexcst.pl
@@ -214,8 +214,8 @@ print "//   Copyright (C) 2002-2016 International Business Machines Corporation 
 print "//   and others. All rights reserved.  \n";
 print "//\n";
 print "//---------------------------------------------------------------------------------\n";
-print "#ifndef RBBIRPT_H\n";
-print "#define RBBIRPT_H\n";
+print "#ifndef REGEXCST_H\n";
+print "#define REGEXCST_H\n";
 print "\n";
 print "#include \"unicode/utypes.h\"\n";
 print "\n";


### PR DESCRIPTION
Header `icu4c/source/i18n/regexcxt.h` is wrongly guarded by [`RBBIRPT_H`](https://github.com/unicode-org/icu/blob/main/icu4c/source/i18n/regexcst.h#L14). I made it a tiny change to `REGEXCST_H`. 

Recently I'm trying to build `icu` into a [`C++20 module`](https://cppreference.com/w/cpp/language/modules.html), and we need a correct guardian in order to build across multiple module partitions. **Thank you!**

*This is an amazing library an I will star it.*