### PR TITLE
ICU-23151 Fix building on Windows using msbuild with clang-cl.

### DIFF
--- a/icu4c/source/common/common.vcxproj
+++ b/icu4c/source/common/common.vcxproj
@@ -53,7 +53,6 @@
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
       <PreprocessorDefinitions>RBBI_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/data/makedata.mak
+++ b/icu4c/source/data/makedata.mak
@@ -243,6 +243,9 @@ COMMON_ICUDATA_ARGUMENTS=$(COMMON_ICUDATA_ARGUMENTS) -u
 !IF "$(CFG)" == "x64\Release" || "$(CFG)" == "x64\Debug"
 COMMON_ICUDATA_ARGUMENTS=$(COMMON_ICUDATA_ARGUMENTS) -a X64
 !ENDIF
+!IF "$(CFG)" == "Release" || "$(CFG)" == "release" || "$(CFG)" == "Debug" || "$(CFG)" == "debug" || "$(CFG)" == "x86\Release" || "$(CFG)" == "x86\Debug"
+COMMON_ICUDATA_ARGUMENTS=$(COMMON_ICUDATA_ARGUMENTS) -a X86
+!ENDIF
 !IF "$(CFG)" == "ARM\Release" || "$(CFG)" == "ARM\Debug"
 COMMON_ICUDATA_ARGUMENTS=$(COMMON_ICUDATA_ARGUMENTS) -a ARM
 !ENDIF

--- a/icu4c/source/extra/uconv/makedata.mak
+++ b/icu4c/source/extra/uconv/makedata.mak
@@ -80,6 +80,12 @@ PATH = $(ICUP)\binARM64;$(PATH)
 
 # If building ARM/ARM, then we need to pass the arch as an argument.
 EXTRA_PKGDATA_ARGUMENTS=
+!IF "$(CFG)" == "x64\Release" || "$(CFG)" == "x64\Debug"
+EXTRA_PKGDATA_ARGUMENTS=-a X64
+!ENDIF
+!IF "$(CFG)" == "Release" || "$(CFG)" == "release" || "$(CFG)" == "Debug" || "$(CFG)" == "debug" || "$(CFG)" == "x86\Release" || "$(CFG)" == "x86\Debug"
+EXTRA_PKGDATA_ARGUMENTS=-a X86
+!ENDIF
 !IF "$(CFG)" == "ARM\Release" || "$(CFG)" == "ARM\Debug"
 EXTRA_PKGDATA_ARGUMENTS=-a ARM
 !ENDIF

--- a/icu4c/source/extra/uconv/uconv.vcxproj
+++ b/icu4c/source/extra/uconv/uconv.vcxproj
@@ -57,7 +57,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/i18n/i18n.vcxproj
+++ b/icu4c/source/i18n/i18n.vcxproj
@@ -54,7 +54,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/io/io.vcxproj
+++ b/icu4c/source/io/io.vcxproj
@@ -54,7 +54,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/layoutex/layoutex.vcxproj
+++ b/icu4c/source/layoutex/layoutex.vcxproj
@@ -72,7 +72,6 @@
       <AssemblerListingLocation>.\x86\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x86\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x86\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
     </ClCompile>
@@ -118,7 +117,6 @@
       <AssemblerListingLocation>.\x64\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x64\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x64\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
     </ClCompile>

--- a/icu4c/source/samples/coll/coll.vcxproj
+++ b/icu4c/source/samples/coll/coll.vcxproj
@@ -99,7 +99,6 @@
       <AssemblerListingLocation>.\x86\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x86\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x86\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -130,7 +129,6 @@
       <AssemblerListingLocation>.\x64\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x64\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x64\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>

--- a/icu4c/source/samples/strsrch/strsrch.vcxproj
+++ b/icu4c/source/samples/strsrch/strsrch.vcxproj
@@ -44,7 +44,6 @@
       <AssemblerListingLocation>.\x86\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x86\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x86\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
@@ -74,7 +73,6 @@
       <AssemblerListingLocation>.\x64\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x64\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x64\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>

--- a/icu4c/source/test/cintltst/cintltst.vcxproj
+++ b/icu4c/source/test/cintltst/cintltst.vcxproj
@@ -50,7 +50,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/test/intltest/intltest.vcxproj
+++ b/icu4c/source/test/intltest/intltest.vcxproj
@@ -51,7 +51,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/test/iotest/iotest.vcxproj
+++ b/icu4c/source/test/iotest/iotest.vcxproj
@@ -50,7 +50,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/test/perf/charperf/charperf.vcxproj
+++ b/icu4c/source/test/perf/charperf/charperf.vcxproj
@@ -81,7 +81,6 @@
       <AssemblerListingLocation>.\x86\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x86\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x86\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -122,7 +121,6 @@
       <AssemblerListingLocation>.\x64\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x64\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x64\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>

--- a/icu4c/source/test/perf/collperf/collperf.vcxproj
+++ b/icu4c/source/test/perf/collperf/collperf.vcxproj
@@ -79,7 +79,6 @@
       <AssemblerListingLocation>.\x86\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x86\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x86\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -118,7 +117,6 @@
       <AssemblerListingLocation>.\x64\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x64\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x64\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>

--- a/icu4c/source/test/perf/collperf2/collperf2.vcxproj
+++ b/icu4c/source/test/perf/collperf2/collperf2.vcxproj
@@ -79,7 +79,6 @@
       <AssemblerListingLocation>.\x86\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x86\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x86\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -118,7 +117,6 @@
       <AssemblerListingLocation>.\x64\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x64\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x64\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>

--- a/icu4c/source/test/perf/convperf/convperf.vcxproj
+++ b/icu4c/source/test/perf/convperf/convperf.vcxproj
@@ -162,7 +162,6 @@
       <AssemblerListingLocation>.\x86\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x86\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x86\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -203,7 +202,6 @@
       <AssemblerListingLocation>.\x64\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x64\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x64\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>

--- a/icu4c/source/test/perf/normperf/dtfmtrtperf.vcxproj
+++ b/icu4c/source/test/perf/normperf/dtfmtrtperf.vcxproj
@@ -84,7 +84,6 @@
       <AssemblerListingLocation>.\x86\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x86\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x86\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -167,7 +166,6 @@
       <AssemblerListingLocation>.\x64\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x64\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x64\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>

--- a/icu4c/source/test/perf/normperf/normperf.vcxproj
+++ b/icu4c/source/test/perf/normperf/normperf.vcxproj
@@ -81,7 +81,6 @@
       <AssemblerListingLocation>.\x86\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x86\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x86\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -122,7 +121,6 @@
       <AssemblerListingLocation>.\x64\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x64\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x64\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>

--- a/icu4c/source/test/perf/strsrchperf/strsrchperf.vcxproj
+++ b/icu4c/source/test/perf/strsrchperf/strsrchperf.vcxproj
@@ -81,7 +81,6 @@
       <AssemblerListingLocation>.\x86\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x86\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x86\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -122,7 +121,6 @@
       <AssemblerListingLocation>.\x64\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x64\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x64\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>

--- a/icu4c/source/test/perf/ubrkperf/ubrkperf.vcxproj
+++ b/icu4c/source/test/perf/ubrkperf/ubrkperf.vcxproj
@@ -79,7 +79,6 @@
       <AssemblerListingLocation>.\x86\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x86\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x86\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -156,7 +155,6 @@
       <AssemblerListingLocation>.\x64\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x64\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x64\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>

--- a/icu4c/source/test/perf/ustrperf/stringperf.vcxproj
+++ b/icu4c/source/test/perf/ustrperf/stringperf.vcxproj
@@ -162,7 +162,6 @@
       <AssemblerListingLocation>.\x86\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x86\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x86\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -203,7 +202,6 @@
       <AssemblerListingLocation>.\x64\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x64\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x64\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>

--- a/icu4c/source/tools/ctestfw/ctestfw.vcxproj
+++ b/icu4c/source/tools/ctestfw/ctestfw.vcxproj
@@ -48,7 +48,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/tools/genbrk/genbrk.vcxproj
+++ b/icu4c/source/tools/genbrk/genbrk.vcxproj
@@ -53,7 +53,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/tools/genccode/genccode.vcxproj
+++ b/icu4c/source/tools/genccode/genccode.vcxproj
@@ -53,7 +53,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/tools/gencfu/gencfu.vcxproj
+++ b/icu4c/source/tools/gencfu/gencfu.vcxproj
@@ -53,7 +53,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/tools/gencmn/gencmn.vcxproj
+++ b/icu4c/source/tools/gencmn/gencmn.vcxproj
@@ -53,7 +53,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/tools/gencnval/gencnval.vcxproj
+++ b/icu4c/source/tools/gencnval/gencnval.vcxproj
@@ -53,7 +53,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/tools/gendict/gendict.vcxproj
+++ b/icu4c/source/tools/gendict/gendict.vcxproj
@@ -53,7 +53,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/tools/gennorm2/gennorm2.vcxproj
+++ b/icu4c/source/tools/gennorm2/gennorm2.vcxproj
@@ -68,7 +68,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/tools/genrb/derb.vcxproj
+++ b/icu4c/source/tools/genrb/derb.vcxproj
@@ -53,7 +53,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/tools/genrb/genrb.vcxproj
+++ b/icu4c/source/tools/genrb/genrb.vcxproj
@@ -53,7 +53,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/tools/gensprep/gensprep.vcxproj
+++ b/icu4c/source/tools/gensprep/gensprep.vcxproj
@@ -53,7 +53,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/tools/gentest/gentest.vcxproj
+++ b/icu4c/source/tools/gentest/gentest.vcxproj
@@ -51,7 +51,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/tools/icuexportdata/icuexportdata.vcxproj
+++ b/icu4c/source/tools/icuexportdata/icuexportdata.vcxproj
@@ -53,7 +53,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/tools/icuinfo/icuinfo.vcxproj
+++ b/icu4c/source/tools/icuinfo/icuinfo.vcxproj
@@ -53,7 +53,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/tools/icuinfo/testplug.vcxproj
+++ b/icu4c/source/tools/icuinfo/testplug.vcxproj
@@ -49,7 +49,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/tools/icupkg/icupkg.vcxproj
+++ b/icu4c/source/tools/icupkg/icupkg.vcxproj
@@ -53,7 +53,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/tools/icuswap/icuswap.vcxproj
+++ b/icu4c/source/tools/icuswap/icuswap.vcxproj
@@ -118,7 +118,6 @@
       <AssemblerListingLocation>.\x86\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x86\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x86\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level4</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -193,7 +192,6 @@
       <AssemblerListingLocation>.\x64\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x64\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x64\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level4</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>

--- a/icu4c/source/tools/makeconv/makeconv.vcxproj
+++ b/icu4c/source/tools/makeconv/makeconv.vcxproj
@@ -53,7 +53,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/tools/pkgdata/pkgdata.cpp
+++ b/icu4c/source/tools/pkgdata/pkgdata.cpp
@@ -476,6 +476,10 @@ main(int argc, char* argv[]) {
         fprintf(stdout, "Note: Ignoring option -b (windows-dynamicbase).\n");
     }
 
+    if (options[WIN_DLL_ARCH].doesOccur) {
+        o.cpuArch = options[WIN_DLL_ARCH].value;
+    }
+
     /* OK options are set up. Now the file lists. */
     tail = nullptr;
     for( n=1; n<argc; n++) {
@@ -775,7 +779,7 @@ static int32_t pkg_executeOptions(UPKGOptions *o) {
                         o->tmpDir,
                         o->entryName,
                         (optMatchArch[0] == 0 ? nullptr : optMatchArch),
-                        nullptr,
+                        o->cpuArch,
                         nullptr,
                         gencFilePath,
                         sizeof(gencFilePath),

--- a/icu4c/source/tools/pkgdata/pkgdata.vcxproj
+++ b/icu4c/source/tools/pkgdata/pkgdata.vcxproj
@@ -53,7 +53,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/icu4c/source/tools/pkgdata/pkgtypes.h
+++ b/icu4c/source/tools/pkgdata/pkgtypes.h
@@ -124,6 +124,7 @@ typedef struct UPKGOptions_
   const char *install;     /* Where to install to (nullptr = don't install) */
   const char *icuroot;     /* where does ICU lives */
   const char *libName;     /* name for library (default: shortName) */
+  const char* cpuArch;     /* CPU Architecture for Clang-CL on Windows. See genccode.c --cpu-arch */
   UBool      rebuild;
   UBool      verbose;
   UBool      quiet;

--- a/icu4c/source/tools/toolutil/pkg_genc.cpp
+++ b/icu4c/source/tools/toolutil/pkg_genc.cpp
@@ -299,7 +299,8 @@ checkAssemblyHeaderName(const char* optAssembly) {
 
 U_CAPI UBool U_EXPORT2
 checkCpuArchitecture(const char* optCpuArch) {
-    return strcmp(optCpuArch, "x64") == 0 || strcmp(optCpuArch, "x86") == 0 || strcmp(optCpuArch, "arm64") == 0;
+    return strcmp(optCpuArch, "x64") == 0 || strcmp(optCpuArch, "x86") == 0 || strcmp(optCpuArch, "arm64") == 0 || strcmp(optCpuArch, "arm") == 0
+        || strcmp(optCpuArch, "X64") == 0 || strcmp(optCpuArch, "X86") == 0 || strcmp(optCpuArch, "ARM64") == 0 || strcmp(optCpuArch, "ARM") == 0;
 }
 
 
@@ -867,12 +868,17 @@ getArchitecture(
         // would most likely be ran on host machine to generate the .obj file for
         // the target architecture.
 #       if defined(__clang__)
-            if (strcmp(optCpuArch, "x64") == 0) {
+            if (!optCpuArch) {
+                fprintf(stderr, "genccode: CPU architecture must be set for Clang-CL\n");
+                exit(U_ILLEGAL_ARGUMENT_ERROR);
+            } if (strcmp(optCpuArch, "x64") == 0 || strcmp(optCpuArch, "X64") == 0) {
                 *pCPU = IMAGE_FILE_MACHINE_AMD64;
-            } else if (strcmp(optCpuArch, "x86") == 0) {
+            } else if (strcmp(optCpuArch, "x86") == 0 || strcmp(optCpuArch, "X86") == 0) {
                 *pCPU = IMAGE_FILE_MACHINE_I386;
-            } else if (strcmp(optCpuArch, "arm64") == 0) {
+            } else if (strcmp(optCpuArch, "arm64") == 0 || strcmp(optCpuArch, "ARM64") == 0) {
                 *pCPU = IMAGE_FILE_MACHINE_ARM64;
+            } else if (strcmp(optCpuArch, "arm") == 0 || strcmp(optCpuArch, "ARM") == 0) {
+                *pCPU = IMAGE_FILE_MACHINE_ARM;
             } else {
                 std::terminate(); // Unreachable.
             }

--- a/icu4c/source/tools/toolutil/toolutil.vcxproj
+++ b/icu4c/source/tools/toolutil/toolutil.vcxproj
@@ -38,7 +38,6 @@
   <!-- Options that are common to all 'Debug' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <BrowseInformation>true</BrowseInformation>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>

--- a/icu4c/source/tools/tzcode/icuzdump.vcxproj
+++ b/icu4c/source/tools/tzcode/icuzdump.vcxproj
@@ -64,7 +64,6 @@
       <AssemblerListingLocation>.\x86\Debug/</AssemblerListingLocation>
       <ObjectFileName>.\x86\Debug/</ObjectFileName>
       <ProgramDataBaseFileName>.\x86\Debug/</ProgramDataBaseFileName>
-      <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <CompileAs>Default</CompileAs>


### PR DESCRIPTION
When building the latest release 77.1 on Windows from the command line I encountered two issues when using Clang-CL as a compiler (cl compiled fine). I have described them in the ticket, but to reiterate the first is a failure to generate sbr files in debug builds and the second is nullptr passed to strcmp when building data in x64 builds. 

For the sbr files, I have removed browse information from the solution. If this is not an acceptable solution I am happy to revisit it, but my understanding is browse information isn't needed anymore per reading this documentation https://learn.microsoft.com/en-us/cpp/build/reference/creating-an-dot-sbr-file and the option could be fairly safely removed.

The second issue I fixed by piggy backing on the existing dll architecture option. This appears to currently specify an architecture for a building a data file instead of letting the system auto-detect it and seemed harmless to always perform. I Updated the code to store off this architecture, and pass it through to writeObjectCode allowing Clang-CL builds to generate the appropriate data file. I updated the data generation code to handle ARM in addition since that option was missing and couldn't be worse than the previous undefined behavior, and preserved support for lowercase options used by --cpu-arch with genccode. I did not add a new option as -c was already used, and having two different ways to specify the architecture seemed more bug prone, but I am open to suggestions.

I compiled the project using the 8 variants of: Win32/x64, Debug/Release, and MSVC/Clang-CL as well as ran the tests for all these configurations which passed. I also compiled all 8 of these variants to ensure Win32 Release Clang-CL as well as all 4 MSVC configurations passed without the change, while the other 3 Clang-CL variants which failed to build.

I was not able to test ARM / ARM64 though invocations of the tool did not change in the makedata.mak scripts for these platforms. My reason for adding the ARM variant is it can't be worse than the previous code here which if reached would have had the same issue with strcmp.

#### Checklist
- [x] Required: Issue filed: ICU-23151
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
