### PR TITLE
ICU-23004 utfiterator.h include <range>

### DIFF
--- a/icu4c/source/common/unicode/utfiterator.h
+++ b/icu4c/source/common/unicode/utfiterator.h
@@ -12,6 +12,9 @@
 #if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API || !defined(UTYPES_H)
 
 #include <iterator>
+#if defined(__cpp_lib_ranges)
+#include <ranges>
+#endif
 #include <string>
 #include <string_view>
 #include <type_traits>


### PR DESCRIPTION
When the compiler supports C++20 ranges, we use them, so utfiterator.h needs to include the `<range>` standard header file. Follow-up to PR #3499.

I am using the same condition here as in utfiteratortest.cpp.

Found by @AnonymousPC, see https://github.com/unicode-org/icu/pull/3499#issuecomment-3021847302

#### Checklist
- [x] Required: Issue filed: ICU-23004
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
