### PR TITLE
ICU-23156 Implement `icupkg --keep` option

### DIFF
--- a/icu4c/source/tools/toolutil/package.h
+++ b/icu4c/source/tools/toolutil/package.h
@@ -53,6 +53,8 @@ public:
     /* Destructor. */
     ~Package();
 
+    void clear();
+
     /**
      * Uses the prefix of the first entry of the package in readPackage(),
      * rather than the package basename.
@@ -123,6 +125,8 @@ public:
 
     /* This variant extracts an item to a specific filename. */
     void extractItem(const char *filesPath, const char *outName, int32_t itemIndex, char outType);
+
+    void keepItems(const Package &listPkg);
 
     int32_t getItemCount() const;
     const Item *getItem(int32_t idx) const;


### PR DESCRIPTION
The `icupkg --keep` option allows users to only keep a certain subset of data items within the data file, and discard the rest. This is to support the workflow of:

1. Profiling the data items accessed via `utrace`
2. Only keeping the relevant items in the data file

This is a workflow that I would find personally helpful in my work to downsize the `icudt.dat` that I'm currently working on.

#### Checklist
- [x] Required: Issue filed: ICU-NNNNN
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
