### PR TITLE
ICU-23054 Fix all 'JdkObsolete' errorprone issues

### DIFF
--- a/icu4j/demos/src/main/java/com/ibm/icu/dev/demo/calendar/CalendarPanel.java
+++ b/icu4j/demos/src/main/java/com/ibm/icu/dev/demo/calendar/CalendarPanel.java
@@ -286,7 +286,7 @@ class CalendarPanel extends Canvas {
         c.setTime(fStartOfMonth);
         c.add(Calendar.DATE, -cell);
 
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder buffer = new StringBuilder();
 
         for (int row = 0; row < numWeeks; row++) {
             for (int col = 0; col < daysInWeek; col++) {

--- a/icu4j/demos/src/main/java/com/ibm/icu/dev/demo/charsetdet/DetectingViewer.java
+++ b/icu4j/demos/src/main/java/com/ibm/icu/dev/demo/charsetdet/DetectingViewer.java
@@ -300,7 +300,7 @@ public class DetectingViewer extends JFrame implements ActionListener
         }
         
         try {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             String encoding = matches[0].getName();
             
             inputStream.reset();

--- a/icu4j/demos/src/main/java/com/ibm/icu/dev/demo/holiday/HolidayBorderPanel.java
+++ b/icu4j/demos/src/main/java/com/ibm/icu/dev/demo/holiday/HolidayBorderPanel.java
@@ -499,7 +499,7 @@ public class HolidayBorderPanel extends Panel {
      * Returns the settings of this HolidayBorderPanel instance as a string.
      */
     public String toString() {
-        StringBuffer str = new StringBuffer("HolidayBorderPanel[");
+        StringBuilder str = new StringBuilder("HolidayBorderPanel[");
 
         // style
         str.append("style=");

--- a/icu4j/demos/src/main/java/com/ibm/icu/dev/demo/holiday/HolidayCalendarDemo.java
+++ b/icu4j/demos/src/main/java/com/ibm/icu/dev/demo/holiday/HolidayCalendarDemo.java
@@ -32,9 +32,9 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.WindowEvent;
 import java.text.DateFormatSymbols;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.Locale;
-import java.util.Vector;
 
 import com.ibm.icu.dev.demo.impl.DemoApplet;
 import com.ibm.icu.dev.demo.impl.DemoTextBox;
@@ -541,7 +541,7 @@ public class HolidayCalendarDemo extends DemoApplet
 
             // Remember which holidays fall on which days in this month,
             // to save the trouble of having to do it later
-            fHolidays.setSize(0);
+            fHolidays.clear();
 
             for (int h = 0; h < fAllHolidays.length; h++)
             {
@@ -553,7 +553,7 @@ public class HolidayCalendarDemo extends DemoApplet
                                 "  #" + h + "/"+fAllHolidays.length+": " + d +" is after end of month " + endOfMonth);
                     }
                     c.setTime(d);
-                    fHolidays.addElement( new HolidayInfo(c.get(Calendar.DATE),
+                    fHolidays.add(new HolidayInfo(c.get(Calendar.DATE),
                                             fAllHolidays[h],
                                             fAllHolidays[h].getDisplayName(fDisplayLocale) ));
 
@@ -668,7 +668,7 @@ public class HolidayCalendarDemo extends DemoApplet
                 int x = (int)((cellPos.x + 1) * cellWidth);
                 int y = (int)(cellPos.y * cellHeight + labelHeight);
 
-                StringBuffer buffer = new StringBuffer();
+                StringBuilder buffer = new StringBuilder();
                 buffer.append(i);
                 String dayNum = buffer.toString();
 
@@ -685,7 +685,7 @@ public class HolidayCalendarDemo extends DemoApplet
                 y = (int)((cellPos.y+1) * cellHeight) + labelHeight;
 
                 while (h < fHolidays.size() &&
-                        (info = (HolidayInfo)fHolidays.elementAt(h)).date <= i)
+                        (info = fHolidays.get(h)).date <= i)
                 {
                     if (info.date == i) {
                         // Draw the holiday here.
@@ -720,7 +720,7 @@ public class HolidayCalendarDemo extends DemoApplet
         private transient int firstDayInMonth;  // Day of week of first day in month
 
         private transient Holiday[] fAllHolidays;
-        private transient Vector    fHolidays = new Vector(5,5);
+        private transient ArrayList<HolidayInfo> fHolidays = new ArrayList<>(5);
 
         private transient boolean dirty = true;
     }

--- a/icu4j/main/charset/src/test/java/com/ibm/icu/dev/test/charset/TestConversion.java
+++ b/icu4j/main/charset/src/test/java/com/ibm/icu/dev/test/charset/TestConversion.java
@@ -947,7 +947,7 @@ public class TestConversion extends TestFmwk {
                     //are there items that must be in unicodeset but are not?
                     (diffset = mapset).removeAll(unicodeset);
                     if(!diffset.isEmpty()){
-                        StringBuffer s = new StringBuffer(diffset.toPattern(true));
+                        StringBuilder s = new StringBuilder(diffset.toPattern(true));
                         if(s.length()>100){
                             s.replace(0, 0x7fffffff, ellipsis);
                         }
@@ -957,7 +957,7 @@ public class TestConversion extends TestFmwk {
                     //are the items that must not be in unicodeset but are?
                     (diffset=mapnotset).retainAll(unicodeset);
                     if(!diffset.isEmpty()){
-                        StringBuffer s = new StringBuffer(diffset.toPattern(true));
+                        StringBuilder s = new StringBuilder(diffset.toPattern(true));
                         if(s.length()>100){
                             s.replace(0, 0x7fffffff, ellipsis);
                         }

--- a/icu4j/main/collate/src/test/java/com/ibm/icu/dev/test/collator/CollationAPITest.java
+++ b/icu4j/main/collate/src/test/java/com/ibm/icu/dev/test/collator/CollationAPITest.java
@@ -850,7 +850,7 @@ public class CollationAPITest extends TestFmwk {
         // they are overridden by any subclass that supports their features.
 
         assertEquals("compare(strings as Object)", 0,
-                col1.compare(new StringBuilder("abc"), new StringBuffer("abc")));
+                col1.compare(new StringBuilder("abc"), new StringBuilder("abc")));
 
         col1.setStrength(Collator.SECONDARY);
         assertNotEquals("getStrength()", Collator.PRIMARY, col1.getStrength());

--- a/icu4j/main/collate/src/test/java/com/ibm/icu/dev/test/collator/CollationIteratorTest.java
+++ b/icu4j/main/collate/src/test/java/com/ibm/icu/dev/test/collator/CollationIteratorTest.java
@@ -463,7 +463,7 @@ public class CollationIteratorTest extends TestFmwk {
         RuleBasedCollator en_us = (RuleBasedCollator)Collator.getInstance(Locale.US);
         CollationElementIterator iter;
         char codepoint;
-        StringBuffer source = new StringBuffer();
+        StringBuilder source = new StringBuilder();
         source.append("\u0e4d\u0e4e\u0e4f");
         // source.append("\u04e8\u04e9");
         iter = en_us.getCollationElementIterator(source.toString());
@@ -517,7 +517,7 @@ public class CollationIteratorTest extends TestFmwk {
             warnln("Error creating Thai collator");
             return;
         }
-        StringBuffer source = new StringBuffer();
+        StringBuilder source = new StringBuilder();
         source.append('\uFDFA');
         CollationElementIterator iter
                         = th_th.getCollationElementIterator(source.toString());

--- a/icu4j/main/collate/src/test/java/com/ibm/icu/dev/test/collator/CollationMiscTest.java
+++ b/icu4j/main/collate/src/test/java/com/ibm/icu/dev/test/collator/CollationMiscTest.java
@@ -649,7 +649,7 @@ public class CollationMiscTest extends TestFmwk {
         String[] test = new String[4];
 
         for(int i = 0; i<4; i++) {
-            StringBuffer temp = new StringBuffer();
+            StringBuilder temp = new StringBuilder();
             for (int j = 0; j < 2047; j++) {
                 temp.append('a');
             }
@@ -1283,8 +1283,8 @@ public class CollationMiscTest extends TestFmwk {
             char ccMix[]   = {0x316, 0x321, 0x300};
             int          sLen;
             int          i;
-            StringBuffer strA = new StringBuffer();
-            StringBuffer strB = new StringBuffer();
+            StringBuilder strA = new StringBuilder();
+            StringBuilder strB = new StringBuilder();
 
             coll.setDecomposition(Collator.CANONICAL_DECOMPOSITION);
 

--- a/icu4j/main/collate/src/test/java/com/ibm/icu/dev/test/format/GlobalizationPreferencesTest.java
+++ b/icu4j/main/collate/src/test/java/com/ibm/icu/dev/test/format/GlobalizationPreferencesTest.java
@@ -275,7 +275,7 @@ public class GlobalizationPreferencesTest extends TestFmwk {
         for (int i = 0; i < INPUT_LOCALEIDS.length; i++) {
             String[] localeStrings = INPUT_LOCALEIDS[i];
             ArrayList<ULocale> locales = new ArrayList<>();
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             for (int j = 0; j < localeStrings.length; j++) {
                 locales.add(new ULocale(localeStrings[j]));
                 if (j != 0) {
@@ -309,7 +309,7 @@ public class GlobalizationPreferencesTest extends TestFmwk {
         for (int i = 0; i < INPUT_LOCALEIDS.length; i++) {
             String[] localeStrings = INPUT_LOCALEIDS[i];
             ULocale[] localeArray = new ULocale[INPUT_LOCALEIDS[i].length];
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             for (int j = 0; j < localeStrings.length; j++) {
                 localeArray[j] = new ULocale(localeStrings[j]);
                 if (j != 0) {

--- a/icu4j/main/collate/src/test/java/com/ibm/icu/dev/test/format/RbnfLenientScannerTest.java
+++ b/icu4j/main/collate/src/test/java/com/ibm/icu/dev/test/format/RbnfLenientScannerTest.java
@@ -120,7 +120,7 @@ public class RbnfLenientScannerTest extends TestFmwk {
 
     @Test
     public void TestAllLocales() {
-        StringBuffer errors = null;
+        StringBuilder errors = null;
         ULocale[] locales = ULocale.getAvailableLocales();
         String[] names = {
             " (spellout) ",
@@ -187,7 +187,7 @@ public class RbnfLenientScannerTest extends TestFmwk {
                             String msg = loc.getName() + names[j] + "ERROR:" + pe.getMessage();
                             logln(msg);
                             if (errors == null) {
-                                errors = new StringBuffer();
+                                errors = new StringBuilder();
                             }
                             errors.append("\n" + msg);
                         }

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/CompactDecimalFormatTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/CompactDecimalFormatTest.java
@@ -464,6 +464,7 @@ public class CompactDecimalFormatTest extends CoreTestFmwk {
     }
 
     @Test
+    @SuppressWarnings("JdkObsolete") // Because of CompactDecimalFormat.format(..., StringBuffer)
     public void TestFieldPosition() {
         CompactDecimalFormat cdf = getCDFInstance(
                 ULocale.forLanguageTag("sw"), CompactStyle.SHORT);

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/DataDrivenFormatTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/DataDrivenFormatTest.java
@@ -158,9 +158,10 @@ public class DataDrivenFormatTest extends CoreTestFmwk {
                 fromSet = new CalendarFieldsSet();
                 fromSet.parseFrom(date);
             }
-            
+
             // run the test
             if(fmt) {
+                @SuppressWarnings("JdkObsolete") // Because of DateFormat.format(...,StringBuffer,...)
                 StringBuffer output = new StringBuffer();
                 cal.clear();
                 FieldPosition pos = new FieldPosition(0);

--- a/icu4j/main/core/src/main/java/com/ibm/icu/impl/Utility.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/impl/Utility.java
@@ -1648,11 +1648,11 @@ public final class Utility {
      * cleared out by, at the end, calling this method with a literal
      * character (which may be -1).
      */
-    public static void appendToRule(StringBuffer rule,
+    public static void appendToRule(StringBuilder rule,
             int c,
             boolean isLiteral,
             boolean escapeUnprintable,
-            StringBuffer quoteBuf) {
+            StringBuilder quoteBuf) {
         // If we are escaping unprintables, then escape them outside
         // quotes.  \\u and \\U are not recognized within quotes.  The same
         // logic applies to literals, but literals are never escaped.
@@ -1740,11 +1740,11 @@ public final class Utility {
      * Append the given string to the rule.  Calls the single-character
      * version of appendToRule for each character.
      */
-    public static void appendToRule(StringBuffer rule,
+    public static void appendToRule(StringBuilder rule,
             String text,
             boolean isLiteral,
             boolean escapeUnprintable,
-            StringBuffer quoteBuf) {
+            StringBuilder quoteBuf) {
         for (int i=0; i<text.length(); ++i) {
             // Okay to process in 16-bit code units here
             appendToRule(rule, text.charAt(i), isLiteral, escapeUnprintable, quoteBuf);
@@ -1755,10 +1755,10 @@ public final class Utility {
      * Given a matcher reference, which may be null, append its
      * pattern as a literal to the given rule.
      */
-    public static void appendToRule(StringBuffer rule,
+    public static void appendToRule(StringBuilder rule,
             UnicodeMatcher matcher,
             boolean escapeUnprintable,
-            StringBuffer quoteBuf) {
+            StringBuilder quoteBuf) {
         if (matcher != null) {
             appendToRule(rule, matcher.toPattern(escapeUnprintable),
                     true, escapeUnprintable, quoteBuf);

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/TestBoilerplate.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/TestBoilerplate.java
@@ -10,9 +10,9 @@ package com.ibm.icu.dev.test;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -41,7 +41,7 @@ public abstract class TestBoilerplate<T> extends TestFmwk {
 
     @SuppressWarnings({"SelfEquals", "EqualsNull"})
     protected final void _test() throws Exception {
-        List<T> list = new LinkedList<T>();
+        List<T> list = new ArrayList<T>();
         while (_addTestObject(list)) {
         }
         T[] testArray = (T[]) list.toArray();

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/TestUnicodeKnownIssues.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/TestUnicodeKnownIssues.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
@@ -134,7 +134,7 @@ public class TestUnicodeKnownIssues {
 
     // TODO: remove for JDK 1.8
     static final class MyConsumer implements UnicodeKnownIssues.Consumer<String> {
-        final List<String> l = new LinkedList<>();
+        final List<String> l = new ArrayList<>();
         @Override
         public void accept(String t) {
             l.add(t);

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/bidi/BidiFmwk.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/bidi/BidiFmwk.java
@@ -85,7 +85,7 @@ public class BidiFmwk extends CoreTestFmwk {
     }
 
     protected static String valueOf(int[] array) {
-        StringBuffer result = new StringBuffer(array.length * 4);
+        StringBuilder result = new StringBuilder(array.length * 4);
         for (int i = 0; i < array.length; i++) {
             result.append(' ');
             result.append(array[i]);
@@ -140,7 +140,7 @@ public class BidiFmwk extends CoreTestFmwk {
     }
     public static String optionToString(int option, int mask,
                                         String[] descriptions) {
-        StringBuffer desc = new StringBuffer(50);
+        StringBuilder desc = new StringBuilder(50);
 
         if ((option &= mask) == 0) {
             return "0";

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/bidi/TestStreaming.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/bidi/TestStreaming.java
@@ -80,7 +80,7 @@ public class TestStreaming extends BidiFmwk {
         byte level;
         int nTests = testCases.length, nLevels = paraLevels.length;
         boolean mismatch, testOK = true;
-        StringBuffer processedLenStr = new StringBuffer(MAXLOOPS * 5);
+        StringBuilder processedLenStr = new StringBuilder(MAXLOOPS * 5);
 
         logln("\nEntering TestStreaming\n");
 

--- a/icu4j/main/framework/src/test/java/com/ibm/icu/dev/test/TestFmwk.java
+++ b/icu4j/main/framework/src/test/java/com/ibm/icu/dev/test/TestFmwk.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.Random;
+import java.util.StringJoiner;
 import java.util.TimeZone;
 
 import org.junit.After;
@@ -229,25 +230,23 @@ abstract public class TestFmwk extends AbstractTestLog {
     // Utility Methods
 
     protected static String hex(char[] s){
-        StringBuffer result = new StringBuffer();
+        StringJoiner result = new StringJoiner(",");
         for (int i = 0; i < s.length; ++i) {
-            if (i != 0) result.append(',');
-            result.append(hex(s[i]));
+            result.add(hex(s[i]));
         }
         return result.toString();
     }
 
     protected static String hex(byte[] s){
-        StringBuffer result = new StringBuffer();
+        StringJoiner result = new StringJoiner(",");
         for (int i = 0; i < s.length; ++i) {
-            if (i != 0) result.append(',');
-            result.append(hex(s[i]));
+            result.add(hex(s[i]));
         }
         return result.toString();
     }
 
     protected static String hex(char ch) {
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder();
         String foo = Integer.toString(ch, 16).toUpperCase();
         for (int i = foo.length(); i < 4; ++i) {
             result.append('0');
@@ -256,7 +255,7 @@ abstract public class TestFmwk extends AbstractTestLog {
     }
 
     protected static String hex(int ch) {
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder();
         String foo = Integer.toString(ch, 16).toUpperCase();
         for (int i = foo.length(); i < 4; ++i) {
             result.append('0');
@@ -440,7 +439,7 @@ abstract public class TestFmwk extends AbstractTestLog {
             return -1;
         }
         int i = 0;
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         int seenMask = 0;
         for (; i < array.length; ++i) {
             String s = array[i];

--- a/icu4j/main/translit/src/main/java/com/ibm/icu/impl/UtilityExtensions.java
+++ b/icu4j/main/translit/src/main/java/com/ibm/icu/impl/UtilityExtensions.java
@@ -22,11 +22,11 @@ public class UtilityExtensions {
      * Append the given string to the rule.  Calls the single-character
      * version of appendToRule for each character.
      */
-    public static void appendToRule(StringBuffer rule,
+    public static void appendToRule(StringBuilder rule,
                                     String text,
                                     boolean isLiteral,
                                     boolean escapeUnprintable,
-                                    StringBuffer quoteBuf) {
+                                    StringBuilder quoteBuf) {
         for (int i=0; i<text.length(); ++i) {
             // Okay to process in 16-bit code units here
             Utility.appendToRule(rule, text.charAt(i), isLiteral, escapeUnprintable, quoteBuf);
@@ -38,10 +38,10 @@ public class UtilityExtensions {
      * Given a matcher reference, which may be null, append its
      * pattern as a literal to the given rule.
      */
-    public static void appendToRule(StringBuffer rule,
+    public static void appendToRule(StringBuilder rule,
                                     UnicodeMatcher matcher,
                                     boolean escapeUnprintable,
-                                    StringBuffer quoteBuf) {
+                                    StringBuilder quoteBuf) {
         if (matcher != null) {
             appendToRule(rule, matcher.toPattern(escapeUnprintable),
                          true, escapeUnprintable, quoteBuf);
@@ -54,7 +54,7 @@ public class UtilityExtensions {
      */
     public static String formatInput(ReplaceableString input,
                                      Transliterator.Position pos) {
-        StringBuffer appendTo = new StringBuffer();
+        StringBuilder appendTo = new StringBuilder();
         formatInput(appendTo, input, pos);
         return com.ibm.icu.impl.Utility.escape(appendTo.toString());
     }
@@ -64,7 +64,7 @@ public class UtilityExtensions {
      * aaa{bbb|ccc|ddd}eee, where the {} indicate the context start
      * and limit, and the || indicate the start and limit.
      */
-    public static StringBuffer formatInput(StringBuffer appendTo,
+    public static StringBuilder formatInput(StringBuilder appendTo,
                                            ReplaceableString input,
                                            Transliterator.Position pos) {
         if (0 <= pos.contextStart &&
@@ -105,7 +105,7 @@ public class UtilityExtensions {
     /**
      * Convenience method.
      */
-    public static StringBuffer formatInput(StringBuffer appendTo,
+    public static StringBuilder formatInput(StringBuilder appendTo,
                                            Replaceable input,
                                            Transliterator.Position pos) {
         return formatInput(appendTo, (ReplaceableString) input, pos);

--- a/icu4j/main/translit/src/main/java/com/ibm/icu/text/CompoundTransliterator.java
+++ b/icu4j/main/translit/src/main/java/com/ibm/icu/text/CompoundTransliterator.java
@@ -415,10 +415,10 @@ class CompoundTransliterator extends Transliterator {
 
         int delta = 0; // delta in length
 
-        StringBuffer log = null;
+        StringBuilder log = null;
         ///CLOVER:OFF
         if (DEBUG) {
-            log = new StringBuffer("CompoundTransliterator{" + getID() +
+            log = new StringBuilder("CompoundTransliterator{" + getID() +
                                    (incremental ? "}i: IN=" : "}: IN="));
             UtilityExtensions.formatInput(log, text, index);
             System.out.println(Utility.escape(log.toString()));

--- a/icu4j/main/translit/src/main/java/com/ibm/icu/text/NameUnicodeTransliterator.java
+++ b/icu4j/main/translit/src/main/java/com/ibm/icu/text/NameUnicodeTransliterator.java
@@ -52,7 +52,7 @@ class NameUnicodeTransliterator extends Transliterator {
 
         int maxLen = UCharacterName.INSTANCE.getMaxCharNameLength() + 1; // allow for temporary trailing space
 
-        StringBuffer name = new StringBuffer(maxLen);
+        StringBuilder name = new StringBuilder(maxLen);
 
         // Get the legal character set
         UnicodeSet legal = new UnicodeSet();
@@ -143,7 +143,7 @@ class NameUnicodeTransliterator extends Transliterator {
                 }
 
                 if (legal.contains(c)) {
-                    UTF16.append(name, c);
+                    name.appendCodePoint(c);
                     // If we go past the longest possible name then abort.
                     // maxLen includes temporary trailing space, so use '>='.
                     if (name.length() >= maxLen) {

--- a/icu4j/main/translit/src/main/java/com/ibm/icu/text/StringMatcher.java
+++ b/icu4j/main/translit/src/main/java/com/ibm/icu/text/StringMatcher.java
@@ -177,8 +177,8 @@ class StringMatcher implements UnicodeMatcher, UnicodeReplacer {
      */
     @Override
     public String toPattern(boolean escapeUnprintable) {
-        StringBuffer result = new StringBuffer();
-        StringBuffer quoteBuf = new StringBuffer();
+        StringBuilder result = new StringBuilder();
+        StringBuilder quoteBuf = new StringBuilder();
         if (segmentNumber > 0) { // i.e., if this is a segment
             result.append('(');
         }
@@ -267,7 +267,7 @@ class StringMatcher implements UnicodeMatcher, UnicodeReplacer {
     @Override
     public String toReplacerPattern(boolean escapeUnprintable) {
         // assert(segmentNumber > 0);
-        StringBuffer rule = new StringBuffer("$");
+        StringBuilder rule = new StringBuilder("$");
         Utility.appendNumber(rule, segmentNumber, 10, 1);
         return rule.toString();
     }

--- a/icu4j/main/translit/src/main/java/com/ibm/icu/text/StringReplacer.java
+++ b/icu4j/main/translit/src/main/java/com/ibm/icu/text/StringReplacer.java
@@ -139,7 +139,7 @@ class StringReplacer implements UnicodeReplacer {
              * the integrity of indices into the key and surrounding context while
              * generating the output text.
              */
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
             int oOutput; // offset into 'output'
             isComplex = false;
 
@@ -190,7 +190,7 @@ class StringReplacer implements UnicodeReplacer {
                 UnicodeReplacer r = data.lookupReplacer(c);
                 if (r == null) {
                     // Accumulate straight (non-segment) text.
-                    UTF16.append(buf, c);
+                    buf.appendCodePoint(c);
                 } else {
                     isComplex = true;
 
@@ -267,8 +267,8 @@ class StringReplacer implements UnicodeReplacer {
      */
     @Override
     public String toReplacerPattern(boolean escapeUnprintable) {
-        StringBuffer rule = new StringBuffer();
-        StringBuffer quoteBuf = new StringBuffer();
+        StringBuilder rule = new StringBuilder();
+        StringBuilder quoteBuf = new StringBuilder();
 
         int cursor = cursorPos;
 
@@ -290,7 +290,7 @@ class StringReplacer implements UnicodeReplacer {
             if (r == null) {
                 Utility.appendToRule(rule, c, false, escapeUnprintable, quoteBuf);
             } else {
-                StringBuffer buf = new StringBuffer(" ");
+                StringBuilder buf = new StringBuilder(" ");
                 buf.append(r.toReplacerPattern(escapeUnprintable));
                 buf.append(' ');
                 Utility.appendToRule(rule, buf.toString(),

--- a/icu4j/main/translit/src/main/java/com/ibm/icu/text/TransliterationRule.java
+++ b/icu4j/main/translit/src/main/java/com/ibm/icu/text/TransliterationRule.java
@@ -489,12 +489,12 @@ class TransliterationRule {
     public String toRule(boolean escapeUnprintable) {
        // int i;
 
-        StringBuffer rule = new StringBuffer();
+        StringBuilder rule = new StringBuilder();
 
         // Accumulate special characters (and non-specials following them)
         // into quoteBuf.  Append quoteBuf, within single quotes, when
         // a non-quoted element must be inserted.
-        StringBuffer quoteBuf = new StringBuffer();
+        StringBuilder quoteBuf = new StringBuilder();
 
         // Do not emit the braces '{' '}' around the pattern if there
         // is neither anteContext nor postContext.

--- a/icu4j/main/translit/src/main/java/com/ibm/icu/text/Transliterator.java
+++ b/icu4j/main/translit/src/main/java/com/ibm/icu/text/Transliterator.java
@@ -1093,9 +1093,9 @@ public abstract class Transliterator implements StringTransform  {
         // characters (which are ignored) and a subsequent run of
         // unfiltered characters (which are transliterated).
 
-        StringBuffer log = null;
+        StringBuilder log = null;
         if (DEBUG) {
-            log = new StringBuffer();
+            log = new StringBuilder();
         }
 
         for (;;) {
@@ -1594,7 +1594,7 @@ public abstract class Transliterator implements StringTransform  {
      */
     public static Transliterator getInstance(String ID,
                                              int dir) {
-        StringBuffer canonID = new StringBuffer();
+        StringBuilder canonID = new StringBuilder();
         List<SingleID> list = new ArrayList<>();
         UnicodeSet[] globalFilter = new UnicodeSet[1];
         if (!TransliteratorIDParser.parseCompoundID(ID, dir, canonID, list, globalFilter)) {
@@ -1635,7 +1635,7 @@ public abstract class Transliterator implements StringTransform  {
      * invalid.
      */
     static Transliterator getBasicInstance(String id, String canonID) {
-        StringBuffer s = new StringBuffer();
+        StringBuilder s = new StringBuilder();
         Transliterator t = registry.get(id, s);
         if (s.length() != 0) {
             // assert(t==0);
@@ -1748,12 +1748,12 @@ public abstract class Transliterator implements StringTransform  {
         // the correct format.  That is: foo => ::foo
         // KEEP in sync with rbt_pars
         if (escapeUnprintable) {
-            StringBuffer rulesSource = new StringBuffer();
+            StringBuilder rulesSource = new StringBuilder();
             String id = getID();
             for (int i=0; i<id.length();) {
                 int c = UTF16.charAt(id, i);
                 if (!Utility.escapeUnprintable(rulesSource, c)) {
-                    UTF16.append(rulesSource, c);
+                    rulesSource.appendCodePoint(c);
                 }
                 i += UTF16.getCharCount(c);
             }

--- a/icu4j/main/translit/src/main/java/com/ibm/icu/text/TransliteratorIDParser.java
+++ b/icu4j/main/translit/src/main/java/com/ibm/icu/text/TransliteratorIDParser.java
@@ -266,7 +266,7 @@ class TransliteratorIDParser {
      */
     public static UnicodeSet parseGlobalFilter(String id, int[] pos, int dir,
                                                int[] withParens,
-                                               StringBuffer canonID) {
+                                               StringBuilder canonID) {
         UnicodeSet filter = null;
         int start = pos[0];
 
@@ -342,7 +342,7 @@ class TransliteratorIDParser {
      * id is consumed without syntax error.
      */
     public static boolean parseCompoundID(String id, int dir,
-                                          StringBuffer canonID,
+                                          StringBuilder canonID,
                                           List<SingleID> list,
                                           UnicodeSet[] globalFilter) {
         int[] pos = new int[] { 0 };

--- a/icu4j/main/translit/src/main/java/com/ibm/icu/text/TransliteratorParser.java
+++ b/icu4j/main/translit/src/main/java/com/ibm/icu/text/TransliteratorParser.java
@@ -75,7 +75,7 @@ class TransliteratorParser {
      * rule.  segmentStandins.charAt(0) is the standin for "$1" and corresponds
      * to StringMatcher object segmentObjects.elementAt(0), etc.
      */
-    private StringBuffer segmentStandins;
+    private StringBuilder segmentStandins;
 
     /**
      * Vector of StringMatcher objects for segments.  Used during the
@@ -409,7 +409,7 @@ class TransliteratorParser {
         public int parse(String rule, int pos, int limit,
                          TransliteratorParser parser) {
             int start = pos;
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
             pos = parseSection(rule, pos, limit, parser, buf, ILLEGAL_TOP, false);
             text = buf.toString();
 
@@ -445,7 +445,7 @@ class TransliteratorParser {
          */
         private int parseSection(String rule, int pos, int limit,
                                  TransliteratorParser parser,
-                                 StringBuffer buf,
+                                 StringBuilder buf,
                                  UnicodeSet illegal,
                                  boolean isSegment) {
             int start = pos;
@@ -500,7 +500,7 @@ class TransliteratorParser {
                     int escaped = Utility.cpFromCodePointAndLength(cpAndLength);
                     pos += Utility.lengthFromCodePointAndLength(cpAndLength);
                     parser.checkVariableRange(escaped, rule, start);
-                    UTF16.append(buf, escaped);
+                    buf.appendCodePoint(escaped);
                     continue;
                 }
                 // Handle quoted matter
@@ -1142,7 +1142,7 @@ class TransliteratorParser {
         char operator = 0;
 
         // Set up segments data
-        segmentStandins = new StringBuffer();
+        segmentStandins = new StringBuilder();
         segmentObjects = new ArrayList<>();
 
         RuleHalf left  = new RuleHalf();
@@ -1535,10 +1535,10 @@ class TransliteratorParser {
 
     /**
      * Append the value of the given variable name to the given
-     * StringBuffer.
+     * StringBuilder.
      * @exception IllegalIcuArgumentException if the name is unknown.
      */
-    private void appendVariableDef(String name, StringBuffer buf) {
+    private void appendVariableDef(String name, StringBuilder buf) {
         char[] ch = variableNames.get(name);
         if (ch == null) {
             // We allow one undefined variable so that variable definition

--- a/icu4j/main/translit/src/main/java/com/ibm/icu/text/TransliteratorRegistry.java
+++ b/icu4j/main/translit/src/main/java/com/ibm/icu/text/TransliteratorRegistry.java
@@ -332,7 +332,7 @@ class TransliteratorRegistry {
      * make aliasReturn empty before calling.
      */
     public Transliterator get(String ID,
-                              StringBuffer aliasReturn) {
+                              StringBuilder aliasReturn) {
         Object[] entry = find(ID);
         return (entry == null) ? null
             : instantiateEntry(ID, entry, aliasReturn);
@@ -423,6 +423,7 @@ class TransliteratorRegistry {
      * An internal class that adapts an enumeration over
      * CaseInsensitiveStrings to an enumeration over Strings.
      */
+    @SuppressWarnings("JdkObsolete") // Because it is used to implement public methods returning `Enumeration`
     private static class IDEnumeration implements Enumeration<String> {
         Enumeration<CaseInsensitiveString> en;
 
@@ -854,7 +855,7 @@ class TransliteratorRegistry {
     @SuppressWarnings("rawtypes")
     private Transliterator instantiateEntry(String ID,
                                             Object[] entryWrapper,
-                                            StringBuffer aliasReturn) {
+                                            StringBuilder aliasReturn) {
         // We actually modify the entry object in some cases.  If it
         // is a string, we may partially parse it and turn it into a
         // more processed precursor.  This makes the next

--- a/icu4j/main/translit/src/test/java/com/ibm/icu/dev/test/translit/AnyScriptTest.java
+++ b/icu4j/main/translit/src/test/java/com/ibm/icu/dev/test/translit/AnyScriptTest.java
@@ -37,7 +37,7 @@ public class AnyScriptTest extends TestFmwk {
     public void TestScripts(){
         // get a couple of characters of each script for testing
 
-        StringBuffer testBuffer = new StringBuffer();
+        StringBuilder testBuffer = new StringBuilder();
         for (int script = 0; script < UScript.CODE_LIMIT; ++script) {
             UnicodeSet test = new UnicodeSet().applyPropertyAlias("script", UScript.getName(script));
             int count = Math.min(20, test.size());
@@ -162,7 +162,7 @@ public class AnyScriptTest extends TestFmwk {
 
     // might want to add to UnicodeSet
     private String getList(UnicodeSet set) {
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder();
         for (UnicodeSetIterator it = new UnicodeSetIterator(set); it.next();) {
             result.append(it.getString());
         }

--- a/icu4j/main/translit/src/test/java/com/ibm/icu/dev/test/translit/CompoundTransliteratorTest.java
+++ b/icu4j/main/translit/src/test/java/com/ibm/icu/dev/test/translit/CompoundTransliteratorTest.java
@@ -230,7 +230,7 @@ public class CompoundTransliteratorTest extends TestFmwk {
         // must be the same after we finalize (see below).
         rsource.replace(0, rsource.length(), "");
         Transliterator.Position index = new Transliterator.Position();
-        StringBuffer log = new StringBuffer();
+        StringBuilder log = new StringBuilder();
 
         for (int i=0; i<source.length(); ++i) {
             if (i != 0) {

--- a/icu4j/main/translit/src/test/java/com/ibm/icu/dev/test/translit/JamoTest.java
+++ b/icu4j/main/translit/src/test/java/com/ibm/icu/dev/test/translit/JamoTest.java
@@ -106,7 +106,7 @@ public class JamoTest extends TestFmwk {
         Transliterator jamoHangul = Transliterator.getInstance("NFC");
         Transliterator hangulJamo = Transliterator.getInstance("NFD");
 
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         for (int i=0; i<HANGUL.length; ++i) {
             String hangul = HANGUL[i];
             String jamo = hangulJamo.transliterate(hangul);
@@ -179,7 +179,7 @@ public class JamoTest extends TestFmwk {
         Transliterator rt = Transliterator.getInstance("NFD;Jamo-Latin;Latin-Jamo;NFC");
 
         int pos = 0;
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         int total = 0;
         int errors = 0;
         while (pos < WHAT_IS_UNICODE.length()) {
@@ -478,7 +478,7 @@ public class JamoTest extends TestFmwk {
      * "x\u11B0y".  See JAMO_NAMES for table of names.
      */
     static String nameToJamo(String input) {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         for (int i=0; i<input.length(); ++i) {
             char c = input.charAt(i);
             if (c == '(') {
@@ -502,7 +502,7 @@ public class JamoTest extends TestFmwk {
      * "x(LG)y".  See JAMO_NAMES for table of names.
      */
     static String jamoToName(String input) {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         for (int i=0; i<input.length(); ++i) {
             char c = input.charAt(i);
             if (c >= 0x1100 && c <= 0x11C2) {

--- a/icu4j/main/translit/src/test/java/com/ibm/icu/dev/test/translit/ReplaceableTest.java
+++ b/icu4j/main/translit/src/test/java/com/ibm/icu/dev/test/translit/ReplaceableTest.java
@@ -89,7 +89,7 @@ public class ReplaceableTest extends TestFmwk {
 
         TestReplaceable (String text, String styles) {
             chars = new ReplaceableString(text);
-            StringBuffer s = new StringBuffer();
+            StringBuilder s = new StringBuilder();
             for (int i = 0; i < text.length(); ++i) {
                 if (styles != null && i < styles.length()) {
                     s.append(styles.charAt(i));
@@ -165,7 +165,7 @@ public class ReplaceableTest extends TestFmwk {
                 newStyle = styles.charAt(limit);
             }
             // dumb implementation for now.
-            StringBuffer s = new StringBuffer();
+            StringBuilder s = new StringBuilder();
             for (int i = 0; i < newLen; ++i) {
                 // this doesn't really handle an embedded NO_STYLE_MARK
                 // in the middle of a long run of characters right -- but

--- a/icu4j/main/translit/src/test/java/com/ibm/icu/dev/test/translit/RoundTripTest.java
+++ b/icu4j/main/translit/src/test/java/com/ibm/icu/dev/test/translit/RoundTripTest.java
@@ -282,9 +282,9 @@ public class RoundTripTest extends TestFmwk {
         try{
             UnicodeSet exemplars = LocaleData.getExemplarSet(new ULocale("zh"),0);
             // create string with all chars
-            StringBuffer b = new StringBuffer();
+            StringBuilder b = new StringBuilder();
             for (UnicodeSetIterator it = new UnicodeSetIterator(exemplars); it.next();) {
-                UTF16.append(b,it.codepoint);
+                b.appendCodePoint(it.codepoint);
             }
             String source = b.toString();
             // transform with Han translit
@@ -1623,7 +1623,7 @@ public class RoundTripTest extends TestFmwk {
         }
 
         final String info(String s) {
-            StringBuffer result = new StringBuffer();
+            StringBuilder result = new StringBuilder();
             result.append("\u200E").append(s).append("\u200E (").append(TestUtility.hex(s)).append("/");
             if (false) { // append age, as a check
                 int cp = 0;

--- a/icu4j/main/translit/src/test/java/com/ibm/icu/dev/test/translit/TestUtility.java
+++ b/icu4j/main/translit/src/test/java/com/ibm/icu/dev/test/translit/TestUtility.java
@@ -38,7 +38,7 @@ public final class TestUtility {
     }
     
     public static String replace(String source, String toBeReplaced, String replacement) {
-        StringBuffer results = new StringBuffer();
+        StringBuilder results = new StringBuilder();
         int len = toBeReplaced.length();
         for (int i = 0; i < source.length(); ++i) {
             if (source.regionMatches(false, i, toBeReplaced, 0, len)) {
@@ -50,16 +50,16 @@ public final class TestUtility {
         }
         return results.toString();
     }
-    
+
     public static String replaceAll(String source, UnicodeSet set, String replacement) {
-        StringBuffer results = new StringBuffer();
+        StringBuilder results = new StringBuilder();
         int cp;
         for (int i = 0; i < source.length(); i += UTF16.getCharCount(cp)) {
             cp = UTF16.charAt(source,i);
             if (set.contains(cp)) {
                 results.append(replacement);
             } else {
-                UTF16.append(results, cp);
+                results.appendCodePoint(cp);
             }
         }
         return results.toString();

--- a/icu4j/main/translit/src/test/java/com/ibm/icu/dev/test/translit/TransliteratorTest.java
+++ b/icu4j/main/translit/src/test/java/com/ibm/icu/dev/test/translit/TransliteratorTest.java
@@ -374,14 +374,14 @@ public class TransliteratorTest extends TestFmwk {
         Transliterator.Position index = new Transliterator.Position();
         ReplaceableString s = new ReplaceableString();
         for (int i=0; i<DATA.length; i+=2) {
-            StringBuffer log;
+            StringBuilder log;
             if (DATA[i] != null) {
-                log = new StringBuffer(s.toString() + " + "
+                log = new StringBuilder(s.toString() + " + "
                         + DATA[i]
                                + " -> ");
                 t.transliterate(s, index, DATA[i]);
             } else {
-                log = new StringBuffer(s.toString() + " => ");
+                log = new StringBuilder(s.toString() + " => ");
                 t.finishTransliteration(s, index);
             }
             UtilityExtensions.formatInput(log, s, index);
@@ -557,7 +557,7 @@ public class TransliteratorTest extends TestFmwk {
         // not used char epsilon = (char)0x3B5;
 
         // sigma upsilon nu -> syn
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append(sigma).append(upsilon).append(nu);
         String syn = buf.toString();
         expect(gl, syn, "syn");
@@ -2178,8 +2178,8 @@ public class TransliteratorTest extends TestFmwk {
         UnicodeSetIterator vIter = new UnicodeSetIterator(vowel);
         UnicodeSetIterator nvIter = new UnicodeSetIterator(non_vowel);
         Transliterator trans = Transliterator.getInstance("Devanagari-Gurmukhi");
-        StringBuffer src = new StringBuffer(" \u0902");
-        StringBuffer expect = new StringBuffer(" \u0A02");
+        StringBuilder src = new StringBuilder(" \u0902");
+        StringBuilder expect = new StringBuilder(" \u0A02");
         while(vIter.next()){
             src.setCharAt(0,(char) vIter.codepoint);
             expect.setCharAt(0,(char) (vIter.codepoint+0x0100));
@@ -2937,7 +2937,7 @@ public class TransliteratorTest extends TestFmwk {
     @Test
     public void TestAny() {
         UnicodeSet alphabetic = new UnicodeSet("[:alphabetic:]").freeze();
-        StringBuffer testString = new StringBuffer();
+        StringBuilder testString = new StringBuilder();
         for (int i = 0; i < UScript.CODE_LIMIT; ++i) {
             UnicodeSet sample = new UnicodeSet().applyPropertyAlias("script", UScript.getShortName(i)).retainAll(alphabetic);
             int count = 5;
@@ -3735,8 +3735,8 @@ the ::BEGIN/::END stuff)
         @Override
         public void run() {
             errorMsg = null;
-            StringBuffer inBuf = new StringBuffer(testData);
-            StringBuffer expectedBuf = new StringBuffer(expectedData);
+            StringBuilder inBuf = new StringBuilder(testData);
+            StringBuilder expectedBuf = new StringBuilder(expectedData);
 
             for(int i = 0; i < 1000; i++) {
                 String in = inBuf.toString();

--- a/icu4j/main/translit/src/test/java/com/ibm/icu/dev/test/translit/WriteCharts.java
+++ b/icu4j/main/translit/src/test/java/com/ibm/icu/dev/test/translit/WriteCharts.java
@@ -17,6 +17,7 @@ import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
@@ -108,10 +109,9 @@ public class WriteCharts {
     }
     
     public static String showScripts(int[] scripts) {
-        StringBuffer results = new StringBuffer();
+        StringJoiner results = new StringJoiner(", ");
         for (int i = 0; i < scripts.length; ++i) {
-            if (i != 0) results.append(", ");
-            results.append(UScript.getName(scripts[i]));
+            results.add(UScript.getName(scripts[i]));
         }
         return results.toString();
     }
@@ -363,15 +363,10 @@ public class WriteCharts {
             out.close();
         }
     }
-    
+
     public static String hex(String s) {
-        int cp;
-        StringBuffer results = new StringBuffer();
-        for (int i = 0; i < s.length(); i += UTF16.getCharCount(cp)) {
-            cp = UTF16.charAt(s, i);
-            if (i != 0) results.append(' ');
-            results.append(Integer.toHexString(cp));
-        }
+        StringJoiner results = new StringJoiner(" ");
+        s.codePoints().mapToObj(Integer::toHexString).forEach(results::add);
         return results.toString().toUpperCase();
     }
     

--- a/icu4j/perf-tests/src/main/java/com/ibm/icu/dev/test/perf/CollationPerformanceTest.java
+++ b/icu4j/perf-tests/src/main/java/com/ibm/icu/dev/test/perf/CollationPerformanceTest.java
@@ -62,36 +62,36 @@ public class CollationPerformanceTest {
         + "-java                      Run test using java.text.Collator.\n";
     
     //enum {FLAG, NUM, STRING} type;
-    static StringBuffer temp_opt_fName      = new StringBuffer("");
-    static StringBuffer temp_opt_locale     = new StringBuffer("en_US");
-    //static StringBuffer temp_opt_langid     = new StringBuffer("0");         // Defaults to value corresponding to opt_locale.
-    static StringBuffer temp_opt_rules      = new StringBuffer("");
-    static StringBuffer temp_opt_help       = new StringBuffer("");
-    static StringBuffer temp_opt_loopCount  = new StringBuffer("1");
-    static StringBuffer temp_opt_iLoopCount = new StringBuffer("1");
-    static StringBuffer temp_opt_terse      = new StringBuffer("false");
-    static StringBuffer temp_opt_qsort      = new StringBuffer("");
-    static StringBuffer temp_opt_binsearch  = new StringBuffer("");
-    static StringBuffer temp_opt_icu        = new StringBuffer("true");
-    //static StringBuffer opt_win        = new StringBuffer("");      // Run with Windows native functions.
-    //static StringBuffer opt_unix       = new StringBuffer("");      // Run with UNIX strcoll, strxfrm functions.
-    //static StringBuffer opt_uselen     = new StringBuffer("");
-    static StringBuffer temp_opt_usekeys    = new StringBuffer("");
-    static StringBuffer temp_opt_strcmp     = new StringBuffer("");
-    static StringBuffer temp_opt_strcmpCPO  = new StringBuffer("");
-    static StringBuffer temp_opt_norm       = new StringBuffer("");
-    static StringBuffer temp_opt_keygen     = new StringBuffer("");
-    static StringBuffer temp_opt_french     = new StringBuffer("");
-    static StringBuffer temp_opt_frenchoff  = new StringBuffer("");
-    static StringBuffer temp_opt_shifted    = new StringBuffer("");
-    static StringBuffer temp_opt_lower      = new StringBuffer("");
-    static StringBuffer temp_opt_upper      = new StringBuffer("");
-    static StringBuffer temp_opt_case       = new StringBuffer("");
-    static StringBuffer temp_opt_level      = new StringBuffer("0");
-    static StringBuffer temp_opt_keyhist    = new StringBuffer("");
-    static StringBuffer temp_opt_itertest   = new StringBuffer("");
-    static StringBuffer temp_opt_dump       = new StringBuffer("");
-    static StringBuffer temp_opt_java       = new StringBuffer("");
+    static StringBuilder temp_opt_fName      = new StringBuilder("");
+    static StringBuilder temp_opt_locale     = new StringBuilder("en_US");
+    //static StringBuilder temp_opt_langid     = new StringBuilder("0");         // Defaults to value corresponding to opt_locale.
+    static StringBuilder temp_opt_rules      = new StringBuilder("");
+    static StringBuilder temp_opt_help       = new StringBuilder("");
+    static StringBuilder temp_opt_loopCount  = new StringBuilder("1");
+    static StringBuilder temp_opt_iLoopCount = new StringBuilder("1");
+    static StringBuilder temp_opt_terse      = new StringBuilder("false");
+    static StringBuilder temp_opt_qsort      = new StringBuilder("");
+    static StringBuilder temp_opt_binsearch  = new StringBuilder("");
+    static StringBuilder temp_opt_icu        = new StringBuilder("true");
+    //static StringBuilder opt_win        = new StringBuilder("");      // Run with Windows native functions.
+    //static StringBuilder opt_unix       = new StringBuilder("");      // Run with UNIX strcoll, strxfrm functions.
+    //static StringBuilder opt_uselen     = new StringBuilder("");
+    static StringBuilder temp_opt_usekeys    = new StringBuilder("");
+    static StringBuilder temp_opt_strcmp     = new StringBuilder("");
+    static StringBuilder temp_opt_strcmpCPO  = new StringBuilder("");
+    static StringBuilder temp_opt_norm       = new StringBuilder("");
+    static StringBuilder temp_opt_keygen     = new StringBuilder("");
+    static StringBuilder temp_opt_french     = new StringBuilder("");
+    static StringBuilder temp_opt_frenchoff  = new StringBuilder("");
+    static StringBuilder temp_opt_shifted    = new StringBuilder("");
+    static StringBuilder temp_opt_lower      = new StringBuilder("");
+    static StringBuilder temp_opt_upper      = new StringBuilder("");
+    static StringBuilder temp_opt_case       = new StringBuilder("");
+    static StringBuilder temp_opt_level      = new StringBuilder("0");
+    static StringBuilder temp_opt_keyhist    = new StringBuilder("");
+    static StringBuilder temp_opt_itertest   = new StringBuilder("");
+    static StringBuilder temp_opt_dump       = new StringBuilder("");
+    static StringBuilder temp_opt_java       = new StringBuilder("");
     
     
     static String   opt_fName      = "";
@@ -1249,8 +1249,8 @@ public class CollationPerformanceTest {
     static class OptionSpec {
         String name;
         int type;
-        StringBuffer value;
-        public OptionSpec(String name, int type, StringBuffer value) {
+        StringBuilder value;
+        public OptionSpec(String name, int type, StringBuilder value) {
             this.name = name;
             this.type = type;
             this.value = value;

--- a/icu4j/samples/src/main/java/com/ibm/icu/samples/iuc/Sample40_PopMsg.java
+++ b/icu4j/samples/src/main/java/com/ibm/icu/samples/iuc/Sample40_PopMsg.java
@@ -26,6 +26,7 @@ import com.ibm.icu.util.UResourceBundle;
  *
  */
 public class Sample40_PopMsg {
+    @SuppressWarnings("JdkObsolete") // Because of MessageFormat.format(...,StringBuffer,...)
     public static void main(String... args) {
         // setup
         Locale defaultLocaleID = Locale.getDefault();

--- a/icu4j/samples/src/main/java/com/ibm/icu/samples/iuc/Sample50_PopSort.java
+++ b/icu4j/samples/src/main/java/com/ibm/icu/samples/iuc/Sample50_PopSort.java
@@ -29,6 +29,7 @@ import com.ibm.icu.util.UResourceBundle;
  *
  */
 public class Sample50_PopSort {
+    @SuppressWarnings("JdkObsolete") // Because of MessageFormat.format(...,StringBuffer,...)
     public static void main(String... args) {
         // setup
         // setup

--- a/icu4j/samples/src/main/java/com/ibm/icu/samples/shaping/ArabicShapingSample.java
+++ b/icu4j/samples/src/main/java/com/ibm/icu/samples/shaping/ArabicShapingSample.java
@@ -216,7 +216,7 @@ public class ArabicShapingSample{
     }
 
     private static void throwUsageError(String message) {
-        StringBuffer buf = new StringBuffer("*** usage error ***\n");
+        StringBuilder buf = new StringBuilder("*** usage error ***\n");
         buf.append(message);
         buf.append("\n");
         buf.append(usage);
@@ -242,7 +242,7 @@ public class ArabicShapingSample{
         "  text can contain unicode escape values in the format '\\uXXXX' only\n";
         
     private static String escapedText(char[] text, int start, int length) {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         for (int i = start, e = start + length; i < e; ++i) {
             char ch = text[i];
             if (ch < 0x20 || ch > 0x7e) {
@@ -266,7 +266,7 @@ public class ArabicShapingSample{
 
     private static String parseText(String text) {
         // process unicode escapes (only)
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         char[] chars = text.toCharArray();
         for (int i = 0; i < chars.length; ++i) {
             char ch = chars[i];

--- a/icu4j/samples/src/main/java/com/ibm/icu/samples/text/pluralformat/PluralFormatSample.java
+++ b/icu4j/samples/src/main/java/com/ibm/icu/samples/text/pluralformat/PluralFormatSample.java
@@ -21,6 +21,7 @@ public class PluralFormatSample {
       PluralFormatExample();
       }
 
+  @SuppressWarnings("JdkObsolete") // Because of MessageFormat.format(...,StringBuffer,...)
   private static void PluralFormatExample(){
 
       System.out.println("=======================================================================================");

--- a/icu4j/tools/build/src/main/java/com/ibm/icu/dev/tool/docs/CodeMangler.java
+++ b/icu4j/tools/build/src/main/java/com/ibm/icu/dev/tool/docs/CodeMangler.java
@@ -240,7 +240,7 @@ public class CodeMangler {
         TreeMap sort = new TreeMap(String.CASE_INSENSITIVE_ORDER);
         sort.putAll(map);
         Iterator iter = sort.entrySet().iterator();
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         if (!nonames) {
             while (iter.hasNext()) {
                 Map.Entry e = (Map.Entry)iter.next();

--- a/icu4j/tools/build/src/main/java/com/ibm/icu/dev/tool/docs/Deprecator.java
+++ b/icu4j/tools/build/src/main/java/com/ibm/icu/dev/tool/docs/Deprecator.java
@@ -34,7 +34,7 @@ public final class Deprecator {
 
         int log = 1;
         boolean help = false;
-        StringBuffer err = new StringBuffer();
+        StringBuilder err = new StringBuilder();
 
         for (int i = 0; i < args.length; ++i) {
             String arg = args[i];

--- a/icu4j/tools/build/src/main/java/com/ibm/icu/dev/tool/docs/GatherAPIData.java
+++ b/icu4j/tools/build/src/main/java/com/ibm/icu/dev/tool/docs/GatherAPIData.java
@@ -361,7 +361,7 @@ public class GatherAPIData implements Doclet {
                 info.setAbstract();
             }
 
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
             if (JavadocHelper.isKindClass(typeElementc)) {
                 buf.append("extends ");
                 buf.append(typeElementc.getSuperclass().toString());

--- a/icu4j/tools/build/src/main/java/com/ibm/icu/dev/tool/docs/ICUJDKCompare.java
+++ b/icu4j/tools/build/src/main/java/com/ibm/icu/dev/tool/docs/ICUJDKCompare.java
@@ -498,7 +498,7 @@ public class ICUJDKCompare {
         }
 
         void debugmsg(MorC t, MorC m, String msg) {
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
             buf.append(t.getName());
             buf.append(" ");
             buf.append(msg);
@@ -541,7 +541,7 @@ public class ICUJDKCompare {
             return true;
         }
 
-        public void toString(MorC m, StringBuffer buf) {
+        public void toString(MorC m, StringBuilder buf) {
             int mod = m.getModifiers();
             if (mod != 0) {
                 buf.append(Modifier.toString(mod) + " ");
@@ -561,7 +561,7 @@ public class ICUJDKCompare {
         }
 
         public String toString() {
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
             buf.append(overrides[0].getName());
             for (int i = 0; i < overrides.length; ++i) {
                 MorC m = overrides[i];
@@ -758,7 +758,7 @@ public class ICUJDKCompare {
     }
 
     private String toString(Field f) {
-        StringBuffer buf = new StringBuffer(f.getName());
+        StringBuilder buf = new StringBuilder(f.getName());
         int mod = f.getModifiers() & MOD_MASK;
         if (mod != 0) {
             buf.append(" " + Modifier.toString(mod));

--- a/icu4j/tools/misc/src/main/java/com/ibm/icu/dev/tool/ime/indic/IndicInputMethodImpl.java
+++ b/icu4j/tools/misc/src/main/java/com/ibm/icu/dev/tool/ime/indic/IndicInputMethodImpl.java
@@ -15,8 +15,8 @@ import java.awt.font.TextAttribute;
 import java.awt.font.TextHitInfo;
 import java.awt.im.spi.InputMethodContext;
 import java.text.AttributedCharacterIterator;
+import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Hashtable;
 import java.util.Map;
 import java.util.Set;
 
@@ -396,7 +396,7 @@ class IndicInputMethodImpl {
         }
 
         public Map getAttributes() {
-            Hashtable result = new Hashtable();
+            HashMap result = new HashMap<>();
             if (index >= committed && committed < text.length) {
                 result.put(TextAttribute.INPUT_METHOD_UNDERLINE, 
                            TextAttribute.UNDERLINE_LOW_ONE_PIXEL);

--- a/icu4j/tools/misc/src/main/java/com/ibm/icu/dev/tool/ime/translit/TransliteratorInputMethod.java
+++ b/icu4j/tools/misc/src/main/java/com/ibm/icu/dev/tool/ime/translit/TransliteratorInputMethod.java
@@ -47,6 +47,7 @@ import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.ReplaceableString;
 import com.ibm.icu.text.Transliterator;
 
+@SuppressWarnings("JdkObsolete") // Because of ReplaceableString(StringBuffer)
 public class TransliteratorInputMethod implements InputMethod {
 
     private static boolean usesAttachedIME() {
@@ -338,7 +339,7 @@ public class TransliteratorInputMethod implements InputMethod {
     // debugging
     private String eventInfo(AWTEvent event) {
         String info = event.toString();
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         int index1 = info.indexOf("[");
         int index2 = info.indexOf(",", index1);
         buf.append(info.substring(index1 + 1, index2));


### PR DESCRIPTION
ICU report: https://mihai-nita.net/tmp/ep/20250710/errorprone2.html#name_JdkObsolete
Issue type: https://errorprone.info/bugpattern/JdkObsolete
Most of them about using `StringBuffer` instead of `StringBuilder`.

In some cases this was not possible because we have public APIs using `StringBuffer`.
For those cases I added `@SuppressWarnings` annotations with a short explanation why.

#### Checklist
- [x] Required: Issue filed: ICU-23054
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
