### PR TITLE
ICU-23164 Avoid segfault due to incomplete cnvalias.icu

### DIFF
--- a/icu4c/source/common/udata.cpp
+++ b/icu4c/source/common/udata.cpp
@@ -1004,6 +1004,7 @@ static UDataMemory *doLoadFromIndividualFiles(const char *pkgName,
                 *  and return it.   */
                 pEntryData->mapAddr = dataMemory.mapAddr;
                 pEntryData->map     = dataMemory.map;
+                pEntryData->length  = dataMemory.length;
 
 #ifdef UDATA_DEBUG
                 fprintf(stderr, "** Mapped file: %s\n", pathBuffer);

--- a/icu4c/source/common/umapfile.cpp
+++ b/icu4c/source/common/umapfile.cpp
@@ -119,6 +119,7 @@ typedef HANDLE MemoryMap;
 
         HANDLE map = nullptr;
         HANDLE file = INVALID_HANDLE_VALUE;
+        DWORD fileLength = 0;
 
         UDataMemory_init(pData); /* Clear the output struct.        */
 
@@ -159,6 +160,8 @@ typedef HANDLE MemoryMap;
             return false;
         }
 
+        fileLength = GetFileSize(file, nullptr);
+
         // Note: We use nullptr/nullptr for lpAttributes parameter below.
         // This means our handle cannot be inherited and we will get the default security descriptor.
         /* create an unnamed Windows file-mapping object for the specified file */
@@ -181,6 +184,8 @@ typedef HANDLE MemoryMap;
             return false;
         }
         pData->map = map;
+        pData->length = fileLength;
+
         return true;
     }
 
@@ -237,6 +242,7 @@ typedef HANDLE MemoryMap;
         pData->map = (char *)data + length;
         pData->pHeader=(const DataHeader *)data;
         pData->mapAddr = data;
+        pData->length = length;
 #if U_PLATFORM == U_PF_IPHONE || U_PLATFORM == U_PF_ANDROID
     // Apparently supported from Android 23 and higher:
     //   https://github.com/ggml-org/llama.cpp/pull/3631
@@ -320,6 +326,7 @@ typedef HANDLE MemoryMap;
         pData->map=p;
         pData->pHeader=(const DataHeader *)p;
         pData->mapAddr=p;
+        pData->length = fileLength;
         return true;
     }
 

--- a/icu4c/source/data/BUILDRULES.py
+++ b/icu4c/source/data/BUILDRULES.py
@@ -62,37 +62,37 @@ def generate(config, io, common_vars):
         "locales",
         None,
         config.use_pool_bundle,
-        [])
+        [DepTarget("cnvalias")])
 
     requests += generate_tree(config, io, common_vars,
         "curr",
         "curr",
         config.use_pool_bundle,
-        [])
+        [DepTarget("cnvalias")])
 
     requests += generate_tree(config, io, common_vars,
         "lang",
         "lang",
         config.use_pool_bundle,
-        [])
+        [DepTarget("cnvalias")])
 
     requests += generate_tree(config, io, common_vars,
         "region",
         "region",
         config.use_pool_bundle,
-        [])
+        [DepTarget("cnvalias")])
 
     requests += generate_tree(config, io, common_vars,
         "zone",
         "zone",
         config.use_pool_bundle,
-        [])
+        [DepTarget("cnvalias")])
 
     requests += generate_tree(config, io, common_vars,
         "unit",
         "unit",
         config.use_pool_bundle,
-        [])
+        [DepTarget("cnvalias")])
 
     requests += generate_tree(config, io, common_vars,
         "coll",
@@ -102,21 +102,21 @@ def generate(config, io, common_vars):
         # Depends on timezoneTypes.res and keyTypeData.res.
         # TODO: We should not need this dependency to build collation.
         # TODO: Bake keyTypeData.res into the common library?
-        [DepTarget("coll_ucadata"), DepTarget("misc_res"), InFile("unidata/UCARules.txt")])
+        [DepTarget("coll_ucadata"), DepTarget("misc_res"), InFile("unidata/UCARules.txt"), DepTarget("cnvalias")])
 
     requests += generate_tree(config, io, common_vars,
         "brkitr",
         "brkitr",
         # Never use pool bundle for coll, brkitr, or rbnf
         False,
-        [DepTarget("brkitr_brk"), DepTarget("dictionaries")])
+        [DepTarget("brkitr_brk"), DepTarget("dictionaries"), DepTarget("cnvalias")])
 
     requests += generate_tree(config, io, common_vars,
         "rbnf",
         "rbnf",
         # Never use pool bundle for coll, brkitr, or rbnf
         False,
-        [])
+        [DepTarget("cnvalias")])
 
     requests += [
         ListRequest(
@@ -158,7 +158,7 @@ def generate_confusables(config, io, common_vars):
         SingleExecutionRequest(
             name = "confusables",
             category = "confusables",
-            dep_targets = [DepTarget("cnvalias")],
+            dep_targets = [],
             input_files = [txt1, txt2],
             output_files = [cfu],
             tool = IcuTool("gencfu"),
@@ -403,7 +403,7 @@ def generate_misc(config, io, common_vars):
         RepeatedExecutionRequest(
             name = "misc_res",
             category = "misc",
-            dep_targets = [DepTarget("cnvalias")], # ICU-21175
+            dep_targets = [DepTarget("cnvalias")],
             input_files = input_files,
             output_files = output_files,
             tool = IcuTool("genrb"),
@@ -427,7 +427,7 @@ def generate_curr_supplemental(config, io, common_vars):
         SingleExecutionRequest(
             name = "curr_supplemental_res",
             category = "curr_supplemental",
-            dep_targets = [],
+            dep_targets = [DepTarget("cnvalias")],
             input_files = [input_file],
             output_files = [output_file],
             tool = IcuTool("genrb"),
@@ -450,7 +450,7 @@ def generate_zone_supplemental(config, io, common_vars):
         SingleExecutionRequest(
             name = "zone_supplemental_res",
             category = "zone_supplemental",
-            dep_targets = [],
+            dep_targets = [DepTarget("cnvalias")],
             input_files = [input_file],
             output_files = [output_file],
             tool = IcuTool("genrb"),
@@ -472,6 +472,7 @@ def generate_translit(config, io, common_vars):
     ]
     dep_files = set(InFile(filename) for filename in io.glob("translit/*.txt"))
     dep_files -= set(input_files)
+    dep_files.add(DepTarget("cnvalias"))
     dep_files = list(sorted(dep_files))
     input_basenames = [v.filename[9:] for v in input_files]
     output_files = [
@@ -509,7 +510,7 @@ def generate_brkitr_lstm(config, io, common_vars):
         RepeatedOrSingleExecutionRequest(
             name = "lstm_res",
             category = "brkitr_lstm",
-            dep_targets = [],
+            dep_targets = [DepTarget("cnvalias")],
             input_files = input_files,
             output_files = output_files,
             tool = IcuTool("genrb"),
@@ -535,7 +536,7 @@ def generate_brkitr_adaboost(config, io, common_vars):
         RepeatedOrSingleExecutionRequest(
             name = "adaboost_res",
             category = "brkitr_adaboost",
-            dep_targets = [],
+            dep_targets = [DepTarget("cnvalias")],
             input_files = input_files,
             output_files = output_files,
             tool = IcuTool("genrb"),
@@ -666,6 +667,7 @@ def generate_tree(
         IndexRequest(
             name = index_file_target_name,
             category = category,
+            dep_targets = [DepTarget("cnvalias")],
             installed_files = installed_files,
             alias_files = alias_files,
             txt_file = index_file_txt,

--- a/icu4c/source/python/icutools/databuilder/request_types.py
+++ b/icu4c/source/python/icutools/databuilder/request_types.py
@@ -291,6 +291,7 @@ class IndexRequest(AbstractRequest):
     def __init__(self, **kwargs):
         self.installed_files = []
         self.alias_files = []
+        self.dep_targets = []
         self.txt_file = None
         self.output_file = None
         self.cldr_version = ""
@@ -324,6 +325,7 @@ class IndexRequest(AbstractRequest):
             SingleExecutionRequest(
                 name = "%s_res" % self.name,
                 category = self.category,
+                dep_targets = self.dep_targets,
                 input_files = [self.txt_file],
                 output_files = [self.output_file],
                 tool = IcuTool("genrb"),

--- a/icu4c/source/tools/gencfu/gencfu.cpp
+++ b/icu4c/source/tools/gencfu/gencfu.cpp
@@ -203,14 +203,6 @@ int  main(int argc, char **argv) {
     return (int)status;
 
 #else
-    /* Initialize ICU */
-    u_init(&status);
-    if (U_FAILURE(status)) {
-        fprintf(stderr, "%s: can not initialize ICU.  status = %s\n",
-            argv[0], u_errorName(status));
-        exit(1);
-    }
-    status = U_ZERO_ERROR;
 
     //  Read in the confusables source file
 


### PR DESCRIPTION
These changes fix a condition where a partial cnvalias.icu will cause a segmentation fault. Here are the issues.

1. You have to build the data fast enough in a parallel build where cnvalias.icu is partially written. For the maximum chance at a failure, write just the header. This is a race condition. The changes to BUILDRULES.py should resolve this issue.
2. The code now does a length check of the internal sizes with the actual size. If at any point the calculated data structure size is larger than the actual size, we return a U_INVALID_FORMAT_ERROR. This avoids the segfault in order to fail a little more gracefully and consistently.
3. The udata functionality didn't actually return the size of the file under certain circumstances. This missing functionality was added. This data can be used for validating the data structure bounds in general.

Various tools call u_init, which only loads cnvalias.icu. If you're trying to load anything besides the canonical name of a charset, this step is important. This file dependency can't really be removed.

@cjchapman helped with testing and creating this fix.

I wrote the ucnv_io.cpp about 23 years ago. It's interesting to revisit it after all these years.

#### Checklist
- [x] Required: Issue filed: ICU-23164
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
