### PR TITLE
ICU-23150 Deprecate C create/getMilligramPerDeciliter, J MILLIGRAM_PER_DECILITER

### DIFF
--- a/icu4c/source/i18n/unicode/measunit.h
+++ b/icu4c/source/i18n/unicode/measunit.h
@@ -1173,6 +1173,7 @@ class U_I18N_API MeasureUnit: public UObject {
      */
     static MeasureUnit getMilligramOfglucosePerDeciliter();
 
+#ifndef U_HIDE_DEPRECATED_API
     /**
      * Returns by pointer, unit of concentr: milligram-per-deciliter.
      * (renamed to milligram-ofglucose-per-deciliter in CLDR 39 / ICU 69).
@@ -1180,7 +1181,7 @@ class U_I18N_API MeasureUnit: public UObject {
      * Also see {@link #createMilligramOfglucosePerDeciliter()}.
      * Also see {@link #getMilligramPerDeciliter()}.
      * @param status ICU error code.
-     * @stable ICU 57
+     * @deprecated ICU 78 use createMilligramOfglucosePerDeciliter(UErrorCode &status)
      */
     static MeasureUnit *createMilligramPerDeciliter(UErrorCode &status);
 
@@ -1189,9 +1190,10 @@ class U_I18N_API MeasureUnit: public UObject {
      * (renamed to milligram-ofglucose-per-deciliter in CLDR 39 / ICU 69).
      * Also see {@link #getMilligramOfglucosePerDeciliter()}.
      * Also see {@link #createMilligramPerDeciliter()}.
-     * @stable ICU 64
+     * @deprecated ICU 78 use getMilligramOfglucosePerDeciliter()
      */
     static MeasureUnit getMilligramPerDeciliter();
+#endif  /* U_HIDE_DEPRECATED_API */
 
     /**
      * Returns by pointer, unit of concentr: millimole-per-liter.

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/MeasureUnitGeneratorTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/MeasureUnitGeneratorTest.java
@@ -480,6 +480,7 @@ public class MeasureUnitGeneratorTest extends CoreTestFmwk {
 
     // Add backward compatibility header for "milligram-per-deciliter"
     private static void addCXXHForMilligramPerDeciliter(PrintStream out) {
+        out.println("#ifndef U_HIDE_DEPRECATED_API");
         out.println("    /**");
         out.println("     * Returns by pointer, unit of concentr: milligram-per-deciliter.");
         out.println("     * (renamed to milligram-ofglucose-per-deciliter in CLDR 39 / ICU 69).");
@@ -487,7 +488,7 @@ public class MeasureUnitGeneratorTest extends CoreTestFmwk {
         out.println("     * Also see {@link #createMilligramOfglucosePerDeciliter()}.");
         out.println("     * Also see {@link #getMilligramPerDeciliter()}.");
         out.println("     * @param status ICU error code.");
-        out.println("     * @stable ICU 57");
+        out.println("     * @deprecated ICU 78 use createMilligramOfglucosePerDeciliter(UErrorCode &status)");
         out.println("     */");
         out.println("    static MeasureUnit *createMilligramPerDeciliter(UErrorCode &status);");
         out.println("");
@@ -496,9 +497,10 @@ public class MeasureUnitGeneratorTest extends CoreTestFmwk {
         out.println("     * (renamed to milligram-ofglucose-per-deciliter in CLDR 39 / ICU 69).");
         out.println("     * Also see {@link #getMilligramOfglucosePerDeciliter()}.");
         out.println("     * Also see {@link #createMilligramPerDeciliter()}.");
-        out.println("     * @stable ICU 64");
+        out.println("     * @deprecated ICU 78 use getMilligramOfglucosePerDeciliter()");
         out.println("     */");
         out.println("    static MeasureUnit getMilligramPerDeciliter();");
+        out.println("#endif  /* U_HIDE_DEPRECATED_API */");
         out.println("");
     }
 
@@ -966,8 +968,9 @@ public class MeasureUnitGeneratorTest extends CoreTestFmwk {
         out.println("    /**");
         out.println("     * Constant for unit of concentr: milligram-per-deciliter");
         out.println("     * (renamed to milligram-ofglucose-per-deciliter in CLDR 39 / ICU 69).");
-        out.println("     * @stable ICU 57");
+        out.println("     * @deprecated ICU 78 use MILLIGRAM_OFGLUCOSE_PER_DECILITER");
         out.println("     */");
+        out.println("    @Deprecated");
         out.println("    public static final MeasureUnit MILLIGRAM_PER_DECILITER = MeasureUnit.internalGetInstance(\"" +
                             type + "\", \"" + code + "\");");
         out.println("");
@@ -990,8 +993,7 @@ public class MeasureUnitGeneratorTest extends CoreTestFmwk {
         out.println("    /**");
         out.println("     * Constant for unit of mass: metric-ton");
         out.println("     * (renamed to tonne in CLDR 42 / ICU 72).");
-        out.println("     * @internal");
-        out.println("     * @deprecated This API is ICU internal only.");
+        out.println("     * @deprecated ICU 78 use TONNE");
         out.println("     */");
         out.println("    @Deprecated");
         out.println("    public static final MeasureUnit METRIC_TON = MeasureUnit.internalGetInstance(\"" +

--- a/icu4j/main/core/src/main/java/com/ibm/icu/util/MeasureUnit.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/util/MeasureUnit.java
@@ -1202,8 +1202,9 @@ public class MeasureUnit implements Serializable {
     /**
      * Constant for unit of concentr: milligram-per-deciliter
      * (renamed to milligram-ofglucose-per-deciliter in CLDR 39 / ICU 69).
-     * @stable ICU 57
+     * @deprecated ICU 78 use MILLIGRAM_OFGLUCOSE_PER_DECILITER
      */
+    @Deprecated
     public static final MeasureUnit MILLIGRAM_PER_DECILITER = MeasureUnit.internalGetInstance("concentr", "milligram-ofglucose-per-deciliter");
 
     /**
@@ -2026,8 +2027,7 @@ public class MeasureUnit implements Serializable {
     /**
      * Constant for unit of mass: metric-ton
      * (renamed to tonne in CLDR 42 / ICU 72).
-     * @internal
-     * @deprecated This API is ICU internal only.
+     * @deprecated ICU 78 use TONNE
      */
     @Deprecated
     public static final MeasureUnit METRIC_TON = MeasureUnit.internalGetInstance("mass", "tonne");


### PR DESCRIPTION
1. Deprecate ICU4C createMilligramPerDeciliter/getMilligramPerDeciliter, ICU4J MILLIGRAM_PER_DECILITER
2. Remove the @internal from ICU4J METRIC_TON (which was deprecated earlier in ICU 78)
3. Update the MeasureUnit generator handling of replaced APIs to match

Note that items 1,2 are per API [discussion and approval at ICU TC meeting 2025-07-1](https://docs.google.com/document/d/19vv8vxCJiaWZEsR56Ospyr_UbJvl0AW86IZCoMM4bxs/edit?tab=t.0#heading=h.mkq7gt1xbpqj)0

#### Checklist
- [x] Required: Issue filed: ICU-23150
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
