### PR TITLE
ICU-23136 Remove template instantiations from MessageFormat-related classes

### DIFF
--- a/icu4c/source/i18n/messageformat2_data_model.cpp
+++ b/icu4c/source/i18n/messageformat2_data_model.cpp
@@ -18,6 +18,8 @@ U_NAMESPACE_BEGIN
 
 namespace message2 {
 
+namespace data_model {
+
 // Implementation
 
 //------------------ SelectorKeys
@@ -913,6 +915,8 @@ MFDataModel::Builder::~Builder() {
         delete bindings;
     }
 }
+
+} // namespace data_model
 } // namespace message2
 
 U_NAMESPACE_END

--- a/icu4c/source/i18n/unicode/messageformat2_arguments.h
+++ b/icu4c/source/i18n/unicode/messageformat2_arguments.h
@@ -29,20 +29,6 @@
 
 U_NAMESPACE_BEGIN
 
-/// @cond DOXYGEN_IGNORE
-// Export an explicit template instantiation of the LocalPointer that is used as a
-// data member of various MessageFormatDataModel classes.
-// (When building DLLs for Windows this is required.)
-// (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
-// for similar examples.)
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API LocalPointerBase<UnicodeString>;
-template class U_I18N_API LocalPointerBase<message2::Formattable>;
-template class U_I18N_API LocalArray<UnicodeString>;
-template class U_I18N_API LocalArray<message2::Formattable>;
-#endif
-/// @endcond
-
 namespace message2 {
 
     class MessageFormatter;
@@ -58,7 +44,7 @@ namespace message2 {
      * @internal ICU 75 technology preview
      * @deprecated This API is for technology preview only.
      */
-    class U_I18N_API MessageArguments : public UObject {
+    class U_I18N_API_CLASS MessageArguments : public UObject {
     public:
         /**
          * Message arguments constructor, which takes a map and returns a container
@@ -71,7 +57,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        MessageArguments(const std::map<UnicodeString, Formattable>& args, UErrorCode& status) {
+        U_I18N_API MessageArguments(const std::map<UnicodeString, Formattable>& args, UErrorCode& status) {
             if (U_FAILURE(status)) {
                 return;
             }
@@ -95,7 +81,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        MessageArguments& operator=(MessageArguments&&) noexcept;
+        U_I18N_API MessageArguments& operator=(MessageArguments&&) noexcept;
         /**
          * Default constructor.
          * Returns an empty arguments mapping.
@@ -103,14 +89,14 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        MessageArguments() = default;
+        U_I18N_API MessageArguments() = default;
         /**
          * Destructor.
          *
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        virtual ~MessageArguments();
+        U_I18N_API virtual ~MessageArguments();
     private:
         friend class MessageContext;
 

--- a/icu4c/source/i18n/unicode/messageformat2_data_model.h
+++ b/icu4c/source/i18n/unicode/messageformat2_data_model.h
@@ -53,7 +53,6 @@ static inline std::vector<T> toStdVector(const T* arr, int32_t len) {
 
 namespace message2 {
     class Checker;
-    class MFDataModel;
     class MessageFormatter;
     class Parser;
     class Serializer;
@@ -63,6 +62,7 @@ namespace message2 {
         class Binding;
         class Literal;
         class Operator;
+        class MFDataModel;
 
       /**
          * The `Literal` class corresponds to the `literal` nonterminal in the MessageFormat 2 grammar,
@@ -197,47 +197,6 @@ namespace message2 {
             /* const */ bool thisIsQuoted = false;
             /* const */ UnicodeString contents;
         };
-  } // namespace data_model
-} // namespace message2
-
-/// @cond DOXYGEN_IGNORE
-// Export an explicit template instantiation of the LocalPointer that is used as a
-// data member of various MFDataModel classes.
-// (When building DLLs for Windows this is required.)
-// (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
-// for similar examples.)
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API LocalPointerBase<message2::data_model::Literal>;
-template class U_I18N_API LocalArray<message2::data_model::Literal>;
-#endif
-#if defined(U_REAL_MSVC)
-#pragma warning(pop)
-#endif
-/// @endcond
-
-U_NAMESPACE_END
-
-/// @cond DOXYGEN_IGNORE
-// Export an explicit template instantiation of the std::variants and std::optionals
-// that are used as a data member of various MFDataModel classes.
-// (When building DLLs for Windows this is required.)
-// (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
-// for similar examples.)
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-#if defined(U_REAL_MSVC) && defined(_MSVC_STL_VERSION)
-struct U_I18N_API std::_Nontrivial_dummy_type;
-template class U_I18N_API std::_Variant_storage_<false, icu::UnicodeString, icu::message2::data_model::Literal>;
-#endif
-template class U_I18N_API std::variant<icu::UnicodeString, icu::message2::data_model::Literal>;
-template class U_I18N_API std::optional<std::variant<icu::UnicodeString, icu::message2::data_model::Literal>>;
-template class U_I18N_API std::optional<icu::message2::data_model::Literal>;
-#endif
-/// @endcond
-
-U_NAMESPACE_BEGIN
-
-namespace message2 {
-  namespace data_model {
 
         /**
          * The `Operand` class corresponds to the `operand` nonterminal in the MessageFormat 2 grammar,
@@ -253,7 +212,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        class U_I18N_API Operand : public UObject {
+        class U_I18N_API_CLASS Operand : public UObject {
         public:
             /**
              * Determines if this operand represents a variable.
@@ -263,7 +222,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            UBool isVariable() const;
+            U_I18N_API UBool isVariable() const;
             /**
              * Determines if this operand represents a literal.
              *
@@ -272,7 +231,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            UBool isLiteral() const;
+            U_I18N_API UBool isLiteral() const;
             /**
              * Determines if this operand is the null operand.
              *
@@ -281,7 +240,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            virtual UBool isNull() const;
+            U_I18N_API virtual UBool isNull() const;
             /**
              * Returns a reference to this operand's variable name.
              * Precondition: isVariable()
@@ -291,7 +250,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            const UnicodeString& asVariable() const;
+            U_I18N_API const UnicodeString& asVariable() const;
             /**
              * Returns a reference to this operand's literal contents.
              * Precondition: isLiteral()
@@ -301,7 +260,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            const Literal& asLiteral() const;
+            U_I18N_API const Literal& asLiteral() const;
             /**
              * Default constructor.
              * Creates a null Operand.
@@ -309,7 +268,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            Operand() : contents(std::nullopt) {}
+            U_I18N_API Operand() : contents(std::nullopt) {}
             /**
              * Variable operand constructor.
              *
@@ -319,7 +278,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            explicit Operand(const UnicodeString& v) : contents(VariableName(v)) {}
+            U_I18N_API explicit Operand(const UnicodeString& v) : contents(VariableName(v)) {}
             /**
              * Literal operand constructor.
              *
@@ -329,7 +288,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            explicit Operand(const Literal& l) : contents(l) {}
+            U_I18N_API explicit Operand(const Literal& l) : contents(l) {}
             /**
              * Non-member swap function.
              * @param o1 will get o2's contents
@@ -338,7 +297,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            friend inline void swap(Operand& o1, Operand& o2) noexcept {
+            U_I18N_API friend inline void swap(Operand& o1, Operand& o2) noexcept {
                 using std::swap;
                 (void) o1;
                 (void) o2;
@@ -350,21 +309,21 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            virtual Operand& operator=(Operand) noexcept;
+            U_I18N_API virtual Operand& operator=(Operand) noexcept;
             /**
              * Copy constructor.
              *
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            Operand(const Operand&);
+            U_I18N_API Operand(const Operand&);
             /**
              * Destructor.
              *
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            virtual ~Operand();
+            U_I18N_API virtual ~Operand();
         private:
             std::optional<std::variant<VariableName, Literal>> contents;
         }; // class Operand
@@ -384,7 +343,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        class U_I18N_API Key : public UObject {
+        class U_I18N_API_CLASS Key : public UObject {
         public:
             /**
              * Determines if this is a wildcard key
@@ -394,7 +353,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            UBool isWildcard() const { return !contents.has_value(); }
+            U_I18N_API UBool isWildcard() const { return !contents.has_value(); }
             /**
              * Returns the contents of this key as a literal.
              * Precondition: !isWildcard()
@@ -404,14 +363,14 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            const Literal& asLiteral() const;
+            U_I18N_API const Literal& asLiteral() const;
             /**
              * Copy constructor.
              *
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            Key(const Key& other) : contents(other.contents) {}
+            U_I18N_API Key(const Key& other) : contents(other.contents) {}
             /**
              * Wildcard constructor; constructs a Key representing the
              * catchall or wildcard key, '*'.
@@ -419,7 +378,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            Key() : contents(std::nullopt) {}
+            U_I18N_API Key() : contents(std::nullopt) {}
             /**
              * Literal key constructor.
              *
@@ -429,7 +388,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            explicit Key(const Literal& lit) : contents(lit) {}
+            U_I18N_API explicit Key(const Literal& lit) : contents(lit) {}
             /**
              * Non-member swap function.
              * @param k1 will get k2's contents
@@ -438,7 +397,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            friend inline void swap(Key& k1, Key& k2) noexcept {
+            U_I18N_API friend inline void swap(Key& k1, Key& k2) noexcept {
                 using std::swap;
 
                 swap(k1.contents, k2.contents);
@@ -449,7 +408,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            Key& operator=(Key) noexcept;
+            U_I18N_API Key& operator=(Key) noexcept;
             /**
              * Less than operator. Compares the literal of `this` with the literal of `other`.
              * This method is used in representing the mapping from key lists to patterns
@@ -463,7 +422,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            bool operator<(const Key& other) const;
+            U_I18N_API bool operator<(const Key& other) const;
             /**
              * Equality operator. Compares the literal of `this` with the literal of `other`.
              * This method is used in representing the mapping from key lists to patterns
@@ -477,34 +436,18 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            bool operator==(const Key& other) const;
+            U_I18N_API bool operator==(const Key& other) const;
             /**
              * Destructor.
              *
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            virtual ~Key();
+            U_I18N_API virtual ~Key();
         private:
             /* const */ std::optional<Literal> contents;
         }; // class Key
-  } // namespace data_model
-} // namespace message2
 
-/// @cond DOXYGEN_IGNORE
-// Export an explicit template instantiation of the LocalPointer that is used as a
-// data member of various MFDataModel classes.
-// (When building DLLs for Windows this is required.)
-// (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
-// for similar examples.)
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API LocalPointerBase<message2::data_model::Key>;
-template class U_I18N_API LocalArray<message2::data_model::Key>;
-#endif
-/// @endcond
-
-namespace message2 {
-  namespace data_model {
         /**
          * The `SelectorKeys` class represents the key list for a single variant.
          * It corresponds to the `keys` array in the `Variant` interface
@@ -515,7 +458,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        class U_I18N_API SelectorKeys : public UObject {
+        class U_I18N_API_CLASS SelectorKeys : public UObject {
         public:
             /**
              * Returns the underlying list of keys.
@@ -527,7 +470,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            std::vector<Key> getKeys() const {
+            U_I18N_API std::vector<Key> getKeys() const {
                 return toStdVector<Key>(keys.getAlias(), len);
             }
             /**
@@ -606,7 +549,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            bool operator<(const SelectorKeys& other) const;
+            U_I18N_API bool operator<(const SelectorKeys& other) const;
             /**
              * Default constructor.
              * Puts the SelectorKeys into a valid but undefined state.
@@ -614,7 +557,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            SelectorKeys() : len(0) {}
+            U_I18N_API SelectorKeys() : len(0) {}
             /**
              * Non-member swap function.
              * @param s1 will get s2's contents
@@ -623,7 +566,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            friend inline void swap(SelectorKeys& s1, SelectorKeys& s2) noexcept {
+            U_I18N_API friend inline void swap(SelectorKeys& s1, SelectorKeys& s2) noexcept {
                 using std::swap;
 
                 swap(s1.len, s2.len);
@@ -635,21 +578,21 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            SelectorKeys(const SelectorKeys& other);
+            U_I18N_API SelectorKeys(const SelectorKeys& other);
             /**
              * Assignment operator.
              *
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            SelectorKeys& operator=(SelectorKeys other) noexcept;
+            U_I18N_API SelectorKeys& operator=(SelectorKeys other) noexcept;
             /**
              * Destructor.
              *
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            virtual ~SelectorKeys();
+            U_I18N_API virtual ~SelectorKeys();
         private:
             friend class Builder;
             friend class message2::Checker;
@@ -663,11 +606,6 @@ namespace message2 {
             SelectorKeys(const UVector& ks, UErrorCode& status);
         }; // class SelectorKeys
 
-
-    } // namespace data_model
-
-
-    namespace data_model {
         class Operator;
 
         /**
@@ -756,48 +694,32 @@ namespace message2 {
             /* const */ UnicodeString name;
             /* const */ Operand rand;
         }; // class Option
-    } // namespace data_model
-} // namespace message2
 
-  /// @cond DOXYGEN_IGNORE
-// Export an explicit template instantiation of the LocalPointer that is used as a
-// data member of various MFDataModel classes.
-// (When building DLLs for Windows this is required.)
-// (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
-// for similar examples.)
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API LocalPointerBase<message2::data_model::Option>;
-template class U_I18N_API LocalArray<message2::data_model::Option>;
-#endif
-/// @endcond
-
-namespace message2 {
-  namespace data_model {
         // Internal only
         #ifndef U_IN_DOXYGEN
         // Options
         // This is a wrapper class around a vector of options that provides lookup operations
-        class U_I18N_API OptionMap : public UObject {
+        class U_I18N_API_CLASS OptionMap : public UObject {
         public:
-            int32_t size() const;
+            U_I18N_API int32_t size() const;
             // Needs to take an error code b/c an earlier copy might have failed
-            const Option& getOption(int32_t, UErrorCode&) const;
-            friend inline void swap(OptionMap& m1, OptionMap& m2) noexcept {
+            U_I18N_API const Option& getOption(int32_t, UErrorCode&) const;
+            U_I18N_API friend inline void swap(OptionMap& m1, OptionMap& m2) noexcept {
                 using std::swap;
 
                 swap(m1.bogus, m2.bogus);
                 swap(m1.options, m2.options);
                 swap(m1.len, m2.len);
             }
-            OptionMap() : len(0) {}
-            OptionMap(const OptionMap&);
-            OptionMap& operator=(OptionMap);
-            std::vector<Option> getOptions() const {
+            U_I18N_API OptionMap() : len(0) {}
+            U_I18N_API OptionMap(const OptionMap&);
+            U_I18N_API OptionMap& operator=(OptionMap);
+            U_I18N_API std::vector<Option> getOptions() const {
                 return toStdVector<Option>(options.getAlias(), len);
             }
-            OptionMap(const UVector&, UErrorCode&);
-            OptionMap(Option*, int32_t);
-            virtual ~OptionMap();
+            U_I18N_API OptionMap(const UVector&, UErrorCode&);
+            U_I18N_API OptionMap(Option*, int32_t);
+            U_I18N_API virtual ~OptionMap();
 
             class U_I18N_API Builder : public UObject {
                 private:
@@ -829,16 +751,7 @@ namespace message2 {
         }; // class OptionMap
         #endif
 
-  } // namespace data_model
-} // namespace message2
-
-U_NAMESPACE_END
-
-U_NAMESPACE_BEGIN
-
-namespace message2 {
-  namespace data_model {
-      /**
+        /**
          * The `Operator` class corresponds to the `FunctionRef` type in the
          * `Expression` interface defined in
          * https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model.md#patterns
@@ -1009,26 +922,7 @@ namespace message2 {
             /* const */ FunctionName name;
             /* const */ OptionMap options;
         }; // class Operator
-  } // namespace data_model
-} // namespace message2
 
-U_NAMESPACE_END
-
-/// @cond DOXYGEN_IGNORE
-// Export an explicit template instantiation of the std::optional that is used as a
-// data member of various MFDataModel classes.
-// (When building DLLs for Windows this is required.)
-// (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
-// for similar examples.)
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API std::optional<icu::message2::data_model::Operator>;
-#endif
-/// @endcond
-
-U_NAMESPACE_BEGIN
-
-namespace message2 {
-  namespace data_model {
       // Internal only
       typedef enum UMarkupType {
           UMARKUP_OPEN = 0,
@@ -1264,7 +1158,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        class U_I18N_API Expression : public UObject {
+        class U_I18N_API_CLASS Expression : public UObject {
         public:
             /**
              * Checks if this expression is an annotation
@@ -1276,7 +1170,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            UBool isStandaloneAnnotation() const;
+            U_I18N_API UBool isStandaloneAnnotation() const;
             /**
              * Checks if this expression has a function
              * annotation (with or without an operand).
@@ -1287,7 +1181,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            UBool isFunctionCall() const;
+            U_I18N_API UBool isFunctionCall() const;
             /**
              * Accesses the function
              * annotating this expression.
@@ -1301,7 +1195,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            const Operator* getOperator(UErrorCode& status) const;
+            U_I18N_API const Operator* getOperator(UErrorCode& status) const;
             /**
              * Accesses the operand of this expression.
              *
@@ -1311,7 +1205,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            const Operand& getOperand() const;
+            U_I18N_API const Operand& getOperand() const;
             /**
              * Gets the attributes of this expression
              *
@@ -1320,7 +1214,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            std::vector<Option> getAttributes() const { return attributes.getOptions(); }
+            U_I18N_API std::vector<Option> getAttributes() const { return attributes.getOptions(); }
             /**
              * The mutable `Expression::Builder` class allows the operator to be constructed
              * incrementally.
@@ -1420,7 +1314,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            friend inline void swap(Expression& e1, Expression& e2) noexcept {
+            U_I18N_API friend inline void swap(Expression& e1, Expression& e2) noexcept {
                 using std::swap;
 
                 swap(e1.rator, e2.rator);
@@ -1433,14 +1327,14 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            Expression(const Expression& other);
+            U_I18N_API Expression(const Expression& other);
             /**
              * Assignment operator.
              *
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            Expression& operator=(Expression) noexcept;
+            U_I18N_API Expression& operator=(Expression) noexcept;
             /**
              * Default constructor.
              * Puts the Expression into a valid but undefined state.
@@ -1448,14 +1342,14 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            Expression();
+            U_I18N_API Expression();
             /**
              * Destructor.
              *
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            virtual ~Expression();
+            U_I18N_API virtual ~Expression();
         private:
             friend class message2::Serializer;
 
@@ -1481,23 +1375,6 @@ namespace message2 {
             /* const */ OptionMap attributes;
             const OptionMap& getAttributesInternal() const { return attributes; }
         }; // class Expression
-  } // namespace data_model
-} // namespace message2
-
-/// @cond DOXYGEN_IGNORE
-// Export an explicit template instantiation of the LocalPointer that is used as a
-// data member of various MFDataModel classes.
-// (When building DLLs for Windows this is required.)
-// (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
-// for similar examples.)
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API LocalPointerBase<message2::data_model::Expression>;
-template class U_I18N_API LocalArray<message2::data_model::Expression>;
-#endif
-/// @endcond
-
-namespace message2 {
-  namespace data_model {
 
       class Pattern;
 
@@ -1512,7 +1389,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        class PatternPart : public UObject {
+        class U_I18N_API_CLASS PatternPart : public UObject {
         public:
             /**
              * Checks if the part is a text part.
@@ -1522,7 +1399,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            UBool isText() const { return std::holds_alternative<UnicodeString>(piece); }
+            U_I18N_API UBool isText() const { return std::holds_alternative<UnicodeString>(piece); }
             /**
              * Checks if the part is a markup part.
              *
@@ -1531,7 +1408,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            UBool isMarkup() const { return std::holds_alternative<Markup>(piece); }
+            U_I18N_API UBool isMarkup() const { return std::holds_alternative<Markup>(piece); }
             /**
              * Checks if the part is an expression part.
              *
@@ -1540,7 +1417,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            UBool isExpression() const { return std::holds_alternative<Expression>(piece); }
+            U_I18N_API UBool isExpression() const { return std::holds_alternative<Expression>(piece); }
             /**
              * Accesses the expression of the part.
              * Precondition: isExpression()
@@ -1550,7 +1427,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            const Expression& contents() const;
+            U_I18N_API const Expression& contents() const;
             /**
              * Accesses the expression of the part.
              * Precondition: isMarkup()
@@ -1560,7 +1437,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            const Markup& asMarkup() const;
+            U_I18N_API const Markup& asMarkup() const;
             /**
              * Accesses the text contents of the part.
              * Precondition: isText()
@@ -1570,7 +1447,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            const UnicodeString& asText() const;
+            U_I18N_API const UnicodeString& asText() const;
             /**
              * Non-member swap function.
              * @param p1 will get p2's contents
@@ -1579,7 +1456,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            friend inline void swap(PatternPart& p1, PatternPart& p2) noexcept {
+            U_I18N_API friend inline void swap(PatternPart& p1, PatternPart& p2) noexcept {
                 using std::swap;
 
                 swap(p1.piece, p2.piece);
@@ -1590,21 +1467,21 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            PatternPart(const PatternPart& other);
+            U_I18N_API PatternPart(const PatternPart& other);
             /**
              * Assignment operator.
              *
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            PatternPart& operator=(PatternPart) noexcept;
+            U_I18N_API PatternPart& operator=(PatternPart) noexcept;
             /**
              * Destructor.
              *
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            virtual ~PatternPart();
+            U_I18N_API virtual ~PatternPart();
             /**
              * Text part constructor. Returns a text pattern part
              * with text `t`.
@@ -1614,7 +1491,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            explicit PatternPart(const UnicodeString& t) : piece(t) {}
+            U_I18N_API explicit PatternPart(const UnicodeString& t) : piece(t) {}
             /**
              * Expression part constructor. Returns an Expression pattern
              * part with expression `e`.
@@ -1624,7 +1501,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            explicit PatternPart(Expression&& e) : piece(e) {}
+            U_I18N_API explicit PatternPart(Expression&& e) : piece(e) {}
             /**
              * Markup part constructor. Returns a Markup pattern
              * part with markup `m`
@@ -1634,7 +1511,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            explicit PatternPart(Markup&& m) : piece(m) {}
+            U_I18N_API explicit PatternPart(Markup&& m) : piece(m) {}
             /**
              * Default constructor.
              * Puts the PatternPart into a valid but undefined state.
@@ -1642,29 +1519,13 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            PatternPart() = default;
+            U_I18N_API PatternPart() = default;
         private:
             friend class Pattern;
 
             std::variant<UnicodeString, Expression, Markup> piece;
         }; // class PatternPart
-  } // namespace data_model
-} // namespace message2
 
-  /// @cond DOXYGEN_IGNORE
-// Export an explicit template instantiation of the LocalPointer that is used as a
-// data member of various MFDataModel classes.
-// (When building DLLs for Windows this is required.)
-// (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
-// for similar examples.)
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API LocalPointerBase<message2::data_model::PatternPart>;
-template class U_I18N_API LocalArray<message2::data_model::PatternPart>;
-#endif
-/// @endcond
-
-namespace message2 {
-  namespace data_model {
         /**
          *  A `Pattern` is a sequence of formattable parts.
          * It corresponds to the `Pattern` interface
@@ -1675,12 +1536,14 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        class U_I18N_API Pattern : public UObject {
+        class U_I18N_API_CLASS Pattern : public UObject {
         private:
             friend class PatternPart;
 
         public:
-            struct Iterator;
+            #ifndef U_IN_DOXYGEN
+            struct U_I18N_API Iterator;
+            #endif
             /**
              * Returns the parts of this pattern
              *
@@ -1690,7 +1553,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            Iterator begin() const {
+            U_I18N_API Iterator begin() const {
                 return Iterator(this, 0);
             }
             /**
@@ -1702,7 +1565,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            Iterator end() const {
+            U_I18N_API Iterator end() const {
                 return Iterator(this, len);
             }
             /**
@@ -1797,7 +1660,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            Pattern() : parts(LocalArray<PatternPart>()) {}
+            U_I18N_API Pattern() : parts(LocalArray<PatternPart>()) {}
             /**
              * Non-member swap function.
              * @param p1 will get p2's contents
@@ -1806,7 +1669,7 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            friend inline void swap(Pattern& p1, Pattern& p2) noexcept {
+            U_I18N_API friend inline void swap(Pattern& p1, Pattern& p2) noexcept {
                 using std::swap;
 
                 swap(p1.bogus, p2.bogus);
@@ -1819,21 +1682,21 @@ namespace message2 {
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            Pattern(const Pattern& other);
+            U_I18N_API Pattern(const Pattern& other);
             /**
              * Assignment operator
              *
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            Pattern& operator=(Pattern) noexcept;
+            U_I18N_API Pattern& operator=(Pattern) noexcept;
             /**
              * Destructor.
              *
              * @internal ICU 75 technology preview
              * @deprecated This API is for technology preview only.
              */
-            virtual ~Pattern();
+            U_I18N_API virtual ~Pattern();
 
             /**
              *  The `Pattern::Iterator` class provides an iterator over the formattable
@@ -2020,9 +1883,7 @@ namespace message2 {
             /* const */ SelectorKeys k;
             /* const */ Pattern p;
         }; // class Variant
-    } // namespace data_model
 
-        namespace data_model {
         /**
          *  A `Binding` pairs a variable name with an expression.
          * It corresponds to the `Declaration` interface
@@ -2154,36 +2015,14 @@ namespace message2 {
             bool hasAnnotation() const { return !local && (annotation != nullptr); }
             void updateAnnotation();
         }; // class Binding
-    } // namespace data_model
-} // namespace message2
-
-  /// @cond DOXYGEN_IGNORE
-// Export an explicit template instantiation of the LocalPointer that is used as a
-// data member of various MFDataModel classes.
-// (When building DLLs for Windows this is required.)
-// (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
-// for similar examples.)
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API LocalPointerBase<message2::data_model::Variant>;
-template class U_I18N_API LocalPointerBase<message2::data_model::Binding>;
-template class U_I18N_API LocalArray<message2::data_model::Variant>;
-template class U_I18N_API LocalArray<message2::data_model::Binding>;
-#endif
-/// @endcond
-
-namespace message2 {
-    using namespace data_model;
-
 
     // Internal only
 
-    class MFDataModel;
-
     #ifndef U_IN_DOXYGEN
-    class Matcher : public UObject {
+    class U_I18N_API_CLASS Matcher : public UObject {
     public:
-        Matcher& operator=(Matcher);
-        Matcher(const Matcher&);
+        U_I18N_API Matcher& operator=(Matcher);
+        U_I18N_API Matcher(const Matcher&);
         /**
          * Non-member swap function.
          * @param m1 will get m2's contents
@@ -2192,7 +2031,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        friend inline void swap(Matcher& m1, Matcher& m2) noexcept {
+        U_I18N_API friend inline void swap(Matcher& m1, Matcher& m2) noexcept {
             using std::swap;
 
             if (m1.bogus) {
@@ -2208,7 +2047,7 @@ namespace message2 {
             swap(m1.variants, m2.variants);
             swap(m1.numVariants, m2.numVariants);
         }
-        virtual ~Matcher();
+        U_I18N_API virtual ~Matcher();
     private:
 
         friend class MFDataModel;
@@ -2231,27 +2070,7 @@ namespace message2 {
         int32_t numVariants = 0;
     }; // class Matcher
     #endif
-} // namespace message2
 
-U_NAMESPACE_END
-
-/// @cond DOXYGEN_IGNORE
-// Export an explicit template instantiation of the std::variant that is used as a
-// data member of various MFDataModel classes.
-// (When building DLLs for Windows this is required.)
-// (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
-// for similar examples.)
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-#if defined(U_REAL_MSVC) && defined(_MSVC_STL_VERSION)
-template class U_I18N_API std::_Variant_storage_<false, icu::message2::Matcher,icu::message2::data_model::Pattern>;
-#endif
-template class U_I18N_API std::variant<icu::message2::Matcher,icu::message2::data_model::Pattern>;
-#endif
-/// @endcond
-
-U_NAMESPACE_BEGIN
-
-namespace message2 {
     // -----------------------------------------------------------------------
     // Public MFDataModel class
 
@@ -2271,7 +2090,7 @@ namespace message2 {
      * @internal ICU 75 technology preview
      * @deprecated This API is for technology preview only.
      */
-    class U_I18N_API MFDataModel : public UMemory {
+    class U_I18N_API_CLASS MFDataModel : public UMemory {
         /*
           Classes that represent nodes in the data model are nested inside the
           `MFDataModel` class.
@@ -2315,7 +2134,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        std::vector<Binding> getLocalVariables() const {
+        U_I18N_API std::vector<Binding> getLocalVariables() const {
             std::vector<Binding> result;
             if (!bogus) {
                 return toStdVector<Binding>(bindings.getAlias(), bindingsLen);
@@ -2330,7 +2149,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        std::vector<VariableName> getSelectors() const {
+        U_I18N_API std::vector<VariableName> getSelectors() const {
             if (std::holds_alternative<Pattern>(body)) {
                 return {};
             }
@@ -2346,7 +2165,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        std::vector<Variant> getVariants() const {
+        U_I18N_API std::vector<Variant> getVariants() const {
             // Return empty vector if no variants
             if (std::holds_alternative<Pattern>(body)) {
                 return {};
@@ -2365,8 +2184,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        const Pattern& getPattern() const;
-
+        U_I18N_API const Pattern& getPattern() const;
         /**
          * The mutable `MFDataModel::Builder` class allows the data model to be
          * constructed incrementally.
@@ -2375,7 +2193,6 @@ namespace message2 {
          * @deprecated This API is for technology preview only.
          */
         class U_I18N_API Builder;
-
         /**
          * Default constructor.
          * Puts the MFDataModel into a valid but undefined state.
@@ -2383,7 +2200,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        MFDataModel();
+        U_I18N_API MFDataModel();
         /**
          * Non-member swap function.
          * @param m1 will get m2's contents
@@ -2392,7 +2209,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        friend inline void swap(MFDataModel& m1, MFDataModel& m2) noexcept {
+        U_I18N_API friend inline void swap(MFDataModel& m1, MFDataModel& m2) noexcept {
             using std::swap;
 
             if (m1.bogus) {
@@ -2413,21 +2230,21 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        MFDataModel& operator=(MFDataModel) noexcept;
+        U_I18N_API MFDataModel& operator=(MFDataModel) noexcept;
         /**
          * Copy constructor.
          *
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        MFDataModel(const MFDataModel& other);
+        U_I18N_API MFDataModel(const MFDataModel& other);
         /**
          * Destructor.
          *
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        virtual ~MFDataModel();
+        U_I18N_API virtual ~MFDataModel();
 
         /**
          * The mutable `MFDataModel::Builder` class allows the data model to be
@@ -2547,9 +2364,9 @@ namespace message2 {
         }; // class Builder
 
     private:
-        friend class Checker;
-        friend class MessageFormatter;
-        friend class Serializer;
+        friend class message2::Checker;
+        friend class message2::MessageFormatter;
+        friend class message2::Serializer;
 
         Pattern empty; // Provided so that `getPattern()` can return a result
                        // if called on a selectors message
@@ -2583,7 +2400,7 @@ namespace message2 {
 
         MFDataModel(const Builder& builder, UErrorCode&) noexcept;
     }; // class MFDataModel
-
+  } // namespace data_model
 } // namespace message2
 
 U_NAMESPACE_END

--- a/icu4c/source/i18n/unicode/messageformat2_formattable.h
+++ b/icu4c/source/i18n/unicode/messageformat2_formattable.h
@@ -95,43 +95,6 @@ namespace message2 {
         UnicodeString zoneId;
     };
 
-    class Formattable;
-} // namespace message2
-
-U_NAMESPACE_END
-
-/// @cond DOXYGEN_IGNORE
-// Export an explicit template instantiation of the std::variant that is used
-// to represent the message2::Formattable class.
-// (When building DLLs for Windows this is required.)
-// (See measunit_impl.h, datefmt.h, collationiterator.h, erarules.h and others
-// for similar examples.)
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-#if defined(U_REAL_MSVC) && defined(_MSVC_STL_VERSION)
-template class U_I18N_API std::_Variant_storage_<false,
-  double,
-  int64_t,
-  icu::UnicodeString,
-  icu::Formattable,
-  icu::message2::DateInfo,
-  const icu::message2::FormattableObject *,
-  std::pair<const icu::message2::Formattable *,int32_t>>;
-#endif
-typedef std::pair<const icu::message2::Formattable*, int32_t> P;
-template class U_I18N_API std::variant<double,
-				       int64_t,
-				       icu::UnicodeString,
-				       icu::Formattable,
-                                       icu::message2::DateInfo,
-				       const icu::message2::FormattableObject*,
-                                       P>;
-#endif
-/// @endcond
-
-U_NAMESPACE_BEGIN
-
-namespace message2 {
-
     /**
      * The `Formattable` class represents a typed value that can be formatted,
      * originating either from a message argument or a literal in the code.
@@ -147,7 +110,7 @@ namespace message2 {
      * @internal ICU 75 technology preview
      * @deprecated This API is for technology preview only.
      */
-    class U_I18N_API Formattable : public UObject {
+    class U_I18N_API_CLASS Formattable : public UObject {
     public:
 
         /**
@@ -156,7 +119,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        UFormattableType getType() const;
+        U_I18N_API UFormattableType getType() const;
 
         /**
          * Gets the double value of this object. If this object is not of type
@@ -167,7 +130,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        double getDouble(UErrorCode& status) const {
+        U_I18N_API double getDouble(UErrorCode& status) const {
             if (U_SUCCESS(status)) {
                 if (isDecimal() && getType() == UFMT_DOUBLE) {
                     return (std::get_if<icu::Formattable>(&contents))->getDouble();
@@ -189,7 +152,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        int32_t getLong(UErrorCode& status) const {
+        U_I18N_API int32_t getLong(UErrorCode& status) const {
             if (U_SUCCESS(status)) {
                 if (isDecimal() && getType() == UFMT_LONG) {
                     return std::get_if<icu::Formattable>(&contents)->getLong();
@@ -212,7 +175,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        int64_t getInt64Value(UErrorCode& status) const {
+        U_I18N_API int64_t getInt64Value(UErrorCode& status) const {
             if (U_SUCCESS(status)) {
                 if (isDecimal() && getType() == UFMT_INT64) {
                     return std::get_if<icu::Formattable>(&contents)->getInt64();
@@ -239,7 +202,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        int64_t         getInt64(UErrorCode& status) const;
+        U_I18N_API int64_t getInt64(UErrorCode& status) const;
         /**
          * Gets the string value of this object. If this object is not of type
          * kString then the result is undefined and the error code is set.
@@ -249,7 +212,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        const UnicodeString& getString(UErrorCode& status) const {
+        U_I18N_API const UnicodeString& getString(UErrorCode& status) const {
             if (U_SUCCESS(status)) {
                 if (std::holds_alternative<UnicodeString>(contents)) {
                     return *std::get_if<UnicodeString>(&contents);
@@ -270,7 +233,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        const DateInfo* getDate(UErrorCode& status) const {
+        U_I18N_API const DateInfo* getDate(UErrorCode& status) const {
             if (U_SUCCESS(status)) {
                 if (isDate()) {
                     return std::get_if<DateInfo>(&contents);
@@ -287,7 +250,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        UBool isNumeric() const { return (getType() == UFMT_DOUBLE || getType() == UFMT_LONG || getType() == UFMT_INT64); }
+        U_I18N_API UBool isNumeric() const { return (getType() == UFMT_DOUBLE || getType() == UFMT_LONG || getType() == UFMT_INT64); }
 
         /**
          * Gets the array value and count of this object. If this object
@@ -299,7 +262,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        const Formattable* getArray(int32_t& count, UErrorCode& status) const;
+        U_I18N_API const Formattable* getArray(int32_t& count, UErrorCode& status) const;
 
         /**
          * Returns a pointer to the FormattableObject contained within this
@@ -311,7 +274,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        const FormattableObject* getObject(UErrorCode& status) const {
+        U_I18N_API const FormattableObject* getObject(UErrorCode& status) const {
             if (U_SUCCESS(status)) {
                 // Can't return a reference since FormattableObject
                 // is an abstract class
@@ -331,7 +294,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        friend inline void swap(Formattable& f1, Formattable& f2) noexcept {
+        U_I18N_API friend inline void swap(Formattable& f1, Formattable& f2) noexcept {
             using std::swap;
 
             swap(f1.contents, f2.contents);
@@ -342,14 +305,14 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        Formattable(const Formattable&);
+        U_I18N_API Formattable(const Formattable&);
         /**
          * Assignment operator
          *
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        Formattable& operator=(Formattable) noexcept;
+        U_I18N_API Formattable& operator=(Formattable) noexcept;
         /**
          * Default constructor. Leaves the Formattable in a
          * valid but undefined state.
@@ -357,7 +320,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        Formattable() : contents(0.0) {}
+        U_I18N_API Formattable() : contents(0.0) {}
         /**
          * String constructor.
          *
@@ -366,7 +329,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        Formattable(const UnicodeString& s) : contents(s) {}
+        U_I18N_API Formattable(const UnicodeString& s) : contents(s) {}
         /**
          * Double constructor.
          *
@@ -375,7 +338,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        Formattable(double d) : contents(d) {}
+        U_I18N_API Formattable(double d) : contents(d) {}
         /**
          * Int64 constructor.
          *
@@ -384,7 +347,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        Formattable(int64_t i) : contents(i) {}
+        U_I18N_API Formattable(int64_t i) : contents(i) {}
         /**
          * Date constructor.
          *
@@ -394,7 +357,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        Formattable(DateInfo&& d) : contents(std::move(d)) {}
+        U_I18N_API Formattable(DateInfo&& d) : contents(std::move(d)) {}
         /**
          * Creates a Formattable object of an appropriate numeric type from a
          * a decimal number in string form.  The Formattable will retain the
@@ -409,7 +372,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        static Formattable forDecimal(std::string_view number, UErrorCode& status);
+        U_I18N_API static Formattable forDecimal(std::string_view number, UErrorCode& status);
         /**
          * Array constructor.
          *
@@ -419,7 +382,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        Formattable(const Formattable* arr, int32_t len) : contents(std::pair(arr, len)) {}
+        U_I18N_API Formattable(const Formattable* arr, int32_t len) : contents(std::pair(arr, len)) {}
         /**
          * Object constructor.
          *
@@ -428,14 +391,14 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        Formattable(const FormattableObject* obj) : contents(obj) {}
+        U_I18N_API Formattable(const FormattableObject* obj) : contents(obj) {}
         /**
          * Destructor.
          *
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        virtual ~Formattable();
+        U_I18N_API virtual ~Formattable();
         /**
          * Converts the Formattable object to an ICU Formattable object.
          * If this has type UFMT_OBJECT or kArray, then `status` is set to
@@ -447,7 +410,7 @@ namespace message2 {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        icu::Formattable asICUFormattable(UErrorCode& status) const;
+        U_I18N_API icu::Formattable asICUFormattable(UErrorCode& status) const;
     private:
 
         std::variant<double,
@@ -481,7 +444,7 @@ namespace message2 {
  * @deprecated This API is for technology preview only.
  */
 #ifndef U_IN_DOXYGEN
-class U_I18N_API ResolvedFunctionOption : public UObject {
+class U_I18N_API_CLASS ResolvedFunctionOption : public UObject {
   private:
 
     /* const */ UnicodeString name;
@@ -492,20 +455,20 @@ class U_I18N_API ResolvedFunctionOption : public UObject {
     /* const */ bool sourceIsLiteral;
 
   public:
-      const UnicodeString& getName() const { return name; }
-      const Formattable& getValue() const { return value; }
-      bool isLiteral() const { return sourceIsLiteral; }
-      ResolvedFunctionOption(const UnicodeString& n, const Formattable& f, bool s)
+      U_I18N_API const UnicodeString& getName() const { return name; }
+      U_I18N_API const Formattable& getValue() const { return value; }
+      U_I18N_API bool isLiteral() const { return sourceIsLiteral; }
+      U_I18N_API ResolvedFunctionOption(const UnicodeString& n, const Formattable& f, bool s)
           : name(n), value(f), sourceIsLiteral(s) {}
-      ResolvedFunctionOption() {}
-      ResolvedFunctionOption(ResolvedFunctionOption&&);
-      ResolvedFunctionOption& operator=(ResolvedFunctionOption&& other) noexcept {
+      U_I18N_API ResolvedFunctionOption() {}
+      U_I18N_API ResolvedFunctionOption(ResolvedFunctionOption&&);
+      U_I18N_API ResolvedFunctionOption& operator=(ResolvedFunctionOption&& other) noexcept {
           name = std::move(other.name);
           value = std::move(other.value);
           sourceIsLiteral = other.sourceIsLiteral;
           return *this;
     }
-    virtual ~ResolvedFunctionOption();
+    U_I18N_API virtual ~ResolvedFunctionOption();
 }; // class ResolvedFunctionOption
 #endif
 
@@ -725,7 +688,7 @@ class U_I18N_API FunctionOptions : public UObject {
      * @internal ICU 75 technology preview
      * @deprecated This API is for technology preview only.
      */
-    class U_I18N_API FormattedPlaceholder : public UObject {
+    class U_I18N_API_CLASS FormattedPlaceholder : public UObject {
     public:
         /**
          * Fallback constructor. Constructs a value that represents a formatting error,
@@ -737,7 +700,7 @@ class U_I18N_API FunctionOptions : public UObject {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        explicit FormattedPlaceholder(const UnicodeString& s) : fallback(s), type(kFallback) {}
+        U_I18N_API explicit FormattedPlaceholder(const UnicodeString& s) : fallback(s), type(kFallback) {}
         /**
          * Constructor for fully formatted placeholders.
          *
@@ -749,7 +712,7 @@ class U_I18N_API FunctionOptions : public UObject {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        FormattedPlaceholder(const FormattedPlaceholder& input, FormattedValue&& output)
+        U_I18N_API FormattedPlaceholder(const FormattedPlaceholder& input, FormattedValue&& output)
             : fallback(input.fallback), source(input.source),
             formatted(std::move(output)), previousOptions(FunctionOptions()), type(kEvaluated) {}
         /**
@@ -764,7 +727,7 @@ class U_I18N_API FunctionOptions : public UObject {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        FormattedPlaceholder(const FormattedPlaceholder& input, FunctionOptions&& opts, FormattedValue&& output)
+        U_I18N_API FormattedPlaceholder(const FormattedPlaceholder& input, FunctionOptions&& opts, FormattedValue&& output)
             : fallback(input.fallback), source(input.source),
             formatted(std::move(output)), previousOptions(std::move(opts)), type(kEvaluated) {}
         /**
@@ -776,7 +739,7 @@ class U_I18N_API FunctionOptions : public UObject {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        FormattedPlaceholder(const Formattable& input, const UnicodeString& fb)
+        U_I18N_API FormattedPlaceholder(const Formattable& input, const UnicodeString& fb)
             : fallback(fb), source(input), type(kUnevaluated) {}
         /**
          * Default constructor. Leaves the FormattedPlaceholder in a
@@ -785,7 +748,7 @@ class U_I18N_API FunctionOptions : public UObject {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        FormattedPlaceholder() : type(kNull) {}
+        U_I18N_API FormattedPlaceholder() : type(kNull) {}
         /**
          * Returns the source `Formattable` value for this placeholder.
          * The result is undefined if this is a null operand.
@@ -795,7 +758,7 @@ class U_I18N_API FunctionOptions : public UObject {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        const message2::Formattable& asFormattable() const;
+        U_I18N_API const message2::Formattable& asFormattable() const;
         /**
          * Returns true iff this is a fallback placeholder.
          *
@@ -805,7 +768,7 @@ class U_I18N_API FunctionOptions : public UObject {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        bool isFallback() const { return type == kFallback; }
+        U_I18N_API bool isFallback() const { return type == kFallback; }
         /**
          * Returns true iff this is a null placeholder.
          *
@@ -815,7 +778,7 @@ class U_I18N_API FunctionOptions : public UObject {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        bool isNullOperand() const { return type == kNull; }
+        U_I18N_API bool isNullOperand() const { return type == kNull; }
         /**
          * Returns true iff this has formatting output.
          *
@@ -825,7 +788,7 @@ class U_I18N_API FunctionOptions : public UObject {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        bool isEvaluated() const { return (type == kEvaluated); }
+        U_I18N_API bool isEvaluated() const { return (type == kEvaluated); }
         /**
          * Returns true iff this represents a valid argument to the formatter.
          *
@@ -834,7 +797,7 @@ class U_I18N_API FunctionOptions : public UObject {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        bool canFormat() const { return !(isFallback() || isNullOperand()); }
+        U_I18N_API bool canFormat() const { return !(isFallback() || isNullOperand()); }
         /**
          * Gets the fallback value of this placeholder, to be used in its place if an error occurs while
          * formatting it.
@@ -842,7 +805,7 @@ class U_I18N_API FunctionOptions : public UObject {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        const UnicodeString& getFallback() const { return fallback; }
+        U_I18N_API const UnicodeString& getFallback() const { return fallback; }
         /**
          * Returns the options of this placeholder. The result is the empty map if !isEvaluated().
          * @return A reference to an option map, capturing the options that were used
@@ -851,15 +814,14 @@ class U_I18N_API FunctionOptions : public UObject {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        const FunctionOptions& options() const { return previousOptions; }
-
+        U_I18N_API const FunctionOptions& options() const { return previousOptions; }
         /**
          * Returns the formatted output of this placeholder. The result is undefined if !isEvaluated().
          * @return          A fully formatted `FormattedPlaceholder`.
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        const FormattedValue& output() const { return formatted; }
+        U_I18N_API const FormattedValue& output() const { return formatted; }
         /**
          * Move assignment operator:
          * The source FormattedPlaceholder will be left in a valid but undefined state.
@@ -867,7 +829,7 @@ class U_I18N_API FunctionOptions : public UObject {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        FormattedPlaceholder& operator=(FormattedPlaceholder&&) noexcept;
+        U_I18N_API FormattedPlaceholder& operator=(FormattedPlaceholder&&) noexcept;
         /**
          * Move constructor:
          * The source FormattedPlaceholder will be left in a valid but undefined state.
@@ -875,7 +837,7 @@ class U_I18N_API FunctionOptions : public UObject {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        FormattedPlaceholder(FormattedPlaceholder&& other) { *this = std::move(other); }
+        U_I18N_API FormattedPlaceholder(FormattedPlaceholder&& other) { *this = std::move(other); }
         /**
          * Formats this as a string, using defaults.  If this is
          * either the null operand or is a fallback value, the return value is the result of formatting the
@@ -891,7 +853,7 @@ class U_I18N_API FunctionOptions : public UObject {
          * @internal ICU 75 technology preview
          * @deprecated This API is for technology preview only.
          */
-        UnicodeString formatToString(const Locale& locale,
+        U_I18N_API UnicodeString formatToString(const Locale& locale,
                                      UErrorCode& status) const;
 
     private:


### PR DESCRIPTION
Make individual members public rather than entire classes, so that private members with templated types don't need to be exported.

#### Checklist
- [x] Required: Issue filed: ICU-23136
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
