### PR TITLE
ICU-23170 commit-checker: workaround for jira api issue

### DIFF
--- a/tools/commit-checker/Pipfile
+++ b/tools/commit-checker/Pipfile
@@ -12,7 +12,7 @@ python_version = "3"
 
 [packages]
 gitpython = "*"
-jira = "*"
+jira = "3.5.0"
 
 [dev-packages]
 pytest = "*"


### PR DESCRIPTION
- workaround for Jira API issue by pinning the API library version.
- This is a temporary fix as surely the API will be turned off someday, so I'm keeping the issue open.

#### Checklist
- [X] Required: Issue filed: ICU-23170
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
