### PR TITLE
ICU-23136 Remove explicit template instantiations for common classes

### DIFF
--- a/icu4c/source/common/charstr.h
+++ b/icu4c/source/common/charstr.h
@@ -21,12 +21,6 @@
 
 U_NAMESPACE_BEGIN
 
-// Windows needs us to DLL-export the MaybeStackArray template specialization,
-// but MacOS X cannot handle it. Same as in digitlst.h.
-#if !U_PLATFORM_IS_DARWIN_BASED
-template class U_COMMON_API MaybeStackArray<char, 40>;
-#endif
-
 /**
  * ICU-internal char * string class.
  * This class does not assume or enforce any particular character encoding.
@@ -38,34 +32,34 @@ template class U_COMMON_API MaybeStackArray<char, 40>;
  * For example:
  *   cs.data()[5]='a';  // no need for setCharAt(5, 'a')
  */
-class U_COMMON_API CharString : public UMemory {
+class U_COMMON_API_CLASS CharString : public UMemory {
 public:
-    CharString() : len(0) { buffer[0]=0; }
-    CharString(StringPiece s, UErrorCode &errorCode) : len(0) {
+    U_COMMON_API CharString() : len(0) { buffer[0]=0; }
+    U_COMMON_API CharString(StringPiece s, UErrorCode &errorCode) : len(0) {
         buffer[0]=0;
         append(s, errorCode);
     }
-    CharString(const CharString &s, UErrorCode &errorCode) : len(0) {
+    U_COMMON_API CharString(const CharString &s, UErrorCode &errorCode) : len(0) {
         buffer[0]=0;
         append(s, errorCode);
     }
-    CharString(const char *s, int32_t sLength, UErrorCode &errorCode) : len(0) {
+    U_COMMON_API CharString(const char *s, int32_t sLength, UErrorCode &errorCode) : len(0) {
         buffer[0]=0;
         append(s, sLength, errorCode);
     }
-    ~CharString() {}
+    U_COMMON_API ~CharString() {}
 
     /**
      * Move constructor; might leave src in an undefined state.
      * This string will have the same contents and state that the source string had.
      */
-    CharString(CharString &&src) noexcept;
+    U_COMMON_API CharString(CharString &&src) noexcept;
     /**
      * Move assignment operator; might leave src in an undefined state.
      * This string will have the same contents and state that the source string had.
      * The behavior is undefined if *this and src are the same object.
      */
-    CharString &operator=(CharString &&src) noexcept;
+    U_COMMON_API CharString &operator=(CharString &&src) noexcept;
 
     /**
      * Replaces this string's contents with the other string's contents.
@@ -73,21 +67,21 @@ public:
      * the assignment operator, to make copies explicit and to
      * use a UErrorCode where memory allocations might be needed.
      */
-    CharString &copyFrom(const CharString &other, UErrorCode &errorCode);
-    CharString &copyFrom(StringPiece s, UErrorCode &errorCode);
+    U_COMMON_API CharString &copyFrom(const CharString &other, UErrorCode &errorCode);
+    U_COMMON_API CharString &copyFrom(StringPiece s, UErrorCode &errorCode);
 
-    UBool isEmpty() const { return len==0; }
-    int32_t length() const { return len; }
-    char operator[](int32_t index) const { return buffer[index]; }
-    StringPiece toStringPiece() const { return StringPiece(buffer.getAlias(), len); }
+    U_COMMON_API UBool isEmpty() const { return len==0; }
+    U_COMMON_API int32_t length() const { return len; }
+    U_COMMON_API char operator[](int32_t index) const { return buffer[index]; }
+    U_COMMON_API StringPiece toStringPiece() const { return StringPiece(buffer.getAlias(), len); }
 
-    const char *data() const { return buffer.getAlias(); }
-    char *data() { return buffer.getAlias(); }
+    U_COMMON_API const char *data() const { return buffer.getAlias(); }
+    U_COMMON_API char *data() { return buffer.getAlias(); }
     /**
      * Allocates length()+1 chars and copies the NUL-terminated data().
      * The caller must uprv_free() the result.
      */
-    char *cloneData(UErrorCode &errorCode) const;
+    U_COMMON_API char *cloneData(UErrorCode &errorCode) const;
     /**
      * Copies the contents of the string into dest.
      * Checks if there is enough space in dest, extracts the entire string if possible,
@@ -103,40 +97,40 @@ public:
      * @param errorCode ICU error code.
      * @return length()
      */
-    int32_t extract(char *dest, int32_t capacity, UErrorCode &errorCode) const;
+    U_COMMON_API int32_t extract(char *dest, int32_t capacity, UErrorCode &errorCode) const;
 
-    bool operator==(const CharString& other) const {
+    U_COMMON_API bool operator==(const CharString& other) const {
         return len == other.length() && (len == 0 || uprv_memcmp(data(), other.data(), len) == 0);
     }
-    bool operator!=(const CharString& other) const {
+    U_COMMON_API bool operator!=(const CharString& other) const {
         return !operator==(other);
     }
 
-    bool operator==(StringPiece other) const {
+    U_COMMON_API bool operator==(StringPiece other) const {
         return len == other.length() && (len == 0 || uprv_memcmp(data(), other.data(), len) == 0);
     }
-    bool operator!=(StringPiece other) const {
+    U_COMMON_API bool operator!=(StringPiece other) const {
         return !operator==(other);
     }
 
     /** @return last index of c, or -1 if c is not in this string */
-    int32_t lastIndexOf(char c) const;
+    U_COMMON_API int32_t lastIndexOf(char c) const;
 
-    bool contains(StringPiece s) const;
+    U_COMMON_API bool contains(StringPiece s) const;
 
-    CharString &clear() { len=0; buffer[0]=0; return *this; }
-    CharString &truncate(int32_t newLength);
+    U_COMMON_API CharString &clear() { len=0; buffer[0]=0; return *this; }
+    U_COMMON_API CharString &truncate(int32_t newLength);
 
-    CharString &append(char c, UErrorCode &errorCode);
-    CharString &append(StringPiece s, UErrorCode &errorCode) {
+    U_COMMON_API CharString &append(char c, UErrorCode &errorCode);
+    U_COMMON_API CharString &append(StringPiece s, UErrorCode &errorCode) {
         return append(s.data(), s.length(), errorCode);
     }
-    CharString &append(const CharString &s, UErrorCode &errorCode) {
+    U_COMMON_API CharString &append(const CharString &s, UErrorCode &errorCode) {
         return append(s.data(), s.length(), errorCode);
     }
-    CharString &append(const char *s, int32_t sLength, UErrorCode &status);
+    U_COMMON_API CharString &append(const char *s, int32_t sLength, UErrorCode &status);
 
-    CharString &appendNumber(int64_t number, UErrorCode &status);
+    U_COMMON_API CharString &appendNumber(int64_t number, UErrorCode &status);
 
     /**
      * Returns a writable buffer for appending and writes the buffer's capacity to
@@ -158,26 +152,28 @@ public:
      * @param errorCode in/out error code
      * @return a buffer with resultCapacity>=min_capacity
      */
-    char *getAppendBuffer(int32_t minCapacity,
-                          int32_t desiredCapacityHint,
-                          int32_t &resultCapacity,
-                          UErrorCode &errorCode);
+    U_COMMON_API char *getAppendBuffer(int32_t minCapacity,
+                                       int32_t desiredCapacityHint,
+                                       int32_t &resultCapacity,
+                                       UErrorCode &errorCode);
 
-    CharString &appendInvariantChars(const UnicodeString &s, UErrorCode &errorCode);
-    CharString &appendInvariantChars(const char16_t* uchars, int32_t ucharsLen, UErrorCode& errorCode);
+    U_COMMON_API CharString &appendInvariantChars(const UnicodeString &s, UErrorCode &errorCode);
+    U_COMMON_API CharString &appendInvariantChars(const char16_t* uchars,
+                                                  int32_t ucharsLen,
+                                                  UErrorCode& errorCode);
 
     /**
      * Appends a filename/path part, e.g., a directory name.
      * First appends a U_FILE_SEP_CHAR or U_FILE_ALT_SEP_CHAR if necessary.
      * Does nothing if s is empty.
      */
-    CharString &appendPathPart(StringPiece s, UErrorCode &errorCode);
+    U_COMMON_API CharString &appendPathPart(StringPiece s, UErrorCode &errorCode);
 
     /**
      * Appends a U_FILE_SEP_CHAR or U_FILE_ALT_SEP_CHAR if this string is not empty
      * and does not already end with a U_FILE_SEP_CHAR or U_FILE_ALT_SEP_CHAR.
      */
-    CharString &ensureEndsWithFileSeparator(UErrorCode &errorCode);
+    U_COMMON_API CharString &ensureEndsWithFileSeparator(UErrorCode &errorCode);
 
 private:
     MaybeStackArray<char, 40> buffer;

--- a/icu4c/source/common/cstr.h
+++ b/icu4c/source/common/cstr.h
@@ -43,11 +43,11 @@
 
 U_NAMESPACE_BEGIN
 
-class U_COMMON_API CStr : public UMemory {
+class U_COMMON_API_CLASS CStr : public UMemory {
   public:
-    CStr(const UnicodeString &in);
-    ~CStr();
-    const char * operator ()() const;
+    U_COMMON_API CStr(const UnicodeString &in);
+    U_COMMON_API ~CStr();
+    U_COMMON_API const char * operator ()() const;
 
   private:
     CharString s;

--- a/icu4c/source/common/normalizer2impl.h
+++ b/icu4c/source/common/normalizer2impl.h
@@ -243,32 +243,36 @@ private:
  * this normalizer2impl.h and in the design doc at
  * https://unicode-org.github.io/icu/design/normalization/custom.html
  */
-class U_COMMON_API Normalizer2Impl : public UObject {
+class U_COMMON_API_CLASS Normalizer2Impl : public UObject {
 public:
-    Normalizer2Impl() : normTrie(nullptr), fCanonIterData(nullptr) {}
-    virtual ~Normalizer2Impl();
+    U_COMMON_API Normalizer2Impl() : normTrie(nullptr), fCanonIterData(nullptr) {}
+    U_COMMON_API virtual ~Normalizer2Impl();
 
-    void init(const int32_t *inIndexes, const UCPTrie *inTrie,
-              const uint16_t *inExtraData, const uint8_t *inSmallFCD);
+    U_COMMON_API void init(const int32_t* inIndexes,
+                           const UCPTrie* inTrie,
+                           const uint16_t* inExtraData,
+                           const uint8_t* inSmallFCD);
 
-    void addLcccChars(UnicodeSet &set) const;
-    void addPropertyStarts(const USetAdder *sa, UErrorCode &errorCode) const;
-    void addCanonIterPropertyStarts(const USetAdder *sa, UErrorCode &errorCode) const;
+    U_COMMON_API void addLcccChars(UnicodeSet& set) const;
+    U_COMMON_API void addPropertyStarts(const USetAdder* sa, UErrorCode& errorCode) const;
+    U_COMMON_API void addCanonIterPropertyStarts(const USetAdder* sa, UErrorCode& errorCode) const;
 
     // low-level properties ------------------------------------------------ ***
 
-    UBool ensureCanonIterData(UErrorCode &errorCode) const;
+    U_COMMON_API UBool ensureCanonIterData(UErrorCode& errorCode) const;
 
     // The trie stores values for lead surrogate code *units*.
     // Surrogate code *points* are inert.
-    uint16_t getNorm16(UChar32 c) const {
+    U_COMMON_API uint16_t getNorm16(UChar32 c) const {
         return U_IS_LEAD(c) ?
             static_cast<uint16_t>(INERT) :
             UCPTRIE_FAST_GET(normTrie, UCPTRIE_16, c);
     }
-    uint16_t getRawNorm16(UChar32 c) const { return UCPTRIE_FAST_GET(normTrie, UCPTRIE_16, c); }
+    U_COMMON_API uint16_t getRawNorm16(UChar32 c) const {
+        return UCPTRIE_FAST_GET(normTrie, UCPTRIE_16, c);
+    }
 
-    UNormalizationCheckResult getCompQuickCheck(uint16_t norm16) const {
+    U_COMMON_API UNormalizationCheckResult getCompQuickCheck(uint16_t norm16) const {
         if(norm16<minNoNo || MIN_YES_YES_WITH_CC<=norm16) {
             return UNORM_YES;
         } else if(minMaybeNo<=norm16) {
@@ -277,11 +281,17 @@ public:
             return UNORM_NO;
         }
     }
-    UBool isAlgorithmicNoNo(uint16_t norm16) const { return limitNoNo<=norm16 && norm16<minMaybeNo; }
-    UBool isCompNo(uint16_t norm16) const { return minNoNo<=norm16 && norm16<minMaybeNo; }
-    UBool isDecompYes(uint16_t norm16) const { return norm16<minYesNo || minMaybeYes<=norm16; }
+    U_COMMON_API UBool isAlgorithmicNoNo(uint16_t norm16) const {
+        return limitNoNo <= norm16 && norm16 < minMaybeNo;
+    }
+    U_COMMON_API UBool isCompNo(uint16_t norm16) const {
+        return minNoNo <= norm16 && norm16 < minMaybeNo;
+    }
+    U_COMMON_API UBool isDecompYes(uint16_t norm16) const {
+        return norm16 < minYesNo || minMaybeYes <= norm16;
+    }
 
-    uint8_t getCC(uint16_t norm16) const {
+    U_COMMON_API uint8_t getCC(uint16_t norm16) const {
         if(norm16>=MIN_NORMAL_MAYBE_YES) {
             return getCCFromNormalYesOrMaybe(norm16);
         }
@@ -290,13 +300,13 @@ public:
         }
         return getCCFromNoNo(norm16);
     }
-    static uint8_t getCCFromNormalYesOrMaybe(uint16_t norm16) {
+    U_COMMON_API static uint8_t getCCFromNormalYesOrMaybe(uint16_t norm16) {
         return static_cast<uint8_t>(norm16 >> OFFSET_SHIFT);
     }
-    static uint8_t getCCFromYesOrMaybeYes(uint16_t norm16) {
+    U_COMMON_API static uint8_t getCCFromYesOrMaybeYes(uint16_t norm16) {
         return norm16>=MIN_NORMAL_MAYBE_YES ? getCCFromNormalYesOrMaybe(norm16) : 0;
     }
-    uint8_t getCCFromYesOrMaybeYesCP(UChar32 c) const {
+    U_COMMON_API uint8_t getCCFromYesOrMaybeYesCP(UChar32 c) const {
         if (c < minCompNoMaybeCP) { return 0; }
         return getCCFromYesOrMaybeYes(getNorm16(c));
     }
@@ -306,7 +316,7 @@ public:
      * @param c A Unicode code point.
      * @return The lccc(c) in bits 15..8 and tccc(c) in bits 7..0.
      */
-    uint16_t getFCD16(UChar32 c) const {
+    U_COMMON_API uint16_t getFCD16(UChar32 c) const {
         if(c<minDecompNoCP) {
             return 0;
         } else if(c<=0xffff) {
@@ -322,7 +332,7 @@ public:
      * @param limit The end of the string, or NULL.
      * @return The lccc(c) in bits 15..8 and tccc(c) in bits 7..0.
      */
-    uint16_t nextFCD16(const char16_t *&s, const char16_t *limit) const {
+    U_COMMON_API uint16_t nextFCD16(const char16_t*& s, const char16_t* limit) const {
         UChar32 c=*s++;
         if(c<minDecompNoCP || !singleLeadMightHaveNonZeroFCD16(c)) {
             return 0;
@@ -340,7 +350,7 @@ public:
      * @param s A valid pointer into a string. Requires start<s.
      * @return The lccc(c) in bits 15..8 and tccc(c) in bits 7..0.
      */
-    uint16_t previousFCD16(const char16_t *start, const char16_t *&s) const {
+    U_COMMON_API uint16_t previousFCD16(const char16_t* start, const char16_t*& s) const {
         UChar32 c=*--s;
         if(c<minDecompNoCP) {
             return 0;
@@ -360,16 +370,16 @@ public:
     }
 
     /** Returns true if the single-or-lead code unit c might have non-zero FCD data. */
-    UBool singleLeadMightHaveNonZeroFCD16(UChar32 lead) const {
+    U_COMMON_API UBool singleLeadMightHaveNonZeroFCD16(UChar32 lead) const {
         // 0<=lead<=0xffff
         uint8_t bits=smallFCD[lead>>8];
         if(bits==0) { return false; }
         return (bits >> ((lead >> 5) & 7)) & 1;
     }
     /** Returns the FCD value from the regular normalization data. */
-    uint16_t getFCD16FromNormData(UChar32 c) const;
+    U_COMMON_API uint16_t getFCD16FromNormData(UChar32 c) const;
 
-    uint16_t getFCD16FromMaybeOrNonZeroCC(uint16_t norm16) const;
+    U_COMMON_API uint16_t getFCD16FromMaybeOrNonZeroCC(uint16_t norm16) const;
 
     /**
      * Gets the decomposition for one code point.
@@ -378,7 +388,7 @@ public:
      * @param length out-only, takes the length of the decomposition, if any
      * @return pointer to the decomposition, or NULL if none
      */
-    const char16_t *getDecomposition(UChar32 c, char16_t buffer[4], int32_t &length) const;
+    U_COMMON_API const char16_t* getDecomposition(UChar32 c, char16_t buffer[4], int32_t& length) const;
 
     /**
      * Gets the raw decomposition for one code point.
@@ -387,12 +397,14 @@ public:
      * @param length out-only, takes the length of the decomposition, if any
      * @return pointer to the decomposition, or NULL if none
      */
-    const char16_t *getRawDecomposition(UChar32 c, char16_t buffer[30], int32_t &length) const;
+    U_COMMON_API const char16_t* getRawDecomposition(UChar32 c,
+                                                     char16_t buffer[30],
+                                                     int32_t& length) const;
 
-    UChar32 composePair(UChar32 a, UChar32 b) const;
+    U_COMMON_API UChar32 composePair(UChar32 a, UChar32 b) const;
 
-    UBool isCanonSegmentStarter(UChar32 c) const;
-    UBool getCanonStartSet(UChar32 c, UnicodeSet &set) const;
+    U_COMMON_API UBool isCanonSegmentStarter(UChar32 c) const;
+    U_COMMON_API UBool getCanonStartSet(UChar32 c, UnicodeSet& set) const;
 
     enum {
         // Fixed norm16 values.
@@ -481,71 +493,90 @@ public:
     // higher-level functionality ------------------------------------------ ***
 
     // NFD without an NFD Normalizer2 instance.
-    UnicodeString &decompose(const UnicodeString &src, UnicodeString &dest,
-                             UErrorCode &errorCode) const;
+    U_COMMON_API UnicodeString& decompose(const UnicodeString& src,
+                                          UnicodeString& dest,
+                                          UErrorCode& errorCode) const;
     /**
      * Decomposes [src, limit[ and writes the result to dest.
      * limit can be NULL if src is NUL-terminated.
      * destLengthEstimate is the initial dest buffer capacity and can be -1.
      */
-    void decompose(const char16_t *src, const char16_t *limit,
-                   UnicodeString &dest, int32_t destLengthEstimate,
-                   UErrorCode &errorCode) const;
+    U_COMMON_API void decompose(const char16_t* src,
+                                const char16_t* limit,
+                                UnicodeString& dest,
+                                int32_t destLengthEstimate,
+                                UErrorCode& errorCode) const;
 
-    const char16_t *decompose(const char16_t *src, const char16_t *limit,
-                           ReorderingBuffer *buffer, UErrorCode &errorCode) const;
-    void decomposeAndAppend(const char16_t *src, const char16_t *limit,
-                            UBool doDecompose,
-                            UnicodeString &safeMiddle,
-                            ReorderingBuffer &buffer,
-                            UErrorCode &errorCode) const;
+    U_COMMON_API const char16_t* decompose(const char16_t* src,
+                                           const char16_t* limit,
+                                           ReorderingBuffer* buffer,
+                                           UErrorCode& errorCode) const;
+    U_COMMON_API void decomposeAndAppend(const char16_t* src,
+                                         const char16_t* limit,
+                                         UBool doDecompose,
+                                         UnicodeString& safeMiddle,
+                                         ReorderingBuffer& buffer,
+                                         UErrorCode& errorCode) const;
 
     /** sink==nullptr: isNormalized()/spanQuickCheckYes() */
-    const uint8_t *decomposeUTF8(uint32_t options,
-                                 const uint8_t *src, const uint8_t *limit,
-                                 ByteSink *sink, Edits *edits, UErrorCode &errorCode) const;
+    U_COMMON_API const uint8_t* decomposeUTF8(uint32_t options,
+                                              const uint8_t* src,
+                                              const uint8_t* limit,
+                                              ByteSink* sink,
+                                              Edits* edits,
+                                              UErrorCode& errorCode) const;
 
-    UBool compose(const char16_t *src, const char16_t *limit,
-                  UBool onlyContiguous,
-                  UBool doCompose,
-                  ReorderingBuffer &buffer,
-                  UErrorCode &errorCode) const;
-    const char16_t *composeQuickCheck(const char16_t *src, const char16_t *limit,
-                                   UBool onlyContiguous,
-                                   UNormalizationCheckResult *pQCResult) const;
-    void composeAndAppend(const char16_t *src, const char16_t *limit,
-                          UBool doCompose,
-                          UBool onlyContiguous,
-                          UnicodeString &safeMiddle,
-                          ReorderingBuffer &buffer,
-                          UErrorCode &errorCode) const;
+    U_COMMON_API UBool compose(const char16_t* src,
+                               const char16_t* limit,
+                               UBool onlyContiguous,
+                               UBool doCompose,
+                               ReorderingBuffer& buffer,
+                               UErrorCode& errorCode) const;
+    U_COMMON_API const char16_t* composeQuickCheck(const char16_t* src,
+                                                   const char16_t* limit,
+                                                   UBool onlyContiguous,
+                                                   UNormalizationCheckResult* pQCResult) const;
+    U_COMMON_API void composeAndAppend(const char16_t* src,
+                                       const char16_t* limit,
+                                       UBool doCompose,
+                                       UBool onlyContiguous,
+                                       UnicodeString& safeMiddle,
+                                       ReorderingBuffer& buffer,
+                                       UErrorCode& errorCode) const;
 
     /** sink==nullptr: isNormalized() */
-    UBool composeUTF8(uint32_t options, UBool onlyContiguous,
-                      const uint8_t *src, const uint8_t *limit,
-                      ByteSink *sink, icu::Edits *edits, UErrorCode &errorCode) const;
+    U_COMMON_API UBool composeUTF8(uint32_t options,
+                                   UBool onlyContiguous,
+                                   const uint8_t* src,
+                                   const uint8_t* limit,
+                                   ByteSink* sink,
+                                   icu::Edits* edits,
+                                   UErrorCode& errorCode) const;
 
-    const char16_t *makeFCD(const char16_t *src, const char16_t *limit,
-                         ReorderingBuffer *buffer, UErrorCode &errorCode) const;
-    void makeFCDAndAppend(const char16_t *src, const char16_t *limit,
-                          UBool doMakeFCD,
-                          UnicodeString &safeMiddle,
-                          ReorderingBuffer &buffer,
-                          UErrorCode &errorCode) const;
+    U_COMMON_API const char16_t* makeFCD(const char16_t* src,
+                                         const char16_t* limit,
+                                         ReorderingBuffer* buffer,
+                                         UErrorCode& errorCode) const;
+    U_COMMON_API void makeFCDAndAppend(const char16_t* src,
+                                       const char16_t* limit,
+                                       UBool doMakeFCD,
+                                       UnicodeString& safeMiddle,
+                                       ReorderingBuffer& buffer,
+                                       UErrorCode& errorCode) const;
 
-    UBool hasDecompBoundaryBefore(UChar32 c) const;
-    UBool norm16HasDecompBoundaryBefore(uint16_t norm16) const;
-    UBool hasDecompBoundaryAfter(UChar32 c) const;
-    UBool norm16HasDecompBoundaryAfter(uint16_t norm16) const;
-    UBool isDecompInert(UChar32 c) const { return isDecompYesAndZeroCC(getNorm16(c)); }
+    U_COMMON_API UBool hasDecompBoundaryBefore(UChar32 c) const;
+    U_COMMON_API UBool norm16HasDecompBoundaryBefore(uint16_t norm16) const;
+    U_COMMON_API UBool hasDecompBoundaryAfter(UChar32 c) const;
+    U_COMMON_API UBool norm16HasDecompBoundaryAfter(uint16_t norm16) const;
+    U_COMMON_API UBool isDecompInert(UChar32 c) const { return isDecompYesAndZeroCC(getNorm16(c)); }
 
-    UBool hasCompBoundaryBefore(UChar32 c) const {
+    U_COMMON_API UBool hasCompBoundaryBefore(UChar32 c) const {
         return c<minCompNoMaybeCP || norm16HasCompBoundaryBefore(getNorm16(c));
     }
-    UBool hasCompBoundaryAfter(UChar32 c, UBool onlyContiguous) const {
+    U_COMMON_API UBool hasCompBoundaryAfter(UChar32 c, UBool onlyContiguous) const {
         return norm16HasCompBoundaryAfter(getNorm16(c), onlyContiguous);
     }
-    UBool isCompInert(UChar32 c, UBool onlyContiguous) const {
+    U_COMMON_API UBool isCompInert(UChar32 c, UBool onlyContiguous) const {
         uint16_t norm16=getNorm16(c);
         return isCompYesAndZeroCC(norm16) &&
             (norm16 & HAS_COMP_BOUNDARY_AFTER) != 0 &&
@@ -553,10 +584,11 @@ public:
             // The last check fetches the mapping's first unit and checks tccc<=1.
     }
 
-    UBool hasFCDBoundaryBefore(UChar32 c) const { return hasDecompBoundaryBefore(c); }
-    UBool hasFCDBoundaryAfter(UChar32 c) const { return hasDecompBoundaryAfter(c); }
-    UBool isFCDInert(UChar32 c) const { return getFCD16(c)<=1; }
-private:
+    U_COMMON_API UBool hasFCDBoundaryBefore(UChar32 c) const { return hasDecompBoundaryBefore(c); }
+    U_COMMON_API UBool hasFCDBoundaryAfter(UChar32 c) const { return hasDecompBoundaryAfter(c); }
+    U_COMMON_API UBool isFCDInert(UChar32 c) const { return getFCD16(c) <= 1; }
+
+  private:
     friend class InitCanonIterData;
     friend class LcccContext;
 

--- a/icu4c/source/common/sharedobject.h
+++ b/icu4c/source/common/sharedobject.h
@@ -51,28 +51,28 @@ private:
  * Either stack-allocate, use LocalPointer, or use addRef()/removeRef().
  * Sharing requires reference-counting.
  */
-class U_COMMON_API SharedObject : public UObject {
+class U_COMMON_API_CLASS SharedObject : public UObject {
 public:
     /** Initializes totalRefCount, softRefCount to 0. */
-    SharedObject() :
+    U_COMMON_API SharedObject() :
             softRefCount(0),
             hardRefCount(0),
             cachePtr(nullptr) {}
 
     /** Initializes totalRefCount, softRefCount to 0. */
-    SharedObject(const SharedObject &other) :
+    U_COMMON_API SharedObject(const SharedObject &other) :
             UObject(other),
             softRefCount(0),
             hardRefCount(0),
             cachePtr(nullptr) {}
 
-    virtual ~SharedObject();
+    U_COMMON_API virtual ~SharedObject();
 
     /**
      * Increments the number of hard references to this object. Thread-safe.
      * Not for use from within the Unified Cache implementation.
      */
-    void addRef() const;
+    U_COMMON_API void addRef() const;
 
     /**
      * Decrements the number of hard references to this object, and
@@ -81,32 +81,32 @@ public:
      * 
      * Not for use from within the UnifiedCache implementation.
      */
-    void removeRef() const;
+    U_COMMON_API void removeRef() const;
 
     /**
      * Returns the number of hard references for this object.
      * Uses a memory barrier.
      */
-    int32_t getRefCount() const;
+    U_COMMON_API int32_t getRefCount() const;
 
     /**
      * If noHardReferences() == true then this object has no hard references.
      * Must be called only from within the internals of UnifiedCache.
      */
-    inline UBool noHardReferences() const { return getRefCount() == 0; }
+    U_COMMON_API inline UBool noHardReferences() const { return getRefCount() == 0; }
 
     /**
      * If hasHardReferences() == true then this object has hard references.
      * Must be called only from within the internals of UnifiedCache.
      */
-    inline UBool hasHardReferences() const { return getRefCount() != 0; }
+    U_COMMON_API inline UBool hasHardReferences() const { return getRefCount() != 0; }
 
     /**
      * Deletes this object if it has no references.
      * Available for non-cached SharedObjects only. Ownership of cached objects
      * is with the UnifiedCache, which is solely responsible for eviction and deletion.
      */
-    void deleteIfZeroRefCount() const;
+    U_COMMON_API void deleteIfZeroRefCount() const;
 
         
     /**

--- a/icu4c/source/i18n/measunit_impl.h
+++ b/icu4c/source/i18n/measunit_impl.h
@@ -39,12 +39,12 @@ CharString U_I18N_API getUnitQuantity(const MeasureUnitImpl &baseMeasureUnitImpl
 /**
  * A struct representing a single unit (optional SI or binary prefix, and dimensionality).
  */
-struct U_I18N_API SingleUnitImpl : public UMemory {
+struct U_I18N_API_CLASS SingleUnitImpl : public UMemory {
     /**
      * Gets a single unit from the MeasureUnit. If there are multiple single units, sets an error
      * code and returns the base dimensionless unit. Parses if necessary.
      */
-    static SingleUnitImpl forMeasureUnit(const MeasureUnit& measureUnit, UErrorCode& status);
+    U_I18N_API static SingleUnitImpl forMeasureUnit(const MeasureUnit& measureUnit, UErrorCode& status);
 
     /** Transform this SingleUnitImpl into a MeasureUnit, simplifying if possible. */
     MeasureUnit build(UErrorCode& status) const;
@@ -57,7 +57,7 @@ struct U_I18N_API SingleUnitImpl : public UMemory {
      * The returned pointer points at memory that exists for the duration of the
      * program's running.
      */
-    const char *getSimpleUnitID() const;
+    U_I18N_API const char* getSimpleUnitID() const;
 
     /**
      * Generates and append a neutral identifier string for a single unit which means we do not include
@@ -196,20 +196,11 @@ struct U_I18N_API SingleUnitImpl : public UMemory {
 // Forward declaration
 struct MeasureUnitImplWithIndex;
 
-// Export explicit template instantiations of MaybeStackArray, MemoryPool and
-// MaybeStackVector. This is required when building DLLs for Windows. (See
-// datefmt.h, collationiterator.h, erarules.h and others for similar examples.)
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API MaybeStackArray<SingleUnitImpl *, 8>;
-template class U_I18N_API MemoryPool<SingleUnitImpl, 8>;
-template class U_I18N_API MaybeStackVector<SingleUnitImpl, 8>;
-#endif
-
 /**
  * Internal representation of measurement units. Capable of representing all complexities of units,
  * including mixed and compound units.
  */
-class U_I18N_API MeasureUnitImpl : public UMemory {
+class U_I18N_API_CLASS MeasureUnitImpl : public UMemory {
   public:
     MeasureUnitImpl() = default;
     MeasureUnitImpl(MeasureUnitImpl &&other) = default;
@@ -232,7 +223,7 @@ class U_I18N_API MeasureUnitImpl : public UMemory {
      * @return A newly parsed value object. Behaviour of this unit is
      * unspecified if an error is returned via status.
      */
-    static MeasureUnitImpl forIdentifier(StringPiece identifier, UErrorCode& status);
+    U_I18N_API static MeasureUnitImpl forIdentifier(StringPiece identifier, UErrorCode& status);
 
     /**
      * Extract the MeasureUnitImpl from a MeasureUnit, or parse if it is not present.
@@ -242,7 +233,7 @@ class U_I18N_API MeasureUnitImpl : public UMemory {
      * @param status Set if an error occurs.
      * @return A reference to either measureUnit.fImpl or memory.
      */
-    static const MeasureUnitImpl& forMeasureUnit(
+    U_I18N_API static const MeasureUnitImpl& forMeasureUnit(
         const MeasureUnit& measureUnit, MeasureUnitImpl& memory, UErrorCode& status);
 
     /**
@@ -267,7 +258,7 @@ class U_I18N_API MeasureUnitImpl : public UMemory {
     }
 
     /** Transform this MeasureUnitImpl into a MeasureUnit, simplifying if possible. */
-    MeasureUnit build(UErrorCode& status) &&;
+    U_I18N_API MeasureUnit build(UErrorCode& status) &&;
 
     /**
      * Create a copy of this MeasureUnitImpl. Don't use copy constructor to make this explicit.
@@ -304,7 +295,7 @@ class U_I18N_API MeasureUnitImpl : public UMemory {
      * @return true if a new item was added. If unit is the dimensionless unit,
      * it is never added: the return value will always be false.
      */
-    bool appendSingleUnit(const SingleUnitImpl& singleUnit, UErrorCode& status);
+    U_I18N_API bool appendSingleUnit(const SingleUnitImpl& singleUnit, UErrorCode& status);
 
     /**
      * Normalizes a MeasureUnitImpl and generate the identifier string in place.
@@ -341,7 +332,7 @@ class U_I18N_API MeasureUnitImpl : public UMemory {
     friend class number::impl::LongNameHandler;
 };
 
-struct U_I18N_API MeasureUnitImplWithIndex : public UMemory {
+struct MeasureUnitImplWithIndex : public UMemory {
     const int32_t index;
     MeasureUnitImpl unitImpl;
     // Makes a copy of unitImpl.
@@ -352,21 +343,6 @@ struct U_I18N_API MeasureUnitImplWithIndex : public UMemory {
         : index(index), unitImpl(MeasureUnitImpl(singleUnitImpl, status)) {
     }
 };
-
-// Export explicit template instantiations of MaybeStackArray, MemoryPool and
-// MaybeStackVector. This is required when building DLLs for Windows. (See
-// datefmt.h, collationiterator.h, erarules.h and others for similar examples.)
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API MaybeStackArray<MeasureUnitImplWithIndex *, 8>;
-template class U_I18N_API MemoryPool<MeasureUnitImplWithIndex, 8>;
-template class U_I18N_API MaybeStackVector<MeasureUnitImplWithIndex, 8>;
-
-// Export an explicit template instantiation of the LocalPointer that is used as a
-// data member of MeasureUnitImpl.
-// (When building DLLs for Windows this is required.)
-template class U_I18N_API LocalPointerBase<MeasureUnitImpl>;
-template class U_I18N_API LocalPointer<MeasureUnitImpl>;
-#endif
 
 U_NAMESPACE_END
 

--- a/icu4c/source/i18n/number_currencysymbols.h
+++ b/icu4c/source/i18n/number_currencysymbols.h
@@ -14,8 +14,8 @@
 U_NAMESPACE_BEGIN
 namespace number::impl {
 
-// Exported as U_I18N_API for tests
-class U_I18N_API CurrencySymbols : public UMemory {
+// Exported as U_I18N_API_CLASS for tests
+class U_I18N_API_CLASS CurrencySymbols : public UMemory {
   public:
     CurrencySymbols() = default; // default constructor: leaves class in valid but undefined state
 
@@ -23,8 +23,10 @@ class U_I18N_API CurrencySymbols : public UMemory {
     CurrencySymbols(CurrencyUnit currency, const Locale& locale, UErrorCode& status);
 
     /** Creates an instance in which some symbols might be pre-populated. */
-    CurrencySymbols(CurrencyUnit currency, const Locale& locale, const DecimalFormatSymbols& symbols,
-                    UErrorCode& status);
+    U_I18N_API CurrencySymbols(CurrencyUnit currency,
+                               const Locale& locale,
+                               const DecimalFormatSymbols& symbols,
+                               UErrorCode& status);
 
     const char16_t* getIsoCode() const;
 

--- a/icu4c/source/i18n/number_patternmodifier.h
+++ b/icu4c/source/i18n/number_patternmodifier.h
@@ -17,27 +17,21 @@
 
 U_NAMESPACE_BEGIN
 
-// Export an explicit template instantiation of the LocalPointer that is used as a
-// data member of AdoptingModifierStore.
-// (When building DLLs for Windows this is required.)
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API LocalPointerBase<number::impl::AdoptingModifierStore>;
-template class U_I18N_API LocalPointer<number::impl::AdoptingModifierStore>;
-#endif
-
 namespace number::impl {
 
 // Forward declaration
 class MutablePatternModifier;
 
-// Exported as U_I18N_API because it is needed for the unit test PatternModifierTest
-class U_I18N_API ImmutablePatternModifier : public MicroPropsGenerator, public UMemory {
+// Exported as U_I18N_API_CLASS because it is needed for the unit test PatternModifierTest
+class U_I18N_API_CLASS ImmutablePatternModifier : public MicroPropsGenerator, public UMemory {
   public:
     ~ImmutablePatternModifier() override = default;
 
     void processQuantity(DecimalQuantity&, MicroProps& micros, UErrorCode& status) const override;
 
-    void applyToMicros(MicroProps& micros, const DecimalQuantity& quantity, UErrorCode& status) const;
+    U_I18N_API void applyToMicros(MicroProps& micros,
+                                  const DecimalQuantity& quantity,
+                                  UErrorCode& status) const;
 
     const Modifier* getModifier(Signum signum, StandardPlural::Form plural) const;
 
@@ -73,7 +67,7 @@ class U_I18N_API ImmutablePatternModifier : public MicroPropsGenerator, public U
  * {@link MutablePatternModifier#createImmutable}, in effect treating this instance as a builder for the immutable
  * variant.
  */
-class U_I18N_API MutablePatternModifier
+class U_I18N_API_CLASS MutablePatternModifier
         : public MicroPropsGenerator,
           public Modifier,
           public SymbolProvider,
@@ -88,7 +82,7 @@ class U_I18N_API MutablePatternModifier
      *            {@link Modifier#isStrong()}. Most of the time, decimal format pattern modifiers should be considered
      *            as non-strong.
      */
-    explicit MutablePatternModifier(bool isStrong);
+    U_I18N_API explicit MutablePatternModifier(bool isStrong);
 
     /**
      * Sets a reference to the parsed decimal format pattern, usually obtained from
@@ -98,7 +92,7 @@ class U_I18N_API MutablePatternModifier
      * @param field
      *            Which field to use for literal characters in the pattern.
      */
-    void setPatternInfo(const AffixPatternProvider *patternInfo, Field field);
+    U_I18N_API void setPatternInfo(const AffixPatternProvider *patternInfo, Field field);
 
     /**
      * Sets attributes that imply changes to the literal interpretation of the pattern string affixes.
@@ -110,7 +104,8 @@ class U_I18N_API MutablePatternModifier
      * @param approximately
      *            Whether to prepend approximately to the sign
      */
-    void setPatternAttributes(UNumberSignDisplay signDisplay, bool perMille, bool approximately);
+    U_I18N_API void setPatternAttributes(UNumberSignDisplay signDisplay, bool perMille,
+                                         bool approximately);
 
     /**
      * Sets locale-specific details that affect the symbols substituted into the pattern string affixes.
@@ -127,8 +122,8 @@ class U_I18N_API MutablePatternModifier
      * @param status
      *            Set if an error occurs while loading currency data.
      */
-    void setSymbols(const DecimalFormatSymbols* symbols, const CurrencyUnit& currency,
-                    UNumberUnitWidth unitWidth, const PluralRules* rules, UErrorCode& status);
+    U_I18N_API void setSymbols(const DecimalFormatSymbols* symbols, const CurrencyUnit& currency,
+                               UNumberUnitWidth unitWidth, const PluralRules* rules, UErrorCode& status);
 
     /**
      * Sets attributes of the current number being processed.
@@ -139,7 +134,7 @@ class U_I18N_API MutablePatternModifier
      *            The plural form of the number, required only if the pattern contains the triple
      *            currency sign, "¤¤¤" (and as indicated by {@link #needsPlurals()}).
      */
-    void setNumberProperties(Signum signum, StandardPlural::Form plural);
+    U_I18N_API void setNumberProperties(Signum signum, StandardPlural::Form plural);
 
     /**
      * Returns true if the pattern represented by this MurkyModifier requires a plural keyword in order to localize.
@@ -148,7 +143,8 @@ class U_I18N_API MutablePatternModifier
     bool needsPlurals() const;
 
     /** Creates a quantity-dependent Modifier for the specified plural form. */
-    AdoptingSignumModifierStore createImmutableForPlural(StandardPlural::Form plural, UErrorCode& status);
+    U_I18N_API AdoptingSignumModifierStore createImmutableForPlural(StandardPlural::Form plural,
+                                                                    UErrorCode& status);
 
     /**
      * Creates a new quantity-dependent Modifier that behaves the same as the current instance, but which is immutable
@@ -163,14 +159,15 @@ class U_I18N_API MutablePatternModifier
      *
      * @return An immutable that supports both positive and negative numbers.
      */
-    ImmutablePatternModifier *createImmutable(UErrorCode &status);
+    U_I18N_API ImmutablePatternModifier *createImmutable(UErrorCode &status);
 
-    MicroPropsGenerator &addToChain(const MicroPropsGenerator *parent);
+    U_I18N_API MicroPropsGenerator &addToChain(const MicroPropsGenerator *parent);
 
-    void processQuantity(DecimalQuantity &, MicroProps &micros, UErrorCode &status) const override;
+    U_I18N_API void processQuantity(DecimalQuantity &, MicroProps &micros,
+                                    UErrorCode &status) const override;
 
-    int32_t apply(FormattedStringBuilder &output, int32_t leftIndex, int32_t rightIndex,
-                  UErrorCode &status) const override;
+    U_I18N_API int32_t apply(FormattedStringBuilder &output, int32_t leftIndex, int32_t rightIndex,
+                             UErrorCode &status) const override;
 
     int32_t getPrefixLength() const override;
 

--- a/icu4c/source/i18n/number_usageprefs.h
+++ b/icu4c/source/i18n/number_usageprefs.h
@@ -30,7 +30,7 @@ namespace number::impl {
  * MeasureUnit appropriate for a particular localized usage: see
  * NumberFormatterSettings::usage().
  */
-class U_I18N_API UsagePrefsHandler : public MicroPropsGenerator, public UMemory {
+class UsagePrefsHandler : public MicroPropsGenerator, public UMemory {
   public:
     UsagePrefsHandler(const Locale &locale, const MeasureUnit &inputUnit, const StringPiece usage,
                       const MicroPropsGenerator *parent, UErrorCode &status);
@@ -61,27 +61,12 @@ class U_I18N_API UsagePrefsHandler : public MicroPropsGenerator, public UMemory 
     const MicroPropsGenerator *fParent;
 };
 
-} // namespace number::impl
-
-// Export explicit template instantiations of LocalPointerBase and LocalPointer.
-// This is required when building DLLs for Windows. (See datefmt.h,
-// collationiterator.h, erarules.h and others for similar examples.)
-//
-// Note: These need to be outside of the number::impl namespace, or Clang will
-// generate a compile error.
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API LocalPointerBase<ComplexUnitsConverter>;
-template class U_I18N_API LocalPointer<ComplexUnitsConverter>;
-#endif
-
-namespace number::impl {
-
 /**
  * A MicroPropsGenerator which converts a measurement from one MeasureUnit to
  * another. In particular, the output MeasureUnit may be a mixed unit. (The
  * input unit may not be a mixed unit.)
  */
-class U_I18N_API UnitConversionHandler : public MicroPropsGenerator, public UMemory {
+class UnitConversionHandler : public MicroPropsGenerator, public UMemory {
   public:
     /**
      * Constructor.

--- a/icu4c/source/i18n/numparse_affixes.h
+++ b/icu4c/source/i18n/numparse_affixes.h
@@ -28,7 +28,7 @@ using ::icu::number::impl::TokenConsumer;
 using ::icu::number::impl::CurrencySymbols;
 
 
-class U_I18N_API CodePointMatcher : public NumberParseMatcher, public UMemory {
+class CodePointMatcher : public NumberParseMatcher, public UMemory {
   public:
     CodePointMatcher() = default;  // WARNING: Leaves the object in an unusable state
 
@@ -44,20 +44,6 @@ class U_I18N_API CodePointMatcher : public NumberParseMatcher, public UMemory {
     UChar32 fCp;
 };
 
-} // namespace numparse::impl
-
-// Export a explicit template instantiations of MaybeStackArray, MemoryPool and CompactUnicodeString.
-// When building DLLs for Windows this is required even though no direct access leaks out of the i18n library.
-// (See digitlst.h, pluralaffix.h, datefmt.h, and others for similar examples.)
-// Note: These need to be outside of the numparse::impl namespace, or Clang will generate a compile error.
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API MaybeStackArray<numparse::impl::CodePointMatcher*, 8>; 
-template class U_I18N_API MaybeStackArray<char16_t, 4>;
-template class U_I18N_API MemoryPool<numparse::impl::CodePointMatcher, 8>;
-template class U_I18N_API numparse::impl::CompactUnicodeString<4>;
-#endif
-
-namespace numparse::impl {
 
 struct AffixTokenMatcherSetupData {
     const CurrencySymbols& currencySymbols;
@@ -78,12 +64,12 @@ struct AffixTokenMatcherSetupData {
  *
  * @author sffc
  */
-// Exported as U_I18N_API for tests
-class U_I18N_API AffixTokenMatcherWarehouse : public UMemory {
+// Exported as U_I18N_API_CLASS for tests
+class U_I18N_API_CLASS AffixTokenMatcherWarehouse : public UMemory {
   public:
     AffixTokenMatcherWarehouse() = default;  // WARNING: Leaves the object in an unusable state
 
-    AffixTokenMatcherWarehouse(const AffixTokenMatcherSetupData* setupData);
+    U_I18N_API AffixTokenMatcherWarehouse(const AffixTokenMatcherSetupData* setupData);
 
     NumberParseMatcher& minusSign();
 
@@ -93,7 +79,7 @@ class U_I18N_API AffixTokenMatcherWarehouse : public UMemory {
 
     NumberParseMatcher& permille();
 
-    NumberParseMatcher& currency(UErrorCode& status);
+    U_I18N_API NumberParseMatcher& currency(UErrorCode& status);
 
     IgnorablesMatcher& ignorables();
 
@@ -143,15 +129,15 @@ class AffixPatternMatcherBuilder : public TokenConsumer, public MutableMatcherCo
 };
 
 
-// Exported as U_I18N_API for tests
-class U_I18N_API AffixPatternMatcher : public ArraySeriesMatcher {
+// Exported as U_I18N_API_CLASS for tests
+class U_I18N_API_CLASS AffixPatternMatcher : public ArraySeriesMatcher {
   public:
     AffixPatternMatcher() = default;  // WARNING: Leaves the object in an unusable state
 
-    static AffixPatternMatcher fromAffixPattern(const UnicodeString& affixPattern,
-                                                AffixTokenMatcherWarehouse& warehouse,
-                                                parse_flags_t parseFlags, bool* success,
-                                                UErrorCode& status);
+    U_I18N_API static AffixPatternMatcher fromAffixPattern(const UnicodeString& affixPattern,
+                                                           AffixTokenMatcherWarehouse& warehouse,
+                                                           parse_flags_t parseFlags, bool* success,
+                                                           UErrorCode& status);
 
     UnicodeString getPattern() const;
 

--- a/icu4c/source/i18n/numparse_currency.h
+++ b/icu4c/source/i18n/numparse_currency.h
@@ -29,8 +29,8 @@ using ::icu::number::impl::CurrencySymbols;
  *
  * @author sffc
  */
-// Exported as U_I18N_API for tests
-class U_I18N_API CombinedCurrencyMatcher : public NumberParseMatcher, public UMemory {
+// Exported as U_I18N_API_CLASS for tests
+class U_I18N_API_CLASS CombinedCurrencyMatcher : public NumberParseMatcher, public UMemory {
   public:
     CombinedCurrencyMatcher() = default;  // WARNING: Leaves the object in an unusable state
 

--- a/icu4c/source/i18n/olsontz.h
+++ b/icu4c/source/i18n/olsontz.h
@@ -113,7 +113,7 @@ class SimpleTimeZone;
  * (UN M.49 - World).  This data is generated from "zone.tab"
  * in the tz database.
  */
-class U_I18N_API OlsonTimeZone: public BasicTimeZone {
+class U_I18N_API_CLASS OlsonTimeZone : public BasicTimeZone {
  public:
     /**
      * Construct from a resource bundle.
@@ -141,7 +141,7 @@ class U_I18N_API OlsonTimeZone: public BasicTimeZone {
     /**
      * Assignment operator
      */
-    OlsonTimeZone& operator=(const OlsonTimeZone& other);
+    U_I18N_API OlsonTimeZone& operator=(const OlsonTimeZone& other);
 
     /**
      * Returns true if the two TimeZone objects are equal.
@@ -156,7 +156,7 @@ class U_I18N_API OlsonTimeZone: public BasicTimeZone {
     /**
      * TimeZone API.
      */
-    static UClassID U_EXPORT2 getStaticClassID();
+    U_I18N_API static UClassID U_EXPORT2 getStaticClassID();
 
     /**
      * TimeZone API.

--- a/icu4c/source/i18n/units_complexconverter.h
+++ b/icu4c/source/i18n/units_complexconverter.h
@@ -17,24 +17,6 @@
 
 U_NAMESPACE_BEGIN
 
-// Export explicit template instantiations of MaybeStackArray, MemoryPool and
-// MaybeStackVector. This is required when building DLLs for Windows. (See
-// datefmt.h, collationiterator.h, erarules.h and others for similar examples.)
-//
-// Note: These need to be outside of the units namespace, or Clang will generate
-// a compile error.
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API MaybeStackArray<units::UnitsConverter*, 8>;
-template class U_I18N_API MemoryPool<units::UnitsConverter, 8>;
-template class U_I18N_API MaybeStackVector<units::UnitsConverter, 8>;
-template class U_I18N_API MaybeStackArray<MeasureUnitImpl*, 8>;
-template class U_I18N_API MemoryPool<MeasureUnitImpl, 8>;
-template class U_I18N_API MaybeStackVector<MeasureUnitImpl, 8>;
-template class U_I18N_API MaybeStackArray<MeasureUnit*, 8>;
-template class U_I18N_API MemoryPool<MeasureUnit, 8>;
-template class U_I18N_API MaybeStackVector<MeasureUnit, 8>;
-#endif
-
 namespace units {
 
 /**
@@ -46,7 +28,7 @@ namespace units {
  *    single unit to another single unit). Therefore, `ComplexUnitsConverter` class contains multiple
  *    instances of the `UnitsConverter` to perform the conversion.
  */
-class U_I18N_API ComplexUnitsConverter : public UMemory {
+class U_I18N_API_CLASS ComplexUnitsConverter : public UMemory {
   public:
     /**
      * Constructs `ComplexUnitsConverter` for an `targetUnit` that could be Single, Compound or Mixed.
@@ -75,8 +57,9 @@ class U_I18N_API ComplexUnitsConverter : public UMemory {
      * @param outputUnits represents the output unit. could be any type. (single, compound or mixed).
      * @param status
      */
-    ComplexUnitsConverter(StringPiece inputUnitIdentifier, StringPiece outputUnitsIdentifier,
-                          UErrorCode &status);
+    U_I18N_API ComplexUnitsConverter(StringPiece inputUnitIdentifier,
+                                     StringPiece outputUnitsIdentifier,
+                                     UErrorCode &status);
 
     /**
      * Constructor of `ComplexUnitsConverter`.
@@ -89,8 +72,10 @@ class U_I18N_API ComplexUnitsConverter : public UMemory {
      * @param ratesInfo a ConversionRates instance containing the unit conversion rates.
      * @param status
      */
-    ComplexUnitsConverter(const MeasureUnitImpl &inputUnit, const MeasureUnitImpl &outputUnits,
-                          const ConversionRates &ratesInfo, UErrorCode &status);
+    U_I18N_API ComplexUnitsConverter(const MeasureUnitImpl &inputUnit,
+                                     const MeasureUnitImpl &outputUnits,
+                                     const ConversionRates &ratesInfo,
+                                     UErrorCode &status);
 
     // Returns true if the specified `quantity` of the `inputUnit`, expressed in terms of the biggest
     // unit in the MeasureUnit `outputUnit`, is greater than or equal to `limit`.
@@ -105,7 +90,7 @@ class U_I18N_API ComplexUnitsConverter : public UMemory {
     //         NOTE:
     //           the smallest element is the only element that could have fractional values. And all
     //           other elements are floored to the nearest integer
-    MaybeStackVector<Measure>
+    U_I18N_API MaybeStackVector<Measure>
     convert(double quantity, icu::number::impl::RoundingImpl *rounder, UErrorCode &status) const;
 
     // TODO(ICU-21937): Make it private after submitting the public units conversion API.

--- a/icu4c/source/i18n/units_converter.cpp
+++ b/icu4c/source/i18n/units_converter.cpp
@@ -23,7 +23,7 @@
 U_NAMESPACE_BEGIN
 namespace units {
 
-void U_I18N_API Factor::multiplyBy(const Factor &rhs) {
+void Factor::multiplyBy(const Factor& rhs) {
     factorNum *= rhs.factorNum;
     factorDen *= rhs.factorDen;
     for (int i = 0; i < CONSTANTS_COUNT; i++) {
@@ -36,7 +36,7 @@ void U_I18N_API Factor::multiplyBy(const Factor &rhs) {
     offset = std::max(rhs.offset, offset);
 }
 
-void U_I18N_API Factor::divideBy(const Factor &rhs) {
+void Factor::divideBy(const Factor& rhs) {
     factorNum *= rhs.factorDen;
     factorDen *= rhs.factorNum;
     for (int i = 0; i < CONSTANTS_COUNT; i++) {
@@ -49,9 +49,9 @@ void U_I18N_API Factor::divideBy(const Factor &rhs) {
     offset = std::max(rhs.offset, offset);
 }
 
-void U_I18N_API Factor::divideBy(const uint64_t constant) { factorDen *= constant; }
+void Factor::divideBy(const uint64_t constant) { factorDen *= constant; }
 
-void U_I18N_API Factor::power(int32_t power) {
+void Factor::power(int32_t power) {
     // multiply all the constant by the power.
     for (int i = 0; i < CONSTANTS_COUNT; i++) {
         constantExponents[i] *= power;
@@ -69,7 +69,7 @@ void U_I18N_API Factor::power(int32_t power) {
     }
 }
 
-void U_I18N_API Factor::applyPrefix(UMeasurePrefix unitPrefix) {
+void Factor::applyPrefix(UMeasurePrefix unitPrefix) {
     if (unitPrefix == UMeasurePrefix::UMEASURE_PREFIX_ONE) {
         // No need to do anything
         return;
@@ -85,7 +85,7 @@ void U_I18N_API Factor::applyPrefix(UMeasurePrefix unitPrefix) {
     }
 }
 
-void U_I18N_API Factor::substituteConstants() {
+void Factor::substituteConstants() {
     for (int i = 0; i < CONSTANTS_COUNT; i++) {
         if (this->constantExponents[i] == 0) {
             continue;
@@ -475,9 +475,9 @@ void U_I18N_API addSingleFactorConstant(StringPiece baseStr, int32_t power, Sign
  * Extracts the compound base unit of a compound unit (`source`). For example, if the source unit is
  * `square-mile-per-hour`, the compound base unit will be `square-meter-per-second`
  */
-MeasureUnitImpl U_I18N_API extractCompoundBaseUnit(const MeasureUnitImpl &source,
-                                                   const ConversionRates &conversionRates,
-                                                   UErrorCode &status) {
+MeasureUnitImpl extractCompoundBaseUnit(const MeasureUnitImpl& source,
+                                        const ConversionRates& conversionRates,
+                                        UErrorCode& status) {
 
     MeasureUnitImpl result;
     if (U_FAILURE(status)) return result;

--- a/icu4c/source/i18n/units_converter.h
+++ b/icu4c/source/i18n/units_converter.h
@@ -71,7 +71,7 @@ typedef enum Signum {
 } Signum;
 
 /* Represents a conversion factor */
-struct U_I18N_API Factor {
+struct U_I18N_API_CLASS Factor {
     double factorNum = 1;
     double factorDen = 1;
     double offset = 0;
@@ -94,10 +94,10 @@ struct U_I18N_API Factor {
     // constantExponents (resetting the exponents).
     //
     // In ICU4J, see UnitConverter.Factor.getConversionRate().
-    void substituteConstants();
+    U_I18N_API void substituteConstants();
 };
 
-struct U_I18N_API ConversionInfo {
+struct ConversionInfo {
     double conversionRate;
     double offset;
     bool reciprocal;
@@ -114,7 +114,7 @@ void U_I18N_API addSingleFactorConstant(StringPiece baseStr, int32_t power, Sign
  * TODO ICU-22683: COnsider moving the handling of special mappings (e.g. beaufort) to a separate
  * struct.
  */
-struct U_I18N_API ConversionRate : public UMemory {
+struct ConversionRate : public UMemory {
     const MeasureUnitImpl source;
     const MeasureUnitImpl target;
     CharString specialSource;
@@ -135,9 +135,9 @@ enum Convertibility {
     UNCONVERTIBLE,
 };
 
-MeasureUnitImpl U_I18N_API extractCompoundBaseUnit(const MeasureUnitImpl &source,
-                                                   const ConversionRates &conversionRates,
-                                                   UErrorCode &status);
+MeasureUnitImpl extractCompoundBaseUnit(const MeasureUnitImpl& source,
+                                        const ConversionRates& conversionRates,
+                                        UErrorCode& status);
 
 /**
  * Check if the convertibility between `source` and `target`.
@@ -162,7 +162,7 @@ Convertibility U_I18N_API extractConvertibility(const MeasureUnitImpl &source,
  *    Only works with SINGLE and COMPOUND units. If one of the units is a
  *    MIXED unit, an error will occur. For more information, see UMeasureUnitComplexity.
  */
-class U_I18N_API UnitsConverter : public UMemory {
+class U_I18N_API_CLASS UnitsConverter : public UMemory {
   public:
     /**
      * Constructor of `UnitConverter`.
@@ -176,7 +176,8 @@ class U_I18N_API UnitsConverter : public UMemory {
      * @param targetIdentifier represents the target unit identifier.
      * @param status
      */
-    UnitsConverter(StringPiece sourceIdentifier, StringPiece targetIdentifier, UErrorCode &status);
+    U_I18N_API UnitsConverter(StringPiece sourceIdentifier, StringPiece targetIdentifier,
+                              UErrorCode &status);
 
     /**
      * Constructor of `UnitConverter`.
@@ -189,8 +190,8 @@ class U_I18N_API UnitsConverter : public UMemory {
      * @param ratesInfo Contains all the needed conversion rates.
      * @param status
      */
-    UnitsConverter(const MeasureUnitImpl &source, const MeasureUnitImpl &target,
-                  const ConversionRates &ratesInfo, UErrorCode &status);
+    U_I18N_API UnitsConverter(const MeasureUnitImpl &source, const MeasureUnitImpl &target,
+                              const ConversionRates &ratesInfo, UErrorCode &status);
 
     /**
      * Compares two single units and returns 1 if the first one is greater, -1 if the second
@@ -209,7 +210,7 @@ class U_I18N_API UnitsConverter : public UMemory {
      * @param inputValue the value to be converted.
      * @return the converted value.
      */
-    double convert(double inputValue) const;
+    U_I18N_API double convert(double inputValue) const;
 
     /**
      * The inverse of convert(): convert a measurement expressed in the target
@@ -218,9 +219,9 @@ class U_I18N_API UnitsConverter : public UMemory {
      * @param inputValue the value to be converted.
      * @return the converted value.
      */
-    double convertInverse(double inputValue) const;
+    U_I18N_API double convertInverse(double inputValue) const;
 
-    ConversionInfo getConversionInfo() const;
+    U_I18N_API ConversionInfo getConversionInfo() const;
 
   private:
     ConversionRate conversionRate_;

--- a/icu4c/source/i18n/units_data.cpp
+++ b/icu4c/source/i18n/units_data.cpp
@@ -395,7 +395,7 @@ const ConversionRateInfo *ConversionRates::extractConversionInfo(StringPiece sou
     return nullptr;
 }
 
-U_I18N_API UnitPreferences::UnitPreferences(UErrorCode &status) {
+UnitPreferences::UnitPreferences(UErrorCode& status) {
     LocalUResourceBundlePointer unitsBundle(ures_openDirect(nullptr, "units", &status));
     UnitPreferencesSink sink(&unitPrefs_, &metadata_);
     ures_getAllItemsWithFallback(unitsBundle.getAlias(), "unitPreferenceData", sink, status);
@@ -410,10 +410,10 @@ CharString getKeyWordValue(const Locale &locale, StringPiece kw, UErrorCode &sta
     return result;
 }
 
-MaybeStackVector<UnitPreference>
-    U_I18N_API UnitPreferences::getPreferencesFor(StringPiece category, StringPiece usage,
-                                                  const Locale &locale, UErrorCode &status) const {
-
+MaybeStackVector<UnitPreference> UnitPreferences::getPreferencesFor(StringPiece category,
+                                                                    StringPiece usage,
+                                                                    const Locale& locale,
+                                                                    UErrorCode& status) const {
     MaybeStackVector<UnitPreference> result;
 
     // TODO: remove this once all the categories are allowed.

--- a/icu4c/source/i18n/units_data.h
+++ b/icu4c/source/i18n/units_data.h
@@ -26,7 +26,7 @@ namespace units {
  * precision conversion - going from feet to inches should cancel out the
  * `ft_to_m` constant.
  */
-class U_I18N_API ConversionRateInfo : public UMemory {
+class ConversionRateInfo : public UMemory {
   public:
     ConversionRateInfo() {}
     ConversionRateInfo(StringPiece sourceUnit, StringPiece baseUnit, StringPiece factor,
@@ -45,22 +45,6 @@ class U_I18N_API ConversionRateInfo : public UMemory {
     CharString systems;
 };
 
-} // namespace units
-
-// Export explicit template instantiations of MaybeStackArray, MemoryPool and
-// MaybeStackVector. This is required when building DLLs for Windows. (See
-// datefmt.h, collationiterator.h, erarules.h and others for similar examples.)
-//
-// Note: These need to be outside of the units namespace, or Clang will generate
-// a compile error.
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API MaybeStackArray<units::ConversionRateInfo*, 8>;
-template class U_I18N_API MemoryPool<units::ConversionRateInfo, 8>;
-template class U_I18N_API MaybeStackVector<units::ConversionRateInfo, 8>;
-#endif
-
-namespace units {
-
 /**
  * Returns ConversionRateInfo for all supported conversions.
  *
@@ -72,7 +56,7 @@ void U_I18N_API getAllConversionRates(MaybeStackVector<ConversionRateInfo> &resu
 /**
  * Contains all the supported conversion rates.
  */
-class U_I18N_API ConversionRates {
+class ConversionRates {
   public:
     /**
      * Constructor
@@ -95,7 +79,7 @@ class U_I18N_API ConversionRates {
 
 // Encapsulates unitPreferenceData information from units resources, specifying
 // a sequence of output unit preferences.
-struct U_I18N_API UnitPreference : public UMemory {
+struct UnitPreference : public UMemory {
     // Set geq to 1.0 by default
     UnitPreference() : geq(1.0) {}
     CharString unit;
@@ -118,7 +102,7 @@ struct U_I18N_API UnitPreference : public UMemory {
  * UnitPreferenceMetadata lives in the anonymous namespace, because it should
  * only be useful to internal code and unit testing code.
  */
-class U_I18N_API UnitPreferenceMetadata : public UMemory {
+class UnitPreferenceMetadata : public UMemory {
   public:
     UnitPreferenceMetadata() {}
     // Constructor, makes copies of the parameters passed to it.
@@ -145,36 +129,17 @@ class U_I18N_API UnitPreferenceMetadata : public UMemory {
                       bool *foundRegion) const;
 };
 
-} // namespace units
-
-// Export explicit template instantiations of MaybeStackArray, MemoryPool and
-// MaybeStackVector. This is required when building DLLs for Windows. (See
-// datefmt.h, collationiterator.h, erarules.h and others for similar examples.)
-//
-// Note: These need to be outside of the units namespace, or Clang will generate
-// a compile error.
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API MaybeStackArray<units::UnitPreferenceMetadata*, 8>;
-template class U_I18N_API MemoryPool<units::UnitPreferenceMetadata, 8>;
-template class U_I18N_API MaybeStackVector<units::UnitPreferenceMetadata, 8>;
-template class U_I18N_API MaybeStackArray<units::UnitPreference*, 8>;
-template class U_I18N_API MemoryPool<units::UnitPreference, 8>;
-template class U_I18N_API MaybeStackVector<units::UnitPreference, 8>;
-#endif
-
-namespace units {
-
 /**
  * Unit Preferences information for various locales and usages.
  */
-class U_I18N_API UnitPreferences {
+class U_I18N_API_CLASS UnitPreferences {
   public:
     /**
      * Constructor, loads all the preference data.
      *
      * @param status Receives status.
      */
-    UnitPreferences(UErrorCode &status);
+    U_I18N_API UnitPreferences(UErrorCode& status);
 
     /**
      * Returns the set of unit preferences in the particular category that best
@@ -199,10 +164,10 @@ class U_I18N_API UnitPreferences {
      * result set.
      * @param status Receives status.
      */
-    MaybeStackVector<UnitPreference> getPreferencesFor(StringPiece category, StringPiece usage,
-                                                       const Locale &locale,
-
-                                                       UErrorCode &status) const;
+    U_I18N_API MaybeStackVector<UnitPreference> getPreferencesFor(StringPiece category,
+                                                                  StringPiece usage,
+                                                                  const Locale& locale,
+                                                                  UErrorCode& status) const;
 
   protected:
     // Metadata about the sets of preferences, this is the index for looking up

--- a/icu4c/source/i18n/units_router.h
+++ b/icu4c/source/i18n/units_router.h
@@ -73,22 +73,6 @@ struct ConverterPreference : UMemory {
           precision(std::move(precision)), targetUnit(complexTarget.copy(status)) {}
 };
 
-} // namespace units
-
-// Export explicit template instantiations of MaybeStackArray, MemoryPool and
-// MaybeStackVector. This is required when building DLLs for Windows. (See
-// datefmt.h, collationiterator.h, erarules.h and others for similar examples.)
-//
-// Note: These need to be outside of the units namespace, or Clang will generate
-// a compile error.
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API MaybeStackArray<units::ConverterPreference*, 8>;
-template class U_I18N_API MemoryPool<units::ConverterPreference, 8>;
-template class U_I18N_API MaybeStackVector<units::ConverterPreference, 8>;
-#endif
-
-namespace units {
-
 /**
  * `UnitsRouter` responsible for converting from a single unit (such as `meter` or `meter-per-second`) to
  * one of the complex units based on the limits.
@@ -117,12 +101,12 @@ namespace units {
  *    `UnitRouter` uses internally `ComplexUnitConverter` in order to convert the input units to the
  *    desired complex units and to check the limit too.
  */
-class U_I18N_API UnitsRouter {
+class U_I18N_API_CLASS UnitsRouter {
   public:
-    UnitsRouter(StringPiece inputUnitIdentifier, const Locale &locale, StringPiece usage,
-                UErrorCode &status);
-    UnitsRouter(const MeasureUnit &inputUnit, const Locale &locale, StringPiece usage,
-                UErrorCode &status);
+    U_I18N_API UnitsRouter(StringPiece inputUnitIdentifier, const Locale &locale, StringPiece usage,
+                           UErrorCode &status);
+    U_I18N_API UnitsRouter(const MeasureUnit &inputUnit, const Locale &locale, StringPiece usage,
+                           UErrorCode &status);
 
     /**
      * Performs locale and usage sensitive unit conversion.
@@ -133,7 +117,8 @@ class U_I18N_API UnitsRouter {
      *     and locale preference, alternatively with the default precision.
      * @param status Receives status.
      */
-    RouteResult route(double quantity, icu::number::impl::RoundingImpl *rounder, UErrorCode &status) const;
+    U_I18N_API RouteResult route(double quantity, icu::number::impl::RoundingImpl *rounder,
+                                 UErrorCode &status) const;
 
     /**
      * Returns the list of possible output units, i.e. the full set of


### PR DESCRIPTION
By removing the use of `__declspec(dllexport)` for private members the need for explicit template instantiations to be able to export these members disappears.

This PR removes such template instantiations from the `icu4c/source/common` internal header files, and then updates everything that's affected by those changes.

#### Checklist
- [x] Required: Issue filed: ICU-23136
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
