### PR TITLE
ICU-23148 Separate deploy to Sonatype in a profile

### DIFF
--- a/.github/workflows/release-icu4j-maven.yml
+++ b/.github/workflows/release-icu4j-maven.yml
@@ -87,7 +87,7 @@ jobs:
           --settings $GITHUB_WORKSPACE/settings.xml \
           --errors --fail-at-end -DdeployAtEnd=true \
           -DskipTests -DskipITs \
-          -P with_sources,with_javadoc,with_signature
+          -P with_sources,with_javadoc,with_signature,to_sonatype
       env:
         MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}

--- a/icu4j/main/charset/pom.xml
+++ b/icu4j/main/charset/pom.xml
@@ -88,14 +88,24 @@
           <skip>false</skip>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.sonatype.central</groupId>
-        <artifactId>central-publishing-maven-plugin</artifactId>
-        <configuration>
-          <skipPublishing>false</skipPublishing>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>to_sonatype</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <configuration>
+              <skipPublishing>false</skipPublishing>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/icu4j/main/icu4j/pom.xml
+++ b/icu4j/main/icu4j/pom.xml
@@ -132,13 +132,6 @@
           <skip>false</skip>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.sonatype.central</groupId>
-        <artifactId>central-publishing-maven-plugin</artifactId>
-        <configuration>
-          <skipPublishing>false</skipPublishing>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 
@@ -162,6 +155,20 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>to_sonatype</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <configuration>
+              <skipPublishing>false</skipPublishing>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
The central-publishing-maven-plugin disables the regular maven-deploy-plugin, and that prevents publishing snapshots to GitHub.

#### Checklist
- [x] Required: Issue filed: ICU-23148
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
