### PR TITLE
ICU-23136 Remove explicit template instantiations for i18n classes

### DIFF
--- a/icu4c/source/i18n/collationiterator.h
+++ b/icu4c/source/i18n/collationiterator.h
@@ -31,27 +31,15 @@ class UVector32;
 /* Large enough for CEs of most short strings. */
 #define CEBUFFER_INITIAL_CAPACITY 40
 
-// Export an explicit template instantiation of the MaybeStackArray that
-//    is used as a data member of CEBuffer.
-//
-//    When building DLLs for Windows this is required even though
-//    no direct access to the MaybeStackArray leaks out of the i18n library.
-//
-// See digitlst.h, pluralaffix.h, datefmt.h, and others for similar examples.
-//
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API MaybeStackArray<int64_t, CEBUFFER_INITIAL_CAPACITY>;
-#endif
-
 /**
  * Collation element iterator and abstract character iterator.
  *
  * When a method returns a code point value, it must be in 0..10FFFF,
  * except it can be negative as a sentinel value.
  */
-class U_I18N_API CollationIterator : public UObject {
+class U_I18N_API_CLASS CollationIterator : public UObject {
 private:
-    class U_I18N_API CEBuffer {
+    class CEBuffer {
     private:
         /** Large enough for CEs of most short strings. */
         static const int32_t INITIAL_CAPACITY = CEBUFFER_INITIAL_CAPACITY;
@@ -69,7 +57,7 @@ private:
             buffer[length++] = ce;
         }
 
-        UBool ensureAppendCapacity(int32_t appCap, UErrorCode &errorCode);
+        U_I18N_API UBool ensureAppendCapacity(int32_t appCap, UErrorCode &errorCode);
 
         inline UBool incLength(UErrorCode &errorCode) {
             // Use INITIAL_CAPACITY for a very simple fastpath.
@@ -278,8 +266,8 @@ protected:
     const CollationData *data;
 
 private:
-    int64_t nextCEFromCE32(const CollationData *d, UChar32 c, uint32_t ce32,
-                           UErrorCode &errorCode);
+    U_I18N_API int64_t nextCEFromCE32(const CollationData *d, UChar32 c, uint32_t ce32,
+                                      UErrorCode &errorCode);
 
     uint32_t getCE32FromPrefix(const CollationData *d, uint32_t ce32,
                                UErrorCode &errorCode);

--- a/icu4c/source/i18n/erarules.h
+++ b/icu4c/source/i18n/erarules.h
@@ -14,19 +14,13 @@
 
 U_NAMESPACE_BEGIN
 
-// Export an explicit template instantiation of LocalMemory used as a data member of EraRules.
-// When building DLLs for Windows this is required even though no direct access leaks out of the i18n library.
-// See digitlst.h, pluralaffix.h, datefmt.h, and others for similar examples.
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API LocalPointerBase<int32_t>;
-template class U_I18N_API LocalMemory<int32_t>;
-#endif
-
-class U_I18N_API EraRules : public UMemory {
+class U_I18N_API_CLASS EraRules : public UMemory {
 public:
-    ~EraRules();
+    U_I18N_API ~EraRules();
 
-    static EraRules* createInstance(const char *calType, UBool includeTentativeEra, UErrorCode& status);
+    U_I18N_API static EraRules* createInstance(const char* calType,
+                                               UBool includeTentativeEra,
+                                               UErrorCode& status);
 
     /**
      * Gets number of effective eras
@@ -53,7 +47,7 @@ public:
      * @return The first year of an era. When a era has no start date, minimum int32
      *          value is returned.
      */
-    int32_t getStartYear(int32_t eraIdx, UErrorCode& status) const;
+    U_I18N_API int32_t getStartYear(int32_t eraIdx, UErrorCode& status) const;
 
     /**
      * Returns era index for the specified year/month/day.
@@ -63,7 +57,7 @@ public:
      * @param status    Receives status
      * @return  era index (or 0, when the specified date is before the first era)
      */
-    int32_t getEraIndex(int32_t year, int32_t month, int32_t day, UErrorCode& status) const;
+    U_I18N_API int32_t getEraIndex(int32_t year, int32_t month, int32_t day, UErrorCode& status) const;
 
     /**
      * Gets the current era index. This is calculated only once for an instance of

--- a/icu4c/source/i18n/formattedval_impl.h
+++ b/icu4c/source/i18n/formattedval_impl.h
@@ -125,18 +125,6 @@ struct U_I18N_API SpanInfo {
     int32_t length;
 };
 
-// Export an explicit template instantiation of the MaybeStackArray that
-//    is used as a data member of CEBuffer.
-//
-//    When building DLLs for Windows this is required even though
-//    no direct access to the MaybeStackArray leaks out of the i18n library.
-//
-// See digitlst.h, pluralaffix.h, datefmt.h, and others for similar examples.
-//
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API MaybeStackArray<SpanInfo, 8>;
-#endif
-
 /**
  * Implementation of FormattedValue based on FormattedStringBuilder.
  *
@@ -145,13 +133,12 @@ template class U_I18N_API MaybeStackArray<SpanInfo, 8>;
  *
  * @author sffc (Shane Carr)
  */
-// Exported as U_I18N_API for tests
-class U_I18N_API FormattedValueStringBuilderImpl : public UMemory, public FormattedValue {
+// Exported as U_I18N_API_CLASS for tests
+class U_I18N_API_CLASS FormattedValueStringBuilderImpl : public UMemory, public FormattedValue {
 public:
+    U_I18N_API FormattedValueStringBuilderImpl(FormattedStringBuilder::Field numericField);
 
-    FormattedValueStringBuilderImpl(FormattedStringBuilder::Field numericField);
-
-    virtual ~FormattedValueStringBuilderImpl();
+    U_I18N_API virtual ~FormattedValueStringBuilderImpl();
 
     FormattedValueStringBuilderImpl(FormattedValueStringBuilderImpl&&) = default;
     FormattedValueStringBuilderImpl& operator=(FormattedValueStringBuilderImpl&&) = default;
@@ -164,8 +151,8 @@ public:
     UBool nextPosition(ConstrainedFieldPosition& cfpos, UErrorCode& status) const override;
 
     // Additional helper functions:
-    UBool nextFieldPosition(FieldPosition& fp, UErrorCode& status) const;
-    void getAllFieldPositions(FieldPositionIteratorHandler& fpih, UErrorCode& status) const;
+    U_I18N_API UBool nextFieldPosition(FieldPosition& fp, UErrorCode& status) const;
+    U_I18N_API void getAllFieldPositions(FieldPositionIteratorHandler& fpih, UErrorCode& status) const;
     inline FormattedStringBuilder& getStringRef() {
         return fString;
     }

--- a/icu4c/source/i18n/number_decnum.h
+++ b/icu4c/source/i18n/number_decnum.h
@@ -15,20 +15,13 @@ U_NAMESPACE_BEGIN
 
 #define DECNUM_INITIAL_CAPACITY 34
 
-// Export an explicit template instantiation of the MaybeStackHeaderAndArray that is used as a data member of DecNum.
-// When building DLLs for Windows this is required even though no direct access to the MaybeStackHeaderAndArray leaks out of the i18n library.
-// (See digitlst.h, pluralaffix.h, datefmt.h, and others for similar examples.)
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API MaybeStackHeaderAndArray<decNumber, char, DECNUM_INITIAL_CAPACITY>;
-#endif
-
 namespace number::impl {
 
 /** A very thin C++ wrapper around decNumber.h */
-// Exported as U_I18N_API for tests
-class U_I18N_API DecNum : public UMemory {
+// Exported as U_I18N_API_CLASS for tests
+class U_I18N_API_CLASS DecNum : public UMemory {
   public:
-    DecNum();  // leaves object in valid but undefined state
+    U_I18N_API DecNum();  // leaves object in valid but undefined state
 
     // Copy-like constructor; use the default move operators.
     DecNum(const DecNum& other, UErrorCode& status);

--- a/icu4c/source/i18n/numparse_compositions.h
+++ b/icu4c/source/i18n/numparse_compositions.h
@@ -11,13 +11,6 @@
 
 U_NAMESPACE_BEGIN
 
-// Export an explicit template instantiation of the MaybeStackArray that is used as a data member of ArraySeriesMatcher.
-// When building DLLs for Windows this is required even though no direct access to the MaybeStackArray leaks out of the i18n library.
-// (See digitlst.h, pluralaffix.h, datefmt.h, and others for similar examples.)
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API MaybeStackArray<const numparse::impl::NumberParseMatcher*, 3>;
-#endif
-
 namespace numparse::impl {
 
 /**
@@ -90,19 +83,19 @@ class U_I18N_API SeriesMatcher : public CompositionMatcher {
  *
  * The object adopts the array, but NOT the matchers contained inside the array.
  */
-// Exported as U_I18N_API for tests
-class U_I18N_API ArraySeriesMatcher : public SeriesMatcher {
+// Exported as U_I18N_API_CLASS for tests
+class U_I18N_API_CLASS ArraySeriesMatcher : public SeriesMatcher {
   public:
-    ArraySeriesMatcher();  // WARNING: Leaves the object in an unusable state
+    U_I18N_API ArraySeriesMatcher();  // WARNING: Leaves the object in an unusable state
 
     typedef MaybeStackArray<const NumberParseMatcher*, 3> MatcherArray;
 
     /** The array is std::move'd */
-    ArraySeriesMatcher(MatcherArray& matchers, int32_t matchersLen);
+    U_I18N_API ArraySeriesMatcher(MatcherArray& matchers, int32_t matchersLen);
 
     UnicodeString toString() const override;
 
-    int32_t length() const override;
+    U_I18N_API int32_t length() const override;
 
   protected:
     const NumberParseMatcher* const* begin() const override;

--- a/icu4c/source/i18n/numparse_impl.h
+++ b/icu4c/source/i18n/numparse_impl.h
@@ -22,22 +22,17 @@
 
 U_NAMESPACE_BEGIN
 
-// Export an explicit template instantiation of the MaybeStackArray that is used as a data member of NumberParserImpl.
-// When building DLLs for Windows this is required even though no direct access to the MaybeStackArray leaks out of the i18n library.
-// (See numparse_compositions.h, numparse_affixes.h, datefmt.h, and others for similar examples.)
-#if U_PF_WINDOWS <= U_PLATFORM && U_PLATFORM <= U_PF_CYGWIN
-template class U_I18N_API MaybeStackArray<const numparse::impl::NumberParseMatcher*, 10>;
-#endif
-
 namespace numparse::impl {
 
-// Exported as U_I18N_API for tests
-class U_I18N_API NumberParserImpl : public MutableMatcherCollection, public UMemory {
+// Exported as U_I18N_API_CLASS for tests
+class U_I18N_API_CLASS NumberParserImpl : public MutableMatcherCollection, public UMemory {
   public:
     virtual ~NumberParserImpl();
 
-    static NumberParserImpl* createSimpleParser(const Locale& locale, const UnicodeString& patternString,
-                                                parse_flags_t parseFlags, UErrorCode& status);
+    U_I18N_API static NumberParserImpl *createSimpleParser(const Locale& locale,
+                                                           const UnicodeString& patternString,
+                                                           parse_flags_t parseFlags,
+                                                           UErrorCode& status);
 
     static NumberParserImpl* createParserFromProperties(
             const number::impl::DecimalFormatProperties& properties, const DecimalFormatSymbols& symbols,
@@ -54,12 +49,13 @@ class U_I18N_API NumberParserImpl : public MutableMatcherCollection, public UMem
 
     parse_flags_t getParseFlags() const;
 
-    void parse(const UnicodeString& input, bool greedy, ParsedNumber& result, UErrorCode& status) const;
+    U_I18N_API void parse(const UnicodeString& input, bool greedy, ParsedNumber& result,
+                          UErrorCode& status) const;
 
     void parse(const UnicodeString& input, int32_t start, bool greedy, ParsedNumber& result,
                UErrorCode& status) const;
 
-    UnicodeString toString() const;
+    U_I18N_API UnicodeString toString() const;
 
   private:
     parse_flags_t fParseFlags;


### PR DESCRIPTION
By removing the use of `__declspec(dllexport)` for private members the need for explicit template instantiations to be able to export these members disappears.

This PR removes such template instantiations from the `icu4c/source/i18n` internal header files.

#### Checklist
- [x] Required: Issue filed: ICU-23136
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
