### PR TITLE
ICU-23142 Fix header guard in regexcmp.h

### DIFF
--- a/icu4c/source/i18n/regexcmp.h
+++ b/icu4c/source/i18n/regexcmp.h
@@ -13,8 +13,8 @@
 //
 
 
-#ifndef RBBISCAN_H
-#define RBBISCAN_H
+#ifndef REGEXCMP_H
+#define REGEXCMP_H
 
 #include "unicode/utypes.h"
 #if !UCONFIG_NO_REGULAR_EXPRESSIONS
@@ -231,4 +231,4 @@ enum SetOperations {
 
 U_NAMESPACE_END
 #endif   // !UCONFIG_NO_REGULAR_EXPRESSIONS
-#endif   // RBBISCAN_H
+#endif   // REGEXCMP_H

--- a/icu4c/source/i18n/regexcst.txt
+++ b/icu4c/source/i18n/regexcst.txt
@@ -30,7 +30,7 @@
 #   input-char           n next-state           ^push-state     action
 #       |                |   |                      |             |
 #       |                |   |                      |             |--- action to be performed by state machine
-#       |                |   |                      |                  See function RBBIRuleScanner::doParseActions()
+#       |                |   |                      |                  See function RegexCompile::doParseActions()
 #       |                |   |                      |
 #       |                |   |                      |--- Push this named state onto the state stack.
 #       |                |   |                           Later, when next state is specified as "pop",


### PR DESCRIPTION
Also fix a comment in regexcst.txt that incorrectly refered an rbbi implementation function rather than the corresponding regex function.

#### Checklist
- [x] Required: Issue filed: ICU-23142
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
