### PR TITLE
ICU-23172 part 2: Make EraRules work if era code sequence starts at >0 and/or has holes

### DIFF
--- a/icu4c/source/i18n/erarules.cpp
+++ b/icu4c/source/i18n/erarules.cpp
@@ -17,6 +17,7 @@
 #include "erarules.h"
 #include "gregoimp.h"
 #include "uassert.h"
+#include "uvectr32.h"
 
 U_NAMESPACE_BEGIN
 
@@ -102,9 +103,9 @@ static int32_t compareEncodedDateWithYMD(int encoded, int year, int month, int d
     }
 }
 
-EraRules::EraRules(LocalMemory<int32_t>& eraStartDates, int32_t numEras)
-    : numEras(numEras) {
-    startDates = std::move(eraStartDates);
+EraRules::EraRules(LocalMemory<int32_t>& startDatesIn, int32_t startDatesLengthIn, int32_t minEraIn, int32_t numErasIn)
+    : startDatesLength(startDatesLengthIn), minEra(minEraIn), numEras(numErasIn) {
+    startDates = std::move(startDatesIn);
     initCurrentEra();
 }
 
@@ -127,12 +128,10 @@ EraRules* EraRules::createInstance(const char *calType, UBool includeTentativeEr
     int32_t numEras = ures_getSize(rb.getAlias());
     int32_t firstTentativeIdx = MAX_INT32;
 
-    LocalMemory<int32_t> startDates(static_cast<int32_t *>(uprv_malloc(numEras * sizeof(int32_t))));
-    if (startDates.isNull()) {
-        status = U_MEMORY_ALLOCATION_ERROR;
+    UVector32 eraStartDates(numEras, status);
+    if (U_FAILURE(status)) {
         return nullptr;
     }
-    uprv_memset(startDates.getAlias(), 0 , numEras * sizeof(int32_t));
 
     while (ures_hasNext(rb.getAlias())) {
         LocalUResourceBundlePointer eraRuleRes(ures_getNextResource(rb.getAlias(), nullptr, &status));
@@ -141,16 +140,27 @@ EraRules* EraRules::createInstance(const char *calType, UBool includeTentativeEr
         }
         const char *eraIdxStr = ures_getKey(eraRuleRes.getAlias());
         char *endp;
-        int32_t eraIdx = static_cast<int32_t>(strtol(eraIdxStr, &endp, 10));
+        int32_t eraIdx = static_cast<int32_t>(uprv_strtol(eraIdxStr, &endp, 10));
         if (static_cast<size_t>(endp - eraIdxStr) != uprv_strlen(eraIdxStr)) {
             status = U_INVALID_FORMAT_ERROR;
             return nullptr;
         }
-        if (eraIdx < 0 || eraIdx >= numEras) {
+        if (eraIdx < 0) {
             status = U_INVALID_FORMAT_ERROR;
             return nullptr;
         }
-        if (isSet(startDates[eraIdx])) {
+        if (eraIdx + 1 > eraStartDates.size()) {
+            eraStartDates.ensureCapacity(eraIdx + 1, status); // needed only to minimize expansions
+            // Fill in 0 for all added slots (else they are undefined)
+            while (eraStartDates.size() < eraIdx + 1) {
+                eraStartDates.addElement(0, status);
+            }
+            if (U_FAILURE(status)) {
+                return nullptr;
+            }
+        }
+        // Now set the startDate that we just read
+        if (isSet(eraStartDates.elementAti(eraIdx))) {
             // start date of the index was already set
             status = U_INVALID_FORMAT_ERROR;
             return nullptr;
@@ -174,7 +184,7 @@ EraRules* EraRules::createInstance(const char *calType, UBool includeTentativeEr
                     status = U_INVALID_FORMAT_ERROR;
                     return nullptr;
                 }
-                startDates[eraIdx] = encodeDate(fields[0], fields[1], fields[2]);
+                eraStartDates.setElementAt(encodeDate(fields[0], fields[1], fields[2]), eraIdx);
             } else if (uprv_strcmp(key, "named") == 0) {
                 const char16_t *val = ures_getString(res.getAlias(), &len, &status);
                 if (u_strncmp(val, VAL_FALSE, VAL_FALSE_LEN) == 0) {
@@ -185,7 +195,7 @@ EraRules* EraRules::createInstance(const char *calType, UBool includeTentativeEr
             }
         }
 
-        if (isSet(startDates[eraIdx])) {
+        if (isSet(eraStartDates.elementAti(eraIdx))) {
             if (hasEnd) {
                 // This implementation assumes either start or end is available, not both.
                 // For now, just ignore the end rule.
@@ -194,7 +204,7 @@ EraRules* EraRules::createInstance(const char *calType, UBool includeTentativeEr
             if (hasEnd) {
                 // The islamic calendars now have an end-only rule for the
                 // second (and final) entry; basically they are in reverse order.
-                startDates[eraIdx] = MIN_ENCODED_START;
+                eraStartDates.setElementAt(MIN_ENCODED_START, eraIdx);
             } else {
                 status = U_INVALID_FORMAT_ERROR;
                 return nullptr;
@@ -213,47 +223,91 @@ EraRules* EraRules::createInstance(const char *calType, UBool includeTentativeEr
         }
     }
 
-    EraRules *result;
-    if (firstTentativeIdx < MAX_INT32 && !includeTentativeEra) {
-        result = new EraRules(startDates, firstTentativeIdx);
-    } else {
-        result = new EraRules(startDates, numEras);
+    // Remove from eraStartDates any tentative eras if they should not be included
+    // (these would be the last entries). Also reduce numEras appropriately.
+    if (!includeTentativeEra) {
+        while (firstTentativeIdx < eraStartDates.size()) {
+            int32_t lastEraIdx = eraStartDates.size() - 1;
+            if (isSet(eraStartDates.elementAti(lastEraIdx))) { // If there are multiple tentativeEras, some may be unset
+                numEras--;
+            }
+            eraStartDates.removeElementAt(lastEraIdx);
+        }
+        // Remove any remaining trailing unSet entries
+        // (can only have these if tentativeEras have been removed)
+        while (eraStartDates.size() > 0 && !isSet(eraStartDates.elementAti(eraStartDates.size() - 1))) {
+            eraStartDates.removeElementAt(eraStartDates.size() - 1);
+        }
     }
-
+    // Remove from eraStartDates any initial 0 entries, keeping the original index (eraCode)
+    // of the first non-zero entry as minEra; then we can add that back to the offset in the
+    // compressed array to get the correct eraCode.
+    int32_t minEra = 0;
+    while (eraStartDates.size() > 0 && !isSet(eraStartDates.elementAti(0))) {
+        eraStartDates.removeElementAt(0);
+        minEra++;
+    }
+    // Convert eraStartDates to int32_t array startDates and pass to EraRules constructor,
+    // along with startDatesLength, minEra and numEras (which may be different from startDatesLength)
+    LocalMemory<int32_t> startDates(static_cast<int32_t *>(uprv_malloc(eraStartDates.size() * sizeof(int32_t))));
+    if (startDates.isNull()) {
+        status = U_MEMORY_ALLOCATION_ERROR;
+        return nullptr;
+    }
+    for (int32_t eraIdx = 0; eraIdx < eraStartDates.size(); eraIdx++) {
+        startDates[eraIdx] = eraStartDates.elementAti(eraIdx);
+    }
+    EraRules *result = new EraRules(startDates, eraStartDates.size(), minEra, numEras);
     if (result == nullptr) {
         status = U_MEMORY_ALLOCATION_ERROR;
     }
     return result;
 }
 
-void EraRules::getStartDate(int32_t eraIdx, int32_t (&fields)[3], UErrorCode& status) const {
+void EraRules::getStartDate(int32_t eraCode, int32_t (&fields)[3], UErrorCode& status) const {
     if(U_FAILURE(status)) {
         return;
     }
-    if (eraIdx < 0 || eraIdx >= numEras) {
-        status = U_ILLEGAL_ARGUMENT_ERROR;
+    int32_t startDate = 0;
+    if (eraCode >= minEra) {
+        int32_t startIdx = eraCode - minEra;
+        if (startIdx < startDatesLength) {
+            startDate = startDates[startIdx];
+        }
+    }
+    if (isSet(startDate)) {
+        decodeDate(startDate, fields);
         return;
     }
-    decodeDate(startDates[eraIdx], fields);
+    // We did not find the requested eraCode in our data
+    status = U_ILLEGAL_ARGUMENT_ERROR;
+    return;
 }
 
-int32_t EraRules::getStartYear(int32_t eraIdx, UErrorCode& status) const {
+int32_t EraRules::getStartYear(int32_t eraCode, UErrorCode& status) const {
     int year = MAX_INT32;   // bogus value
     if(U_FAILURE(status)) {
         return year;
     }
-    if (eraIdx < 0 || eraIdx >= numEras) {
-        status = U_ILLEGAL_ARGUMENT_ERROR;
+    int32_t startDate = 0;
+    if (eraCode >= minEra) {
+        int32_t startIdx = eraCode - minEra;
+        if (startIdx < startDatesLength) {
+            startDate = startDates[startIdx];
+        }
+    }
+    if (isSet(startDate)) {
+        int fields[3];
+        decodeDate(startDate, fields);
+        year = fields[0];
         return year;
     }
-    int fields[3];
-    decodeDate(startDates[eraIdx], fields);
-    year = fields[0];
-
+    // We did not find the requested eraCode in our data
+    status = U_ILLEGAL_ARGUMENT_ERROR;
     return year;
 }
 
-int32_t EraRules::getEraIndex(int32_t year, int32_t month, int32_t day, UErrorCode& status) const {
+int32_t EraRules::getEraCode(int32_t year, int32_t month, int32_t day, UErrorCode& status) const {
     if(U_FAILURE(status)) {
         return -1;
     }
@@ -262,36 +316,33 @@ int32_t EraRules::getEraIndex(int32_t year, int32_t month, int32_t day, UErrorCo
         status = U_ILLEGAL_ARGUMENT_ERROR;
         return -1;
     }
-    if (numEras > 1 && startDates[numEras-1] == MIN_ENCODED_START) {
+    if (numEras > 1 && startDates[startDatesLength-1] == MIN_ENCODED_START) {
         // Multiple eras in reverse order, linear search from beginning.
         // Currently only for islamic.
-        for (int eraIdx = 0; eraIdx < numEras; eraIdx++) {
-            if (compareEncodedDateWithYMD(startDates[eraIdx], year, month, day) <= 0) {
-                return eraIdx;
+        for (int startIdx = 0; startIdx < startDatesLength; startIdx++) {
+            if (!isSet(startDates[startIdx])) {
+                continue;
+            }
+            if (compareEncodedDateWithYMD(startDates[startIdx], year, month, day) <= 0) {
+                return minEra + startIdx;
             }
         }
     }
-    int32_t high = numEras; // last index + 1
-    int32_t low;
-
-    // Short circuit for recent years.  Most modern computations will
-    // occur in the last few eras.
-    if (compareEncodedDateWithYMD(startDates[getCurrentEraIndex()], year, month, day) <= 0) {
-        low = getCurrentEraIndex();
-    } else {
-        low = 0;
-    }
-
-    // Do binary search
-    while (low < high - 1) {
-        int i = (low + high) / 2;
-        if (compareEncodedDateWithYMD(startDates[i], year, month, day) <= 0) {
-            low = i;
-        } else {
-            high = i;
+    // Linear search from the end, which should hit the most likely eras first.
+    // Also this is the most efficient for any era if we have < 8 or so eras, so only less
+    // efficient for early eras in Japanese calendar (while we still have them). Formerly
+    // this used binary search which would only be better for those early Japanese eras,
+    // but now that is much more difficult since there may be holes in the sorted list.
+    // Note with this change, this no longer uses or depends on currentEra.
+    for (int startIdx = startDatesLength; startIdx > 0;) {
+        if (!isSet(startDates[--startIdx])) {
+            continue;
+        }
+        if (compareEncodedDateWithYMD(startDates[startIdx], year, month, day) <= 0) {
+            return minEra + startIdx;
         }
     }
-    return low;
+    return minEra;
 }
 
 void EraRules::initCurrentEra() {
@@ -312,30 +363,13 @@ void EraRules::initCurrentEra() {
     int32_t year, mid;
     int8_t  month0, dom;
     Grego::timeToFields(localMillis, year, month0, dom, mid, ec);
-    if (U_FAILURE(ec)) return;
-    int currentEncodedDate = encodeDate(year, month0 + 1 /* changes to 1-base */, dom);
-    int eraIdx = numEras - 1;
-    if (eraIdx > 0 && startDates[eraIdx] == MIN_ENCODED_START) {
-        // Multiple eras in reverse order, search from beginning.
-        // Currently only for islamic. Here current era must be
-        // in the array.
-        for (eraIdx = 0; eraIdx < numEras; eraIdx++) {
-            if (currentEncodedDate >= startDates[eraIdx]) {
-                break;
-            }
-        }
-    } else {
-        // The usual behavior, search from end
-        while (eraIdx > 0) {
-            if (currentEncodedDate >= startDates[eraIdx]) {
-                break;
-            }
-            eraIdx--;
-        }
-        // Note: current era could be before the first era.
-        // In this case, this implementation returns the first era index (0).
+    currentEra = minEra;
+    if (U_FAILURE(ec)) { return; }
+    // Now that getEraCode no longer depends on currentEra, we can just do this:
+    currentEra = getEraCode(year, month0 + 1 /* changes to 1-base */, dom, ec);
+    if (U_FAILURE(ec)) {
+        currentEra = minEra;
     }
-    currentEra = eraIdx;
 }
 
 U_NAMESPACE_END

--- a/icu4c/source/i18n/erarules.h
+++ b/icu4c/source/i18n/erarules.h
@@ -24,59 +24,69 @@ public:
 
     /**
      * Gets number of effective eras
-     * @return  number of effective eras
+     * @return  number of effective eras (not the same as max era code)
      */
     inline int32_t getNumberOfEras() const {
         return numEras;
     }
 
     /**
+     * Gets maximum defined era code for the current calendar
+     * @return  maximum defined era code
+     */
+    inline int32_t getMaxEraCode() const {
+        return minEra + startDatesLength - 1;
+    }
+
+    /**
      * Gets start date of an era
-     * @param eraIdx    Era index
+     * @param eraCode   Era code
      * @param fields    Receives date fields. The result includes values of year, month,
      *                  day of month in this order. When an era has no start date, the result
      *                  will be January 1st in year whose value is minimum integer.
      * @param status    Receives status.
      */
-    void getStartDate(int32_t eraIdx, int32_t (&fields)[3], UErrorCode& status) const;
+    void getStartDate(int32_t eraCode, int32_t (&fields)[3], UErrorCode& status) const;
 
     /**
      * Gets start year of an era
-     * @param eraIdx    Era index
+     * @param eraCode   Era code
      * @param status    Receives status.
      * @return The first year of an era. When a era has no start date, minimum int32
      *          value is returned.
      */
-    U_I18N_API int32_t getStartYear(int32_t eraIdx, UErrorCode& status) const;
+    U_I18N_API int32_t getStartYear(int32_t eraCode, UErrorCode& status) const;
 
     /**
-     * Returns era index for the specified year/month/day.
+     * Returns era code for the specified year/month/day.
      * @param year  Year
      * @param month Month (1-base)
      * @param day   Day of month
      * @param status    Receives status
-     * @return  era index (or 0, when the specified date is before the first era)
+     * @return  era code (or code of earliest era when date is before that era)
      */
-    U_I18N_API int32_t getEraIndex(int32_t year, int32_t month, int32_t day, UErrorCode& status) const;
+    U_I18N_API int32_t getEraCode(int32_t year, int32_t month, int32_t day, UErrorCode& status) const;
 
     /**
-     * Gets the current era index. This is calculated only once for an instance of
+     * Gets the current era code. This is calculated only once for an instance of
      * EraRules. The current era calculation is based on the default time zone at
      * the time of instantiation.
      *
-     * @return era index of current era (or 0, when current date is before the first era)
+     * @return era code of current era (or era code of earliest era when current date is before any era)
      */
-    inline int32_t getCurrentEraIndex() const {
+    inline int32_t getCurrentEraCode() const {
         return currentEra;
     }
 
 private:
-    EraRules(LocalMemory<int32_t>& eraStartDates, int32_t numEra);
+    EraRules(LocalMemory<int32_t>& startDatesIn, int32_t startDatesLengthIn, int32_t minEraIn, int32_t numErasIn);
 
     void initCurrentEra();
 
     LocalMemory<int32_t> startDates;
-    int32_t numEras;
+    int32_t startDatesLength;
+    int32_t minEra;  // minimum valid era code, for first entry in startDates
+    int32_t numEras; // number of valid era codes (not necessarily the same as startDates length
     int32_t currentEra;
 };
 

--- a/icu4c/source/i18n/japancal.cpp
+++ b/icu4c/source/i18n/japancal.cpp
@@ -98,7 +98,7 @@ static void U_CALLCONV initializeEras(UErrorCode &status) {
     if (U_FAILURE(status)) {
         return;
     }
-    gCurrentEra = gJapaneseEraRules->getCurrentEraIndex();
+    gCurrentEra = gJapaneseEraRules->getCurrentEraCode();
 }
 
 static void init(UErrorCode &status) {
@@ -222,9 +222,9 @@ void JapaneseCalendar::handleComputeFields(int32_t julianDay, UErrorCode& status
     //Calendar::timeToFields(theTime, quick, status);
     GregorianCalendar::handleComputeFields(julianDay, status);
     int32_t year = internalGet(UCAL_EXTENDED_YEAR); // Gregorian year
-    int32_t eraIdx = gJapaneseEraRules->getEraIndex(year, internalGetMonth(status) + 1, internalGet(UCAL_DAY_OF_MONTH), status);
+    int32_t eraCode = gJapaneseEraRules->getEraCode(year, internalGetMonth(status) + 1, internalGet(UCAL_DAY_OF_MONTH), status);
 
-    int32_t startYear = gJapaneseEraRules->getStartYear(eraIdx, status) - 1;
+    int32_t startYear = gJapaneseEraRules->getStartYear(eraCode, status) - 1;
     if (U_FAILURE(status)) {
         return;
     }
@@ -232,7 +232,7 @@ void JapaneseCalendar::handleComputeFields(int32_t julianDay, UErrorCode& status
         status = U_ILLEGAL_ARGUMENT_ERROR;
         return;
     }
-    internalSet(UCAL_ERA, eraIdx);
+    internalSet(UCAL_ERA, eraCode);
     internalSet(UCAL_YEAR, year);
 }
 
@@ -261,7 +261,7 @@ int32_t JapaneseCalendar::handleGetLimit(UCalendarDateFields field, ELimitType l
         if (limitType == UCAL_LIMIT_MINIMUM || limitType == UCAL_LIMIT_GREATEST_MINIMUM) {
             return 0;
         }
-        return gJapaneseEraRules->getNumberOfEras() - 1; // max known era, not gCurrentEra
+        return gJapaneseEraRules->getMaxEraCode(); // max known era, not gCurrentEra
     case UCAL_YEAR:
         {
             switch (limitType) {
@@ -295,7 +295,7 @@ int32_t JapaneseCalendar::getActualMaximum(UCalendarDateFields field, UErrorCode
     if (U_FAILURE(status)) {
         return 0; // error case... any value
     }
-    if (era == gJapaneseEraRules->getNumberOfEras() - 1) { // max known era, not gCurrentEra
+    if (era == gJapaneseEraRules->getMaxEraCode()) { // max known era, not gCurrentEra
         // TODO: Investigate what value should be used here - revisit after 4.0.
         return handleGetLimit(UCAL_YEAR, UCAL_LIMIT_MAXIMUM);
     }

--- a/icu4c/source/test/cintltst/ccaltst.c
+++ b/icu4c/source/test/cintltst/ccaltst.c
@@ -2163,6 +2163,7 @@ static const EraTestItem eraTestItems[] = {
 
 static const UChar zoneGMT[] = { 0x47,0x4D,0x54,0 };
 
+// When era 0 is deleted in some calendars, this test will need to be modified
 void TestAddRollEra0AndEraBounds(void) {
     const EraTestItem * eraTestItemPtr;
     for (eraTestItemPtr = eraTestItems; eraTestItemPtr->locale != NULL; eraTestItemPtr++) {

--- a/icu4c/source/test/intltest/erarulestest.cpp
+++ b/icu4c/source/test/intltest/erarulestest.cpp
@@ -79,9 +79,9 @@ void EraRulesTest::testAPIs() {
             errln("Failed to create a Calendar instance.");
             continue;
         }
-        int32_t currentIdx = rules1->getCurrentEraIndex();
+        int32_t currentIdx = rules1->getCurrentEraCode();
         int32_t currentYear = cal->get(UCAL_YEAR, status);
-        int32_t idx = rules1->getEraIndex(
+        int32_t idx = rules1->getEraCode(
                 currentYear, cal->get(UCAL_MONTH, status) + 1,
                 cal->get(UCAL_DATE, status), status);
         if (U_FAILURE(status)) {
@@ -113,8 +113,8 @@ void EraRulesTest::testJapanese() {
         return;
     }
     // Rules should have an era after Heisei
-    int32_t numRules = rules->getNumberOfEras();
-    if (numRules <= HEISEI) {
+    int32_t maxEra = rules->getMaxEraCode();
+    if (maxEra <= HEISEI) {
         errln("Era after Heisei is not available.");
         return;
     }

--- a/icu4c/source/test/intltest/incaltst.cpp
+++ b/icu4c/source/test/intltest/incaltst.cpp
@@ -595,6 +595,7 @@ void IntlCalendarTest::TestJapaneseFormat() {
         simpleTest(loc, expect, expectDate, status);
     }
     {
+        // When era for 1776 is deleted, format result will be different
         UnicodeString expect = CharsToUnicodeString("\\u5b89\\u6c385\\u5e747\\u67084\\u65e5\\u6728\\u66dc\\u65e5");
         UDate         expectDate = -6106032422000.0; // 1776-07-04T00:00:00Z-075258
         Locale        loc("ja_JP@calendar=japanese");
@@ -622,6 +623,7 @@ void IntlCalendarTest::TestJapaneseFormat() {
         
     }
     {   // This Feb 29th falls on a leap year by gregorian year, but not by Japanese year.
+        // When era for 1456 is deleted, format result will be different
         UnicodeString expect = CharsToUnicodeString("\\u5EB7\\u6B632\\u5e742\\u670829\\u65e5\\u65e5\\u66dc\\u65e5");
         UDate         expectDate =  -16214400422000.0;  // 1456-03-09T00:00Z-075258
         Locale        loc("ja_JP@calendar=japanese");

--- a/icu4j/main/core/src/main/java/com/ibm/icu/util/JapaneseCalendar.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/util/JapaneseCalendar.java
@@ -344,10 +344,10 @@ public class JapaneseCalendar extends GregorianCalendar {
     protected void handleComputeFields(int julianDay) {
         super.handleComputeFields(julianDay);
         int year = internalGet(EXTENDED_YEAR);
-        int eraIdx = ERA_RULES.getEraIndex(year, internalGet(MONTH) + 1 /* 1-base */, internalGet(DAY_OF_MONTH));
+        int eraCode = ERA_RULES.getEraCode(year, internalGet(MONTH) + 1 /* 1-base */, internalGet(DAY_OF_MONTH));
 
-        internalSet(ERA, eraIdx);
-        internalSet(YEAR, year - ERA_RULES.getStartYear(eraIdx) + 1);
+        internalSet(ERA, eraCode);
+        internalSet(YEAR, year - ERA_RULES.getStartYear(eraCode) + 1);
     }
 
     //-------------------------------------------------------------------------
@@ -400,7 +400,7 @@ public class JapaneseCalendar extends GregorianCalendar {
         SHOWA = 234;
         HEISEI = 235;
         REIWA = 236;
-        CURRENT_ERA = ERA_RULES.getCurrentEraIndex();
+        CURRENT_ERA = ERA_RULES.getCurrentEraCode();
     }
 
     /**
@@ -417,7 +417,7 @@ public class JapaneseCalendar extends GregorianCalendar {
             if (limitType == MINIMUM || limitType == GREATEST_MINIMUM) {
                 return 0;
             }
-            return ERA_RULES.getNumberOfEras() - 1; // max known era, not always CURRENT_ERA
+            return ERA_RULES.getMaxEraCode(); // max known era, not always CURRENT_ERA
         case YEAR:
         {
             switch (limitType) {
@@ -464,7 +464,7 @@ public class JapaneseCalendar extends GregorianCalendar {
     public int getActualMaximum(int field) {
         if (field == YEAR) {
             int era = get(Calendar.ERA);
-            if (era == ERA_RULES.getNumberOfEras() - 1) {
+            if (era == ERA_RULES.getMaxEraCode()) {
                 // TODO: Investigate what value should be used here - revisit after 4.0.
                 return handleGetLimit(YEAR, MAXIMUM);
             } else {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/EraRulesTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/EraRulesTest.java
@@ -41,20 +41,20 @@ public class EraRulesTest extends CoreTestFmwk {
             }
             int numEras2 = rules2.getNumberOfEras();
             if (numEras2 < numEras1) {
-                errln("Number of era including tentative eras is fewer than one without tentative eras in calendar: "
+                errln("Number of eras including tentative eras is fewer than one without tentative eras in calendar: "
                         + calId);
             }
 
             Calendar cal = Calendar.getInstance(TimeZone.GMT_ZONE, new ULocale("en"));
-            int currentIdx = rules1.getCurrentEraIndex();
+            int currentEra = rules1.getCurrentEraCode();
             int currentYear = cal.get(Calendar.YEAR);
-            int idx = rules1.getEraIndex(currentYear, cal.get(Calendar.MONTH) + 1, cal.get(Calendar.DATE));
-            if (idx != currentIdx) {
-                errln("Current era index:" + currentIdx + " is different from era index of now:" + idx
+            int eraCode = rules1.getEraCode(currentYear, cal.get(Calendar.MONTH) + 1, cal.get(Calendar.DATE));
+            if (eraCode != currentEra) {
+                errln("Current era code:" + currentEra + " is different from era code of now:" + eraCode
                         + " in calendar:" + calId);
             }
 
-            int eraStartYear = rules1.getStartYear(currentIdx);
+            int eraStartYear = rules1.getStartYear(currentEra);
             if (currentYear < eraStartYear) {
                 errln("Current era's start year is after the current year in calendar:" + calId);
             }
@@ -65,8 +65,8 @@ public class EraRulesTest extends CoreTestFmwk {
     public void testJapanese() {
         EraRules rules = EraRules.getInstance(CalType.JAPANESE, true);
         // Rules should have an era after Heisei
-        int numRules = rules.getNumberOfEras();
-        if (numRules <= JapaneseCalendar.HEISEI) {
+        int maxEra = rules.getMaxEraCode();
+        if (maxEra <= JapaneseCalendar.HEISEI) {
             errln("Era after Heisei is not available.");
         }
         int postHeiseiStartYear = rules.getStartYear(JapaneseCalendar.HEISEI + 1);

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/IBMCalendarTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/IBMCalendarTest.java
@@ -1710,6 +1710,7 @@ public class IBMCalendarTest extends CalendarTestFmwk {
 
     @Test
     public void TestAddRollEra0AndEraBounds() {
+        // When era 0 is deleted in some calendars, this test will need to be modified
         final String[] localeIDs = {
             // calendars with non-modern era 0 that goes backwards, max era == 1
             "en@calendar=gregorian",


### PR DESCRIPTION
This is the second and final part of a multipart change to convert era data from an array to a map (only affects the name data, the era rules data was already a map), and then to allow era codes that do not start from 0, or may potentially have holes in the sequence (as long as the date ranges for the eras are contiguous). This is needed to unblock some changes to era data in CLDR, such as for coptic (eliminating the current first era) and japanese (eliminating eras before Meiji). The first part was done in PR #3588.

- This second part makes the internal EraRules class handle supplemental calendar eras data (which was already in map form) in which the era code sequence may not start at 0, or may have holes in it.
    - As part of this I added a method getMaxEraCode() which now may produce a different result than getNumberOfEras(); some clients want one behavior and some the other (at least in test code). I also renamed some methods to make it clear they were dealing with an era code, not an era index that might be assumed to be sequential from 0, and an index into something. It may also be useful to add getMinEraCode() in the future.
    - I tested this change partly by manually deleting eras 0-229 from the Japanese calendar data in C `data/misc/supplementalData.txt`, integrating that change over to ICU4J, and running the normal tests for both C and J with that change, and with some logging to verify proper construction of data in EraRules. That supplementalData.txt change is not in the PR however; it will happen in a near-future CLDR-ICU integration after the eras are deleted in CLDR.
    - There are currently some tests that try to calculate with era 0 in all calendars, which will need to be modified when we no longer have era 0 in some calendars. There are also tests that try to format dates in the Japanese calendar for Gregorian years like 1456 or 1776, these will produce a different formatted result if the corresponding Japanese-calendar eras are deleted. I added notes for these but thought it premature to change the tests themselves (until we actually remove the eras).

#### Checklist
- [x] Required: Issue filed: ICU-23172
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
