### PR TITLE
ICU-23005 Replace use of CharString with Locale to simplify the code

### DIFF
--- a/icu4c/source/common/locbased.cpp
+++ b/icu4c/source/common/locbased.cpp
@@ -11,85 +11,36 @@
 **********************************************************************
 */
 #include "locbased.h"
-#include "cstring.h"
-#include "charstr.h"
+#include "uresimp.h"
 
 U_NAMESPACE_BEGIN
 
-Locale LocaleBased::getLocale(const CharString* valid, const CharString* actual,
-                              ULocDataLocaleType type, UErrorCode& status) {
-    const char* id = getLocaleID(valid, actual, type, status);
-    return Locale(id != nullptr ? id : "");
-}
-
-const char* LocaleBased::getLocaleID(const CharString* valid, const CharString* actual,
+const Locale& LocaleBased::getLocale(const Locale& valid, const Locale& actual,
                                      ULocDataLocaleType type, UErrorCode& status) {
     if (U_FAILURE(status)) {
-        return nullptr;
+        return Locale::getRoot();
     }
 
     switch(type) {
     case ULOC_VALID_LOCALE:
-        return valid == nullptr ? "" : valid->data();
+        return valid;
     case ULOC_ACTUAL_LOCALE:
-        return actual == nullptr ? "" : actual->data();
+        return actual;
     default:
         status = U_ILLEGAL_ARGUMENT_ERROR;
+        return Locale::getRoot();
+    }
+}
+
+const char* LocaleBased::getLocaleID(const Locale& valid, const Locale& actual,
+                                     ULocDataLocaleType type, UErrorCode& status) {
+    const Locale& locale = getLocale(valid, actual, type, status);
+
+    if (U_FAILURE(status)) {
         return nullptr;
     }
-}
 
-void LocaleBased::setLocaleIDs(const CharString* validID, const CharString* actualID, UErrorCode& status) {
-    setValidLocaleID(validID, status);
-    setActualLocaleID(actualID,status);
-}
-void LocaleBased::setLocaleIDs(const char* validID, const char* actualID, UErrorCode& status) {
-    setValidLocaleID(validID, status);
-    setActualLocaleID(actualID,status);
-}
-
-void LocaleBased::setLocaleID(const char* id, CharString*& dest, UErrorCode& status) {
-    if (U_FAILURE(status)) { return; }
-    if (id == nullptr || *id == 0) {
-        delete dest;
-        dest = nullptr;
-    } else {
-        if (dest == nullptr) {
-            dest = new CharString(id, status);
-            if (dest == nullptr) {
-                status = U_MEMORY_ALLOCATION_ERROR;
-                return;
-            }
-        } else {
-            dest->copyFrom(id, status);
-        }
-    }
-}
-
-void LocaleBased::setLocaleID(const CharString* id, CharString*& dest, UErrorCode& status) {
-    if (U_FAILURE(status)) { return; }
-    if (id == nullptr || id->isEmpty()) {
-        delete dest;
-        dest = nullptr;
-    } else {
-        if (dest == nullptr) {
-            dest = new CharString(*id, status);
-            if (dest == nullptr) {
-                status = U_MEMORY_ALLOCATION_ERROR;
-                return;
-            }
-        } else {
-            dest->copyFrom(*id, status);
-        }
-    }
-}
-
-bool LocaleBased::equalIDs(const CharString* left, const CharString* right) {
-    // true if both are nullptr
-    if (left == nullptr && right == nullptr) return true;
-    // false if only one is nullptr
-    if (left == nullptr || right == nullptr) return false;
-    return *left == *right;
+    return locale == Locale::getRoot() ? kRootLocaleName : locale.getName();
 }
 
 U_NAMESPACE_END

--- a/icu4c/source/common/locbased.h
+++ b/icu4c/source/common/locbased.h
@@ -16,17 +16,8 @@
 #include "unicode/locid.h"
 #include "unicode/uobject.h"
 
-/**
- * Macro to declare a locale LocaleBased wrapper object for the given
- * object, which must have two members named `validLocale' and
- * `actualLocale' of which are pointers to the internal icu::CharString.
- */
-#define U_LOCALE_BASED(varname, objname) \
-  LocaleBased varname((objname).validLocale, (objname).actualLocale)
-
 U_NAMESPACE_BEGIN
 
-class CharString;
 /**
  * A utility class that unifies the implementation of getLocale() by
  * various ICU services.  This class is likely to be removed in the
@@ -39,12 +30,6 @@ class U_COMMON_API LocaleBased : public UMemory {
  public:
 
     /**
-     * Construct a LocaleBased wrapper around the two pointers.  These
-     * will be aliased for the lifetime of this object.
-     */
-    inline LocaleBased(CharString*& validAlias, CharString*& actualAlias);
-
-    /**
      * Return locale meta-data for the service object wrapped by this
      * object.  Either the valid or the actual locale may be
      * retrieved.
@@ -54,8 +39,8 @@ class U_COMMON_API LocaleBased : public UMemory {
      * @param status input-output error code
      * @return the indicated locale
      */
-    static Locale getLocale(
-        const CharString* valid, const CharString* actual,
+    static const Locale& getLocale(
+        const Locale& valid, const Locale& actual,
         ULocDataLocaleType type, UErrorCode& status);
 
     /**
@@ -69,50 +54,10 @@ class U_COMMON_API LocaleBased : public UMemory {
      * @return the indicated locale ID
      */
     static const char* getLocaleID(
-        const CharString* valid, const CharString* actual,
+        const Locale& valid, const Locale& actual,
         ULocDataLocaleType type, UErrorCode& status);
 
-    /**
-     * Set the locale meta-data for the service object wrapped by this
-     * object.  If either parameter is zero, it is ignored.
-     * @param valid the ID of the valid locale
-     * @param actual the ID of the actual locale
-     */
-    void setLocaleIDs(const char* valid, const char* actual, UErrorCode& status);
-    void setLocaleIDs(const CharString* valid, const CharString* actual, UErrorCode& status);
-
-    static void setLocaleID(const char* id, CharString*& dest, UErrorCode& status);
-    static void setLocaleID(const CharString* id, CharString*& dest, UErrorCode& status);
-
-    static bool equalIDs(const CharString* left, const CharString* right);
-
- private:
-
-    void setValidLocaleID(const CharString* id, UErrorCode& status);
-    void setActualLocaleID(const CharString* id, UErrorCode& status);
-    void setValidLocaleID(const char* id, UErrorCode& status);
-    void setActualLocaleID(const char* id, UErrorCode& status);
-
-    CharString*& valid;
-    CharString*& actual;
 };
-
-inline LocaleBased::LocaleBased(CharString*& validAlias, CharString*& actualAlias) :
-    valid(validAlias), actual(actualAlias) {
-}
-
-inline void LocaleBased::setValidLocaleID(const CharString* id, UErrorCode& status) {
-    setLocaleID(id, valid, status);
-}
-inline void LocaleBased::setActualLocaleID(const CharString* id, UErrorCode& status) {
-    setLocaleID(id, actual, status);
-}
-inline void LocaleBased::setValidLocaleID(const char* id, UErrorCode& status) {
-    setLocaleID(id, valid, status);
-}
-inline void LocaleBased::setActualLocaleID(const char* id, UErrorCode& status) {
-    setLocaleID(id, actual, status);
-}
 
 U_NAMESPACE_END
 

--- a/icu4c/source/common/unicode/brkiter.h
+++ b/icu4c/source/common/unicode/brkiter.h
@@ -58,8 +58,6 @@ U_NAMESPACE_END
 
 U_NAMESPACE_BEGIN
 
-class CharString;
-
 /**
  * The BreakIterator class implements methods for finding the location
  * of boundaries in text. BreakIterator is an abstract base class.
@@ -650,9 +648,9 @@ protected:
 private:
 
     /** @internal (private) */
-    CharString* actualLocale = nullptr;
-    CharString* validLocale = nullptr;
-    CharString* requestLocale = nullptr;
+    Locale actualLocale;
+    Locale validLocale;
+    Locale requestLocale;
 };
 
 #ifndef U_HIDE_DEPRECATED_API

--- a/icu4c/source/i18n/calendar.cpp
+++ b/icu4c/source/i18n/calendar.cpp
@@ -702,7 +702,9 @@ fAreAllFieldsSet(false),
 fAreFieldsVirtuallySet(false),
 fLenient(true),
 fRepeatedWallTime(UCAL_WALLTIME_LAST),
-fSkippedWallTime(UCAL_WALLTIME_LAST)
+fSkippedWallTime(UCAL_WALLTIME_LAST),
+validLocale(Locale::getRoot()),
+actualLocale(Locale::getRoot())
 {
     clear();
     if (U_FAILURE(success)) {
@@ -725,7 +727,9 @@ fAreAllFieldsSet(false),
 fAreFieldsVirtuallySet(false),
 fLenient(true),
 fRepeatedWallTime(UCAL_WALLTIME_LAST),
-fSkippedWallTime(UCAL_WALLTIME_LAST)
+fSkippedWallTime(UCAL_WALLTIME_LAST),
+validLocale(Locale::getRoot()),
+actualLocale(Locale::getRoot())
 {
     LocalPointer<TimeZone> zone(adoptZone, success);
     if (U_FAILURE(success)) {
@@ -755,7 +759,9 @@ fAreAllFieldsSet(false),
 fAreFieldsVirtuallySet(false),
 fLenient(true),
 fRepeatedWallTime(UCAL_WALLTIME_LAST),
-fSkippedWallTime(UCAL_WALLTIME_LAST)
+fSkippedWallTime(UCAL_WALLTIME_LAST),
+validLocale(Locale::getRoot()),
+actualLocale(Locale::getRoot())
 {
     if (U_FAILURE(success)) {
         return;
@@ -774,8 +780,6 @@ fSkippedWallTime(UCAL_WALLTIME_LAST)
 Calendar::~Calendar()
 {
     delete fZone;
-    delete actualLocale;
-    delete validLocale;
 }
 
 // -------------------------------------
@@ -814,10 +818,8 @@ Calendar::operator=(const Calendar &right)
         fWeekendCease            = right.fWeekendCease;
         fWeekendCeaseMillis      = right.fWeekendCeaseMillis;
         fNextStamp               = right.fNextStamp;
-        UErrorCode status = U_ZERO_ERROR;
-        U_LOCALE_BASED(locBased, *this);
-        locBased.setLocaleIDs(right.validLocale, right.actualLocale, status);
-        U_ASSERT(U_SUCCESS(status));
+        validLocale = right.validLocale;
+        actualLocale = right.actualLocale;
     }
 
     return *this;
@@ -4135,9 +4137,8 @@ Calendar::setWeekData(const Locale& desiredLocale, const char *type, UErrorCode&
     }
 
     if (U_SUCCESS(status)) {
-        U_LOCALE_BASED(locBased,*this);
-        locBased.setLocaleIDs(ures_getLocaleByType(monthNames.getAlias(), ULOC_VALID_LOCALE, &status),
-                              ures_getLocaleByType(monthNames.getAlias(), ULOC_ACTUAL_LOCALE, &status), status);
+        validLocale = Locale(ures_getLocaleByType(monthNames.getAlias(), ULOC_VALID_LOCALE, &status));
+        actualLocale = Locale(ures_getLocaleByType(monthNames.getAlias(), ULOC_ACTUAL_LOCALE, &status));
     } else {
         status = U_USING_FALLBACK_WARNING;
         return;

--- a/icu4c/source/i18n/dcfmtsym.cpp
+++ b/icu4c/source/i18n/dcfmtsym.cpp
@@ -117,7 +117,10 @@ DecimalFormatSymbols::DecimalFormatSymbols(const Locale& loc, const NumberingSys
 }
 
 DecimalFormatSymbols::DecimalFormatSymbols()
-        : UObject(), locale(Locale::getRoot()) {
+    : UObject(),
+      locale(Locale::getRoot()),
+      actualLocale(Locale::getRoot()),
+      validLocale(Locale::getRoot()) {
     initialize();
 }
 
@@ -135,8 +138,6 @@ DecimalFormatSymbols::createWithLastResortData(UErrorCode& status) {
 
 DecimalFormatSymbols::~DecimalFormatSymbols()
 {
-    delete actualLocale;
-    delete validLocale;
 }
 
 // -------------------------------------
@@ -164,12 +165,8 @@ DecimalFormatSymbols::operator=(const DecimalFormatSymbols& rhs)
             currencySpcAfterSym[i].fastCopyFrom(rhs.currencySpcAfterSym[i]);
         }
         locale = rhs.locale;
-
-        UErrorCode status = U_ZERO_ERROR;
-        U_LOCALE_BASED(locBased, *this);
-        locBased.setLocaleIDs(rhs.validLocale, rhs.actualLocale, status);
-        U_ASSERT(U_SUCCESS(status));
-
+        actualLocale = rhs.actualLocale;
+        validLocale = rhs.validLocale;
         fIsCustomCurrencySymbol = rhs.fIsCustomCurrencySymbol; 
         fIsCustomIntlCurrencySymbol = rhs.fIsCustomIntlCurrencySymbol; 
         fCodePointZero = rhs.fCodePointZero;
@@ -208,8 +205,8 @@ DecimalFormatSymbols::operator==(const DecimalFormatSymbols& that) const
     }
     // No need to check fCodePointZero since it is based on fSymbols
     return locale == that.locale &&
-        LocaleBased::equalIDs(actualLocale, that.actualLocale) &&
-        LocaleBased::equalIDs(validLocale, that.validLocale);
+           actualLocale == that.actualLocale &&
+           validLocale == that.validLocale;
 }
 
 // -------------------------------------
@@ -406,15 +403,10 @@ DecimalFormatSymbols::initialize(const Locale& loc, UErrorCode& status,
 
     // Set locale IDs
     // TODO: Is there a way to do this without depending on the resource bundle instance?
-    U_LOCALE_BASED(locBased, *this);
-    locBased.setLocaleIDs(
-        ures_getLocaleByType(
-            numberElementsRes.getAlias(),
-            ULOC_VALID_LOCALE, &status),
-        ures_getLocaleByType(
-            numberElementsRes.getAlias(),
-            ULOC_ACTUAL_LOCALE, &status),
-        status);
+    actualLocale = Locale(
+        ures_getLocaleByType(numberElementsRes.getAlias(), ULOC_ACTUAL_LOCALE, &status));
+    validLocale = Locale(
+        ures_getLocaleByType(numberElementsRes.getAlias(), ULOC_VALID_LOCALE, &status));
 
     // Now load the rest of the data from the data sink.
     // Start with loading this nsName if it is not Latin.

--- a/icu4c/source/i18n/dtfmtsym.cpp
+++ b/icu4c/source/i18n/dtfmtsym.cpp
@@ -400,10 +400,8 @@ DateFormatSymbols::createZoneStrings(const UnicodeString *const * otherStrings)
  */
 void
 DateFormatSymbols::copyData(const DateFormatSymbols& other) {
-    UErrorCode status = U_ZERO_ERROR;
-    U_LOCALE_BASED(locBased, *this);
-    locBased.setLocaleIDs(other.validLocale, other.actualLocale, status);
-    U_ASSERT(U_SUCCESS(status));
+    validLocale = other.validLocale;
+    actualLocale = other.actualLocale;
     assignArray(fEras, fErasCount, other.fEras, other.fErasCount);
     assignArray(fEraNames, fEraNamesCount, other.fEraNames, other.fEraNamesCount);
     assignArray(fNarrowEras, fNarrowErasCount, other.fNarrowEras, other.fNarrowErasCount);
@@ -496,8 +494,6 @@ DateFormatSymbols& DateFormatSymbols::operator=(const DateFormatSymbols& other)
 DateFormatSymbols::~DateFormatSymbols()
 {
     dispose();
-    delete actualLocale;
-    delete validLocale;
 }
 
 void DateFormatSymbols::dispose()
@@ -537,10 +533,8 @@ void DateFormatSymbols::dispose()
     delete[] fStandaloneWideDayPeriods;
     delete[] fStandaloneNarrowDayPeriods;
 
-    delete actualLocale;
-    actualLocale = nullptr;
-    delete validLocale;
-    validLocale = nullptr;
+    actualLocale = Locale::getRoot();
+    validLocale = Locale::getRoot();
     disposeZoneStrings();
 }
 
@@ -2344,12 +2338,11 @@ DateFormatSymbols::initializeData(const Locale& locale, const char *type, UError
         }
     }
 
-    U_LOCALE_BASED(locBased, *this);
     // if we make it to here, the resource data is cool, and we can get everything out
     // of it that we need except for the time-zone and localized-pattern data, which
     // are stored in a separate file
-    locBased.setLocaleIDs(ures_getLocaleByType(cb.getAlias(), ULOC_VALID_LOCALE, &status),
-                          ures_getLocaleByType(cb.getAlias(), ULOC_ACTUAL_LOCALE, &status), status);
+    validLocale = Locale(ures_getLocaleByType(cb.getAlias(), ULOC_VALID_LOCALE, &status));
+    actualLocale = Locale(ures_getLocaleByType(cb.getAlias(), ULOC_ACTUAL_LOCALE, &status));
 
     // Load eras
     initField(&fEras, fErasCount, calendarSink, buildResourcePath(path, gErasTag, gNamesAbbrTag, status), status);

--- a/icu4c/source/i18n/format.cpp
+++ b/icu4c/source/i18n/format.cpp
@@ -24,7 +24,6 @@
 #include "utypeinfo.h"  // for 'typeid' to work
 
 #include "unicode/utypes.h"
-#include "charstr.h"
 
 #ifndef U_I18N_IMPLEMENTATION
 #error U_I18N_IMPLEMENTATION not set - must be set for all ICU source files in i18n/ - see https://unicode-org.github.io/icu/userguide/howtouseicu
@@ -71,7 +70,7 @@ FieldPosition::clone() const {
 // default constructor
 
 Format::Format()
-    : UObject()
+    : UObject(), actualLocale(Locale::getRoot()), validLocale(Locale::getRoot())
 {
 }
 
@@ -79,8 +78,6 @@ Format::Format()
 
 Format::~Format()
 {
-    delete actualLocale;
-    delete validLocale;
 }
 
 // -------------------------------------
@@ -99,10 +96,8 @@ Format&
 Format::operator=(const Format& that)
 {
     if (this != &that) {
-        UErrorCode status = U_ZERO_ERROR;
-        U_LOCALE_BASED(locBased, *this);
-        locBased.setLocaleIDs(that.validLocale, that.actualLocale, status);
-        U_ASSERT(U_SUCCESS(status));
+        actualLocale = that.actualLocale;
+        validLocale = that.validLocale;
     }
     return *this;
 }
@@ -210,10 +205,8 @@ Format::getLocaleID(ULocDataLocaleType type, UErrorCode& status) const {
 
 void
 Format::setLocaleIDs(const char* valid, const char* actual) {
-    U_LOCALE_BASED(locBased, *this);
-    UErrorCode status = U_ZERO_ERROR;
-    locBased.setLocaleIDs(valid, actual, status);
-    U_ASSERT(U_SUCCESS(status));
+    actualLocale = Locale(actual);
+    validLocale = Locale(valid);
 }
 
 U_NAMESPACE_END

--- a/icu4c/source/i18n/unicode/calendar.h
+++ b/icu4c/source/i18n/unicode/calendar.h
@@ -55,7 +55,6 @@ class ICUServiceFactory;
 typedef int32_t UFieldResolutionTable[12][8];
 
 class BasicTimeZone;
-class CharString;
 /**
  * `Calendar` is an abstract base class for converting between
  * a `UDate` object and a set of integer fields such as
@@ -2371,8 +2370,8 @@ private:
 #endif  /* U_HIDE_INTERNAL_API */
 
  private:
-    CharString* validLocale = nullptr;
-    CharString* actualLocale = nullptr;
+    Locale validLocale;
+    Locale actualLocale;
 
  public:
 #if !UCONFIG_NO_SERVICE

--- a/icu4c/source/i18n/unicode/dcfmtsym.h
+++ b/icu4c/source/i18n/unicode/dcfmtsym.h
@@ -48,7 +48,6 @@
 
 U_NAMESPACE_BEGIN
 
-class CharString;
 /**
  * This class represents the set of symbols needed by DecimalFormat
  * to format numbers. DecimalFormat creates for itself an instance of
@@ -508,8 +507,8 @@ private:
 
     Locale locale;
 
-    CharString* actualLocale = nullptr;
-    CharString* validLocale = nullptr;
+    Locale actualLocale;
+    Locale validLocale;
     const char16_t* currPattern = nullptr;
 
     UnicodeString currencySpcBeforeSym[UNUM_CURRENCY_SPACING_COUNT];

--- a/icu4c/source/i18n/unicode/dtfmtsym.h
+++ b/icu4c/source/i18n/unicode/dtfmtsym.h
@@ -43,7 +43,6 @@ U_NAMESPACE_BEGIN
 /* forward declaration */
 class SimpleDateFormat;
 class Hashtable;
-class CharString;
 
 /**
  * DateFormatSymbols is a public class for encapsulating localizable date-time
@@ -937,8 +936,8 @@ private:
     /** valid/actual locale information 
      *  these are always ICU locales, so the length should not be a problem
      */
-    CharString* validLocale = nullptr;
-    CharString* actualLocale = nullptr;
+    Locale validLocale;
+    Locale actualLocale;
 
     DateFormatSymbols() = delete; // default constructor not implemented
 

--- a/icu4c/source/i18n/unicode/format.h
+++ b/icu4c/source/i18n/unicode/format.h
@@ -45,7 +45,6 @@
 
 U_NAMESPACE_BEGIN
 
-class CharString;
 /**
  * Base class for all formats.  This is an abstract base class which
  * specifies the protocol for classes which convert other objects or
@@ -298,8 +297,8 @@ protected:
                                        UParseError& parseError);
 
  private:
-    CharString* actualLocale = nullptr;
-    CharString* validLocale = nullptr;
+    Locale actualLocale;
+    Locale validLocale;
 };
 
 U_NAMESPACE_END


### PR DESCRIPTION
This brings a lot of the code that uses `LocaleBased` back to how it was before the refactoring of ICU-23000, accessing the `validLocale` and `actualLocale` fields directly instead of through `LocaleBased` helper functions that now no longer are necessary.

This also makes it possible to remove the `U_LOCALE_BASED()` macro and `LocaleBased` then ends up becoming a trivial class that now contains nothing more than two static helper functions.

The purpose of this PR is to simplify the code, but it should also not have any negative performance impact so with the `/usr/bin/time` test from ICU-23000 averaged over 10 runs it looks like this, with a dramatic change in the user / system time division but no noticeable change in wall time and a tiny reduction in memory consumption:

|| before | after | _ratio_ |
| :--- | ---: | ---: | ---: |
| User time (seconds) | 69.22 | 60.04 | 86.73% |
| System time (seconds) | 1.98 | 9.96 | 504.00% |
| Percent of CPU this job got | 266.80% | 261.20% | 97.90% |
| Elapsed (wall clock) time (h:mm:ss or m:ss) | 00:26.63 | 00:26.75 | 100.43% |
| Average shared text size (kbytes) | 0 | 0 ||
| Average unshared data size (kbytes) | 0 | 0 ||
| Average stack size (kbytes) | 0 | 0 ||
| Average total size (kbytes) | 0 | 0 ||
| Maximum resident set size (kbytes) | 225148 | 224944 | 99.91% |
| Average resident set size (kbytes) | 0 | 0 ||
| Major (requiring I/O) page faults | 0 | 0 ||
| Minor (reclaiming a frame) page faults | 44183 | 44305 | 100.28% |
| Voluntary context switches | 461694 | 1436460 | 311.13% |
| Involuntary context switches | 3291 | 3898 | 118.44% |
| Swaps | 0 | 0 ||
| File system inputs | 0 | 0 ||
| File system outputs | 0 | 0 ||
| Socket messages sent | 0 | 0 ||
| Socket messages received | 0 | 0 ||
| Signals delivered | 0 | 0 ||
| Page size (bytes) | 4096 | 4096 | 100.00% |
| Exit status | 0 | 0 ||

#### Checklist
- [x] Required: Issue filed: ICU-23005
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
