### PR TITLE
ICU-23184 fix NFRuleSet constructor to return error to avoid null deref later

### DIFF
--- a/icu4c/source/i18n/nfrs.cpp
+++ b/icu4c/source/i18n/nfrs.cpp
@@ -164,9 +164,11 @@ NFRuleSet::NFRuleSet(RuleBasedNumberFormat *_owner, UnicodeString* descriptions,
     // and delete it from the description
     if (description.charAt(0) == gPercent) {
         int32_t pos = description.indexOf(gColon);
-        if (pos == -1) {
+        // if there are no name or the name is "%".
+        if (pos < 2) {
             // throw new IllegalArgumentException("Rule set name doesn't end in colon");
             status = U_PARSE_ERROR;
+            return;
         } else {
             name.setTo(description, 0, pos);
             while (pos < description.length() && PatternProps::isWhiteSpace(description.charAt(++pos))) {
@@ -180,6 +182,7 @@ NFRuleSet::NFRuleSet(RuleBasedNumberFormat *_owner, UnicodeString* descriptions,
     if (description.isEmpty()) {
         // throw new IllegalArgumentException("Empty rule set description");
         status = U_PARSE_ERROR;
+        return;
     }
 
     fIsPublic = name.indexOf(gPercentPercent, 2, 0) != 0;
@@ -220,6 +223,9 @@ NFRuleSet::parseRules(UnicodeString& description, UErrorCode& status)
         }
         currentDescription.setTo(description, oldP, p - oldP);
         NFRule::makeRules(currentDescription, this, rules.last(), owner, rules, status);
+        if (U_FAILURE(status)) {
+            return;
+        }
         oldP = p + 1;
     }
 
@@ -244,6 +250,9 @@ NFRuleSet::parseRules(UnicodeString& description, UErrorCode& status)
             // same as the preceding rule's base value in fraction
             // rule sets)
             rule->setBaseValue(defaultBaseValue, status);
+            if (U_FAILURE(status)) {
+                return;
+            }
         }
         else {
             // if it's a regular rule that already knows its base value,

--- a/icu4c/source/i18n/rbnf.cpp
+++ b/icu4c/source/i18n/rbnf.cpp
@@ -1592,6 +1592,8 @@ RuleBasedNumberFormat::init(const UnicodeString& rules, LocalizationInfo* locali
             fRuleSets[curRuleSet] = new NFRuleSet(this, ruleSetDescriptions, curRuleSet, status);
             if (fRuleSets[curRuleSet] == nullptr) {
                 status = U_MEMORY_ALLOCATION_ERROR;
+            }
+            if (U_FAILURE(status)) {
                 return;
             }
             ++curRuleSet;
@@ -1601,6 +1603,8 @@ RuleBasedNumberFormat::init(const UnicodeString& rules, LocalizationInfo* locali
         fRuleSets[curRuleSet] = new NFRuleSet(this, ruleSetDescriptions, curRuleSet, status);
         if (fRuleSets[curRuleSet] == nullptr) {
             status = U_MEMORY_ALLOCATION_ERROR;
+        }
+        if (U_FAILURE(status)) {
             return;
         }
     }
@@ -1622,6 +1626,9 @@ RuleBasedNumberFormat::init(const UnicodeString& rules, LocalizationInfo* locali
     {
         for (int i = 0; i < numRuleSets; i++) {
             fRuleSets[i]->parseRules(ruleSetDescriptions[i], status);
+            if (U_FAILURE(status)) {
+                return;
+            }
         }
     }
 
@@ -1640,6 +1647,9 @@ RuleBasedNumberFormat::init(const UnicodeString& rules, LocalizationInfo* locali
             NFRuleSet* rs = findRuleSet(name, status);
             if (rs == nullptr) {
                 break; // error
+            }
+            if (U_FAILURE(status)) {
+                return;
             }
             if (i == 0) {
                 defaultRuleSet = rs;

--- a/icu4c/source/test/intltest/itrbnf.cpp
+++ b/icu4c/source/test/intltest/itrbnf.cpp
@@ -85,6 +85,7 @@ void IntlTestRBNF::runIndexedTest(int32_t index, UBool exec, const char* &name, 
         TESTCASE(33, TestInfiniteRecursion);
         TESTCASE(34, testOmissionReplacementWithPluralRules);
         TESTCASE(35, TestNullDereferenceWRITE23149);
+        TESTCASE(36, TestNullDereferenceREAD23184);
 #else
         TESTCASE(0, TestRBNFDisabled);
 #endif
@@ -2761,6 +2762,23 @@ IntlTestRBNF::TestNullDereferenceWRITE23149() {
    UErrorCode status = U_ZERO_ERROR;
    // The following call should not crash
    icu::RuleBasedNumberFormat rbfmt(test, Locale("en"), perror, status);
+}
+
+void
+IntlTestRBNF::TestNullDereferenceREAD23184() {
+    icu::Formattable result;
+    UParseError perror;
+    UErrorCode status = U_ZERO_ERROR;
+    icu::RuleBasedNumberFormat rbfmt(u"x00:>%>>;%:;<0<<", Locale::getUS(), perror, status);
+    if (U_SUCCESS(status)) {
+       errln("Construct \"x00:>%%>>;%%:;<0<<\" should get error");
+    }
+
+    status = U_ZERO_ERROR;
+    icu::RuleBasedNumberFormat rbfmt2(u"x00:>%>>;%;<0<<", Locale::getUS(), perror, status);
+    if (U_SUCCESS(status)) {
+       errln("Construct \"x00:>%%>>;%%;<0<<\" should get error");
+    }
 }
 
 /* U_HAVE_RBNF */

--- a/icu4c/source/test/intltest/itrbnf.h
+++ b/icu4c/source/test/intltest/itrbnf.h
@@ -166,6 +166,7 @@ public:
     void TestInfiniteRecursion();
     void testOmissionReplacementWithPluralRules();
     void TestNullDereferenceWRITE23149();
+    void TestNullDereferenceREAD23184();
 
 protected:
     virtual void doTest(RuleBasedNumberFormat* formatter, const char* const testData[][2], UBool testParsing);

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/NFRuleSet.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/NFRuleSet.java
@@ -118,6 +118,9 @@ final class NFRuleSet {
             if (pos == -1) {
                 throw new IllegalArgumentException("Rule set name doesn't end in colon");
             }
+            if (pos < 2) {
+                throw new IllegalArgumentException("Rule set name is '%'");
+            }
             else {
                 String ruleName = description.substring(0, pos);
                 this.isParseable = !ruleName.endsWith("@noparse");

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/RBNFParseTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/RBNFParseTest.java
@@ -194,4 +194,19 @@ public class RBNFParseTest extends CoreTestFmwk {
             }
         }
     }
+    @Test
+    public void Test23184EmptyRuleSet() {
+        try {
+            RuleBasedNumberFormat rbnf = new RuleBasedNumberFormat("x00:>%>>;%;<0<<", Locale.US);
+            errln("Failed: should throw IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            // success!
+        }
+        try {
+            RuleBasedNumberFormat rbnf = new RuleBasedNumberFormat("x00:>%>>;%:;<0<<", Locale.US);
+            errln("Failed: should throw IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            // success!
+        }
+    }
 }


### PR DESCRIPTION

#### Checklist
- [X] Required: Issue filed: ICU-23184
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

The fuzzer generated test data is very large (4300 lenght unicode string) . Not sure how to minimize it. Depends on the fuzzer to  test.

