### PR TITLE
ICU-23190 Delete obsolete U_HAVE_PLACEMENT_NEW

### DIFF
--- a/icu4c/source/common/cmemory.h
+++ b/icu4c/source/common/cmemory.h
@@ -334,9 +334,7 @@ public:
     // No heap allocation. Use only on the stack.
     static void* U_EXPORT2 operator new(size_t) noexcept = delete;
     static void* U_EXPORT2 operator new[](size_t) noexcept = delete;
-#if U_HAVE_PLACEMENT_NEW
     static void* U_EXPORT2 operator new(size_t, void*) noexcept = delete;
-#endif
 
     /**
      * Default constructor initializes with internal T[stackCapacity] buffer.
@@ -570,9 +568,7 @@ public:
     // No heap allocation. Use only on the stack.
     static void* U_EXPORT2 operator new(size_t) noexcept = delete;
     static void* U_EXPORT2 operator new[](size_t) noexcept = delete;
-#if U_HAVE_PLACEMENT_NEW
     static void* U_EXPORT2 operator new(size_t, void*) noexcept = delete;
-#endif
 
     /**
      * Default constructor initializes with internal H+T[stackCapacity] buffer.

--- a/icu4c/source/common/unicode/localpointer.h
+++ b/icu4c/source/common/unicode/localpointer.h
@@ -70,9 +70,7 @@ public:
     // No heap allocation. Use only on the stack.
     static void* U_EXPORT2 operator new(size_t) = delete;
     static void* U_EXPORT2 operator new[](size_t) = delete;
-#if U_HAVE_PLACEMENT_NEW
     static void* U_EXPORT2 operator new(size_t, void*) = delete;
-#endif
 
     /**
      * Constructor takes ownership.

--- a/icu4c/source/common/unicode/platform.h
+++ b/icu4c/source/common/unicode/platform.h
@@ -369,19 +369,6 @@
 #endif
 
 /**
- * \def U_HAVE_PLACEMENT_NEW
- * Determines whether to override placement new and delete for STL.
- * @stable ICU 2.6
- */
-#ifdef U_HAVE_PLACEMENT_NEW
-    /* Use the predefined value. */
-#elif defined(__BORLANDC__)
-#   define U_HAVE_PLACEMENT_NEW 0
-#else
-#   define U_HAVE_PLACEMENT_NEW 1
-#endif
-
-/**
  * \def U_HAVE_DEBUG_LOCATION_NEW 
  * Define this to define the MFC debug version of the operator new.
  *

--- a/icu4c/source/common/unicode/uobject.h
+++ b/icu4c/source/common/unicode/uobject.h
@@ -157,7 +157,6 @@ public:
      */
     static void U_EXPORT2 operator delete[](void *p) noexcept;
 
-#if U_HAVE_PLACEMENT_NEW
     /**
      * Override for ICU4C C++ memory management for STL.
      * See new().
@@ -171,7 +170,7 @@ public:
      * @stable ICU 2.6
      */
     static inline void U_EXPORT2 operator delete(void *, void *) noexcept {}
-#endif /* U_HAVE_PLACEMENT_NEW */
+
 #if U_HAVE_DEBUG_LOCATION_NEW
     /**
       * This method overrides the MFC debug version of the operator new

--- a/icu4c/source/common/uresimp.h
+++ b/icu4c/source/common/uresimp.h
@@ -120,9 +120,7 @@ public:
     // No heap allocation. Use only on the stack.
     static void* U_EXPORT2 operator new(size_t) noexcept = delete;
     static void* U_EXPORT2 operator new[](size_t) noexcept = delete;
-#if U_HAVE_PLACEMENT_NEW
     static void* U_EXPORT2 operator new(size_t, void*) noexcept = delete;
-#endif
 
     StackUResourceBundle();
     ~StackUResourceBundle();

--- a/icu4c/source/configure
+++ b/icu4c/source/configure
@@ -686,8 +686,6 @@ U_HAVE_TZNAME
 U_TZSET
 U_HAVE_TZSET
 U_HAVE_POPEN
-U_HAVE_PLACEMENT_NEW
-U_OVERRIDE_CXX_ALLOCATION
 U_NL_LANGINFO_CODESET
 U_HAVE_NL_LANGINFO_CODESET
 U_IS_BIG_ENDIAN
@@ -2111,54 +2109,6 @@ printf "%s\n" "$ac_res" >&6; }
   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
 
 } # ac_fn_c_check_func
-
-# ac_fn_cxx_try_link LINENO
-# -------------------------
-# Try to link conftest.$ac_ext, and return whether this succeeded.
-ac_fn_cxx_try_link ()
-{
-  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-  rm -f conftest.$ac_objext conftest.beam conftest$ac_exeext
-  if { { ac_try="$ac_link"
-case "(($ac_try" in
-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
-  *) ac_try_echo=$ac_try;;
-esac
-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-printf "%s\n" "$ac_try_echo"; } >&5
-  (eval "$ac_link") 2>conftest.err
-  ac_status=$?
-  if test -s conftest.err; then
-    grep -v '^ *+' conftest.err >conftest.er1
-    cat conftest.er1 >&5
-    mv -f conftest.er1 conftest.err
-  fi
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; } && {
-	 test -z "$ac_cxx_werror_flag" ||
-	 test ! -s conftest.err
-       } && test -s conftest$ac_exeext && {
-	 test "$cross_compiling" = yes ||
-	 test -x conftest$ac_exeext
-       }
-then :
-  ac_retval=0
-else case e in #(
-  e) printf "%s\n" "$as_me: failed program was:" >&5
-sed 's/^/| /' conftest.$ac_ext >&5
-
-	ac_retval=1 ;;
-esac
-fi
-  # Delete the IPA/IPO (Inter Procedural Analysis/Optimization) information
-  # created by the PGI compiler (conftest_ipa8_conftest.oo), as it would
-  # interfere with the next link command; also delete a directory that is
-  # left behind by Apple's compiler.  We do this before executing the actions.
-  rm -rf conftest.dSYM conftest_ipa8_conftest.oo
-  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
-  as_fn_set_status $ac_retval
-
-} # ac_fn_cxx_try_link
 ac_configure_args_raw=
 for ac_arg
 do
@@ -7411,109 +7361,6 @@ printf "%s\n" "$ac_cv_nl_langinfo_codeset" >&6; }
   else
       CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_NL_LANGINFO_CODESET=0"
   fi
-fi
-
-
-
-ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for properly overriding new and delete" >&5
-printf %s "checking for properly overriding new and delete... " >&6; }
-U_OVERRIDE_CXX_ALLOCATION=0
-U_HAVE_PLACEMENT_NEW=0
-if test ${ac_cv_override_cxx_allocation_ok+y}
-then :
-  printf %s "(cached) " >&6
-else case e in #(
-  e) cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <stdlib.h>
-    class UMemory {
-    public:
-    void *operator new(size_t size) {return malloc(size);}
-    void *operator new[](size_t size) {return malloc(size);}
-    void operator delete(void *p) {free(p);}
-    void operator delete[](void *p) {free(p);}
-    };
-
-int
-main (void)
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_link "$LINENO"
-then :
-  ac_cv_override_cxx_allocation_ok=yes
-else case e in #(
-  e) ac_cv_override_cxx_allocation_ok=no ;;
-esac
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
-    conftest$ac_exeext conftest.$ac_ext  ;;
-esac
-fi
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_override_cxx_allocation_ok" >&5
-printf "%s\n" "$ac_cv_override_cxx_allocation_ok" >&6; }
-if test $ac_cv_override_cxx_allocation_ok = yes
-then
-    U_OVERRIDE_CXX_ALLOCATION=1
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for placement new and delete" >&5
-printf %s "checking for placement new and delete... " >&6; }
-    if test ${ac_cv_override_placement_new_ok+y}
-then :
-  printf %s "(cached) " >&6
-else case e in #(
-  e) cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <stdlib.h>
-        class UMemory {
-        public:
-        void *operator new(size_t size) {return malloc(size);}
-        void *operator new[](size_t size) {return malloc(size);}
-        void operator delete(void *p) {free(p);}
-        void operator delete[](void *p) {free(p);}
-        void * operator new(size_t, void *ptr) { return ptr; }
-        void operator delete(void *, void *) {}
-        };
-
-int
-main (void)
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_link "$LINENO"
-then :
-  ac_cv_override_placement_new_ok=yes
-else case e in #(
-  e) ac_cv_override_placement_new_ok=no ;;
-esac
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
-    conftest$ac_exeext conftest.$ac_ext  ;;
-esac
-fi
-
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_override_placement_new_ok" >&5
-printf "%s\n" "$ac_cv_override_placement_new_ok" >&6; }
-    if test $ac_cv_override_placement_new_ok = yes
-    then
-        U_HAVE_PLACEMENT_NEW=1
-    else
-        CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_PLACEMENT_NEW=0"
-    fi
-else
-    CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_OVERRIDE_CXX_ALLOCATION=0"
 fi
 
 

--- a/icu4c/source/configure.ac
+++ b/icu4c/source/configure.ac
@@ -696,50 +696,6 @@ fi
 AC_SUBST(U_HAVE_NL_LANGINFO_CODESET)
 AC_SUBST(U_NL_LANGINFO_CODESET)
 
-AC_LANG(C++)
-AC_MSG_CHECKING([for properly overriding new and delete])
-U_OVERRIDE_CXX_ALLOCATION=0
-U_HAVE_PLACEMENT_NEW=0
-AC_CACHE_VAL(ac_cv_override_cxx_allocation_ok,
-    [AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <stdlib.h>
-    class UMemory {
-    public:
-    void *operator new(size_t size) {return malloc(size);}
-    void *operator new[](size_t size) {return malloc(size);}
-    void operator delete(void *p) {free(p);}
-    void operator delete[](void *p) {free(p);}
-    };
-    ]], [])],[ac_cv_override_cxx_allocation_ok=yes],[ac_cv_override_cxx_allocation_ok=no])] )
-AC_MSG_RESULT($ac_cv_override_cxx_allocation_ok)
-if test $ac_cv_override_cxx_allocation_ok = yes
-then
-    U_OVERRIDE_CXX_ALLOCATION=1
-    AC_MSG_CHECKING([for placement new and delete])
-    AC_CACHE_VAL(ac_cv_override_placement_new_ok,
-        [AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <stdlib.h>
-        class UMemory {
-        public:
-        void *operator new(size_t size) {return malloc(size);}
-        void *operator new[](size_t size) {return malloc(size);}
-        void operator delete(void *p) {free(p);}
-        void operator delete[](void *p) {free(p);}
-        void * operator new(size_t, void *ptr) { return ptr; }
-        void operator delete(void *, void *) {}
-        };
-        ]], [])],[ac_cv_override_placement_new_ok=yes],[ac_cv_override_placement_new_ok=no])] )
-    AC_MSG_RESULT($ac_cv_override_placement_new_ok)
-    if test $ac_cv_override_placement_new_ok = yes
-    then
-        U_HAVE_PLACEMENT_NEW=1
-    else
-        CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_PLACEMENT_NEW=0"
-    fi
-else
-    CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_OVERRIDE_CXX_ALLOCATION=0"
-fi
-AC_SUBST(U_OVERRIDE_CXX_ALLOCATION)
-AC_SUBST(U_HAVE_PLACEMENT_NEW)
-
 AC_LANG(C)
 AC_CHECK_FUNC(popen)
 if test x$ac_cv_func_popen = xyes

--- a/icu4c/source/i18n/fphdlimp.h
+++ b/icu4c/source/i18n/fphdlimp.h
@@ -76,9 +76,7 @@ class U_I18N_API FieldPositionIteratorHandler : public FieldPositionHandler {
   // This attempts to encourage that by blocking heap allocation.
   static void* U_EXPORT2 operator new(size_t) noexcept = delete;
   static void* U_EXPORT2 operator new[](size_t) noexcept = delete;
-#if U_HAVE_PLACEMENT_NEW
   static void* U_EXPORT2 operator new(size_t, void*) noexcept = delete;
-#endif
 
  public:
   FieldPositionIteratorHandler(FieldPositionIterator* posIter, UErrorCode& status);

--- a/icu4c/source/test/intltest/uobjtest.cpp
+++ b/icu4c/source/test/intltest/uobjtest.cpp
@@ -507,7 +507,7 @@ void UObjectTest::testIDs()
 
 void UObjectTest::testUMemory() {
     // additional tests for code coverage
-#if U_OVERRIDE_CXX_ALLOCATION && U_HAVE_PLACEMENT_NEW
+#if U_OVERRIDE_CXX_ALLOCATION
     alignas(UnicodeString) char bytes[sizeof(UnicodeString)];
     UnicodeString *p;
     enum { len=20 };


### PR DESCRIPTION
This was originally added by commit bb0daf402d17b352f710d8e867ad7bcbcc0dd9d3 as a workaround for HP/UX then not having a standards compliant C++ compiler. But ICU4C made having a standards compliant C++ compiler a hard requirement many years ago, so this no longer serves any purpose and ought to be deleted to simplify the code base.

#### Checklist
- [x] Required: Issue filed: ICU-23190
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

ALLOW_MANY_COMMITS=true