### PR TITLE
ICU-22775 fix StringSearch pattern CE mem mgmt

### DIFF
--- a/icu4c/source/i18n/usearch.cpp
+++ b/icu4c/source/i18n/usearch.cpp
@@ -177,8 +177,9 @@ inline void * allocateMemory(uint32_t size, UErrorCode *status)
 * before calling this method. destination not to be nullptr and has at least
 * size destinationlength.
 * @param destination target array
-* @param offset destination offset to add value
 * @param destinationlength target array size, return value for the new size
+* @param destOnHeap whether the destination array is heap-allocated
+* @param offset destination offset to add value
 * @param value to be added
 * @param increments incremental size expected
 * @param status output error if any, caller to check status before calling
@@ -187,21 +188,24 @@ inline void * allocateMemory(uint32_t size, UErrorCode *status)
 */
 static
 inline int32_t * addTouint32_tArray(int32_t    *destination,
-                                    uint32_t    offset,
                                     uint32_t   *destinationlength,
+                                    bool        destOnHeap,
+                                    uint32_t    offset,
                                     uint32_t    value,
                                     uint32_t    increments,
                                     UErrorCode *status)
 {
-    uint32_t newlength = *destinationlength;
-    if (offset + 1 == newlength) {
-        newlength += increments;
+    if (offset >= *destinationlength) {
+        uint32_t newlength = offset + increments;
         int32_t* temp = static_cast<int32_t*>(allocateMemory(
                                          sizeof(int32_t) * newlength, status));
         if (U_FAILURE(*status)) {
-            return nullptr;
+            return destination;
         }
         uprv_memcpy(temp, destination, sizeof(int32_t) * (size_t)offset);
+        if (destOnHeap) {
+            uprv_free(destination);
+        }
         *destinationlength = newlength;
         destination        = temp;
     }
@@ -217,8 +221,9 @@ inline int32_t * addTouint32_tArray(int32_t    *destination,
 * before calling this method. destination not to be nullptr and has at least
 * size destinationlength.
 * @param destination target array
-* @param offset destination offset to add value
 * @param destinationlength target array size, return value for the new size
+* @param destOnHeap whether the destination array is heap-allocated
+* @param offset destination offset to add value
 * @param value to be added
 * @param increments incremental size expected
 * @param status output error if any, caller to check status before calling
@@ -227,29 +232,28 @@ inline int32_t * addTouint32_tArray(int32_t    *destination,
 */
 static
 inline int64_t * addTouint64_tArray(int64_t    *destination,
-                                    uint32_t    offset,
                                     uint32_t   *destinationlength,
+                                    bool        destOnHeap,
+                                    uint32_t    offset,
                                     uint64_t    value,
                                     uint32_t    increments,
                                     UErrorCode *status)
 {
-    uint32_t newlength = *destinationlength;
-    if (offset + 1 == newlength) {
-        newlength += increments;
+    if (offset >= *destinationlength) {
+        uint32_t newlength = offset + increments;
         int64_t* temp = static_cast<int64_t*>(allocateMemory(
                                          sizeof(int64_t) * newlength, status));
-
         if (U_FAILURE(*status)) {
-            return nullptr;
+            return destination;
         }
-
         uprv_memcpy(temp, destination, sizeof(int64_t) * (size_t)offset);
+        if (destOnHeap) {
+            uprv_free(destination);
+        }
         *destinationlength = newlength;
         destination        = temp;
     }
-
     destination[offset] = value;
-
     return destination;
 }
 
@@ -299,22 +303,22 @@ inline void initializePatternCETable(UStringSearch *strsrch, UErrorCode *status)
            U_SUCCESS(*status)) {
         uint32_t newce = getCE(strsrch, ce);
         if (newce) {
-            int32_t *temp = addTouint32_tArray(cetable, offset, &cetablesize,
-                                  newce,
-                                  patternlength - ucol_getOffset(coleiter) + 1,
-                                  status);
-            if (U_FAILURE(*status)) {
-                return;
-            }
+            cetable = addTouint32_tArray(
+                cetable, &cetablesize, /* destOnHeap= */ cetable != pattern->cesBuffer,
+                offset, newce, patternlength - ucol_getOffset(coleiter) + 1, status);
             offset ++;
-            if (cetable != temp && cetable != pattern->cesBuffer) {
-                uprv_free(cetable);
-            }
-            cetable = temp;
         }
     }
 
-    cetable[offset]   = 0;
+    cetable = addTouint32_tArray(
+        cetable, &cetablesize, /* destOnHeap= */ cetable != pattern->cesBuffer,
+        offset, 0, 1, status);
+    if (U_FAILURE(*status)) {
+        if (cetable != pattern->cesBuffer) {
+            uprv_free(cetable);
+        }
+        return;
+    }
     pattern->ces       = cetable;
     pattern->cesLength = offset;
 }
@@ -368,25 +372,21 @@ inline void initializePatternPCETable(UStringSearch *strsrch,
     // **  whether a CE is signed or unsigned. For example, look at routine above this one.)
     while ((pce = iter.nextProcessed(nullptr, nullptr, status)) != UCOL_PROCESSED_NULLORDER &&
            U_SUCCESS(*status)) {
-        int64_t *temp = addTouint64_tArray(pcetable, offset, &pcetablesize,
-                              pce,
-                              patternlength - ucol_getOffset(coleiter) + 1,
-                              status);
-
-        if (U_FAILURE(*status)) {
-            return;
-        }
-
+        pcetable = addTouint64_tArray(
+            pcetable, &pcetablesize, /* destOnHeap= */ pcetable != pattern->pcesBuffer,
+            offset, pce, patternlength - ucol_getOffset(coleiter) + 1, status);
         offset += 1;
-
-        if (pcetable != temp && pcetable != pattern->pcesBuffer) {
-            uprv_free(pcetable);
-        }
-
-        pcetable = temp;
     }
 
-    pcetable[offset]   = 0;
+    pcetable = addTouint64_tArray(
+        pcetable, &pcetablesize, /* destOnHeap= */ pcetable != pattern->pcesBuffer,
+        offset, 0, 1, status);
+    if (U_FAILURE(*status)) {
+        if (pcetable != pattern->pcesBuffer) {
+            uprv_free(pcetable);
+        }
+        return;
+    }
     pattern->pces       = pcetable;
     pattern->pcesLength = offset;
 }

--- a/icu4c/source/test/intltest/srchtest.cpp
+++ b/icu4c/source/test/intltest/srchtest.cpp
@@ -170,6 +170,7 @@ void StringSearchTest::runIndexedTest(int32_t index, UBool exec,
         CASE(34, TestSubclass)
         CASE(35, TestCoverage)
         CASE(36, TestDiacriticMatch)
+        CASE(37, TestBug22775)
         default: name = ""; break;
     }
 #else
@@ -2450,6 +2451,24 @@ void StringSearchTest::TestCoverage(){
     if (stub1 != stub2){
         errln("SearchIterator::operator =  assigned object should be equal");
     }
+}
+
+void StringSearchTest::TestBug22775() {
+    IcuTestErrorCode errorCode(*this, "TestBug22775()");
+    // Used to crash in Java due to bad management of the pattern collation element array.
+    UnicodeString pattern(
+        u"Xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        u"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        u"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        u"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa響");
+    LocalPointer<RuleBasedCollator> collator(
+        static_cast<RuleBasedCollator *>(
+            Collator::createInstance(Locale::getUS(), errorCode)),
+        errorCode);
+    collator->setAttribute(UCOL_STRENGTH, UCOL_PRIMARY, errorCode);
+    StringCharacterIterator text(u" ");
+    StringSearch stringSearch(pattern, text, collator.getAlias(), nullptr, errorCode);
+    stringSearch.next(errorCode);
 }
 
 #endif /* !UCONFIG_NO_BREAK_ITERATION */

--- a/icu4c/source/test/intltest/srchtest.h
+++ b/icu4c/source/test/intltest/srchtest.h
@@ -91,6 +91,7 @@ private:
     void TestSubclass();
     void TestCoverage();
     void TestDiacriticMatch();
+    void TestBug22775();
 #endif
 };
 

--- a/icu4j/main/collate/src/main/java/com/ibm/icu/text/StringSearch.java
+++ b/icu4j/main/collate/src/main/java/com/ibm/icu/text/StringSearch.java
@@ -658,9 +658,8 @@ public final class StringSearch extends SearchIterator {
      * @return new destination array, destination if there was no new allocation
      */
     private static int[] addToIntArray(int[] destination, int offset, int value, int increments) {
-        int newlength = destination.length;
-        if (offset + 1 == newlength) {
-            newlength += increments;
+        if (offset >= destination.length) {
+            int newlength = offset + increments;
             int temp[] = new int[newlength];
             System.arraycopy(destination, 0, temp, 0, offset);
             destination = temp;
@@ -681,11 +680,10 @@ public final class StringSearch extends SearchIterator {
      * @param increments incremental size expected
      * @return new destination array, destination if there was no new allocation
      */
-    private static long[] addToLongArray(long[] destination, int offset, int destinationlength,
-            long value, int increments) {
-        int newlength = destinationlength;
-        if (offset + 1 == newlength) {
-            newlength += increments;
+    private static long[] addToLongArray(
+            long[] destination, int offset, long value, int increments) {
+        if (offset >= destination.length) {
+            int newlength = offset + increments;
             long temp[] = new long[newlength];
             System.arraycopy(destination, 0, temp, 0, offset);
             destination = temp;
@@ -722,15 +720,14 @@ public final class StringSearch extends SearchIterator {
         while ((ce = coleiter.next()) != CollationElementIterator.NULLORDER) {
             int newce = getCE(ce);
             if (newce != CollationElementIterator.IGNORABLE /* 0 */) {
-                int[] temp = addToIntArray(cetable, offset, newce,
+                cetable = addToIntArray(cetable, offset, newce,
                         patternlength - coleiter.getOffset() + 1);
                 offset++;
-                cetable = temp;
             }
             result += (coleiter.getMaxExpansion(ce) - 1);
         }
 
-        cetable[offset] = 0;
+        cetable = addToIntArray(cetable, offset, 0, 1);
         pattern_.CE_ = cetable;
         pattern_.CELength_ = offset;
 
@@ -747,7 +744,6 @@ public final class StringSearch extends SearchIterator {
      */
     private int initializePatternPCETable() {
         long[] pcetable = new long[INITIAL_ARRAY_SIZE_];
-        int pcetablesize = pcetable.length;
         int patternlength = pattern_.text_.length();
         CollationElementIterator coleiter = utilIter_;
 
@@ -768,12 +764,11 @@ public final class StringSearch extends SearchIterator {
         // ** (the rest of the code in this file seems to play fast-and-loose with
         // ** whether a CE is signed or unsigned. For example, look at routine above this one.)
         while ((pce = iter.nextProcessed(null)) != CollationPCE.PROCESSED_NULLORDER) {
-            long[] temp = addToLongArray(pcetable, offset, pcetablesize, pce, patternlength - coleiter.getOffset() + 1);
+            pcetable = addToLongArray(pcetable, offset, pce, patternlength - coleiter.getOffset() + 1);
             offset++;
-            pcetable = temp;
         }
 
-        pcetable[offset] = 0;
+        pcetable = addToLongArray(pcetable, offset, 0, 1);
         pattern_.PCE_ = pcetable;
         pattern_.PCELength_ = offset;
 

--- a/icu4j/main/collate/src/test/java/com/ibm/icu/dev/test/search/SearchTest.java
+++ b/icu4j/main/collate/src/test/java/com/ibm/icu/dev/test/search/SearchTest.java
@@ -2220,4 +2220,21 @@ public class SearchTest extends TestFmwk {
             errln("Error initializing a new StringSearch object");
         }
     }
+
+    @Test
+    public void TestBug22775() {
+        // Used to crash due to bad management of the pattern collation element array.
+        String pattern = "Xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa響";
+        RuleBasedCollator collator = (RuleBasedCollator) Collator.getInstance(Locale.US);
+        collator.setStrength(Collator.PRIMARY);
+        StringSearch stringSearch = new StringSearch(
+                pattern,
+                new StringCharacterIterator(" "),
+                collator
+        );
+        stringSearch.next();
+    }
 }


### PR DESCRIPTION
- the main bug in Java initializePatternPCETable() was that the pcetablesize never got updated
- in C++, if the pattern CE loops encountered a failure, they didn't free the array (unlikely but possible near OOM)
- I think I made the memory management less convoluted
- for good measure, I used the "append" functions to add the null terminator, rather than rely on these functions having over-allocated by one for the real collation elements

#### Checklist
- [x] Required: Issue filed: ICU-22775
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
