### PR TITLE
ICU-23192 Replace use of CharString with FixedString for data members

### DIFF
--- a/icu4c/source/common/BUILD.bazel
+++ b/icu4c/source/common/BUILD.bazel
@@ -64,6 +64,7 @@ cc_library(
         "umutex.cpp",
         "sharedobject.cpp",
         "utrace.cpp",
+        "fixedstring.cpp",
     ],
     deps = [
         ":headers",

--- a/icu4c/source/common/common.vcxproj
+++ b/icu4c/source/common/common.vcxproj
@@ -274,6 +274,7 @@
     <ClCompile Include="utf_impl.cpp" />
     <ClCompile Include="static_unicode_sets.cpp" />
     <ClCompile Include="restrace.cpp" />
+    <ClCompile Include="fixedstring.cpp" />
     <ClInclude Include="localsvc.h" />
     <ClInclude Include="msvcres.h" />
     <ClInclude Include="pluralmap.h" />

--- a/icu4c/source/common/common.vcxproj.filters
+++ b/icu4c/source/common/common.vcxproj.filters
@@ -652,6 +652,9 @@
     <ClCompile Include="restrace.cpp">
       <Filter>data &amp; memory</Filter>
     </ClCompile>
+    <ClCompile Include="fixedstring.cpp">
+      <Filter>strings</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ubidi_props.h">

--- a/icu4c/source/common/common_uwp.vcxproj
+++ b/icu4c/source/common/common_uwp.vcxproj
@@ -408,6 +408,7 @@
     <ClCompile Include="utf_impl.cpp" />
     <ClCompile Include="static_unicode_sets.cpp" />
     <ClCompile Include="restrace.cpp" />
+    <ClCompile Include="fixedstring.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="localsvc.h" />

--- a/icu4c/source/common/fixedstring.cpp
+++ b/icu4c/source/common/fixedstring.cpp
@@ -1,0 +1,29 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: https://www.unicode.org/copyright.html
+
+#include "fixedstring.h"
+
+#include "unicode/unistr.h"
+#include "unicode/utypes.h"
+
+U_NAMESPACE_BEGIN
+
+U_EXPORT void copyInvariantChars(const UnicodeString& src, FixedString& dst, UErrorCode& status) {
+    if (U_FAILURE(status)) {
+        return;
+    }
+
+    if (src.isEmpty()) {
+        dst.clear();
+        return;
+    }
+
+    int32_t length = src.length();
+    if (!dst.reserve(length + 1)) {
+        status = U_MEMORY_ALLOCATION_ERROR;
+        return;
+    }
+    src.extract(0, length, dst.getAlias(), length + 1, US_INV);
+}
+
+U_NAMESPACE_END

--- a/icu4c/source/common/fixedstring.h
+++ b/icu4c/source/common/fixedstring.h
@@ -32,7 +32,7 @@ public:
 
     FixedString(std::string_view init) {
         size_t size = init.size();
-        if (reserve(size + 1)) {
+        if (size > 0 && reserve(size + 1)) {
             uprv_memcpy(ptr, init.data(), size);
             ptr[size] = '\0';
         }

--- a/icu4c/source/common/fixedstring.h
+++ b/icu4c/source/common/fixedstring.h
@@ -13,6 +13,8 @@
 
 U_NAMESPACE_BEGIN
 
+class UnicodeString;
+
 /**
  * ICU-internal fixed-length char* string class.
  * This is a complement to CharString to store fixed-length strings efficiently
@@ -94,6 +96,8 @@ public:
 private:
     char* ptr = nullptr;
 };
+
+U_COMMON_API void copyInvariantChars(const UnicodeString& src, FixedString& dst, UErrorCode& status);
 
 U_NAMESPACE_END
 

--- a/icu4c/source/common/fixedstring.h
+++ b/icu4c/source/common/fixedstring.h
@@ -5,6 +5,7 @@
 #define FIXEDSTRING_H
 
 #include <string_view>
+#include <utility>
 
 #include "unicode/uobject.h"
 #include "unicode/utypes.h"
@@ -28,7 +29,7 @@ public:
     FixedString() = default;
     ~FixedString() { operator delete[](ptr); }
 
-    FixedString(const FixedString&) = delete;
+    FixedString(const FixedString& other) : FixedString(other.data()) {}
 
     FixedString(std::string_view init) {
         size_t size = init.size();
@@ -57,7 +58,7 @@ public:
         return *this;
     }
 
-    FixedString(FixedString&&) noexcept = delete;
+    FixedString(FixedString&& other) noexcept : ptr(std::exchange(other.ptr, nullptr)) {}
 
     FixedString& operator=(FixedString&& other) noexcept {
         operator delete[](ptr);

--- a/icu4c/source/common/localebuilder.cpp
+++ b/icu4c/source/common/localebuilder.cpp
@@ -8,6 +8,7 @@
 #include "bytesinkutil.h"  // StringByteSink<CharString>
 #include "charstr.h"
 #include "cstring.h"
+#include "fixedstring.h"
 #include "ulocimp.h"
 #include "unicode/localebuilder.h"
 #include "unicode/locid.h"
@@ -131,14 +132,13 @@ LocaleBuilder& LocaleBuilder::setVariant(StringPiece variant)
         variant_ = nullptr;
         return *this;
     }
-    CharString* new_variant = new CharString(variant, status_);
-    if (U_FAILURE(status_)) { return *this; }
-    if (new_variant == nullptr) {
+    FixedString* new_variant = new FixedString(variant);
+    if (new_variant == nullptr || new_variant->isEmpty()) {
         status_ = U_MEMORY_ALLOCATION_ERROR;
         return *this;
     }
-    transform(new_variant->data(), new_variant->length());
-    if (!ultag_isVariantSubtags(new_variant->data(), new_variant->length())) {
+    transform(new_variant->getAlias(), variant.length());
+    if (!ultag_isVariantSubtags(new_variant->data(), variant.length())) {
         delete new_variant;
         status_ = U_ILLEGAL_ARGUMENT_ERROR;
         return *this;

--- a/icu4c/source/common/sources.txt
+++ b/icu4c/source/common/sources.txt
@@ -23,6 +23,7 @@ emojiprops.cpp
 errorcode.cpp
 filteredbrk.cpp
 filterednormalizer2.cpp
+fixedstring.cpp
 icudataver.cpp
 icuplug.cpp
 loadednormalizer2impl.cpp

--- a/icu4c/source/common/uloc_keytype.cpp
+++ b/icu4c/source/common/uloc_keytype.cpp
@@ -146,14 +146,15 @@ initFromResourceBundle(UErrorCode& sts) {
         // empty value indicates that BCP key is same with the legacy key.
         const char* bcpKeyId = legacyKeyId;
         if (!uBcpKeyId.isEmpty()) {
-            int32_t length = uBcpKeyId.length();
             icu::FixedString* bcpKeyIdBuf = gKeyTypeStringPool->create();
-            if (bcpKeyIdBuf == nullptr || !bcpKeyIdBuf->reserve(length + 1)) {
+            if (bcpKeyIdBuf == nullptr) {
                 sts = U_MEMORY_ALLOCATION_ERROR;
                 break;
             }
-
-            uBcpKeyId.extract(0, length, bcpKeyIdBuf->getAlias(), length + 1, US_INV);
+            copyInvariantChars(uBcpKeyId, *bcpKeyIdBuf, sts);
+            if (U_FAILURE(sts)) {
+                break;
+            }
             bcpKeyId = bcpKeyIdBuf->data();
         }
 
@@ -242,13 +243,15 @@ initFromResourceBundle(UErrorCode& sts) {
                 // empty value indicates that BCP type is same with the legacy type.
                 const char* bcpTypeId = legacyTypeId;
                 if (!uBcpTypeId.isEmpty()) {
-                    int32_t length = uBcpTypeId.length();
                     icu::FixedString* bcpTypeIdBuf = gKeyTypeStringPool->create();
-                    if (bcpTypeIdBuf == nullptr || !bcpTypeIdBuf->reserve(length + 1)) {
+                    if (bcpTypeIdBuf == nullptr) {
                         sts = U_MEMORY_ALLOCATION_ERROR;
                         break;
                     }
-                    uBcpTypeId.extract(0, length, bcpTypeIdBuf->getAlias(), length + 1, US_INV);
+                    copyInvariantChars(uBcpTypeId, *bcpTypeIdBuf, sts);
+                    if (U_FAILURE(sts)) {
+                        break;
+                    }
                     bcpTypeId = bcpTypeIdBuf->data();
                 }
 

--- a/icu4c/source/common/unicode/localebuilder.h
+++ b/icu4c/source/common/unicode/localebuilder.h
@@ -18,7 +18,7 @@
  */
 
 U_NAMESPACE_BEGIN
-class CharString;
+class FixedString;
 
 /**
  * <code>LocaleBuilder</code> is used to build instances of <code>Locale</code>
@@ -297,7 +297,7 @@ private:
     char language_[9];
     char script_[5];
     char region_[4];
-    CharString *variant_;  // Pointer not object so we need not #include internal charstr.h.
+    FixedString *variant_;  // Pointer not object so we need not #include internal fixedstring.h.
     icu::Locale *extensions_;  // Pointer not object. Storage for all other fields.
 
 };

--- a/icu4c/source/i18n/measunit_extra.cpp
+++ b/icu4c/source/i18n/measunit_extra.cpp
@@ -1386,7 +1386,10 @@ void MeasureUnitImpl::serialize(UErrorCode &status) {
     if (U_FAILURE(status)) {
         return;
     }
-    this->identifier = CharString(result, status);
+    this->identifier = result.toStringPiece();
+    if (this->identifier.isEmpty() != result.isEmpty()) {
+        status = U_MEMORY_ALLOCATION_ERROR;
+    }
 }
 
 MeasureUnit MeasureUnitImpl::build(UErrorCode &status) && {

--- a/icu4c/source/i18n/measunit_impl.h
+++ b/icu4c/source/i18n/measunit_impl.h
@@ -11,6 +11,7 @@
 #include "unicode/measunit.h"
 #include "cmemory.h"
 #include "charstr.h"
+#include "fixedstring.h"
 
 U_NAMESPACE_BEGIN
 
@@ -249,11 +250,14 @@ class U_I18N_API_CLASS MeasureUnitImpl : public UMemory {
     /**
      * Used for currency units.
      */
-    static inline MeasureUnitImpl forCurrencyCode(StringPiece currencyCode) {
+    static inline MeasureUnitImpl forCurrencyCode(StringPiece currencyCode, UErrorCode& status) {
         MeasureUnitImpl result;
-        UErrorCode localStatus = U_ZERO_ERROR;
-        result.identifier.append(currencyCode, localStatus);
-        // localStatus is not expected to fail since currencyCode should be 3 chars long
+        if (U_SUCCESS(status)) {
+            result.identifier = currencyCode;
+            if (result.identifier.isEmpty() != currencyCode.empty()) {
+                status = U_MEMORY_ALLOCATION_ERROR;
+            }
+        }
         return result;
     }
 
@@ -317,7 +321,7 @@ class U_I18N_API_CLASS MeasureUnitImpl : public UMemory {
     /**
      * The full unit identifier.  Owned by the MeasureUnitImpl.  Empty if not computed.
      */
-    CharString identifier;
+    FixedString identifier;
 
     /**
      * Represents the unit constant denominator.

--- a/icu4c/source/i18n/number_longnames.cpp
+++ b/icu4c/source/i18n/number_longnames.cpp
@@ -1152,13 +1152,13 @@ void LongNameHandler::processPatternTimes(MeasureUnitImpl &&productUnit,
     if (U_FAILURE(status)) {
         return;
     }
-    if (productUnit.identifier.length() == 0) {
+    if (productUnit.identifier.isEmpty()) {
         // MeasureUnit(): no units: return empty strings.
         return;
     }
 
     MeasureUnit builtinUnit;
-    if (MeasureUnit::findBySubType(productUnit.identifier.toStringPiece(), &builtinUnit)) {
+    if (MeasureUnit::findBySubType(productUnit.identifier.data(), &builtinUnit)) {
         // TODO(icu-units#145): spec doesn't cover builtin-per-builtin, it
         // breaks them all down. Do we want to drop this?
         // - findBySubType isn't super efficient, if we skip it and go to basic

--- a/icu4c/source/i18n/tzgnames.cpp
+++ b/icu4c/source/i18n/tzgnames.cpp
@@ -24,6 +24,7 @@
 #include "charstr.h"
 #include "cmemory.h"
 #include "cstring.h"
+#include "fixedstring.h"
 #include "mutex.h"
 #include "uhash.h"
 #include "uassert.h"
@@ -294,7 +295,7 @@ private:
     TextTrieMap fGNamesTrie;
     UBool fGNamesTrieFullyLoaded;
 
-    CharString fTargetRegion;
+    FixedString fTargetRegion;
 
     void initialize(const Locale& locale, UErrorCode& status);
     void cleanup();
@@ -406,13 +407,25 @@ TZGNCore::initialize(const Locale& locale, UErrorCode& status) {
     int32_t regionLen = static_cast<int32_t>(uprv_strlen(region));
     if (regionLen == 0) {
         CharString loc = ulocimp_addLikelySubtags(fLocale.getName(), status);
-        ulocimp_getSubtags(loc.toStringPiece(), nullptr, nullptr, &fTargetRegion, nullptr, nullptr, status);
+        CharString tmp;
+        ulocimp_getSubtags(loc.toStringPiece(), nullptr, nullptr, &tmp, nullptr, nullptr, status);
         if (U_FAILURE(status)) {
             cleanup();
             return;
         }
+        fTargetRegion = tmp.toStringPiece();
+        if (fTargetRegion.isEmpty() != tmp.isEmpty()) {
+            status = U_MEMORY_ALLOCATION_ERROR;
+            cleanup();
+            return;
+        }
     } else {
-        fTargetRegion.append(region, regionLen, status);
+        fTargetRegion = {region, static_cast<std::string_view::size_type>(regionLen)};
+        if (fTargetRegion.isEmpty()) {
+            status = U_MEMORY_ALLOCATION_ERROR;
+            cleanup();
+            return;
+        }
     }
 
     // preload generic names for the default zone

--- a/icu4c/source/i18n/tznames_impl.cpp
+++ b/icu4c/source/i18n/tznames_impl.cpp
@@ -2149,20 +2149,21 @@ TZDBTimeZoneNames::TZDBTimeZoneNames(const Locale& locale)
     if (regionLen == 0) {
         UErrorCode status = U_ZERO_ERROR;
         CharString loc = ulocimp_addLikelySubtags(fLocale.getName(), status);
-        ulocimp_getSubtags(loc.toStringPiece(), nullptr, nullptr, &fRegion, nullptr, nullptr, status);
+        CharString tmp;
+        ulocimp_getSubtags(loc.toStringPiece(), nullptr, nullptr, &tmp, nullptr, nullptr, status);
+        fRegion = tmp.toStringPiece();
+        U_ASSERT(fRegion.isEmpty() == tmp.isEmpty());
         if (U_SUCCESS(status)) {
             useWorld = false;
         }
     } else {
-        UErrorCode status = U_ZERO_ERROR;
-        fRegion.append(region, regionLen, status);
-        U_ASSERT(U_SUCCESS(status));
+        fRegion = {region, static_cast<std::string_view::size_type>(regionLen)};
+        U_ASSERT(!fRegion.isEmpty());
         useWorld = false;
     }
     if (useWorld) {
-        UErrorCode status = U_ZERO_ERROR;
-        fRegion.append("001", status);
-        U_ASSERT(U_SUCCESS(status));
+        fRegion = "001";
+        U_ASSERT(!fRegion.isEmpty());
     }
 }
 
@@ -2240,7 +2241,7 @@ TZDBTimeZoneNames::find(const UnicodeString& text, int32_t start, uint32_t types
         return nullptr;
     }
 
-    TZDBNameSearchHandler handler(types, fRegion.toStringPiece());
+    TZDBNameSearchHandler handler(types, fRegion.data());
     gTZDBNamesTrie->search(text, start, (TextTrieMapSearchResultHandler *)&handler, status);
     if (U_FAILURE(status)) {
         return nullptr;

--- a/icu4c/source/i18n/tznames_impl.h
+++ b/icu4c/source/i18n/tznames_impl.h
@@ -26,7 +26,7 @@
 #include "uhash.h"
 #include "uvector.h"
 #include "umutex.h"
-#include "charstr.h"
+#include "fixedstring.h"
 
 // Some zone display names involving supplementary characters can be over 50 chars, 100 UTF-16 code units, 200 UTF-8 bytes
 #define ZONE_NAME_U16_MAX 128
@@ -256,7 +256,7 @@ public:
 
 private:
     Locale fLocale;
-    CharString fRegion;
+    FixedString fRegion;
 };
 
 U_NAMESPACE_END

--- a/icu4c/source/i18n/unicode/fmtable.h
+++ b/icu4c/source/i18n/unicode/fmtable.h
@@ -34,7 +34,7 @@
 
 U_NAMESPACE_BEGIN
 
-class CharString;
+class FixedString;
 
 namespace number::impl {
 class DecimalQuantity;
@@ -665,12 +665,12 @@ public:
     void adoptDecimalQuantity(number::impl::DecimalQuantity *dq);
 
     /**
-     * Internal function to return the CharString pointer.
+     * Internal function to return the FixedString pointer.
      * @param status error code
-     * @return pointer to the CharString - may become invalid if the object is modified
+     * @return pointer to the FixedString - may become invalid if the object is modified
      * @internal
      */
-    CharString *internalGetCharString(UErrorCode &status);
+    FixedString *internalGetFixedString(UErrorCode &status);
 
 #endif  /* U_HIDE_INTERNAL_API */
 
@@ -700,7 +700,7 @@ private:
         }               fArrayAndCount;
     } fValue;
 
-    CharString           *fDecimalStr;
+    FixedString* fDecimalStr;
 
     number::impl::DecimalQuantity *fDecimalQuantity;
 

--- a/icu4c/source/i18n/units_converter.cpp
+++ b/icu4c/source/i18n/units_converter.cpp
@@ -7,6 +7,7 @@
 
 #include "charstr.h"
 #include "cmemory.h"
+#include "cstring.h"
 #include "double-conversion-string-to-double.h"
 #include "measunit_impl.h"
 #include "putilimp.h"
@@ -212,8 +213,8 @@ Factor loadSingleFactor(StringPiece source, const ConversionRates &ratesInfo, UE
         return {};
     }
 
-    Factor result = extractFactorConversions(conversionUnit->factor.toStringPiece(), status);
-    result.offset = strHasDivideSignToDouble(conversionUnit->offset.toStringPiece(), status);
+    Factor result = extractFactorConversions(conversionUnit->factor.data(), status);
+    result.offset = strHasDivideSignToDouble(conversionUnit->offset.data(), status);
 
     return result;
 }
@@ -283,8 +284,8 @@ UBool checkSimpleUnit(const MeasureUnitImpl &unit, UErrorCode &status) {
 // SingleUnitImpl's simpleUnitID to get the corresponding ConversionRateInfo;
 // from that we get the specialMappingName (which may be empty if the simple unit
 // converts to base using factor + offset instelad of a special mapping).
-CharString getSpecialMappingName(const MeasureUnitImpl &simpleUnit, const ConversionRates &ratesInfo,
-                          UErrorCode &status) {
+StringPiece getSpecialMappingName(const MeasureUnitImpl& simpleUnit, const ConversionRates& ratesInfo,
+                                  UErrorCode& status) {
     if (!checkSimpleUnit(simpleUnit, status)) {
         return {};
     }
@@ -298,9 +299,7 @@ CharString getSpecialMappingName(const MeasureUnitImpl &simpleUnit, const Conver
         status = U_INTERNAL_PROGRAM_ERROR;
         return {};
     }
-    CharString result;
-    result.copyFrom(conversionUnit->specialMappingName, status);
-    return result;
+    return conversionUnit->specialMappingName.data();
 }
 
 /**
@@ -311,10 +310,18 @@ CharString getSpecialMappingName(const MeasureUnitImpl &simpleUnit, const Conver
 void loadConversionRate(ConversionRate &conversionRate, const MeasureUnitImpl &source,
                         const MeasureUnitImpl &target, Convertibility unitsState,
                         const ConversionRates &ratesInfo, UErrorCode &status) {
+    StringPiece specialSource = getSpecialMappingName(source, ratesInfo, status);
+    StringPiece specialTarget = getSpecialMappingName(target, ratesInfo, status);
 
-    conversionRate.specialSource = getSpecialMappingName(source, ratesInfo, status);
-    conversionRate.specialTarget = getSpecialMappingName(target, ratesInfo, status);
-    
+    conversionRate.specialSource = specialSource;
+    conversionRate.specialTarget = specialTarget;
+
+    if (conversionRate.specialSource.isEmpty() != specialSource.empty() ||
+        conversionRate.specialTarget.isEmpty() != specialTarget.empty()) {
+        status = U_MEMORY_ALLOCATION_ERROR;
+        return;
+    }
+
     if (conversionRate.specialSource.isEmpty() && conversionRate.specialTarget.isEmpty()) {
         // Represents the conversion factor from the source to the target.
         Factor finalFactor;
@@ -500,7 +507,7 @@ MeasureUnitImpl extractCompoundBaseUnit(const MeasureUnitImpl& source,
         // Multiply the power of the singleUnit by the power of the baseUnit. For example, square-hectare
         // must be pow4-meter. (NOTE: hectare --> square-meter)
         auto baseUnits =
-            MeasureUnitImpl::forIdentifier(rateInfo->baseUnit.toStringPiece(), status).singleUnits;
+            MeasureUnitImpl::forIdentifier(rateInfo->baseUnit.data(), status).singleUnits;
         for (int32_t i = 0, baseUnitsCount = baseUnits.length(); i < baseUnitsCount; i++) {
             baseUnits[i]->dimensionality *= singleUnit.dimensionality;
             // TODO: Deal with SI-prefix
@@ -626,21 +633,19 @@ int32_t UnitsConverter::compareTwoUnits(const MeasureUnitImpl &firstUnit,
         return 0;
     }
 
-    CharString firstSpecial = getSpecialMappingName(firstUnit, ratesInfo, status);
-    CharString secondSpecial = getSpecialMappingName(secondUnit, ratesInfo, status);
-    if (!firstSpecial.isEmpty() || !secondSpecial.isEmpty()) {
-        if (firstSpecial.isEmpty()) {
+    StringPiece firstSpecial = getSpecialMappingName(firstUnit, ratesInfo, status);
+    StringPiece secondSpecial = getSpecialMappingName(secondUnit, ratesInfo, status);
+    if (!firstSpecial.empty() || !secondSpecial.empty()) {
+        if (firstSpecial.empty()) {
             // non-specials come first
             return -1;
         }
-        if (secondSpecial.isEmpty()) {
+        if (secondSpecial.empty()) {
             // non-specials come first
             return 1;
         }
         // both are specials, compare lexicographically
-        StringPiece firstSpecialPiece = firstSpecial.toStringPiece();
-        StringPiece secondSpecialPiece = secondSpecial.toStringPiece();
-        return firstSpecialPiece.compare(secondSpecialPiece);
+        return firstSpecial.compare(secondSpecial);
     }
 
     // Represents the conversion factor from the firstUnit to the base
@@ -757,7 +762,7 @@ double UnitsConverter::convert(double inputValue) const {
         if (!conversionRate_.specialSource.isEmpty()) {
             // We  have a special mapping from source to base (not using factor, offset).
             // Currently the only supported mapping is a scale-based mapping for beaufort.
-            base = (conversionRate_.specialSource == StringPiece("beaufort"))?
+            base = uprv_strcmp(conversionRate_.specialSource.data(), "beaufort") == 0 ?
                 scaleToBase(inputValue, minMetersPerSecForBeaufort, maxBeaufort): inputValue;
         } else {
             // Standard mapping (using factor) from source to base.
@@ -767,7 +772,7 @@ double UnitsConverter::convert(double inputValue) const {
         if (!conversionRate_.specialTarget.isEmpty()) {
             // We  have a special mapping from base to target (not using factor, offset).
             // Currently the only supported mapping is a scale-based mapping for beaufort.
-            result = (conversionRate_.specialTarget == StringPiece("beaufort"))?
+            result = uprv_strcmp(conversionRate_.specialTarget.data(), "beaufort") == 0 ?
                 baseToScale(base, minMetersPerSecForBeaufort, maxBeaufort): base;
         } else {
             // Standard mapping (using factor) from base to target.
@@ -800,7 +805,7 @@ double UnitsConverter::convertInverse(double inputValue) const {
         if (!conversionRate_.specialTarget.isEmpty()) {
             // We  have a special mapping from target to base (not using factor).
             // Currently the only supported mapping is a scale-based mapping for beaufort.
-            base = (conversionRate_.specialTarget == StringPiece("beaufort"))?
+            base = uprv_strcmp(conversionRate_.specialTarget.data(), "beaufort") == 0 ?
                 scaleToBase(inputValue, minMetersPerSecForBeaufort, maxBeaufort): inputValue;
         } else {
             // Standard mapping (using factor) from target to base.
@@ -810,7 +815,7 @@ double UnitsConverter::convertInverse(double inputValue) const {
         if (!conversionRate_.specialSource.isEmpty()) {
             // We  have a special mapping from base to source (not using factor).
             // Currently the only supported mapping is a scale-based mapping for beaufort.
-            result = (conversionRate_.specialSource == StringPiece("beaufort"))?
+            result = uprv_strcmp(conversionRate_.specialSource.data(), "beaufort") == 0 ?
                 baseToScale(base, minMetersPerSecForBeaufort, maxBeaufort): base;
         } else {
             // Standard mapping (using factor) from base to source.

--- a/icu4c/source/i18n/units_converter.h
+++ b/icu4c/source/i18n/units_converter.h
@@ -8,6 +8,7 @@
 #define __UNITS_CONVERTER_H__
 
 #include "cmemory.h"
+#include "fixedstring.h"
 #include "measunit_impl.h"
 #include "unicode/errorcode.h"
 #include "unicode/stringpiece.h"
@@ -117,8 +118,8 @@ void U_I18N_API addSingleFactorConstant(StringPiece baseStr, int32_t power, Sign
 struct ConversionRate : public UMemory {
     const MeasureUnitImpl source;
     const MeasureUnitImpl target;
-    CharString specialSource;
-    CharString specialTarget;
+    FixedString specialSource;
+    FixedString specialTarget;
     double factorNum = 1;
     double factorDen = 1;
     double sourceOffset = 0;

--- a/icu4c/source/i18n/units_data.cpp
+++ b/icu4c/source/i18n/units_data.cpp
@@ -109,15 +109,25 @@ class ConversionRateDataSink : public ResourceSink {
                 status = U_MEMORY_ALLOCATION_ERROR;
                 return;
             } else {
-                cr->sourceUnit.append(srcUnit, status);
-                cr->baseUnit.appendInvariantChars(baseUnit, status);
-                if (!factor.isBogus()) {
-                    cr->factor.appendInvariantChars(factor, status);
-                    trimSpaces(cr->factor, status);
+                cr->sourceUnit = srcUnit;
+                if (cr->sourceUnit.isEmpty() != (*srcUnit == '\0')) {
+                    status = U_MEMORY_ALLOCATION_ERROR;
                 }
-                if (!offset.isBogus()) cr->offset.appendInvariantChars(offset, status);
-                if (!special.isBogus()) cr->specialMappingName.appendInvariantChars(special, status);
-                cr->systems.appendInvariantChars(systems, status);
+                copyInvariantChars(baseUnit, cr->baseUnit, status);
+                if (U_SUCCESS(status) && !factor.isBogus()) {
+                    CharString tmp;
+                    tmp.appendInvariantChars(factor, status);
+                    trimSpaces(tmp, status);
+                    if (U_SUCCESS(status)) {
+                        cr->factor = tmp.toStringPiece();
+                        if (cr->factor.isEmpty() != tmp.isEmpty()) {
+                            status = U_MEMORY_ALLOCATION_ERROR;
+                        }
+                    }
+                }
+                if (!offset.isBogus()) { copyInvariantChars(offset, cr->offset, status); }
+                if (!special.isBogus()) { copyInvariantChars(special, cr->specialMappingName, status); }
+                copyInvariantChars(systems, cr->systems, status);
             }
         }
     }
@@ -216,9 +226,7 @@ class UnitPreferencesSink : public ResourceSink {
                         if (U_FAILURE(status)) { return; }
                         for (int32_t i = 0; unitPref.getKeyAndValue(i, key, value); ++i) {
                             if (uprv_strcmp(key, "unit") == 0) {
-                                int32_t length;
-                                const char16_t *u = value.getString(length, status);
-                                up->unit.appendInvariantChars(u, length, status);
+                                copyInvariantChars(value.getUnicodeString(status), up->unit, status);
                             } else if (uprv_strcmp(key, "geq") == 0) {
                                 int32_t length;
                                 const char16_t *g = value.getString(length, status);
@@ -388,7 +396,9 @@ void U_I18N_API getAllConversionRates(MaybeStackVector<ConversionRateInfo> &resu
 const ConversionRateInfo *ConversionRates::extractConversionInfo(StringPiece source,
                                                                  UErrorCode &status) const {
     for (size_t i = 0, n = conversionInfo_.length(); i < n; ++i) {
-        if (conversionInfo_[i]->sourceUnit == source) return conversionInfo_[i];
+        if (uprv_strncmp(conversionInfo_[i]->sourceUnit.data(), source.data(), source.size()) == 0) {
+            return conversionInfo_[i];
+        }
     }
 
     status = U_INTERNAL_PROGRAM_ERROR;
@@ -432,7 +442,11 @@ MaybeStackVector<UnitPreference> UnitPreferences::getPreferencesFor(StringPiece 
                 || localeUnitCharString == "kelvin"
             ) {
                 UnitPreference unitPref;
-                unitPref.unit.append(localeUnitCharString, status);
+                unitPref.unit = localeUnitCharString.toStringPiece();
+                if (unitPref.unit.isEmpty() != localeUnitCharString.isEmpty()) {
+                    status = U_MISSING_RESOURCE_ERROR;
+                    return result;
+                }
                 result.emplaceBackAndCheckErrorCode(status, unitPref);
                 return result;
             }
@@ -470,9 +484,10 @@ MaybeStackVector<UnitPreference> UnitPreferences::getPreferencesFor(StringPiece 
             for (int32_t j = 0; unitsMatchSystem && j < measureUnit.singleUnits.length(); j++) {
                 const SingleUnitImpl* singleUnit = measureUnit.singleUnits[j];
                 const ConversionRateInfo* rateInfo = rates.extractConversionInfo(singleUnit->getSimpleUnitID(), status);
-                CharString systems(rateInfo->systems, status);
-                if (!systems.contains("metric_adjacent")) { // "metric-adjacent" is considered to match all the locale systems
-                    if (!systems.contains(localeSystem.data())) {
+                const char* systems = rateInfo->systems.data();
+                // "metric-adjacent" is considered to match all the locale systems
+                if (uprv_strstr(systems, "metric_adjacent") == nullptr) {
+                    if (uprv_strstr(systems, localeSystem.data()) == nullptr) {
                         unitsMatchSystem = false;
                     }
                 }

--- a/icu4c/source/i18n/units_data.h
+++ b/icu4c/source/i18n/units_data.h
@@ -11,6 +11,7 @@
 
 #include "charstr.h"
 #include "cmemory.h"
+#include "fixedstring.h"
 #include "unicode/stringpiece.h"
 #include "unicode/uobject.h"
 
@@ -31,18 +32,21 @@ class ConversionRateInfo : public UMemory {
     ConversionRateInfo() {}
     ConversionRateInfo(StringPiece sourceUnit, StringPiece baseUnit, StringPiece factor,
                        StringPiece offset, UErrorCode &status)
-        : sourceUnit(), baseUnit(), factor(), offset(), specialMappingName() {
-        this->sourceUnit.append(sourceUnit, status);
-        this->baseUnit.append(baseUnit, status);
-        this->factor.append(factor, status);
-        this->offset.append(offset, status);
+        : sourceUnit(sourceUnit), baseUnit(baseUnit), factor(factor), offset(offset),
+          specialMappingName(), systems() {
+        if (this->sourceUnit.isEmpty() != sourceUnit.empty() ||
+            this->baseUnit.isEmpty() != baseUnit.empty() ||
+            this->factor.isEmpty() != factor.empty() ||
+            this->offset.isEmpty() != offset.empty()) {
+            status = U_MEMORY_ALLOCATION_ERROR;
+        }
     }
-    CharString sourceUnit;
-    CharString baseUnit;
-    CharString factor;
-    CharString offset;
-    CharString specialMappingName; // the name of a special mapping used instead of factor + optional offset.
-    CharString systems;
+    FixedString sourceUnit;
+    FixedString baseUnit;
+    FixedString factor;
+    FixedString offset;
+    FixedString specialMappingName; // the name of a special mapping used instead of factor + optional offset.
+    FixedString systems;
 };
 
 /**
@@ -82,13 +86,12 @@ class ConversionRates {
 struct UnitPreference : public UMemory {
     // Set geq to 1.0 by default
     UnitPreference() : geq(1.0) {}
-    CharString unit;
+    FixedString unit;
     double geq;
     UnicodeString skeleton;
 
     UnitPreference(const UnitPreference &other) {
-        UErrorCode status = U_ZERO_ERROR;
-        this->unit.append(other.unit, status);
+        this->unit = other.unit;
         this->geq = other.geq;
         this->skeleton = other.skeleton;
     }

--- a/icu4c/source/test/depstest/dependencies.txt
+++ b/icu4c/source/test/depstest/dependencies.txt
@@ -853,6 +853,7 @@ group: platform
     cmemory.o uobject.o
     cstring.o cwchar.o uinvchar.o
     charstr.o
+    fixedstring.o
     unistr.o  # for CharString::appendInvariantChars(const UnicodeString &s, UErrorCode &errorCode)
     appendable.o stringpiece.o ustrtrns.o  # for unistr.o
     ustring.o  # Other platform files really just need u_strlen

--- a/icu4c/source/test/intltest/rbbimonkeytest.h
+++ b/icu4c/source/test/intltest/rbbimonkeytest.h
@@ -20,6 +20,7 @@
 #include "unicode/unistr.h"
 #include "unicode/uobject.h"
 
+#include "charstr.h"
 #include "simplethread.h"
 #include "ucbuf.h"
 #include "uhash.h"

--- a/icu4c/source/test/intltest/strtest.cpp
+++ b/icu4c/source/test/intltest/strtest.cpp
@@ -899,6 +899,11 @@ StringTest::TestFixedString() {
     assertTrue("default alias is nullptr", s.getAlias() == nullptr);
     assertEquals("default data is empty", "", s.data());
 
+    FixedString empty("");
+    assertTrue("empty is empty", empty.isEmpty());
+    assertTrue("empty alias is nullptr", empty.getAlias() == nullptr);
+    assertEquals("empty data is empty", "", empty.data());
+
     bool success = s.reserve(1);
     assertTrue("reserve success", success);
     assertFalse("reserved is empty", s.isEmpty());

--- a/icu4c/source/test/intltest/strtest.cpp
+++ b/icu4c/source/test/intltest/strtest.cpp
@@ -887,11 +887,11 @@ StringTest::Testctou() {
 void
 StringTest::TestFixedString() {
     static_assert(std::is_default_constructible_v<FixedString>);
-    static_assert(!std::is_copy_constructible_v<FixedString>);
+    static_assert(std::is_copy_constructible_v<FixedString>);
     static_assert(std::is_constructible_v<FixedString, std::string_view>);
     static_assert(std::is_copy_assignable_v<FixedString>);
     static_assert(std::is_assignable_v<FixedString, std::string_view>);
-    static_assert(!std::is_move_constructible_v<FixedString>);
+    static_assert(std::is_move_constructible_v<FixedString>);
     static_assert(std::is_move_assignable_v<FixedString>);
 
     FixedString s;
@@ -909,11 +909,6 @@ StringTest::TestFixedString() {
     assertFalse("reserved is empty", s.isEmpty());
     assertFalse("reserved alias is nullptr", s.getAlias() == nullptr);
 
-    s.clear();
-    assertTrue("cleared is empty", s.isEmpty());
-    assertTrue("cleared alias is nullptr", s.getAlias() == nullptr);
-    assertEquals("cleared data is empty", "", s.data());
-
     static constexpr char text[] = "foo";
 
     FixedString init(text);
@@ -921,25 +916,43 @@ StringTest::TestFixedString() {
     assertFalse("initialized alias is nullptr", init.getAlias() == nullptr);
     assertEquals("initialized data is text", text, init.data());
 
+    FixedString copied(init);
+    assertFalse("copied is empty", copied.isEmpty());
+    assertFalse("copied alias is nullptr", copied.getAlias() == nullptr);
+    assertFalse("copied alias is same", copied.getAlias() == init.getAlias());
+    assertEquals("copied data is text", text, copied.data());
+
+    FixedString moved(std::move(copied));
+    assertFalse("moved is empty", moved.isEmpty());
+    assertFalse("moved alias is nullptr", moved.getAlias() == nullptr);
+    assertEquals("moved data is text", text, moved.data());
+
+    assertTrue("copied is empty after move", copied.isEmpty());
+    assertTrue("copied alias is nullptr after move", copied.getAlias() == nullptr);
+    assertEquals("copied data is empty after move", "", copied.data());
+
+    moved.clear();
+    assertTrue("cleared is empty", moved.isEmpty());
+    assertTrue("cleared alias is nullptr", moved.getAlias() == nullptr);
+    assertEquals("cleared data is empty", "", moved.data());
+
     s = text;
     assertFalse("assigned is empty", s.isEmpty());
     assertFalse("assigned alias is nullptr", s.getAlias() == nullptr);
     assertEquals("assigned data is text", text, s.data());
 
-    FixedString copied;
     copied = s;
-    assertFalse("copied is empty", copied.isEmpty());
-    assertFalse("copied alias is nullptr", copied.getAlias() == nullptr);
-    assertFalse("copied alias is same", copied.getAlias() == s.getAlias());
-    assertEquals("copied data is text", text, copied.data());
+    assertFalse("assign copied is empty", copied.isEmpty());
+    assertFalse("assign copied alias is nullptr", copied.getAlias() == nullptr);
+    assertFalse("assign copied alias is same", copied.getAlias() == s.getAlias());
+    assertEquals("assign copied data is text", text, copied.data());
 
-    FixedString moved;
     moved = std::move(copied);
-    assertFalse("moved is empty", moved.isEmpty());
-    assertFalse("moved alias is nullptr", moved.getAlias() == nullptr);
-    assertEquals("moved data is text", text, moved.data());
+    assertFalse("assign moved is empty", moved.isEmpty());
+    assertFalse("assign moved alias is nullptr", moved.getAlias() == nullptr);
+    assertEquals("assign moved data is text", text, moved.data());
 
-    assertTrue("copied is empty", copied.isEmpty());
-    assertTrue("copied alias is nullptr", copied.getAlias() == nullptr);
-    assertEquals("copied data is empty", "", copied.data());
+    assertTrue("copied is empty after move assign", copied.isEmpty());
+    assertTrue("copied alias is nullptr after move assign", copied.getAlias() == nullptr);
+    assertEquals("copied data is empty after move assign", "", copied.data());
 }

--- a/icu4c/source/test/intltest/strtest.cpp
+++ b/icu4c/source/test/intltest/strtest.cpp
@@ -257,6 +257,7 @@ void StringTest::runIndexedTest(int32_t index, UBool exec, const char *&name, ch
     TESTCASE_AUTO(TestCharStrAppendNumber);
     TESTCASE_AUTO(Testctou);
     TESTCASE_AUTO(TestFixedString);
+    TESTCASE_AUTO(TestCopyInvariantChars);
     TESTCASE_AUTO_END;
 }
 
@@ -955,4 +956,37 @@ StringTest::TestFixedString() {
     assertTrue("copied is empty after move assign", copied.isEmpty());
     assertTrue("copied alias is nullptr after move assign", copied.getAlias() == nullptr);
     assertEquals("copied data is empty after move assign", "", copied.data());
+}
+
+void
+StringTest::TestCopyInvariantChars() {
+    IcuTestErrorCode status(*this, "TestCopyInvariantChars()");
+
+    static constexpr char text[] = "bar";
+
+    UnicodeString src(text);
+    FixedString dst;
+    copyInvariantChars(src, dst, status);
+
+    status.errIfFailureAndReset();
+    assertFalse("copied is empty", dst.isEmpty());
+    assertFalse("copied alias is nullptr", dst.getAlias() == nullptr);
+    assertEquals("copied data is text", text, dst.data());
+
+    src = "fubar";
+    status.set(U_INTERNAL_PROGRAM_ERROR);
+    copyInvariantChars(src, dst, status);
+
+    status.expectErrorAndReset(U_INTERNAL_PROGRAM_ERROR);
+    assertFalse("copied is empty", dst.isEmpty());
+    assertFalse("copied alias is nullptr", dst.getAlias() == nullptr);
+    assertEquals("copied data is text", text, dst.data());
+
+    src.remove();
+    copyInvariantChars(src, dst, status);
+
+    status.errIfFailureAndReset();
+    assertTrue("copied is empty", dst.isEmpty());
+    assertTrue("copied alias is nullptr", dst.getAlias() == nullptr);
+    assertEquals("copied data is empty", "", dst.data());
 }

--- a/icu4c/source/test/intltest/strtest.h
+++ b/icu4c/source/test/intltest/strtest.h
@@ -58,6 +58,7 @@ private:
     void TestCharStrAppendNumber();
     void Testctou();
     void TestFixedString();
+    void TestCopyInvariantChars();
 };
 
 #endif

--- a/icu4c/source/test/intltest/units_data_test.cpp
+++ b/icu4c/source/test/intltest/units_data_test.cpp
@@ -78,9 +78,9 @@ void UnitsDataTest::testGetAllConversionRates() {
         ConversionRateInfo *cri = conversionInfo[i];
         logln("* conversionInfo %d: source=\"%s\", baseUnit=\"%s\", factor=\"%s\", offset=\"%s\"", i,
               cri->sourceUnit.data(), cri->baseUnit.data(), cri->factor.data(), cri->offset.data());
-        assertTrue("sourceUnit", cri->sourceUnit.length() > 0);
-        assertTrue("baseUnit", cri->baseUnit.length() > 0);
-        assertTrue("factor || special", cri->factor.length() > 0 || cri->specialMappingName.length() > 0);
+        assertFalse("sourceUnit", cri->sourceUnit.isEmpty());
+        assertFalse("baseUnit", cri->baseUnit.isEmpty());
+        assertFalse("factor || special", cri->factor.isEmpty() && cri->specialMappingName.isEmpty());
     }
 }
 


### PR DESCRIPTION
When `CharString` is used as a data member that never is modified (apart from initialization), it can be replaced with `FixedString` in order to save a little memory (which, in case anyone creates a lot of any of these objects, could add up).

#### Checklist
- [x] Required: Issue filed: ICU-23192
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

ALLOW_MANY_COMMITS=true