### PR TITLE
ICU-23189 Test on modern GCC and modern Clang for modern C++

### DIFF
--- a/.github/workflows/icu4c.yml
+++ b/.github/workflows/icu4c.yml
@@ -86,21 +86,28 @@ jobs:
           make install;
           PATH=$PREFIX/bin:$PATH make -C test/hdrtst check
 
-  #gcc 11 with c++ 20
-  gcc11-cpp20:
-    runs-on: ubuntu-22.04  # Updated in BRS
+  #gcc 14 with c++ 20 and later
+  gcc14-cpp20-23:
+    # Ubuntu 24.04 Noble Numbat rather than 22.04 Jammy Jellyfish so we can get GCC 14.
+    runs-on: ubuntu-24.04  # Updated in BRS
+    strategy:
+      fail-fast: false
+      matrix:
+        flags:
+          - '-std=c++20'
+          - '-std=c++23'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Install GCC-11
+      - name: Install GCC-14
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt update
-          sudo apt install gcc-11 g++-11
+          sudo apt install gcc-14 g++-14
       - name: Build and Test
         env:
-          CC: gcc-11
-          CXX: g++-11
-          CXXFLAGS: -std=c++20 -fext-numeric-literals
+          CC: gcc-14
+          CXX: g++-14
+          CXXFLAGS: ${{ matrix.flags }} -fext-numeric-literals
         run: |
           cd icu4c/source;
           ./runConfigureICU Linux
@@ -325,26 +332,42 @@ jobs:
         run: |
           cd icu4c/source && ./runConfigureICU --enable-debug --disable-release Linux/clang && make -j -l4.5 check
 
-  # Clang Linux 18 with CPP20 and treat warnings as errors
-  clang18-cpp20-warning-as-errors:
+  # Modern Clang (18 and later) with C++20 and 23 and treat warnings as errors
+  clang-18-19-cpp-20-23-warning-as-errors:
       runs-on: ubuntu-22.04  # Updated in BRS
       strategy:
         fail-fast: false
         matrix:
+          clang-version:
+            - '18'
+            # TODO(egg): Clang 20 and later have -Wnontrivial-memcall, which currently warns in ICU.
+            # Bump this to 21 once fixed.
+            - '19'
           flags:
             - '-std=c++20'
             - '-std=c++20 -stdlib=libc++'
+            - '-std=c++23 -stdlib=libc++'
+          exclude:
+            # Most of C++20 was available in Clang 18, see https://clang.llvm.org/cxx_status.html#cxx20,
+            # so testing C++20 with Clang 18 is unlikely to find errors that are found by the
+            # Clang 19 C++20 build.
+            - clang-version: '18'
+              flags: '-std=c++20'
+            - clang-version: '18'
+              flags: '-std=c++20 -stdlib=libc++'
       steps:
         - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        - name: Install Clang-18
+        - name: Install Modern Clang
+          env:
+            CLANG_VERSION: ${{ matrix.clang-version }}
           run: |
             wget https://apt.llvm.org/llvm.sh
             chmod u+x llvm.sh
-            sudo ./llvm.sh 18 all
-        - name: Clang-18 build and Test
+            sudo ./llvm.sh $CLANG_VERSION all
+        - name: Modern Clang build and Test
           env:
-            CC: clang-18
-            CXX: clang++-18
+            CC: clang-${{ matrix.clang-version }}
+            CXX: clang++-${{ matrix.clang-version }}
             CPPFLAGS: '-Wall -Wextra -Wctad-maybe-unsupported -Werror'
             CXXFLAGS: ${{ matrix.flags }}
           run: |

--- a/icu4c/source/common/unicode/unistr.h
+++ b/icu4c/source/common/unicode/unistr.h
@@ -1924,30 +1924,39 @@ public:
   inline UBool isBogus() const;
 
 #ifndef U_HIDE_DRAFT_API
+private:
+  // These type aliases are private; there is no guarantee that they will remain
+  // aliases to the same types in subsequent versions of ICU.
+  // Note that whether `std::u16string_view::const_iterator` is a pointer or a
+  // class that models contiguous_iterator is platform-dependent.
+  using unspecified_iterator = std::u16string_view::const_iterator;
+  using unspecified_reverse_iterator = std::u16string_view::const_reverse_iterator;
+
+public:
   /**
    * @return an iterator to the first code unit in this string.
    *     The iterator may be a pointer or a contiguous-iterator object.
    * @draft ICU 78
    */
-  auto begin() const { return std::u16string_view(*this).begin(); }
+  unspecified_iterator begin() const { return std::u16string_view(*this).begin(); }
   /**
    * @return an iterator to just past the last code unit in this string.
    *     The iterator may be a pointer or a contiguous-iterator object.
    * @draft ICU 78
    */
-  auto end() const { return std::u16string_view(*this).end(); }
+  unspecified_iterator end() const { return std::u16string_view(*this).end(); }
   /**
    * @return a reverse iterator to the last code unit in this string.
    *     The iterator may be a pointer or a contiguous-iterator object.
    * @draft ICU 78
    */
-  auto rbegin() const { return std::u16string_view(*this).rbegin(); }
+  unspecified_reverse_iterator rbegin() const { return std::u16string_view(*this).rbegin(); }
   /**
    * @return a reverse iterator to just before the first code unit in this string.
    *     The iterator may be a pointer or a contiguous-iterator object.
    * @draft ICU 78
    */
-  auto rend() const { return std::u16string_view(*this).rend(); }
+  unspecified_reverse_iterator rend() const { return std::u16string_view(*this).rend(); }
 #endif  // U_HIDE_DRAFT_API
 
   //========================================

--- a/icu4c/source/common/unicode/utfiterator.h
+++ b/icu4c/source/common/unicode/utfiterator.h
@@ -1859,7 +1859,8 @@ private:
 /** @internal */
 template<typename CP32, UTFIllFormedBehavior behavior>
 struct UTFStringCodePointsAdaptor
-#if U_CPLUSPLUS_VERSION >= 23 && __cpp_lib_ranges >= 2022'02  // http://wg21.link/P2387R3.
+#if U_CPLUSPLUS_VERSION >= 23 && __cpp_lib_ranges >= 2022'02 &&                                         \
+    __cpp_lib_bind_back >= 2022'02 // http://wg21.link/P2387R3.
     : std::ranges::range_adaptor_closure<UTFStringCodePointsAdaptor<CP32, behavior>>
 #endif
 {
@@ -2570,7 +2571,8 @@ private:
 /** @internal */
 template<typename CP32>
 struct UnsafeUTFStringCodePointsAdaptor
-#if U_CPLUSPLUS_VERSION >= 23 && __cpp_lib_ranges >= 2022'02  // http://wg21.link/P2387R3.
+#if U_CPLUSPLUS_VERSION >= 23 && __cpp_lib_ranges >= 2022'02 &&                                         \
+    __cpp_lib_bind_back >= 2022'02 // http://wg21.link/P2387R3.
     : std::ranges::range_adaptor_closure<UnsafeUTFStringCodePointsAdaptor<CP32>>
 #endif
 {

--- a/icu4c/source/test/intltest/rbbitst.cpp
+++ b/icu4c/source/test/intltest/rbbitst.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <array>
+#include <exception>  // For std::terminate.
 #include <cinttypes>
 #include <list>
 #include <optional>

--- a/icu4c/source/test/intltest/utfiteratortest.cpp
+++ b/icu4c/source/test/intltest/utfiteratortest.cpp
@@ -740,7 +740,7 @@ public:
                                               std::ranges::views::reverse |
                                               std::ranges::views::transform(codePoint),
                                           std::u32string_view(U"𒉭")));
-#if U_CPLUSPLUS_VERSION >= 23 && __cpp_lib_ranges >= 2022'02
+#if U_CPLUSPLUS_VERSION >= 23 && __cpp_lib_ranges >= 2022'02 && __cpp_lib_bind_back >= 2022'02
             assertTrue("reversed common bidirectional filtered range: one big pipeline",
                        std::ranges::equal(
                            card
@@ -765,7 +765,7 @@ public:
                                               std::ranges::views::reverse |
                                               std::ranges::views::transform(codePoint),
                                           std::u32string_view(U"𒉭")));
-#if U_CPLUSPLUS_VERSION >= 23 && __cpp_lib_ranges >= 2022'02
+#if U_CPLUSPLUS_VERSION >= 23 && __cpp_lib_ranges >= 2022'02 && __cpp_lib_bind_back >= 2022'02
             assertTrue("reversed unsafe common bidirectional filtered range: one big pipeline",
                        std::ranges::equal(
                            card

--- a/icu4c/source/test/intltest/utfiteratortest.cpp
+++ b/icu4c/source/test/intltest/utfiteratortest.cpp
@@ -605,8 +605,9 @@ public:
                                         u"𒂍𒁾𒁀𒀀𒂠 𒉌𒁺𒉈𒂗\n"
                                         u"𒂍𒁾𒁀𒀀 𒀀𒈾𒀀𒀭 𒉌𒀝\n"
                                         u"𒁾𒈬 𒉌𒋃 𒃻𒅗𒁺𒈬 𒉌𒅥\n";
+        auto lines3sqq = text | std::ranges::views::lazy_split(u'\n') | std::views::drop(2);
         // Code units from the third line in `text`.
-        auto codeUnits = *(text | std::ranges::views::lazy_split(u'\n') | std::views::drop(2)).begin();
+        auto codeUnits = *lines3sqq.begin();
         using CodeUnitRange = decltype(codeUnits);
         // This range has a sentinel.
         static_assert(!std::ranges::common_range<CodeUnitRange>);


### PR DESCRIPTION
Note that the default GCC build is using GCC 11 already, as it is the default on ubuntu 22.04, so we don’t need a separate GCC 11 build. Bump that to 14, which is the most recent we can get on the latest GitHub runner (24.04), and make it build for C++20 and C++23.

Also make clang build for C++23. Try both Clang 18 and 19, as their libc++s have different sets of features (before this change, utfiterator did not compile with Clang 18 in C++23 mode, but compiled with Clang 19).

Fix UB in utfiteratortest.cpp which resulted in a segfault with GCC.

#### Checklist
- [x] Required: Issue filed: ICU-23189
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

ALLOW_MANY_COMMITS=meow