### PR TITLE
ICU-20392 Let the compiler do its job by simplifying Locale::Nest

### DIFF
--- a/icu4c/source/common/locid.cpp
+++ b/icu4c/source/common/locid.cpp
@@ -253,20 +253,6 @@ void copyToArray(std::string_view sv, T* that) {
 
 U_NAMESPACE_BEGIN
 
-Locale::Nest::Nest() : language{'\0'}, script{'\0'}, region{'\0'}, variantBegin{0}, baseName{'\0'} {}
-Locale::Nest::~Nest() = default;
-
-Locale::Nest::Nest(const Nest& other) {
-    uprv_memcpy(this, &other, sizeof *this);
-}
-
-Locale::Nest& Locale::Nest::operator=(const Nest& other) {
-    if (this != &other) {
-        uprv_memcpy(this, &other, sizeof *this);
-    }
-    return *this;
-}
-
 void Locale::Nest::init(std::string_view language,
                         std::string_view script,
                         std::string_view region,

--- a/icu4c/source/common/unicode/locid.h
+++ b/icu4c/source/common/unicode/locid.h
@@ -1178,17 +1178,17 @@ private:
     struct Nest {
         static constexpr size_t SIZE = 32;
 
-        const ELocaleType type = eNEST;
-        char language[4];
-        char script[5];
-        char region[4];
-        uint8_t variantBegin;
+        ELocaleType type = eNEST;
+        char language[4] = {'\0'};
+        char script[5] = {'\0'};
+        char region[4] = {'\0'};
+        uint8_t variantBegin = 0;
         char baseName[SIZE -
                       sizeof type -
                       sizeof language -
                       sizeof script -
                       sizeof region -
-                      sizeof variantBegin];
+                      sizeof variantBegin] = {'\0'};
 
         const char* getLanguage() const { return language; }
         const char* getScript() const { return script; }
@@ -1199,12 +1199,6 @@ private:
         // Doesn't inherit from UMemory, shouldn't be heap allocated.
         static void* U_EXPORT2 operator new(size_t) noexcept = delete;
         static void* U_EXPORT2 operator new[](size_t) noexcept = delete;
-
-        Nest();
-        ~Nest();
-
-        Nest(const Nest& other);
-        Nest& operator=(const Nest& other);
 
         void init(std::string_view language,
                   std::string_view script,


### PR DESCRIPTION
There's no need to define constructors, destructors and operators that just do the same thing as the compiler generated default ones do.

#### Checklist
- [x] Required: Issue filed: ICU-20392
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
