### PR TITLE
ICU-23197 rework J DateFormatSymbols eraNames loading as in C, update tests

### DIFF
--- a/icu4j/main/core/src/main/java/com/ibm/icu/impl/EraRules.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/impl/EraRules.java
@@ -40,10 +40,14 @@ public class EraRules {
     }
 
     public static EraRules getInstance(CalType calType, boolean includeTentativeEra) {
+        return getInstance(calType.getId(), includeTentativeEra);
+    }
+
+    public static EraRules getInstance(String calId, boolean includeTentativeEra) {
         UResourceBundle supplementalDataRes = UResourceBundle.getBundleInstance(ICUData.ICU_BASE_NAME,
                 "supplementalData", ICUResourceBundle.ICU_DATA_CLASS_LOADER);
         UResourceBundle calendarDataRes = supplementalDataRes.get("calendarData");
-        UResourceBundle calendarTypeRes = calendarDataRes.get(calType.getId());
+        UResourceBundle calendarTypeRes = calendarDataRes.get(calId);
         UResourceBundle erasRes = calendarTypeRes.get("eras");
 
         int numEras = erasRes.getSize();
@@ -58,10 +62,10 @@ public class EraRules {
             try {
                 eraIdx = Integer.parseInt(eraIdxStr);
             } catch (NumberFormatException e) {
-                throw new ICUException("Invalid era rule key:" + eraIdxStr + " in era rule data for " + calType.getId());
+                throw new ICUException("Invalid era rule key:" + eraIdxStr + " in era rule data for " + calId);
             }
             if (eraIdx < 0) {
-                throw new ICUException("Era rule key:" + eraIdxStr + " in era rule data for " + calType.getId()
+                throw new ICUException("Era rule key:" + eraIdxStr + " in era rule data for " + calId
                         + " must be >= 0");
             }
             if (eraIdx + 1 > eraStartDates.size()) {
@@ -74,7 +78,7 @@ public class EraRules {
             // Now set the startDate that we just read
             if (isSet(eraStartDates.get(eraIdx).intValue())) {
                 throw new ICUException(
-                        "Duplicated era rule for rule key:" + eraIdxStr + " in era rule data for " + calType.getId());
+                        "Duplicated era rule for rule key:" + eraIdxStr + " in era rule data for " + calId);
             }
 
             boolean hasName = true;
@@ -88,7 +92,7 @@ public class EraRules {
                     if (fields.length != 3 || !isValidRuleStartDate(fields[0], fields[1], fields[2])) {
                         throw new ICUException(
                                 "Invalid era rule date data:" + Arrays.toString(fields) + " in era rule data for "
-                                + calType.getId());
+                                + calId);
                     }
                     eraStartDates.set(eraIdx, encodeDate(fields[0], fields[1], fields[2]));
                 } else if (key.equals("named")) {
@@ -112,7 +116,7 @@ public class EraRules {
                     eraStartDates.set(eraIdx, MIN_ENCODED_START);
                 } else {
                     throw new ICUException("Missing era start/end rule date for key:" + eraIdxStr + " in era rule data for "
-                            + calType.getId());
+                            + calId);
                 }
             }
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/JapaneseTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/JapaneseTest.java
@@ -253,17 +253,13 @@ public class JapaneseTest extends CalendarTestFmwk {
         }
         String testString2 = testFmt2.format(refDate);
         if (testString2.length() < 2 || testString2.charAt(1) != '1') {
-            if (!logKnownIssue("ICU-23182", "Japanese calendar formatting")) {
-                errln("Formatting year 1 in created numeric style, got " + testString2 + " but expected 2nd char to be 1");
-            }
+            errln("Formatting year 1 in created numeric style, got " + testString2 + " but expected 2nd char to be 1");
         }
         // Now switch the patterns and verify that Gannen use follows the pattern
         testFmt1.applyPattern(patNumr);
         testString1 = testFmt1.format(refDate);
         if (testString1.length() < 2 || testString1.charAt(1) != '1') { //
-            if (!logKnownIssue("ICU-23182", "Japanese calendar formatting")) {
-                errln("Formatting year 1 in applied numeric style, got " + testString1 + " but expected 2nd char to be 1");
-            }
+            errln("Formatting year 1 in applied numeric style, got " + testString1 + " but expected 2nd char to be 1");
         }
         testFmt2.applyPattern(patText);
         testString2 = testFmt2.format(refDate);
@@ -290,10 +286,10 @@ public class JapaneseTest extends CalendarTestFmwk {
         fmt.applyPattern("G y");
         logln("fmt's locale = " + fmt.getLocale(ULocale.ACTUAL_LOCALE));
         //SimpleDateFormat fmt = new SimpleDateFormat("G y", new ULocale("en_US@calendar=japanese"));
-        long aDateLong = -3197117222000L; // 1868-09-08 00:00 Pacific Time (GMT-07:52:58)
+        long aDateLong = -3193229222000L; // 1868-10-23 00:00 Pacific Time (GMT-07:52:58)
         if (TimeZone.getDefaultTimeZoneType() == TimeZone.TIMEZONE_JDK) {
             // Java time zone implementation does not support LMTs
-            aDateLong = -3197116800000L; // 1868-09-08 00:00 Pacific Time (GMT-08:00)
+            aDateLong = -3193228800000L; // 1868-10-23 00:00 Pacific Time (GMT-08:00)
         }
         Date aDate = new Date(aDateLong);
         logln("aDate: " + aDate.toString() +", from " + aDateLong);
@@ -304,9 +300,7 @@ public class JapaneseTest extends CalendarTestFmwk {
         logln("as Japanese Calendar: " + str);
         String expected = "Meiji 1";
         if(!str.equals(expected)) {
-            if (!logKnownIssue("ICU-23186", "Japanese calendar round trip fails")) {
-                errln("FAIL: Expected " + expected + " but got " + str);
-            }
+            errln("FAIL: Expected " + expected + " but got " + str);
         }
         Date otherDate;
         try {
@@ -319,10 +313,8 @@ public class JapaneseTest extends CalendarTestFmwk {
                 long oLong = otherDate.getTime();
                 long aLong = otherDate.getTime();
 
-                if (!logKnownIssue("ICU-23186", "Japanese calendar round trip fails")) {
-                    errln("FAIL: Parse incorrect of " + expected + ":  wanted " + aDate + " ("+aLong+"), but got " +  " " +
-                        otherDate + " ("+oLong+") = " + str3 + " not " + dd.toString() );
-                }
+                errln("FAIL: Parse incorrect of " + expected + ":  wanted " + aDate + " ("+aLong+"), but got " +  " " +
+                    otherDate + " ("+oLong+") = " + str3 + " not " + dd.toString() );
             } else {
                 logln("Parsed OK: " + expected);
             }

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DateIntervalFormatTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DateIntervalFormatTest.java
@@ -884,10 +884,6 @@ public class DateIntervalFormatTest extends CoreTestFmwk {
             String expected = data[i++];
             String formatted = dtitvfmt.format(dtitv);
             if ( !formatted.equals(Utility.unescape(expected)) )  {
-                if (locName.equals("ja-u-ca-japanese") &&
-                    logKnownIssue("ICU-23182", "Japanese calendar formatting")) {
-                    continue;
-                }
                 if (locName.equals("de") && 
                     ( oneSkeleton.equals("hv") || oneSkeleton.equals("hz") ) &&
                     logKnownIssue("ICU-23185", "Date time formatting with hz and hv needs revisiting")) {
@@ -2457,10 +2453,6 @@ public class DateIntervalFormatTest extends CoreTestFmwk {
 
     @Test
     public void testTicket21222JapaneseEraDiff() {
-        if (logKnownIssue("ICU-23182", "Japanese calendar formatting")) {
-            return;
-        }
-    
         Calendar cal = Calendar.getInstance(TimeZone.GMT_ZONE);
         DateIntervalFormat japanese = DateIntervalFormat.getInstance(
             "h", new ULocale("ja@calendar=japanese"));

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DateTimeGeneratorTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DateTimeGeneratorTest.java
@@ -343,11 +343,6 @@ public class DateTimeGeneratorTest extends CoreTestFmwk {
                 if (GENERATE_TEST_DATA) {
                     logln("new String[] {\"" + testSkeleton + "\", \"" + Utility.escape(formatted) + "\"},");
                 } else if (!formatted.equals(testFormatted)) {
-                    if (uLocale.getName().equals("ja@calendar=japanese") && 
-                        (testSkeleton.equals("yM") || testSkeleton.equals("yMd")) &&
-                        logKnownIssue("ICU-23182", "Japanese calendar formatting") ) {
-                        continue;
-                    }
                     errln(uLocale + "\tformatted string doesn't match test case: " + testSkeleton + "\t generated: " +  pattern + "\t expected: " + testFormatted + "\t got: " + formatted);
                     if (true) { // debug
                         pattern = dtfg.getBestPattern(testSkeleton);


### PR DESCRIPTION
- Rework ICU4J DateFormatSymbols eraNames loading code to match ICU4C rework in [PR #3600 commit 4](https://github.com/unicode-org/icu/pull/3600/commits/a95018f03db53308c0416f01e8d857688cecfee1)
    - Now that eraNames data are in map form and EraRules has been updated, rework the eraNames loading code originally added in PR [#3588](https://github.com/unicode-org/icu/pull/3588) so the CalendarSink treats the eraNames data as a table (more natural, and needed in C to remove leaks), then a new initEras function handles the conversion to array and also fills in missing values from parent(s). The latter solves the problem with not loading the narrow modern era names in Japanese, for example.
- Then update tests:
    - Remove the logKnownIssue test skips for ICU-23182/ICU-23186
    - Update for fixed Meiji start date

#### Checklist
- [x] Required: Issue filed: ICU-23197
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
