### PR TITLE
ICU4C Check type variable on null before dereferencing

### DIFF
--- a/icu4c/source/common/udata.cpp
+++ b/icu4c/source/common/udata.cpp
@@ -1291,7 +1291,7 @@ doOpenChoice(const char *path, const char *type, const char *name,
     dataPath = u_getDataDirectory();
 
     /****    Time zone individual files override  */
-    if (isICUData && isTimeZoneFile(name, type)) {
+    if (isICUData && type!=nullptr && isTimeZoneFile(name, type)) {
         const char *tzFilesDir = u_getTimeZoneFilesDirectory(pErrorCode);
         if (tzFilesDir[0] != 0) {
 #ifdef UDATA_DEBUG


### PR DESCRIPTION
I found possible null dereference with Svace static analyzer.

A variable `type` is checking on nullptr at https://github.com/unicode-org/icu/blob/d805423d52468b829e65190168c48daf27f297da/icu4c/source/common/udata.cpp#L1264.
But later it is used without checking on https://github.com/unicode-org/icu/blob/d805423d52468b829e65190168c48daf27f297da/icu4c/source/common/udata.cpp#L1294.