### PR TITLE
ICU-23056 Update urename.h generator to write clang-tidy exception

### DIFF
--- a/icu4c/source/tools/genren/genren.pl
+++ b/icu4c/source/tools/genren/genren.pl
@@ -106,8 +106,9 @@ print HEADER <<"EndOfHeaderComment";
 
 #if !U_DISABLE_RENAMING
 
-// Disable Renaming for Visual Studio's IntelliSense feature, so that 'Go-to-Definition' (F12) will work.
-#if !(defined(_MSC_VER) && defined(__INTELLISENSE__))
+// Disable Renaming for Visual Studio's IntelliSense feature and for LLVM's Clang-Tidy tool, so that
+// 'Go-to-Definition' (F12) and 'include-cleaner' respectively will work.
+#if !(defined(_MSC_VER) && defined(__INTELLISENSE__)) && !defined(__clang_analyzer__)
 
 /* We need the U_ICU_ENTRY_POINT_RENAME definition. There's a default one in unicode/uvernum.h we can use, but we will give
    the platform a chance to define it first.
@@ -250,7 +251,7 @@ foreach(sort keys(%CFuncs)) {
 
 print HEADER <<"EndOfHeaderFooter";
 
-#endif /* !(defined(_MSC_VER) && defined(__INTELLISENSE__)) */
+#endif /* !(defined(_MSC_VER) && defined(__INTELLISENSE__)) && !defined(__clang_analyzer__) */
 #endif /* U_DISABLE_RENAMING */
 #endif /* URENAME_H */
 


### PR DESCRIPTION
Update the urename.h generator script to write the modified the #ifdef conditions surrounding the body, with the new clang-tidy exception.

#### Checklist
- [x] Required: Issue filed: ICU-23056
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
