### PR TITLE
ICU-23105 Update NumberFormatterApiTest/formatUnitsAliases to fail when the units are not parsable

### DIFF
--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
@@ -5995,32 +5995,49 @@ public class NumberFormatterApiTest extends CoreTestFmwk {
 
         class TestCase {
             final MeasureUnit measureUnit;
+            final String measureUnitString; // Only used if measureUnit is nullptr
             final String expectedFormat;
 
             TestCase(MeasureUnit measureUnit, String expectedFormat) {
                 this.measureUnit = measureUnit;
+                this.measureUnitString = null;
+                this.expectedFormat = expectedFormat;
+            }
+
+            TestCase(String measureUnitString, String expectedFormat) {
+                this.measureUnit = null;
+                this.measureUnitString = measureUnitString;
                 this.expectedFormat = expectedFormat;
             }
         }
 
         TestCase[] testCases = {
                 // Aliases
+                new TestCase(MeasureUnit.MILLIGRAM_OFGLUCOSE_PER_DECILITER, "2 milligrams per deciliter"),
                 new TestCase(MeasureUnit.MILLIGRAM_PER_DECILITER, "2 milligrams per deciliter"),
                 new TestCase(MeasureUnit.LITER_PER_100KILOMETERS, "2 liters per 100 kilometers"),
                 new TestCase(MeasureUnit.PART_PER_MILLION, "2 parts per million"),
                 new TestCase(MeasureUnit.MILLIMETER_OF_MERCURY, "2 millimeters of mercury"),
 
                 // Replacements
-                new TestCase(MeasureUnit.MILLIGRAM_OFGLUCOSE_PER_DECILITER, "2 milligrams per deciliter"),
-                new TestCase(MeasureUnit.forIdentifier("millimeter-ofhg"), "2 millimeters of mercury"),
-                new TestCase(MeasureUnit.forIdentifier("liter-per-100-kilometer"), "2 liters per 100 kilometers"),
-                new TestCase(MeasureUnit.forIdentifier("part-per-1e6"), "2 parts per million"),
+                new TestCase("millimeter-ofhg", "2 millimeters of mercury"),
+                new TestCase("liter-per-100-kilometer", "2 liters per 100 kilometers"),
+                new TestCase("permillion", "2 parts per million"),
+                new TestCase("part-per-million", "2 parts per million"),
+                new TestCase("part-per-1e6", "2 parts per million"),
         };
 
         for (TestCase testCase : testCases) {
+            if ("permillion".equals(testCase.measureUnitString) ||
+                "part-per-million".equals(testCase.measureUnitString)) {
+                logKnownIssue("ICU-23222", "Ensure unit aliases work correctly to avoid breaking callers");
+                continue;
+            }
+
+            MeasureUnit measureUnit = testCase.measureUnitString != null ? MeasureUnit.forIdentifier(testCase.measureUnitString) : testCase.measureUnit;
             String actualFormat = NumberFormatter
                     .withLocale(ULocale.ENGLISH)
-                    .unit(testCase.measureUnit)
+                    .unit(measureUnit)
                     .unitWidth(UnitWidth.FULL_NAME)
                     .format(2.0)
                     .toString();


### PR DESCRIPTION
# Description

The issue occurred because unit parsing failures were not checked or the status reset. As a result, if one unit failed to parse, the status carried an error and caused all subsequent test cases to fail.  

Changes made:
- Updated expected formats tests for unit aliases in both C++ and Java test files.  
- Refactored test cases to use `unique_ptr` for `MeasureUnit` in C++ and adjusted the constructor in Java.  
- Introduced logging for known issues related to unit aliases.  

Note: This issue still exists — [ICU-23222](https://unicode-org.atlassian.net/browse/ICU-23222).  


#### Checklist
- [x] Required: Issue filed: ICU-23105
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable


[ICU-23222]: https://unicode-org.atlassian.net/browse/ICU-23222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ