### PR TITLE
ICU-23222 Enhance unit alias handling

### DIFF
--- a/icu4c/source/i18n/number_longnames.cpp
+++ b/icu4c/source/i18n/number_longnames.cpp
@@ -438,6 +438,7 @@ void getMeasureData(const Locale &locale,
     subKey.append(unit.getType(), status);
     subKey.append("/", status);
 
+    // TODO(ICU-23226): Refactor LongNameHandler to use gUnitAliases and gUnitReplacements measunit_extra.cpp instead of local reasource bundle.
     // Check if unitSubType is an alias or not.
     LocalUResourceBundlePointer aliasBundle(ures_open(U_ICUDATA_ALIAS, "metadata", &status));
 

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
@@ -5992,10 +5992,9 @@ public class NumberFormatterApiTest extends CoreTestFmwk {
 
     @Test
     public void formatUnitsAliases() {
-
         class TestCase {
             final MeasureUnit measureUnit;
-            final String measureUnitString; // Only used if measureUnit is nullptr
+            final String measureUnitString; // Only used if measureUnit is null
             final String expectedFormat;
 
             TestCase(MeasureUnit measureUnit, String expectedFormat) {
@@ -6012,37 +6011,95 @@ public class NumberFormatterApiTest extends CoreTestFmwk {
         }
 
         TestCase[] testCases = {
-                // Aliases
-                new TestCase(MeasureUnit.MILLIGRAM_OFGLUCOSE_PER_DECILITER, "2 milligrams per deciliter"),
-                new TestCase(MeasureUnit.MILLIGRAM_PER_DECILITER, "2 milligrams per deciliter"),
-                new TestCase(MeasureUnit.LITER_PER_100KILOMETERS, "2 liters per 100 kilometers"),
-                new TestCase(MeasureUnit.PART_PER_MILLION, "2 parts per million"),
-                new TestCase(MeasureUnit.MILLIMETER_OF_MERCURY, "2 millimeters of mercury"),
-
-                // Replacements
-                new TestCase("millimeter-ofhg", "2 millimeters of mercury"),
-                new TestCase("liter-per-100-kilometer", "2 liters per 100 kilometers"),
+                // permillion
                 new TestCase("permillion", "2 parts per million"),
                 new TestCase("part-per-million", "2 parts per million"),
+                // new TestCase("portion-per-million", "2 parts per million"),
+                // new TestCase("portion-per-1e6", "2 parts per million"),
                 new TestCase("part-per-1e6", "2 parts per million"),
+                new TestCase(MeasureUnit.PART_PER_1E6, "2 parts per million"),
+
+                 // part-per-billion
+                new TestCase("portion-per-1e9", "2 parts per billion"),
+                new TestCase("part-per-1e9", "2 parts per billion"),
+                new TestCase(MeasureUnit.PART_PER_1E9, "2 parts per billion"),
+
+                // pound-foot
+                new TestCase("pound-foot", "2 pound-force-feet"),
+                new TestCase("pound-force-foot", "2 pound-force-feet"),
+                new TestCase(MeasureUnit.POUND_FOOT, "2 pound-force-feet"),
+
+                // pound-force
+                new TestCase(MeasureUnit.POUND_FORCE, "2 pounds of force"),
+                new TestCase("pound-force", "2 pounds of force"),
+
+                // pound-per-square-inch
+                new TestCase("pound-per-square-inch", "2 pounds-force per square inch"),
+                new TestCase("pound-force-per-square-inch", "2 pounds-force per square inch"),
+                new TestCase(MeasureUnit.POUND_PER_SQUARE_INCH,  "2 pounds-force per square inch"),
+                
+                // millimeter-of-mercury
+                new TestCase("millimeter-of-mercury", "2 millimeters of mercury"),
+                new TestCase("millimeter-ofhg", "2 millimeters of mercury"),
+                new TestCase(MeasureUnit.MILLIMETER_OF_MERCURY,  "2 millimeters of mercury"),
+
+                // inch-hg
+                new TestCase("inch-hg", "2 inches of mercury"),
+                new TestCase("inch-ofhg", "2 inches of mercury"),
+                new TestCase(MeasureUnit.INCH_HG,  "2 inches of mercury"),
+
+                // liter-per-100kilometers
+                new TestCase("liter-per-100kilometers", "2 liters per 100 kilometers"),
+                new TestCase("liter-per-100-kilometer", "2 liters per 100 kilometers"),
+                new TestCase(MeasureUnit.LITER_PER_100KILOMETERS,  "2 liters per 100 kilometers"),
+
+                // meter-per-second-squared
+                new TestCase("meter-per-second-squared", "2 meters per second squared"),
+                new TestCase("meter-per-square-second", "2 meters per second squared"),
+                new TestCase(MeasureUnit.METER_PER_SECOND_SQUARED,  "2 meters per second squared"),
+
+                // metric-ton
+                new TestCase("metric-ton", "2 metric tons"),
+                new TestCase("tonne", "2 metric tons"),
+                new TestCase(MeasureUnit.METRIC_TON,  "2 metric tons"),
+                new TestCase(MeasureUnit.TONNE,  "2 metric tons"),
+
+                // milligram-per-deciliter
+                new TestCase("milligram-per-deciliter", "2 milligrams per deciliter"),
+                new TestCase("milligram-ofglucose-per-deciliter", "2 milligrams per deciliter"),
+                new TestCase(MeasureUnit.MILLIGRAM_PER_DECILITER, "2 milligrams per deciliter"),
+                new TestCase(MeasureUnit.MILLIGRAM_OFGLUCOSE_PER_DECILITER, "2 milligrams per deciliter"),
+
+                // Arbitrary
+                new TestCase("meter-permillion", "2 meter-parts per 1000000"),
+                new TestCase("permillion-meter", "2 parts per 1000000-meter"),
+                new TestCase("tonne-per-second", "2 metric tons per second"),
+                new TestCase("part-per-1e6-per-100", "expect exception"),
+                new TestCase("permillion-per-100", "expect exception"),
+
         };
 
         for (TestCase testCase : testCases) {
-            if ("permillion".equals(testCase.measureUnitString) ||
-                "part-per-million".equals(testCase.measureUnitString)) {
-                logKnownIssue("ICU-23222", "Ensure unit aliases work correctly to avoid breaking callers");
-                continue;
-            }
+                if ("expect exception".equals(testCase.expectedFormat)) {
+                        try {
+                                MeasureUnit.forIdentifier(testCase.measureUnitString);
+                                fail("exception expected");
+                        } catch (Exception e) {
+                                // Pass
+                        }
+                        continue;
+                }
 
-            MeasureUnit measureUnit = testCase.measureUnitString != null ? MeasureUnit.forIdentifier(testCase.measureUnitString) : testCase.measureUnit;
-            String actualFormat = NumberFormatter
-                    .withLocale(ULocale.ENGLISH)
-                    .unit(measureUnit)
-                    .unitWidth(UnitWidth.FULL_NAME)
-                    .format(2.0)
-                    .toString();
+                MeasureUnit measureUnit = testCase.measureUnit != null ? testCase.measureUnit
+                                : MeasureUnit.forIdentifier(testCase.measureUnitString);
+                String actualFormat = NumberFormatter
+                                .withLocale(ULocale.ENGLISH)
+                                .unit(measureUnit)
+                                .unitWidth(UnitWidth.FULL_NAME)
+                                .format(2.0)
+                                .toString();
 
-            assertEquals("test unit aliases", testCase.expectedFormat, actualFormat);
+                assertEquals("test unit aliases", testCase.expectedFormat, actualFormat);
         }
     }
 

--- a/icu4j/main/core/src/main/java/com/ibm/icu/impl/number/LongNameHandler.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/impl/number/LongNameHandler.java
@@ -331,6 +331,7 @@ public class LongNameHandler
         }
     }
 
+    // TODO(ICU-23226): Refactor LongNameHandler to use UnitAliases.java instead of local AliasSink class
     private static final class AliasSink extends UResource.Sink {
         String replacement;
 

--- a/icu4j/main/core/src/main/java/com/ibm/icu/impl/units/UnitAliases.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/impl/units/UnitAliases.java
@@ -1,0 +1,89 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+package com.ibm.icu.impl.units;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.ibm.icu.impl.ICUData;
+import com.ibm.icu.impl.ICUResourceBundle;
+import com.ibm.icu.impl.IllegalIcuArgumentException;
+import com.ibm.icu.impl.UResource;
+import com.ibm.icu.util.UResourceBundle;
+
+/**
+ * UnitAliases is a class that holds all the aliases and their replacements for
+ * units.
+ */
+public class UnitAliases {
+    /**
+     * A class to hold the alias and replacement.
+     */
+    public static class Alias {
+        public final String alias;
+        public final String replacement;
+
+        public Alias(String alias, String replacement) {
+            this.alias = alias;
+            this.replacement = replacement;
+        }
+    }
+
+    private static final class AllAliasSink extends UResource.Sink {
+        private final Map<String, String> mapAliasToReplacement = new HashMap<>();
+
+        @Override
+        public void put(UResource.Key key, UResource.Value value, boolean noFallback) {
+            String alias = key.toString();
+            UResource.Table aliasEntryTable = value.getTable();
+            
+            if (aliasEntryTable.findValue("replacement", value)) {
+                String replacement = value.toString();
+                this.mapAliasToReplacement.put(alias, replacement);
+            } else {
+                throw new IllegalIcuArgumentException("No replacement found for alias: " + alias);
+            }
+        }
+
+        public Map<String, String> getAliasMap() {
+            return Collections.unmodifiableMap(mapAliasToReplacement);
+        }
+    }
+
+    private final Map<String, String> mapAliasToReplacement;
+
+    public UnitAliases() {
+        // Read unit aliases
+        ICUResourceBundle metadataResource = (ICUResourceBundle) UResourceBundle
+                .getBundleInstance(ICUData.ICU_BASE_NAME, "metadata");
+        AllAliasSink aliasSink = new AllAliasSink();
+        metadataResource.getAllChildrenWithFallback("alias/unit", aliasSink);
+        this.mapAliasToReplacement = aliasSink.getAliasMap();
+    }
+
+    /**
+     * Returns a list of all the aliases.
+     * 
+     * @return an unmodifiable list of aliases
+     */
+    public List<Alias> getAliases() {
+        List<Alias> aliasList = new ArrayList<>(mapAliasToReplacement.size());
+        for (Map.Entry<String, String> entry : mapAliasToReplacement.entrySet()) {
+            aliasList.add(new Alias(entry.getKey(), entry.getValue()));
+        }
+        return Collections.unmodifiableList(aliasList);
+    }
+
+    /**
+     * Returns the replacement unit for a given alias, or null if no alias exists.
+     * 
+     * @param alias the alias unit to look up
+     * @return the replacement unit, or null if not found
+     */
+    public String getReplacement(String alias) {
+        return mapAliasToReplacement.get(alias);
+    }
+}

--- a/icu4j/main/core/src/main/java/com/ibm/icu/impl/units/UnitsData.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/impl/units/UnitsData.java
@@ -6,6 +6,7 @@ package com.ibm.icu.impl.units;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 
 import com.ibm.icu.impl.ICUData;
 import com.ibm.icu.impl.ICUResourceBundle;
@@ -22,8 +23,15 @@ public class UnitsData {
     // data once, and provide access to it via static methods. (Partial change
     // has been done already.)
 
+
+
+    // Array of alias IDs.
+    private static List<UnitAliases.Alias> aliases = null;
+
     // Array of simple unit IDs.
     private static String[] simpleUnits = null;
+
+
 
     // Maps from the value associated with each simple unit ID to a category
     // index number.
@@ -42,6 +50,14 @@ public class UnitsData {
         return simpleUnits;
     }
 
+    public static List<UnitAliases.Alias> getAliases() {
+        return aliases;
+    }
+
+    public static String getReplacementFromAliasIndex(int aliasIndex) {
+        return aliases.get(aliasIndex).replacement;
+    }
+
     static {
         // Read simple units
         ICUResourceBundle resource;
@@ -50,6 +66,10 @@ public class UnitsData {
         resource.getAllItemsWithFallback("convertUnits", sink);
         simpleUnits = sink.simpleUnits;
         simpleUnitCategories = sink.simpleUnitCategories;
+
+        // Read aliases
+        UnitAliases unitAliases = new UnitAliases();
+        aliases = unitAliases.getAliases();
     }
 
     public ConversionRates getConversionRates() {
@@ -167,6 +187,9 @@ public class UnitsData {
     public static class Constants {
         // TODO: consider moving the Trie-offset-related constants into
         // MeasureUnitImpl.java, the only place they're being used?
+
+        // Trie value offset for aliases, e.g. "portion" replaced by "part"
+        public static final int kAliasOffset = 51200; // This will give a very big space for the units ids.
 
         // Trie value offset for simple units, e.g. "gram", "nautical-mile",
         // "fluid-ounce-imperial".


### PR DESCRIPTION
# Summary

In this PR, we **introduced unit aliases** into the **unit parser Trie**.  When the parser **encounters a unit alias** (e.g., **"permillion" → "part-per-1e6"**),  it **ignores the alias**, **replaces it with the canonical unit identifier**,  and then **continues parsing** as if the alias had never appeared.  

This guarantees that **all units with aliases are normalized** to their replacements,  ensuring **consistent parsing results** across both aliases and canonical forms.

### Example:

```
Input: "meter-permillion-second"
          │
          ▼
[1] Parser reads "meter"
    ✔ Parsed: [meter]
    Remaining: "permillion-second"

[2] Parser reads "permillion"
    🔎 Alias detected → replace with "part-per-1e6"
    ✔ Parsed so far: [meter]
    Remaining becomes: "part-per-1e6-second"

[3] Continue parsing...
    - "part"   → Parsed: [meter, part]
    - "per"    → Parsed: [meter, part, per]
    - "1e6"    → Parsed: [meter, part, per, 1e6]
    - "second" → Parsed: [meter, part, per, 1e6, second]

[✔] Final Result:
    "meter-part-per-1e6-second"
```
#### Before / After (at a glance)

Input : meter-permillion-second
Output: meter-part-per-1e6-second

#### Mini Parse Tree 

```
UnitsExpression
├─ Unit("meter")
├─ Unit("part")
├─ Token("per")
├─ Const("1e6")
└─ Unit("second")
```

-----------------
# Problem Statement

The problem is that we need to scan a CLDR unit ID (string) for any known aliases and replace each alias with its canonical replacement.

## Options

### 1) Brute force

Scan for each alias across the entire string; when an alias is found, replace it in-place (or build a new string with the replacement).

Pros
- Simple to implement.

Cons
- Performance: O(N × M), where N = length of the ID and M = number of aliases (each alias checked against the whole string).


### 2) Dedicated alias Trie

Build a separate Trie containing all aliases. At the start of beside the parsing Trie, run a pass over the CLDR ID to find/replace aliases using this Trie.

Pros
- Completes alias work up-front; parsing code doesn’t need to think about aliases afterward.

Cons
- Extra pass on every parse to check for aliases (often there are none).
- The mutated ID must represent the entire CLDR ID (see Option 3 which does need only the remainig part (unparsed part)).
- Requires maintaining a second Trie alongside the Parsing Trie.


### 3) Integrate aliases into the Parsing Trie (current PR)

Add alias entries directly to the existing Parsing Trie. When the parser encounters an alias token, it ignores that token, splices in the alias’s replacement, and continues parsing the remaining (unparsed) tail of the CLDR ID.

Pros
- No pre-scan for aliases; replacements occur naturally during parsing.
- No need to rewrite/add the entire string—only the unparsed remainder after the alias.
- No separate alias Trie to maintain.

Cons
- Less obvious than Option 2 and requires careful handling of token boundaries and continuation logic.

-----------------
# Implementations

## ICU4J

- Refactor NumberFormatterApiTest to improve test case structure for unit aliases.
- Introduce UnitAliases class to manage unit aliases and their replacements.
- Update UnitsData to load aliases and integrate them into the unit parsing logic.
- Modify LongNameHandler to prepare for future refactoring related to unit aliases.
- Add alias handling in MeasureUnitImpl to support alias replacements during parsing.

## ICU4C

- Introduced a new UnitAliasesSink class to collect unit aliases and their replacements from resource tables.
- Added support for alias handling in the Parser class, allowing for dynamic replacement of unit identifiers.
- Updated the initUnitExtras function to populate global vectors for unit aliases and replacements.
- Enhanced NumberFormatterApiTest to include tests for new unit aliases and ensure compatibility with existing formats.
- Added comments for future refactoring of LongNameHandler to utilize the new aliasing system.

---------------
#### Checklist
- [x] Required: Issue filed: ICU-23222
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
