### PR TITLE
ICU-23159 Changed parseUCARules() in the genrb tool to use a CharStri…

### DIFF
--- a/icu4c/source/tools/genrb/parse.cpp
+++ b/icu4c/source/tools/genrb/parse.cpp
@@ -320,9 +320,8 @@ parseUCARules(ParseState* state, char *tag, uint32_t startline, const struct USt
     struct SResource *result = nullptr;
     struct UString   *tokenValue;
     FileStream       *file          = nullptr;
-    char              filename[256] = { '\0' };
-    char              cs[128]       = { '\0' };
-    uint32_t          line;
+    CharString       filename;
+    uint32_t         line;
     UBool quoted = false;
     UCHARBUF *ucbuf=nullptr;
     UChar32   c     = 0;
@@ -345,15 +344,15 @@ parseUCARules(ParseState* state, char *tag, uint32_t startline, const struct USt
     /* make the filename including the directory */
     if (state->inputdir != nullptr)
     {
-        uprv_strcat(filename, state->inputdir);
+        filename.append(state->inputdir, -1, *status);
 
         if (state->inputdir[state->inputdirLength - 1] != U_FILE_SEP_CHAR)
         {
-            uprv_strcat(filename, U_FILE_SEP_STRING);
+            filename.append(U_FILE_SEP_CHAR, *status);
         }
     }
 
-    u_UCharsToChars(tokenValue->fChars, cs, tokenValue->fLength);
+    filename.appendInvariantChars(tokenValue->fChars, tokenValue->fLength, *status);
 
     expect(state, TOK_CLOSE_BRACE, nullptr, nullptr, nullptr, status);
 
@@ -361,16 +360,15 @@ parseUCARules(ParseState* state, char *tag, uint32_t startline, const struct USt
     {
         return nullptr;
     }
-    uprv_strcat(filename, cs);
 
     if(state->omitCollationRules) {
         return res_none();
     }
 
-    ucbuf = ucbuf_open(filename, &cp, getShowWarning(),false, status);
+    ucbuf = ucbuf_open(filename.data(), &cp, getShowWarning(),false, status);
 
     if (U_FAILURE(*status)) {
-        error(line, "An error occurred while opening the input file %s\n", filename);
+        error(line, "An error occurred while opening the input file %s\n", filename.data());
         return nullptr;
     }
 


### PR DESCRIPTION
…ng object for its filename manipulation.

Use of CharString should eliminate the possibility of buffer overflow problems.

I tested this by creating a directory with really long filenames (I used the filename in the ticket) and tried building ICU.  The `genrb` tool worked fine, but `genbrk` errored out (but didn't crash).  I also tried it with a normal-length path to confirm that ICU still built properly (that the changed code did the same thing as the original code).

#### Checklist
- [x] Required: Issue filed: ICU-23159
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
