### PR TITLE
ICU-23165 Fixed crash in the ISO 2022-CN converter.

### DIFF
--- a/icu4c/source/common/ucnv2022.cpp
+++ b/icu4c/source/common/ucnv2022.cpp
@@ -597,7 +597,7 @@ _ISO2022Open(UConverter *cnv, UConverterLoadArgs *pArgs, UErrorCode *errorCode){
             /* open the required converters and cache them */
             myConverterData->myConverterArray[GB2312_1] =
                 ucnv_loadSharedData("ibm-5478", &stackPieces, &stackArgs, errorCode);
-            if(version==1) {
+            if(version>=1) {
                 myConverterData->myConverterArray[ISO_IR_165] =
                     ucnv_loadSharedData("iso-ir-165", &stackPieces, &stackArgs, errorCode);
             }

--- a/icu4c/source/test/cintltst/ncnvtst.c
+++ b/icu4c/source/test/cintltst/ncnvtst.c
@@ -79,6 +79,7 @@ static void TestFlushInternalBuffer(void);  /*for improved code coverage in ucnv
 static void TestResetBehaviour(void);
 static void TestTruncated(void);
 static void TestUnicodeSet(void);
+static void TestISO2022Crash(void);
 
 static void TestWithBufferSize(int32_t osize, int32_t isize);
 
@@ -137,6 +138,7 @@ void addExtraTests(TestNode** root)
      addTest(root, &TestRegressionUTF32,            "tsconv/ncnvtst/TestRegressionUTF32");
      addTest(root, &TestTruncated,                  "tsconv/ncnvtst/TestTruncated");
      addTest(root, &TestUnicodeSet,                 "tsconv/ncnvtst/TestUnicodeSet");
+     addTest(root, &TestISO2022Crash,               "tsconv/ncnvtst/TestISO2022Crash");
 }
 
 /*test surrogate behaviour*/
@@ -2060,4 +2062,33 @@ TestUnicodeSet(void) {
     }
 
     uset_close(set);
+}
+
+// Test for https://unicode-org.atlassian.net/browse/ICU-23165
+static void TestISO2022Crash(void) {
+    static const char offendingText[] = {
+        0x6d, 0x1b, 0x24, 0x29, 0x45, 0x65, 0x6c, 0x3a,
+        0x6c, 0x2e, 0x27, 0x41, 0x41, 0x0e, 0x41, 0x6c,
+    };
+    UErrorCode   err = U_ZERO_ERROR;
+    UConverter * cnv = ucnv_open("ISO_2022,locale=zh,version=2", &err);
+    if (U_FAILURE(err)) {
+        log_data_err("Unable to open ISO-2022-CN converter: %s\n", u_errorName(err));
+        return;
+    }
+    ucnv_setToUCallBack(cnv, UCNV_TO_U_CALLBACK_ESCAPE, NULL, NULL, NULL, &err);
+    if (U_FAILURE(err)) {
+        log_data_err("Unable to setToUCallBack for ISO-2022-CN converter: %s\n", u_errorName(err));
+        ucnv_close(cnv);
+        return;
+    }
+    {
+        UChar         toUChars[100];
+        UChar *       toUCharsPtr = toUChars;
+        const UChar * toUCharsLimit = toUCharsPtr + 100;
+        const char *  inCharsPtr = offendingText;
+        const char *  inCharsLimit = offendingText + sizeof(offendingText);
+        ucnv_toUnicode(cnv, &toUCharsPtr, toUCharsLimit, &inCharsPtr, inCharsLimit, NULL, true, &err);
+    }
+    ucnv_close(cnv);
 }


### PR DESCRIPTION
There was an erroneous version check in one spot that could cause certain input strings to dereference a null pointer because a particular conversion table wasn't allocated. Added an appropriate unit test.

#### Checklist
- [x] Required: Issue filed: ICU-23165
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
