### PR TITLE
ICU-23056 ICU 78 scrub issues

### DIFF
--- a/icu4c/source/test/intltest/dtfmtrtts.cpp
+++ b/icu4c/source/test/intltest/dtfmtrtts.cpp
@@ -296,10 +296,6 @@ void DateFormatRoundTripTest::test(DateFormat *fmt, const Locale &origLocale, UB
       return;
     } 
     //logln(UnicodeString("Min date is ") + fullFormat(minDate)  + " for " + origLocale.getName());
-    if (uprv_strncmp(origLocale.getBaseName(),"scn",3) == 0) {
-        logKnownIssue("CLDR-18923", "Quoting in scn atTime/relative dateTimeFormats causes format/parse issues");
-        return;
-    }   
 
     pat = dynamic_cast<SimpleDateFormat*>(fmt)->toPattern(pat);
 

--- a/icu4c/source/test/intltest/dtifmtts.cpp
+++ b/icu4c/source/test/intltest/dtifmtts.cpp
@@ -2467,10 +2467,6 @@ void DateIntervalFormatTest::testTicket20710_IntervalIdentity() {
 
     for (int32_t i = 0; i < count; i++) {
         const Locale locale = locales[i];
-        if (uprv_strncmp(locale.getBaseName(),"scn",3) == 0) {
-            logKnownIssue("CLDR-18923", "Quoting in scn atTime/relative dateTimeFormats causes format/parse issues");
-            continue;
-        }
         LocalPointer<DateTimePatternGenerator> gen(DateTimePatternGenerator::createInstance(locale, status));
         LocalPointer<Calendar> calendar(Calendar::createInstance(TimeZone::createTimeZone(timeZone), status));
         calendar->setTime(static_cast<UDate>(1563235200000), status);

--- a/icu4c/source/test/intltest/numbertest_api.cpp
+++ b/icu4c/source/test/intltest/numbertest_api.cpp
@@ -6233,10 +6233,6 @@ void NumberFormatterApiTest::TestPortionFormat() {
     };
 
     for (auto testCase : testCases) {
-        //if (uprv_strcmp(testCase.unitIdentifier, "portion-per-1e9") != 0) {
-        //    logKnownIssue("CLDR-18274", "The data for portion-per-XYZ is not determined yet.");
-        //    continue;
-        //}
         MeasureUnit unit = MeasureUnit::forIdentifier(testCase.unitIdentifier, status);
         LocalizedNumberFormatter lnf =
             NumberFormatter::withLocale(Locale::forLanguageTag(testCase.locale, status))

--- a/icu4c/source/test/intltest/tsdate.cpp
+++ b/icu4c/source/test/intltest/tsdate.cpp
@@ -289,10 +289,6 @@ void IntlTestDateFormat::monsterTest(/*char *par*/)
         }
         for (int32_t i=0; i<count; ++i)
         {
-            if (uprv_strncmp(locales[i].getBaseName(),"scn",3) == 0) {
-                logKnownIssue("CLDR-18923", "Quoting in scn atTime/relative dateTimeFormats causes format/parse issues");
-                continue;
-            }
             UnicodeString name = UnicodeString(locales[i].getName(), "");
             logln(UnicodeString("Testing ") + name + "...");
             testLocale(/*par, */locales[i], name);

--- a/icu4c/source/test/intltest/tzfmttst.cpp
+++ b/icu4c/source/test/intltest/tzfmttst.cpp
@@ -171,16 +171,6 @@ TimeZoneFormatTest::TestTimeZoneRoundTrip() {
 
     // Run the roundtrip test
     for (int32_t locidx = 0; locidx < nLocales; locidx++) {
-        if (logKnownIssue("CLDR-18924", "Timezone round trip issues in ku, shn, sv for various zones") &&
-            (
-                (uprv_strcmp(LOCALES[locidx].getBaseName(),"ku") == 0) ||
-                (uprv_strncmp(LOCALES[locidx].getBaseName(),"ku_",3) == 0) ||
-                (uprv_strncmp(LOCALES[locidx].getBaseName(),"shn",3) == 0) ||
-                (uprv_strcmp(LOCALES[locidx].getBaseName(),"sv") == 0) ||
-                (uprv_strncmp(LOCALES[locidx].getBaseName(),"sv_",3) == 0)
-            )) {
-            continue;
-        }
 
         for (int32_t patidx = 0; patidx < UPRV_LENGTHOF(PATTERNS); patidx++) {
             SimpleDateFormat* sdf = new SimpleDateFormat(UnicodeString(PATTERNS[patidx]), LOCALES[locidx], status);
@@ -593,12 +583,6 @@ void TimeZoneFormatTest::RunTimeRoundTripTests(int32_t threadNumber) {
         timer = Calendar::getNow();
 
         while ((tzid = tzids->snext(status))) {
-            if (logKnownIssue("CLDR-18924", "Time round trip issues for Pacific/Apia in various locales and Pacific/Honolulu in Swedish" ) &&
-                (tzid->compare(u"Pacific/Apia", -1) == 0
-                || (tzid->compare(u"Pacific/Honolulu", -1) == 0 && uprv_strncmp(gLocaleData->locales[locidx].getBaseName(),"sv_",3) == 0))) {
-                continue;
-            }
-
             if (uprv_strcmp(PATTERNS[patidx], "V") == 0) {
                 // Some zones do not have short ID assigned, such as Asia/Riyadh87.
                 // The time roundtrip will fail for such zones with pattern "V" (short zone ID).

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/MeasureUnitTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/MeasureUnitTest.java
@@ -249,9 +249,6 @@ public class MeasureUnitTest extends CoreTestFmwk {
         mf = MeasureFormat.getInstance(ULocale.GERMAN, FormatWidth.WIDE, nf);
         verifyFormatPeriod("de FULL", mf, fullDataDe);
         mf = MeasureFormat.getInstance(ULocale.GERMAN, FormatWidth.NUMERIC, nf);
-        if (!logKnownIssue("CLDR-18905", "German narrow change needs revisiting")) {
-            verifyFormatPeriod("de NUMERIC", mf, numericDataDe);
-        }
 
         // Same tests, with Java Locale
         nf = NumberFormat.getNumberInstance(Locale.GERMAN);
@@ -259,9 +256,6 @@ public class MeasureUnitTest extends CoreTestFmwk {
         mf = MeasureFormat.getInstance(Locale.GERMAN, FormatWidth.WIDE, nf);
         verifyFormatPeriod("de FULL(Java Locale)", mf, fullDataDe);
         mf = MeasureFormat.getInstance(Locale.GERMAN, FormatWidth.NUMERIC, nf);
-        if (!logKnownIssue("CLDR-18905", "German narrow change needs revisiting")) {
-            verifyFormatPeriod("de NUMERIC(Java Locale)", mf, numericDataDe);
-        }
 
         ULocale bengali = ULocale.forLanguageTag("bn");
         nf = NumberFormat.getNumberInstance(bengali);
@@ -530,8 +524,8 @@ public class MeasureUnitTest extends CoreTestFmwk {
             }
             String result = mf.formatMeasures(hours, minutes);
             if (!result.equals(row[2])) {
-                if (((ULocale)row[0]).equals(ULocale.GERMAN) && 
-                    ((FormatWidth)row[1]).equals(FormatWidth.NARROW) && 
+                if (((ULocale)row[0]).equals(ULocale.GERMAN) &&
+                    ((FormatWidth)row[1]).equals(FormatWidth.NARROW) &&
                     logKnownIssue("CLDR-18905", "German narrow change needs revisiting")
                     ) {
                     continue;
@@ -1588,11 +1582,6 @@ public class MeasureUnitTest extends CoreTestFmwk {
             if (unit.getType() == "currency") {
                 continue;
             }
-
-            //if (unit.getIdentifier().equals("part-per-1e9")) {
-            //	logKnownIssue("ICU-22781", "Handle concentr/perbillion in ICU");
-            //	continue;
-            //}
 
             // Prove that all built-in units are parseable, except "generic" temperature
             // (and for now, beaufort units)

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/NumberFormatTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/NumberFormatTest.java
@@ -7195,10 +7195,6 @@ public class NumberFormatTest extends CoreTestFmwk {
         };
 
         for (TestCase testCase : testCases) {
-            //if (testCase.unitIdentifier.compareTo("portion-per-1e9") != 0) {
-            //    logKnownIssue("CLDR-18274", "The data for portion-per-XYZ is not determined yet.");
-            //    continue;
-            //}
             MeasureUnit unit = MeasureUnit.forIdentifier(testCase.unitIdentifier);
             LocalizedNumberFormatter formatter = NumberFormatter.withLocale(ULocale.forLanguageTag(testCase.locale))
                     .unit(unit)

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/TimeZoneFormatTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/TimeZoneFormatTest.java
@@ -144,16 +144,6 @@ public class TimeZoneFormatTest extends CoreTestFmwk {
 
         // Run the roundtrip test
         for (int locidx = 0; locidx < LOCALES.length; locidx++) {
-            if (logKnownIssue("CLDR-18924", "Timezone round trip issues in ku, shn, sv for various zones") &&
-            	(
-            	    LOCALES[locidx].getBaseName().equals("ku") ||
-                    LOCALES[locidx].getBaseName().startsWith("ku_") ||
-                    LOCALES[locidx].getBaseName().startsWith("shn") ||
-                    LOCALES[locidx].getBaseName().equals("sv") ||
-                    LOCALES[locidx].getBaseName().startsWith("sv_")
-                )) {
-                continue;
-            }
             logln("Locale: " + LOCALES[locidx].toString());
 
             for (int patidx = 0; patidx < PATTERNS.length; patidx++) {
@@ -410,14 +400,6 @@ public class TimeZoneFormatTest extends CoreTestFmwk {
                 }
 
                 for (String id : ids) {
-                	if (logKnownIssue("CLDR-18924", "Time round trip issues for Pacific/Apia in various locales and Pacific/Honolulu in Swedish") &&
-                		(
-                		    id.equals("Pacific/Apia") ||
-                		    (id.equals("Pacific/Honolulu") && LOCALES[locidx].getLanguage().equals("sv"))
-                		)) {
-                		continue;
-                	}
-
                 	if (PATTERNS[patidx].equals("V")) {
                         // Some zones do not have short ID assigned, such as Asia/Riyadh87.
                         // The time roundtrip will fail for such zones with pattern "V" (short zone ID).
@@ -433,12 +415,6 @@ public class TimeZoneFormatTest extends CoreTestFmwk {
                         if (id.indexOf('/') < 0 || LOC_EXCLUSION_PATTERN.matcher(id).matches()) {
                             continue;
                         }
-                    }
-
-                    if ((id.equals("Pacific/Apia") || id.equals("Pacific/Midway") || id.equals("Pacific/Pago_Pago"))
-                            && PATTERNS[patidx].equals("vvvv")
-                            && logKnownIssue("11052", "Ambiguous zone name - Samoa Time")) {
-                        continue;
                     }
 
                     BasicTimeZone btz = (BasicTimeZone)TimeZone.getTimeZone(id, TimeZone.TIMEZONE_ICU);

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DateIntervalFormatTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/DateIntervalFormatTest.java
@@ -2581,10 +2581,6 @@ public class DateIntervalFormatTest extends CoreTestFmwk {
 
         for (int i = 0; i < locales.length; i++) {
             ULocale locale = locales[i];
-            if (locale.getBaseName().startsWith("scn")) {
-                logKnownIssue("CLDR-18923", "Quoting in scn atTime/relative dateTimeFormats causes format/parse issues");
-                continue;
-            }
             DateTimePatternGenerator gen = DateTimePatternGenerator.getInstance(locale);
             Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone(timeZone));
             calendar.setTimeInMillis(1563235200000l);

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/IntlTestDateFormat.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/format/IntlTestDateFormat.java
@@ -268,10 +268,6 @@ public class IntlTestDateFormat extends CoreTestFmwk {
         long count = locales.length;
         if (locales != null  &&  count != 0) {
             for (int i=0; i<count; ++i) {
-                if (locales[i].getBaseName().startsWith("scn")) {
-                    logKnownIssue("CLDR-18923", "Quoting in scn atTime/relative dateTimeFormats causes format/parse issues");
-                    continue;
-                }
                 String name = locales[i].getDisplayName();
                 logln("Testing " + name + "...");
                 try {


### PR DESCRIPTION
Removing known issues and TODOs that have been marked as complete in Jira.
- CLDR-18274
- CLDR-18923
- CLDR-18924
- ICU-11052

The following known issues and TODOs are closed, but removing logKnownIssue() (completely) yields test failures:
- CLDR-18901 Disallow [❰❱] in XML element values.
  - --> CLDR team fixing remaining cases
- CLDR-18905 How long can narrow be for hour duration (units)?
  - --> **change ICU tests**
- ICU-23104 With integration of CLDR 48 m1 data, strange handling of 'part-per-1e9' in number skeletons
  - **ICU TODO**
- ICU-23185 became CLDR-18934 Revisit Date time formatting with hz and hv patterns for German
  - --> **change ICU tests**
- ICU-23202
  - TODO removed in https://github.com/unicode-org/icu/pull/3699

#### Checklist
- [x] Required: Issue filed: ICU-23056
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
