### PR TITLE
ICU-23228 Fix bugs from static analyzer

### DIFF
--- a/icu4c/source/common/normalizer2impl.cpp
+++ b/icu4c/source/common/normalizer2impl.cpp
@@ -585,6 +585,10 @@ const char16_t *
 Normalizer2Impl::decompose(const char16_t *src, const char16_t *limit,
                            ReorderingBuffer *buffer,
                            UErrorCode &errorCode) const {
+    if(src==nullptr) {
+        errorCode=U_ILLEGAL_ARGUMENT_ERROR;
+        return src;
+    }
     UChar32 minNoCP=minDecompNoCP;
     if(limit==nullptr) {
         src=copyLowPrefixFromNulTerminated(src, minNoCP, buffer, errorCode);

--- a/icu4c/source/common/uresbund.cpp
+++ b/icu4c/source/common/uresbund.cpp
@@ -1449,14 +1449,14 @@ UResourceBundle *init_resb_result(
     }
     if(key != nullptr) {
         ures_appendResPath(resB, key, static_cast<int32_t>(uprv_strlen(key)), status);
-        if(resB->fResPath[resB->fResPathLen-1] != RES_PATH_SEPARATOR) {
+        if(resB->fResPathLen > 0 && resB->fResPath[resB->fResPathLen-1] != RES_PATH_SEPARATOR) {
             ures_appendResPath(resB, RES_PATH_SEPARATOR_S, 1, status);
         }
     } else if(idx >= 0) {
         char buf[256];
         int32_t len = T_CString_integerToString(buf, idx, 10);
         ures_appendResPath(resB, buf, len, status);
-        if(resB->fResPath[resB->fResPathLen-1] != RES_PATH_SEPARATOR) {
+        if(resB->fResPathLen > 0 && resB->fResPath[resB->fResPathLen-1] != RES_PATH_SEPARATOR) {
             ures_appendResPath(resB, RES_PATH_SEPARATOR_S, 1, status);
         }
     }

--- a/icu4c/source/i18n/calendar.cpp
+++ b/icu4c/source/i18n/calendar.cpp
@@ -1828,6 +1828,9 @@ void Calendar::roll(UCalendarDateFields field, int32_t amount, UErrorCode& statu
             }
             if (era > 0 || newYear >= 1) {
                 int32_t maxYear = getActualMaximum(field, status);
+                if (U_FAILURE(status)) {
+                    return;
+                }
                 if (maxYear < 32768) {
                     // this era has real bounds, roll should wrap years
                     if (newYear < 1) {

--- a/icu4c/source/i18n/dtptngen.cpp
+++ b/icu4c/source/i18n/dtptngen.cpp
@@ -2816,6 +2816,9 @@ PtnSkeleton::PtnSkeleton(const PtnSkeleton& other) {
 }
 
 void PtnSkeleton::copyFrom(const PtnSkeleton& other) {
+    if (this == &other) {
+        return;
+    }
     uprv_memcpy(type, other.type, sizeof(type));
     original.copyFrom(other.original);
     baseOriginal.copyFrom(other.baseOriginal);

--- a/icu4c/source/i18n/rulebasedcollator.cpp
+++ b/icu4c/source/i18n/rulebasedcollator.cpp
@@ -665,8 +665,9 @@ RuleBasedCollator::setReorderCodes(const int32_t *reorderCodes, int32_t length,
     if(length == 1 && reorderCodes[0] == UCOL_REORDER_CODE_NONE) {
         length = 0;
     }
-    if(length == settings->reorderCodesLength &&
-            uprv_memcmp(reorderCodes, settings->reorderCodes, length * 4) == 0) {
+    if (length == settings->reorderCodesLength &&
+            (length == 0 || 
+                uprv_memcmp(reorderCodes, settings->reorderCodes, length * 4) == 0)) {
         return;
     }
     const CollationSettings &defaultSettings = getDefaultSettings();

--- a/icu4c/source/i18n/uspoof.cpp
+++ b/icu4c/source/i18n/uspoof.cpp
@@ -169,7 +169,7 @@ uspoof_clone(const USpoofChecker *sc, UErrorCode *status) {
     }
     if (U_FAILURE(*status)) {
         delete result;
-        result = nullptr;
+        return nullptr;
     }
     return result->asUSpoofChecker();
 }


### PR DESCRIPTION
When analyzing chromium code 
During the analysis chromium code with clang-sa, cppcheck and clang-tidy, we find a number of bugs.

Fix bugs from static analyzer (first part)
icu4c/source/common/cmemory.h - "Arguments must not be overlapping buffers"
icu4c/source/i18n/dtptngen.cpp - "Arguments must not be overlapping buffers"
icu4c/source/common/normalizer2impl.cpp - "Dereference of null pointer"(icu4c/source/source/i18n/rulebasedcollator.cpp:1376)
icu4c/source/i18n/uspoof.cpp - "Dereference of null pointer"
icu4c/source/common/uresbund.cpp  - "Access of the field 'fResBuf' at negative byte offset -1" when fResPathLen == 0
icu4c/source/i18n/calendar.cpp - "Division by zero" (getActualMaximum can return 0)

#### Checklist
- [x] Required: Issue filed: ICU-23228
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-23228 Fix Clang Static Analyzer findings"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-23228 Fix Clang Static Analyzer findings"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
