### PR TITLE
ICU-23231 Update BRS release tag docs with new release tag naming scheme

### DIFF
--- a/docs/processes/release/tasks/publish/index.md
+++ b/docs/processes/release/tasks/publish/index.md
@@ -102,7 +102,7 @@ Use the GitHub GUI to create both the "release" and the "tag" at the same time:
 
 <https://github.com/unicode-org/icu/releases/new>
 
-1. Fill in the tag name, such as `release-63-1rc` or `release-63-1`, and make the
+1. Fill in the tag name, such as `release-63.1rc` or `release-63.1`, and make the
 target the "maint/maint-xx" branch (such as `maint/maint-63`).
 1. Set the title to `ICU 63 RC` or `ICU 63.1`.
 1. Fill in the description using the
@@ -127,8 +127,12 @@ repository, they might have something different for the "latest" tag).
 A possible future alternative might be a sym-link folder, or HTTP redirect that
 points to the latest release.
 
-We no longer need to add the note about Git LFS files, as GitHub now includes
+Note: We no longer need to add the note about Git LFS files, as GitHub now includes
 them in the auto-generated .zip downloads.
+
+Note: The release tag name convention changed with ICU 78.
+Prior, the convention was like `release-63-rc` or `release-63-1`.
+Afterwards, the convention is like `release-63.1rc` or `release-63.1`.
 
 #### Maintenance release
 


### PR DESCRIPTION
Updating the docs for BRS tasks to reflect the new git tag naming convention that is applied to Github releases.

Targeting branch `main` because these are docs update and thus should be on `main` so that they show up immediately.

#### Checklist
- [X] Required: Issue filed: ICU-23231
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [X] API docs and/or User Guide docs changed or added, if applicable
