### PR TITLE
ICU-23345 Require Range to be a range in UTFStringCodePoints to improve error messages

### DIFF
--- a/icu4c/source/common/unicode/utfiterator.h
+++ b/icu4c/source/common/unicode/utfiterator.h
@@ -12,6 +12,9 @@
 #if U_SHOW_CPLUSPLUS_API || U_SHOW_CPLUSPLUS_HEADER_API || !defined(UTYPES_H)
 
 #include <iterator>
+#if __has_include(<version>)
+#include <version>
+#endif
 #if defined(__cpp_lib_ranges)
 #include <ranges>
 #endif
@@ -1749,6 +1752,9 @@ auto utfIterator(UnitIter p) {
  * @see utfStringCodePoints
  */
 template<typename CP32, UTFIllFormedBehavior behavior, typename Range>
+#if defined(__cpp_lib_ranges)
+    requires std::ranges::range<Range>
+#endif
 class UTFStringCodePoints {
     static_assert(sizeof(CP32) == 4, "CP32 must be a 32-bit type to hold a code point");
 public:
@@ -2467,6 +2473,9 @@ auto unsafeUTFIterator(UnitIter iter) {
  * @see unsafeUTFStringCodePoints
  */
 template<typename CP32, typename Range>
+#if defined(__cpp_lib_ranges)
+    requires std::ranges::range<Range>
+#endif
 class UnsafeUTFStringCodePoints {
     static_assert(sizeof(CP32) == 4, "CP32 must be a 32-bit type to hold a code point");
 public:


### PR DESCRIPTION
Suggested by @jmr after seeing the error messages generated by `UTFStringCodePoints<..., char>` (which was how this API worked in an earlier draft).

TODO: Fill out the checklist below.

#### Checklist
- [x] Required: Issue filed: ICU-23345
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-1234 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
