### PR TITLE
ICU-23348 Fix thread safety issues with parsing and formatting in RuleBasedNumberFormat

### DIFF
--- a/icu4c/source/i18n/rbnf.cpp
+++ b/icu4c/source/i18n/rbnf.cpp
@@ -785,6 +785,10 @@ RuleBasedNumberFormat::operator=(const RuleBasedNumberFormat& rhs)
     setDefaultRuleSet(rhs.getDefaultRuleSetName(), status);
     setRoundingMode(rhs.getRoundingMode());
 
+    if (lenient) {
+        initializeCollator(status);
+    }
+
     capitalizationInfoSet = rhs.capitalizationInfoSet;
     capitalizationForUIListMenu = rhs.capitalizationForUIListMenu;
     capitalizationForStandAlone = rhs.capitalizationForStandAlone;
@@ -1202,7 +1206,11 @@ RuleBasedNumberFormat::adjustForCapitalizationContext(int32_t startPos,
                 (capitalizationContext == UDISPCTX_CAPITALIZATION_FOR_STANDALONE && capitalizationForStandAlone)) ) {
             // titlecase first word of currentResult, here use sentence iterator unlike current implementations
             // in LocaleDisplayNamesImpl::adjustForUsageAndContext and RelativeDateFormat::format
-            currentResult.toTitle(capitalizationBrkIter, locale, U_TITLECASE_NO_LOWERCASE | U_TITLECASE_NO_BREAK_ADJUSTMENT);
+            // Clone the break iterator to avoid mutating it in a const method (thread safety).
+            LocalPointer<BreakIterator> iter(capitalizationBrkIter->clone());
+            if (iter.isValid()) {
+                currentResult.toTitle(iter.getAlias(), locale, U_TITLECASE_NO_LOWERCASE | U_TITLECASE_NO_BREAK_ADJUSTMENT);
+            }
         }
     }
 #endif
@@ -1273,6 +1281,10 @@ RuleBasedNumberFormat::setLenient(UBool enabled)
     if (!enabled && collator) {
         delete collator;
         collator = nullptr;
+    } else if (enabled && collator == nullptr) {
+        // Eagerly initialize the collator so that getCollator() is thread-safe.
+        UErrorCode status = U_ZERO_ERROR;
+        initializeCollator(status);
     }
 }
 
@@ -1686,55 +1698,52 @@ RuleBasedNumberFormat::dispose()
 //-----------------------------------------------------------------------
 
 /**
- * Returns the collator to use for lenient parsing.  The collator is lazily created:
- * this function creates it the first time it's called.
- * @return The collator to use for lenient parsing, or null if lenient parsing
+ * Initializes the collator for lenient parsing. Must be called from
+ * non-const methods (setLenient, operator=) so that getCollator() can
+ * be thread-safe.
+ */
+void
+RuleBasedNumberFormat::initializeCollator(UErrorCode &status)
+{
+#if !UCONFIG_NO_COLLATION
+    if (collator != nullptr || !fRuleSets) {
+        return;
+    }
+
+    Collator* temp = Collator::createInstance(locale, status);
+    RuleBasedCollator* newCollator;
+    if (U_SUCCESS(status) && (newCollator = dynamic_cast<RuleBasedCollator*>(temp)) != nullptr) {
+        if (lenientParseRules) {
+            UnicodeString rules(newCollator->getRules());
+            rules.append(*lenientParseRules);
+
+            newCollator = new RuleBasedCollator(rules, status);
+            // Exit if newCollator could not be created.
+            if (newCollator == nullptr) {
+                status = U_MEMORY_ALLOCATION_ERROR;
+                return;
+            }
+        } else {
+            temp = nullptr;
+        }
+        if (U_SUCCESS(status)) {
+            newCollator->setAttribute(UCOL_DECOMPOSITION_MODE, UCOL_ON, status);
+            collator = newCollator;
+        } else {
+            delete newCollator;
+        }
+    }
+    delete temp;
+#endif
+}
+
+/**
+ * Returns the collator to use for lenient parsing, or null if lenient parsing
  * is turned off.
 */
 const RuleBasedCollator*
 RuleBasedNumberFormat::getCollator() const
 {
-#if !UCONFIG_NO_COLLATION
-    if (!fRuleSets) {
-        return nullptr;
-    }
-
-    // lazy-evaluate the collator
-    if (collator == nullptr && lenient) {
-        // create a default collator based on the formatter's locale,
-        // then pull out that collator's rules, append any additional
-        // rules specified in the description, and create a _new_
-        // collator based on the combination of those rules
-
-        UErrorCode status = U_ZERO_ERROR;
-
-        Collator* temp = Collator::createInstance(locale, status);
-        RuleBasedCollator* newCollator;
-        if (U_SUCCESS(status) && (newCollator = dynamic_cast<RuleBasedCollator*>(temp)) != nullptr) {
-            if (lenientParseRules) {
-                UnicodeString rules(newCollator->getRules());
-                rules.append(*lenientParseRules);
-
-                newCollator = new RuleBasedCollator(rules, status);
-                // Exit if newCollator could not be created.
-                if (newCollator == nullptr) {
-                    return nullptr;
-                }
-            } else {
-                temp = nullptr;
-            }
-            if (U_SUCCESS(status)) {
-                newCollator->setAttribute(UCOL_DECOMPOSITION_MODE, UCOL_ON, status);
-                // cast away const
-                const_cast<RuleBasedNumberFormat*>(this)->collator = newCollator;
-            } else {
-                delete newCollator;
-            }
-        }
-        delete temp;
-    }
-#endif
-
     // if lenient-parse mode is off, this will be null
     // (see setLenientParseMode())
     return collator;

--- a/icu4c/source/i18n/unicode/rbnf.h
+++ b/icu4c/source/i18n/unicode/rbnf.h
@@ -1135,6 +1135,7 @@ private:
     friend class FractionalPartSubstitution;
 
     inline NFRuleSet * getDefaultRuleSet() const;
+    void initializeCollator(UErrorCode &status);
     const RuleBasedCollator * getCollator() const;
     DecimalFormatSymbols * initializeDecimalFormatSymbols(UErrorCode &status);
     const DecimalFormatSymbols * getDecimalFormatSymbols() const;

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/RuleBasedNumberFormat.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/RuleBasedNumberFormat.java
@@ -1356,6 +1356,11 @@ public class RuleBasedNumberFormat extends NumberFormat implements Cloneable {
      */
     public void setLenientParseMode(boolean enabled) {
         lenientParse = enabled;
+        if (enabled) {
+            // Eagerly initialize the scanner provider so that getLenientScannerProvider()
+            // is thread-safe when called from parse().
+            initializeLenientScannerProvider();
+        }
     }
 
     /**
@@ -1392,10 +1397,20 @@ public class RuleBasedNumberFormat extends NumberFormat implements Cloneable {
      * @stable ICU 4.4
      */
     public RbnfLenientScannerProvider getLenientScannerProvider() {
-        // there's a potential race condition if two threads try to set/get the scanner at
-        // the same time, but you get what you get, and you shouldn't be using this from
-        // multiple threads anyway.
         if (scannerProvider == null && lenientParse && !lookedForScanner) {
+            initializeLenientScannerProvider();
+        }
+
+        return scannerProvider;
+    }
+
+    /**
+     * Attempts to instantiate the default lenient scanner provider. Called eagerly from
+     * setLenientParseMode() so that getLenientScannerProvider() does not need to perform lazy
+     * initialization from parse() (thread safety).
+     */
+    private void initializeLenientScannerProvider() {
+        if (scannerProvider == null && !lookedForScanner) {
             try {
                 lookedForScanner = true;
                 Class<?> cls = Class.forName("com.ibm.icu.impl.text.RbnfScannerProviderImpl");
@@ -1406,8 +1421,6 @@ public class RuleBasedNumberFormat extends NumberFormat implements Cloneable {
                 // any failure, we just ignore and return null
             }
         }
-
-        return scannerProvider;
     }
 
     /**
@@ -2052,10 +2065,12 @@ public class RuleBasedNumberFormat extends NumberFormat implements Cloneable {
                     // should only happen when deserializing, etc.
                     capitalizationBrkIter = BreakIterator.getSentenceInstance(locale);
                 }
+                // Clone the break iterator to avoid mutating it (thread safety).
+                BreakIterator iter = (BreakIterator) capitalizationBrkIter.clone();
                 return UCharacter.toTitleCase(
                         locale,
                         result,
-                        capitalizationBrkIter,
+                        iter,
                         UCharacter.TITLECASE_NO_LOWERCASE
                                 | UCharacter.TITLECASE_NO_BREAK_ADJUSTMENT);
             }


### PR DESCRIPTION
I recommend moving the collator construction from `RuleBasedNumberFormat::getCollator` to `RuleBasedNumberFormat::setLenient(true)`. The getCollator casts away const, and this initialization doesn’t seem thread safe.

Also the formatting code can use `adjustForCapitalizationContext`, which uses the same break iterator between threads, which is not thread safe. It should clone the break iterator to keep the state separate between threads.

#### Checklist
- [x] Required: Issue filed: ICU-23348
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
