### PR TITLE
ICU-23360 Deduplicate subdivision suffix strings in ValiditySet

### DIFF
--- a/icu4j/main/core/src/main/java/com/ibm/icu/impl/ValidIdentifiers.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/impl/ValidIdentifiers.java
@@ -62,7 +62,7 @@ public class ValidIdentifiers {
                         pos2 = pos = s.charAt(0) < 'A' ? 3 : 2;
                     }
                     final String key = s.substring(0, pos);
-                    final String subdivision = s.substring(pos2);
+                    final String subdivision = s.substring(pos2).intern();
 
                     Set<String> oldSet = _subdivisionData.get(key);
                     if (oldSet == null) {


### PR DESCRIPTION
Deduplicate subdivision suffix strings in `ValiditySet` by calling `intern()` on each suffix during construction. Of ~5,910 expanded subdivision entries, only 1,992 suffixes are unique; the remaining 3,918 are duplicate `String` objects (~195 KB).

### Problem

`ValiditySet` calls `substring()` for each subdivision suffix, creating a new `String` per entry. Suffixes like `"01"`, `"02"`, `"zzzz"` repeat across many of the 257 regions:

| Suffix | Occurrences |
|--------|-------------|
| `"zzzz"` | 257 |
| `"05"` | 56 |
| `"03"` | 55 |
| `"01"` | 52 |
| `"06"` | 52 |

Total: 5,910 suffix strings, 1,992 unique, 3,918 duplicates (~195 KB wasted).

### Fix

Call `intern()` on each subdivision suffix string. The JVM's intern pool ensures that identical suffixes share a single String instance. The change is a one-line addition.

On Android, `ValidityData` is initialized in the zygote process, which is forked to launch every app. Deduplicating these strings means the shared pages backing them are less likely to be copy-on-written post-fork, so the ~195 KB saving is effectively per-process across every running app.

### Why not intern more broadly?

Other interning targets were analyzed and rejected:

- **Region keys** (subdivisionData map keys): unique within each map by definition. Cross-`ValiditySet` sharing (e.g. `"us"` in both the deprecated and regular `ValiditySet`) would save at most 257 short strings (~12 KB), but would require hoisting the pool out of the constructor into `ValidityData.static{}` and passing it as a constructor parameter, since the `deprecated` and `regular` `ValiditySet` instances are constructed in separate calls.
- **regularData strings** (language, currency, script, etc.): stored in `HashSet`s that already deduplicate internally. Cross-`ValiditySet` overlap is rare by design.
- **Full `Set<String>` dedup** across `ValiditySet` instances: two different `Datasubtype`s for the same `Datatype` having identical code sets is not expected in practice.

### icu4c

No parallel icu4c change needed. The C++ side doesn't have an equivalent `ValidIdentifiers`/`ValiditySet` class; subdivision validity goes through a different code path.

#### Checklist
- [x] Required: Issue filed: ICU-23360
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf