### PR TITLE
ICU-23341 Update tests for Japanese eras

### DIFF
--- a/icu4c/source/test/cintltst/ccaltst.c
+++ b/icu4c/source/test/cintltst/ccaltst.c
@@ -2168,7 +2168,7 @@ void TestAddRollEra0AndEraBounds(void) {
     const EraTestItem * eraTestItemPtr;
     for (eraTestItemPtr = eraTestItems; eraTestItemPtr->locale != NULL; eraTestItemPtr++) {
         if (uprv_strstr(eraTestItemPtr->locale, "calendar=japanese") != NULL &&
-                log_knownIssue("ICU-23341", "ICU needs to handle removal of data for pre-Meiji Japanese eras")) {
+                log_knownIssue("ICU-23108", "ICU needs to implement era inheritance")) {
             continue;
         }
         UErrorCode status = U_ZERO_ERROR;

--- a/icu4c/source/test/intltest/incaltst.cpp
+++ b/icu4c/source/test/intltest/incaltst.cpp
@@ -579,7 +579,7 @@ void IntlCalendarTest::TestJapaneseFormat() {
     
     // Now, try in Japanese
     {
-        UnicodeString expect = CharsToUnicodeString("\\u5e73\\u621013\\u5e749\\u67088\\u65e5\\u571f\\u66dc\\u65e5");
+        UnicodeString expect = u"平成13年9月8日土曜日";
         UDate         expectDate = 999932400000.0; // Testing a recent date
         Locale        loc("ja_JP@calendar=japanese");
         
@@ -587,16 +587,15 @@ void IntlCalendarTest::TestJapaneseFormat() {
         simpleTest(loc, expect, expectDate, status);
     }
     {
-        UnicodeString expect = CharsToUnicodeString("\\u5e73\\u621013\\u5e749\\u67088\\u65e5\\u571f\\u66dc\\u65e5");
+        UnicodeString expect = u"平成13年9月8日土曜日";
         UDate         expectDate = 999932400000.0; // Testing a recent date
         Locale        loc("ja_JP@calendar=japanese");
         
         status = U_ZERO_ERROR;
         simpleTest(loc, expect, expectDate, status);
     }
-    if (!logKnownIssue("ICU-23341", "ICU needs to handle removal of data for pre-Meiji Japanese eras")) {
-        // When era for 1776 is deleted, format result will be different
-        UnicodeString expect = CharsToUnicodeString("\\u5b89\\u6c385\\u5e747\\u67084\\u65e5\\u6728\\u66dc\\u65e5");
+    if (!logKnownIssue("ICU-23108", "ICU needs to implement era inheritance")) {
+        UnicodeString expect = u"西暦1776年7月4日木曜日";
         UDate         expectDate = -6106032422000.0; // 1776-07-04T00:00:00Z-075258
         Locale        loc("ja_JP@calendar=japanese");
         
@@ -604,8 +603,8 @@ void IntlCalendarTest::TestJapaneseFormat() {
         simpleTest(loc, expect, expectDate, status);    
         
     }
-    {   // Jitterbug 1869 - this is an ambiguous era. (Showa 64 = Jan 6 1989, but Showa could be 2 other eras) )
-        UnicodeString expect = CharsToUnicodeString("\\u662d\\u548c64\\u5e741\\u67086\\u65e5\\u91d1\\u66dc\\u65e5");
+    {
+        UnicodeString expect = u"昭和64年1月6日金曜日";
         UDate         expectDate = 600076800000.0;
         Locale        loc("ja_JP@calendar=japanese");
         
@@ -613,8 +612,8 @@ void IntlCalendarTest::TestJapaneseFormat() {
         simpleTest(loc, expect, expectDate, status);    
         
     }
-    {   // 1989 Jan 9 Monday = Heisei 1; full is Gy年M月d日EEEE => 平成元年1月9日月曜日
-        UnicodeString expect = CharsToUnicodeString("\\u5E73\\u6210\\u5143\\u5E741\\u67089\\u65E5\\u6708\\u66DC\\u65E5");
+    {   // 1989 Jan 9 Monday = Heisei 1; full is Gy年M月d日EEEE
+        UnicodeString expect = u"平成元年1月9日月曜日";
         UDate         expectDate = 600336000000.0;
         Locale        loc("ja_JP@calendar=japanese");
         
@@ -622,10 +621,8 @@ void IntlCalendarTest::TestJapaneseFormat() {
         simpleTest(loc, expect, expectDate, status);    
         
     }
-    if (!logKnownIssue("ICU-23341", "ICU needs to handle removal of data for pre-Meiji Japanese eras")) {
-        // This Feb 29th falls on a leap year by gregorian year, but not by Japanese year.
-        // When era for 1456 is deleted, format result will be different
-        UnicodeString expect = CharsToUnicodeString("\\u5EB7\\u6B632\\u5e742\\u670829\\u65e5\\u65e5\\u66dc\\u65e5");
+    if (!logKnownIssue("ICU-23108", "ICU needs to implement era inheritance")) {
+        UnicodeString expect = u"西暦1456年2月29日日曜日";
         UDate         expectDate =  -16214400422000.0;  // 1456-03-09T00:00Z-075258
         Locale        loc("ja_JP@calendar=japanese");
         

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/IBMCalendarTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/IBMCalendarTest.java
@@ -2480,9 +2480,7 @@ public class IBMCalendarTest extends CalendarTestFmwk {
         TimeZone zoneGMT = TimeZone.getFrozenTimeZone("GMT");
         for (String localeID : localeIDs) {
             if (localeID.contains("calendar=japanese")
-                    && logKnownIssue(
-                            "ICU-23341",
-                            "ICU needs to handle removal of data for pre-Meiji Japanese eras")) {
+                    && logKnownIssue("ICU-23108", "ICU needs to implement era inheritance")) {
                 continue;
             }
             Calendar ucalTest = Calendar.getInstance(zoneGMT, new ULocale(localeID));

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/JapaneseTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/JapaneseTest.java
@@ -462,8 +462,7 @@ public class JapaneseTest extends CalendarTestFmwk {
         int expectedA[] = {Calendar.ERA, JapaneseCalendar.MEIJI};
         checkExpected(c, expectedA);
 
-        if (!logKnownIssue(
-                "ICU-23341", "ICU needs to handle removal of data for pre-Meiji Japanese eras")) {
+        if (!logKnownIssue("ICU-23108", "ICU needs to implement era inheritance")) {
             logln("test setting era and year and month and date");
             c.clear();
             c.set(Calendar.ERA, JapaneseCalendar.MEIJI);
@@ -471,7 +470,7 @@ public class JapaneseTest extends CalendarTestFmwk {
             c.set(Calendar.MONTH, Calendar.JANUARY);
             c.set(Calendar.DATE, 1);
 
-            int expectedC[] = {Calendar.ERA, JapaneseCalendar.MEIJI - 1};
+            int expectedC[] = {Calendar.ERA, JapaneseCalendar.AD};
             checkExpected(c, expectedC);
 
             logln("test setting  year and month and date THEN era");


### PR DESCRIPTION
Updated some test expectations, however these are still not passing as ICU does not currently implement the `inheritEra`s field, so the Japanese calendar doesn't have the Gregorian eras.

#### Checklist
- [x] Required: Issue filed: ICU-23341
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf
