### PR TITLE
ICU-23361 fixed potential NULL pointer dereference

### DIFF
--- a/icu4c/source/i18n/rbnf.cpp
+++ b/icu4c/source/i18n/rbnf.cpp
@@ -649,11 +649,13 @@ StringLocalizationInfo::create(const UnicodeString& info, UParseError& perror, U
 }
 
 StringLocalizationInfo::~StringLocalizationInfo() {
-    for (char16_t*** p = data; *p; ++p) {
-        // remaining data is simply pointer into our unicode string data.
-        if (*p) uprv_free(*p);
+    if (data) {
+        for (char16_t*** p = data; *p; ++p) {
+            // remaining data is simply pointer into our unicode string data.
+            if (*p) uprv_free(*p);
+        }
+        uprv_free(data);
     }
-    if (data) uprv_free(data);
     if (info) uprv_free(info);
 }
 


### PR DESCRIPTION
Added a check for if (data) before iterating over the pointer array to prevent a segfault if the data member is null.

Found by PostgresPro.
Fixes: eb31068f2a ("ICU-3634 localized RBNF rule set names - text description")

#### Checklist
- [x] Required: Issue filed: ICU-23361
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
