### PR TITLE
ICU-23334 Fix plurrule_fuzzer: clamp UPluralType enum and add NULL check

### DIFF
--- a/icu4c/source/test/fuzzer/plurrule_fuzzer.cpp
+++ b/icu4c/source/test/fuzzer/plurrule_fuzzer.cpp
@@ -12,7 +12,7 @@
 
 
 void TestPluralRules(icu::PluralRules* pp, int32_t number, double dbl,  UErrorCode& status) {
-    if (U_FAILURE(status)) {
+    if (U_FAILURE(status) || pp == nullptr) {
         return;
     }
     pp->select(number);
@@ -31,8 +31,8 @@ void TestPluralRulesWithLocale(
     pp.reset(icu::PluralRules::forLocale(locale, type, status));
     TestPluralRules(pp.get(), number, dbl, status);
 
-    type = static_cast<UPluralType>(
-        static_cast<int>(type) % (static_cast<int>(UPLURAL_TYPE_COUNT)));
+    // Clamp type to valid values: 0 (CARDINAL) or 1 (ORDINAL)
+    type = static_cast<UPluralType>(static_cast<int>(type) % 2);
 
     status = U_ZERO_ERROR;
     pp.reset(icu::PluralRules::forLocale(locale, type, status));
@@ -62,6 +62,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
     std::memcpy(&type, fuzzData.data(), sizeof(type));
     fuzzData.remove_prefix(sizeof(type));
+
+    // Clamp type to valid values: 0 (CARDINAL) or 1 (ORDINAL)
+    type = static_cast<UPluralType>(static_cast<int>(type) % 2);
 
     size_t len = fuzzData.size() / sizeof(char16_t);
     icu::UnicodeString text(false, reinterpret_cast<const char16_t*>(fuzzData.data()), len);


### PR DESCRIPTION
## Summary
- **Invalid enum values**: `UPluralType type` is read directly from fuzz data via `memcpy`, allowing arbitrary integer values. Only 0 (CARDINAL) and 1 (ORDINAL) are valid — passing other values to `PluralRules::forLocale()` is undefined behavior. Fix: clamp with `% 2` after reading.
- **NULL check**: Add `nullptr` guard in `TestPluralRules` before calling `pp->select()`, matching the defensive pattern in other ICU fuzzers.
- **Deprecated API**: Replace `UPLURAL_TYPE_COUNT` (deprecated) with explicit `2`.

## Coverage
60-second LibFuzzer run, empty seed corpus, ASan instrumentation:

| Metric | Original | Fixed | Change |
|--------|----------|-------|--------|
| Edge coverage | 2327 | 2695 | **+15.81%** (+368) |
| Feature coverage | 8057 | 9033 | +12.11% (+976) |

Both original and fixed fuzzers run clean (no crashes).