### PR TITLE
ICU-23365 Initialize pointer members in TransliterationRule constructor to prevent crash

### DIFF
--- a/icu4c/source/i18n/rbt_rule.cpp
+++ b/icu4c/source/i18n/rbt_rule.cpp
@@ -65,7 +65,15 @@ TransliterationRule::TransliterationRule(const UnicodeString& input,
                                          const TransliterationRuleData* theData,
                                          UErrorCode& status) :
     UMemory(),
+    anteContext(nullptr),
+    key(nullptr),
+    postContext(nullptr),
+    output(nullptr),
     segments(nullptr),
+    segmentsCount(0),
+    anteContextLength(0),
+    keyLength(0),
+    flags(0),
     data(theData) {
 
     if (U_FAILURE(status)) {


### PR DESCRIPTION
## Description

`TransliterationRule`'s main constructor (`rbt_rule.cpp:58`) does not initialize
its pointer members (`anteContext`, `key`, `postContext`, `output`) in the initializer
list. If the constructor returns early (e.g., when `U_FAILURE(status)` at line 72),
these pointers remain uninitialized. When the `LocalPointer` destructor subsequently
calls `~TransliterationRule()`, it executes `delete` on garbage pointer values,
causing a SEGV.

Triggered via the public API `Transliterator::createFromRules()` with a 15-byte
malformed input.

### Root Cause

The initializer list only initializes `segments(nullptr)` and `data(theData)`.
On early return, `anteContext`, `key`, `postContext`, and `output` contain garbage.
The destructor unconditionally deletes all of them.

### Fix

Add `nullptr` initialization for all pointer members and zero-initialization for
scalar members in the initializer list. After this fix, early returns leave all
pointers as `nullptr`, and `delete nullptr` is a safe no-op per the C++ standard.

### Reproduction

Crash input (15 bytes):
```bash
echo 'AAAcAAABABgYJAAYGCsA' | base64 -d > crash.bin
```

**Fuzzer:**
```cpp
#include <stddef.h>
#include <stdint.h>
#include <cstring>
#include <memory>
#include "unicode/translit.h"
#include "unicode/unistr.h"
#include "unicode/parseerr.h"
#include "unicode/utypes.h"

extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
    if (size < 3) return 0;
    uint8_t dir = data[0] & 1;
    data++; size--;
    size_t unistr_size = size / 2;
    std::unique_ptr<char16_t[]> fuzzbuff(new char16_t[unistr_size]);
    std::memcpy(fuzzbuff.get(), data, unistr_size * 2);
    icu::UnicodeString fuzzstr(false, fuzzbuff.get(), unistr_size);

    UErrorCode status = U_ZERO_ERROR;
    UParseError pe;
    std::unique_ptr<icu::Transliterator> t(
        icu::Transliterator::createFromRules(
            UNICODE_STRING_SIMPLE("fuzz"), fuzzstr,
            dir ? UTRANS_FORWARD : UTRANS_REVERSE, pe, status));
    if (U_SUCCESS(status) && t) {
        icu::UnicodeString sample(u"Hello World 123");
        t->transliterate(sample);
    }
    return 0;
}
```

**Standalone (no fuzzer):**
```cpp
#include "unicode/translit.h"
#include "unicode/unistr.h"
#include "unicode/parseerr.h"
#include "unicode/utypes.h"
#include <cstring>
#include <fstream>
#include <vector>

int main(int argc, char* argv[]) {
    std::ifstream file(argv[1], std::ios::binary);
    std::vector<uint8_t> data((std::istreambuf_iterator<char>(file)),
                               std::istreambuf_iterator<char>());
    if (data.size() < 3) return 1;
    uint8_t dir = data[0] & 1;
    size_t unistr_size = (data.size() - 1) / 2;
    std::vector<char16_t> buf(unistr_size);
    memcpy(buf.data(), data.data() + 1, unistr_size * 2);
    icu::UnicodeString rules(false, buf.data(), unistr_size);
    UErrorCode status = U_ZERO_ERROR;
    UParseError pe;
    icu::Transliterator* t = icu::Transliterator::createFromRules(
        UNICODE_STRING_SIMPLE("test"), rules,
        dir ? UTRANS_FORWARD : UTRANS_REVERSE, pe, status);
    if (U_SUCCESS(status) && t) {
        icu::UnicodeString sample(u"Hello");
        t->transliterate(sample);
        delete t;
    }
    return 0;
}
```

**Before fix:** SEGV at rbt_rule.cpp:196
**After fix:** createFromRules failed: U_MEMORY_ALLOCATION_ERROR (graceful error return)

Contribution: Found by FuzzingBrain (O2Lab, Texas A&M University) using a custom transliterator fuzzer targeting the previously unfuzzed createFromRules() API surface.

#### Checklist
- [x] Required: Issue filed: ICU-23365
- [x] Required: The PR title must be prefixed with a JIRA Issue number
- [x] Required: Each commit message must be prefixed with a JIRA Issue number
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable