### PR TITLE
ICU-23371 Reduce the memory footprint subdivisionData in ValidIdentifiers

### DIFF
--- a/icu4j/main/core/src/main/java/com/ibm/icu/impl/ValidIdentifiers.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/impl/ValidIdentifiers.java
@@ -11,7 +11,6 @@ package com.ibm.icu.impl;
 import com.ibm.icu.impl.locale.AsciiUtil;
 import com.ibm.icu.util.UResourceBundle;
 import com.ibm.icu.util.UResourceBundleIterator;
-import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -74,18 +73,12 @@ public class ValidIdentifiers {
                 HashMap<String, Set<String>> _subdivisionData2 = new HashMap<String, Set<String>>();
                 // protect the sets
                 for (Entry<String, Set<String>> e : _subdivisionData.entrySet()) {
-                    Set<String> value = e.getValue();
-                    // optimize a bit by using singleton
-                    Set<String> set =
-                            value.size() == 1
-                                    ? Collections.singleton(value.iterator().next())
-                                    : Collections.unmodifiableSet(value);
-                    _subdivisionData2.put(e.getKey(), set);
+                    _subdivisionData2.put(e.getKey(), toImmutableSet(e.getValue()));
                 }
 
-                this.subdivisionData = Collections.unmodifiableMap(_subdivisionData2);
+                this.subdivisionData = toImmutableMap(_subdivisionData2);
             } else {
-                this.regularData = Collections.unmodifiableSet(plainData);
+                this.regularData = toImmutableSet(plainData);
                 this.subdivisionData = null;
             }
         }
@@ -151,9 +144,9 @@ public class ValidIdentifiers {
                     }
                     values.put(subkey, new ValiditySet(subvalues, key == Datatype.subdivision));
                 }
-                _data.put(key, Collections.unmodifiableMap(values));
+                _data.put(key, toImmutableMap(values));
             }
-            data = Collections.unmodifiableMap(_data);
+            data = toImmutableMap(_data);
         }
 
         private static void addRange(String string, Set<String> subvalues) {
@@ -205,5 +198,13 @@ public class ValidIdentifiers {
             }
         }
         return null;
+    }
+
+    private static <E> Set<E> toImmutableSet(Set<E> set) {
+        return Set.copyOf(set);
+    }
+
+    private static <K, V> Map<K, V> toImmutableMap(Map<K, V> map) {
+        return Map.copyOf(map);
     }
 }


### PR DESCRIPTION
HashSet internally uses HashMap requests extra memory footprints for each entry. Use Set.copyOf(Set) to avoid the memory overhead The heap dump shows ~351kB reduction.

Also, use Map.copyOf(map) instead of HashMap. It reduces the memory footprint by ~52kB.


#### Checklist
- [x] Required: Issue filed: ICU-23371
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf
