### PR TITLE
ICU-23371 Reduce the memory footprints of TransliteratorRegistry

### DIFF
--- a/icu4j/main/translit/src/main/java/com/ibm/icu/text/AnyTransliterator.java
+++ b/icu4j/main/translit/src/main/java/com/ibm/icu/text/AnyTransliterator.java
@@ -49,7 +49,7 @@ class AnyTransliterator extends Transliterator {
     static final String LATIN_PIVOT = "-Latin;Latin-";
 
     /** Cache mapping UScriptCode values to Transliterator*. */
-    private ConcurrentHashMap<Integer, Transliterator> cache;
+    private volatile ConcurrentHashMap<Integer, Transliterator> cache;
 
     /** The target or target/variant string. */
     private String target;
@@ -122,7 +122,6 @@ class AnyTransliterator extends Transliterator {
     private AnyTransliterator(String id, String theTarget, String theVariant, int theTargetScript) {
         super(id, null);
         targetScript = theTargetScript;
-        cache = new ConcurrentHashMap<Integer, Transliterator>();
 
         target = theTarget;
         if (theVariant.length() > 0) {
@@ -168,7 +167,7 @@ class AnyTransliterator extends Transliterator {
         }
 
         Integer key = source;
-        Transliterator t = cache.get(key);
+        Transliterator t = getCache().get(key);
         if (t == null) {
             String sourceName = UScript.getName(source);
             String id = sourceName + TARGET_SEP + target;
@@ -194,7 +193,7 @@ class AnyTransliterator extends Transliterator {
                     v.add(t);
                     t = new CompoundTransliterator(v);
                 }
-                Transliterator prevCachedT = cache.putIfAbsent(key, t);
+                Transliterator prevCachedT = getCache().putIfAbsent(key, t);
                 if (prevCachedT != null) {
                     t = prevCachedT;
                 }
@@ -386,7 +385,7 @@ class AnyTransliterator extends Transliterator {
         if (filter != null && filter instanceof UnicodeSet) {
             filter = new UnicodeSet((UnicodeSet) filter);
         }
-        return new AnyTransliterator(getID(), filter, target, targetScript, null, cache);
+        return new AnyTransliterator(getID(), filter, target, targetScript, null, getCache());
     }
 
     /* (non-Javadoc)
@@ -401,5 +400,16 @@ class AnyTransliterator extends Transliterator {
         if (myFilter.size() != 0) {
             targetSet.addAll(0, 0x10FFFF);
         }
+    }
+
+    private ConcurrentHashMap<Integer, Transliterator> getCache() {
+        if (cache == null) {
+            synchronized (this) {
+                if (cache == null) {
+                    cache = new ConcurrentHashMap<>();
+                }
+            }
+        }
+        return cache;
     }
 }

--- a/icu4j/main/translit/src/main/java/com/ibm/icu/text/TransliteratorRegistry.java
+++ b/icu4j/main/translit/src/main/java/com/ibm/icu/text/TransliteratorRegistry.java
@@ -23,7 +23,6 @@ import com.ibm.icu.util.UResourceBundle;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -31,6 +30,8 @@ import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 class TransliteratorRegistry {
@@ -51,7 +52,7 @@ class TransliteratorRegistry {
      * Transliterator), RuleBasedTransliterator.Data, Transliterator.Factory, or one of the entry
      * classes defined here (AliasEntry or ResourceEntry).
      */
-    private Map<CaseInsensitiveString, Object[]> registry;
+    private final Map<CaseInsensitiveString, Object[]> registry;
 
     /**
      * DAG of visible IDs by spec. Hashtable: source => (Hashtable: target => (Vector: variant)) The
@@ -61,11 +62,14 @@ class TransliteratorRegistry {
      * <p>Keys are CaseInsensitiveString objects. Values are Hashtable of (CaseInsensitiveString ->
      * Vector of CaseInsensitiveString)
      */
-    private Map<CaseInsensitiveString, Map<CaseInsensitiveString, List<CaseInsensitiveString>>>
+    private final Map<
+                    CaseInsensitiveString, Map<CaseInsensitiveString, List<CaseInsensitiveString>>>
             specDAG;
 
     /** Vector of public full IDs (CaseInsensitiveString objects). */
     private final Set<CaseInsensitiveString> availableIDs;
+
+    private final Map<String, CaseInsensitiveString> stvStringPool;
 
     // ----------------------------------------------------------------------
     // class Spec
@@ -312,13 +316,10 @@ class TransliteratorRegistry {
     // ----------------------------------------------------------------------
 
     public TransliteratorRegistry() {
-        registry = Collections.synchronizedMap(new HashMap<CaseInsensitiveString, Object[]>());
-        specDAG =
-                Collections.synchronizedMap(
-                        new HashMap<
-                                CaseInsensitiveString,
-                                Map<CaseInsensitiveString, List<CaseInsensitiveString>>>());
+        registry = new ConcurrentHashMap<>();
+        specDAG = new ConcurrentHashMap<>();
         availableIDs = new LinkedHashSet<>();
+        stvStringPool = Collections.synchronizedMap(new WeakHashMap<>());
     }
 
     /**
@@ -536,21 +537,13 @@ class TransliteratorRegistry {
     private void registerSTV(String source, String target, String variant) {
         // assert(source.length() > 0);
         // assert(target.length() > 0);
-        CaseInsensitiveString cisrc = new CaseInsensitiveString(source);
-        CaseInsensitiveString citrg = new CaseInsensitiveString(target);
-        CaseInsensitiveString civar = new CaseInsensitiveString(variant);
-        Map<CaseInsensitiveString, List<CaseInsensitiveString>> targets = specDAG.get(cisrc);
-        if (targets == null) {
-            targets =
-                    Collections.synchronizedMap(
-                            new HashMap<CaseInsensitiveString, List<CaseInsensitiveString>>());
-            specDAG.put(cisrc, targets);
-        }
-        List<CaseInsensitiveString> variants = targets.get(citrg);
-        if (variants == null) {
-            variants = new ArrayList<CaseInsensitiveString>();
-            targets.put(citrg, variants);
-        }
+        CaseInsensitiveString cisrc = toInternedSTVString(source);
+        CaseInsensitiveString citrg = toInternedSTVString(target);
+        CaseInsensitiveString civar = toInternedSTVString(variant);
+        Map<CaseInsensitiveString, List<CaseInsensitiveString>> targets =
+                specDAG.computeIfAbsent(cisrc, key -> new ConcurrentHashMap<>());
+        List<CaseInsensitiveString> variants =
+                targets.computeIfAbsent(citrg, key -> new ArrayList<>(/* initialCapacity= */ 1));
         // assert(NO_VARIANT == "");
         // We add the variant string.  If it is the special "no variant"
         // string, that is, the empty string, we add it at position zero.
@@ -891,6 +884,10 @@ class TransliteratorRegistry {
                                 ID, parser.idBlockVector, parser.dataVector, parser.compoundFilter);
             }
         }
+    }
+
+    private CaseInsensitiveString toInternedSTVString(String key) {
+        return stvStringPool.computeIfAbsent(key, CaseInsensitiveString::new);
     }
 }
 


### PR DESCRIPTION
1. Intern CaseSensitiveString objects for source, target, variant in the registry
2. Use a default capacity of 1 for variant list. The source-target key  is mostly linked to 1 variant only.
3. Use ConcurrentHashMap instead of Collections.synchronizedMap(new HashMap())
4. Lazily initialize the script code cache in AnyTransliterator.

In total, it saves ~110 kB.

#### Checklist
- [x] Required: Issue filed: ICU-23371
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf
