### PR TITLE
ICU-23371 Deduplicate DayPeriodRulesData

### DIFF
--- a/icu4j/main/core/src/main/java/com/ibm/icu/impl/DayPeriodRules.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/impl/DayPeriodRules.java
@@ -12,6 +12,7 @@ import com.ibm.icu.util.ICUException;
 import com.ibm.icu.util.ULocale;
 import com.ibm.icu.util.UResourceBundle;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public final class DayPeriodRules {
@@ -345,6 +346,8 @@ public final class DayPeriodRules {
         DayPeriodRulesDataSink sink = new DayPeriodRulesDataSink(data);
         rb.getAllItemsWithFallback("", sink);
 
+        deduplicateDayPeriodRulesData(data);
+
         return data;
     }
 
@@ -434,5 +437,18 @@ public final class DayPeriodRules {
         String numStr = setNumStr.substring(3); // e.g. "set17" -> "17"
         return Integer.parseInt(
                 numStr); // This throws NumberFormatException if numStr isn't a proper number.
+    }
+
+    private static void deduplicateDayPeriodRulesData(DayPeriodRulesData data) {
+        Map<List<DayPeriod>, DayPeriod[]> internedDayPeriods = new HashMap<>();
+        for (DayPeriodRules rule : data.rules) {
+            if (rule != null && rule.dayPeriodForHour != null) {
+                DayPeriod[] dayPeriods = rule.dayPeriodForHour;
+                // Use List.of(dayPeriods) as a key to identify the deduplicated DayPeriod[]
+                // objects.
+                rule.dayPeriodForHour =
+                        internedDayPeriods.computeIfAbsent(List.of(dayPeriods), (l) -> dayPeriods);
+            }
+        }
     }
 }


### PR DESCRIPTION
It saves a few kB in memory.

Some sets uses the same rule, e.g.
```
        set1{
            am{
                before{"12:00"}
                from{"00:00"}
            }
            pm{
                before{"24:00"}
                from{"12:00"}
            }
        }

        set66{
            am{
                before{"12:00"}
                from{"00:00"}
            }
            pm{
                before{"24:00"}
                from{"12:00"}
            }
        }
```

Duplication reported to CLDR via CLDR-19391.

The purpose isn't clear, but we can deduplicate them in the runtime.

#### Checklist
- [x] Required: Issue filed: ICU-23371
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
