### PR TITLE
ICU-23376 Minimize the number of states of the DFA

### DIFF
--- a/icu4c/source/common/rbbitblb.cpp
+++ b/icu4c/source/common/rbbitblb.cpp
@@ -561,7 +561,7 @@ void RBBITableBuilder::bofFixup() {
 //                        transition tables for these states, by the algorithm
 //                        of fig. 3.44 in Aho.
 //
-//                        Most of the comments are quotes of Aho's psuedo-code.
+//                        Most of the comments are quotes of Aho's pseudo-code.
 //
 //-----------------------------------------------------------------------------
 void RBBITableBuilder::buildStateTable() {
@@ -1001,6 +1001,256 @@ void  RBBITableBuilder::mergeRuleStatusVals() {
 
 
 
+//-----------------------------------------------------------------------------
+//
+//    minimizeStates    Minimize the number of states of the DFA, by Algorithm
+//                      3.6 in Aho.  The one twist is that instead of starting
+//                      from a partition in two groups (accepting and non-
+//                      accepting states), we partition according to all
+//                      relevant properties of the states, namely the values of:
+//                      - fAccepting—which may be non-accepting,
+//                        unconditionally accepting, or the index of a
+//                        lookahead—;
+//                      - fLookAhead;
+//                      - fTagsIdx.
+//
+//-----------------------------------------------------------------------------
+
+void RBBITableBuilder::minimizeStates() {
+    if (U_FAILURE(*fStatus)) {
+        return;
+    }
+
+#if UPRV_HAS_FEATURE(address_sanitizer) || UPRV_HAS_FEATURE(undefined_behavior_sanitizer)
+    if (fDStates->size() > 512) {
+        // This algorithm is sluggish on large state machines, and even more sluggish with
+        // sanitizers, which leads the fuzzer into the weeds, see
+        // https://github.com/unicode-org/icu/pull/3948#issuecomment-4335461360.
+        *fStatus = U_REGEX_PATTERN_TOO_BIG;
+        return;
+    }
+#endif
+    struct StateType {
+        uint32_t fAccepting;
+        uint32_t fLookAhead;
+        int32_t fTagsIdx;
+        bool operator==(StateType const &other) const {
+            return fAccepting == other.fAccepting &&
+                   fLookAhead == other.fLookAhead &&
+                   fTagsIdx == other.fTagsIdx;
+        }
+    };
+    // We wrap `UVector`s in `LocalPointer`s throughout so we can move them,
+    // including into `UVector`s (by orphaning them from the `LocalPointer`
+    // and having the enclosing `UVector` adopt them). 
+    // Group the states by types (but we have no maps so this is verbose).
+    // If there are no lookaheads and no tags, there are only two types
+    // (accepting and non-accepting) in which case this is exactly step 1
+    // of Algorithm 3.6.
+    struct TypeToStates : UMemory {
+        TypeToStates(const StateType &type, UErrorCode &status)
+            : type(type), states(new UVector(status), status) {}
+        StateType type;
+        LocalPointer<UVector> states;
+    };
+    UVector initialPartition(*fStatus);
+    initialPartition.setDeleter(
+        [](void *p) { delete static_cast<TypeToStates *>(p); });
+    for (int32_t i = 0; i < fDStates->size(); ++i) {
+        const RBBIStateDescriptor &state =
+            *static_cast<RBBIStateDescriptor *>(fDStates->elementAt(i));
+        const StateType type{state.fAccepting,
+                             state.fLookAhead,
+                             state.fTagsIdx};
+        int32_t j = 0;
+        for (; j < initialPartition.size(); ++j) {
+            auto &[type_j, states] =
+                *static_cast<TypeToStates *>(initialPartition.elementAt(j));
+            if (type_j == type) {
+                states->addElement(i, *fStatus);
+                break;
+            }
+        }
+        if (j == initialPartition.size()) {
+            auto newEntry = LocalPointer<TypeToStates>(new TypeToStates(type, *fStatus), *fStatus);
+            if (U_FAILURE(*fStatus)) {
+                return;
+            }
+            newEntry->states->addElement(i, *fStatus);
+            initialPartition.adoptElement(newEntry.orphan(), *fStatus);
+        }
+    }
+    // The partition Π from Algorithm 3.6.
+    // (We could call it Π, but some member companies that integrate the ICU
+    // code base prohibit non-ASCII identifiers…).
+    LocalPointer<UVector> partition(new UVector(*fStatus), *fStatus);
+    if (U_FAILURE(*fStatus)) {
+        return;
+    }
+    partition->setDeleter(
+        [](void *p) { delete static_cast<UVector*>(p); });
+    
+    for (int32_t i = 0; i < initialPartition.size(); ++i) {
+        partition->adoptElement(
+            static_cast<TypeToStates*>(initialPartition.elementAt(i))->states.orphan(),
+            *fStatus);
+    }
+    // Given the index of a state 𝑠 in `fDStates`, returns a UVector of integers
+    // σ(𝑠) such that 𝑠.fDtran[i] (the index of the state reached by the
+    // transition from 𝑠 on the character class with index i) is in Π[σ(𝑠)[i]].
+    // We then have σ(𝑠) == σ(𝑡) if and only if “for all input symbols 𝑎, states
+    // 𝑠 and 𝑡 have transitions on 𝑎 to states in the same group of Π” (which is
+    // what defines the refinement of 𝐺 in Fig. 3.45).
+    auto partition_signature =
+        [&partition, this](int32_t stateIndex) -> LocalPointer<UVector> {
+            const RBBIStateDescriptor &state =
+                *static_cast<RBBIStateDescriptor*>(
+                    fDStates->elementAt(stateIndex));
+            LocalPointer<UVector> result(
+                new UVector(state.fDtran->size(), *fStatus), *fStatus);
+            if (U_FAILURE(*fStatus)) {
+                return LocalPointer<UVector>(nullptr);
+            }
+            for (int32_t i = 0; i < state.fDtran->size(); ++i) {
+                int32_t toState = state.fDtran->elementAti(i);
+                for (int32_t partIndex = 0;
+                     partIndex < partition->size();
+                     ++partIndex) {
+                    const UVector &part =
+                        *static_cast<UVector*>(partition->elementAt(partIndex));
+                    if (part.contains(toState)) {
+                        result->addElement(partIndex, *fStatus);
+                        break;
+                    }
+                }
+            }
+            result->setComparer([](const UElement left, const UElement right) -> UBool {
+                return left.integer == right.integer;
+            });
+            return result;
+        };
+    // The loop between steps 2. and 3. of Algorithm 3.6.
+    for (;;) {
+        // Π_new.
+        LocalPointer<UVector> partitionNew(new UVector(*fStatus), *fStatus);
+        if (U_FAILURE(*fStatus)) {
+            return;
+        }
+        partitionNew->setDeleter(
+            [](void *p) { delete static_cast<UVector*>(p); });
+        // The procedure from Figure 3.45, Construction of Π_new.
+        bool refined = false;
+        for (int32_t i = 0; i < partition->size(); ++i) {
+            // Group 𝐺 in Π (=`partition`).
+            const UVector &group = *static_cast<UVector*>(partition->elementAt(i));
+            // Partition 𝐺 based on the signature, see above.
+            struct SignatureToStates : UMemory {
+                SignatureToStates(LocalPointer<UVector> signature, UErrorCode &status)
+                    : signature(std::move(signature)), states(new UVector(status), status) {
+                }
+                LocalPointer<UVector> signature;
+                LocalPointer<UVector> states;
+            };
+            UVector groupRefinement(*fStatus);
+            groupRefinement.setDeleter([](void *p) { delete static_cast<SignatureToStates*>(p); });
+            for (int32_t j = 0; j < group.size(); ++j) {
+                // Index of a state in the group.
+                const int32_t s = group.elementAti(j);
+                auto signature = partition_signature(s);
+                int32_t k = 0;
+                for (; k < groupRefinement.size(); ++k) {
+                    const auto &[subgroupSignature, subgroup] =
+                        *static_cast<SignatureToStates*>(groupRefinement.elementAt(k));
+                    if (*subgroupSignature == *signature) {
+                        subgroup->addElement(s, *fStatus);
+                        break;
+                    }
+                }
+                if (k == groupRefinement.size()) {
+                    const auto newEntry =
+                        new SignatureToStates(std::move(signature), *fStatus);
+                    if (U_FAILURE(*fStatus)) {
+                        return;
+                    }
+                    if (newEntry == nullptr) {
+                      *fStatus = U_MEMORY_ALLOCATION_ERROR;
+                      return;
+                    }
+                    newEntry->states->addElement(s, *fStatus);
+                    groupRefinement.adoptElement(newEntry, *fStatus);
+                }
+            }
+            refined |= groupRefinement.size() > 1;
+            for (int32_t j = 0; j < groupRefinement.size(); ++j) {
+                auto &[_, subgroup] = *static_cast<SignatureToStates*>(
+                    groupRefinement.elementAt(j));
+                partitionNew->adoptElement(subgroup.orphan(), *fStatus);
+            }
+        }
+        if (refined) {
+            partition = std::move(partitionNew);
+        } else {
+            break;
+        }
+    }
+    // We will use the indices in `partition` as the new state indices.  Make
+    // sure that the start (1) and stop (0) states remain in their correct
+    // places; everything else can merrily be scrambled.
+    for (int i = 0; i < partition->size(); ++i) {
+        UVector *const part_i = static_cast<UVector *>(partition->elementAt(i));
+        if (part_i->contains(0)) {
+            void *const part_0 = partition->elementAt(0);
+            // No swap on UVector, so we briefly remove the deleter.
+            const auto deleter = partition->setDeleter(nullptr);
+            partition->setElementAt(part_i, 0);
+            partition->setElementAt(part_0, i);
+            partition->setDeleter(deleter);
+        } else if (part_i->contains(1)) {
+            void *const part_1 = partition->elementAt(1);
+            const auto deleter = partition->setDeleter(nullptr);
+            partition->setElementAt(part_i, 1);
+            partition->setElementAt(part_1, i);
+            partition->setDeleter(deleter);
+        }
+    }
+    if (U_FAILURE(*fStatus)) {
+        return;
+    }
+    // We cannot use LocalArray nor new[] because, on uint16_t, they would call
+    // the global new[] and delete[].
+    LocalMemory<uint16_t> oldStateToPart(static_cast<uint16_t*>(
+        uprv_malloc(sizeof(uint16_t) * fDStates->size())));
+    if (oldStateToPart == nullptr) {
+        return;
+    }
+    for (int i = 0; i < partition->size(); ++i) {
+        const UVector &part = *static_cast<UVector*>(partition->elementAt(i));
+        for (int j = 0; j < part.size(); ++j) {
+            oldStateToPart[part.elementAti(j)] = i;
+        }
+    }
+    LocalPointer<UVector> oldStates(fDStates);
+    fDStates = LocalPointer<UVector>(new UVector(*fStatus), *fStatus).orphan();
+    if (U_FAILURE(*fStatus)) {
+        return;
+    }
+    for (int i = 0; i < partition->size(); ++i) {
+        const UVector &part = *static_cast<UVector*>(partition->elementAt(i));
+        RBBIStateDescriptor *const state =
+            static_cast<RBBIStateDescriptor*>(oldStates->elementAt(part.elementAti(0)));
+        fDStates->addElement(state, *fStatus);
+        for (int j = 0; j < state->fDtran->size(); ++j) {
+            state->fDtran->setElementAt(oldStateToPart[state->fDtran->elementAti(j)], j);
+        }
+        oldStates->setElementAt(nullptr, part.elementAti(0));
+    }
+    oldStates->setDeleter([](void *p) { delete static_cast<RBBIStateDescriptor*>(p); });
+}
+
+
+
+
+
 
 
 //-----------------------------------------------------------------------------
@@ -1196,41 +1446,6 @@ void RBBITableBuilder::removeColumn(int32_t column) {
     }
 }
 
-/*
- * findDuplicateState
- */
-bool RBBITableBuilder::findDuplicateState(IntPair *states) {
-    int32_t numStates = fDStates->size();
-    int32_t numCols = fRB->fSetBuilder->getNumCharCategories();
-
-    for (; states->first<numStates-1; states->first++) {
-        RBBIStateDescriptor* firstSD = static_cast<RBBIStateDescriptor*>(fDStates->elementAt(states->first));
-        for (states->second=states->first+1; states->second<numStates; states->second++) {
-            RBBIStateDescriptor* duplSD = static_cast<RBBIStateDescriptor*>(fDStates->elementAt(states->second));
-            if (firstSD->fAccepting != duplSD->fAccepting ||
-                firstSD->fLookAhead != duplSD->fLookAhead ||
-                firstSD->fTagsIdx   != duplSD->fTagsIdx) {
-                continue;
-            }
-            bool rowsMatch = true;
-            for (int32_t col=0; col < numCols; ++col) {
-                int32_t firstVal = firstSD->fDtran->elementAti(col);
-                int32_t duplVal = duplSD->fDtran->elementAti(col);
-                if (!((firstVal == duplVal) ||
-                        ((firstVal == states->first || firstVal == states->second) &&
-                        (duplVal  == states->first || duplVal  == states->second)))) {
-                    rowsMatch = false;
-                    break;
-                }
-            }
-            if (rowsMatch) {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
 
 bool RBBITableBuilder::findDuplicateSafeState(IntPair *states) {
     int32_t numStates = fSafeTable->size();
@@ -1257,34 +1472,6 @@ bool RBBITableBuilder::findDuplicateSafeState(IntPair *states) {
         }
     }
     return false;
-}
-
-
-void RBBITableBuilder::removeState(IntPair duplStates) {
-    const int32_t keepState = duplStates.first;
-    const int32_t duplState = duplStates.second;
-    U_ASSERT(keepState < duplState);
-    U_ASSERT(duplState < fDStates->size());
-
-    RBBIStateDescriptor* duplSD = static_cast<RBBIStateDescriptor*>(fDStates->elementAt(duplState));
-    fDStates->removeElementAt(duplState);
-    delete duplSD;
-
-    int32_t numStates = fDStates->size();
-    int32_t numCols = fRB->fSetBuilder->getNumCharCategories();
-    for (int32_t state=0; state<numStates; ++state) {
-        RBBIStateDescriptor* sd = static_cast<RBBIStateDescriptor*>(fDStates->elementAt(state));
-        for (int32_t col=0; col<numCols; col++) {
-            int32_t existingVal = sd->fDtran->elementAti(col);
-            int32_t newVal = existingVal;
-            if (existingVal == duplState) {
-                newVal = keepState;
-            } else if (existingVal > duplState) {
-                newVal = existingVal - 1;
-            }
-            sd->fDtran->setElementAt(newVal, col);
-        }
-    }
 }
 
 void RBBITableBuilder::removeSafeState(IntPair duplStates) {
@@ -1317,15 +1504,9 @@ void RBBITableBuilder::removeSafeState(IntPair duplStates) {
  * RemoveDuplicateStates
  */
 int32_t RBBITableBuilder::removeDuplicateStates() {
-    IntPair dupls = {3, 0};
-    int32_t numStatesRemoved = 0;
-
-    while (findDuplicateState(&dupls)) {
-        // printf("Removing duplicate states (%d, %d)\n", dupls.first, dupls.second);
-        removeState(dupls);
-        ++numStatesRemoved;
-    }
-    return numStatesRemoved;
+    const int32_t oldStateCount = fDStates->size();
+    minimizeStates();
+    return fDStates->size() - oldStateCount;
 }
 
 

--- a/icu4c/source/common/rbbitblb.cpp
+++ b/icu4c/source/common/rbbitblb.cpp
@@ -1458,41 +1458,6 @@ void RBBITableBuilder::removeColumn(int32_t column) {
     }
 }
 
-/*
- * findDuplicateState
- */
-bool RBBITableBuilder::findDuplicateState(IntPair *states) {
-    int32_t numStates = fDStates->size();
-    int32_t numCols = fRB->fSetBuilder->getNumCharCategories();
-
-    for (; states->first<numStates-1; states->first++) {
-        RBBIStateDescriptor* firstSD = static_cast<RBBIStateDescriptor*>(fDStates->elementAt(states->first));
-        for (states->second=states->first+1; states->second<numStates; states->second++) {
-            RBBIStateDescriptor* duplSD = static_cast<RBBIStateDescriptor*>(fDStates->elementAt(states->second));
-            if (firstSD->fAccepting != duplSD->fAccepting ||
-                firstSD->fLookAhead != duplSD->fLookAhead ||
-                firstSD->fTagsIdx   != duplSD->fTagsIdx) {
-                continue;
-            }
-            bool rowsMatch = true;
-            for (int32_t col=0; col < numCols; ++col) {
-                int32_t firstVal = firstSD->fDtran->elementAti(col);
-                int32_t duplVal = duplSD->fDtran->elementAti(col);
-                if (!((firstVal == duplVal) ||
-                        ((firstVal == states->first || firstVal == states->second) &&
-                        (duplVal  == states->first || duplVal  == states->second)))) {
-                    rowsMatch = false;
-                    break;
-                }
-            }
-            if (rowsMatch) {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
 
 bool RBBITableBuilder::findDuplicateSafeState(IntPair *states) {
     int32_t numStates = fSafeTable->size();
@@ -1519,34 +1484,6 @@ bool RBBITableBuilder::findDuplicateSafeState(IntPair *states) {
         }
     }
     return false;
-}
-
-
-void RBBITableBuilder::removeState(IntPair duplStates) {
-    const int32_t keepState = duplStates.first;
-    const int32_t duplState = duplStates.second;
-    U_ASSERT(keepState < duplState);
-    U_ASSERT(duplState < fDStates->size());
-
-    RBBIStateDescriptor* duplSD = static_cast<RBBIStateDescriptor*>(fDStates->elementAt(duplState));
-    fDStates->removeElementAt(duplState);
-    delete duplSD;
-
-    int32_t numStates = fDStates->size();
-    int32_t numCols = fRB->fSetBuilder->getNumCharCategories();
-    for (int32_t state=0; state<numStates; ++state) {
-        RBBIStateDescriptor* sd = static_cast<RBBIStateDescriptor*>(fDStates->elementAt(state));
-        for (int32_t col=0; col<numCols; col++) {
-            int32_t existingVal = sd->fDtran->elementAti(col);
-            int32_t newVal = existingVal;
-            if (existingVal == duplState) {
-                newVal = keepState;
-            } else if (existingVal > duplState) {
-                newVal = existingVal - 1;
-            }
-            sd->fDtran->setElementAt(newVal, col);
-        }
-    }
 }
 
 void RBBITableBuilder::removeSafeState(IntPair duplStates) {

--- a/icu4c/source/common/rbbitblb.cpp
+++ b/icu4c/source/common/rbbitblb.cpp
@@ -1090,14 +1090,6 @@ void RBBITableBuilder::minimizeStates() {
         [](void *p) { delete static_cast<UVector*>(p); });
     
     for (int32_t i = 0; i < initialPartition.size(); ++i) {
-        auto* const states = new UVector(*fStatus);
-        if (U_FAILURE(*fStatus)) {
-            return;
-        }
-        if (states == nullptr) {
-          *fStatus = U_MEMORY_ALLOCATION_ERROR;
-          return;
-        }
         partition->adoptElement(
             static_cast<TypeToStates*>(initialPartition.elementAt(i))->states.release(),
             *fStatus);

--- a/icu4c/source/common/rbbitblb.cpp
+++ b/icu4c/source/common/rbbitblb.cpp
@@ -1208,10 +1208,9 @@ void RBBITableBuilder::minimizeStates() {
     if (U_FAILURE(*fStatus)) {
         return;
     }
-    std::unique_ptr<uint16_t[]> oldStateToPart(new uint16_t[fDStates->size()]());
-    if (oldStateToPart == nullptr) {
-      *fStatus = U_MEMORY_ALLOCATION_ERROR;
-      return;
+    LocalArray<uint16_t> oldStateToPart(new uint16_t[fDStates->size()](), *fStatus);
+    if (U_FAILURE(*fStatus)) {
+        return;
     }
     for (int i = 0; i < partition->size(); ++i) {
         const UVector &part = *static_cast<UVector*>(partition->elementAt(i));

--- a/icu4c/source/common/rbbitblb.cpp
+++ b/icu4c/source/common/rbbitblb.cpp
@@ -1170,6 +1170,7 @@ void RBBITableBuilder::minimizeStates() {
                 std::unique_ptr<UVector> states;
             };
             UVector groupRefinement(*fStatus);
+            groupRefinement.setDeleter([](void *p) { delete static_cast<SignatureToStates*>(p); });
             for (int32_t j = 0; j < group.size(); ++j) {
                 // Index of a state in the group.
                 const int32_t s = group.elementAti(j);
@@ -1194,7 +1195,7 @@ void RBBITableBuilder::minimizeStates() {
                       return;
                     }
                     newEntry->states->addElement(s, *fStatus);
-                    groupRefinement.addElement(newEntry, *fStatus);
+                    groupRefinement.adoptElement(newEntry, *fStatus);
                 }
             }
             refined |= groupRefinement.size() > 1;

--- a/icu4c/source/common/rbbitblb.cpp
+++ b/icu4c/source/common/rbbitblb.cpp
@@ -561,7 +561,7 @@ void RBBITableBuilder::bofFixup() {
 //                        transition tables for these states, by the algorithm
 //                        of fig. 3.44 in Aho.
 //
-//                        Most of the comments are quotes of Aho's psuedo-code.
+//                        Most of the comments are quotes of Aho's pseudo-code.
 //
 //-----------------------------------------------------------------------------
 void RBBITableBuilder::buildStateTable() {
@@ -1001,6 +1001,275 @@ void  RBBITableBuilder::mergeRuleStatusVals() {
 
 
 
+//-----------------------------------------------------------------------------
+//
+//    minimizeStates    Minimize the number of states of the DFA, by Algorithm
+//                      3.6 in Aho.  The one twist is that instead of starting
+//                      from a partition in two groups (accepting and non-
+//                      accepting states), we partition according to all
+//                      relevant properties of the states, namely the values of:
+//                      - fAccepting—which may be non-accepting,
+//                        unconditionally accepting, or the index of a
+//                        lookahead—;
+//                      - fLookAhead;
+//                      - fTagsIdx.
+//
+//-----------------------------------------------------------------------------
+
+void RBBITableBuilder::minimizeStates() {
+    if (U_FAILURE(*fStatus)) {
+        return;
+    }
+    struct StateType {
+        uint32_t fAccepting;
+        uint32_t fLookAhead;
+        int32_t fTagsIdx;
+        bool operator==(StateType const &other) const {
+            return fAccepting == other.fAccepting &&
+                   fLookAhead == other.fLookAhead &&
+                   fTagsIdx == other.fTagsIdx;
+        }
+    };
+    // Group the states by types (but we have no maps so this is verbose).
+    // If there are no lookaheads and no tags, there are only two types
+    // (accepting and non-accepting) in which case this is exactly step 1
+    // of Algorithm 3.6.
+    struct TypeToStates {
+        TypeToStates(const StateType &type, UErrorCode &status)
+            : type(type), states(new UVector(status)) {
+            if (U_SUCCESS(status) && states == nullptr) {
+                status = U_MEMORY_ALLOCATION_ERROR;
+            }
+        }
+        StateType type;
+        std::unique_ptr<UVector> states;
+    };
+    UVector initialPartition(*fStatus);
+    initialPartition.setDeleter(
+        [](void *p) { delete static_cast<TypeToStates *>(p); });
+    for (int32_t i = 0; i < fDStates->size(); ++i) {
+        const RBBIStateDescriptor &state =
+            *static_cast<RBBIStateDescriptor *>(fDStates->elementAt(i));
+        const StateType type{state.fAccepting,
+                             state.fLookAhead,
+                             state.fTagsIdx};
+        int32_t j = 0;
+        for (; j < initialPartition.size(); ++j) {
+            auto &[type_j, states] =
+                *static_cast<TypeToStates *>(initialPartition.elementAt(j));
+            if (type_j == type) {
+                states->addElement(i, *fStatus);
+                break;
+            }
+        }
+        if (j == initialPartition.size()) {
+            const auto newEntry = new TypeToStates(type, *fStatus);
+            if (U_FAILURE(*fStatus)) {
+                return;
+            }
+            if (newEntry == nullptr) {
+              *fStatus = U_MEMORY_ALLOCATION_ERROR;
+              return;
+            }
+            newEntry->states->addElement(i, *fStatus);
+            initialPartition.adoptElement(newEntry, *fStatus);
+        }
+    }
+    // The partition Π from Algorithm 3.6.
+    // (We could call it Π, but some member companies that integrate the ICU
+    // code base prohibit non-ASCII identifiers…).
+    std::unique_ptr<UVector> partition(new UVector(*fStatus));
+    if (U_FAILURE(*fStatus)) {
+        return;
+    }
+    if (partition == nullptr) {
+      *fStatus = U_MEMORY_ALLOCATION_ERROR;
+      return;
+    }
+    partition->setDeleter(
+        [](void *p) { delete static_cast<UVector*>(p); });
+    
+    for (int32_t i = 0; i < initialPartition.size(); ++i) {
+        auto* const states = new UVector(*fStatus);
+        if (U_FAILURE(*fStatus)) {
+            return;
+        }
+        if (states == nullptr) {
+          *fStatus = U_MEMORY_ALLOCATION_ERROR;
+          return;
+        }
+        partition->adoptElement(
+            static_cast<TypeToStates*>(initialPartition.elementAt(i))->states.release(),
+            *fStatus);
+    }
+    // Given the index of a state 𝑠 in `fDStates`, returns a UVector of integers
+    // σ(𝑠) such that 𝑠.fDtran[i] (the index of the state reached by the
+    // transition from 𝑠 on the character class with index i) is in Π[σ(𝑠)[i]].
+    // We then have σ(𝑠) == σ(𝑡) if and only if “for all input symbols 𝑎, states
+    // 𝑠 and 𝑡 have transitions on 𝑎 to states in the same group of Π” (which is
+    // what defines the refinement of 𝐺 in Fig. 3.45).
+    auto partition_signature =
+        [&partition, this](int32_t stateIndex) -> std::unique_ptr<UVector> {
+            const RBBIStateDescriptor &state =
+                *static_cast<RBBIStateDescriptor*>(
+                    fDStates->elementAt(stateIndex));
+            std::unique_ptr<UVector> result(
+                new UVector(state.fDtran->size(), *fStatus));
+            if (U_FAILURE(*fStatus)) {
+                return nullptr;
+            }
+            if (result == nullptr) {
+                *fStatus = U_MEMORY_ALLOCATION_ERROR;
+                return nullptr;
+            }
+            for (int32_t i = 0; i < state.fDtran->size(); ++i) {
+                int32_t toState = state.fDtran->elementAti(i);
+                for (int32_t partIndex = 0;
+                     partIndex < partition->size();
+                     ++partIndex) {
+                    const UVector &part =
+                        *static_cast<UVector*>(partition->elementAt(partIndex));
+                    if (part.contains(toState)) {
+                        result->addElement(partIndex, *fStatus);
+                        break;
+                    }
+                }
+            }
+            result->setComparer([](const UElement left, const UElement right) -> UBool {
+                return left.integer == right.integer;
+            });
+            return result;
+        };
+    // The loop between steps 2. and 3. of Algorithm 3.6.
+    for (;;) {
+        // Π_new.
+        std::unique_ptr<UVector> partitionNew(new UVector(*fStatus));
+        if (U_FAILURE(*fStatus)) {
+            return;
+        }
+        if (partitionNew == nullptr) {
+          *fStatus = U_MEMORY_ALLOCATION_ERROR;
+          return;
+        }
+        partitionNew->setDeleter(
+            [](void *p) { delete static_cast<UVector*>(p); });
+        // The procedure from Figure 3.45, Construction of Π_new.
+        bool refined = false;
+        for (int32_t i = 0; i < partition->size(); ++i) {
+            // Group 𝐺 in Π (=`partition`).
+            const UVector &group = *static_cast<UVector*>(partition->elementAt(i));
+            // Partition 𝐺 based on the signature, see above.
+            struct SignatureToStates {
+                SignatureToStates(std::unique_ptr<UVector> signature, UErrorCode &status)
+                    : signature(std::move(signature)), states(new UVector(status)) {
+                    if (U_SUCCESS(status) && states == nullptr) {
+                        status = U_MEMORY_ALLOCATION_ERROR;
+                    }
+                }
+                std::unique_ptr<UVector> signature;
+                std::unique_ptr<UVector> states;
+            };
+            UVector groupRefinement(*fStatus);
+            for (int32_t j = 0; j < group.size(); ++j) {
+                // Index of a state in the group.
+                const int32_t s = group.elementAti(j);
+                auto signature = partition_signature(s);
+                int32_t k = 0;
+                for (; k < groupRefinement.size(); ++k) {
+                    const auto &[subgroupSignature, subgroup] =
+                        *static_cast<SignatureToStates*>(groupRefinement.elementAt(k));
+                    if (*subgroupSignature == *signature) {
+                        subgroup->addElement(s, *fStatus);
+                        break;
+                    }
+                }
+                if (k == groupRefinement.size()) {
+                    const auto newEntry =
+                        new SignatureToStates(std::move(signature), *fStatus);
+                    if (U_FAILURE(*fStatus)) {
+                        return;
+                    }
+                    if (newEntry == nullptr) {
+                      *fStatus = U_MEMORY_ALLOCATION_ERROR;
+                      return;
+                    }
+                    newEntry->states->addElement(s, *fStatus);
+                    groupRefinement.addElement(newEntry, *fStatus);
+                }
+            }
+            refined |= groupRefinement.size() > 1;
+            for (int32_t j = 0; j < groupRefinement.size(); ++j) {
+                auto &[_, subgroup] = *static_cast<SignatureToStates*>(
+                    groupRefinement.elementAt(j));
+                partitionNew->adoptElement(subgroup.release(), *fStatus);
+            }
+        }
+        if (refined) {
+            partition = std::move(partitionNew);
+        } else {
+            break;
+        }
+    }
+    // We will use the indices in `partition` as the new state indices.  Make
+    // sure that the start (1) and stop (0) states remain in their correct
+    // places; everything else can merrily be scrambled.
+    for (int i = 0; i < partition->size(); ++i) {
+        UVector *const part_i = static_cast<UVector *>(partition->elementAt(i));
+        if (part_i->contains(0)) {
+            void *const part_0 = partition->elementAt(0);
+            // No swap on UVector, so we briefly remove the deleter.
+            const auto deleter = partition->setDeleter(nullptr);
+            partition->setElementAt(part_i, 0);
+            partition->setElementAt(part_0, i);
+            partition->setDeleter(deleter);
+        } else if (part_i->contains(1)) {
+            void *const part_1 = partition->elementAt(1);
+            const auto deleter = partition->setDeleter(nullptr);
+            partition->setElementAt(part_i, 1);
+            partition->setElementAt(part_1, i);
+            partition->setDeleter(deleter);
+        }
+    }
+    if (U_FAILURE(*fStatus)) {
+        return;
+    }
+    std::unique_ptr<uint16_t[]> oldStateToPart(new uint16_t[fDStates->size()]());
+    if (oldStateToPart == nullptr) {
+      *fStatus = U_MEMORY_ALLOCATION_ERROR;
+      return;
+    }
+    for (int i = 0; i < partition->size(); ++i) {
+        const UVector &part = *static_cast<UVector*>(partition->elementAt(i));
+        for (int j = 0; j < part.size(); ++j) {
+            oldStateToPart[part.elementAti(j)] = i;
+        }
+    }
+    std::unique_ptr<UVector> oldStates(fDStates);
+    fDStates = new UVector(*fStatus);
+    if (U_FAILURE(*fStatus)) {
+        return;
+    }
+    if (fDStates == nullptr) {
+      *fStatus = U_MEMORY_ALLOCATION_ERROR;
+      return;
+    }
+    for (int i = 0; i < partition->size(); ++i) {
+        const UVector &part = *static_cast<UVector*>(partition->elementAt(i));
+        RBBIStateDescriptor *const state =
+            static_cast<RBBIStateDescriptor*>(oldStates->elementAt(part.elementAti(0)));
+        fDStates->addElement(state, *fStatus);
+        for (int j = 0; j < state->fDtran->size(); ++j) {
+            state->fDtran->setElementAt(oldStateToPart[state->fDtran->elementAti(j)], j);
+        }
+        oldStates->setElementAt(nullptr, part.elementAti(0));
+    }
+    oldStates->setDeleter([](void *p) { delete static_cast<RBBIStateDescriptor*>(p); });
+}
+
+
+
+
+
 
 
 //-----------------------------------------------------------------------------
@@ -1317,15 +1586,9 @@ void RBBITableBuilder::removeSafeState(IntPair duplStates) {
  * RemoveDuplicateStates
  */
 int32_t RBBITableBuilder::removeDuplicateStates() {
-    IntPair dupls = {3, 0};
-    int32_t numStatesRemoved = 0;
-
-    while (findDuplicateState(&dupls)) {
-        // printf("Removing duplicate states (%d, %d)\n", dupls.first, dupls.second);
-        removeState(dupls);
-        ++numStatesRemoved;
-    }
-    return numStatesRemoved;
+    const int32_t oldStateCount = fDStates->size();
+    minimizeStates();
+    return fDStates->size() - oldStateCount;
 }
 
 

--- a/icu4c/source/common/rbbitblb.cpp
+++ b/icu4c/source/common/rbbitblb.cpp
@@ -1032,6 +1032,9 @@ void RBBITableBuilder::minimizeStates() {
                    fTagsIdx == other.fTagsIdx;
         }
     };
+    // We wrap `UVector`s in `LocalPointer`s throughout so we can move them,
+    // including into `UVector`s (by orphaning them from the `LocalPointer`
+    // and having the enclosing `UVector` adopt them). 
     // Group the states by types (but we have no maps so this is verbose).
     // If there are no lookaheads and no tags, there are only two types
     // (accepting and non-accepting) in which case this is exactly step 1

--- a/icu4c/source/common/rbbitblb.cpp
+++ b/icu4c/source/common/rbbitblb.cpp
@@ -1064,16 +1064,12 @@ void RBBITableBuilder::minimizeStates() {
             }
         }
         if (j == initialPartition.size()) {
-            const auto newEntry = new TypeToStates(type, *fStatus);
+            auto newEntry = LocalPointer<TypeToStates>(new TypeToStates(type, *fStatus), *fStatus);
             if (U_FAILURE(*fStatus)) {
                 return;
             }
-            if (newEntry == nullptr) {
-              *fStatus = U_MEMORY_ALLOCATION_ERROR;
-              return;
-            }
             newEntry->states->addElement(i, *fStatus);
-            initialPartition.adoptElement(newEntry, *fStatus);
+            initialPartition.adoptElement(newEntry.orphan(), *fStatus);
         }
     }
     // The partition Π from Algorithm 3.6.
@@ -1224,13 +1220,9 @@ void RBBITableBuilder::minimizeStates() {
         }
     }
     LocalPointer<UVector> oldStates(fDStates);
-    fDStates = new UVector(*fStatus);
+    fDStates = LocalPointer<UVector>(new UVector(*fStatus), *fStatus).orphan();
     if (U_FAILURE(*fStatus)) {
         return;
-    }
-    if (fDStates == nullptr) {
-      *fStatus = U_MEMORY_ALLOCATION_ERROR;
-      return;
     }
     for (int i = 0; i < partition->size(); ++i) {
         const UVector &part = *static_cast<UVector*>(partition->elementAt(i));

--- a/icu4c/source/common/rbbitblb.cpp
+++ b/icu4c/source/common/rbbitblb.cpp
@@ -13,6 +13,8 @@
 
 #include "unicode/utypes.h"
 
+#include <memory>
+
 #if !UCONFIG_NO_BREAK_ITERATION
 
 #include "unicode/unistr.h"
@@ -1036,13 +1038,9 @@ void RBBITableBuilder::minimizeStates() {
     // of Algorithm 3.6.
     struct TypeToStates {
         TypeToStates(const StateType &type, UErrorCode &status)
-            : type(type), states(new UVector(status)) {
-            if (U_SUCCESS(status) && states == nullptr) {
-                status = U_MEMORY_ALLOCATION_ERROR;
-            }
-        }
+            : type(type), states(new UVector(status), status) {}
         StateType type;
-        std::unique_ptr<UVector> states;
+        LocalPointer<UVector> states;
     };
     UVector initialPartition(*fStatus);
     initialPartition.setDeleter(
@@ -1078,20 +1076,16 @@ void RBBITableBuilder::minimizeStates() {
     // The partition Π from Algorithm 3.6.
     // (We could call it Π, but some member companies that integrate the ICU
     // code base prohibit non-ASCII identifiers…).
-    std::unique_ptr<UVector> partition(new UVector(*fStatus));
+    LocalPointer<UVector> partition(new UVector(*fStatus), *fStatus);
     if (U_FAILURE(*fStatus)) {
         return;
-    }
-    if (partition == nullptr) {
-      *fStatus = U_MEMORY_ALLOCATION_ERROR;
-      return;
     }
     partition->setDeleter(
         [](void *p) { delete static_cast<UVector*>(p); });
     
     for (int32_t i = 0; i < initialPartition.size(); ++i) {
         partition->adoptElement(
-            static_cast<TypeToStates*>(initialPartition.elementAt(i))->states.release(),
+            static_cast<TypeToStates*>(initialPartition.elementAt(i))->states.orphan(),
             *fStatus);
     }
     // Given the index of a state 𝑠 in `fDStates`, returns a UVector of integers
@@ -1101,18 +1095,14 @@ void RBBITableBuilder::minimizeStates() {
     // 𝑠 and 𝑡 have transitions on 𝑎 to states in the same group of Π” (which is
     // what defines the refinement of 𝐺 in Fig. 3.45).
     auto partition_signature =
-        [&partition, this](int32_t stateIndex) -> std::unique_ptr<UVector> {
+        [&partition, this](int32_t stateIndex) -> LocalPointer<UVector> {
             const RBBIStateDescriptor &state =
                 *static_cast<RBBIStateDescriptor*>(
                     fDStates->elementAt(stateIndex));
-            std::unique_ptr<UVector> result(
-                new UVector(state.fDtran->size(), *fStatus));
+            LocalPointer<UVector> result(
+                new UVector(state.fDtran->size(), *fStatus), *fStatus);
             if (U_FAILURE(*fStatus)) {
-                return nullptr;
-            }
-            if (result == nullptr) {
-                *fStatus = U_MEMORY_ALLOCATION_ERROR;
-                return nullptr;
+                return LocalPointer<UVector>(nullptr);
             }
             for (int32_t i = 0; i < state.fDtran->size(); ++i) {
                 int32_t toState = state.fDtran->elementAti(i);
@@ -1135,13 +1125,9 @@ void RBBITableBuilder::minimizeStates() {
     // The loop between steps 2. and 3. of Algorithm 3.6.
     for (;;) {
         // Π_new.
-        std::unique_ptr<UVector> partitionNew(new UVector(*fStatus));
+        LocalPointer<UVector> partitionNew(new UVector(*fStatus), *fStatus);
         if (U_FAILURE(*fStatus)) {
             return;
-        }
-        if (partitionNew == nullptr) {
-          *fStatus = U_MEMORY_ALLOCATION_ERROR;
-          return;
         }
         partitionNew->setDeleter(
             [](void *p) { delete static_cast<UVector*>(p); });
@@ -1152,14 +1138,11 @@ void RBBITableBuilder::minimizeStates() {
             const UVector &group = *static_cast<UVector*>(partition->elementAt(i));
             // Partition 𝐺 based on the signature, see above.
             struct SignatureToStates {
-                SignatureToStates(std::unique_ptr<UVector> signature, UErrorCode &status)
-                    : signature(std::move(signature)), states(new UVector(status)) {
-                    if (U_SUCCESS(status) && states == nullptr) {
-                        status = U_MEMORY_ALLOCATION_ERROR;
-                    }
+                SignatureToStates(LocalPointer<UVector> signature, UErrorCode &status)
+                    : signature(std::move(signature)), states(new UVector(status), status) {
                 }
-                std::unique_ptr<UVector> signature;
-                std::unique_ptr<UVector> states;
+                LocalPointer<UVector> signature;
+                LocalPointer<UVector> states;
             };
             UVector groupRefinement(*fStatus);
             groupRefinement.setDeleter([](void *p) { delete static_cast<SignatureToStates*>(p); });
@@ -1194,7 +1177,7 @@ void RBBITableBuilder::minimizeStates() {
             for (int32_t j = 0; j < groupRefinement.size(); ++j) {
                 auto &[_, subgroup] = *static_cast<SignatureToStates*>(
                     groupRefinement.elementAt(j));
-                partitionNew->adoptElement(subgroup.release(), *fStatus);
+                partitionNew->adoptElement(subgroup.orphan(), *fStatus);
             }
         }
         if (refined) {
@@ -1237,7 +1220,7 @@ void RBBITableBuilder::minimizeStates() {
             oldStateToPart[part.elementAti(j)] = i;
         }
     }
-    std::unique_ptr<UVector> oldStates(fDStates);
+    LocalPointer<UVector> oldStates(fDStates);
     fDStates = new UVector(*fStatus);
     if (U_FAILURE(*fStatus)) {
         return;

--- a/icu4c/source/common/rbbitblb.cpp
+++ b/icu4c/source/common/rbbitblb.cpp
@@ -13,8 +13,6 @@
 
 #include "unicode/utypes.h"
 
-#include <memory>
-
 #if !UCONFIG_NO_BREAK_ITERATION
 
 #include "unicode/unistr.h"

--- a/icu4c/source/common/rbbitblb.h
+++ b/icu4c/source/common/rbbitblb.h
@@ -105,6 +105,7 @@ private:
     void     flagLookAheadStates();
     void     flagTaggedStates();
     void     mergeRuleStatusVals();
+    void     minimizeStates();
 
     /**
      * Merge redundant state table columns, eliminating character classes with identical behavior.
@@ -113,23 +114,6 @@ private:
     int32_t  mergeColumns();
 
     void     addRuleRootNodes(UVector *dest, RBBINode *node);
-
-    /**
-     *  Find duplicate (redundant) states, beginning at the specified pair,
-     *  within this state table. This is an iterator-like function, used to
-     *  identify states (state table rows) that can be eliminated.
-     *  @param states in/out parameter, specifies where to start looking for duplicates,
-     *                and returns the first pair of duplicates found, if any.
-     *  @return true if duplicate states were found, false otherwise.
-     */
-    bool findDuplicateState(IntPair *states);
-
-    /** Remove a duplicate state.
-     * @param duplStates The duplicate states. The first is kept, the second is removed.
-     *                   All references to the second in the state table are retargeted
-     *                   to the first.
-     */
-    void removeState(IntPair duplStates);
 
     /** Find the next duplicate state in the safe reverse table. An iterator function.
      *  @param states in/out parameter, specifies where to start looking for duplicates,

--- a/icu4c/source/common/rbbitblb.h
+++ b/icu4c/source/common/rbbitblb.h
@@ -105,6 +105,7 @@ private:
     void     flagLookAheadStates();
     void     flagTaggedStates();
     void     mergeRuleStatusVals();
+    void     minimizeStates();
 
     /**
      * Merge redundant state table columns, eliminating character classes with identical behavior.

--- a/icu4c/source/common/rbbitblb.h
+++ b/icu4c/source/common/rbbitblb.h
@@ -115,23 +115,6 @@ private:
 
     void     addRuleRootNodes(UVector *dest, RBBINode *node);
 
-    /**
-     *  Find duplicate (redundant) states, beginning at the specified pair,
-     *  within this state table. This is an iterator-like function, used to
-     *  identify states (state table rows) that can be eliminated.
-     *  @param states in/out parameter, specifies where to start looking for duplicates,
-     *                and returns the first pair of duplicates found, if any.
-     *  @return true if duplicate states were found, false otherwise.
-     */
-    bool findDuplicateState(IntPair *states);
-
-    /** Remove a duplicate state.
-     * @param duplStates The duplicate states. The first is kept, the second is removed.
-     *                   All references to the second in the state table are retargeted
-     *                   to the first.
-     */
-    void removeState(IntPair duplStates);
-
     /** Find the next duplicate state in the safe reverse table. An iterator function.
      *  @param states in/out parameter, specifies where to start looking for duplicates,
      *                and returns the first pair of duplicates found, if any.


### PR DESCRIPTION
This halves the size of the `line*.brk` (from 73 424 bytes to 37 224 for `line.brk`, similarly for the others); it does nothing for `char.brk` or `sent.brk`, and not much for `word.brk` (23 120 to 22 672).

The C++ implementation is atrocious because of our lack of decent data structures, this was 30 lines of Python and would probably not be very much more in modern C++…

CC @aheninger, @robertbastian.

#### Checklist
- [x] Required: Issue filed: ICU-23376
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
