### PR TITLE
ICU-23379 Fix potential null pointer dereference in NumberFormat::format

### DIFF
--- a/icu4c/source/i18n/numfmt.cpp
+++ b/icu4c/source/i18n/numfmt.cpp
@@ -570,6 +570,10 @@ NumberFormat::format(const Formattable& obj,
       // trying to format a different currency.
       // Right now, we clone.
       LocalPointer<NumberFormat> cloneFmt(this->clone());
+      if (cloneFmt.isNull()) {
+          status = U_MEMORY_ALLOCATION_ERROR;
+          return appendTo;
+      }
       cloneFmt->setCurrency(iso, status);
       // next line should NOT recurse, because n is numeric whereas obj was a wrapper around currency amount.
       return cloneFmt->format(*n, appendTo, pos, status);
@@ -625,6 +629,10 @@ NumberFormat::format(const Formattable& obj,
       // trying to format a different currency.
       // Right now, we clone.
       LocalPointer<NumberFormat> cloneFmt(this->clone());
+      if (cloneFmt.isNull()) {
+          status = U_MEMORY_ALLOCATION_ERROR;
+          return appendTo;
+      }
       cloneFmt->setCurrency(iso, status);
       // next line should NOT recurse, because n is numeric whereas obj was a wrapper around currency amount.
       return cloneFmt->format(*n, appendTo, posIter, status);


### PR DESCRIPTION
Add null pointer checks after `this->clone()` calls in `NumberFormat::format` to prevent crashes under out-of-memory conditions or when the source object is in an invalid state.

Both instances in `numfmt.cpp` where `cloneFmt->setCurrency` was called immediately after `clone()` without verification have been fixed to return `U_MEMORY_ALLOCATION_ERROR` if the clone fails.

#### Checklist
- [x] Required: Issue filed: ICU-23379
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf
