### PR TITLE
ICU-23394 Validate binary RBBI data offsets in RBBIDataWrapper::init()

### DIFF
--- a/icu4c/source/common/rbbidata.cpp
+++ b/icu4c/source/common/rbbidata.cpp
@@ -102,6 +102,23 @@ void RBBIDataWrapper::init(const RBBIDataHeader *data, UErrorCode &status) {
     //       that is no longer supported.  At that time fFormatVersion was
     //       an int32_t field, rather than an array of 4 bytes.
 
+    uint32_t totalLen = fHeader->fLength;
+    if (totalLen < sizeof(RBBIDataHeader)) {
+        status = U_INVALID_FORMAT_ERROR;
+        return;
+    }
+
+    // Validate all offset+length pairs against the total data length.
+    // Prevent integer overflow by checking each addend against totalLen first.
+    if (fHeader->fFTable > totalLen || fHeader->fFTableLen > totalLen - fHeader->fFTable ||
+        fHeader->fRTable > totalLen || fHeader->fRTableLen > totalLen - fHeader->fRTable ||
+        fHeader->fTrie > totalLen || fHeader->fTrieLen > totalLen - fHeader->fTrie ||
+        fHeader->fRuleSource > totalLen || fHeader->fRuleSourceLen > totalLen - fHeader->fRuleSource ||
+        fHeader->fStatusTable > totalLen || fHeader->fStatusTableLen > totalLen - fHeader->fStatusTable) {
+        status = U_INVALID_FORMAT_ERROR;
+        return;
+    }
+
     fDontFreeData = false;
     if (data->fFTableLen != 0) {
         fForwardTable = reinterpret_cast<const RBBIStateTable*>(reinterpret_cast<const char*>(data) + fHeader->fFTable);

--- a/icu4c/source/test/intltest/rbbiapts.cpp
+++ b/icu4c/source/test/intltest/rbbiapts.cpp
@@ -1147,6 +1147,40 @@ void RBBIAPITest::TestGetBinaryRules() {
 }
 
 
+void RBBIAPITest::TestMalformedBinaryData() {
+    // Crafted binary data with out-of-bounds offset fields (fTrie = 0x66666666).
+    // Before the fix, this caused a SEGV in ucptrie_openFromBinary() via wild pointer.
+    // After the fix, the constructor must return U_INVALID_FORMAT_ERROR.
+    static const uint8_t data[] = {
+        0xa0, 0xb1, 0x00, 0x00, 0x06, 0x00, 0xff, 0xff, 0x14, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+        0x66, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x51, 0x00, 0x00, 0x66, 0x66,
+        0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x0c, 0x0c, 0x0c, 0x0c,
+        0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c,
+        0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c,
+        0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x66, 0xd5, 0xd5, 0xd5, 0xd5, 0xd5, 0xd5,
+        0xd5, 0xd5, 0xd5, 0xd5, 0x66, 0x66, 0x66, 0x62, 0x66, 0x66, 0x66, 0x66,
+        0x66, 0x66, 0x9a, 0x99, 0xb9, 0x99, 0x99, 0x9a, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x0a, 0x0a
+    };
+    UErrorCode status = U_ZERO_ERROR;
+    RuleBasedBreakIterator bi(data, sizeof(data), status);
+    if (status != U_INVALID_FORMAT_ERROR) {
+        errln("%s:%d Expected U_INVALID_FORMAT_ERROR from malformed binary data, got %s",
+              __FILE__, __LINE__, u_errorName(status));
+    }
+
+    // Also test a truncated header (less than sizeof(RBBIDataHeader)).
+    static const uint8_t shortData[] = {0xa0, 0xb1, 0x00, 0x00, 0x06, 0x00};
+    status = U_ZERO_ERROR;
+    RuleBasedBreakIterator bi2(shortData, sizeof(shortData), status);
+    if (status != U_INVALID_FORMAT_ERROR) {
+        errln("%s:%d Expected U_INVALID_FORMAT_ERROR from truncated data, got %s",
+              __FILE__, __LINE__, u_errorName(status));
+    }
+}
+
+
 void RBBIAPITest::TestRefreshInputText() {
     /*
      *  RefreshInput changes out the input of a Break Iterator without
@@ -1465,6 +1499,7 @@ void RBBIAPITest::runIndexedTest( int32_t index, UBool exec, const char* &name, 
     TESTCASE_AUTO(TestRoundtripRules);
     TESTCASE_AUTO(TestGetBinaryRules);
 #endif
+    TESTCASE_AUTO(TestMalformedBinaryData);
     TESTCASE_AUTO(TestRefreshInputText);
 #if !UCONFIG_NO_BREAK_ITERATION
     TESTCASE_AUTO(TestFilteredBreakIteratorBuilder);

--- a/icu4c/source/test/intltest/rbbiapts.h
+++ b/icu4c/source/test/intltest/rbbiapts.h
@@ -72,6 +72,11 @@ public:
     void TestGetBinaryRules();
 
     /**
+     * Test that malformed binary RBBI data returns U_INVALID_FORMAT_ERROR.
+     **/
+    void TestMalformedBinaryData();
+
+    /**
      * Tests grouping effect of 'single quotes' in rules.
      **/
     void TestQuoteGrouping();

--- a/icu4j/main/core/src/main/java/com/ibm/icu/impl/RBBIDataWrapper.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/impl/RBBIDataWrapper.java
@@ -324,6 +324,22 @@ public final class RBBIDataWrapper {
         int pos = DH_SIZE * 4; // offset of end of header, which has DH_SIZE fields, all int32_t (4
         // bytes)
 
+        // Validate all offset+length pairs against the total data length.
+        int totalLen = This.fHeader.fLength;
+        if (totalLen < pos
+                || This.fHeader.fFTable > totalLen
+                || This.fHeader.fFTableLen > totalLen - This.fHeader.fFTable
+                || This.fHeader.fRTable > totalLen
+                || This.fHeader.fRTableLen > totalLen - This.fHeader.fRTable
+                || This.fHeader.fTrie > totalLen
+                || This.fHeader.fTrieLen > totalLen - This.fHeader.fTrie
+                || This.fHeader.fRuleSource > totalLen
+                || This.fHeader.fRuleSourceLen > totalLen - This.fHeader.fRuleSource
+                || This.fHeader.fStatusTable > totalLen
+                || This.fHeader.fStatusTableLen > totalLen - This.fHeader.fStatusTable) {
+            throw new IOException("Break iterator Rule data corrupt");
+        }
+
         //
         // Read in the Forward state transition table as an array of shorts.
         //

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBITest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/rbbi/RBBITest.java
@@ -14,6 +14,8 @@ import com.ibm.icu.text.BreakIterator;
 import com.ibm.icu.text.RuleBasedBreakIterator;
 import com.ibm.icu.util.CodePointTrie;
 import com.ibm.icu.util.ULocale;
+import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.text.CharacterIterator;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1225,6 +1227,36 @@ public class RBBITest extends CoreTestFmwk {
             assertEquals("following" + idx, fns.expectedFollow(idx), bi.following(idx));
             idx = fns.randomStringIndex();
             assertEquals("preceding" + idx, fns.expectedPreceding(idx), bi.preceding(idx));
+        }
+    }
+
+    @Test
+    public void TestMalformedBinaryData() {
+        // Crafted RBBI data with out-of-bounds offsets (fTrie = 0x66666666).
+        // RBBIDataWrapper.get() must throw IOException, not crash.
+        byte[] data = {
+            (byte)0x00, (byte)0x00, (byte)0xb1, (byte)0xa0,  // magic (big-endian)
+            (byte)0x06, (byte)0x00, (byte)0x00, (byte)0x00,  // format version
+            (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x74,  // fLength = 116
+            (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00,  // fCatCount
+            (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x50,  // fFTable offset
+            (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00,  // fFTableLen
+            (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x50,  // fRTable offset
+            (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00,  // fRTableLen
+            (byte)0x66, (byte)0x66, (byte)0x66, (byte)0x66,  // fTrie = 0x66666666 (OOB)
+            (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x10,  // fTrieLen
+            (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x50,  // fRuleSource offset
+            (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00,  // fRuleSourceLen
+            (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x50,  // fStatusTable offset
+            (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00,  // fStatusTableLen
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 // reserved
+        };
+        ByteBuffer buf = ByteBuffer.wrap(data);
+        try {
+            RBBIDataWrapper.get(buf);
+            errln("Expected IOException from malformed RBBI binary data");
+        } catch (IOException e) {
+            // Expected
         }
     }
 }


### PR DESCRIPTION
Validate all offset+length pairs (fFTable, fRTable, fTrie, fRuleSource,
fStatusTable) against the total data length in `RBBIDataWrapper::init()`
before computing any pointers. Malformed input now returns
`U_INVALID_FORMAT_ERROR` instead of producing wild pointers.

#### Checklist
- [x] Required: Issue filed: [ICU-23394](https://unicode-org.atlassian.net/browse/ICU-23394)
- [x] Required: The PR title must be prefixed with a JIRA Issue number.
- [x] Required: Each commit message must be prefixed with a JIRA Issue number.
- [ ] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

[ICU-23394]: https://unicode-org.atlassian.net/browse/ICU-23394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ