### PR TITLE
ICU-23394 Validate serialized spoof data in SpoofData deserialization

### DIFF
--- a/icu4c/source/common/rbbidata.cpp
+++ b/icu4c/source/common/rbbidata.cpp
@@ -102,6 +102,23 @@ void RBBIDataWrapper::init(const RBBIDataHeader *data, UErrorCode &status) {
     //       that is no longer supported.  At that time fFormatVersion was
     //       an int32_t field, rather than an array of 4 bytes.
 
+    uint32_t totalLen = fHeader->fLength;
+    if (totalLen < sizeof(RBBIDataHeader)) {
+        status = U_INVALID_FORMAT_ERROR;
+        return;
+    }
+
+    // Validate all offset+length pairs against the total data length.
+    // Prevent integer overflow by checking each addend against totalLen first.
+    if (fHeader->fFTable > totalLen || fHeader->fFTableLen > totalLen - fHeader->fFTable ||
+        fHeader->fRTable > totalLen || fHeader->fRTableLen > totalLen - fHeader->fRTable ||
+        fHeader->fTrie > totalLen || fHeader->fTrieLen > totalLen - fHeader->fTrie ||
+        fHeader->fRuleSource > totalLen || fHeader->fRuleSourceLen > totalLen - fHeader->fRuleSource ||
+        fHeader->fStatusTable > totalLen || fHeader->fStatusTableLen > totalLen - fHeader->fStatusTable) {
+        status = U_INVALID_FORMAT_ERROR;
+        return;
+    }
+
     fDontFreeData = false;
     if (data->fFTableLen != 0) {
         fForwardTable = reinterpret_cast<const RBBIStateTable*>(reinterpret_cast<const char*>(data) + fHeader->fFTable);

--- a/icu4c/source/i18n/uspoof_impl.cpp
+++ b/icu4c/source/i18n/uspoof_impl.cpp
@@ -687,6 +687,52 @@ void SpoofData::initPtrs(UErrorCode &status) {
     if (U_FAILURE(status)) {
         return;
     }
+
+    int32_t totalLen = fRawData->fLength;
+    if (totalLen < static_cast<int32_t>(sizeof(SpoofDataHeader))) {
+        status = U_INVALID_FORMAT_ERROR;
+        return;
+    }
+
+    // Validate all offset+size pairs against the total data length.
+    if (fRawData->fCFUKeys < 0 || fRawData->fCFUKeys > totalLen ||
+        fRawData->fCFUKeysSize < 0 ||
+        fRawData->fCFUKeysSize > (totalLen - fRawData->fCFUKeys) / static_cast<int32_t>(sizeof(int32_t))) {
+        status = U_INVALID_FORMAT_ERROR;
+        return;
+    }
+    if (fRawData->fCFUStringIndex < 0 || fRawData->fCFUStringIndex > totalLen ||
+        fRawData->fCFUStringIndexSize < 0 ||
+        fRawData->fCFUStringIndexSize > (totalLen - fRawData->fCFUStringIndex) / static_cast<int32_t>(sizeof(uint16_t))) {
+        status = U_INVALID_FORMAT_ERROR;
+        return;
+    }
+    if (fRawData->fCFUStringTable < 0 || fRawData->fCFUStringTable > totalLen ||
+        fRawData->fCFUStringTableLen < 0 ||
+        fRawData->fCFUStringTableLen > (totalLen - fRawData->fCFUStringTable) / static_cast<int32_t>(sizeof(char16_t))) {
+        status = U_INVALID_FORMAT_ERROR;
+        return;
+    }
+
+    // Ensure consistency: offsets and sizes must agree.
+    // If keys exist, the value index and string table must also exist.
+    if (fRawData->fCFUKeysSize > 0 &&
+        (fRawData->fCFUKeys == 0 || fRawData->fCFUStringIndex == 0 || fRawData->fCFUStringTable == 0)) {
+        status = U_INVALID_FORMAT_ERROR;
+        return;
+    }
+    // If offset is zero, size must also be zero.
+    if ((fRawData->fCFUKeys == 0) != (fRawData->fCFUKeysSize == 0)) {
+        status = U_INVALID_FORMAT_ERROR;
+        return;
+    }
+    // Value index table must have at least as many entries as the keys table,
+    // since both are accessed by the same index from binary search.
+    if (fRawData->fCFUKeysSize > 0 && fRawData->fCFUStringIndexSize < fRawData->fCFUKeysSize) {
+        status = U_INVALID_FORMAT_ERROR;
+        return;
+    }
+
     if (fRawData->fCFUKeys != 0) {
         fCFUKeys = reinterpret_cast<int32_t*>(reinterpret_cast<char*>(fRawData) + fRawData->fCFUKeys);
     }
@@ -768,6 +814,10 @@ int32_t SpoofData::confusableLookup(UChar32 inChar, UnicodeString &dest) const {
     // The result after the loop will be in lo.
     int32_t lo = 0;
     int32_t hi = length();
+    if (hi == 0 || fCFUKeys == nullptr) {
+        dest.append(inChar);
+        return 1;
+    }
     do {
         int32_t mid = (lo + hi) / 2;
         if (codePointAt(mid) > inChar) {
@@ -808,6 +858,12 @@ int32_t SpoofData::appendValueTo(int32_t index, UnicodeString& dest) const {
     if (stringLength == 1) {
         dest.append(static_cast<char16_t>(value));
     } else {
+        int32_t tableLen = fRawData->fCFUStringTableLen;
+        if (fCFUStrings == nullptr || value > tableLen ||
+            stringLength > tableLen - value) {
+            dest.append(static_cast<UChar32>(0xFFFD));
+            return 1;
+        }
         dest.append(fCFUStrings + value, stringLength);
     }
 

--- a/icu4c/source/test/intltest/itspoof.cpp
+++ b/icu4c/source/test/intltest/itspoof.cpp
@@ -109,6 +109,7 @@ void IntlTestSpoof::runIndexedTest( int32_t index, UBool exec, const char* &name
     TESTCASE_AUTO(testBug13314_MixedNumbers);
     TESTCASE_AUTO(testBug13328_MixedCombiningMarks);
     TESTCASE_AUTO(testCombiningDot);
+    TESTCASE_AUTO(testMalformedSpoofData);
     TESTCASE_AUTO_END;
 }
 
@@ -843,6 +844,44 @@ void IntlTestSpoof::testCombiningDot() {
         TEST_ASSERT_SUCCESS(status);
         int32_t expected = cas.shouldFail ? USPOOF_HIDDEN_OVERLAY : 0;
         assertEquals(cas.input, expected, failedChecks);
+    }
+}
+
+void IntlTestSpoof::testMalformedSpoofData() {
+    // Crafted serialized spoof data that triggers a NULL deref in confusableLookup()
+    // when fCFUKeys is nullptr but fCFUKeysSize > 0. Before the fix, uspoof_check()
+    // would SEGV. After the fix, uspoof_openFromSerialized must return U_INVALID_FORMAT_ERROR.
+    static const uint8_t nullDerefData[] = {
+        0xef, 0xfd, 0x45, 0x38, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x6f, 0x00, 0x00, 0x00, 0xaf,
+        0xaf, 0xaf, 0xaf, 0xaf, 0xaf, 0xaf, 0xaf, 0x4a, 0xaf, 0xaf, 0xaf, 0xaf,
+        0xa9, 0xaf, 0xaf, 0xaf, 0xaf, 0xaf, 0xaf, 0xaf, 0xaf, 0xaf, 0xaf, 0x6f,
+        0x00, 0x00, 0x00, 0xaf, 0xaf, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xfb, 0xff, 0xff, 0xff, 0xff, 0x0a, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff
+    };
+
+    UErrorCode status = U_ZERO_ERROR;
+    int32_t actualLength = 0;
+    USpoofChecker *sc = uspoof_openFromSerialized(
+        nullDerefData, sizeof(nullDerefData), &actualLength, &status);
+    if (U_SUCCESS(status)) {
+        // If it somehow opened, close it, but this is a test failure.
+        uspoof_close(sc);
+        errln("%s:%d Expected U_INVALID_FORMAT_ERROR from malformed spoof data (null deref case), got %s",
+              __FILE__, __LINE__, u_errorName(status));
+    }
+
+    // Truncated header: less than sizeof(SpoofDataHeader).
+    static const uint8_t shortData[] = {0xef, 0xfd, 0x45, 0x38, 0x02, 0x00};
+    status = U_ZERO_ERROR;
+    sc = uspoof_openFromSerialized(shortData, sizeof(shortData), &actualLength, &status);
+    if (U_SUCCESS(status)) {
+        uspoof_close(sc);
+        errln("%s:%d Expected U_INVALID_FORMAT_ERROR from truncated spoof data, got %s",
+              __FILE__, __LINE__, u_errorName(status));
     }
 }
 

--- a/icu4c/source/test/intltest/itspoof.h
+++ b/icu4c/source/test/intltest/itspoof.h
@@ -60,6 +60,8 @@ public:
 
     void testCombiningDot();
 
+    void testMalformedSpoofData();
+
     // Internal functions to run a single skeleton test case.
     void checkSkeleton(const USpoofChecker *sc, uint32_t flags, const char *input, const char *expected,
                        int32_t lineNum);

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/SpoofChecker.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/SpoofChecker.java
@@ -2042,6 +2042,21 @@ public class SpoofChecker {
             int CFUStringTableOffset = bytes.getInt();
             int CFUStringTableSize = bytes.getInt();
 
+            // Validate offsets and sizes against total data length.
+            if (dataLength < 36  // minimum header size (9 int32 fields)
+                    || CFUKeysOffset < 0 || CFUKeysOffset > dataLength
+                    || CFUKeysSize < 0 || CFUKeysSize > (dataLength - CFUKeysOffset) / 4
+                    || CFUValuesOffset < 0 || CFUValuesOffset > dataLength
+                    || CFUValuesSize < 0 || CFUValuesSize > (dataLength - CFUValuesOffset) / 2
+                    || CFUStringTableOffset < 0 || CFUStringTableOffset > dataLength
+                    || CFUStringTableSize < 0 || CFUStringTableSize > (dataLength - CFUStringTableOffset) / 2) {
+                throw new java.io.IOException("Bad Spoof Check Data: invalid offsets or sizes.");
+            }
+            // Cross-table consistency: values table must be at least as large as keys table.
+            if (CFUKeysSize > 0 && CFUValuesSize < CFUKeysSize) {
+                throw new java.io.IOException("Bad Spoof Check Data: values table smaller than keys table.");
+            }
+
             // We have now read the file header, and obtained the position for each
             // of the data items. Now read each in turn, first seeking the
             // input stream to the position of the data item.
@@ -2071,6 +2086,10 @@ public class SpoofChecker {
             // The result after the loop will be in lo.
             int lo = 0;
             int hi = length();
+            if (hi == 0 || fCFUKeys == null) {
+                dest.appendCodePoint(inChar);
+                return;
+            }
             do {
                 int mid = (lo + hi) / 2;
                 if (codePointAt(mid) > inChar) {


### PR DESCRIPTION
Bounds check all offset+size pairs in `SpoofData::initPtrs()`, add
cross-table consistency validation, guard against null/empty data in
`confusableLookup()`, and bounds check string table access in
`appendValueTo()`. Malformed serialized data now returns
`U_INVALID_FORMAT_ERROR`.

#### Checklist
- [x] Required: Issue filed: [ICU-23394](https://unicode-org.atlassian.net/browse/ICU-23394)
- [x] Required: The PR title must be prefixed with a JIRA Issue number.
- [x] Required: Each commit message must be prefixed with a JIRA Issue number.
- [ ] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

[ICU-23394]: https://unicode-org.atlassian.net/browse/ICU-23394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ