### PR TITLE
ICU-23394 Validate serialized trie data in utrie2/ucptrie deserialization

### DIFF
--- a/icu4c/source/common/ucptrie.cpp
+++ b/icu4c/source/common/ucptrie.cpp
@@ -82,6 +82,12 @@ ucptrie_openFromBinary(UCPTrieType type, UCPTrieValueWidth valueWidth,
     tempTrie.type = type;
     tempTrie.valueWidth = valueWidth;
 
+    if (tempTrie.indexLength <= 0 || tempTrie.dataLength <= 0x80 ||
+            tempTrie.dataLength < UCPTRIE_HIGH_VALUE_NEG_DATA_OFFSET) {
+        *pErrorCode = U_INVALID_FORMAT_ERROR;
+        return nullptr;
+    }
+
     // Calculate the actual length.
     int32_t actualLength = (int32_t)sizeof(UCPTrieHeader) + tempTrie.indexLength * 2;
     if (valueWidth == UCPTRIE_VALUE_BITS_16) {
@@ -111,6 +117,16 @@ ucptrie_openFromBinary(UCPTrieType type, UCPTrieValueWidth valueWidth,
     const uint16_t *p16 = (const uint16_t *)(header + 1);
     trie->index = p16;
     p16 += trie->indexLength;
+
+    // Validate index entries: each value + FAST_DATA_MASK must be < dataLength.
+    int32_t maxDataIndex = trie->dataLength - 1;
+    for (int32_t i = 0; i < trie->indexLength; ++i) {
+        if ((int32_t)trie->index[i] + UCPTRIE_FAST_DATA_MASK > maxDataIndex) {
+            uprv_free(trie);
+            *pErrorCode = U_INVALID_FORMAT_ERROR;
+            return nullptr;
+        }
+    }
 
     // Get the data.
     int32_t nullValueOffset = trie->dataNullOffset;

--- a/icu4c/source/common/utrie2.cpp
+++ b/icu4c/source/common/utrie2.cpp
@@ -174,6 +174,25 @@ utrie2_openFromSerialized(UTrie2ValueBits valueBits,
     tempTrie.dataNullOffset=header->dataNullOffset;
 
     tempTrie.highStart=header->shiftedHighStart<<UTRIE2_SHIFT_1;
+
+    if(tempTrie.indexLength<=0 || tempTrie.dataLength<=0 ||
+            tempTrie.dataLength<UTRIE2_DATA_GRANULARITY ||
+            tempTrie.dataLength<=UTRIE2_BAD_UTF8_DATA_OFFSET) {
+        *pErrorCode=U_INVALID_FORMAT_ERROR;
+        return nullptr;
+    }
+    if(valueBits==UTRIE2_16_VALUE_BITS) {
+        if(tempTrie.dataNullOffset>=(tempTrie.indexLength+tempTrie.dataLength)) {
+            *pErrorCode=U_INVALID_FORMAT_ERROR;
+            return nullptr;
+        }
+    } else {
+        if(tempTrie.dataNullOffset>=tempTrie.dataLength) {
+            *pErrorCode=U_INVALID_FORMAT_ERROR;
+            return nullptr;
+        }
+    }
+
     tempTrie.highValueIndex=tempTrie.dataLength-UTRIE2_DATA_GRANULARITY;
     if(valueBits==UTRIE2_16_VALUE_BITS) {
         tempTrie.highValueIndex+=tempTrie.indexLength;

--- a/icu4c/source/test/cintltst/trie2test.c
+++ b/icu4c/source/test/cintltst/trie2test.c
@@ -1425,6 +1425,35 @@ Trie12ConversionTest(void) {
                        checkRanges2, UPRV_LENGTHOF(checkRanges2));
 }
 
+static void
+MalformedSerializedTrieTest(void) {
+    /* Crafted 20-byte serialized UTrie2 with dataNullOffset and dataLength
+       values that cause utrie2_openFromSerialized() to read past the
+       allocated buffer. Before the fix this was a heap OOB read. */
+    static const uint8_t data[] = {
+        0x32, 0x69, 0x72, 0x54, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x14, 0x76, 0x76, 0x76, 0x76, 0x76,
+        0x76, 0x76, 0x76, 0x76
+    };
+    UErrorCode status = U_ZERO_ERROR;
+    int32_t actualLength = 0;
+    UTrie2 *trie = utrie2_openFromSerialized(
+        UTRIE2_16_VALUE_BITS, data, sizeof(data), &actualLength, &status);
+    if (U_SUCCESS(status)) {
+        log_err("utrie2_openFromSerialized(malformed) succeeded, expected U_INVALID_FORMAT_ERROR\n");
+        utrie2_close(trie);
+    }
+
+    /* Also try with 32-bit value bits. */
+    status = U_ZERO_ERROR;
+    trie = utrie2_openFromSerialized(
+        UTRIE2_32_VALUE_BITS, data, sizeof(data), &actualLength, &status);
+    if (U_SUCCESS(status)) {
+        log_err("utrie2_openFromSerialized(malformed, 32-bit) succeeded, expected U_INVALID_FORMAT_ERROR\n");
+        utrie2_close(trie);
+    }
+}
+
 void
 addTrie2Test(TestNode** root) {
     addTest(root, &TrieTest, "tsutil/trie2test/TrieTest");
@@ -1434,4 +1463,5 @@ addTrie2Test(TestNode** root) {
     addTest(root, &FreeBlocksTest, "tsutil/trie2test/FreeBlocksTest");
     addTest(root, &GrowDataArrayTest, "tsutil/trie2test/GrowDataArrayTest");
     addTest(root, &Trie12ConversionTest, "tsutil/trie2test/Trie12ConversionTest");
+    addTest(root, &MalformedSerializedTrieTest, "tsutil/trie2test/MalformedSerializedTrieTest");
 }

--- a/icu4c/source/test/cintltst/ucptrietest.c
+++ b/icu4c/source/test/cintltst/ucptrietest.c
@@ -1644,6 +1644,38 @@ static void ShortAllSameBlocksTest(void) {
     umutablecptrie_close(mutableTrie);
 }
 
+static void
+MalformedSerializedCPTrieTest(void) {
+    /* Crafted 24-byte serialized UCPTrie with index entries pointing outside
+       the data array. Before the fix, ucptrie_get() would read 2 bytes at
+       an attacker-controlled offset past the allocation. */
+    static const uint8_t data[] = {
+        0x33, 0x69, 0x72, 0x54, 0x00, 0x0f, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0xce, 0xce, 0xce,
+        0xce, 0xce, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x28
+    };
+    UErrorCode status = U_ZERO_ERROR;
+    int32_t actualLength = 0;
+    UCPTrie *trie = ucptrie_openFromBinary(
+        UCPTRIE_TYPE_FAST, UCPTRIE_VALUE_BITS_16,
+        data, sizeof(data), &actualLength, &status);
+    if (U_SUCCESS(status)) {
+        log_err("ucptrie_openFromBinary(malformed) succeeded, expected U_INVALID_FORMAT_ERROR\n");
+        ucptrie_close(trie);
+    }
+
+    /* Truncated data: less than header size. */
+    static const uint8_t shortData[] = {0x33, 0x69, 0x72, 0x54, 0x00, 0x0f};
+    status = U_ZERO_ERROR;
+    trie = ucptrie_openFromBinary(
+        UCPTRIE_TYPE_FAST, UCPTRIE_VALUE_BITS_16,
+        shortData, sizeof(shortData), &actualLength, &status);
+    if (U_SUCCESS(status)) {
+        log_err("ucptrie_openFromBinary(truncated) succeeded, expected U_INVALID_FORMAT_ERROR\n");
+        ucptrie_close(trie);
+    }
+}
+
 void
 addUCPTrieTest(TestNode** root) {
     addTest(root, &TrieTestSet1, "tsutil/ucptrietest/TrieTestSet1");
@@ -1659,4 +1691,5 @@ addUCPTrieTest(TestNode** root) {
     addTest(root, &TrieTestGetRangesFixedSurr, "tsutil/ucptrietest/TrieTestGetRangesFixedSurr");
     addTest(root, &TestSmallNullBlockMatchesFast, "tsutil/ucptrietest/TestSmallNullBlockMatchesFast");
     addTest(root, &ShortAllSameBlocksTest, "tsutil/ucptrietest/ShortAllSameBlocksTest");
+    addTest(root, &MalformedSerializedCPTrieTest, "tsutil/ucptrietest/MalformedSerializedCPTrieTest");
 }

--- a/icu4j/main/core/src/main/java/com/ibm/icu/impl/Trie2.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/impl/Trie2.java
@@ -137,6 +137,22 @@ public abstract class Trie2 implements Iterable<Trie2.Range> {
             This.index2NullOffset = header.index2NullOffset;
             This.dataNullOffset = header.dataNullOffset;
             This.highStart = header.shiftedHighStart << UTRIE2_SHIFT_1;
+
+            // Validate lengths and offsets.
+            if (This.indexLength <= 0 || This.dataLength <= 0
+                    || This.dataLength <= UTRIE2_BAD_UTF8_DATA_OFFSET) {
+                throw new IOException("UTrie2 serialized format error: invalid lengths.");
+            }
+            if (width == ValueWidth.BITS_16) {
+                if (This.dataNullOffset >= This.indexLength + This.dataLength) {
+                    throw new IOException("UTrie2 serialized format error: dataNullOffset out of range.");
+                }
+            } else {
+                if (This.dataNullOffset >= This.dataLength) {
+                    throw new IOException("UTrie2 serialized format error: dataNullOffset out of range.");
+                }
+            }
+
             This.highValueIndex = This.dataLength - UTRIE2_DATA_GRANULARITY;
             if (width == ValueWidth.BITS_16) {
                 This.highValueIndex += This.indexLength;

--- a/icu4j/main/core/src/main/java/com/ibm/icu/util/CodePointTrie.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/util/CodePointTrie.java
@@ -228,6 +228,13 @@ public abstract class CodePointTrie extends CodePointMap {
             dataLength |= ((options & OPTIONS_DATA_LENGTH_MASK) << 4);
             dataNullOffset |= ((options & OPTIONS_DATA_NULL_OFFSET_MASK) << 8);
 
+            // Validate minimum lengths.
+            if (indexLength <= 0 || dataLength <= ASCII_LIMIT
+                    || dataLength < HIGH_VALUE_NEG_DATA_OFFSET) {
+                throw new ICUUncheckedIOException(
+                        "CodePointTrie data header has invalid index or data length");
+            }
+
             int highStart = shiftedHighStart << SHIFT_2;
 
             // Calculate the actual length, minus the header.
@@ -244,6 +251,16 @@ public abstract class CodePointTrie extends CodePointMap {
             }
 
             char[] index = ICUBinary.getChars(bytes, indexLength, 0);
+
+            // Validate index entries: each value + FAST_DATA_MASK must be < dataLength.
+            int maxDataIndex = dataLength - 1;
+            for (int i = 0; i < indexLength; ++i) {
+                if ((int) index[i] + FAST_DATA_MASK > maxDataIndex) {
+                    throw new ICUUncheckedIOException(
+                            "CodePointTrie index entry out of range at " + i);
+                }
+            }
+
             switch (valueWidth) {
                 case BITS_16:
                     {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/CodePointTrieTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/CodePointTrieTest.java
@@ -1202,4 +1202,26 @@ public final class CodePointTrieTest extends CoreTestFmwk {
     public void BlockPropertyTest() {
         testIntProperty("block", "[:^blk=No_Block:]", UProperty.BLOCK);
     }
+
+    @Test
+    public void TestMalformedSerializedCPTrie() {
+        // Crafted UCPTrie data with out-of-range index entries.
+        // Must throw an exception, not produce out-of-bounds reads.
+        byte[] data = {
+            0x54, 0x72, 0x69, 0x33,  // signature "Tri3" (big-endian)
+            0x00, 0x00,              // options
+            0x00, 0x0f,              // indexLength = 15
+            0x00, 0x00,              // dataLength bits 15..0 = 0 (too small)
+            0x00, 0x00,              // index3NullOffset
+            0x00, 0x00,              // dataNullOffset
+            0x00, 0x00               // shiftedHighStart
+        };
+        ByteBuffer buf = ByteBuffer.wrap(data);
+        try {
+            CodePointTrie.fromBinary(null, null, buf);
+            errln("Expected exception from malformed CodePointTrie data");
+        } catch (Exception e) {
+            // Expected
+        }
+    }
 }

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/Trie2Test.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/Trie2Test.java
@@ -771,6 +771,28 @@ public class Trie2Test extends CoreTestFmwk {
         checkTrieRanges("set2-overlap.withClone", "setRanges2", true, setRanges2, checkRanges2);
     }
 
+    @Test
+    public void TestMalformedSerializedTrie2() {
+        // Crafted UTrie2 data with dataNullOffset and dataLength that cause
+        // out-of-bounds array access. Must throw an exception, not crash.
+        byte[] data = {
+            0x54, 0x72, 0x69, 0x32,  // signature "Tri2" (big-endian)
+            0x00, 0x00,              // options: 16-bit values
+            0x00, 0x00,              // indexLength = 0 (invalid)
+            0x00, 0x00,              // shiftedDataLength = 0 (invalid)
+            0x00, 0x00,              // index2NullOffset
+            0x76, 0x76,              // dataNullOffset = 0x7676 (OOB)
+            0x00, 0x00               // shiftedHighStart
+        };
+        ByteBuffer buf = ByteBuffer.wrap(data);
+        try {
+            Trie2.createFromSerialized(buf);
+            errln("Expected exception from malformed UTrie2 data");
+        } catch (IOException | IllegalArgumentException e) {
+            // Expected
+        }
+    }
+
     private String where() {
         StackTraceElement[] st = new Throwable().getStackTrace();
         String w = "File: " + st[1].getFileName() + ", Line " + st[1].getLineNumber();


### PR DESCRIPTION
Add bounds checking in `utrie2_openFromSerialized()` (dataNullOffset,
dataLength, indexLength) and `ucptrie_openFromBinary()` (index entry
range scan, dataLength minimum). Malformed serialized data now returns
`U_INVALID_FORMAT_ERROR`.

#### Checklist
- [x] Required: Issue filed: [ICU-23394](https://unicode-org.atlassian.net/browse/ICU-23394)
- [x] Required: The PR title must be prefixed with a JIRA Issue number.
- [x] Required: Each commit message must be prefixed with a JIRA Issue number.
- [ ] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable

[ICU-23394]: https://unicode-org.atlassian.net/browse/ICU-23394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ