### PR TITLE
ICU-23247 Decrease initial delay for CI check enforcement job

### DIFF
--- a/.github/workflows/wait-for-checks.yml
+++ b/.github/workflows/wait-for-checks.yml
@@ -36,5 +36,5 @@ jobs:
         # "neutral" is interpreted by this action as a failure.
         # Since the jobs are superfluous, they can be ignored.
         ignore: "CI-ICU4C,CI-ICU4J,ClusterFuzzLite/CIFuzz"
-        # Wait for 2 minutes before this action begins its work by polling Github for job/check status
-        delay: 120s
+        # Wait for 1 minute before this action begins its work by polling Github for job/check status
+        delay: 60s


### PR DESCRIPTION
Some CI runs (ex: docs) can be done quicker than 2 minutes, so may as well lower the delay on `enforce-all-checks` to 60 seconds instead of 120.

#### Checklist
- [X] Required: Issue filed: ICU-23247
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [X] Approver: Feel free to merge on my behalf
