### PR TITLE
ICU-23402 Fix build on 64bit GNU/Hurd

### DIFF
--- a/icu4c/source/configure
+++ b/icu4c/source/configure
@@ -6004,7 +6004,7 @@ printf %s "checking whether we can use static library optimization option... " >
             OLD_LDFLAGS="${LDFLAGS}"
 
             case "${host}" in
-            *-linux*|i*86-*-*bsd*|i*86-pc-gnu|*-haiku*)
+            *-linux*|i*86-*-*bsd*|*-pc-gnu|*-haiku*)
                 if test "$GCC" = yes; then
                     CPPFLAGS="${CPPFLAGS} -ffunction-sections -fdata-sections"
                     LDFLAGS="${LDFLAGS} -Wl,--gc-sections"
@@ -7009,7 +7009,7 @@ printf %s "checking for genccode assembly... " >&6; }
 # Check to see if genccode can generate simple assembly.
 GENCCODE_ASSEMBLY=
 case "${host}" in
-*-linux*|*-kfreebsd*-gnu*|i*86-*-*bsd*|i*86-pc-gnu)
+*-linux*|*-kfreebsd*-gnu*|i*86-*-*bsd*|*-pc-gnu)
     if test "$GCC" = yes; then
         # We're using gcc, and the simple -a gcc command line works for genccode
         GENCCODE_ASSEMBLY="-a gcc"

--- a/icu4c/source/configure.ac
+++ b/icu4c/source/configure.ac
@@ -306,7 +306,7 @@ if test "$ENABLE_STATIC" = "YES"; then
             OLD_LDFLAGS="${LDFLAGS}"
 
             case "${host}" in
-            *-linux*|i*86-*-*bsd*|i*86-pc-gnu|*-haiku*)
+            *-linux*|i*86-*-*bsd*|*-pc-gnu|*-haiku*)
                 if test "$GCC" = yes; then
                     CPPFLAGS="${CPPFLAGS} -ffunction-sections -fdata-sections"
                     LDFLAGS="${LDFLAGS} -Wl,--gc-sections"
@@ -613,7 +613,7 @@ AC_MSG_CHECKING([for genccode assembly])
 # Check to see if genccode can generate simple assembly.
 GENCCODE_ASSEMBLY=
 case "${host}" in
-*-linux*|*-kfreebsd*-gnu*|i*86-*-*bsd*|i*86-pc-gnu)
+*-linux*|*-kfreebsd*-gnu*|i*86-*-*bsd*|*-pc-gnu)
     if test "$GCC" = yes; then
         # We're using gcc, and the simple -a gcc command line works for genccode
         GENCCODE_ASSEMBLY="-a gcc"


### PR DESCRIPTION
ICU fails to build on 64-bit GNU/Hurd like this currently (see e.g. https://buildd.debian.org/status/fetch.php?pkg=icu&arch=hurd-amd64&ver=78.3-1&stamp=1773860709&raw=0):

```
make[3]: Making `all' in `uconv'
make[4]: Entering directory '/build/reproducible-path/icu-78.3/source/extra/uconv'
mkdir uconvmsg
c++ -Wdate-time -D_FORTIFY_SOURCE=2 -DU_TIMEZONE_FILES_DIR=/usr/share/zoneinfo-icu/44/le/ -D_REENTRANT -DU_HAVE_ELF_H=1 -I. -I../../common -I../../i18n -I./../toolutil -DUNISTR_FROM_CHAR_EXPLICIT=explicit -DUNISTR_FROM_STRING_EXPLICIT=explicit -DU_ALL_IMPLEMENTATION -DU_ATTRIBUTE_DEPRECATED= -DUCONVMSG_LINK=uconvmsg -g -O2 -ffile-prefix-map=/build/reproducible-path/icu-78.3=. -fstack-protector-strong -Wformat -Werror=format-security -fcf-protection -fexcess-precision=fast -fexcess-precision=fast -W -Wall -pedantic -Wpointer-arith -Wwrite-strings -Wno-long-long -std=c++17 -c -o uconv.o uconv.cpp
cc -Wdate-time -D_FORTIFY_SOURCE=2 -DU_TIMEZONE_FILES_DIR=/usr/share/zoneinfo-icu/44/le/ -D_REENTRANT -DU_HAVE_ELF_H=1 -I. -I../../common -I../../i18n -I./../toolutil -DUNISTR_FROM_CHAR_EXPLICIT=explicit -DUNISTR_FROM_STRING_EXPLICIT=explicit -DU_ALL_IMPLEMENTATION -DU_ATTRIBUTE_DEPRECATED= -DUCONVMSG_LINK=uconvmsg -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/build/reproducible-path/icu-78.3=. -fstack-protector-strong -Wformat -Werror=format-security -fcf-protection -std=c11 -Wall -pedantic -Wshadow -Wpointer-arith -Wmissing-prototypes -Wwrite-strings -c -o uwmsg.o uwmsg.c
LD_LIBRARY_PATH=../../lib:../../stubdata:../../tools/ctestfw:$LD_LIBRARY_PATH  ../../bin/genrb -e UTF-8 -s resources -d uconvmsg root.txt
../../bin/genrb: can not initialize ICU.  status = U_INVALID_FORMAT_ERROR
make[4]: *** [Makefile:176: uconvmsg/root.res] Error 1
```

This appears to be because autoconf does only take 32-bit Hurd into account. This PR makes the build pass.


#### Checklist
- [x] Required: Issue filed: ICU-23402
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf
