### PR TITLE
ICU-23403 Fix data race in CurrencyPrecision.withCurrency

### DIFF
--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/number/NumberFormatterApiTest.java
@@ -6960,4 +6960,43 @@ public class NumberFormatterApiTest extends CoreTestFmwk {
         FormattedValueTest.checkFormattedValue(
                 message, result, result.toString(), expectedFieldPositions);
     }
+
+    @Test
+    public void testCurrencyPrecisionCacheMutation() {
+        Currency usd = Currency.getInstance("USD");
+
+        // Precision gets cached, we want to make sure the cache isn't overwritten.
+
+        // 1. Format using the cached Precision as is
+        String actual1 =
+                NumberFormatter.with()
+                        .precision(Precision.currency(CurrencyUsage.STANDARD))
+                        .locale(Locale.US)
+                        .unit(usd)
+                        .format(123.0)
+                        .toString();
+        assertEquals("Initial formatting with cached Precision", "$123.00", actual1);
+
+        // 2. Format modifying the Precision's trailingZeroDisplay
+        String actual2 =
+                NumberFormatter.with()
+                        .precision(
+                                Precision.currency(CurrencyUsage.STANDARD)
+                                        .trailingZeroDisplay(TrailingZeroDisplay.HIDE_IF_WHOLE))
+                        .locale(Locale.US)
+                        .unit(usd)
+                        .format(123.0)
+                        .toString();
+        assertEquals("Formatting with modified trailingZeroDisplay", "$123", actual2);
+
+        // 3. Format like the first time again, expect the same result
+        String actual3 =
+                NumberFormatter.with()
+                        .precision(Precision.currency(CurrencyUsage.STANDARD))
+                        .locale(Locale.US)
+                        .unit(usd)
+                        .format(123.0)
+                        .toString();
+        assertEquals("Subsequent formatting with cached Precision", "$123.00", actual3);
+    }
 }

--- a/icu4j/main/core/src/main/java/com/ibm/icu/number/CurrencyPrecision.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/number/CurrencyPrecision.java
@@ -37,8 +37,9 @@ public abstract class CurrencyPrecision extends Precision {
     public Precision withCurrency(Currency currency) {
         if (currency != null) {
             Precision retval = constructFromCurrency(this, currency);
-            retval.trailingZeroDisplay = trailingZeroDisplay;
-            return retval;
+            // trailingZeroDisplay returns a clone if trailingZeroDisplay differs,
+            // preventing data races on shared static instances (e.g. FIXED_FRAC_0).
+            return retval.trailingZeroDisplay(trailingZeroDisplay);
         } else {
             throw new IllegalArgumentException("Currency must not be null");
         }

--- a/icu4j/main/core/src/main/java/com/ibm/icu/number/Precision.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/number/Precision.java
@@ -346,6 +346,10 @@ public abstract class Precision {
      * @stable ICU 69
      */
     public Precision trailingZeroDisplay(TrailingZeroDisplay trailingZeroDisplay) {
+        // Question: Should we avoid cloning if one is null and the other is AUTO?
+        if (this.trailingZeroDisplay == trailingZeroDisplay) {
+            return this;
+        }
         Precision result = this.createCopy();
         result.trailingZeroDisplay = trailingZeroDisplay;
         return result;


### PR DESCRIPTION
Clone the Precision object returned by constructFromCurrency before mutating its trailingZeroDisplay field. This prevents mutating shared static instances like FIXED_FRAC_0 or FIXED_FRAC_2 when multiple threads concurrently call withCurrency.

This was investigated and fixed by Gemini.


#### Checklist
- [x] Required: Issue filed: /ICU-23403
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf
