### PR TITLE
ICU-23371 Use weak reference for the values in the stvStringPool cache

### DIFF
--- a/icu4j/main/translit/src/main/java/com/ibm/icu/text/TransliteratorRegistry.java
+++ b/icu4j/main/translit/src/main/java/com/ibm/icu/text/TransliteratorRegistry.java
@@ -20,6 +20,7 @@ import com.ibm.icu.lang.UScript;
 import com.ibm.icu.text.RuleBasedTransliterator.Data;
 import com.ibm.icu.util.CaseInsensitiveString;
 import com.ibm.icu.util.UResourceBundle;
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -32,6 +33,7 @@ import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 class TransliteratorRegistry {
@@ -69,7 +71,13 @@ class TransliteratorRegistry {
     /** Vector of public full IDs (CaseInsensitiveString objects). */
     private final Set<CaseInsensitiveString> availableIDs;
 
-    private final Map<String, CaseInsensitiveString> stvStringPool;
+    /**
+     * CaseInsensitiveString refers to the key here, and thus according to the API doc of
+     * WeakHashMap, the value needs to be a WeakReference. We currently can't use
+     * `CaseInsensitiveString` as the key because IDEnumeration returns unfolded string, and we need
+     * to preserve the unfolded value of CaseInsensitiveString.
+     */
+    private final Map<String, WeakReference<CaseInsensitiveString>> stvStringPool;
 
     // ----------------------------------------------------------------------
     // class Spec
@@ -882,7 +890,19 @@ class TransliteratorRegistry {
     }
 
     private CaseInsensitiveString toInternedSTVString(String key) {
-        return stvStringPool.computeIfAbsent(key, CaseInsensitiveString::new);
+        AtomicReference<CaseInsensitiveString> ref = new AtomicReference<>();
+        stvStringPool.compute(
+                key,
+                (k, holder) -> {
+                    CaseInsensitiveString newValue;
+                    if (holder == null || (newValue = holder.get()) == null) {
+                        newValue = new CaseInsensitiveString(k);
+                        holder = new WeakReference<>(newValue);
+                    }
+                    ref.set(newValue);
+                    return holder;
+                });
+        return ref.get();
     }
 }
 


### PR DESCRIPTION
To fix a memory leak due to the strong reference from the value to the key.

#### Checklist
- [x] Required: Issue filed: ICU-23371
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf
