### PR TITLE
ICU-23317 Rounding seconds in metazone mapping date data in cldr-to-icu

### DIFF
--- a/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/IcuFunctions.java
+++ b/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/IcuFunctions.java
@@ -228,5 +228,44 @@ final class IcuFunctions {
         }
     }
 
+    // For DATE_ROUND_SEC_FN
+    private enum RoundingType {
+        UP,
+        DOWN
+    }
+
+    private static final Pattern DATE_WITH_SECONDS_PATTERN = Pattern.compile("(\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}):(\\d{2})");
+
+    /**
+     * For rounding up/down useMetaZone from/to date. Older version of ICU cannot
+     * handle metazone mapping from/to date with second field. For example,
+     * Africa/Monrovia maps to metazone GMT starting 1970-01-07T00:44:30.
+     * This function round up/down second field to drop the second field.
+     * For 'from' attribute with non-zero seconds, we want to round up to next
+     * minute. For 'to' attribute with non-zero seconds, we want to round off.
+     * At this moment, we only have the Monrovia / 'from' requires this rounding
+     * operation.
+     */
+    static final NamedFunction DATE_ROUND_SEC_FN =
+        NamedFunction.create(
+            "date_round_sec",
+            2,
+            args -> {
+                String dateStr = args.get(0);
+                Matcher matcher = DATE_WITH_SECONDS_PATTERN.matcher(dateStr);
+                if (matcher.matches()) {
+                    RoundingType roundingType = RoundingType.valueOf(args.get(1));
+                    String secStr = matcher.group(2);
+                    if (secStr.equals("00") || roundingType == RoundingType.DOWN) {
+                        dateStr = dateStr.substring(0, dateStr.length() - 3);
+                    } else {
+                        LocalDateTime ldt = LocalDateTime.parse(matcher.group(1).replace(' ', 'T') + ":00");
+                        ldt = ldt.plusMinutes(1);
+                        dateStr = ldt.toString().replace('T', ' ').substring(0, dateStr.length() - 3);
+                    }
+                }
+                return dateStr;
+            });
+
     private IcuFunctions() {}
 }

--- a/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/LdmlConverter.java
+++ b/tools/cldr/cldr-to-icu/src/main/java/org/unicode/icu/tool/cldrtoicu/LdmlConverter.java
@@ -228,6 +228,7 @@ public final class LdmlConverter {
                         readLinesFromResource("/ldml2icu_supplemental.txt"),
                         IcuFunctions.ALGORITHM_FN,
                         IcuFunctions.DATE_FN,
+                        IcuFunctions.DATE_ROUND_SEC_FN,
                         IcuFunctions.DAY_NUMBER_FN,
                         IcuFunctions.EXP_FN,
                         IcuFunctions.YMD_FN);

--- a/tools/cldr/cldr-to-icu/src/main/resources/ldml2icu_supplemental.txt
+++ b/tools/cldr/cldr-to-icu/src/main/resources/ldml2icu_supplemental.txt
@@ -322,15 +322,15 @@
 //supplementalData/metaZones/metazoneInfo/timezone[@type="(%W)"]/usesMetazone[@mzone="(%W)"] ; /metazoneInfo/"$1"/<$2> ; values=$2
 # If we also have from and/or to, then we produce a 3-element array, with from/to (possibly default) as the 2nd/3rd elements.
 # Note that ICU code before version 79 will only handle from/to if the array is exactly 3 elements
-//supplementalData/metaZones/metazoneInfo/timezone[@type="(%W)"]/usesMetazone[@from="(%A)"][@mzone="(%W)"] ; /metazoneInfo/"$1"/<$2> ; values=$3 "$2" "9999-12-31 23:59"
-//supplementalData/metaZones/metazoneInfo/timezone[@type="(%W)"]/usesMetazone[@from="(%A)"][@to="(%A)"][@mzone="(%W)"] ; /metazoneInfo/"$1"/<$2> ; values=$4 "$2" "$3"
-//supplementalData/metaZones/metazoneInfo/timezone[@type="(%W)"]/usesMetazone[@to="(%A)"][@mzone="(%W)"] ; /metazoneInfo/"$1"/<1970-01-01 00:00> ; values=$3 "1970-01-01 00:00" "$2"
+//supplementalData/metaZones/metazoneInfo/timezone[@type="(%W)"]/usesMetazone[@from="(%A)"][@mzone="(%W)"] ; /metazoneInfo/"$1"/<$2> ; values=$3 "&date_round_sec($2, UP)" "9999-12-31 23:59"
+//supplementalData/metaZones/metazoneInfo/timezone[@type="(%W)"]/usesMetazone[@from="(%A)"][@to="(%A)"][@mzone="(%W)"] ; /metazoneInfo/"$1"/<$2> ; values=$4 "&date_round_sec($2, UP)" "&date_round_sec($3, DOWN)"
+//supplementalData/metaZones/metazoneInfo/timezone[@type="(%W)"]/usesMetazone[@to="(%A)"][@mzone="(%W)"] ; /metazoneInfo/"$1"/<1970-01-01 00:00> ; values=$3 "1970-01-01 00:00" "&date_round_sec($2, DOWN)"
 # If we have stdOffset and dstOffset, then we produce the same as above (metazone only or plus from/to) and currently just ignore the stdOffset and dstOffset.
 # We cannot add them as 4th/5th elements or the resulting metaZones.txt would not be compatible with ICU versions < 79.
 //supplementalData/metaZones/metazoneInfo/timezone[@type="(%W)"]/usesMetazone[@mzone="(%W)"][@stdOffset="(%A)"][@dstOffset="(%A)"] ; /metazoneInfo/"$1"/<$2> ; values=$2
-//supplementalData/metaZones/metazoneInfo/timezone[@type="(%W)"]/usesMetazone[@from="(%A)"][@mzone="(%W)"][@stdOffset="(%A)"][@dstOffset="(%A)"] ; /metazoneInfo/"$1"/<$2> ; values=$3 "$2" "9999-12-31 23:59"
-//supplementalData/metaZones/metazoneInfo/timezone[@type="(%W)"]/usesMetazone[@from="(%A)"][@to="(%A)"][@mzone="(%W)"][@stdOffset="(%A)"][@dstOffset="(%A)"] ; /metazoneInfo/"$1"/<$2> ; values=$4 "$2" "$3"
-//supplementalData/metaZones/metazoneInfo/timezone[@type="(%W)"]/usesMetazone[@to="(%A)"][@mzone="(%W)"][@stdOffset="(%A)"][@dstOffset="(%A)"] ; /metazoneInfo/"$1"/<1970-01-01 00:00> ; values=$3 "1970-01-01 00:00" "$2"
+//supplementalData/metaZones/metazoneInfo/timezone[@type="(%W)"]/usesMetazone[@from="(%A)"][@mzone="(%W)"][@stdOffset="(%A)"][@dstOffset="(%A)"] ; /metazoneInfo/"$1"/<$2> ; values=$3 "&date_round_sec($2, UP)" "9999-12-31 23:59"
+//supplementalData/metaZones/metazoneInfo/timezone[@type="(%W)"]/usesMetazone[@from="(%A)"][@to="(%A)"][@mzone="(%W)"][@stdOffset="(%A)"][@dstOffset="(%A)"] ; /metazoneInfo/"$1"/<$2> ; values=$4 "&date_round_sec($2, UP)" "&date_round_sec($3, DOWN)"
+//supplementalData/metaZones/metazoneInfo/timezone[@type="(%W)"]/usesMetazone[@to="(%A)"][@mzone="(%W)"][@stdOffset="(%A)"][@dstOffset="(%A)"] ; /metazoneInfo/"$1"/<1970-01-01 00:00> ; values=$3 "1970-01-01 00:00" "&date_round_sec($2, DOWN)"
 #
 //supplementalData/metaZones/metazoneIds/metazoneId[@shortId="(%A)"][@longId="(%A)"][@deprecated="false"] ; /metazoneIds/$1 ; values=$2
 


### PR DESCRIPTION
ICU metazone handling code cannot parse from/to data value in metazone mapping data. This PR updates the cldr-to-icu tool to do rounding if metazone mapping data has non-zero seconds.

If we ignore backward compatibility support, we can update the code to handle non-zero seconds. It can be done easily in the new version of ICU. However, we use the same data binary for older ICU releases.

Once this PR is merged, CLDR can use from = 1972-01-07 00:44:30 for Monrovia / metazone GMT mapping (see CLDR-18985). cldr-to-icu converter will round up to next minute (1972-01-07 00:45).

#### Checklist
- [x] Required: Issue filed: ICU-23317
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
