### PR TITLE
ICU-22926 Update the link to CLDR Zone-Tzid mapping data page

### DIFF
--- a/icu4c/source/i18n/unicode/timezone.h
+++ b/icu4c/source/i18n/unicode/timezone.h
@@ -481,7 +481,7 @@ public:
     * system time zone ID is unknown or unmappable to a Windows time zone, then the result will be
     * empty, but the operation itself remains successful (no error status set on return).
     *
-    * <p>This implementation utilizes <a href="http://unicode.org/cldr/charts/supplemental/zone_tzid.html">
+    * <p>This implementation utilizes <a href="https://www.unicode.org/cldr/charts/latest/supplemental/zone_tzid.html">
     * Zone-Tzid mapping data</a>. The mapping data is updated time to time. To get the latest changes,
     * please read the ICU user guide section <a href="https://unicode-org.github.io/icu/userguide/datetime/timezone#updating-the-time-zone-data">
     * Updating the Time Zone Data</a>.
@@ -509,7 +509,7 @@ public:
     * Windows time zone ID is unknown or unmappable to a system time zone, then the result
     * will be empty, but the operation itself remains successful (no error status set on return).
     *
-    * <p>This implementation utilizes <a href="http://unicode.org/cldr/charts/supplemental/zone_tzid.html">
+    * <p>This implementation utilizes <a href="https://www.unicode.org/cldr/charts/latest/supplemental/zone_tzid.html">
     * Zone-Tzid mapping data</a>. The mapping data is updated time to time. To get the latest changes,
     * please read the ICU user guide section <a href="https://unicode-org.github.io/icu/userguide/datetime/timezone#updating-the-time-zone-data">
     * Updating the Time Zone Data</a>.

--- a/icu4j/main/core/src/main/java/com/ibm/icu/util/TimeZone.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/util/TimeZone.java
@@ -1237,9 +1237,9 @@ public abstract class TimeZone implements Serializable, Cloneable, Freezable<Tim
      * null</code>.
      *
      * <p>This implementation utilizes <a
-     * href="http://unicode.org/cldr/charts/supplemental/zone_tzid.html">Zone-Tzid mapping data</a>.
-     * The mapping data is updated time to time. To get the latest changes, please read the ICU user
-     * guide section <a
+     * href="https://www.unicode.org/cldr/charts/latest/supplemental/zone_tzid.html">Zone-Tzid
+     * mapping data</a>. The mapping data is updated time to time. To get the latest changes, please
+     * read the ICU user guide section <a
      * href="https://unicode-org.github.io/icu/userguide/datetime/timezone#updating-the-time-zone-data">
      * Updating the Time Zone Data</a>.
      *
@@ -1300,9 +1300,9 @@ public abstract class TimeZone implements Serializable, Cloneable, Freezable<Tim
      * </code>.
      *
      * <p>This implementation utilizes <a
-     * href="http://unicode.org/cldr/charts/supplemental/zone_tzid.html">Zone-Tzid mapping data</a>.
-     * The mapping data is updated time to time. To get the latest changes, please read the ICU user
-     * guide section <a
+     * href="https://www.unicode.org/cldr/charts/latest/supplemental/zone_tzid.html">Zone-Tzid
+     * mapping data</a>. The mapping data is updated time to time. To get the latest changes, please
+     * read the ICU user guide section <a
      * href="https://unicode-org.github.io/icu/userguide/datetime/timezone#updating-the-time-zone-data">
      * Updating the Time Zone Data</a>.
      *


### PR DESCRIPTION
Fixed the CLDR Zone-Tzid mapping data page link

old: http://unicode.org/cldr/charts/supplemental/zone_tzid.html
new: https://www.unicode.org/cldr/charts/latest/supplemental/zone_tzid.html (redirected to the latest release version page)

#### Checklist
- [x] Required: Issue filed: ICU-22926
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
