### PR TITLE
ICU-23392 Avoid OOB read in StringToIeee on identifiers with embedded NUL

### DIFF
--- a/icu4c/source/i18n/measunit_extra.cpp
+++ b/icu4c/source/i18n/measunit_extra.cpp
@@ -668,9 +668,9 @@ public:
     // The value must be a positive integer within the range [1, INT64_MAX].
     // The input can be in integer or scientific notation.
     static uint64_t parseStringToLong(const StringPiece strNum, UErrorCode &status) {
-        // We are processing well-formed input, so we don't need any special options to
-        // StringToDoubleConverter.
-        StringToDoubleConverter converter(0, 0, 0, "", "");
+        // Pass nullptr (not "") for the infinity/NaN symbols; "" would match an
+        // embedded NUL in strNum and read OOB in ConsumeSubStringImpl (ICU-23392).
+        StringToDoubleConverter converter(0, 0, 0, nullptr, nullptr);
         int32_t count;
         double double_result = converter.StringToDouble(strNum.data(), strNum.length(), &count);
         if (count != strNum.length()) {

--- a/icu4c/source/test/intltest/units_test.cpp
+++ b/icu4c/source/test/intltest/units_test.cpp
@@ -55,6 +55,7 @@ class UnitsTest : public IntlTest {
     void testMeasureUnit_withConstantDenominator();
     void testUnitsConstantsDenomenator_getIdentifier();
     void testConverter();
+    void testForIdentifierEmbeddedNul();
 };
 
 extern IntlTest *createUnitsTest() { return new UnitsTest(); }
@@ -75,7 +76,18 @@ void UnitsTest::runIndexedTest(int32_t index, UBool exec, const char *&name, cha
     TESTCASE_AUTO(testMeasureUnit_withConstantDenominator);
     TESTCASE_AUTO(testUnitsConstantsDenomenator_getIdentifier);
     TESTCASE_AUTO(testConverter);
+    TESTCASE_AUTO(testForIdentifierEmbeddedNul);
     TESTCASE_AUTO_END;
+}
+
+// ICU-23392: a unit identifier substring containing an embedded NUL must be
+// rejected without an OOB read inside double-conversion's StringToIeee.
+void UnitsTest::testForIdentifierEmbeddedNul() {
+    IcuTestErrorCode status(*this, "testForIdentifierEmbeddedNul");
+    (void) MeasureUnit::forIdentifier(StringPiece("\0", 1), status);
+    assertEquals("forIdentifier(\"\\0\") must reject",
+                 U_ILLEGAL_ARGUMENT_ERROR, status.get());
+    status.reset();
 }
 
 // Tests the hard-coded constants in the code against constants that appear in


### PR DESCRIPTION
Per ICU-23392.

`Token::parseStringToLong` in `measunit_extra.cpp` passes literal `""` for
`infinity_symbol_` and `nan_symbol_` to `StringToDoubleConverter`.
`StringToIeee` only NULL-checks those pointers, so an empty (but non-null)
literal enters the symbol-match path. When the substring being parsed
begins with a NUL byte (which the unit-identifier parser can hand it as a
fallback constant-denominator token), `ConsumeFirstCharacter` spuriously
matches the empty literal's terminator and `ConsumeSubStringImpl` reads
one byte past the end of the empty string global.

Reachable from V8 via `Intl.NumberFormat` with a crafted unit option, through
`NumberFormatter::forSkeleton → parseIdentifierUnitOption →
MeasureUnit::forIdentifier → Parser::parse → parseStringToLong`.

### Fix

Pass `nullptr` instead of `""` so the existing NULL guards in `StringToIeee`
skip the symbol-match path entirely. `parseStringToLong` only parses
positive-integer / scientific-notation digit strings, so disabling
Inf/NaN parsing is semantically correct.

### Test

Adds `UnitsTest::testForIdentifierEmbeddedNul`, a focused regression test
that calls `MeasureUnit::forIdentifier(StringPiece("\0", 1), status)` and
asserts `U_ILLEGAL_ARGUMENT_ERROR`.

Verified with AddressSanitizer:
- **Before the fix**: the test triggers the documented OOB at
  `double-conversion-string-to-double.cpp:91` in `ConsumeSubStringImpl`.
- **After the fix**: the test passes and `forIdentifier` reports
  `U_ILLEGAL_ARGUMENT_ERROR`.

Full `UnitsTest`, `NumberTest` (including `NumberSkeletonTest`,
`NumberRangeFormatterTest`, `NumberFormatterApiTest`) and `MeasureFormatTest`
pass with no regression.
