### PR TITLE
ICU-23395 Fix out-of-bounds read in expandCompositCharAtNear()

### DIFF
--- a/icu4c/source/common/ushape.cpp
+++ b/icu4c/source/common/ushape.cpp
@@ -1055,7 +1055,7 @@ expandCompositCharAtNear(char16_t *dest, int32_t sourceLength, int32_t destSize,
 
                     *pErrorCode=U_NO_SPACE_AVAILABLE;
                 }
-            }else if(lamAlefOption && isLamAlefChar(dest[i+1])) {
+            }else if(lamAlefOption && i < sourceLength - 1 && isLamAlefChar(dest[i+1])) {
                 if(dest[i] == SPACE_CHAR){
                     lamalefChar = dest[i+1];
                     dest[i+1] = LAM_CHAR;

--- a/icu4c/source/test/cintltst/cbiditst.c
+++ b/icu4c/source/test/cintltst/cbiditst.c
@@ -92,6 +92,7 @@ static void doTailTest(void);
 
 static void testBracketOverflow(void);
 static void TestExplicitLevel0(void);
+static void TestExpandCompositCharAtNearOOB(void);
 static void testUBidiWriteReorderedBufferOverflow(void);
 static void testUBidiGetRunsBufferOverflow(void);
 
@@ -156,6 +157,7 @@ addComplexTest(TestNode** root) {
     addTest(root, testReorderArabicMathSymbols, "complex/bidi/bug-9024");
     addTest(root, doArabicShapingTestForBug9024, "complex/arabic-shaping/bug-9024");
     addTest(root, doArabicShapingTestForNewCharacters, "complex/arabic-shaping/shaping2");
+    addTest(root, TestExpandCompositCharAtNearOOB, "complex/arabic-shaping/ICU-23395");
 }
 
 static void
@@ -5005,4 +5007,65 @@ static void TestExplicitLevel0(void) {
         }
     }
     ubidi_close(bidi);
+}
+
+/*
+ * ICU-23395: expandCompositCharAtNear reads dest[i+1] when i == sourceLength-1.
+ * With sourceLength=300 the read goes past the stack buffer[300].
+ * With sourceLength=301 the read goes past the heap-allocated tempBuffer.
+ */
+static void
+TestExpandCompositCharAtNearOOB(void) {
+    UErrorCode errorCode;
+    int32_t length;
+
+    /* Test 1: sourceLength=300 (stack buffer path) */
+    {
+        UChar source300[300];
+        UChar dest300[300];
+        int32_t i;
+        for (i = 0; i < 299; ++i) {
+            source300[i] = 0x0020;  /* space */
+        }
+        source300[299] = 0xFEF5;  /* lam-alef ligature */
+
+        errorCode = U_ZERO_ERROR;
+        length = u_shapeArabic(source300, 300,
+                               dest300, 300,
+                               U_SHAPE_LETTERS_UNSHAPE | U_SHAPE_LENGTH_FIXED_SPACES_NEAR |
+                               U_SHAPE_TEXT_DIRECTION_LOGICAL,
+                               &errorCode);
+
+        if (U_FAILURE(errorCode)) {
+            log_err("ICU-23395 stack buffer path: u_shapeArabic failed with %s\n",
+                    u_errorName(errorCode));
+        } else if (length != 300) {
+            log_err("ICU-23395 stack buffer path: expected length 300, got %d\n", length);
+        }
+    }
+
+    /* Test 2: sourceLength=301 (heap buffer path) */
+    {
+        UChar source301[301];
+        UChar dest301[301];
+        int32_t i;
+        for (i = 0; i < 300; ++i) {
+            source301[i] = 0x0020;  /* space */
+        }
+        source301[300] = 0xFEF5;  /* lam-alef ligature */
+
+        errorCode = U_ZERO_ERROR;
+        length = u_shapeArabic(source301, 301,
+                               dest301, 301,
+                               U_SHAPE_LETTERS_UNSHAPE | U_SHAPE_LENGTH_FIXED_SPACES_NEAR |
+                               U_SHAPE_TEXT_DIRECTION_LOGICAL,
+                               &errorCode);
+
+        if (U_FAILURE(errorCode)) {
+            log_err("ICU-23395 heap buffer path: u_shapeArabic failed with %s\n",
+                    u_errorName(errorCode));
+        } else if (length != 301) {
+            log_err("ICU-23395 heap buffer path: expected length 301, got %d\n", length);
+        }
+    }
 }

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/shaping/ArabicShapingRegTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/shaping/ArabicShapingRegTest.java
@@ -273,4 +273,31 @@ public class ArabicShapingRegTest extends CoreTestFmwk {
                 "ArabicShaping.isYehHamzaChar(char) failed.",
                 getStaticCharacterHelperFunctionValue("isYehHamzaChar", (char) 0xfe89));
     }
+
+    /**
+     * ICU-23395: Verify that u_shapeArabic does not read past the buffer
+     * when the last character is a lam-alef ligature.
+     * Tests both the stack buffer path (length=300) and heap buffer path (length=301).
+     */
+    @Test
+    public void TestExpandCompositCharAtNearOOB() throws Exception {
+        ArabicShaping shaper =
+                new ArabicShaping(LETTERS_UNSHAPE | LENGTH_FIXED_SPACES_NEAR | TEXT_DIRECTION_LOGICAL);
+
+        // Stack buffer path: 299 spaces + U+FEF5
+        char[] source300 = new char[300];
+        java.util.Arrays.fill(source300, 0, 299, ' ');
+        source300[299] = '\uFEF5';
+        char[] dest300 = new char[300];
+        int len300 = shaper.shape(source300, 0, 300, dest300, 0, 300);
+        assertEquals("ICU-23395 stack buffer path: unexpected length", 300, len300);
+
+        // Heap buffer path: 300 spaces + U+FEF5
+        char[] source301 = new char[301];
+        java.util.Arrays.fill(source301, 0, 300, ' ');
+        source301[300] = '\uFEF5';
+        char[] dest301 = new char[301];
+        int len301 = shaper.shape(source301, 0, 301, dest301, 0, 301);
+        assertEquals("ICU-23395 heap buffer path: unexpected length", 301, len301);
+    }
 }


### PR DESCRIPTION
Replaces #3963 (rebased onto current main per @eggrobin's review).

## Fix

`expandCompositCharAtNear()` reads `dest[i+1]` when `i == sourceLength-1`, which is one past the allocated buffer. This is an OOB read when:
- `sourceLength == 300` (past the stack `buffer[300]`)
- `sourceLength >= 301` (past the heap-allocated `tempBuffer`)

One-line fix: add `i < sourceLength - 1` bounds check before the `dest[i+1]` access.

## Tests

Both C (`cbiditst.c`) and Java (`ArabicShapingRegTest.java`) tests exercise:
1. **Stack buffer path** (`sourceLength=300`): 299 spaces + U+FEF5 lam-alef ligature
2. **Heap buffer path** (`sourceLength=301`): 300 spaces + U+FEF5 lam-alef ligature

Per @eggrobin's review, the test inputs are minimal and both calls succeed without error.

Note: the Java `expandCompositCharAtNear` iterates backwards and does not have this bug, but the Java test is included for consistency.