### PR TITLE
ICU-23408 Fix null pointer dereference in DateTimePatternGenerator copy constructor

### DIFF
--- a/icu4c/source/i18n/dtptngen.cpp
+++ b/icu4c/source/i18n/dtptngen.cpp
@@ -332,7 +332,7 @@ DateTimePatternGenerator::createEmptyInstance(UErrorCode& status) {
     return U_SUCCESS(status) ? result.orphan() : nullptr;
 }
 
-DateTimePatternGenerator::DateTimePatternGenerator(UErrorCode &status) :
+DateTimePatternGenerator::DateTimePatternGenerator() :
     UObject()
 {
     emptyString.getTerminatedBuffer();
@@ -341,7 +341,15 @@ DateTimePatternGenerator::DateTimePatternGenerator(UErrorCode &status) :
     distanceInfo = new DistanceInfo();
     patternMap = new PatternMap();
     if (fp == nullptr || dtMatcher == nullptr || distanceInfo == nullptr || patternMap == nullptr) {
-        internalErrorCode = status = U_MEMORY_ALLOCATION_ERROR;
+        internalErrorCode = U_MEMORY_ALLOCATION_ERROR;
+    }
+}
+
+DateTimePatternGenerator::DateTimePatternGenerator(UErrorCode &status) :
+    DateTimePatternGenerator()
+{
+    if (U_FAILURE(internalErrorCode)) {
+        status = internalErrorCode;
     }
 }
 
@@ -352,24 +360,35 @@ DateTimePatternGenerator::DateTimePatternGenerator(const Locale& locale, UErrorC
 }
 
 DateTimePatternGenerator::DateTimePatternGenerator(const DateTimePatternGenerator& other) :
-    UObject()
+    DateTimePatternGenerator()
 {
-    emptyString.getTerminatedBuffer();
-    fp = new FormatParser();
-    dtMatcher = new DateTimeMatcher();
-    distanceInfo = new DistanceInfo();
-    patternMap = new PatternMap();
-    if (fp == nullptr || dtMatcher == nullptr || distanceInfo == nullptr || patternMap == nullptr) {
-        internalErrorCode = U_MEMORY_ALLOCATION_ERROR;
-        return;
-    }
-    *this=other;
+    *this = other;
 }
 
 DateTimePatternGenerator&
 DateTimePatternGenerator::operator=(const DateTimePatternGenerator& other) {
     // reflexive case
     if (&other == this) {
+        return *this;
+    }
+    // Heal a previously-broken object: if any of the core helpers are missing
+    // (e.g. from a prior OOM during construction), try to allocate them now.
+    // If (re)allocation still fails, leave internalErrorCode set and bail out
+    // without dereferencing null pointers below.
+    if (fp == nullptr) {
+        fp = new FormatParser();
+    }
+    if (dtMatcher == nullptr) {
+        dtMatcher = new DateTimeMatcher();
+    }
+    if (distanceInfo == nullptr) {
+        distanceInfo = new DistanceInfo();
+    }
+    if (patternMap == nullptr) {
+        patternMap = new PatternMap();
+    }
+    if (fp == nullptr || dtMatcher == nullptr || distanceInfo == nullptr || patternMap == nullptr) {
+        internalErrorCode = U_MEMORY_ALLOCATION_ERROR;
         return *this;
     }
     internalErrorCode = other.internalErrorCode;

--- a/icu4c/source/i18n/dtptngen.cpp
+++ b/icu4c/source/i18n/dtptngen.cpp
@@ -361,6 +361,7 @@ DateTimePatternGenerator::DateTimePatternGenerator(const DateTimePatternGenerato
     patternMap = new PatternMap();
     if (fp == nullptr || dtMatcher == nullptr || distanceInfo == nullptr || patternMap == nullptr) {
         internalErrorCode = U_MEMORY_ALLOCATION_ERROR;
+        return;
     }
     *this=other;
 }

--- a/icu4c/source/i18n/dtptngen.cpp
+++ b/icu4c/source/i18n/dtptngen.cpp
@@ -348,7 +348,7 @@ DateTimePatternGenerator::DateTimePatternGenerator() :
 DateTimePatternGenerator::DateTimePatternGenerator(UErrorCode &status) :
     DateTimePatternGenerator()
 {
-    if (U_FAILURE(internalErrorCode)) {
+    if (U_FAILURE(internalErrorCode) && U_SUCCESS(status)) {
         status = internalErrorCode;
     }
 }
@@ -371,6 +371,14 @@ DateTimePatternGenerator::operator=(const DateTimePatternGenerator& other) {
     if (&other == this) {
         return *this;
     }
+    // Don't try to copy a broken source object: bail out cleanly instead of
+    // crashing on `*fp = *(other.fp);` etc., and avoid falsely "healing" by
+    // copying a failed internalErrorCode below.
+    if (U_FAILURE(other.internalErrorCode)) {
+        return *this;
+    }
+
+
     // Heal a previously-broken object: if any of the core helpers are missing
     // (e.g. from a prior OOM during construction), try to allocate them now.
     // If (re)allocation still fails, leave internalErrorCode set and bail out

--- a/icu4c/source/i18n/unicode/dtptngen.h
+++ b/icu4c/source/i18n/unicode/dtptngen.h
@@ -574,6 +574,12 @@ public:
 
 private:
     /**
+     * Default constructor. Allocates the core helper objects; sets
+     * internalErrorCode to U_MEMORY_ALLOCATION_ERROR on failure.
+     */
+    DateTimePatternGenerator();
+
+    /**
      * Constructor.
      */
     DateTimePatternGenerator(UErrorCode & status);


### PR DESCRIPTION
### Linked Jira issue
ICU-23408

### Summary
In `DateTimePatternGenerator`'s copy constructor, when one of the four `new`
calls (`fp`, `dtMatcher`, `distanceInfo`, `patternMap`) fails, `internalErrorCode`
is set to `U_MEMORY_ALLOCATION_ERROR`, but execution falls through to
`*this = other`, which dereferences those null pointers
(e.g. `*fp = *(other.fp)`, `dtMatcher->copyFrom(...)`).

### Cause
Missing `return;` after the error code assignment.

### Fix
Add `return;` so the constructor exits without touching the null pointers.

### Testing
Existing tests pass. No new test added — the OOM path requires allocator
injection that is not part of the standard test harness.

### Notes
Found by static analysis (Svace, ISP RAS).

#### Checklist
- [x] Required: Issue filed: ICU-23408
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf