### PR TITLE
ICU-23409 Fix null pointer dereference in CollationBuilder::parseAndBuild when copyOnWrite returns NULL

### DIFF
--- a/icu4c/source/i18n/collationbuilder.cpp
+++ b/icu4c/source/i18n/collationbuilder.cpp
@@ -254,7 +254,12 @@ CollationBuilder::parseAndBuild(const UnicodeString &ruleString,
     variableTop = base->settings->variableTop;
     parser.setSink(this);
     parser.setImporter(importer);
-    CollationSettings &ownedSettings = *SharedObject::copyOnWrite(tailoring->settings);
+    CollationSettings *ownedSettingsPtr = SharedObject::copyOnWrite(tailoring->settings);
+    if (ownedSettingsPtr == nullptr) {
+        errorCode = U_MEMORY_ALLOCATION_ERROR;
+        return nullptr;
+    }
+    CollationSettings &ownedSettings = *ownedSettingsPtr;
     parser.parse(ruleString, ownedSettings, outParseError, errorCode);
     errorReason = parser.getErrorReason();
     if(U_FAILURE(errorCode)) { return nullptr; }


### PR DESCRIPTION
### Linked Jira issue
ICU-23409

### Summary
In `CollationBuilder::parseAndBuild` (`icu4c/source/i18n/collationbuilder.cpp`),
the result of `SharedObject::copyOnWrite<CollationSettings>(tailoring->settings)`
was dereferenced via `*` directly into a reference, without a NULL check.

### Cause
`SharedObject::copyOnWrite()` can return NULL on allocation failure;
dereferencing it produces undefined behavior and would crash when
`ownedSettings` is later used (e.g. in `CollationFastLatin::getOptions`).

### Fix
Take the result into a temporary pointer, check for NULL, propagate
`U_MEMORY_ALLOCATION_ERROR` via `errorCode` and `return nullptr;`
otherwise bind the reference as before.

### Testing
Existing tests pass (no behavior change on the success path). No new test
added — the OOM path requires allocator injection that is not part of
the standard test harness.

### Notes
Found by static analysis (Svace, ISP RAS).

#### Checklist
- [x] Required: Issue filed: ICU-23409
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf