### PR TITLE
ICU-23410 Fix null pointer dereferences in DecimalQuantity::ensureCapacity on allocation failure

### DIFF
--- a/icu4c/source/i18n/number_decimalquantity.cpp
+++ b/icu4c/source/i18n/number_decimalquantity.cpp
@@ -1320,15 +1320,23 @@ void DecimalQuantity::ensureCapacity(int32_t capacity) {
     if (capacity == 0) { return; }
     int32_t oldCapacity = usingBytes ? fBCD.bcdBytes.len : 0;
     if (!usingBytes) {
-        // TODO: There is nothing being done to check for memory allocation failures.
         // TODO: Consider indexing by nybbles instead of bytes in C++, so that we can
         // make these arrays half the size.
-        fBCD.bcdBytes.ptr = static_cast<int8_t*>(uprv_malloc(capacity * sizeof(int8_t)));
+        int8_t* newPtr = static_cast<int8_t*>(uprv_malloc(capacity * sizeof(int8_t)));
+        if (newPtr == nullptr) {
+            fBCD.bcdBytes.ptr = nullptr;
+            fBCD.bcdBytes.len = 0;
+            return;
+        }
+        fBCD.bcdBytes.ptr = newPtr;
         fBCD.bcdBytes.len = capacity;
         // Initialize the byte array to zeros (this is done automatically in Java)
         uprv_memset(fBCD.bcdBytes.ptr, 0, capacity * sizeof(int8_t));
     } else if (oldCapacity < capacity) {
-        auto* bcd1 = static_cast<int8_t*>(uprv_malloc(capacity * 2 * sizeof(int8_t)));
+        int8_t* bcd1 = static_cast<int8_t*>(uprv_malloc(capacity * 2 * sizeof(int8_t)));
+        if (bcd1 == nullptr) {
+            return;
+        }
         uprv_memcpy(bcd1, fBCD.bcdBytes.ptr, oldCapacity * sizeof(int8_t));
         // Initialize the rest of the byte array to zeros (this is done automatically in Java)
         uprv_memset(bcd1 + oldCapacity, 0, (capacity - oldCapacity) * sizeof(int8_t));


### PR DESCRIPTION
### Linked Jira issue
ICU-23410

### Summary
`DecimalQuantity::ensureCapacity` (`icu4c/source/i18n/number_decimalquantity.cpp`)
contained an explicit `// TODO: There is nothing being done to check for
memory allocation failures.` Both `uprv_malloc` results were used in
`uprv_memset` / `uprv_memcpy` without a NULL check.

### Cause
On OOM `uprv_malloc` returns NULL; dereferencing it in `memset`/`memcpy`
is undefined behavior.

### Fix
The function has no `UErrorCode` parameter (changing it would be an
ABI break), so the minimal fix:
- First branch: store the result in a temporary, on NULL reset
  `fBCD.bcdBytes.{ptr,len}` to a consistent empty state and return.
- Second branch: on NULL `bcd1`, return early — the existing buffer is
  left untouched so the object remains usable at its old capacity.

Also removed the stale `// TODO` comment that is now addressed, and
replaced `auto*` with an explicit `int8_t*` in the second branch for
stylistic consistency.

### Testing
Existing tests pass (no behavior change on the success path). No new
test added — the OOM path requires allocator injection that is not part
of the standard test harness.

### Notes
Found by static analysis (Svace, ISP RAS).

#### Checklist
- [x] Required: Issue filed: ICU-23410
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf