### PR TITLE
ICU-23411 Fix null pointer dereference in initNumberSkeletons on allocation failure

### DIFF
--- a/icu4c/source/i18n/number_skeletons.cpp
+++ b/icu4c/source/i18n/number_skeletons.cpp
@@ -140,6 +140,10 @@ void U_CALLCONV initNumberSkeletons(UErrorCode& status) {
     // Copy the result into the global constant pointer
     size_t numBytes = result.length() * sizeof(char16_t);
     kSerializedStemTrie = static_cast<char16_t*>(uprv_malloc(numBytes));
+    if (kSerializedStemTrie == nullptr) {
+        status = U_MEMORY_ALLOCATION_ERROR;
+        return;
+    }
     uprv_memcpy(kSerializedStemTrie, result.getBuffer(), numBytes);
 }
 


### PR DESCRIPTION
### Linked Jira issue
ICU-23411

### Summary
In `initNumberSkeletons` (`icu4c/source/i18n/number_skeletons.cpp`),
the result of `uprv_malloc(numBytes)` was assigned to the global
`kSerializedStemTrie` and immediately passed to `uprv_memcpy` without
a NULL check.

### Cause
On OOM `uprv_malloc` returns NULL; the subsequent `uprv_memcpy` is
then undefined behavior.

### Fix
`initNumberSkeletons` already takes `UErrorCode& status`, so on NULL
set `status = U_MEMORY_ALLOCATION_ERROR;` and `return;` before the
memcpy.

### Testing
Existing tests pass (no behavior change on the success path). No new
test added — the OOM path requires allocator injection that is not
part of the standard test harness.

### Notes
Found by static analysis (Svace, ISP RAS).

#### Checklist
- [x] Required: Issue filed: ICU-23411
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
