### PR TITLE
ICU-23403 Make fields final in Precision and ScientificNotation

### DIFF
--- a/icu4j/main/core/src/main/java/com/ibm/icu/number/CurrencyPrecision.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/number/CurrencyPrecision.java
@@ -2,7 +2,9 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 package com.ibm.icu.number;
 
+import com.ibm.icu.number.NumberFormatter.TrailingZeroDisplay;
 import com.ibm.icu.util.Currency;
+import java.math.MathContext;
 
 /**
  * A class that defines a rounding strategy parameterized by a currency to be used when formatting
@@ -16,6 +18,10 @@ import com.ibm.icu.util.Currency;
 public abstract class CurrencyPrecision extends Precision {
 
     /* package-private */ CurrencyPrecision() {}
+
+    /* package-private */ CurrencyPrecision(MathContext mc, TrailingZeroDisplay tzd) {
+        super(mc, tzd);
+    }
 
     /**
      * Associates a currency with this rounding strategy.

--- a/icu4j/main/core/src/main/java/com/ibm/icu/number/FractionPrecision.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/number/FractionPrecision.java
@@ -3,6 +3,8 @@
 package com.ibm.icu.number;
 
 import com.ibm.icu.impl.number.RoundingUtils;
+import com.ibm.icu.number.NumberFormatter.TrailingZeroDisplay;
+import java.math.MathContext;
 
 /**
  * A class that defines a rounding strategy based on a number of fraction places and optionally
@@ -16,6 +18,10 @@ import com.ibm.icu.impl.number.RoundingUtils;
 public abstract class FractionPrecision extends Precision {
 
     /* package-private */ FractionPrecision() {}
+
+    /* package-private */ FractionPrecision(MathContext mc, TrailingZeroDisplay tzd) {
+        super(mc, tzd);
+    }
 
     /**
      * Override maximum fraction digits with maximum significant digits depending on the magnitude

--- a/icu4j/main/core/src/main/java/com/ibm/icu/number/Precision.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/number/Precision.java
@@ -25,11 +25,17 @@ import java.math.MathContext;
  */
 public abstract class Precision {
 
-    /* package-private final */ MathContext mathContext;
-    /* package-private final */ TrailingZeroDisplay trailingZeroDisplay;
+    /* package-private */ final MathContext mathContext;
+    /* package-private */ final TrailingZeroDisplay trailingZeroDisplay;
 
     /* package-private */ Precision() {
-        mathContext = RoundingUtils.DEFAULT_MATH_CONTEXT_UNLIMITED;
+        this(RoundingUtils.DEFAULT_MATH_CONTEXT_UNLIMITED, null);
+    }
+
+    /* package-private */ Precision(
+            MathContext mathContext, TrailingZeroDisplay trailingZeroDisplay) {
+        this.mathContext = mathContext;
+        this.trailingZeroDisplay = trailingZeroDisplay;
     }
 
     /**
@@ -350,9 +356,7 @@ public abstract class Precision {
         if (this.trailingZeroDisplay == trailingZeroDisplay) {
             return this;
         }
-        Precision result = this.createCopy();
-        result.trailingZeroDisplay = trailingZeroDisplay;
-        return result;
+        return this.createCopy(this.mathContext, trailingZeroDisplay);
     }
 
     /**
@@ -366,24 +370,11 @@ public abstract class Precision {
         if (this.mathContext.equals(mathContext)) {
             return this;
         }
-        Precision other = createCopy();
-        other.mathContext = mathContext;
-        return other;
+        return this.createCopy(mathContext, this.trailingZeroDisplay);
     }
 
     /** Package-private clone method */
-    abstract Precision createCopy();
-
-    /**
-     * Call this function to copy the fields from the Precision base class.
-     *
-     * <p>Note: It would be nice if this returned the copy, but most impls return the child class,
-     * not Precision.
-     */
-    /* package-private */ void createCopyHelper(Precision copy) {
-        copy.mathContext = mathContext;
-        copy.trailingZeroDisplay = trailingZeroDisplay;
-    }
+    abstract Precision createCopy(MathContext mc, TrailingZeroDisplay tzd);
 
     /**
      * @internal
@@ -611,6 +602,10 @@ public abstract class Precision {
         @Deprecated
         public BogusRounder() {}
 
+        private BogusRounder(MathContext mc, TrailingZeroDisplay tzd) {
+            super(mc, tzd);
+        }
+
         /**
          * {@inheritDoc}
          *
@@ -624,10 +619,8 @@ public abstract class Precision {
         }
 
         @Override
-        BogusRounder createCopy() {
-            BogusRounder copy = new BogusRounder();
-            createCopyHelper(copy);
-            return copy;
+        BogusRounder createCopy(MathContext mc, TrailingZeroDisplay tzd) {
+            return new BogusRounder(mc, tzd);
         }
 
         /**
@@ -638,15 +631,17 @@ public abstract class Precision {
          */
         @Deprecated
         public Precision into(Precision precision) {
-            Precision copy = precision.createCopy();
-            createCopyHelper(copy);
-            return copy;
+            return precision.createCopy(this.mathContext, this.trailingZeroDisplay);
         }
     }
 
     static class InfiniteRounderImpl extends Precision {
 
         public InfiniteRounderImpl() {}
+
+        public InfiniteRounderImpl(MathContext mc, TrailingZeroDisplay tzd) {
+            super(mc, tzd);
+        }
 
         @Override
         public void apply(DecimalQuantity value) {
@@ -655,10 +650,8 @@ public abstract class Precision {
         }
 
         @Override
-        InfiniteRounderImpl createCopy() {
-            InfiniteRounderImpl copy = new InfiniteRounderImpl();
-            createCopyHelper(copy);
-            return copy;
+        InfiniteRounderImpl createCopy(MathContext mc, TrailingZeroDisplay tzd) {
+            return new InfiniteRounderImpl(mc, tzd);
         }
     }
 
@@ -671,6 +664,13 @@ public abstract class Precision {
             this.maxFrac = maxFrac;
         }
 
+        public FractionRounderImpl(
+                int minFrac, int maxFrac, MathContext mc, TrailingZeroDisplay tzd) {
+            super(mc, tzd);
+            this.minFrac = minFrac;
+            this.maxFrac = maxFrac;
+        }
+
         @Override
         public void apply(DecimalQuantity value) {
             value.roundToMagnitude(getRoundingMagnitudeFraction(maxFrac), mathContext);
@@ -678,10 +678,8 @@ public abstract class Precision {
         }
 
         @Override
-        FractionRounderImpl createCopy() {
-            FractionRounderImpl copy = new FractionRounderImpl(minFrac, maxFrac);
-            createCopyHelper(copy);
-            return copy;
+        FractionRounderImpl createCopy(MathContext mc, TrailingZeroDisplay tzd) {
+            return new FractionRounderImpl(minFrac, maxFrac, mc, tzd);
         }
     }
 
@@ -690,6 +688,13 @@ public abstract class Precision {
         final int maxSig;
 
         public SignificantRounderImpl(int minSig, int maxSig) {
+            this.minSig = minSig;
+            this.maxSig = maxSig;
+        }
+
+        public SignificantRounderImpl(
+                int minSig, int maxSig, MathContext mc, TrailingZeroDisplay tzd) {
+            super(mc, tzd);
             this.minSig = minSig;
             this.maxSig = maxSig;
         }
@@ -715,10 +720,8 @@ public abstract class Precision {
         }
 
         @Override
-        SignificantRounderImpl createCopy() {
-            SignificantRounderImpl copy = new SignificantRounderImpl(minSig, maxSig);
-            createCopyHelper(copy);
-            return copy;
+        SignificantRounderImpl createCopy(MathContext mc, TrailingZeroDisplay tzd) {
+            return new SignificantRounderImpl(minSig, maxSig, mc, tzd);
         }
     }
 
@@ -737,6 +740,24 @@ public abstract class Precision {
                 int maxSig,
                 RoundingPriority priority,
                 boolean retain) {
+            this.minFrac = minFrac;
+            this.maxFrac = maxFrac;
+            this.minSig = minSig;
+            this.maxSig = maxSig;
+            this.priority = priority;
+            this.retain = retain;
+        }
+
+        public FracSigRounderImpl(
+                int minFrac,
+                int maxFrac,
+                int minSig,
+                int maxSig,
+                RoundingPriority priority,
+                boolean retain,
+                MathContext mc,
+                TrailingZeroDisplay tzd) {
+            super(mc, tzd);
             this.minFrac = minFrac;
             this.maxFrac = maxFrac;
             this.minSig = minSig;
@@ -790,11 +811,9 @@ public abstract class Precision {
         }
 
         @Override
-        FracSigRounderImpl createCopy() {
-            FracSigRounderImpl copy =
-                    new FracSigRounderImpl(minFrac, maxFrac, minSig, maxSig, priority, retain);
-            createCopyHelper(copy);
-            return copy;
+        FracSigRounderImpl createCopy(MathContext mc, TrailingZeroDisplay tzd) {
+            return new FracSigRounderImpl(
+                    minFrac, maxFrac, minSig, maxSig, priority, retain, mc, tzd);
         }
     }
 
@@ -806,6 +825,11 @@ public abstract class Precision {
             this.increment = increment;
         }
 
+        public IncrementRounderImpl(BigDecimal increment, MathContext mc, TrailingZeroDisplay tzd) {
+            super(mc, tzd);
+            this.increment = increment;
+        }
+
         @Override
         public void apply(DecimalQuantity value) {
             value.roundToIncrement(increment, mathContext);
@@ -813,10 +837,8 @@ public abstract class Precision {
         }
 
         @Override
-        IncrementRounderImpl createCopy() {
-            IncrementRounderImpl copy = new IncrementRounderImpl(increment);
-            createCopyHelper(copy);
-            return copy;
+        IncrementRounderImpl createCopy(MathContext mc, TrailingZeroDisplay tzd) {
+            return new IncrementRounderImpl(increment, mc, tzd);
         }
     }
 
@@ -835,6 +857,17 @@ public abstract class Precision {
             this.maxFrac = maxFrac;
         }
 
+        public IncrementOneRounderImpl(
+                BigDecimal increment,
+                int minFrac,
+                int maxFrac,
+                MathContext mc,
+                TrailingZeroDisplay tzd) {
+            super(increment, mc, tzd);
+            this.minFrac = minFrac;
+            this.maxFrac = maxFrac;
+        }
+
         @Override
         public void apply(DecimalQuantity value) {
             value.roundToMagnitude(-maxFrac, mathContext);
@@ -842,10 +875,8 @@ public abstract class Precision {
         }
 
         @Override
-        IncrementOneRounderImpl createCopy() {
-            IncrementOneRounderImpl copy = new IncrementOneRounderImpl(increment, minFrac, maxFrac);
-            createCopyHelper(copy);
-            return copy;
+        IncrementOneRounderImpl createCopy(MathContext mc, TrailingZeroDisplay tzd) {
+            return new IncrementOneRounderImpl(increment, minFrac, maxFrac, mc, tzd);
         }
     }
 
@@ -860,6 +891,17 @@ public abstract class Precision {
             this.maxFrac = maxFrac;
         }
 
+        public IncrementFiveRounderImpl(
+                BigDecimal increment,
+                int minFrac,
+                int maxFrac,
+                MathContext mc,
+                TrailingZeroDisplay tzd) {
+            super(increment, mc, tzd);
+            this.minFrac = minFrac;
+            this.maxFrac = maxFrac;
+        }
+
         @Override
         public void apply(DecimalQuantity value) {
             value.roundToNickel(-maxFrac, mathContext);
@@ -867,11 +909,8 @@ public abstract class Precision {
         }
 
         @Override
-        IncrementFiveRounderImpl createCopy() {
-            IncrementFiveRounderImpl copy =
-                    new IncrementFiveRounderImpl(increment, minFrac, maxFrac);
-            createCopyHelper(copy);
-            return copy;
+        IncrementFiveRounderImpl createCopy(MathContext mc, TrailingZeroDisplay tzd) {
+            return new IncrementFiveRounderImpl(increment, minFrac, maxFrac, mc, tzd);
         }
     }
 
@@ -882,6 +921,11 @@ public abstract class Precision {
             this.usage = usage;
         }
 
+        public CurrencyRounderImpl(CurrencyUsage usage, MathContext mc, TrailingZeroDisplay tzd) {
+            super(mc, tzd);
+            this.usage = usage;
+        }
+
         @Override
         public void apply(DecimalQuantity value) {
             // Call .withCurrency() before .apply()!
@@ -889,10 +933,8 @@ public abstract class Precision {
         }
 
         @Override
-        CurrencyRounderImpl createCopy() {
-            CurrencyRounderImpl copy = new CurrencyRounderImpl(usage);
-            createCopyHelper(copy);
-            return copy;
+        CurrencyRounderImpl createCopy(MathContext mc, TrailingZeroDisplay tzd) {
+            return new CurrencyRounderImpl(usage, mc, tzd);
         }
     }
 

--- a/icu4j/main/core/src/main/java/com/ibm/icu/number/ScientificNotation.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/number/ScientificNotation.java
@@ -27,10 +27,10 @@ import java.text.Format.Field;
  */
 public class ScientificNotation extends Notation {
 
-    int engineeringInterval;
-    boolean requireMinInt;
-    int minExponentDigits;
-    SignDisplay exponentSignDisplay;
+    final int engineeringInterval;
+    final boolean requireMinInt;
+    final int minExponentDigits;
+    final SignDisplay exponentSignDisplay;
 
     /* package-private */ ScientificNotation(
             int engineeringInterval,
@@ -58,9 +58,11 @@ public class ScientificNotation extends Notation {
      */
     public ScientificNotation withMinExponentDigits(int minExponentDigits) {
         if (minExponentDigits >= 1 && minExponentDigits <= RoundingUtils.MAX_INT_FRAC_SIG) {
-            ScientificNotation other = createCopy();
-            other.minExponentDigits = minExponentDigits;
-            return other;
+            return new ScientificNotation(
+                    this.engineeringInterval,
+                    this.requireMinInt,
+                    minExponentDigits,
+                    this.exponentSignDisplay);
         } else {
             throw new IllegalArgumentException(
                     "Integer digits must be between 1 and "
@@ -82,15 +84,11 @@ public class ScientificNotation extends Notation {
      * @see NumberFormatter
      */
     public ScientificNotation withExponentSignDisplay(SignDisplay exponentSignDisplay) {
-        ScientificNotation other = createCopy();
-        other.exponentSignDisplay = exponentSignDisplay;
-        return other;
-    }
-
-    /** Package-private clone method */
-    ScientificNotation createCopy() {
         return new ScientificNotation(
-                engineeringInterval, requireMinInt, minExponentDigits, exponentSignDisplay);
+                this.engineeringInterval,
+                this.requireMinInt,
+                this.minExponentDigits,
+                exponentSignDisplay);
     }
 
     /* package-private */ MicroPropsGenerator withLocaleData(


### PR DESCRIPTION
Follow-up to #3978

This makes the fields in Precision and ScientificNotation `final`.

_Gemini, and AI by Google, was used in making this pull request_

#### Checklist
- [x] Required: Issue filed: ICU-23403
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-23403 Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-23403 Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
