### PR TITLE
reject RBNF plural rules whose divisor overflows to zero

### DIFF
--- a/icu4c/source/i18n/nfrule.cpp
+++ b/icu4c/source/i18n/nfrule.cpp
@@ -504,6 +504,13 @@ NFRule::extractSubstitutions(const NFRuleSet* owner,
         }
         rulePatternFormat = formatter->createPluralFormat(pluralType,
                 ruleText.tempSubString(endType + 1, pluralRuleEnd - endType - 1), status);
+        if (U_SUCCESS(status) && getDivisor() <= 0) {
+            // radix^exponent overflowed 64 bits, so doFormat() would divide the
+            // number by a zero (or wrapped-negative) divisor. Reject the rule, like
+            // the modulus and integral-part substitutions already do for a zero divisor.
+            status = U_PARSE_ERROR;
+            return;
+        }
     }
 }
 

--- a/icu4c/source/test/intltest/itrbnf.cpp
+++ b/icu4c/source/test/intltest/itrbnf.cpp
@@ -2834,6 +2834,15 @@ IntlTestRBNF::TestDividedByZero() {
     UErrorCode status = U_ZERO_ERROR;
     RuleBasedNumberFormat rbnf(u"7060920374060940374/4:[]", Locale::getUS(), perror, status);
     assertEquals("base is too large", U_NUMBER_ARG_OUTOFBOUNDS_ERROR, status);
+
+    // A $(cardinal,...)$ rule whose radix^exponent overflows 64 bits: the
+    // divisor is zero, so doFormat() would divide the number by it. The rule
+    // must be rejected at construction instead of dividing by zero.
+    status = U_ZERO_ERROR;
+    RuleBasedNumberFormat pluralDivisor(
+        u"0: zero;\n4611686018427387904/16: big $(cardinal,one{a}other{b})$;",
+        Locale::getEnglish(), perror, status);
+    assertEquals("zero divisor from overflow", U_PARSE_ERROR, status);
 }
 
 void

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/RbnfTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/RbnfTest.java
@@ -2202,6 +2202,20 @@ public class RbnfTest extends CoreTestFmwk {
         }
     }
 
+    @Test
+    public void TestDivisorOverflow() {
+        // A $(cardinal,...)$ rule whose radix^exponent overflows 64 bits: the divisor is
+        // zero, so doFormat() would divide the number by it (ArithmeticException: / by zero).
+        // The rule must be rejected at construction instead, like a zero-divisor substitution.
+        try {
+            new RuleBasedNumberFormat(
+                    "0: zero;\n4611686018427387904/16: big $(cardinal,one{a}other{b})$;");
+            errln("Rule with a zero divisor from overflow should have been rejected");
+        } catch (IllegalStateException e) {
+            // expected
+        }
+    }
+
     /**
      * This test is a little contrived for English, but the grammar is relevant for several
      * languages, including: Latin, Germanic, Slavic and Indic. It's pretty common, especially for

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/NFRule.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/NFRule.java
@@ -412,6 +412,12 @@ final class NFRule {
             rulePatternFormat =
                     formatter.createPluralFormat(
                             pluralType, ruleText.substring(endType + 1, pluralRuleEnd));
+            if (getDivisor() <= 0) {
+                // radix^exponent overflowed 64 bits, so doFormat() would divide the
+                // number by a zero (or wrapped-negative) divisor. Reject the rule, like
+                // the modulus and integral-part substitutions already do for a zero divisor.
+                throw new IllegalStateException("Rule with divisor " + getDivisor());
+            }
         }
     }
 


### PR DESCRIPTION
A slash divisor descriptor with a `$(cardinal,...)$` body sets `rulePatternFormat` but creates no modulus or integral-part substitution, so the divisor checks in those substitution constructors never run. When `radix^exponent` overflows 64 bits the power helper wraps to 0 (`util64_pow` in ICU4C, `NFRule.power` in ICU4J), and `doFormat()` then divides the formatted number by that zero divisor: integer divide by zero, SIGFPE on x86-64 in C, `ArithmeticException: / by zero` in Java.

`extractSubstitutions` now rejects the rule as soon as the plural format is built and `getDivisor() == 0`, mirroring the existing zero-divisor guards in the modulus and integral-part substitutions. ICU4C surfaces `U_PARSE_ERROR`; ICU4J throws `IllegalStateException`, matching how those substitutions already reject a zero divisor.

Confirmed the same crash exists in ICU4J (the Number Format Tester / `numbers.jsp` throws `/ by zero`), so the fix and the test are mirrored to both. The C++ `TestDividedByZero` and the new Java `TestDivisorOverflow` both fail without the fix and pass with it.

#### Checklist
- [ ] Required: Issue filed: ICU-NNNNN
- [ ] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
