### PR TITLE
ICU-23413 Fix null pointer dereference in RuleBasedNumberFormat::getRuleSetDisplayName

### DIFF
--- a/icu4c/source/i18n/rbnf.cpp
+++ b/icu4c/source/i18n/rbnf.cpp
@@ -943,6 +943,11 @@ RuleBasedNumberFormat::getRuleSetDisplayName(int32_t index, const Locale& locale
         UnicodeString localeName(localeParam.getBaseName(), -1, UnicodeString::kInvariant); 
         int32_t len = localeName.length();
         char16_t* localeStr = localeName.getBuffer(len + 1);
+        if (localeStr == nullptr) {
+            UnicodeString bogus;
+            bogus.setToBogus();
+            return bogus;
+        }
         while (len >= 0) {
             localeStr[len] = 0;
             int32_t ix = localizations->indexForLocale(localeStr);

--- a/icu4c/source/i18n/rbnf.cpp
+++ b/icu4c/source/i18n/rbnf.cpp
@@ -943,25 +943,22 @@ RuleBasedNumberFormat::getRuleSetDisplayName(int32_t index, const Locale& locale
         UnicodeString localeName(localeParam.getBaseName(), -1, UnicodeString::kInvariant); 
         int32_t len = localeName.length();
         char16_t* localeStr = localeName.getBuffer(len + 1);
-        if (localeStr == nullptr) {
-            UnicodeString bogus;
-            bogus.setToBogus();
-            return bogus;
-        }
-        while (len >= 0) {
-            localeStr[len] = 0;
-            int32_t ix = localizations->indexForLocale(localeStr);
-            if (ix >= 0) {
-                UnicodeString name(true, localizations->getDisplayName(ix, index), -1);
-                return name;
+        if (localeStr != nullptr) {
+            while (len >= 0) {
+                localeStr[len] = 0;
+                int32_t ix = localizations->indexForLocale(localeStr);
+                if (ix >= 0) {
+                    UnicodeString name(true, localizations->getDisplayName(ix, index), -1);
+                    return name;
+                }
+                
+                // trim trailing portion, skipping over omitted sections
+                do { --len;} while (len > 0 && localeStr[len] != 0x005f); // underscore
+                while (len > 0 && localeStr[len-1] == 0x005F) --len;
             }
-            
-            // trim trailing portion, skipping over omitted sections
-            do { --len;} while (len > 0 && localeStr[len] != 0x005f); // underscore
-            while (len > 0 && localeStr[len-1] == 0x005F) --len;
+            UnicodeString name(true, localizations->getRuleSetName(index), -1);
+            return name;
         }
-        UnicodeString name(true, localizations->getRuleSetName(index), -1);
-        return name;
     }
     UnicodeString bogus;
     bogus.setToBogus();


### PR DESCRIPTION
### Linked Jira issue
ICU-23413

### Summary
In `RuleBasedNumberFormat::getRuleSetDisplayName` (`icu4c/source/i18n/rbnf.cpp`),
the result of `localeName.getBuffer(len + 1)` was indexed via
`localeStr[len] = 0` in the following loop without a NULL check.

### Cause
`UnicodeString::getBuffer(int32_t)` returns NULL on allocation failure
(or when the string is bogus); the indexed write is then undefined
behavior.

### Fix
Return a bogus `UnicodeString` when `getBuffer` returns NULL.

### Testing
Existing tests pass (no behavior change on the success path). No new
test added — the OOM path requires allocator injection that is not
part of the standard test harness.

### Notes
Found by static analysis (Svace, ISP RAS).

#### Checklist
- [x] Required: Issue filed: ICU-23413
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
