### PR TITLE
ICU-23414 Fix null pointer dereference in TransliterationRule copy constructor on allocation failure

### DIFF
--- a/icu4c/source/i18n/rbt_rule.cpp
+++ b/icu4c/source/i18n/rbt_rule.cpp
@@ -167,7 +167,9 @@ TransliterationRule::TransliterationRule(TransliterationRule& other) :
         data(other.data) {
     if (other.segmentsCount > 0) {
         segments = static_cast<UnicodeFunctor**>(uprv_malloc(other.segmentsCount * sizeof(UnicodeFunctor*)));
-        uprv_memcpy(segments, other.segments, (size_t)other.segmentsCount*sizeof(segments[0]));
+        if (segments != nullptr) {
+            uprv_memcpy(segments, other.segments, (size_t)other.segmentsCount*sizeof(segments[0]));
+        }
     }
 
     if (other.anteContext != nullptr) {


### PR DESCRIPTION
### Linked Jira issue
ICU-23414

### Summary
In the `TransliterationRule` copy constructor (`icu4c/source/i18n/rbt_rule.cpp`),
the result of `uprv_malloc` for the `segments` array was passed to
`uprv_memcpy` without a NULL check.

### Cause
On OOM `uprv_malloc` returns NULL; the subsequent `uprv_memcpy` is then
undefined behavior.

### Fix
The constructor has no `UErrorCode`, so guard the `uprv_memcpy` with a
NULL check. On failure `segments` stays `nullptr`, which the rest of the
object already tolerates.

### Testing
Existing tests pass (no behavior change on the success path). No new
test added — the OOM path requires allocator injection that is not
part of the standard test harness.

### Notes
Found by static analysis (Svace, ISP RAS).

#### Checklist
- [x] Required: Issue filed: ICU-23414
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
