### PR TITLE
ICU-23415 Fix null pointer dereference in RelativeDateFormat copy constructor on allocation failure

### DIFF
--- a/icu4c/source/i18n/reldtfmt.cpp
+++ b/icu4c/source/i18n/reldtfmt.cpp
@@ -58,7 +58,11 @@ RelativeDateFormat::RelativeDateFormat(const RelativeDateFormat& other) :
     }
     if (fDatesLen > 0) {
         fDates = static_cast<URelativeString*>(uprv_malloc(sizeof(fDates[0]) * static_cast<size_t>(fDatesLen)));
-        uprv_memcpy(fDates, other.fDates, sizeof(fDates[0])*(size_t)fDatesLen);
+        if (fDates != nullptr) {
+            uprv_memcpy(fDates, other.fDates, sizeof(fDates[0])*(size_t)fDatesLen);
+        } else {
+            fDatesLen = 0;
+        }
     }
 #if !UCONFIG_NO_BREAK_ITERATION
     if (other.fCapitalizationBrkIter != nullptr) {


### PR DESCRIPTION
### Linked Jira issue
ICU-23415

### Summary
In the `RelativeDateFormat` copy constructor (`icu4c/source/i18n/reldtfmt.cpp`),
the result of `uprv_malloc` for `fDates` was passed to `uprv_memcpy`
without a NULL check.

### Cause
On OOM `uprv_malloc` returns NULL; the subsequent `uprv_memcpy` is then
undefined behavior.

### Fix
The constructor has no `UErrorCode`, so guard the `uprv_memcpy` with a
NULL check and reset `fDatesLen = 0` on failure so the object stays
internally consistent.

### Testing
Existing tests pass (no behavior change on the success path). No new
test added — the OOM path requires allocator injection that is not
part of the standard test harness.

### Notes
Found by static analysis (Svace, ISP RAS).

#### Checklist
- [x] Required: Issue filed: ICU-23415
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
