### PR TITLE
ICU-23416 Fix null pointer dereference in TimeUnitFormat::copyHash on allocation failure

### DIFF
--- a/icu4c/source/i18n/tmutfmt.cpp
+++ b/icu4c/source/i18n/tmutfmt.cpp
@@ -722,6 +722,10 @@ TimeUnitFormat::copyHash(const Hashtable* source, Hashtable* target, UErrorCode&
             const UHashTok valueTok = element->value;
             const MessageFormat** value = static_cast<const MessageFormat**>(valueTok.pointer);
             MessageFormat** newVal = static_cast<MessageFormat**>(uprv_malloc(UTMUTFMT_FORMAT_STYLE_COUNT * sizeof(MessageFormat*)));
+            if (newVal == nullptr) {
+                status = U_MEMORY_ALLOCATION_ERROR;
+                return;
+            }
             newVal[0] = value[0]->clone();
             newVal[1] = value[1]->clone();
             target->put(UnicodeString(*key), newVal, status);


### PR DESCRIPTION
### Linked Jira issue
ICU-23416

### Summary
In `TimeUnitFormat::copyHash` (`icu4c/source/i18n/tmutfmt.cpp`), the
result of `uprv_malloc` for `newVal` was dereferenced via
`newVal[0] = value[0]->clone()` without a NULL check.

### Cause
On OOM `uprv_malloc` returns NULL; the subsequent indexed writes are
undefined behavior.

### Fix
`copyHash` already takes `UErrorCode& status`, so on NULL set
`status = U_MEMORY_ALLOCATION_ERROR;` and `return;` before the
dereference.

### Testing
Existing tests pass (no behavior change on the success path). No new
test added — the OOM path requires allocator injection that is not
part of the standard test harness.

### Notes
Found by static analysis (Svace, ISP RAS).

#### Checklist
- [x] Required: Issue filed: ICU-23416
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
