### PR TITLE
cap fullStage2Length to avoid size overflow in reconstituteData

### DIFF
--- a/icu4c/source/common/ucnvmbcs.cpp
+++ b/icu4c/source/common/ucnvmbcs.cpp
@@ -1487,6 +1487,13 @@ reconstituteData(UConverterMBCSTable *mbcsTable,
                  UErrorCode *pErrorCode) {
     uint16_t *stage1;
     uint32_t *stage2;
+    /* Guard the size computation against uint32_t overflow: a malformed table with
+       a large fullStage2Length would wrap dataLength to a small value, producing an
+       undersized allocation and out-of-bounds writes below. */
+    if(((uint64_t)stage1Length*2+(uint64_t)fullStage2Length*4+mbcsTable->fromUBytesLength)>0xffffffff) {
+        *pErrorCode=U_INVALID_TABLE_FORMAT;
+        return;
+    }
     uint32_t dataLength=stage1Length*2+fullStage2Length*4+mbcsTable->fromUBytesLength;
     mbcsTable->reconstitutedData = static_cast<uint8_t*>(uprv_malloc(dataLength));
     if(mbcsTable->reconstitutedData==nullptr) {


### PR DESCRIPTION
#### Description

`reconstituteData()` in the MBCS converter loader computes
`dataLength = stage1Length*2 + fullStage2Length*4 + fromUBytesLength` in `uint32_t`.
A table with a large `fullStage2Length` wraps this sum to a small value, so `uprv_malloc`
allocates an undersized buffer that the following `uprv_memcpy` and stage-2 pointer
arithmetic overrun.

This adds a 64-bit overflow check that rejects the table with `U_INVALID_TABLE_FORMAT`,
mirroring the other malformed-table guards already in the loader (`ucnv_MBCSLoad`).

Found while fuzzing the converter loader with mutated `.cnv` table data.

#### Checklist
- [ ] Required: Issue filed: ICU-NNNNN
- [ ] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
