### PR TITLE
ICU-23421 code point iterators & ranges: add base(), front(), back()

### DIFF
--- a/icu4c/source/common/unicode/utfiterator.h
+++ b/icu4c/source/common/unicode/utfiterator.h
@@ -1198,7 +1198,7 @@ public:
      * @draft ICU 78
      */
     U_FORCE_INLINE bool operator==(const UTFIterator &other) const {
-        return getLogicalPosition() == other.getLogicalPosition();
+        return base() == other.base();
     }
     /**
      * @param other Another iterator
@@ -1220,7 +1220,7 @@ public:
         !std::is_same_v<Sentinel, UTFIterator> && !std::is_same_v<Sentinel, UnitIter>,
         bool>
     operator==(const UTFIterator &iter, const Sentinel &s) {
-        return iter.getLogicalPosition() == s;
+        return iter.base() == s;
     }
 
 #if U_CPLUSPLUS_VERSION < 20
@@ -1239,7 +1239,7 @@ public:
         !std::is_same_v<Sentinel, UTFIterator> && !std::is_same_v<Sentinel, UnitIter>,
         bool>
     operator==(const Sentinel &s, const UTFIterator &iter) {
-        return iter.getLogicalPosition() == s;
+        return iter.base() == s;
     }
     /**
      * @param iter A UTFIterator
@@ -1264,6 +1264,18 @@ public:
         bool>
     operator!=(const Sentinel &s, const UTFIterator &iter) { return !(iter == s); }
 #endif  // C++17
+
+    /**
+     * Returns the current position as a code unit iterator.
+     * Similar to iter->begin() but also works at the exclusive end().
+     *
+     * @return current position as a code unit iterator
+     * @draft ICU 79
+     */
+    U_FORCE_INLINE UnitIter base() const {
+        // Return the logical position.
+        return state_ <= 0 ? p_ : units_.begin();
+    }
 
     /**
      * Decodes the code unit sequence at the current position.
@@ -1385,10 +1397,6 @@ public:
 
 private:
     friend class std::reverse_iterator<UTFIterator<CP32, behavior, UnitIter>>;
-
-    U_FORCE_INLINE UnitIter getLogicalPosition() const {
-        return state_ <= 0 ? p_ : units_.begin();
-    }
 
     // operator*() etc. are logically const.
     mutable UnitIter p_;
@@ -1568,7 +1576,7 @@ public:
     using iterator_category = std::bidirectional_iterator_tag;
 
     U_FORCE_INLINE explicit reverse_iterator(U_HEADER_ONLY_NAMESPACE::UTFIterator<CP32, behavior, UnitIter> iter) :
-            p_(iter.getLogicalPosition()), start_(iter.start_), limit_(iter.limit_),
+            p_(iter.base()), start_(iter.start_), limit_(iter.limit_),
             units_(0, 0, false, p_, p_) {}
     U_FORCE_INLINE reverse_iterator() : p_{}, start_{}, limit_{}, units_(0, 0, false, p_, p_) {}
 
@@ -1582,6 +1590,11 @@ public:
         return getLogicalPosition() == other.getLogicalPosition();
     }
     U_FORCE_INLINE bool operator!=(const reverse_iterator &other) const { return !operator==(other); }
+
+    U_FORCE_INLINE U_HEADER_ONLY_NAMESPACE::UTFIterator<CP32, behavior, UnitIter> base() const {
+        return U_HEADER_ONLY_NAMESPACE::UTFIterator<CP32, behavior, UnitIter>(
+            start_, getLogicalPosition(), limit_);
+    }
 
     U_FORCE_INLINE CodeUnits_ operator*() const {
         if (state_ == 0) {
@@ -1894,6 +1907,28 @@ public:
         return std::make_reverse_iterator(begin());
     }
 
+    /**
+     * Returns the CodeUnits for the first character/code point.
+     * Requires that the range is not empty.
+     *
+     * @return the CodeUnits for the first character/code point.
+     * @draft ICU 79
+     */
+    auto front() const {
+        return *begin();
+    }
+
+    /**
+     * Returns the CodeUnits for the last character/code point.
+     * Requires that the range is not empty.
+     *
+     * @return the CodeUnits for the last character/code point.
+     * @draft ICU 79
+     */
+    auto back() const {
+        return *(--end());
+    }
+
 private:
     Range unitRange;
 };
@@ -2029,7 +2064,7 @@ public:
      * @draft ICU 78
      */
     U_FORCE_INLINE bool operator==(const UnsafeUTFIterator &other) const {
-        return getLogicalPosition() == other.getLogicalPosition();
+        return base() == other.base();
     }
     /**
      * @param other Another iterator
@@ -2049,7 +2084,7 @@ public:
         !std::is_same_v<Sentinel, UnsafeUTFIterator> && !std::is_same_v<Sentinel, UnitIter>,
         bool>
     operator==(const UnsafeUTFIterator &iter, const Sentinel &s) {
-        return iter.getLogicalPosition() == s;
+        return iter.base() == s;
     }
 
 #if U_CPLUSPLUS_VERSION < 20
@@ -2064,7 +2099,7 @@ public:
         !std::is_same_v<Sentinel, UnsafeUTFIterator> && !std::is_same_v<Sentinel, UnitIter>,
         bool>
     operator==(const Sentinel &s, const UnsafeUTFIterator &iter) {
-        return iter.getLogicalPosition() == s;
+        return iter.base() == s;
     }
     /**
      * @param iter An UnsafeUTFIterator
@@ -2089,6 +2124,18 @@ public:
         bool>
     operator!=(const Sentinel &s, const UnsafeUTFIterator &iter) { return !(iter == s); }
 #endif  // C++17
+
+    /**
+     * Returns the current position as a code unit iterator.
+     * Similar to iter->begin() but also works at the exclusive end().
+     *
+     * @return current position as a code unit iterator
+     * @draft ICU 79
+     */
+    U_FORCE_INLINE UnitIter base() const {
+        // Return the logical position.
+        return state_ <= 0 ? p_ : units_.begin();
+    }
 
     /**
      * Decodes the code unit sequence at the current position.
@@ -2210,10 +2257,6 @@ public:
 
 private:
     friend class std::reverse_iterator<UnsafeUTFIterator<CP32, UnitIter>>;
-
-    U_FORCE_INLINE UnitIter getLogicalPosition() const {
-        return state_ <= 0 ? p_ : units_.begin();
-    }
 
     // operator*() etc. are logically const.
     mutable UnitIter p_;
@@ -2382,7 +2425,7 @@ public:
     using iterator_category = std::bidirectional_iterator_tag;
 
     U_FORCE_INLINE explicit reverse_iterator(U_HEADER_ONLY_NAMESPACE::UnsafeUTFIterator<CP32, UnitIter> iter) :
-            p_(iter.getLogicalPosition()), units_(0, 0, p_, p_) {}
+            p_(iter.base()), units_(0, 0, p_, p_) {}
     U_FORCE_INLINE reverse_iterator() : p_{}, units_(0, 0, p_, p_) {}
 
     U_FORCE_INLINE reverse_iterator(reverse_iterator &&src) noexcept = default;
@@ -2395,6 +2438,11 @@ public:
         return getLogicalPosition() == other.getLogicalPosition();
     }
     U_FORCE_INLINE bool operator!=(const reverse_iterator &other) const { return !operator==(other); }
+
+    U_FORCE_INLINE U_HEADER_ONLY_NAMESPACE::UnsafeUTFIterator<CP32, UnitIter> base() const {
+        return U_HEADER_ONLY_NAMESPACE::UnsafeUTFIterator<CP32, UnitIter>(
+            getLogicalPosition());
+    }
 
     U_FORCE_INLINE UnsafeCodeUnits_ operator*() const {
         if (state_ == 0) {
@@ -2630,6 +2678,28 @@ public:
      */
     auto rend() const {
         return std::make_reverse_iterator(begin());
+    }
+
+    /**
+     * Returns the CodeUnits for the first character/code point.
+     * Requires that the range is not empty.
+     *
+     * @return the CodeUnits for the first character/code point.
+     * @draft ICU 79
+     */
+    auto front() const {
+        return *begin();
+    }
+
+    /**
+     * Returns the CodeUnits for the last character/code point.
+     * Requires that the range is not empty.
+     *
+     * @return the CodeUnits for the last character/code point.
+     * @draft ICU 79
+     */
+    auto back() const {
+        return *(--end());
     }
 
 private:

--- a/icu4c/source/test/intltest/utfiteratortest.cpp
+++ b/icu4c/source/test/intltest/utfiteratortest.cpp
@@ -371,6 +371,8 @@ public:
         TESTCASE_AUTO(testCommonContiguousRange);
 #endif
 
+        TESTCASE_AUTO(testBaseFrontBack);
+
         TESTCASE_AUTO(testAllCodePoints);
         TESTCASE_AUTO(testAllScalarValues);
 
@@ -838,6 +840,79 @@ public:
                                       std::u32string_view(U"𒀭𒊺𒉀​𒍠𒊩")));
     }
 #endif
+
+    void testBaseFrontBack() {
+        // Mostly API tests. Code is also covered by internal usage of base(),
+        // and by front() and back() calling well-tested functions.
+        {
+            // UTF-16 validating
+            auto sv = u"ç🚂カ.🚴"sv;
+            auto cpRange = utfStringCodePoints<UChar32, UTF_BEHAVIOR_NEGATIVE>(sv);
+            assertEquals("cpRange16.front()", u'ç', cpRange.front().codePoint());
+            assertTrue("cpRange16.back()", u"🚴"sv == cpRange.back().stringView());
+            auto early = cpRange.begin();
+            assertTrue("cpRange16.begin().base()", early.base() == sv.begin());
+            ++ ++ ++early;
+            assertTrue("cpRange16.begin()+3.base()", early.base() == sv.begin() + 4);
+            // Internally moves the code unit iterator but keeps base() as is.
+            assertEquals("cpRange16.begin()+3.*", u'.', early->codePoint());
+            assertTrue("cpRange16.begin()+3.*.base()", early.base() == sv.begin() + 4);
+
+            auto late = cpRange.end();
+            assertTrue("cpRange16.end().base()", late.base() == sv.end());
+            -- --late;
+            assertTrue("cpRange16.end()-2.base()", late.base() == early.base());
+
+            // reverse iterators
+            auto rEarly = cpRange.rbegin();
+            assertTrue("cpRange16.rbegin().base()", rEarly.base() == cpRange.end());
+            ++ ++rEarly;
+            assertTrue("cpRange16.rbegin()+2.base()", rEarly.base() == early);
+            auto rLate = cpRange.rend();
+            assertTrue("cpRange16.rend().base()", rLate.base() == cpRange.begin());
+            -- -- --rLate;
+            assertTrue("cpRange16.rend()-3.base()", rLate.base() == late);
+            // Internally moves the code unit iterator but keeps base() as is.
+            assertEquals("cpRange16.rend()-3.*", u'カ', rLate->codePoint());
+            assertTrue("cpRange16.rend()-3.*.base()", rLate.base() == late);
+            // Reverse base() looks forward.
+            assertEquals("cpRange16.rend()-3.*.base().*", u'.', rLate.base()->codePoint());
+        }
+        {
+            // UTF-8 unsafe, adjusted offsets, otherwise same code
+            auto sv = u8"ç🚂カ.🚴"sv;
+            auto cpRange = unsafeUTFStringCodePoints<UChar32>(sv);
+            assertEquals("cpRange8.front()", u'ç', cpRange.front().codePoint());
+            assertTrue("cpRange8.back()", u8"🚴"sv == cpRange.back().stringView());
+            auto early = cpRange.begin();
+            assertTrue("cpRange8.begin().base()", early.base() == sv.begin());
+            ++ ++ ++early;
+            assertTrue("cpRange8.begin()+3.base()", early.base() == sv.begin() + 9);
+            // Internally moves the code unit iterator but keeps base() as is.
+            assertEquals("cpRange8.begin()+3.*", u'.', early->codePoint());
+            assertTrue("cpRange8.begin()+3.*.base()", early.base() == sv.begin() + 9);
+
+            auto late = cpRange.end();
+            assertTrue("cpRange8.end().base()", late.base() == sv.end());
+            -- --late;
+            assertTrue("cpRange8.end()-2.base()", late.base() == early.base());
+
+            // reverse iterators
+            auto rEarly = cpRange.rbegin();
+            assertTrue("cpRange8.rbegin().base()", rEarly.base() == cpRange.end());
+            ++ ++rEarly;
+            assertTrue("cpRange8.rbegin()+2.base()", rEarly.base() == early);
+            auto rLate = cpRange.rend();
+            assertTrue("cpRange8.rend().base()", rLate.base() == cpRange.begin());
+            -- -- --rLate;
+            assertTrue("cpRange8.rend()-3.base()", rLate.base() == late);
+            // Internally moves the code unit iterator but keeps base() as is.
+            assertEquals("cpRange8.rend()-3.*", u'カ', rLate->codePoint());
+            assertTrue("cpRange8.rend()-3.*.base()", rLate.base() == late);
+            // Reverse base() looks forward.
+            assertEquals("cpRange8.rend()-3.*.base().*", u'.', rLate.base()->codePoint());
+        }
+    }
 
     // implementation code coverage ---------------------------------------- ***
 


### PR DESCRIPTION
This is a small addition to the [C++ code point iterator APIs](https://unicode-org.github.io/icu/userguide/strings/cpp-code-point-iterator.html). These are actually common functions in C++ standard iterators and ranges that we had overlooked.

From the ticket:
C++ “ranges” or “containers” usually have a front() function for the first element, and a back() function for the last one. This has turned out to be something that would be a useful addition to [Unsafe]UTFStringCodePoints. Simple example:
- https://en.cppreference.com/cpp/string/basic_string_view
- https://en.cppreference.com/cpp/string/basic_string_view/front
- https://en.cppreference.com/cpp/string/basic_string_view/back

A C++ iterator often wraps another, “more basic” iterator, and commonly provides a base() function to access that. [Unsafe]UTFIterator wraps a code unit iterator; base() would return a code unit iterator at the current logical position. It would be like fetching the current CodeUnits and calling their begin(), except that those cannot be fetched from an exclusive-end() iterator; base() would be much easier to use.

Real example: use std::advance() to move a code point iterator forward n code points, then call its base() to find the position in the input string/string_view, which will usually have moved by a larger number of code units.
- [std::ranges::advance - cppreference.com](https://en.cppreference.com/cpp/iterator/ranges/advance)

Similarly, a reverse_iterator usually has a base() function to return an original-direction iterator at the same logical position. The reverse_iterator wrappers over [Unsafe]UTFIterator should have that, too.
- https://en.cppreference.com/cpp/iterator/reverse_iterator/base

New API signatures in common/unicode/utfiterator.h. Note that the reverse_iterator classes are template specializations of C++ reverse_iterator and do not have the usual API docs.

#### Checklist
- [x] Required: Issue filed: ICU-23421
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
