### PR TITLE
ICU-22148 deprecate ICUUncheckedIOException, now is-an UncheckedIOException

### DIFF
--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/serializable/CompatibilityTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/serializable/CompatibilityTest.java
@@ -185,7 +185,7 @@ public class CompatibilityTest extends CoreTestFmwk {
             jarFile = conn.getJarFile();
             Enumeration<JarEntry> entries = jarFile.entries();
             while (entries.hasMoreElements()) {
-                JarEntry entry = (JarEntry) entries.nextElement();
+                JarEntry entry = entries.nextElement();
                 if (!entry.isDirectory()) {
                     String entryName = entry.getName();
 

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/serializable/SerializableTestUtility.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/serializable/SerializableTestUtility.java
@@ -82,7 +82,7 @@ public class SerializableTestUtility {
     }
 
     public static Handler getHandler(String className) {
-        return (Handler) map.get(className);
+        return map.get(className);
     }
 
     private static class TimeZoneHandler implements Handler {
@@ -774,7 +774,28 @@ public class SerializableTestUtility {
     private abstract static class ExceptionHandlerBase implements Handler {
         @Override
         public boolean hasSameBehavior(Object a, Object b) {
-            return sameThrowable((Exception) a, (Exception) b);
+            boolean same = sameThrowable((Exception) a, (Exception) b);
+            // TODO: Delete the following code when we no longer test with pre-ICU 79 data.
+            if (!same && a instanceof ICUUncheckedIOException) {
+                // ICU 79 changed the base class, see ICU-22148.
+                // Deserialization works as well as possible,
+                // but the objects are not quite the same.
+                // The new API contract guarantees that getCause() returns an IOException.
+                // The causes should also never be null here,
+                // but getCause() appears to not enforce that from deserialization.
+                // Compare message strings when they are explicit, not computed.
+                // When an exception has a null message and a non-null cause,
+                // then getMessage() computes a message string.
+                var a2 = (ICUUncheckedIOException) a;
+                var b2 = (ICUUncheckedIOException) b;
+                String oldMsg = a2.getMessage(); // null if neither message nor cause
+                String newMsg = b2.getMessage(); // never null because there is a cause
+                same =
+                        (newMsg.startsWith("java.") || newMsg.equals(a2.getMessage()))
+                                && a2.getCause() != null
+                                && b2.getCause() != null;
+            }
+            return same;
         }
 
         // Exception.equals() does not seem to work.

--- a/icu4j/main/core/src/main/java/com/ibm/icu/util/ICUUncheckedIOException.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/util/ICUUncheckedIOException.java
@@ -8,43 +8,70 @@
  */
 package com.ibm.icu.util;
 
+import java.io.IOException;
+import java.io.ObjectStreamException;
+import java.io.UncheckedIOException;
+
 /**
- * Unchecked version of {@link java.io.IOException}. Some ICU APIs do not throw the standard
- * exception but instead wrap it into this unchecked version.
+ * Unchecked version of {@link IOException}. Some ICU APIs do not throw the standard exception but
+ * instead wrap it into this unchecked version.
  *
- * <p>This currently extends {@link RuntimeException}, but when ICU can rely on Java 8 this class
- * should be changed to extend java.io.UncheckedIOException instead.
+ * <p>Since ICU 79, this is a deprecated subclass of {@link UncheckedIOException}. You should catch
+ * the standard unchecked exception.
  *
- * @stable ICU 53
+ * <p>This class had been introduced as a subclass of {@link RuntimeException}, because at that time
+ * ICU did not yet require Java 8+.
+ *
+ * @deprecated ICU 79
  */
-public class ICUUncheckedIOException extends RuntimeException {
+@Deprecated
+public class ICUUncheckedIOException extends UncheckedIOException {
     private static final long serialVersionUID = 1210263498513384449L;
+
+    /**
+     * Field added in ICU 79 for serialization format versioning.
+     *
+     * <p>Until ICU 78, the base class was just a RuntimeException. The cause could be null or any
+     * Throwable.
+     *
+     * <p>Since ICU 79, the base class is an UncheckedIOException, and its cause must be a non-null
+     * IOException.
+     *
+     * <p>Not final, so that (a) the compiler does not omit the readResolve() code that acts on it
+     * being 0 from an old object, and (b) readResolve() can update it.
+     */
+    private int serialVersion = 1;
 
     /**
      * Default constructor.
      *
-     * @stable ICU 53
+     * @deprecated ICU 79
      */
-    public ICUUncheckedIOException() {}
+    @Deprecated
+    public ICUUncheckedIOException() {
+        super(new IOException());
+    }
 
     /**
      * Constructor.
      *
      * @param message exception message string
-     * @stable ICU 53
+     * @deprecated ICU 79
      */
+    @Deprecated
     public ICUUncheckedIOException(String message) {
-        super(message);
+        super(message, new IOException(message));
     }
 
     /**
      * Constructor.
      *
      * @param cause original exception (normally a {@link java.io.IOException})
-     * @stable ICU 53
+     * @deprecated ICU 79
      */
+    @Deprecated
     public ICUUncheckedIOException(Throwable cause) {
-        super(cause);
+        super(cause instanceof IOException ? (IOException) cause : new IOException(cause));
     }
 
     /**
@@ -52,9 +79,43 @@ public class ICUUncheckedIOException extends RuntimeException {
      *
      * @param message exception message string
      * @param cause original exception (normally a {@link java.io.IOException})
-     * @stable ICU 53
+     * @deprecated ICU 79
      */
+    @Deprecated
     public ICUUncheckedIOException(String message, Throwable cause) {
-        super(message, cause);
+        super(message, cause instanceof IOException ? (IOException) cause : new IOException(cause));
+    }
+
+    private Object readResolve() throws ObjectStreamException {
+        if (serialVersion == 0) {
+            // The deserialized object was from ICU 78 or earlier.
+            // The cause may be null, or else it may not be an IOException, in which case
+            // we cannot even fetch it via ICU 79's new base class
+            // UncheckedIOException.getCause().
+            IOException io = null;
+            boolean replace = false;
+            try {
+                io = getCause();
+            } catch (NullPointerException e) {
+                // No cause, fall through to initCause().
+                // This is unreachable if getCause() on a deserialized object returns null;
+                // the UncheckedIOException *constructors* do not allow a null cause.
+            } catch (ClassCastException e) {
+                // Non-null, incompatible, unrecoverable cause. initCause() cannot be called.
+                replace = true;
+            }
+            if (io == null) {
+                io = new IOException(getMessage());
+                io.setStackTrace(getStackTrace());
+                if (replace) {
+                    ICUUncheckedIOException sub = new ICUUncheckedIOException(getMessage(), io);
+                    sub.setStackTrace(getStackTrace());
+                    return sub;
+                }
+                initCause(io);
+            }
+            serialVersion = 1;
+        }
+        return this;
     }
 }


### PR DESCRIPTION
... as agreed in the ICU-TC meeting on 2026-apr-02, with extra work to handle Java serialization.
- deprecate ICUUncheckedIOException
- change its base class from RuntimeException to UncheckedIOException
- this requires a non-null IOException as the cause, so adjust the constructors to make one if we don't already have one
- deserializing an object from ICU 78 or earlier:
    - Java inserts the new base class, but the cause can be null, or can be a Throwable that is not an IOException;
      problem: UncheckedIOException promises a non-null getCause(), and its getCause() casts the internal cause to an IOException;
      without intervention, a deserialized object could have its getCause() return null or throw a ClassCastException
    - add a new instance field for distinguishing the class format version
    - add a readResolve() method which deals with old objects,
      adding a cause if there is none, or
      replacing the deserialized object with a whole new one if there is an incompatible cause
      (because initCause() cannot be called if there is already a cause)
    - adjust the serialization test expectation: the result is functional, but not equal to a freshly constructed object
    - the tests do exercise objects with/without message, with/without cause

Don't change existing code that throws an ICUUncheckedIOException so that callers that catch that continue to work.

#### Checklist
- [x] Required: Issue filed: ICU-22148
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
