### PR TITLE
ICU-23341 Support Gregorian era inheritance in Japanese calendar and …

### DIFF
--- a/icu4c/source/i18n/dtfmtsym.cpp
+++ b/icu4c/source/i18n/dtfmtsym.cpp
@@ -1896,6 +1896,31 @@ CalendarDataSink::~CalendarDataSink() {
 }
 
 //------------------------------------------------------
+static CharString
+&buildResourcePath(CharString &path, const char* segment1, UErrorCode &errorCode) {
+    return path.clear().append(segment1, -1, errorCode);
+}
+
+static CharString
+&buildResourcePath(CharString &path, const char* segment1, const char* segment2,
+                   UErrorCode &errorCode) {
+    return buildResourcePath(path, segment1, errorCode).append('/', errorCode)
+                                                       .append(segment2, -1, errorCode);
+}
+
+static CharString
+&buildResourcePath(CharString &path, const char* segment1, const char* segment2,
+                   const char* segment3, UErrorCode &errorCode) {
+    return buildResourcePath(path, segment1, segment2, errorCode).append('/', errorCode)
+                                                                 .append(segment3, -1, errorCode);
+}
+
+static CharString
+&buildResourcePath(CharString &path, const char* segment1, const char* segment2,
+                   const char* segment3, const char* segment4, UErrorCode &errorCode) {
+    return buildResourcePath(path, segment1, segment2, segment3, errorCode).append('/', errorCode)
+                                                                           .append(segment4, -1, errorCode);
+}
 
 static void
 initField(UnicodeString **field, int32_t& length, const char16_t *data, LastResortSize numStr, LastResortSize strLen, UErrorCode &status) {
@@ -1957,48 +1982,77 @@ initField(UnicodeString **field, int32_t& length, CalendarDataSink &sink, CharSt
 }
 
 static void
-initEras(UnicodeString **field, int32_t& length, CalendarDataSink &sink, CharString &key, const UResourceBundle *ctebPtr, const char* eraWidth, int32_t maxEra, UErrorCode &status) {
-    if (U_SUCCESS(status)) {
-        length = 0;
-        UnicodeString keyUString(key.data(), -1, US_INV);
-        Hashtable *eraNamesTable = static_cast<Hashtable*>(sink.maps.get(keyUString));
+loadEraNames(UnicodeString *eras, int32_t length, Hashtable *eraNamesTable, UResourceBundle *calBaseBundle,
+        const char *eraWidth, const EraRules *eraRules, UErrorCode &status) {
+    if (U_FAILURE(status)) {
+        return;
+    }
+    int32_t maxEra = eraRules->getMaxEraCode();
+    U_ASSERT(maxEra < length);
+    const char *calType = eraRules->getCalendarType();
 
-        if (eraNamesTable != nullptr) {
-            UErrorCode resStatus = U_ZERO_ERROR;
-            LocalUResourceBundlePointer ctewb(ures_getByKeyWithFallback(ctebPtr, eraWidth, nullptr, &resStatus));
-            const UResourceBundle *ctewbPtr = (U_SUCCESS(resStatus))? ctewb.getAlias() : nullptr;
-            *field = new UnicodeString[maxEra + 1];
-            if (*field == nullptr) {
-                status = U_MEMORY_ALLOCATION_ERROR;
-                return;
-            }
-            length = maxEra + 1;
-            for (int32_t eraCode = 0; eraCode <= maxEra; eraCode++) {
-                char eraCodeStr[12]; // T_CString_integerToString is documented to generate at most 12 bytes including nul terminator
-                int32_t eraCodeStrLen = T_CString_integerToString(eraCodeStr, eraCode, 10);
-                UnicodeString eraCodeKey = UnicodeString(eraCodeStr, eraCodeStrLen, US_INV);
-                UnicodeString *eraName = static_cast<UnicodeString*>(eraNamesTable->get(eraCodeKey));
-                (*field)[eraCode].remove();
-                if (eraName != nullptr) {
-                    // Get eraName from map (created by CalendarSink)
-                    (*field)[eraCode].fastCopyFrom(*eraName);
-                } else if (ctewbPtr != nullptr) {
-                    // Try filling in missing items from parent locale(s)
-                    resStatus = U_ZERO_ERROR;
-                    LocalUResourceBundlePointer ctewkb(ures_getByKeyWithFallback(ctewbPtr, eraCodeStr, nullptr, &resStatus));
-                    if (U_SUCCESS(resStatus)) {
-                        int32_t eraNameLen;
-                        const UChar* eraNamePtr = ures_getString(ctewkb.getAlias(), &eraNameLen, &resStatus);
-                        if (U_SUCCESS(resStatus)) {
-                            (*field)[eraCode].setTo(false, eraNamePtr, eraNameLen);
-                        }
-                    }
+    UErrorCode resStatus = U_ZERO_ERROR;
+    LocalUResourceBundlePointer ctb(ures_getByKeyWithFallback(calBaseBundle, calType, nullptr, &resStatus));
+    LocalUResourceBundlePointer cteb(ures_getByKeyWithFallback(ctb.getAlias(), gErasTag, nullptr, &resStatus));
+    LocalUResourceBundlePointer ctewb(ures_getByKeyWithFallback(cteb.getAlias(), eraWidth, nullptr, &resStatus));
+    const UResourceBundle *ctewbPtr = (U_SUCCESS(resStatus))? ctewb.getAlias() : nullptr;
+
+    for (int32_t eraCode = 0; eraCode <= maxEra; eraCode++) {
+        char eraCodeStr[12]; // T_CString_integerToString is documented to generate at most 12 bytes including nul terminator
+        int32_t eraCodeStrLen = T_CString_integerToString(eraCodeStr, eraCode, 10);
+        UnicodeString eraCodeKey = UnicodeString(eraCodeStr, eraCodeStrLen, US_INV);
+        UnicodeString *eraName = static_cast<UnicodeString*>(eraNamesTable->get(eraCodeKey));
+        eras[eraCode].remove();
+        if (eraName != nullptr) {
+            // Get eraName from map (created by CalendarSink)
+            eras[eraCode].fastCopyFrom(*eraName);
+        } else if (ctewbPtr != nullptr) {
+            // Try filling in missing items from parent locale(s)
+            resStatus = U_ZERO_ERROR;
+            LocalUResourceBundlePointer ctewkb(ures_getByKeyWithFallback(ctewbPtr, eraCodeStr, nullptr, &resStatus));
+            if (U_SUCCESS(resStatus)) {
+                int32_t eraNameLen;
+                const UChar* eraNamePtr = ures_getString(ctewkb.getAlias(), &eraNameLen, &resStatus);
+                if (U_SUCCESS(resStatus)) {
+                    eras[eraCode].setTo(false, eraNamePtr, eraNameLen);
                 }
             }
-            return;
         }
-        status = U_MISSING_RESOURCE_ERROR;
     }
+
+    // Also load era names from resource corresponding to the inherited era rules if any.
+    const EraRules *inheritEraRules = eraRules->getInheritEraRules();
+    if (inheritEraRules != nullptr) {
+        loadEraNames(eras, length, eraNamesTable, calBaseBundle, eraWidth, inheritEraRules, status);
+    }
+}
+
+static void initEras(UnicodeString **field, int32_t& length, CalendarDataSink &sink, UResourceBundle *calBaseBundle,
+        const char *eraWidth, EraRules *eraRules, UErrorCode &status) {
+    if (U_FAILURE(status)) {
+        return;
+    }
+    CharString key;
+    buildResourcePath(key, gErasTag, eraWidth, status);
+    if (U_FAILURE(status)) {
+        return;
+    }
+    UnicodeString keyUString(key.data(), -1, US_INV);
+    Hashtable *eraNamesTable = static_cast<Hashtable*>(sink.maps.get(keyUString));
+    if (eraNamesTable == nullptr) {
+        status = U_MISSING_RESOURCE_ERROR;
+        return;
+    }
+
+    // Note: maxEra value should be from the primary EraRules.
+    int32_t maxEra = eraRules->getMaxEraCode();
+    *field = new UnicodeString[maxEra + 1];
+    if (*field == nullptr) {
+        status = U_MEMORY_ALLOCATION_ERROR;
+        return;
+    }
+    length = maxEra + 1;
+    loadEraNames(*field, length, eraNamesTable, calBaseBundle, eraWidth, eraRules, status);
 }
 
 static void
@@ -2019,32 +2073,6 @@ initLeapMonthPattern(UnicodeString *field, int32_t index, CalendarDataSink &sink
         }
         status = U_MISSING_RESOURCE_ERROR;
     }
-}
-
-static CharString
-&buildResourcePath(CharString &path, const char* segment1, UErrorCode &errorCode) {
-    return path.clear().append(segment1, -1, errorCode);
-}
-
-static CharString
-&buildResourcePath(CharString &path, const char* segment1, const char* segment2,
-                   UErrorCode &errorCode) {
-    return buildResourcePath(path, segment1, errorCode).append('/', errorCode)
-                                                       .append(segment2, -1, errorCode);
-}
-
-static CharString
-&buildResourcePath(CharString &path, const char* segment1, const char* segment2,
-                   const char* segment3, UErrorCode &errorCode) {
-    return buildResourcePath(path, segment1, segment2, errorCode).append('/', errorCode)
-                                                                 .append(segment3, -1, errorCode);
-}
-
-static CharString
-&buildResourcePath(CharString &path, const char* segment1, const char* segment2,
-                   const char* segment3, const char* segment4, UErrorCode &errorCode) {
-    return buildResourcePath(path, segment1, segment2, segment3, errorCode).append('/', errorCode)
-                                                                           .append(segment4, -1, errorCode);
 }
 
 typedef struct {
@@ -2407,26 +2435,18 @@ DateFormatSymbols::initializeData(const Locale& locale, const char *type, UError
     if (type == nullptr) {
         type = "gregorian";
     }
-    LocalPointer<EraRules> eraRules(EraRules::createInstance(type, false, status));
-    int32_t maxEra = (U_SUCCESS(status))? eraRules->getMaxEraCode(): 0;
-    UErrorCode resStatus = U_ZERO_ERROR;
-    LocalUResourceBundlePointer ctpb(ures_getByKeyWithFallback(cb.getAlias(), type, nullptr, &resStatus));
-    LocalUResourceBundlePointer cteb(ures_getByKeyWithFallback(ctpb.getAlias(), gErasTag, nullptr, &resStatus));
-    const UResourceBundle *ctebPtr = (U_SUCCESS(resStatus))? cteb.getAlias() : nullptr;
     // Load eras
-    initEras(&fEras, fErasCount, calendarSink, buildResourcePath(path, gErasTag, gNamesAbbrTag, status),
-            ctebPtr, gNamesAbbrTag, maxEra, status);
+    LocalPointer<EraRules> eraRules(EraRules::createInstance(type, false, status));
+    initEras(&fEras, fErasCount, calendarSink, cb.getAlias(), gNamesAbbrTag, eraRules.getAlias(), status);
     UErrorCode oldStatus = status;
-    initEras(&fEraNames, fEraNamesCount, calendarSink, buildResourcePath(path, gErasTag, gNamesWideTag, status),
-            ctebPtr, gNamesWideTag, maxEra, status);
+    initEras(&fEraNames, fEraNamesCount, calendarSink, cb.getAlias(), gNamesWideTag, eraRules.getAlias(), status);
     if (status == U_MISSING_RESOURCE_ERROR) { // Workaround because eras/wide was omitted from CLDR 1.3
         status = oldStatus;
         assignArray(fEraNames, fEraNamesCount, fEras, fErasCount);
     }
     // current ICU4J falls back to abbreviated if narrow eras are missing, so we will too
     oldStatus = status;
-    initEras(&fNarrowEras, fNarrowErasCount, calendarSink, buildResourcePath(path, gErasTag, gNamesNarrowTag, status),
-            ctebPtr, gNamesNarrowTag, maxEra, status);
+    initEras(&fNarrowEras, fNarrowErasCount, calendarSink, cb.getAlias(), gNamesNarrowTag, eraRules.getAlias(), status);
     if (status == U_MISSING_RESOURCE_ERROR) { // Workaround because eras/wide was omitted from CLDR 1.3
         status = oldStatus;
         assignArray(fNarrowEras, fNarrowErasCount, fEras, fErasCount);

--- a/icu4c/source/i18n/erarules.cpp
+++ b/icu4c/source/i18n/erarules.cpp
@@ -17,6 +17,7 @@
 #include "erarules.h"
 #include "gregoimp.h"
 #include "uassert.h"
+#include "uinvchar.h"
 #include "uvectr32.h"
 
 U_NAMESPACE_BEGIN
@@ -103,22 +104,49 @@ static int32_t compareEncodedDateWithYMD(int encoded, int year, int month, int d
     }
 }
 
-EraRules::EraRules(LocalMemory<int32_t>& startDatesIn, int32_t startDatesLengthIn, int32_t minEraIn, int32_t numErasIn)
-    : startDatesLength(startDatesLengthIn), minEra(minEraIn), numEras(numErasIn) {
+EraRules::EraRules(const char* calTypeId, LocalMemory<int32_t>& startDatesIn, int32_t startDatesLengthIn,
+        int32_t minEraIn, int32_t numErasIn)
+        : startDatesLength(startDatesLengthIn), minEra(minEraIn), numEras(numErasIn), inheritEraRules(nullptr) {
+    U_ASSERT(uprv_strlen(calTypeId) <= MAX_CAL_ID_LENGTH);
+    uprv_strcpy(this->calTypeId, calTypeId);
     startDates = std::move(startDatesIn);
     initCurrentEra();
 }
 
 EraRules::~EraRules() {
+    delete inheritEraRules;
 }
 
-EraRules* EraRules::createInstance(const char *calType, UBool includeTentativeEra, UErrorCode& status) {
+EraRules* EraRules::createInstance(const char *calTypeId, UBool includeTentativeEra, UErrorCode& status) {
     if(U_FAILURE(status)) {
         return nullptr;
     }
+    if (calTypeId == nullptr || uprv_strlen(calTypeId) > MAX_CAL_ID_LENGTH) {
+        status = U_ILLEGAL_ARGUMENT_ERROR;
+        return nullptr;
+    }
+
     LocalUResourceBundlePointer rb(ures_openDirect(nullptr, "supplementalData", &status));
     ures_getByKey(rb.getAlias(), "calendarData", rb.getAlias(), &status);
-    ures_getByKey(rb.getAlias(), calType, rb.getAlias(), &status);
+    ures_getByKey(rb.getAlias(), calTypeId, rb.getAlias(), &status);
+
+    // Check they key "inheritEras" to see if this calendar inherits eras from another calendar.
+    const char *inheritCalType = nullptr;
+    char inheritCalTypeBuf[MAX_CAL_ID_LENGTH + 1];
+    int32_t inheritCalTypeLen = 0;
+    UErrorCode tmpStatus = U_ZERO_ERROR;
+    const UChar *inheritCalTypeStr = ures_getStringByKey(rb.getAlias(), "inheritEras", &inheritCalTypeLen, &tmpStatus);
+    if (U_SUCCESS(tmpStatus)) {
+        if (inheritCalTypeLen > MAX_CAL_ID_LENGTH && !uprv_isInvariantUString(inheritCalTypeStr, inheritCalTypeLen)) {
+            // calendar type ID from data is too long or not in ASCII
+            status = U_INVALID_FORMAT_ERROR;
+            return nullptr;
+        }
+        u_UCharsToChars(inheritCalTypeStr, inheritCalTypeBuf, inheritCalTypeLen);
+        inheritCalTypeBuf[inheritCalTypeLen] = 0;
+        inheritCalType = inheritCalTypeBuf;
+    }
+
     ures_getByKey(rb.getAlias(), "eras", rb.getAlias(), &status);
 
     if (U_FAILURE(status)) {
@@ -257,11 +285,47 @@ EraRules* EraRules::createInstance(const char *calType, UBool includeTentativeEr
     for (int32_t eraIdx = 0; eraIdx < eraStartDates.size(); eraIdx++) {
         startDates[eraIdx] = eraStartDates.elementAti(eraIdx);
     }
-    EraRules *result = new EraRules(startDates, eraStartDates.size(), minEra, numEras);
-    if (result == nullptr) {
-        status = U_MEMORY_ALLOCATION_ERROR;
+    LocalPointer<EraRules> result(new EraRules(calTypeId, startDates, eraStartDates.size(), minEra, numEras), status);
+    if (U_FAILURE(status)) {
+        return nullptr;
     }
-    return result;
+
+    // Initialize era rules from inherited calendar
+    if (inheritCalType) {
+        tmpStatus = U_ZERO_ERROR;
+        LocalPointer<EraRules> tmpEraRules(createInstance(inheritCalType, includeTentativeEra, status), tmpStatus);
+        if (U_FAILURE(tmpStatus)) {
+            status = tmpStatus;
+            return nullptr;
+        }
+        if (U_FAILURE(status)) {
+            return nullptr;
+        }
+        result->inheritEraRules = tmpEraRules.orphan();
+    }
+
+    return result.orphan();
+}
+
+int32_t EraRules::getNextEraCode(int32_t eraCode) const {
+    int32_t nextEra = eraCode + 1;
+    if (nextEra < minEra) {
+        if (inheritEraRules != nullptr) {
+            if (nextEra > inheritEraRules->getMaxEraCode()) {
+                nextEra = minEra;
+            } else {
+                nextEra = inheritEraRules->getNextEraCode(eraCode);
+            }
+        } else {
+            nextEra = minEra;
+        }
+    } else {
+        int32_t maxEra = getMaxEraCode();
+        if (nextEra > maxEra) {
+            nextEra = maxEra;
+        }
+    }
+    return nextEra;
 }
 
 void EraRules::getStartDate(int32_t eraCode, int32_t (&fields)[3], UErrorCode& status) const {
@@ -269,7 +333,14 @@ void EraRules::getStartDate(int32_t eraCode, int32_t (&fields)[3], UErrorCode& s
         return;
     }
     int32_t startDate = 0;
-    if (eraCode >= minEra) {
+    if (eraCode < minEra) {
+        if (inheritEraRules != nullptr) {
+            if (eraCode >= inheritEraRules->getMinEraCode()) {
+                inheritEraRules->getStartDate(eraCode, fields, status);
+                return;
+            }
+        }
+    } else {
         int32_t startIdx = eraCode - minEra;
         if (startIdx < startDatesLength) {
             startDate = startDates[startIdx];
@@ -289,22 +360,9 @@ int32_t EraRules::getStartYear(int32_t eraCode, UErrorCode& status) const {
     if(U_FAILURE(status)) {
         return year;
     }
-    int32_t startDate = 0;
-    if (eraCode >= minEra) {
-        int32_t startIdx = eraCode - minEra;
-        if (startIdx < startDatesLength) {
-            startDate = startDates[startIdx];
-        }
-    }
-    if (isSet(startDate)) {
-        int fields[3];
-        decodeDate(startDate, fields);
-        year = fields[0];
-        return year;
-    }
-    // We did not find the requested eraCode in our data
-    status = U_ILLEGAL_ARGUMENT_ERROR;
-    return year;
+    int32_t fields[3] = {0, 0, 0};
+    getStartDate(eraCode, fields, status);
+    return fields[0];
 }
 
 int32_t EraRules::getEraCode(int32_t year, int32_t month, int32_t day, UErrorCode& status) const {
@@ -327,6 +385,7 @@ int32_t EraRules::getEraCode(int32_t year, int32_t month, int32_t day, UErrorCod
                 return minEra + startIdx;
             }
         }
+        return minEra + startDatesLength - 1;
     }
     // Linear search from the end, which should hit the most likely eras first.
     // Also this is the most efficient for any era if we have < 8 or so eras, so only less
@@ -342,10 +401,19 @@ int32_t EraRules::getEraCode(int32_t year, int32_t month, int32_t day, UErrorCod
             return minEra + startIdx;
         }
     }
+
+    // Note: Inherit era rules should be only applied to date before the start of minEra.
+    if (inheritEraRules != nullptr) {
+        return inheritEraRules->getEraCode(year, month, day, status);
+    }
+
     return minEra;
 }
 
 void EraRules::initCurrentEra() {
+    // Note: This implementation assumes current era is the primary era rules,
+    // not in inherited era rules.
+
     // Compute local wall time in millis using ICU's default time zone.
     UErrorCode ec = U_ZERO_ERROR;
     UDate localMillis = ucal_getNow();

--- a/icu4c/source/i18n/erarules.h
+++ b/icu4c/source/i18n/erarules.h
@@ -10,7 +10,10 @@
 
 #include "unicode/localpointer.h"
 #include "unicode/uobject.h"
+#include "unicode/unistr.h"
 #include "cmemory.h"
+
+#define MAX_CAL_ID_LENGTH 31    // Currently, maximum calendar type length is 19 
 
 U_NAMESPACE_BEGIN
 
@@ -21,13 +24,30 @@ public:
     U_I18N_API static EraRules* createInstance(const char* calType,
                                                UBool includeTentativeEra,
                                                UErrorCode& status);
+    /**
+     * Gets the calendar type ID
+     * @return  calendar type ID
+     */
+    inline const char* getCalendarType() const {
+        return calTypeId;
+    }
+
+    /**
+     * Gets the era rules of the calendar from which the current calendar inherits eras,
+     * or nullptr if there is no such calendar.
+     * @return  era rules of the calendar from which the current calendar inherits eras,
+     * or nullptr.
+     */
+    inline const EraRules* getInheritEraRules() const {
+        return inheritEraRules;
+    }
 
     /**
      * Gets number of effective eras
      * @return  number of effective eras (not the same as max era code)
      */
     inline int32_t getNumberOfEras() const {
-        return numEras;
+        return inheritEraRules == nullptr ? numEras : numEras + inheritEraRules->getNumberOfEras();
     }
 
     /**
@@ -39,6 +59,25 @@ public:
     }
 
     /**
+     * Gets minimum defined era code for the current calendar
+     * @return  minimum defined era code
+     */
+    inline int32_t getMinEraCode() const {
+        int minEraCode = minEra;
+        if (inheritEraRules != nullptr) {
+            minEraCode = inheritEraRules->getMinEraCode();
+        }
+        return minEraCode;
+    }
+
+    /**
+     * Gets next era code
+     * @param eraCode Current era code
+     * @return Next era code. If not available, maximum era code is returned.
+     */
+    U_I18N_API int32_t getNextEraCode(int32_t eraCode) const;
+
+    /**
      * Gets start date of an era
      * @param eraCode   Era code
      * @param fields    Receives date fields. The result includes values of year, month,
@@ -46,7 +85,7 @@ public:
      *                  will be January 1st in year whose value is minimum integer.
      * @param status    Receives status.
      */
-    void getStartDate(int32_t eraCode, int32_t (&fields)[3], UErrorCode& status) const;
+    U_I18N_API void getStartDate(int32_t eraCode, int32_t (&fields)[3], UErrorCode& status) const;
 
     /**
      * Gets start year of an era
@@ -79,15 +118,18 @@ public:
     }
 
 private:
-    EraRules(LocalMemory<int32_t>& startDatesIn, int32_t startDatesLengthIn, int32_t minEraIn, int32_t numErasIn);
+    EraRules(const char* calTypeId, LocalMemory<int32_t>& startDatesIn, int32_t startDatesLengthIn,
+        int32_t minEraIn, int32_t numErasIn);
 
     void initCurrentEra();
 
+    char calTypeId[MAX_CAL_ID_LENGTH + 1];  // calendar type id
     LocalMemory<int32_t> startDates;
     int32_t startDatesLength;
     int32_t minEra;  // minimum valid era code, for first entry in startDates
     int32_t numEras; // number of valid era codes (not necessarily the same as startDates length
     int32_t currentEra;
+    EraRules* inheritEraRules;
 };
 
 U_NAMESPACE_END

--- a/icu4c/source/i18n/japancal.cpp
+++ b/icu4c/source/i18n/japancal.cpp
@@ -139,7 +139,7 @@ const char *JapaneseCalendar::getType() const
     return "japanese";
 }
 
-int32_t JapaneseCalendar::getDefaultMonthInYear(int32_t eyear, UErrorCode& status) 
+int32_t JapaneseCalendar::getDefaultMonthInYear(int32_t extendedYear, UErrorCode& status) 
 {
     if (U_FAILURE(status)) {
       return 0;
@@ -147,40 +147,47 @@ int32_t JapaneseCalendar::getDefaultMonthInYear(int32_t eyear, UErrorCode& statu
     int32_t era = internalGetEra();
     // TODO do we assume we can trust 'era'?  What if it is denormalized?
 
-    int32_t month = 0;
+    if (era == 0) {
+        // era 0 in Japanese calendar is Gregorian BC
+        return GregorianCalendar::getDefaultMonthInYear(extendedYear, status);
+    }
 
     // Find out if we are at the edge of an era
-    int32_t eraStart[3] = { 0,0,0 };
+    int32_t eraStart[3] = {0, 0, 0};
     gJapaneseEraRules->getStartDate(era, eraStart, status);
     if (U_FAILURE(status)) {
         return 0;
     }
-    if(eyear == eraStart[0]) {
-        // Yes, we're in the first year of this era.
-        return eraStart[1]  // month
-                -1;         // return 0-based month
+    if (extendedYear == eraStart[0]) {
+        return eraStart[1] - 1; // return 0-based month
+    } else {
+        return 0;
     }
-
-    return month;
 }
 
-int32_t JapaneseCalendar::getDefaultDayInMonth(int32_t eyear, int32_t month, UErrorCode& status) 
+int32_t JapaneseCalendar::getDefaultDayInMonth(int32_t extendedYear, int32_t month, UErrorCode& status) 
 {
     if (U_FAILURE(status)) {
         return 0;
     }
     int32_t era = internalGetEra();
-    int32_t day = 1;
 
-    int32_t eraStart[3] = { 0,0,0 };
+    if (era == 0) {
+        // era 0 in Japanese calendar is Gregorian BC
+        return GregorianCalendar::getDefaultDayInMonth(extendedYear, month, status);
+    }
+
+    int32_t eraStart[3] = {0, 0, 0};
     gJapaneseEraRules->getStartDate(era, eraStart, status);
     if (U_FAILURE(status)) {
         return 0;
     }
-    if (eyear == eraStart[0] && (month == eraStart[1] - 1)) {
-        return eraStart[2];
+    if (extendedYear == eraStart[0]) { // if it is year 1..
+        if (month == (eraStart[1] - 1)) { // if it is the emperor's first month..
+            return eraStart[2]; // return the D_O_M of accession
+        }
     }
-    return day;
+    return 1;
 }
 
 
@@ -194,24 +201,34 @@ int32_t JapaneseCalendar::handleGetExtendedYear(UErrorCode& status)
     if (U_FAILURE(status)) {
         return 0;
     }
+
     // EXTENDED_YEAR in JapaneseCalendar is a Gregorian year
     // The default value of EXTENDED_YEAR is 1970 (Showa 45)
-
     if (newerField(UCAL_EXTENDED_YEAR, UCAL_YEAR) == UCAL_EXTENDED_YEAR &&
         newerField(UCAL_EXTENDED_YEAR, UCAL_ERA) == UCAL_EXTENDED_YEAR) {
         return internalGet(UCAL_EXTENDED_YEAR, kGregorianEpoch);
     }
-    int32_t eraStartYear = gJapaneseEraRules->getStartYear(internalGet(UCAL_ERA, gCurrentEra), status);
-    if (U_FAILURE(status)) {
-        return 0;
-    }
 
     // extended year is a gregorian year, where 1 = 1AD,  0 = 1BC, -1 = 2BC, etc
-    int32_t year = internalGet(UCAL_YEAR, 1);   // pin to minimum of year 1 (first year)
-    // add gregorian starting year, subtract one because year starts at 1
-    if (uprv_add32_overflow(year, eraStartYear - 1,  &year)) {
-        status = U_ILLEGAL_ARGUMENT_ERROR;
-        return 0;
+    int32_t era = internalGet(UCAL_ERA, gCurrentEra);
+    int32_t year = internalGet(UCAL_YEAR, 1);
+    if (era == 0) {
+        // era 0 in Japanese calendar is Gregorian BC
+        // year = 1 - year;
+        if (uprv_mul32_overflow(year, -1, &year) || uprv_add32_overflow(year, 1, &year)) {
+            status = U_ILLEGAL_ARGUMENT_ERROR;
+            return 0;
+        }
+    } else {
+        int32_t eraStartYear = gJapaneseEraRules->getStartYear(internalGet(UCAL_ERA, gCurrentEra), status);
+        if (U_FAILURE(status)) {
+            return 0;
+        }
+        // add gregorian starting year, subtract one because year starts at 1
+        if (uprv_add32_overflow(year, eraStartYear - 1,  &year)) {
+            status = U_ILLEGAL_ARGUMENT_ERROR;
+            return 0;
+        }
     }
     return year;
 }
@@ -219,21 +236,36 @@ int32_t JapaneseCalendar::handleGetExtendedYear(UErrorCode& status)
 
 void JapaneseCalendar::handleComputeFields(int32_t julianDay, UErrorCode& status)
 {
-    //Calendar::timeToFields(theTime, quick, status);
-    GregorianCalendar::handleComputeFields(julianDay, status);
-    int32_t year = internalGet(UCAL_EXTENDED_YEAR); // Gregorian year
-    int32_t eraCode = gJapaneseEraRules->getEraCode(year, internalGetMonth(status) + 1, internalGet(UCAL_DAY_OF_MONTH), status);
-
-    int32_t startYear = gJapaneseEraRules->getStartYear(eraCode, status) - 1;
     if (U_FAILURE(status)) {
         return;
     }
-    if (uprv_add32_overflow(year, -startYear,  &year)) {
-        status = U_ILLEGAL_ARGUMENT_ERROR;
+    //Calendar::timeToFields(theTime, quick, status);
+    GregorianCalendar::handleComputeFields(julianDay, status);
+    int32_t extendedYear = internalGet(UCAL_EXTENDED_YEAR); // Gregorian year
+    int32_t eraCode = gJapaneseEraRules->getEraCode(extendedYear, internalGetMonth(status) + 1, internalGet(UCAL_DAY_OF_MONTH), status);
+    if (U_FAILURE(status)) {
         return;
     }
+    U_ASSERT(eraCode >= 0); // getEraCode() returns -1 only when status is failure
+
     internalSet(UCAL_ERA, eraCode);
-    internalSet(UCAL_YEAR, year);
+    int32_t year;
+    if (eraCode == 0) {
+        // Gregorian BC
+        // year = 1 - extendedYear;
+        if (uprv_mul32_overflow(extendedYear, -1, &year) || uprv_add32_overflow(year, 1, &year)) {
+            status = U_ILLEGAL_ARGUMENT_ERROR;
+            return;
+        }
+    } else if (eraCode == 1) {
+        // Gregorian AD
+        year = extendedYear;
+    } else {
+        // Japanese era. extendedYear is at least 1868 (Meiji 1), so it should never
+        // cause integer overflow here.
+        year = extendedYear - gJapaneseEraRules->getStartYear(eraCode, status) + 1;
+    }
+    internalSet(YEAR, year);
 }
 
 /*
@@ -295,17 +327,28 @@ int32_t JapaneseCalendar::getActualMaximum(UCalendarDateFields field, UErrorCode
     if (U_FAILURE(status)) {
         return 0; // error case... any value
     }
-    if (era == gJapaneseEraRules->getMaxEraCode()) { // max known era, not gCurrentEra
+    if (era >= gJapaneseEraRules->getMaxEraCode()) { // max known era, not gCurrentEra
         // TODO: Investigate what value should be used here - revisit after 4.0.
         return handleGetLimit(UCAL_YEAR, UCAL_LIMIT_MAXIMUM);
     }
-    int32_t nextEraStart[3] = { 0,0,0 };
-    gJapaneseEraRules->getStartDate(era + 1, nextEraStart, status);
+    if (era == 0) {
+        // era 0 is Gregorian BC and has no era start year data.
+        return GregorianCalendar::getActualMaximum(UCAL_YEAR, status);
+    }
+
+    // Use getNextEraCode() instead of +1, because there might be gaps between eras.
+    int32_t nextEra = gJapaneseEraRules->getNextEraCode(era);
+    U_ASSERT(nextEra != era);
+    int32_t nextEraStart[3] = {0, 0, 0};
+    gJapaneseEraRules->getStartDate(nextEra, nextEraStart, status);
     int32_t nextEraYear = nextEraStart[0];
     int32_t nextEraMonth = nextEraStart[1]; // 1-base
     int32_t nextEraDate = nextEraStart[2];
 
     int32_t eraStartYear = gJapaneseEraRules->getStartYear(era, status);
+    if (U_FAILURE(status)) {
+        return 0;
+    }
     int32_t maxYear = nextEraYear - eraStartYear + 1;   // 1-base
     if (nextEraMonth == 1 && nextEraDate == 1) {
         // Subtract 1, because the next era starts at Jan 1

--- a/icu4c/source/i18n/japancal.h
+++ b/icu4c/source/i18n/japancal.h
@@ -204,7 +204,7 @@ protected:
      */
     virtual int32_t getDefaultDayInMonth(int32_t eyear, int32_t month, UErrorCode& status) override;
 
-    virtual bool isEra0CountingBackward() const override { return false; }
+    virtual bool isEra0CountingBackward() const override { return true; }
 };
 
 U_NAMESPACE_END

--- a/icu4c/source/test/intltest/erarulestest.cpp
+++ b/icu4c/source/test/intltest/erarulestest.cpp
@@ -6,6 +6,7 @@
 #if !UCONFIG_NO_FORMATTING
 
 #include "unicode/calendar.h"
+#include "unicode/gregocal.h"
 #include "unicode/localpointer.h"
 #include "unicode/unistr.h"
 #include "unicode/timezone.h"
@@ -104,7 +105,9 @@ void EraRulesTest::testAPIs() {
 }
 
 void EraRulesTest::testJapanese() {
-    const int32_t HEISEI = 235; // ICU4C does not define constants for eras
+    // ICU4C does not define constants for eras
+    const int32_t MEIJI = 232;
+    const int32_t HEISEI = 235;
 
     UErrorCode status = U_ZERO_ERROR;
     LocalPointer<EraRules> rules(EraRules::createInstance("japanese", true, status));
@@ -125,6 +128,46 @@ void EraRulesTest::testJapanese() {
     if (postHeiseiStartYear != 2019) {
         errln(UnicodeString("Era after Heisei should start in 2019, but got ") + postHeiseiStartYear);
     }
+
+    // Note: Current CLDR data uses 1868-10-23 as the start date of Meiji.
+    // This is not really accurate, because it does not count Lunar-solar
+    // calendar system used before Meiji 6. This might be changed in future.
+    assertEquals("1868-10-23", MEIJI, rules->getEraCode(1868, 10, 23, status));
+    assertEquals("1868-10-22", GregorianCalendar::AD, rules->getEraCode(1868, 10, 22, status));
+    assertEquals("0001-01-01", GregorianCalendar::AD, rules->getEraCode(1, 1, 1,status));
+    assertEquals("0000-12-31", GregorianCalendar::BC, rules->getEraCode(0, 12, 31, status));
+    assertEquals("-1000-01-01", GregorianCalendar::BC, rules->getEraCode(-1000, 1, 1, status));
+
+    const int32_t expectedEraCodes[] = {0, 1, 232, 233, 234, 235, 236};
+    int32_t era = rules->getMinEraCode();
+    assertEquals("Minimum era", expectedEraCodes[0], era);
+    for (int32_t i = 1; i < UPRV_LENGTHOF(expectedEraCodes); i++) {
+        era = rules->getNextEraCode(era);
+        assertEquals(UnicodeString("Era index ") + i, expectedEraCodes[i], era);
+    }
+    // getNextEraCode returns maximum era when the input era is already
+    // maximum era.
+    era = rules->getNextEraCode(era);
+    assertEquals("Max era", maxEra, era);
+
+    // getNextEracode returns next available era code even the input
+    // era data does not exist.
+    era = rules->getNextEraCode(100);
+    assertEquals("getNextEraCode(100)", 232, era);
+
+    // getNextEracode returns the maximum era code if the input
+    // era code is greater than the maximum.
+    era = rules->getNextEraCode(maxEra + 1);
+    assertEquals("getNextEraCode(maxEra+1)", maxEra, era);
+
+    // getNextEracode returns the minimum era code if the input
+    // era code is less than the minimum.
+    int32_t minEra = rules->getMinEraCode();
+    era = rules->getNextEraCode(minEra - 1);
+    assertEquals("getNextEraCode(minEra-1)", minEra, era);
+
+        int numEras = rules->getNumberOfEras();
+    assertEquals("Numbers of Eras", UPRV_LENGTHOF(expectedEraCodes), numEras);
 }
 
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/test/intltest/incaltst.cpp
+++ b/icu4c/source/test/intltest/incaltst.cpp
@@ -579,8 +579,8 @@ void IntlCalendarTest::TestJapaneseFormat() {
     
     // Now, try in Japanese
     {
-        UnicodeString expect = u"平成13年9月8日土曜日";
-        UDate         expectDate = 999932400000.0; // Testing a recent date
+        UnicodeString expect = u"令和8年6月5日金曜日";
+        UDate         expectDate = 1780642800000.0; // Testing a recent date
         Locale        loc("ja_JP@calendar=japanese");
         
         status = U_ZERO_ERROR;
@@ -588,20 +588,19 @@ void IntlCalendarTest::TestJapaneseFormat() {
     }
     {
         UnicodeString expect = u"平成13年9月8日土曜日";
-        UDate         expectDate = 999932400000.0; // Testing a recent date
+        UDate         expectDate = 999932400000.0;
         Locale        loc("ja_JP@calendar=japanese");
         
         status = U_ZERO_ERROR;
         simpleTest(loc, expect, expectDate, status);
     }
-    if (!logKnownIssue("ICU-23108", "ICU needs to implement era inheritance")) {
+    {
         UnicodeString expect = u"西暦1776年7月4日木曜日";
         UDate         expectDate = -6106032422000.0; // 1776-07-04T00:00:00Z-075258
         Locale        loc("ja_JP@calendar=japanese");
         
         status = U_ZERO_ERROR;
         simpleTest(loc, expect, expectDate, status);    
-        
     }
     {
         UnicodeString expect = u"昭和64年1月6日金曜日";
@@ -610,7 +609,6 @@ void IntlCalendarTest::TestJapaneseFormat() {
         
         status = U_ZERO_ERROR;
         simpleTest(loc, expect, expectDate, status);    
-        
     }
     {   // 1989 Jan 9 Monday = Heisei 1; full is Gy年M月d日EEEE
         UnicodeString expect = u"平成元年1月9日月曜日";
@@ -619,16 +617,22 @@ void IntlCalendarTest::TestJapaneseFormat() {
         
         status = U_ZERO_ERROR;
         simpleTest(loc, expect, expectDate, status);    
-        
     }
-    if (!logKnownIssue("ICU-23108", "ICU needs to implement era inheritance")) {
+    {
         UnicodeString expect = u"西暦1456年2月29日日曜日";
-        UDate         expectDate =  -16214400422000.0;  // 1456-03-09T00:00Z-075258
+        UDate         expectDate =  -16214400422000.0;  // 1456-03-09T00:00-075258
         Locale        loc("ja_JP@calendar=japanese");
         
         status = U_ZERO_ERROR;
         simpleTest(loc, expect, expectDate, status);    
+    }
+    {
+        UnicodeString expect = u"紀元前15年7月10日火曜日";
+        UDate         expectDate =  -62592710822000.0;  // 00:00 (UTC 07:52:58) on July 10, BC 15 
+        Locale        loc("ja_JP@calendar=japanese");
         
+        status = U_ZERO_ERROR;
+        simpleTest(loc, expect, expectDate, status);    
     }
 }
 

--- a/icu4j/main/core/src/main/java/com/ibm/icu/impl/EraRules.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/impl/EraRules.java
@@ -24,13 +24,16 @@ public class EraRules {
     private static final int MONTH_MASK = 0x0000FF00;
     private static final int DAY_MASK = 0x000000FF;
 
+    private String calTypeId;
     private int[] startDates;
     private int minEra; // minimum valid era code, for first entry in startDates[]
     private int
             numEras; // number of valid era codes (not necessarily the same as startDates.length)
     private int currentEra;
+    private EraRules inheritEraRules;
 
-    private EraRules(int[] startDates, int minEra, int numEras) {
+    private EraRules(String calTypeId, int[] startDates, int minEra, int numEras) {
+        this.calTypeId = calTypeId;
         this.startDates = startDates;
         this.minEra = minEra;
         this.numEras = numEras;
@@ -49,6 +52,13 @@ public class EraRules {
                         ICUResourceBundle.ICU_DATA_CLASS_LOADER);
         UResourceBundle calendarDataRes = supplementalDataRes.get("calendarData");
         UResourceBundle calendarTypeRes = calendarDataRes.get(calId);
+
+        // Check they key "inheritEras" to see if this calendar inherits eras from another calendar.
+        String inheritCalType = null;
+        if (calendarTypeRes.containsKey("inheritEras")) {
+            inheritCalType = calendarTypeRes.getString("inheritEras");
+        }
+
         UResourceBundle erasRes = calendarTypeRes.get("eras");
 
         int numEras = erasRes.getSize();
@@ -183,8 +193,33 @@ public class EraRules {
         for (int eraIdx = 0; eraIdx < eraStartDates.size(); eraIdx++) {
             startDates[eraIdx] = eraStartDates.get(eraIdx).intValue();
         }
-        ;
-        return new EraRules(startDates, minEra, numEras);
+
+        EraRules eraRules = new EraRules(calId, startDates, minEra, numEras);
+
+        // Initialize era rules from inherited calendar
+        if (inheritCalType != null) {
+            eraRules.inheritEraRules = getInstance(inheritCalType, includeTentativeEra);
+        }
+
+        return eraRules;
+    }
+
+    /**
+     * Gets calendar type ID
+     *
+     * @return calendar type ID
+     */
+    public String getCalendarTypeId() {
+        return calTypeId;
+    }
+
+    /**
+     * Gets inherit EraRules
+     *
+     * @return calendar type ID
+     */
+    public EraRules getInheritEraRules() {
+        return inheritEraRules;
     }
 
     /**
@@ -193,7 +228,7 @@ public class EraRules {
      * @return number of effective eras (not the same as max era code)
      */
     public int getNumberOfEras() {
-        return numEras;
+        return inheritEraRules == null ? numEras : numEras + inheritEraRules.getNumberOfEras();
     }
 
     /**
@@ -206,7 +241,47 @@ public class EraRules {
     }
 
     /**
-     * Gets start date of an era
+     * Gets minimum defined era code for the current calendar
+     *
+     * @return minimum defined era code
+     */
+    public int getMinEraCode() {
+        int minEraCode = minEra;
+        if (inheritEraRules != null) {
+            minEraCode = inheritEraRules.getMinEraCode();
+        }
+        return minEraCode;
+    }
+
+    /**
+     * Gets next era code
+     *
+     * @param eraCode Current era code
+     * @return Next era code. If not available, maximum era code is returned.
+     */
+    public int getNextEraCode(int eraCode) {
+        int nextEra = eraCode + 1;
+        if (nextEra < minEra) {
+            if (inheritEraRules != null) {
+                if (nextEra > inheritEraRules.getMaxEraCode()) {
+                    nextEra = minEra;
+                } else {
+                    nextEra = inheritEraRules.getNextEraCode(eraCode);
+                }
+            } else {
+                nextEra = minEra;
+            }
+        } else {
+            int maxEra = getMaxEraCode();
+            if (nextEra > maxEra) {
+                nextEra = maxEra;
+            }
+        }
+        return nextEra;
+    }
+
+    /**
+     * Gets start date of an era in proleptic Gregorian calendar
      *
      * @param eraCode Era code
      * @param fillIn Receives date fields if supplied. If null, or size of array is less than 3,
@@ -216,7 +291,11 @@ public class EraRules {
      */
     public int[] getStartDate(int eraCode, int[] fillIn) {
         int startDate = 0;
-        if (eraCode >= minEra) {
+        if (eraCode < minEra) {
+            if (inheritEraRules != null) {
+                return inheritEraRules.getStartDate(eraCode, fillIn);
+            }
+        } else {
             int startIdx = eraCode - minEra;
             if (startIdx < startDates.length) {
                 startDate = startDates[startIdx];
@@ -230,30 +309,19 @@ public class EraRules {
     }
 
     /**
-     * Gets start year of an era
+     * Gets start year of an era in proleptic Gregorian calendar
      *
      * @param eraCode Era code
      * @return The first year of an era. When a era has no start date, minimum integer value is
      *     returned.
      */
     public int getStartYear(int eraCode) {
-        int startDate = 0;
-        if (eraCode >= minEra) {
-            int startIdx = eraCode - minEra;
-            if (startIdx < startDates.length) {
-                startDate = startDates[startIdx];
-            }
-        }
-        if (isSet(startDate)) {
-            int[] fields = decodeDate(startDate, null);
-            return fields[0];
-        }
-        // We did not find the requested eraCode in our data
-        throw new IllegalArgumentException("eraCode is not found in our data");
+        int[] date = getStartDate(eraCode, null);
+        return date[0];
     }
 
     /**
-     * Returns era code for the specified year/month/day.
+     * Returns era code for the specified year/month/day in proleptic Gregorian calendar.
      *
      * @param year Year
      * @param month Month (1-base)
@@ -276,7 +344,9 @@ public class EraRules {
                     return minEra + startIdx;
                 }
             }
+            return minEra + startDates.length - 1;
         }
+
         // Linear search from the end, which should hit the most likely eras first.
         // Also this is the most efficient for any era if we have < 8 or so eras, so only less
         // efficient for early eras in Japanese calendar (while we still have them). Formerly
@@ -291,6 +361,12 @@ public class EraRules {
                 return minEra + startIdx;
             }
         }
+
+        // Note: Inherit era rules should be only applied to date before the start of minEra.
+        if (inheritEraRules != null) {
+            return inheritEraRules.getEraCode(year, month, day);
+        }
+
         return minEra;
     }
 
@@ -306,6 +382,8 @@ public class EraRules {
     }
 
     private void initCurrentEra() {
+        // Note: This implementation assumes current era is the primary era rules,
+        // not in inherited era rules.
         long localMillis = System.currentTimeMillis();
         TimeZone zone = TimeZone.getDefault();
         localMillis += zone.getOffset(localMillis);

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/DateFormatSymbols.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/DateFormatSymbols.java
@@ -1980,40 +1980,66 @@ public class DateFormatSymbols implements Serializable, Cloneable {
     protected String[] initEras(
             String erasKey,
             Map<String, Map<String, String>> maps,
-            ICUResourceBundle calBundle,
-            int maxEra) {
+            ICUResourceBundle calBaseBundle,
+            EraRules eraRules) {
         Map<String, String> eraNamesTable = maps.get(erasKey);
         if (eraNamesTable == null) {
             return null;
         }
-        ICUResourceBundle calErasWidthBundle = calBundle.findWithFallback(erasKey);
+
+        // Note: maxEra value should be from the primary EraRules.
+        int maxEra = eraRules.getMaxEraCode();
         String[] eraArray = new String[maxEra + 1];
-        if (eraArray != null) {
-            for (int eraCode = 0; eraCode <= maxEra; eraCode++) {
-                String eraKey = Integer.toString(eraCode);
-                String eraName = eraNamesTable.get(eraKey);
-                if (eraName != null) {
-                    eraArray[eraCode] = eraName;
-                } else {
-                    // For a map, the sink does not seem to fill in parent entries for keys
-                    // that do not exist in the current bundle, that is why we need to explicitly
-                    // fill these in. Also true in ICU4C. Also pre-set to empty string in case
-                    // there is no parent entry.
-                    eraArray[eraCode] = "";
-                    if (calErasWidthBundle != null) {
-                        ICUResourceBundle calErasWidthKeyBundle =
-                                calErasWidthBundle.findWithFallback(eraKey);
-                        if (calErasWidthKeyBundle != null) {
-                            eraName = calErasWidthKeyBundle.getString();
-                            if (eraName != null) {
-                                eraArray[eraCode] = eraName;
-                            }
+        loadEraNames(eraArray, eraNamesTable, calBaseBundle, erasKey, eraRules);
+        return eraArray;
+    }
+
+    private void loadEraNames(
+            String[] eraArray,
+            Map<String, String> eraNamesTable,
+            ICUResourceBundle calBaseBundle,
+            String erasKey,
+            EraRules eraRules) {
+        int maxEra = eraRules.getMaxEraCode();
+        assert maxEra <= eraArray.length;
+        ICUResourceBundle calTypeBundle =
+                calBaseBundle.findWithFallback(eraRules.getCalendarTypeId());
+        ICUResourceBundle calErasWidthBundle = calTypeBundle.findWithFallback(erasKey);
+        for (int eraCode = 0; eraCode <= maxEra; eraCode++) {
+            if (eraArray[eraCode] != null && !eraArray[eraCode].isEmpty()) {
+                // Do not overwrite value if already filled in.
+                // Note: This can only happen when inherited era rules has
+                // duplicated era codes with primary era rules.
+                continue;
+            }
+            String eraKey = Integer.toString(eraCode);
+            String eraName = eraNamesTable.get(eraKey);
+            if (eraName != null) {
+                eraArray[eraCode] = eraName;
+            } else {
+                // For a map, the sink does not seem to fill in parent entries for keys
+                // that do not exist in the current bundle, that is why we need to explicitly
+                // fill these in. Also true in ICU4C. Also pre-set to empty string in case
+                // there is no parent entry.
+                eraArray[eraCode] = "";
+                if (calErasWidthBundle != null) {
+                    ICUResourceBundle calErasWidthKeyBundle =
+                            calErasWidthBundle.findWithFallback(eraKey);
+                    if (calErasWidthKeyBundle != null) {
+                        eraName = calErasWidthKeyBundle.getString();
+                        if (eraName != null) {
+                            eraArray[eraCode] = eraName;
                         }
                     }
                 }
             }
         }
-        return eraArray;
+
+        // Also load era names from resource corresponding to the inherited era rules if any.
+        EraRules inheritEraRules = eraRules.getInheritEraRules();
+        if (inheritEraRules != null) {
+            loadEraNames(eraArray, eraNamesTable, calBaseBundle, erasKey, inheritEraRules);
+        }
     }
 
     /**
@@ -2088,12 +2114,11 @@ public class DateFormatSymbols implements Serializable, Cloneable {
             calTypeForEras = "gregorian";
             eraRules = EraRules.getInstance(calTypeForEras, false);
         }
-        int maxEra = (eraRules != null) ? eraRules.getMaxEraCode() : 0;
-        ICUResourceBundle calBundle = b.findWithFallback("calendar/" + calTypeForEras);
+        ICUResourceBundle calBaseBundle = b.findWithFallback("calendar");
 
-        eras = initEras("eras/abbreviated", maps, calBundle, maxEra);
-        eraNames = initEras("eras/wide", maps, calBundle, maxEra);
-        narrowEras = initEras("eras/narrow", maps, calBundle, maxEra);
+        eras = initEras("eras/abbreviated", maps, calBaseBundle, eraRules);
+        eraNames = initEras("eras/wide", maps, calBaseBundle, eraRules);
+        narrowEras = initEras("eras/narrow", maps, calBaseBundle, eraRules);
 
         months = arrays.get("monthNames/format/wide");
         shortMonths = arrays.get("monthNames/format/abbreviated");

--- a/icu4j/main/core/src/main/java/com/ibm/icu/util/JapaneseCalendar.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/util/JapaneseCalendar.java
@@ -258,18 +258,22 @@ public class JapaneseCalendar extends GregorianCalendar {
     protected int handleGetExtendedYear() {
         // EXTENDED_YEAR in JapaneseCalendar is a Gregorian year
         // The default value of EXTENDED_YEAR is 1970 (Showa 45)
-        int year;
         if (newerField(EXTENDED_YEAR, YEAR) == EXTENDED_YEAR
                 && newerField(EXTENDED_YEAR, ERA) == EXTENDED_YEAR) {
-            year = internalGet(EXTENDED_YEAR, GREGORIAN_EPOCH);
-        } else {
-            // extended year is a gregorian year, where 1 = 1AD,  0 = 1BC, -1 = 2BC, etc
-            year =
-                    internalGet(YEAR, 1) // pin to minimum of year 1 (first year)
-                            + ERA_RULES.getStartYear(
-                                    internalGet(ERA, CURRENT_ERA)) // add gregorian starting year
-                            - 1; // Subtract one because year starts at 1
+            return internalGet(EXTENDED_YEAR, GREGORIAN_EPOCH);
         }
+
+        // extended year is a gregorian year, where 1 = 1AD,  0 = 1BC, -1 = 2BC, etc
+        int era = internalGet(ERA, CURRENT_ERA);
+        int year = internalGet(YEAR, 1);
+        if (era == 0) {
+            // era 0 in Japanese calendar is Gregorian BC
+            year = 1 - year;
+        } else {
+            int eraStartYear = ERA_RULES.getStartYear(era);
+            year = eraStartYear + year - 1; // Subtract one because year starts at 1
+        }
+
         return year;
     }
 
@@ -288,14 +292,17 @@ public class JapaneseCalendar extends GregorianCalendar {
         // computeFields(status); // No need to compute fields here - expect the caller already did
         // so.
 
+        if (era == 0) {
+            // era 0 in Japanese calendar is Gregorian BC
+            return super.getDefaultMonthInYear(extendedYear);
+        }
+
         // Find out if we are at the edge of an era
         int[] eraStart = ERA_RULES.getStartDate(era, null);
         if (extendedYear == eraStart[0]) {
-            return eraStart[1] // month..
-                    - 1; // return 0-based month
-        } else {
-            return super.getDefaultMonthInYear(extendedYear);
+            return eraStart[1] - 1; // return 0-based month
         }
+        return 0;
     }
 
     /**
@@ -311,15 +318,18 @@ public class JapaneseCalendar extends GregorianCalendar {
     @Override
     protected int getDefaultDayInMonth(int extendedYear, int month) {
         int era = internalGet(ERA, CURRENT_ERA);
-        int[] eraStart = ERA_RULES.getStartDate(era, null);
+        if (era == 0) {
+            // era 0 in Japanese calendar is Gregorian BC
+            return super.getDefaultDayInMonth(extendedYear, month);
+        }
 
+        int[] eraStart = ERA_RULES.getStartDate(era, null);
         if (extendedYear == eraStart[0]) { // if it is year 1..
             if (month == (eraStart[1] - 1)) { // if it is the emperor's first month..
                 return eraStart[2]; // return the D_O_M of accession
             }
         }
-
-        return super.getDefaultDayInMonth(extendedYear, month);
+        return 1;
     }
 
     /**
@@ -328,13 +338,26 @@ public class JapaneseCalendar extends GregorianCalendar {
     @Override
     protected void handleComputeFields(int julianDay) {
         super.handleComputeFields(julianDay);
-        int year = internalGet(EXTENDED_YEAR);
+        int extendedYear = internalGet(EXTENDED_YEAR);
         int eraCode =
                 ERA_RULES.getEraCode(
-                        year, internalGet(MONTH) + 1 /* 1-base */, internalGet(DAY_OF_MONTH));
+                        extendedYear,
+                        internalGet(MONTH) + 1 /* 1-base */,
+                        internalGet(DAY_OF_MONTH));
 
         internalSet(ERA, eraCode);
-        internalSet(YEAR, year - ERA_RULES.getStartYear(eraCode) + 1);
+        int year;
+        if (eraCode == 0) {
+            // Gregorian BC
+            year = 1 - extendedYear;
+        } else if (eraCode == 1) {
+            // Gregorian AD
+            year = extendedYear;
+        } else {
+            // Japanese era since Meiji
+            year = extendedYear - ERA_RULES.getStartYear(eraCode) + 1;
+        }
+        internalSet(YEAR, year);
     }
 
     // -------------------------------------------------------------------------
@@ -458,26 +481,35 @@ public class JapaneseCalendar extends GregorianCalendar {
      */
     @Override
     public int getActualMaximum(int field) {
-        if (field == YEAR) {
-            int era = get(Calendar.ERA);
-            if (era == ERA_RULES.getMaxEraCode()) {
-                // TODO: Investigate what value should be used here - revisit after 4.0.
-                return handleGetLimit(YEAR, MAXIMUM);
-            } else {
-                int[] nextEraStart = ERA_RULES.getStartDate(era + 1, null);
-                int nextEraYear = nextEraStart[0];
-                int nextEraMonth = nextEraStart[1]; // 1-base
-                int nextEraDate = nextEraStart[2];
-
-                int maxYear = nextEraYear - ERA_RULES.getStartYear(era) + 1; // 1-base
-                if (nextEraMonth == 1 && nextEraDate == 1) {
-                    // Substract 1, because the next era starts at Jan 1
-                    maxYear--;
-                }
-                return maxYear;
-            }
+        if (field != YEAR) {
+            return super.getActualMaximum(field);
         }
-        return super.getActualMaximum(field);
+
+        int era = get(Calendar.ERA);
+        if (era >= ERA_RULES.getMaxEraCode()) {
+            // TODO: Investigate what value should be used here - revisit after 4.0.
+            return handleGetLimit(YEAR, MAXIMUM);
+        }
+
+        if (era == 0) {
+            // era 0 is Gregorian BC and has no era start year data.
+            return super.getActualMaximum(YEAR);
+        }
+
+        // Use getNextEraCode() instead of +1, because there might be gaps between eras.
+        int nextEra = ERA_RULES.getNextEraCode(era);
+        assert nextEra != era; // already checked (era) is not a max era code
+        int[] nextEraStart = ERA_RULES.getStartDate(nextEra, null);
+        int nextEraYear = nextEraStart[0];
+        int nextEraMonth = nextEraStart[1]; // 1-base
+        int nextEraDate = nextEraStart[2];
+
+        int maxYear = nextEraYear - ERA_RULES.getStartYear(era) + 1; // 1-base
+        if (nextEraMonth == 1 && nextEraDate == 1) {
+            // Substract 1, because the next era starts at Jan 1
+            maxYear--;
+        }
+        return maxYear;
     }
 
     /**
@@ -489,6 +521,6 @@ public class JapaneseCalendar extends GregorianCalendar {
     @Override
     @Deprecated
     protected boolean isEra0CountingBackward() {
-        return false;
+        return true;
     }
 }

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/EraRulesTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/EraRulesTest.java
@@ -6,6 +6,7 @@ import com.ibm.icu.dev.test.CoreTestFmwk;
 import com.ibm.icu.impl.CalType;
 import com.ibm.icu.impl.EraRules;
 import com.ibm.icu.util.Calendar;
+import com.ibm.icu.util.GregorianCalendar;
 import com.ibm.icu.util.JapaneseCalendar;
 import com.ibm.icu.util.TimeZone;
 import com.ibm.icu.util.ULocale;
@@ -78,5 +79,45 @@ public class EraRulesTest extends CoreTestFmwk {
         if (postHeiseiStartYear != 2019) {
             errln("Era after Heisei should start in 2019, but got " + postHeiseiStartYear);
         }
+
+        // Note: Current CLDR data uses 1868-10-23 as the start date of Meiji.
+        // This is not really accurate, because it does not count Lunar-solar
+        // calendar system used before Meiji 6. This might be changed in future.
+        assertEquals("1868-10-23", JapaneseCalendar.MEIJI, rules.getEraCode(1868, 10, 23));
+        assertEquals("1868-10-22", GregorianCalendar.AD, rules.getEraCode(1868, 10, 22));
+        assertEquals("0001-01-01", GregorianCalendar.AD, rules.getEraCode(1, 1, 1));
+        assertEquals("0000-12-31", GregorianCalendar.BC, rules.getEraCode(0, 12, 31));
+        assertEquals("-1000-01-01", GregorianCalendar.BC, rules.getEraCode(-1000, 1, 1));
+
+        final int[] expectedEraCodes = {0, 1, 232, 233, 234, 235, 236};
+        int era = rules.getMinEraCode();
+        assertEquals("Minimum era", expectedEraCodes[0], era);
+        for (int i = 1; i < expectedEraCodes.length; i++) {
+            era = rules.getNextEraCode(era);
+            assertEquals("Era index " + i, expectedEraCodes[i], era);
+        }
+        // getNextEraCode returns maximum era when the input era is already
+        // maximum era.
+        era = rules.getNextEraCode(era);
+        assertEquals("Max era", maxEra, era);
+
+        // getNextEracode returns next available era code even the input
+        // era data does not exist.
+        era = rules.getNextEraCode(100);
+        assertEquals("getNextEraCode(100)", 232, era);
+
+        // getNextEracode returns the maximum era code if the input
+        // era code is greater than the maximum.
+        era = rules.getNextEraCode(maxEra + 1);
+        assertEquals("getNextEraCode(maxEra+1)", maxEra, era);
+
+        // getNextEracode returns the minimum era code if the input
+        // era code is less than the minimum.
+        int minEra = rules.getMinEraCode();
+        era = rules.getNextEraCode(minEra - 1);
+        assertEquals("getNextEraCode(minEra-1)", minEra, era);
+
+        int numEras = rules.getNumberOfEras();
+        assertEquals("Numbers of Eras", expectedEraCodes.length, numEras);
     }
 }

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/IBMCalendarTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/IBMCalendarTest.java
@@ -2464,8 +2464,9 @@ public class IBMCalendarTest extends CalendarTestFmwk {
             "en@calendar=gregorian",
             "en@calendar=roc",
             "en@calendar=coptic",
-            // calendars with non-modern era 0 that goes forwards, max era > 1
+            // calendars with non-modern era 0 that goes backwards, max era > 1
             "en@calendar=japanese",
+            // calendars with non-modern era 0 that goes forwards, max era > 1
             "en@calendar=chinese",
             // calendars with non-modern era 0 that goes forwards, max era == 1
             "en@calendar=ethiopic",
@@ -2479,14 +2480,11 @@ public class IBMCalendarTest extends CalendarTestFmwk {
         };
         TimeZone zoneGMT = TimeZone.getFrozenTimeZone("GMT");
         for (String localeID : localeIDs) {
-            if (localeID.contains("calendar=japanese")
-                    && logKnownIssue("ICU-23108", "ICU needs to implement era inheritance")) {
-                continue;
-            }
             Calendar ucalTest = Calendar.getInstance(zoneGMT, new ULocale(localeID));
             String calType = ucalTest.getType();
             boolean era0YearsGoBackwards =
                     (calType.equals("gregorian")
+                            || calType.equals("japanese")
                             || calType.equals("roc")
                             || calType.equals("coptic"));
             int yrBefore, yrAfter, yrMax, eraAfter, eraMax, eraNow;

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/JapaneseTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/JapaneseTest.java
@@ -462,26 +462,24 @@ public class JapaneseTest extends CalendarTestFmwk {
         int expectedA[] = {Calendar.ERA, JapaneseCalendar.MEIJI};
         checkExpected(c, expectedA);
 
-        if (!logKnownIssue("ICU-23108", "ICU needs to implement era inheritance")) {
-            logln("test setting era and year and month and date");
-            c.clear();
-            c.set(Calendar.ERA, JapaneseCalendar.MEIJI);
-            c.set(Calendar.YEAR, 1);
-            c.set(Calendar.MONTH, Calendar.JANUARY);
-            c.set(Calendar.DATE, 1);
+        logln("test setting era and year and month and date");
+        c.clear();
+        c.set(Calendar.ERA, JapaneseCalendar.MEIJI);
+        c.set(Calendar.YEAR, 1);
+        c.set(Calendar.MONTH, Calendar.JANUARY);
+        c.set(Calendar.DATE, 1);
 
-            int expectedC[] = {Calendar.ERA, JapaneseCalendar.AD};
-            checkExpected(c, expectedC);
+        int expectedC[] = {Calendar.ERA, JapaneseCalendar.AD};
+        checkExpected(c, expectedC);
 
-            logln("test setting  year and month and date THEN era");
-            c.clear();
-            c.set(Calendar.YEAR, 1);
-            c.set(Calendar.MONTH, Calendar.JANUARY);
-            c.set(Calendar.DATE, 1);
-            c.set(Calendar.ERA, JapaneseCalendar.MEIJI);
+        logln("test setting  year and month and date THEN era");
+        c.clear();
+        c.set(Calendar.YEAR, 1);
+        c.set(Calendar.MONTH, Calendar.JANUARY);
+        c.set(Calendar.DATE, 1);
+        c.set(Calendar.ERA, JapaneseCalendar.MEIJI);
 
-            checkExpected(c, expectedC);
-        }
+        checkExpected(c, expectedC);
 
         logln("test setting era and year");
         c.clear();


### PR DESCRIPTION
…DateFormat.

CLDR dropped Japanese calendar era data before Meiji. Also it introduced a new behavior that inheriting Gregorian calendar before Meiji (inheritEras: gregorian). This spec update requires following changes.

- DateFormatSmbols initialization code to load era data from calendar type specified by "inheritEras".
- Skip era index without definitions. (Japanese calendar inherit era 0 and 1 from Gregorian, but next era after 1 needs to be era 232 Meiji)

With these changes, this PR also removes `logKnownIssues` introduced by the previous CLDR data integration.

#### Checklist
- [x] Required: Issue filed: ICU-23341
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf

