### PR TITLE
ICU-23426 MessageFormat: Update spec tests and fix accompanying bugs

### DIFF
--- a/icu4c/source/i18n/messageformat2.cpp
+++ b/icu4c/source/i18n/messageformat2.cpp
@@ -463,10 +463,13 @@ void MessageFormatter::formatPattern(MessageContext& context,
                   // register an error directly
                   if (status == U_MF_FORMATTING_ERROR) {
                       status = U_ZERO_ERROR;
-                      // TODO: The name of the formatter that failed is unavailable.
+                      // The name of the formatter that failed is unavailable.
                       // Not ideal, but it's hard for `formatToString()`
                       // to pass along more detailed diagnostics
                       context.getErrors().setFormattingError(status);
+                  } else if (status == U_MF_BAD_OPTION) {
+                      status = U_ZERO_ERROR;
+                      context.getErrors().setBadOption(status);
                   }
               }
         }

--- a/icu4c/source/i18n/messageformat2_errors.cpp
+++ b/icu4c/source/i18n/messageformat2_errors.cpp
@@ -33,6 +33,10 @@ namespace message2 {
         addError(DynamicError(DynamicErrorType::BadOptionError, formatterName), status);
     }
 
+    void DynamicErrors::setBadOption(UErrorCode& status) {
+        addError(DynamicError(DynamicErrorType::BadOptionError, UnicodeString("unknown formatter")), status);
+    }
+
     void DynamicErrors::setOperandMismatchError(const FunctionName& formatterName, UErrorCode& status) {
         addError(DynamicError(DynamicErrorType::OperandMismatchError, formatterName), status);
     }

--- a/icu4c/source/i18n/messageformat2_errors.h
+++ b/icu4c/source/i18n/messageformat2_errors.h
@@ -131,6 +131,8 @@ namespace message2 {
         // Used when the name of the offending formatter is unknown
         void setFormattingError(UErrorCode&);
         void setBadOption(const FunctionName&, UErrorCode&);
+        // Used when the name of the offending formatter is unknown
+        void setBadOption(UErrorCode&);
         void setOperandMismatchError(const FunctionName&, UErrorCode&);
         bool hasDataModelError() const { return staticErrors.hasDataModelError(); }
         bool hasFormattingError() const { return formattingError; }

--- a/icu4c/source/i18n/messageformat2_function_registry.cpp
+++ b/icu4c/source/i18n/messageformat2_function_registry.cpp
@@ -316,7 +316,7 @@ bool validateNumberLiteral(const UnicodeString& s) {
     // Parse integer digits
     // (%x30 / (%x31-39 *DIGIT))
     if (s[i] == '0') {
-        if (!inBounds(s, i + 1) || s[i + 1] != PERIOD) {
+        if (inBounds(s, i + 1) && s[i + 1] != PERIOD) {
             return false;
         }
         i++;
@@ -1688,10 +1688,11 @@ static void setFailsFromFunctionValue(const FunctionValue& optionValue,
         input = formattableToNumber(arg.unwrap(), status);
         if (U_FAILURE(status)) {
             // 7. Else,
-            // 7i. Emit "bad-input" Resolution Error.
+            // 7i. Emit "bad-operand" Resolution Error.
             status = U_MF_OPERAND_MISMATCH_ERROR;
             // 7ii. Use a fallback value as the resolved value of the expression.
             // Further steps of this algorithm are not followed.
+            return;
         }
     }
 
@@ -1795,7 +1796,9 @@ UnicodeString StandardFunctions::TestFunctionValue::formatToString(UErrorCode& s
     if (U_FAILURE(status)) {
         return {};
     }
-    if (!canFormat || failsFormat) {
+    if (failsFormat) {
+        status = U_MF_BAD_OPTION;
+    } else if (!canFormat) {
         status = U_MF_FORMATTING_ERROR;
     }
     if (!canFormat) {

--- a/testdata/message2/spec/fallback.json
+++ b/testdata/message2/spec/fallback.json
@@ -4,52 +4,59 @@
   "description": "Test cases for fallback behaviour.",
   "defaultTestProperties": {
     "bidiIsolation": "none",
-    "locale": "en-US",
-    "expErrors": true
+    "locale": "en-US"
   },
   "tests": [
     {
       "description": "function with unquoted literal operand",
       "src": "{42 :test:function fails=format}",
       "exp": "{|42|}",
-      "expParts": [{ "type": "fallback", "source": "|42|" }]
+      "expParts": [{ "type": "fallback", "source": "|42|" }],
+      "expErrors": [{ "type": "bad-option" }]
     },
     {
       "description": "function with quoted literal operand",
       "src": "{|C:\\\\| :test:function fails=format}",
-      "exp": "{|C:\\\\|}"
+      "exp": "{|C:\\\\|}",
+      "expErrors": [{ "type": "bad-operand" }]
     },
     {
       "description": "unannotated implicit input variable",
       "src": "{$var}",
-      "exp": "{$var}"
+      "exp": "{$var}",
+      "expErrors": [{ "type": "unresolved-variable" }]
     },
     {
       "description": "annotated implicit input variable",
       "src": "{$var :number}",
       "exp": "{$var}",
-      "expParts": [{ "type": "fallback", "source": "$var" }]
+      "expParts": [{ "type": "fallback", "source": "$var" }],
+      "expErrors": [{ "type": "unresolved-variable" }, { "type": "bad-operand" }]
     },
     {
       "description": "local variable with unknown function in declaration",
       "src": ".local $var = {|val| :test:undefined} {{{$var}}}",
-      "exp": "{$var}"
+      "exp": "{$var}",
+      "expErrors": [{ "type": "unknown-function" }]
     },
     {
       "description": "function with local variable operand with unknown function in declaration",
       "src": ".local $var = {|val| :test:undefined} {{{$var :test:function}}}",
-      "exp": "{$var}"
+      "exp": "{$var}",
+      "expErrors": [{ "type": "unknown-function" }, { "type": "bad-operand" }]
     },
     {
       "description": "local variable with unknown function in placeholder",
       "src": ".local $var = {|val|} {{{$var :test:undefined}}}",
-      "exp": "{$var}"
+      "exp": "{$var}",
+      "expErrors": [{ "type": "unknown-function" }]
     },
     {
       "description": "function with no operand",
       "src": "{:test:undefined}",
       "exp": "{:test:undefined}",
-      "expParts": [{ "type": "fallback", "source": ":test:undefined" }]
+      "expParts": [{ "type": "fallback", "source": ":test:undefined" }],
+      "expErrors": [{ "type": "unknown-function" }]
     }
   ]
 }

--- a/testdata/message2/spec/functions/date.json
+++ b/testdata/message2/spec/functions/date.json
@@ -5,7 +5,7 @@
   "defaultTestProperties": {
     "bidiIsolation": "none",
     "locale": "en-US",
-    "expErrors": false
+    "expErrors": []
   },
   "tests": [
     {
@@ -33,13 +33,13 @@
       "src": "{|2006-01-02T15:04:06| :date}"
     },
     {
-      "src": "{|2006-01-02| :date style=long}"
+      "src": "{|2006-01-02| :date length=long}"
     },
     {
-      "src": ".local $d = {|2006-01-02| :date style=long} {{{$d}}}"
+      "src": ".local $d = {|2006-01-02| :date length=long} {{{$d}}}"
     },
     {
-      "src": ".local $d = {|2006-01-02| :datetime dateStyle=long timeStyle=long} {{{$d :date}}}"
+      "src": ".local $d = {|2006-01-02| :datetime dateLength=long timePrecision=second} {{{$d :date}}}"
     }
   ]
 }

--- a/testdata/message2/spec/functions/datetime.json
+++ b/testdata/message2/spec/functions/datetime.json
@@ -5,7 +5,7 @@
   "defaultTestProperties": {
     "bidiIsolation": "none",
     "locale": "en-US",
-    "expErrors": false
+    "expErrors": []
   },
   "tests": [
     {
@@ -45,13 +45,10 @@
       "src": "{|2006-01-02T15:04:06| :datetime}"
     },
     {
-      "src": "{|2006-01-02T15:04:06| :datetime year=numeric month=2-digit}"
+      "src": "{|2006-01-02T15:04:06| :datetime dateLength=long}"
     },
     {
-      "src": "{|2006-01-02T15:04:06| :datetime dateStyle=long}"
-    },
-    {
-      "src": "{|2006-01-02T15:04:06| :datetime timeStyle=medium}"
+      "src": "{|2006-01-02T15:04:06| :datetime timePrecision=second}"
     },
     {
       "src": "{$dt :datetime}",

--- a/testdata/message2/spec/functions/time.json
+++ b/testdata/message2/spec/functions/time.json
@@ -5,7 +5,7 @@
   "defaultTestProperties": {
     "bidiIsolation": "none",
     "locale": "en-US",
-    "expErrors": false
+    "expErrors": []
   },
   "tests": [
     {
@@ -30,13 +30,13 @@
       "src": "{|2006-01-02T15:04:06| :time}"
     },
     {
-      "src": "{|2006-01-02T15:04:06| :time style=medium}"
+      "src": "{|2006-01-02T15:04:06| :time precision=second}"
     },
     {
-      "src": ".local $t = {|2006-01-02T15:04:06| :time style=medium} {{{$t}}}"
+      "src": ".local $t = {|2006-01-02T15:04:06| :time precision=second} {{{$t}}}"
     },
     {
-      "src": ".local $t = {|2006-01-02T15:04:06| :datetime dateStyle=long timeStyle=long} {{{$t :time}}}"
+      "src": ".local $t = {|2006-01-02T15:04:06| :datetime dateLength=long timePrecision=second} {{{$t :time}}}"
     }
   ]
 }

--- a/testdata/message2/valid-tests.json
+++ b/testdata/message2/valid-tests.json
@@ -152,6 +152,10 @@
     {
       "src" : "{{􍅲}}",
       "exp" : "􍅲"
+    },
+    {
+      "src": ".local $x = {foo} {{{$x :string} bar}}",
+      "exp": "foo bar"
     }
   ]
 }


### PR DESCRIPTION
This commit updates the spec test suite to the contents of https://github.com/unicode-org/message-format-wg/tree/main/test as of commit 54e77bdfac36cca2ad6e42d2913e4208b7b6bc0d

The following bugs, exposed by new spec tests, are fixed:
- Handle bad option errors correctly in formatPattern()
- Validate "0" number literal correctly in implementation of test functions
- For test functions, return bad option error when format=fails (matching the spec for test functions)
- Add test for using :string as a formatter (this is not in the spec test suite yet)

#### Checklist
- [x] Required: Issue filed: ICU-23426
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf
