### PR TITLE
ICU-23247 Fix error MSB8036: The Windows SDK version 10.0.0.0 was not found

### DIFF
--- a/.github/workflows/icu4c.yml
+++ b/.github/workflows/icu4c.yml
@@ -400,7 +400,7 @@ jobs:
           - test_flags: 'x86 Debug'
             build_flags: '/p:Configuration=Debug /p:Platform=Win32'
           - test_flags: 'arm Release'
-            build_flags: '/p:Configuration=Release /p:Platform=ARM'
+            build_flags: '/p:Configuration=Release /p:Platform=ARM64'
           - test_flags: 'x64 Release cpplatest'
             build_flags: '/p:OverrideLanguageStandard=stdcpplatest /p:Configuration=Release /p:Platform=x64'
           - test_flags: 'x64 Release'
@@ -498,7 +498,7 @@ jobs:
         # Extract ICU version from the release tag
         $releaseTag = '${{ inputs.gitReleaseTag }}'.replace('release-','')
         # Determine the new file name based on the version
-        $newZipName = "icu4c-${releaseTag}-${{ matrix.win_ver }}-MSVC2022"
+        $newZipName = "icu4c-${releaseTag}-${{ matrix.win_ver }}-MSVC2026"
         # Debugging: Print the new zip name
         Write-Host "New Zip Name: $newZipName"
         # Rename the existing zip file

--- a/icu4c/source/allinone/Build.Windows.PlatformToolset.props
+++ b/icu4c/source/allinone/Build.Windows.PlatformToolset.props
@@ -14,11 +14,13 @@
       v141 is the Visual Studio 2017 toolset. (15.0)
       v142 is the Visual Studio 2019 toolset. (16.0)
       v143 is the Visual Studio 2022 toolset. (17.0)
+      v145 is the Visual Studio 2026 toolset. (18.0)
     -->
     <AutoDetectedPlatformToolset Condition="'$(BuildToolVersion)'=='14.0'">v140</AutoDetectedPlatformToolset>
     <AutoDetectedPlatformToolset Condition="'$(BuildToolVersion)'=='15.0'">v141</AutoDetectedPlatformToolset>
     <AutoDetectedPlatformToolset Condition="'$(BuildToolVersion)'=='16.0'">v142</AutoDetectedPlatformToolset>
     <AutoDetectedPlatformToolset Condition="'$(BuildToolVersion)'=='17.0'">v143</AutoDetectedPlatformToolset>
+    <AutoDetectedPlatformToolset Condition="'$(BuildToolVersion)'=='18.0'">v145</AutoDetectedPlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="EmptyDefaultPlatformToolset">
     <DefaultPlatformToolset Condition=" '$(DefaultPlatformToolset)' == '' ">$(AutoDetectedPlatformToolset)</DefaultPlatformToolset>
@@ -32,11 +34,11 @@
     If not already set, use the latest installed version of the Windows 10 SDK.
     The Windows 10 SDK is backwards compatible to Windows 7, as long as WINVER and _WIN32_WINNT are set before compiling.
     Note:
-      - With VS2019, VS2022 using a value of "10.0" means that it will use the latest installed version.
+      - With VS2019, VS2022, 2026 using a value of "10.0" means that it will use the latest installed version.
       - With VS2017, we need to manually detect the latest SDK version from the registry.
       - With VS2015, use the Windows 8.1 SDK.
   -->
-  <PropertyGroup Condition="'$(WindowsTargetPlatformVersion)'=='' and ('$(PlatformToolset)'=='v142' or '$(PlatformToolset)'=='v143')">
+  <PropertyGroup Condition="'$(WindowsTargetPlatformVersion)'=='' and ('$(PlatformToolset)'=='v142' or '$(PlatformToolset)'=='v143' or '$(PlatformToolset)'=='v145')">
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(WindowsTargetPlatformVersion)'=='' and ('$(PlatformToolset)'=='v141' or '$(AutodetectWin10SDK)'=='true')">


### PR DESCRIPTION
All of this is to handle VS 2026, which is now the default Windows runner on GitHub.

---

VS 2026 (Platform Toolset = 'v145') dropped support for 32-bit ARM.

I changed the CI tests to check ARM64 instead, so ARM related problems will still be detected.
Users can build ARM 32 on their own machines, we just don't test it in CI anymore.

---

Although there seems to be a version missing (v144) in `Build.Windows.PlatformToolset.props`, that is not a mistake.

See https://developercommunity.microsoft.com/t/11019486

> _The error occurs because there is **no official v144 Platform Toolset** in VS. While the latest updates to VS 2022 used a compiler versioned 14.4x, the build system continued to use the label **v143** for compatibility. With your upgrade to **VS 2026 (v18.0)**, Microsoft has moved the primary toolset version to **v145**. Because your project file is explicitly looking for ‘**v144**’—a version that does not exist in the software’s registry—MSBuild is unable to locate the necessary build tools to complete the process._

---

#### Checklist
- [x] Required: Issue filed: ICU-23247
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf
