### PR TITLE
icu: Update and standardize Central Kurdish (ckb, ckb_IQ, ckb_IR) locales

### DIFF
--- a/icu4c/source/data/locales/ckb.txt
+++ b/icu4c/source/data/locales/ckb.txt
@@ -1,4 +1,4 @@
-﻿// © 2016 and later: Unicode, Inc. and others.
+// © 2016 and later: Unicode, Inc. and others.
 // License & terms of use: http://www.unicode.org/copyright.html
 // Generated using tools/cldr/cldr-to-icu/
 ckb{
@@ -9,7 +9,7 @@ ckb{
     NumberElements{
         arab{
             patterns{
-                percentFormat{"#,##0 %"}
+                percentFormat{"#,##0 %"}
             }
             symbols{
                 minusSign{"‏-"}
@@ -33,7 +33,7 @@ ckb{
                 "h:mm:ss a",
                 "h:mm a",
                 "G y MMMM d, EEEE",
-                "dی MMMMی y G",
+                "d ی MMMMی y G",
                 "G y MMM d",
                 "G y-MM-dd",
                 "{1} {0}",
@@ -45,13 +45,13 @@ ckb{
             availableFormats{
                 Ed{"E dھەم"}
                 MEd{"E، M/d"}
-                MMMEd{"E، dی MMM"}
-                MMMd{"dی MMM"}
+                MMMEd{"E، d ی MMM"}
+                MMMd{"d ی MMM"}
                 yM{"M/y"}
                 yMEd{"E، d/M/y"}
                 yMMM{"MMMی y"}
-                yMMMEd{"E، dی MMMی y"}
-                yMMMd{"dی MMMی y"}
+                yMMMEd{"E، d ی MMMی y"}
+                yMMMd{"d ی MMMی y"}
                 yMd{"d/M/y"}
             }
             intervalFormats{
@@ -63,10 +63,10 @@ ckb{
                     M{"MMM–MMM"}
                 }
                 MMMEd{
-                    d{"E، dی MMM – E، dی MMM"}
+                    d{"E، d ی MMM – E، d ی MMM"}
                 }
                 MMMd{
-                    d{"d–dی MMM"}
+                    d{"d–d ی MMM"}
                 }
                 fallback{"{0} – {1}"}
                 yMEd{
@@ -79,9 +79,9 @@ ckb{
                     y{"MMMی y – MMMی y"}
                 }
                 yMMMd{
-                    M{"dی MMM – dی MMMی y"}
-                    d{"d–dی MMMی y"}
-                    y{"dی MMMMی y – dی MMMMی y"}
+                    M{"d ی MMM – d ی MMMی y"}
+                    d{"d–d ی MMMی y"}
+                    y{"d ی MMMMی y – d ی MMMMی y"}
                 }
                 yMd{
                     y{"d/M/y – d/M/y"}
@@ -99,7 +99,7 @@ ckb{
                 "h:mm:ss a",
                 "h:mm a",
                 "y MMMM d, EEEE",
-                "dی MMMMی y",
+                "d ی MMMMی y",
                 "y MMM d",
                 "y-MM-dd",
                 "{1} {0}",
@@ -121,18 +121,18 @@ ckb{
             availableFormats{
                 Ed{"E dھەم"}
                 MEd{"E، M/d"}
-                MMMEd{"E، dی MMM"}
+                MMMEd{"E، d ی MMM"}
                 MMMMW{
                     one{"هەفتەی W ی MMMM"}
                     other{"هەفتەی W ی MMMM"}
                 }
-                MMMd{"dی MMM"}
+                MMMd{"d ی MMM"}
                 h{"hی a"}
                 yM{"M/y"}
                 yMEd{"E، d/M/y"}
                 yMMM{"MMMی y"}
-                yMMMEd{"E، dی MMMی y"}
-                yMMMd{"dی MMMی y"}
+                yMMMEd{"E، d ی MMMی y"}
+                yMMMd{"d ی MMMی y"}
                 yMd{"d/M/y"}
                 yw{
                     one{"هەفتەی w ی Y"}
@@ -190,7 +190,7 @@ ckb{
                     wide{
                         "کانوونی دووەم",
                         "شوبات",
-                        "ئازار",
+                        "ئادار",
                         "نیسان",
                         "ئایار",
                         "حوزەیران",
@@ -199,7 +199,21 @@ ckb{
                         "ئەیلوول",
                         "تشرینی یەکەم",
                         "تشرینی دووەم",
-                        "کانونی یەکەم",
+                        "کانوونی یەکەم",
+                    }
+                    abbreviated{
+                        "کانوونی دوو",
+                        "شوبات",
+                        "ئادار",
+                        "نیسان",
+                        "ئایار",
+                        "حوزەیران",
+                        "تەمووز",
+                        "ئاب",
+                        "ئەیلوول",
+                        "تشرینی یەک",
+                        "تشرینی دوو",
+                        "کانوونی یەک",
                     }
                 }
                 stand-alone{

--- a/icu4c/source/data/locales/ckb_IQ.txt
+++ b/icu4c/source/data/locales/ckb_IQ.txt
@@ -1,5 +1,6 @@
-﻿// © 2016 and later: Unicode, Inc. and others.
+// © 2016 and later: Unicode, Inc. and others.
 // License & terms of use: http://www.unicode.org/copyright.html
 // Generated using tools/cldr/cldr-to-icu/
 ckb_IQ{
+    %%Parent{"ckb"}
 }

--- a/icu4c/source/data/locales/ckb_IR.txt
+++ b/icu4c/source/data/locales/ckb_IR.txt
@@ -2,8 +2,6 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 // Generated using tools/cldr/cldr-to-icu/
 ckb_IR{
-    %%Parent{"ckb"}
-
     // 1. Enable Persian/Extended Arabic numbering system (۰، ۱، ۲، ۳، ۴، ۵، ۶، ۷، ۸، ۹)
     defaultNumberingSystem{"arabext"}
 
@@ -36,7 +34,7 @@ ckb_IR{
                 "yMMdd",
             }
             // 2. Gregorian month names in Latin script
-            months{
+            monthNames{
                 format{
                     wide{
                         "January",
@@ -96,7 +94,7 @@ ckb_IR{
                 "GGGGGyMMdd",
             }
             // 3. Persian calendar with corrected native Kurdish month names
-            months{
+            monthNames{
                 format{
                     wide{
                         "خاکەلێوە",

--- a/icu4c/source/data/locales/ckb_IR.txt
+++ b/icu4c/source/data/locales/ckb_IR.txt
@@ -2,6 +2,8 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 // Generated using tools/cldr/cldr-to-icu/
 ckb_IR{
+    %%Parent{"ckb"}
+
     // 1. Enable Persian/Extended Arabic numbering system (۰، ۱، ۲، ۳، ۴، ۵، ۶، ۷، ۸، ۹)
     defaultNumberingSystem{"arabext"}
 

--- a/icu4c/source/data/locales/ckb_IR.txt
+++ b/icu4c/source/data/locales/ckb_IR.txt
@@ -1,7 +1,12 @@
-﻿// © 2016 and later: Unicode, Inc. and others.
+// © 2016 and later: Unicode, Inc. and others.
 // License & terms of use: http://www.unicode.org/copyright.html
 // Generated using tools/cldr/cldr-to-icu/
 ckb_IR{
+    %%Parent{"ckb"}
+
+    // 1. Enable Persian/Extended Arabic numbering system (۰، ۱، ۲، ۳، ۴، ۵، ۶، ۷، ۸، ۹)
+    defaultNumberingSystem{"arabext"}
+
     calendar{
         default{"persian"}
         gregorian{
@@ -11,7 +16,7 @@ ckb_IR{
                 "HH:mm:ss",
                 "HH:mm",
                 "y MMMM d, EEEE",
-                "dی MMMMی y",
+                "d ی MMMMی y",
                 "y MMM d",
                 "y-MM-dd",
                 "{1} {0}",
@@ -30,6 +35,39 @@ ckb_IR{
                 "yMMMd",
                 "yMMdd",
             }
+            // 2. Gregorian month names in Latin script
+            months{
+                format{
+                    wide{
+                        "January",
+                        "February",
+                        "March",
+                        "April",
+                        "May",
+                        "June",
+                        "July",
+                        "August",
+                        "September",
+                        "October",
+                        "November",
+                        "December",
+                    }
+                    abbreviated{
+                        "Jan",
+                        "Feb",
+                        "Mar",
+                        "Apr",
+                        "May",
+                        "Jun",
+                        "Jul",
+                        "Aug",
+                        "Sep",
+                        "Oct",
+                        "Nov",
+                        "Dec",
+                    }
+                }
+            }
         }
         persian{
             DateTimePatterns{
@@ -38,7 +76,7 @@ ckb_IR{
                 "HH:mm:ss",
                 "HH:mm",
                 "G y MMMM d, EEEE",
-                "dی MMMMی y G",
+                "d ی MMMMی y G",
                 "G y MMM d",
                 "G y-MM-dd",
                 "{1} {0}",
@@ -57,7 +95,8 @@ ckb_IR{
                 "GyMMMd",
                 "GGGGGyMMdd",
             }
-            monthNames{
+            // 3. Persian calendar with corrected native Kurdish month names
+            months{
                 format{
                     wide{
                         "خاکەلێوە",
@@ -67,11 +106,25 @@ ckb_IR{
                         "گەلاوێژ",
                         "خەرمانان",
                         "ڕەزبەر",
-                        "گەڵاڕێزان",
+                        "خەزەڵوەر",
                         "سەرماوەز",
                         "بەفرانبار",
                         "ڕێبەندان",
-                        "ڕەشەمە",
+                        "ڕەشەمێ",
+                    }
+                    abbreviated{
+                        "خاکەلێوە",
+                        "گوڵان",
+                        "جۆزەردان",
+                        "پووشپەڕ",
+                        "گەلاوێژ",
+                        "خەرمانان",
+                        "ڕەزبەر",
+                        "خەزەڵوەر",
+                        "سەرماوەز",
+                        "بەفرانبار",
+                        "ڕێبەندان",
+                        "ڕەشەمێ",
                     }
                 }
             }


### PR DESCRIPTION
Hello Unicode ICU Team,

I have updated and standardized the Central Kurdish (Sorani) locale data files (`ckb.txt`, `ckb_IQ.txt`, and `ckb_IR.txt`) to fix typography issues, improve spacing, and align regional formatting for both Iraq and Iran locales.

### Summary of Changes:
1. **General/Typography Fixes (`ckb.txt`):** Fixed a spelling inconsistency in December, added missing abbreviated month names, and updated March to the standard form "ئادار". Also fixed day numbering spacing from `dی` to `d ی`.
2. **Iraq Locale (`ckb_IQ.txt`):** Set as a clean inheritance from the base locale to keep the standard numbering system and regional Gregorian months intact.
3. **Iran Locale (`ckb_IR.txt`):** Maintained the Persian calendar as default with pure Kurdish month names. Set Gregorian months to Latin script for a clean UI and enabled the `arabext` numbering system.

Please review and merge these enhancements. Thank you!
