### PR TITLE
ICU-23297 A new UnicodeSet parser: Java edition

### DIFF
--- a/icu4c/source/common/uniset_props.cpp
+++ b/icu4c/source/common/uniset_props.cpp
@@ -631,6 +631,10 @@ class UnicodeSet::Lexer {
                 if (last == u':') {
                     if (!hex.has_value()) {
                         hex.emplace();
+                        if (start == parsePosition_.getIndex() - 1) {
+                            errorCode = U_ILLEGAL_ARGUMENT_ERROR;
+                            return {};
+                        }
                         for (char16_t digit : std::u16string_view(pattern_).substr(
                                  start, parsePosition_.getIndex() - 1 - start)) {
                             uint8_t nibble;
@@ -975,7 +979,7 @@ void UnicodeSet::parseUnicodeSet(Lexer &lexer,
     // A pattern that preserves the original syntax but strips spaces, normalizes escaping, etc.
     UnicodeString prettyPrintedPattern;
     if (lexer.lookahead().set() != nullptr) {
-        // UnicodeSet ::= property-query | named-element
+        // UnicodeSet ::= property-query
         // Extension:
         //              | set-valued-variable
         *this = *lexer.lookahead().set();
@@ -999,7 +1003,7 @@ void UnicodeSet::parseUnicodeSet(Lexer &lexer,
             }
             prettyPrintedPattern.append(u']');
         } else {
-            U_UNICODESET_RETURN_WITH_PARSE_ERROR(R"([: | \p | \P | \N | [)",
+            U_UNICODESET_RETURN_WITH_PARSE_ERROR("property-query | [",
                                                  lexer.lookahead().debugString(), lexer,
                                                  ec);
         }

--- a/icu4c/source/test/intltest/usettest.cpp
+++ b/icu4c/source/test/intltest/usettest.cpp
@@ -4821,7 +4821,7 @@ void UnicodeSetTest::TestParseErrors() {
     for (const auto expression : std::vector<std::u16string_view>{
             // Java error message: "Invalid property pattern".
             u"[:]",
-            uR"(\p)"
+            uR"(\p)",
             u"[:^]",
             uR"(\P)",
             uR"(\N)",

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/RBBISymbolTable.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/RBBISymbolTable.java
@@ -17,12 +17,6 @@ class RBBISymbolTable implements SymbolTable {
     HashMap<String, RBBISymbolTableEntry> fHashTable;
     RBBIRuleScanner fRuleScanner;
 
-    // These next two fields are part of the mechanism for passing references to
-    //   already-constructed UnicodeSets back to the UnicodeSet constructor
-    //   when the pattern includes $variable references.
-    String ffffString;
-    UnicodeSet fCachedSetLookup;
-
     static class RBBISymbolTableEntry {
         String key;
         RBBINode val;
@@ -31,7 +25,6 @@ class RBBISymbolTable implements SymbolTable {
     RBBISymbolTable(RBBIRuleScanner rs) {
         fRuleScanner = rs;
         fHashTable = new HashMap<String, RBBISymbolTableEntry>();
-        ffffString = "\uffff";
     }
 
     //
@@ -43,63 +36,48 @@ class RBBISymbolTable implements SymbolTable {
     //
     @Override
     public char[] lookup(String s) {
-        RBBISymbolTableEntry el;
-        RBBINode varRefNode;
-        RBBINode exprNode;
-
-        RBBINode usetNode;
-        String retString;
-
-        el = fHashTable.get(s);
+        final RBBISymbolTableEntry el = fHashTable.get(s);
         if (el == null) {
             return null;
         }
 
-        // Walk through any chain of variable assignments that ultimately resolve to a Set Ref.
-        varRefNode = el.val;
-        while (varRefNode.fLeftChild.fType == RBBINode.varRef) {
-            varRefNode = varRefNode.fLeftChild;
-        }
-
-        exprNode = varRefNode.fLeftChild; // Root node of expression for variable
-        if (exprNode.fType == RBBINode.setRef) {
-            // The $variable refers to a single UnicodeSet
-            //   return the ffffString, which will subsequently be interpreted as a
-            //   stand-in character for the set by RBBISymbolTable::lookupMatcher()
-            usetNode = exprNode.fLeftChild;
-            fCachedSetLookup = usetNode.fInputSet;
-            retString = ffffString;
-        } else {
-            // The variable refers to something other than just a set.
-            // This is an error in the rules being compiled.  $Variables inside of UnicodeSets
-            //   must refer only to another set, not to some random non-set expression.
-            //   Note:  single characters are represented as sets, so they are ok.
-            fRuleScanner.error(RBBIRuleBuilder.U_BRK_MALFORMED_SET);
-            retString = exprNode.fText;
-            fCachedSetLookup = null;
-        }
-        return retString.toCharArray();
+        final RBBINode exprNode = el.val.fLeftChild; // Root node of expression for variable
+        // Return the original source string for the expression.
+        // Note that for set-valued variables used in UnicodeSet expressions, this would be rejected
+        // by the UnicodeSet parser if the source itself contains variable references.  For
+        // instance, with
+        //     $CaseIgnorable   = [[:Mn:][:Me:][:Cf:][:Lm:][:Sk:] \u0027 \u00AD \u2019];
+        //     $Cased = [[:Upper_Case:][:Lower_Case:][:Lt:] - $CaseIgnorable];
+        // If lookupSet were not overridden, when parsing the right-hand side of
+        //     $NotCased        = [[^ $Cased] - $CaseIgnorable];
+        // there would be a call to lookup("Cased") which would return
+        //     "[[:Upper_Case:][:Lower_Case:][:Lt:]-$CaseIgnorable]". This contains a variable,
+        // which is  disallowed by the UnicodeSet parser inside a variable expansion.
+        // However, set-valued variables are pre-parsed, and returned by lookupSet instead, so this
+        // call to lookup() never happens; instead, lookupSet("CaseIgnorable") is called when
+        // computing $Cased and returns the non-null value of $CaseIgnorable, and then when
+        // computing $NotCased, lookupSet("Cased") returns the value computed for $Cased.
+        return exprNode.fText.toCharArray();
     }
 
-    //
-    //  RBBISymbolTable::lookupMatcher   This function from the abstract symbol table
-    //                                   interface maps a single stand-in character to a
-    //                                   pointer to a Unicode Set.   The Unicode Set code uses this
-    //                                   mechanism to get all references to the same $variable
-    //                                   name to refer to a single common Unicode Set instance.
-    //
-    //    This implementation cheats a little, and does not maintain a map of stand-in chars
-    //    to sets.  Instead, it takes advantage of the fact that  the UnicodeSet
-    //    constructor will always call this function right after calling lookup(),
-    //    and we just need to remember what set to return between these two calls.
+    @Override
+    public UnicodeSet lookupSet(String s) {
+        final RBBISymbolTableEntry el = fHashTable.get(s);
+        if (el == null) {
+            return null;
+        }
+        final RBBINode exprNode = el.val.fLeftChild;
+        if (exprNode.fType == RBBINode.setRef) {
+            return exprNode.fLeftChild.fInputSet;
+        } else {
+            return null;
+        }
+    }
+
+    // No longer used, see ICU-23297.
     @Override
     public UnicodeMatcher lookupMatcher(int ch) {
-        UnicodeSet retVal = null;
-        if (ch == 0xffff) {
-            retVal = fCachedSetLookup;
-            fCachedSetLookup = null;
-        }
-        return retVal;
+        return null;
     }
 
     //

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/SymbolTable.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/SymbolTable.java
@@ -53,6 +53,18 @@ public interface SymbolTable {
     char[] lookup(String s);
 
     /**
+     * Returns a pre-parsed set associated with the variable with the given name, or null if there
+     * is no such set (as is the case for an undefined or string-valued variable).
+     *
+     * @internal
+     * @deprecated This API is ICU internal only.
+     */
+    @Deprecated
+    default UnicodeSet lookupSet(String name) {
+        return null;
+    }
+
+    /**
      * Lookup the UnicodeMatcher associated with the given character, and return it. Return {@code
      * null} if not found.
      *

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/UnicodeSet.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/UnicodeSet.java
@@ -13,7 +13,6 @@ import com.ibm.icu.impl.CharacterPropertiesImpl;
 import com.ibm.icu.impl.PatternProps;
 import com.ibm.icu.impl.RuleCharacterIterator;
 import com.ibm.icu.impl.SortedSetRelation;
-import com.ibm.icu.impl.StringRange;
 import com.ibm.icu.impl.UCaseProps;
 import com.ibm.icu.impl.UCharacterProperty;
 import com.ibm.icu.impl.UPropertyAliases;
@@ -627,19 +626,6 @@ public class UnicodeSet extends UnicodeFilter
             } else {
                 app.append(UTF16.getLeadSurrogate(c)).append(UTF16.getTrailSurrogate(c));
             }
-        } catch (IOException e) {
-            throw new ICUUncheckedIOException(e);
-        }
-    }
-
-    /**
-     * TODO: create class Appendables?
-     *
-     * @throws IOException
-     */
-    private static void append(Appendable app, CharSequence s) {
-        try {
-            app.append(s);
         } catch (IOException e) {
             throw new ICUUncheckedIOException(e);
         }
@@ -2519,7 +2505,7 @@ public class UnicodeSet extends UnicodeFilter
 
         StringBuilder rebuiltPat = new StringBuilder();
         RuleCharacterIterator chars = new RuleCharacterIterator(pattern, symbols, pos);
-        applyPattern(chars, symbols, rebuiltPat, options, 0);
+        applyPattern(pattern, pos, chars, symbols, rebuiltPat, options, 0);
         if (chars.inVariable()) {
             syntaxError(chars, "Extra chars in variable value");
         }
@@ -2539,21 +2525,14 @@ public class UnicodeSet extends UnicodeFilter
         return this;
     }
 
-    // Add constants to make the applyPattern() code easier to follow.
-
-    private static final int LAST0_START = 0, LAST1_RANGE = 1, LAST2_SET = 2;
-    private static final int MODE0_NONE = 0, MODE1_INBRACKET = 1, MODE2_OUTBRACKET = 2;
-    private static final int SETMODE0_NONE = 0,
-            SETMODE1_UNICODESET = 1,
-            SETMODE2_PROPERTYPAT = 2,
-            SETMODE3_PREPARSED = 3;
-
     private static final int MAX_DEPTH = 100;
 
     /**
      * Parse the pattern from the given RuleCharacterIterator. The iterator is advanced over the
      * parsed pattern.
      *
+     * @param pattern The pattern, only used by debug traces.
+     * @param parsePosition The ParsePosition underlying chars, only used by debug traces.
      * @param chars iterator over the pattern characters. Upon return it will be advanced to the
      *     first character after the parsed pattern, or the end of the iteration if all characters
      *     are parsed.
@@ -2565,401 +2544,15 @@ public class UnicodeSet extends UnicodeFilter
      *     case options are mutually exclusive.
      */
     private void applyPattern(
+            String pattern,
+            ParsePosition parsePosition,
             RuleCharacterIterator chars,
             SymbolTable symbols,
-            Appendable rebuiltPat,
+            StringBuilder rebuiltPat,
             int options,
             int depth) {
-        if (depth > MAX_DEPTH) {
-            syntaxError(chars, "Pattern nested too deeply");
-        }
-
-        // Syntax characters: [ ] ^ - & { }
-
-        // Recognized special forms for chars, sets: c-c s-s s&s
-
-        int opts = RuleCharacterIterator.PARSE_VARIABLES | RuleCharacterIterator.PARSE_ESCAPES;
-        if ((options & IGNORE_SPACE) != 0) {
-            opts |= RuleCharacterIterator.SKIP_WHITESPACE;
-        }
-
-        StringBuilder patBuf = new StringBuilder(), buf = null;
-        boolean usePat = false;
-        UnicodeSet scratch = null;
-        RuleCharacterIterator.Position backup = null;
-
-        // mode: 0=before [, 1=between [...], 2=after ]
-        // lastItem: 0=none, 1=char, 2=set
-        int lastItem = LAST0_START, lastChar = 0, mode = MODE0_NONE;
-        char op = 0;
-
-        boolean invert = false;
-
-        clear();
-        String lastString = null;
-
-        while (mode != MODE2_OUTBRACKET && !chars.atEnd()) {
-            // Eclipse stated the following is "dead code"
-            /*
-            if (false) {
-                // Debugging assertion
-                if (!((lastItem == 0 && op == 0) ||
-                        (lastItem == 1 && (op == 0 || op == '-')) ||
-                        (lastItem == 2 && (op == 0 || op == '-' || op == '&')))) {
-                    throw new IllegalArgumentException();
-                }
-            }*/
-
-            int c = 0;
-            boolean literal = false;
-            UnicodeSet nested = null;
-
-            // -------- Check for property pattern
-
-            // setMode: 0=none, 1=unicodeset, 2=propertypat, 3=preparsed
-            int setMode = SETMODE0_NONE;
-            if (resemblesPropertyPattern(chars, opts)) {
-                setMode = SETMODE2_PROPERTYPAT;
-            }
-
-            // -------- Parse '[' of opening delimiter OR nested set.
-            // If there is a nested set, use `setMode' to define how
-            // the set should be parsed.  If the '[' is part of the
-            // opening delimiter for this pattern, parse special
-            // strings "[", "[^", "[-", and "[^-".  Check for stand-in
-            // characters representing a nested set in the symbol
-            // table.
-
-            else {
-                // Prepare to backup if necessary
-                backup = chars.getPos(backup);
-                c = chars.next(opts);
-                literal = chars.isEscaped();
-
-                if (c == '[' && !literal) {
-                    if (mode == MODE1_INBRACKET) {
-                        chars.setPos(backup); // backup
-                        setMode = SETMODE1_UNICODESET;
-                    } else {
-                        // Handle opening '[' delimiter
-                        mode = MODE1_INBRACKET;
-                        patBuf.append('[');
-                        backup = chars.getPos(backup); // prepare to backup
-                        c = chars.next(opts);
-                        literal = chars.isEscaped();
-                        if (c == '^' && !literal) {
-                            invert = true;
-                            patBuf.append('^');
-                            backup = chars.getPos(backup); // prepare to backup
-                            c = chars.next(opts);
-                            literal = chars.isEscaped();
-                        }
-                        // Fall through to handle special leading '-';
-                        // otherwise restart loop for nested [], \p{}, etc.
-                        if (c == '-') {
-                            literal = true;
-                            // Fall through to handle literal '-' below
-                        } else {
-                            chars.setPos(backup); // backup
-                            continue;
-                        }
-                    }
-                } else if (symbols != null) {
-                    UnicodeMatcher m = symbols.lookupMatcher(c); // may be null
-                    if (m != null) {
-                        try {
-                            nested = (UnicodeSet) m;
-                            setMode = SETMODE3_PREPARSED;
-                        } catch (ClassCastException e) {
-                            syntaxError(chars, "Syntax error");
-                        }
-                    }
-                }
-            }
-
-            // -------- Handle a nested set.  This either is inline in
-            // the pattern or represented by a stand-in that has
-            // previously been parsed and was looked up in the symbol
-            // table.
-
-            if (setMode != SETMODE0_NONE) {
-                if (lastItem == LAST1_RANGE) {
-                    if (op != 0) {
-                        syntaxError(chars, "Char expected after operator");
-                    }
-                    add_unchecked(lastChar, lastChar);
-                    _appendToPat(patBuf, lastChar, false);
-                    lastItem = LAST0_START;
-                    op = 0;
-                }
-
-                if (op == '-' || op == '&') {
-                    patBuf.append(op);
-                }
-
-                if (nested == null) {
-                    if (scratch == null) scratch = new UnicodeSet();
-                    nested = scratch;
-                }
-                switch (setMode) {
-                    case SETMODE1_UNICODESET:
-                        nested.applyPattern(chars, symbols, patBuf, options, depth + 1);
-                        break;
-                    case SETMODE2_PROPERTYPAT:
-                        chars.skipIgnored(opts);
-                        nested.applyPropertyPattern(chars, patBuf, symbols);
-                        break;
-                    case SETMODE3_PREPARSED: // `nested' already parsed
-                        nested._toPattern(patBuf, false);
-                        break;
-                }
-
-                usePat = true;
-
-                if (mode == MODE0_NONE) {
-                    // Entire pattern is a category; leave parse loop
-                    set(nested);
-                    mode = MODE2_OUTBRACKET;
-                    break;
-                }
-
-                switch (op) {
-                    case '-':
-                        removeAll(nested);
-                        break;
-                    case '&':
-                        retainAll(nested);
-                        break;
-                    case 0:
-                        addAll(nested);
-                        break;
-                }
-
-                op = 0;
-                lastItem = LAST2_SET;
-
-                continue;
-            }
-
-            if (mode == MODE0_NONE) {
-                syntaxError(chars, "Missing '['");
-            }
-
-            // -------- Parse special (syntax) characters.  If the
-            // current character is not special, or if it is escaped,
-            // then fall through and handle it below.
-
-            if (!literal) {
-                switch (c) {
-                    case ']':
-                        if (lastItem == LAST1_RANGE) {
-                            add_unchecked(lastChar, lastChar);
-                            _appendToPat(patBuf, lastChar, false);
-                        }
-                        // Treat final trailing '-' as a literal
-                        if (op == '-') {
-                            add_unchecked(op, op);
-                            patBuf.append(op);
-                        } else if (op == '&') {
-                            syntaxError(chars, "Trailing '&'");
-                        }
-                        patBuf.append(']');
-                        mode = MODE2_OUTBRACKET;
-                        continue;
-                    case '-':
-                        if (op == 0) {
-                            if (lastItem != LAST0_START) {
-                                op = (char) c;
-                                continue;
-                            } else if (lastString != null) {
-                                op = (char) c;
-                                continue;
-                            } else {
-                                // Treat final trailing '-' as a literal
-                                add_unchecked(c, c);
-                                c = chars.next(opts);
-                                literal = chars.isEscaped();
-                                if (c == ']' && !literal) {
-                                    patBuf.append("-]");
-                                    mode = MODE2_OUTBRACKET;
-                                    continue;
-                                }
-                            }
-                        }
-                        syntaxError(chars, "'-' not after char, string, or set");
-                        break;
-                    case '&':
-                        if (lastItem == LAST2_SET && op == 0) {
-                            op = (char) c;
-                            continue;
-                        }
-                        syntaxError(chars, "'&' not after set");
-                        break;
-                    case '^':
-                        syntaxError(chars, "'^' not after '['");
-                        break;
-                    case '{':
-                        if (op != 0 && op != '-') {
-                            syntaxError(chars, "Missing operand after operator");
-                        }
-                        if (lastItem == LAST1_RANGE) {
-                            add_unchecked(lastChar, lastChar);
-                            _appendToPat(patBuf, lastChar, false);
-                        }
-                        lastItem = LAST0_START;
-                        if (buf == null) {
-                            buf = new StringBuilder();
-                        } else {
-                            buf.setLength(0);
-                        }
-                        boolean ok = false;
-                        while (!chars.atEnd()) {
-                            c = chars.next(opts);
-                            literal = chars.isEscaped();
-                            if (c == '}' && !literal) {
-                                ok = true;
-                                break;
-                            }
-                            appendCodePoint(buf, c);
-                        }
-                        if (!ok) {
-                            syntaxError(chars, "Invalid multicharacter string");
-                        }
-                        // We have new string. Add it to set and continue;
-                        // we don't need to drop through to the further
-                        // processing
-                        String curString = buf.toString();
-                        if (op == '-') {
-                            int lastSingle =
-                                    CharSequences.getSingleCodePoint(
-                                            lastString == null ? "" : lastString);
-                            int curSingle = CharSequences.getSingleCodePoint(curString);
-                            if (lastSingle != Integer.MAX_VALUE && curSingle != Integer.MAX_VALUE) {
-                                add(lastSingle, curSingle);
-                            } else {
-                                if (strings == EMPTY_STRINGS) {
-                                    strings = new TreeSet<>();
-                                }
-                                try {
-                                    StringRange.expand(lastString, curString, true, strings);
-                                } catch (Exception e) {
-                                    syntaxError(chars, e.getMessage());
-                                }
-                            }
-                            lastString = null;
-                            op = 0;
-                        } else {
-                            add(curString);
-                            lastString = curString;
-                        }
-                        patBuf.append('{');
-                        _appendToPat(patBuf, curString, false);
-                        patBuf.append('}');
-                        continue;
-                    case SymbolTable.SYMBOL_REF:
-                        //         symbols  nosymbols
-                        // [a-$]   error    error (ambiguous)
-                        // [a$]    anchor   anchor
-                        // [a-$x]  var "x"* literal '$'
-                        // [a-$.]  error    literal '$'
-                        // *We won't get here in the case of var "x"
-                        backup = chars.getPos(backup);
-                        c = chars.next(opts);
-                        literal = chars.isEscaped();
-                        boolean anchor = (c == ']' && !literal);
-                        if (symbols == null && !anchor) {
-                            c = SymbolTable.SYMBOL_REF;
-                            chars.setPos(backup);
-                            break; // literal '$'
-                        }
-                        if (anchor && op == 0) {
-                            if (lastItem == LAST1_RANGE) {
-                                add_unchecked(lastChar, lastChar);
-                                _appendToPat(patBuf, lastChar, false);
-                            }
-                            add_unchecked(UnicodeMatcher.ETHER);
-                            usePat = true;
-                            patBuf.append(SymbolTable.SYMBOL_REF).append(']');
-                            mode = MODE2_OUTBRACKET;
-                            continue;
-                        }
-                        syntaxError(chars, "Unquoted '$'");
-                        break;
-                    default:
-                        break;
-                }
-            }
-
-            // -------- Parse literal characters.  This includes both
-            // escaped chars ("\u4E01") and non-syntax characters
-            // ("a").
-
-            switch (lastItem) {
-                case LAST0_START:
-                    if (op == '-' && lastString != null) {
-                        syntaxError(chars, "Invalid range");
-                    }
-                    lastItem = LAST1_RANGE;
-                    lastChar = c;
-                    lastString = null;
-                    break;
-                case LAST1_RANGE:
-                    if (op == '-') {
-                        if (lastString != null) {
-                            syntaxError(chars, "Invalid range");
-                        }
-                        if (lastChar >= c) {
-                            // Don't allow redundant (a-a) or empty (b-a) ranges;
-                            // these are most likely typos.
-                            syntaxError(chars, "Invalid range");
-                        }
-                        add_unchecked(lastChar, c);
-                        _appendToPat(patBuf, lastChar, false);
-                        patBuf.append(op);
-                        _appendToPat(patBuf, c, false);
-                        lastItem = LAST0_START;
-                        op = 0;
-                    } else {
-                        add_unchecked(lastChar, lastChar);
-                        _appendToPat(patBuf, lastChar, false);
-                        lastChar = c;
-                    }
-                    break;
-                case LAST2_SET:
-                    if (op != 0) {
-                        syntaxError(chars, "Set expected after operator");
-                    }
-                    lastChar = c;
-                    lastItem = LAST1_RANGE;
-                    break;
-            }
-        }
-
-        if (mode != MODE2_OUTBRACKET) {
-            syntaxError(chars, "Missing ']'");
-        }
-
-        chars.skipIgnored(opts);
-
-        /*
-         * Handle global flags (invert, case insensitivity). If this pattern should be compiled
-         * case-insensitive, then we need to close over case BEFORE COMPLEMENTING. This makes
-         * patterns like /[^abc]/i work.
-         */
-        if ((options & CASE_MASK) != 0) {
-            closeOver(options);
-        }
-        if (invert) {
-            complement().removeAllStrings(); // code point complement
-        }
-
-        // Use the rebuilt pattern (pat) only if necessary.  Prefer the
-        // generated pattern.
-        if (usePat) {
-            append(rebuiltPat, patBuf.toString());
-        } else {
-            appendNewPattern(rebuiltPat, false, true);
-        }
+        final var lexer = new UnicodeSetLexer(pattern, parsePosition, chars, options, symbols);
+        parseUnicodeSet(lexer, rebuiltPat, options, depth);
     }
 
     private static void syntaxError(RuleCharacterIterator chars, String msg) {
@@ -3593,7 +3186,7 @@ public class UnicodeSet extends UnicodeFilter
             }
         }
 
-        if (valueAlias != null && !valueAlias.isEmpty()) {
+        if (valueAlias != null) {
             p = UCharacter.getPropertyEnum(propertyAlias);
 
             // Treat gc as gcm
@@ -3741,138 +3334,6 @@ public class UnicodeSet extends UnicodeFilter
         return pattern.regionMatches(pos, "[:", 0, 2)
                 || pattern.regionMatches(true, pos, "\\p", 0, 2)
                 || pattern.regionMatches(pos, "\\N", 0, 2);
-    }
-
-    /**
-     * Return true if the given iterator appears to point at a property pattern. Regardless of the
-     * result, return with the iterator unchanged.
-     *
-     * @param chars iterator over the pattern characters. Upon return it will be unchanged.
-     * @param iterOpts RuleCharacterIterator options
-     */
-    private static boolean resemblesPropertyPattern(RuleCharacterIterator chars, int iterOpts) {
-        boolean result = false;
-        iterOpts &= ~RuleCharacterIterator.PARSE_ESCAPES;
-        RuleCharacterIterator.Position pos = chars.getPos(null);
-        int c = chars.next(iterOpts);
-        if (c == '[' || c == '\\') {
-            int d = chars.next(iterOpts & ~RuleCharacterIterator.SKIP_WHITESPACE);
-            result = (c == '[') ? (d == ':') : (d == 'N' || d == 'p' || d == 'P');
-        }
-        chars.setPos(pos);
-        return result;
-    }
-
-    /**
-     * Parse the given property pattern at the given parse position.
-     *
-     * @param symbols TODO
-     */
-    private UnicodeSet applyPropertyPattern(
-            String pattern, ParsePosition ppos, SymbolTable symbols) {
-        int pos = ppos.getIndex();
-
-        // On entry, ppos should point to one of the following locations:
-
-        // Minimum length is 5 characters, e.g. \p{L}
-        if ((pos + 5) > pattern.length()) {
-            return null;
-        }
-
-        boolean posix = false; // true for [:pat:], false for \p{pat} \P{pat} \N{pat}
-        boolean isName = false; // true for \N{pat}, o/w false
-        boolean invert = false;
-
-        // Look for an opening [:, [:^, \p, or \P
-        if (pattern.regionMatches(pos, "[:", 0, 2)) {
-            posix = true;
-            pos = PatternProps.skipWhiteSpace(pattern, (pos + 2));
-            if (pos < pattern.length() && pattern.charAt(pos) == '^') {
-                ++pos;
-                invert = true;
-            }
-        } else if (pattern.regionMatches(true, pos, "\\p", 0, 2)
-                || pattern.regionMatches(pos, "\\N", 0, 2)) {
-            char c = pattern.charAt(pos + 1);
-            invert = (c == 'P');
-            isName = (c == 'N');
-            pos = PatternProps.skipWhiteSpace(pattern, (pos + 2));
-            if (pos == pattern.length() || pattern.charAt(pos++) != '{') {
-                // Syntax error; "\p" or "\P" not followed by "{"
-                return null;
-            }
-        } else {
-            // Open delimiter not seen
-            return null;
-        }
-
-        // Look for the matching close delimiter, either :] or }
-        int close = pattern.indexOf(posix ? ":]" : "}", pos);
-        if (close < 0) {
-            // Syntax error; close delimiter missing
-            return null;
-        }
-
-        // Look for an '=' sign.  If this is present, we will parse a
-        // medium \p{gc=Cf} or long \p{GeneralCategory=Format}
-        // pattern.
-        int equals = pattern.indexOf('=', pos);
-        String propName, valueName;
-        if (equals >= 0 && equals < close && !isName) {
-            // Equals seen; parse medium/long pattern
-            propName = pattern.substring(pos, equals);
-            valueName = pattern.substring(equals + 1, close);
-        } else {
-            // Handle case where no '=' is seen, and \N{}
-            propName = pattern.substring(pos, close);
-            valueName = null;
-
-            // Handle \N{name}
-            if (isName) {
-                // This is a little inefficient since it means we have to
-                // parse "na" back to UProperty.NAME even though we already
-                // know it's UProperty.NAME.  If we refactor the API to
-                // support args of (int, String) then we can remove
-                // "na" and make this a little more efficient.
-                valueName = propName;
-                propName = "na";
-            }
-        }
-
-        applyPropertyAlias(propName, valueName, symbols);
-
-        if (invert) {
-            complement().removeAllStrings(); // code point complement
-        }
-
-        // Move to the limit position after the close delimiter
-        ppos.setIndex(close + (posix ? 2 : 1));
-
-        return this;
-    }
-
-    /**
-     * Parse a property pattern.
-     *
-     * @param chars iterator over the pattern characters. Upon return it will be advanced to the
-     *     first character after the parsed pattern, or the end of the iteration if all characters
-     *     are parsed.
-     * @param rebuiltPat the pattern that was parsed, rebuilt or copied from the input pattern, as
-     *     appropriate.
-     * @param symbols TODO
-     */
-    private void applyPropertyPattern(
-            RuleCharacterIterator chars, Appendable rebuiltPat, SymbolTable symbols) {
-        String patStr = chars.getCurrentBuffer();
-        int start = chars.getCurrentBufferPos();
-        ParsePosition pos = new ParsePosition(start);
-        applyPropertyPattern(patStr, pos, symbols);
-        int length = pos.getIndex() - start;
-        if (length == 0) {
-            syntaxError(chars, "Invalid property pattern");
-        }
-        chars.jumpahead(length);
-        append(rebuiltPat, patStr.substring(start, pos.getIndex()));
     }
 
     // ----------------------------------------------------------------
@@ -4219,6 +3680,33 @@ public class UnicodeSet extends UnicodeFilter
          */
         @Override
         public String parseReference(String text, ParsePosition pos, int limit) {
+            return null;
+        }
+
+        /**
+         * If the source text has a valid variable starting at pos, advances pos past that variable
+         * and returns the name that should be passed to lookup or lookupSet. Otherwise, returns
+         * null and does not advance pos. By default, this method checks for variables with a $
+         * sigil, but it can be overriden to support other variable syntaxes, e.g., the use of short
+         * Line_Break value aliases for sets in UAX #14 rules ([QU-\p{Pi}] for [\p{lb=QU}-\p{Pi}]).
+         *
+         * @internal
+         * @deprecated This API is ICU internal only.
+         */
+        @Deprecated
+        public String scanVariable(String text, ParsePosition pos, int limit) {
+            if (pos.getIndex() >= limit) {
+                return null;
+            }
+            if (text.charAt(pos.getIndex()) == '$') {
+                final var pastDollar = new ParsePosition(pos.getIndex() + 1);
+                final var name = parseReference(text, pastDollar, limit);
+                if (name != null) {
+                    pos.setIndex(pastDollar.getIndex());
+                    return name;
+                }
+                return null;
+            }
             return null;
         }
     }
@@ -5415,6 +4903,274 @@ public class UnicodeSet extends UnicodeFilter
             }
             return rangeStart++;
         }
+    }
+
+    void setPattern(String newPat) {
+        pat = newPat;
+    }
+
+    private static class GrammaticalConstructProperties {
+        boolean containsRestriction = false;
+    }
+
+    void parseUnicodeSet(UnicodeSetLexer lexer, StringBuilder rebuiltPat, int options, int depth) {
+        clear();
+
+        if (depth > MAX_DEPTH) {
+            throw lexer.syntaxError("depth <= " + MAX_DEPTH, "depth = " + depth);
+        }
+
+        boolean isComplement = false;
+        // Whether to keep the syntax of the pattern at this level, only doing basic
+        // pretty-printing, e.g.,
+        // turn [ c - z[a]a - b ] into [c-z[a]a-b], but not into [a-z].
+        // This is true for a property query, or when there is a nested set.  Note that since we
+        // recurse,
+        // innermost sets consisting only of ranges will get simplified.
+        boolean preserveSyntaxInPattern = false;
+        // A pattern that preserves the original syntax but strips spaces, normalizes escaping, etc.
+        final var prettyPrintedPattern = new StringBuilder();
+        if (lexer.lookahead().set() != null) {
+            // UnicodeSet ::= property-query
+            // Extension:
+            //              | set-valued-variable
+            set(lexer.lookahead().set());
+            _toPattern(prettyPrintedPattern, /* escapeUnprintable= */ false);
+            lexer.advance();
+            preserveSyntaxInPattern = true;
+        } else {
+            // UnicodeSet ::=                [   Union ]
+            //              | Complement ::= [ ^ Union ]
+            if (lexer.acceptSetOperator('[')) {
+                prettyPrintedPattern.append('[');
+                if (lexer.acceptSetOperator('^')) {
+                    prettyPrintedPattern.append('^');
+                    isComplement = true;
+                }
+                final var unionProperties = new GrammaticalConstructProperties();
+                parseUnion(lexer, prettyPrintedPattern, options, depth, unionProperties);
+                preserveSyntaxInPattern |= unionProperties.containsRestriction;
+                if (!lexer.acceptSetOperator(']')) {
+                    throw lexer.syntaxError("]", lexer.lookahead().debugString());
+                }
+                prettyPrintedPattern.append(']');
+            } else {
+                throw lexer.syntaxError("property-query | [", lexer.lookahead().debugString());
+            }
+        }
+
+        /**
+         * Handle global flags (isComplement, case insensitivity). If this pattern should be
+         * compiled case-insensitive, then we need to close over case BEFORE COMPLEMENTING. This
+         * makes patterns like /[^abc]/i work.
+         */
+        if ((options & CASE_MASK) != 0) {
+            closeOver(options);
+        }
+        if (isComplement) {
+            complement().removeAllStrings(); // code point complement
+        }
+        if (preserveSyntaxInPattern) {
+            rebuiltPat.append(prettyPrintedPattern);
+        } else {
+            final var sb = new StringBuffer();
+            _generatePattern(sb, /* escapeUnprintable= */ false);
+            rebuiltPat.append(sb);
+        }
+    }
+
+    void parseUnion(
+            UnicodeSetLexer lexer,
+            StringBuilder rebuiltPat,
+            int options,
+            int depth,
+            GrammaticalConstructProperties properties) {
+        // Union ::= Terms
+        //         | UnescapedHyphenMinus Terms
+        //         | Terms UnescapedHyphenMinus
+        //         | UnescapedHyphenMinus Terms UnescapedHyphenMinus
+        // Terms ::= ""
+        //         | Terms Term
+        if (lexer.acceptSetOperator('-')) {
+            add('-');
+            // When we otherwise preserve the syntax, we escape an initial UnescapedHyphenMinus, but
+            // not a
+            // final one, for consistency with older ICU behaviour.
+            rebuiltPat.append("\\-");
+        }
+        while (!lexer.atEnd()) {
+            // Note that while a HYPHEN-MINUS mapped by the symbol table is treated as a literal at
+            // the
+            // beginning of the Union, it is treated as a set elsewhere, including at the end.
+            if (lexer.acceptSetOperator('-')) {
+                // We can be here on the first iteration: [--] is allowed by the
+                // grammar and by the old parser.
+                rebuiltPat.append('-');
+                add('-');
+                return;
+            } else if (lexer.lookahead().isSetOperator('$')) {
+                if (lexer.lookahead2().isSetOperator(']')) {
+                    // ICU extensions: A $ is allowed as a literal-element.
+                    // A Term at the end of a Union consisting of a single $ is an anchor.
+                    rebuiltPat.append('$');
+                    // Consume the dollar.
+                    lexer.advance();
+                    add(ETHER);
+                    properties.containsRestriction = true;
+                    return;
+                }
+            }
+            if (lexer.lookahead().isSetOperator(']')) {
+                return;
+            }
+            parseTerm(lexer, rebuiltPat, options, depth, properties);
+        }
+    }
+
+    void parseTerm(
+            UnicodeSetLexer lexer,
+            StringBuilder rebuiltPat,
+            int options,
+            int depth,
+            GrammaticalConstructProperties properties) {
+        // Term ::= Elements
+        //        | Restriction
+        if (lexer.lookahead().isSetOperator('[') || lexer.lookahead().set() != null) {
+            properties.containsRestriction = true;
+            parseRestriction(lexer, rebuiltPat, options, depth);
+        } else {
+            parseElements(lexer, rebuiltPat);
+        }
+    }
+
+    void parseRestriction(UnicodeSetLexer lexer, StringBuilder rebuiltPat, int options, int depth) {
+        // Parse a https://www.unicode.org/reports/tr61/#Restriction:
+        //   Restriction  ::= UnicodeSet
+        //                  | Intersection
+        //                  | Difference
+        //   Intersection ::= Restriction & UnicodeSet
+        //   Difference   ::= Restriction - UnicodeSet
+        // or, rewritten to be LL,
+        //   Restriction    ::= UnicodeSet RightHandSides
+        //   RightHandSides ::= ""
+        //                    | & UnicodeSet RightHandSides
+        //                    | - UnicodeSet RightHandSides
+        // but note that the tree resulting from this LL version is not an expression tree: the
+        // operations are left-associative.
+        // Start by parsing the first UnicodeSet.
+        final var leftHandSide = new UnicodeSet();
+        leftHandSide.parseUnicodeSet(lexer, rebuiltPat, options, depth + 1);
+        addAll(leftHandSide);
+        // Now keep looking for an operator that would continue the RightHandSide.
+        // The loop terminates because when we run out of source text, the lookahead token will not
+        // be a set
+        // operator, so that we hit the else branch and return.
+        for (; ; ) {
+            if (lexer.acceptSetOperator('&')) {
+                // Intersection ::= Restriction & UnicodeSet
+                rebuiltPat.append('&');
+                final var rightHandSide = new UnicodeSet();
+                rightHandSide.parseUnicodeSet(lexer, rebuiltPat, options, depth + 1);
+                retainAll(rightHandSide);
+            } else if (lexer.lookahead().isSetOperator('-')) {
+                // Here the grammar requires two tokens of lookahead to figure out whether the - is
+                // the operator
+                // of a Difference or an UnescapedHyphenMinus in the enclosing Union.
+                if (lexer.lookahead2().isSetOperator(']')) {
+                    // The operator is actually an UnescapedHyphenMinus; terminate the Restriction
+                    // before it.  We return to parseTerm, which immediately returns to parseUnion,
+                    // which will accept the - and add it to *this.
+                    return;
+                }
+                // Consume the hyphen-minus.
+                lexer.advance();
+                // Difference ::= Restriction - UnicodeSet
+                rebuiltPat.append('-');
+                final var rightHandSide = new UnicodeSet();
+                rightHandSide.parseUnicodeSet(lexer, rebuiltPat, options, depth + 1);
+                removeAll(rightHandSide);
+            } else {
+                // Not an operator, end of the Restriction.
+                return;
+            }
+        }
+    }
+
+    void parseElements(UnicodeSetLexer lexer, StringBuilder rebuiltPat) {
+        // Elements     ::= Element
+        //                | Range
+        // Range        ::= RangeElement - RangeElement
+        // RangeElement ::= literal-element
+        //                | escaped-element
+        //                | named-element
+        //                | bracketed-element
+        // Element      ::= RangeElement
+        //                | string-literal
+        // codePoint().has_value() on a lexical element if it is a RangeElement.
+        if (lexer.lookahead().isStringLiteral()) {
+            add(lexer.lookahead().element());
+            rebuiltPat.append('{');
+            _appendToPat(rebuiltPat, lexer.lookahead().element(), /* escapeUnprintable= */ false);
+            rebuiltPat.append('}');
+            lexer.advance();
+            return;
+        }
+        int first;
+        if (lexer.lookahead().isSetOperator('$')) {
+            // Disallowed by UTS #61, but historically accepted by ICU.  This is an extension.
+            first = '$';
+        } else if (lexer.lookahead().codePoint() != null) {
+            first = lexer.lookahead().codePoint();
+        } else {
+            throw lexer.syntaxError(
+                    "RangeElement | string-literal", lexer.lookahead().debugString());
+        }
+        lexer.advance();
+        _appendToPat(rebuiltPat, first, /* escapeUnprintable= */ false);
+        if (!lexer.lookahead().isSetOperator('-')) {
+            // No operator,
+            // Elements ::= Element
+            add(first);
+            return;
+        }
+        // Here the grammar requires two tokens of lookahead to figure out whether the - is the
+        // operator
+        // of a Range or an UnescapedHyphenMinus in the enclosing Union.
+        if (lexer.lookahead2().isSetOperator(']')) {
+            // The operator is actually an UnescapedHyphenMinus; terminate the Elements before it.
+            add(first);
+            return;
+        }
+        // Consume the hyphen-minus.
+        lexer.advance();
+        // Elements ::= Range ::= RangeElement - RangeElement
+        rebuiltPat.append('-');
+        int last;
+        if (lexer.lookahead().isSetOperator('$')) {
+            // Disallowed by UTS #61, but historically accepted by ICU except at the end of a Union.
+            // This is an extension.
+            last = '$';
+            if (lexer.lookahead2().isSetOperator(']')) {
+                throw lexer.syntaxError(
+                        "Term after Range ending in unescaped $",
+                        lexer.lookahead().debugString()
+                                + " followed by "
+                                + lexer.lookahead2().debugString());
+            }
+        } else if (lexer.lookahead().codePoint() != null) {
+            last = lexer.lookahead().codePoint();
+        } else {
+            throw lexer.syntaxError("RangeElement", lexer.lookahead().debugString());
+        }
+        if (last <= first) {
+            throw lexer.syntaxError(
+                    "first < last in Range",
+                    Character.toString(last) + "-" + Character.toString(first));
+        }
+        lexer.advance();
+        _appendToPat(rebuiltPat, last, /* escapeUnprintable= */ false);
+        add(first, last);
+        return;
     }
 }
 // eof

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/UnicodeSetLexer.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/UnicodeSetLexer.java
@@ -1,0 +1,721 @@
+// © 2025 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+package com.ibm.icu.text;
+
+import com.ibm.icu.impl.PatternProps;
+import com.ibm.icu.impl.RuleCharacterIterator;
+import com.ibm.icu.impl.Utility;
+import com.ibm.icu.text.UnicodeSet.XSymbolTable;
+import com.ibm.icu.util.VersionInfo;
+import java.text.ParsePosition;
+import java.util.Locale;
+
+class UnicodeSetLexer {
+    UnicodeSetLexer(
+            final String pattern,
+            final ParsePosition parsePosition,
+            RuleCharacterIterator chars,
+            int unicodeSetOptions,
+            final SymbolTable symbols) {
+        pattern_ = pattern;
+        parsePosition_ = parsePosition;
+        chars_ = chars;
+        unicodeSetOptions_ = unicodeSetOptions;
+        charsOptions_ =
+                RuleCharacterIterator.PARSE_ESCAPES
+                        | ((unicodeSetOptions & UnicodeSet.IGNORE_SPACE) != 0
+                                ? RuleCharacterIterator.SKIP_WHITESPACE
+                                : 0);
+        symbols_ = symbols;
+        if (symbols instanceof XSymbolTable) {
+            xsymbols_ = (XSymbolTable) symbols;
+        } else {
+            xsymbols_ = null;
+        }
+    }
+
+    IllegalArgumentException syntaxError(String expected, String actual) {
+        return new IllegalArgumentException(
+                "Expected " + expected + ", got " + actual + " " + getPositionForDebugging());
+    }
+
+    private IllegalArgumentException lexicalError(String message) {
+        return new IllegalArgumentException(message + " " + getPositionForDebugging(BEHIND));
+    }
+
+    static class LexicalElement {
+        boolean isSetOperator(char op) {
+            return category_ == Category.SET_OPERATOR && string_.charAt(0) == op;
+        }
+
+        boolean isStringLiteral() {
+            return category_ == Category.STRING_LITERAL;
+        }
+
+        boolean isNamedElement() {
+            return category_ == Category.NAMED_ELEMENT;
+        }
+
+        boolean isBracketedElement() {
+            return category_ == Category.BRACKETED_ELEMENT;
+        }
+
+        String element() {
+            if (category_ == Category.LITERAL_ELEMENT
+                    || category_ == Category.ESCAPED_ELEMENT
+                    || category_ == Category.BRACKETED_ELEMENT
+                    || category_ == Category.STRING_LITERAL) {
+                return string_;
+            }
+            return null;
+        }
+
+        Integer codePoint() {
+            if (category_ == Category.LITERAL_ELEMENT
+                    || category_ == Category.ESCAPED_ELEMENT
+                    || category_ == Category.BRACKETED_ELEMENT
+                    || category_ == Category.NAMED_ELEMENT) {
+                return string_.codePointAt(0);
+            }
+            return null;
+        }
+
+        // If `this` is a valid property-query or set-valued-variable, returns the set represented
+        // by this lexical element.  Null otherwise.
+        UnicodeSet set() {
+            if (category_ == Category.PROPERTY_QUERY || category_ == Category.VARIABLE) {
+                return set_;
+            }
+            return null;
+        }
+
+        String debugString() {
+            return category_.toString() + " '" + sourceText_ + "'";
+        }
+
+        // See https://unicode.org/reports/tr61#Lexical-Elements.
+        enum Category {
+            SET_OPERATOR,
+            LITERAL_ELEMENT,
+            ESCAPED_ELEMENT,
+            NAMED_ELEMENT,
+            BRACKETED_ELEMENT,
+            STRING_LITERAL,
+            PROPERTY_QUERY,
+            // Used for ill-formed variables and set-valued variables that are not directly a
+            // property-query, e.g., $basicLatinLetters=[A-Za-z].  Variables that expand to a single
+            // lexical element instead have the category of that lexical element, e.g., $Ll=\p{Ll}
+            // has
+            // the category PROPERTY_QUERY, $a=a has the category LITERAL_ELEMENT, and
+            // $s={Zeichenkette}
+            // has the category STRING_LITERAL.
+            VARIABLE,
+            END_OF_TEXT;
+
+            @Override
+            public String toString() {
+                return this == END_OF_TEXT
+                        ? "(end of text)"
+                        : super.toString().toLowerCase(Locale.ROOT).replace('_', '-');
+            }
+        }
+
+        // Note that contrary to the C++, we do not have a `precomputedSet` (outliving this object)
+        // separate from the `set` (owned by this `LexicalElement`), since we have garbage
+        // collection.
+        LexicalElement(
+                Category category,
+                String string,
+                RuleCharacterIterator.Position after,
+                UnicodeSet set,
+                CharSequence sourceText) {
+            category_ = category;
+            string_ = string;
+            after_ = after;
+            set_ = set;
+            sourceText_ = sourceText;
+        }
+
+        Category category_;
+        String string_;
+        RuleCharacterIterator.Position after_;
+        UnicodeSet set_;
+        CharSequence sourceText_;
+    }
+
+    private String AHEAD = "☞";
+    private String BEHIND = "☜";
+
+    // Used by error messages produced by the parser; these are based on unexpected lookaheads, and
+    // therefore always pertain to issues ahead.
+    private String getPositionForDebugging() {
+        return getPositionForDebugging(AHEAD);
+    }
+
+    // Also used in error messages produced by the lexer, which pertain to text behind: we scan and
+    // then find out that the lexical element was ill-formed.
+    private String getPositionForDebugging(String marker) {
+        return pattern_.subSequence(0, parsePosition_.getIndex())
+                + marker
+                + pattern_.subSequence(
+                        parsePosition_.getIndex(),
+                        Math.min(pattern_.length(), parsePosition_.getIndex() + 60));
+    }
+
+    boolean acceptSetOperator(char op) {
+        if (lookahead().isSetOperator(op)) {
+            advance();
+            return true;
+        }
+        return false;
+    }
+
+    LexicalElement lookahead() {
+        if (ahead_ == null) {
+            RuleCharacterIterator.Position before = getPos();
+            ahead_ = nextToken();
+            chars_.setPos(before);
+        }
+        return ahead_;
+    }
+
+    LexicalElement lookahead2() {
+        if (ahead2_ == null) {
+            // Note that if someone has called `getCharacterIterator` and played with the result,
+            // `before` may not actually be before `ahead_`, but we do not actually depend on this
+            // here, since we start from ahead_.after_.
+            RuleCharacterIterator.Position before = getPos();
+            chars_.setPos(lookahead().after_);
+            ahead2_ = nextToken();
+            chars_.setPos(before);
+        }
+        return ahead2_;
+    }
+
+    // For use in older functions that take the `RuleCharacterIterator` directly.
+    // Any advancement of the resulting `RuleCharacterIterator` has no effect on the result of
+    // subsequentcalls to `lookahead`, `lookahead2`, `advance`, or `acceptSetOperator`.
+    // Once `advance` or `acceptSetOperator` has been called, the result of a call to
+    // `getCharacterIterator` preceding the call to `advance` or `acceptSetOperator` must no longer
+    // be used.
+    RuleCharacterIterator getCharacterIterator() {
+        // Make sure we compute a correct `ahead_.after_` so we do not depend on the current value
+        // of `getPos()` for lexing.
+        lookahead();
+        return chars_;
+    }
+
+    boolean atEnd() {
+        return chars_.atEnd();
+    }
+
+    void advance() {
+        // If someone called `getCharacterIterator`, we are now changing the character iterator
+        // under their feet; further, we may not have an `ahead_`, so if they keep playing with it
+        // we would be working on incorrect values of `getPos`.  This is why the result of
+        // `getCharacterIterator` must no longer be used.
+        chars_.setPos(lookahead().after_);
+        ahead_ = ahead2_;
+        ahead2_ = null;
+    }
+
+    // A version of getPos that returns its position instead of taking it as at out parameter.
+    private RuleCharacterIterator.Position getPos() {
+        final var result = new RuleCharacterIterator.Position();
+        chars_.getPos(result);
+        return result;
+    }
+
+    private LexicalElement nextToken() {
+        chars_.skipIgnored(charsOptions_);
+        if (chars_.atEnd()) {
+            return new LexicalElement(
+                    LexicalElement.Category.END_OF_TEXT, null, getPos(), /* set= */ null, "");
+        }
+        final int start = parsePosition_.getIndex();
+        final RuleCharacterIterator.Position before = getPos();
+        if (xsymbols_ != null) {
+            // Whereas a SymbolTable only defines the lexing of variables past the $, an
+            // XSymbolTable defines the complete lexing of variables, and may subtract from other
+            // lexical elements in the process.
+            // Note that we do not check that the XSymbolTable is not redefining operators; it is up
+            // to the implementer of an XSymbolTable to ensure that their lexing results in a
+            // conformant extension of UnicodeSet syntax.
+            final var nameEnd = new ParsePosition(parsePosition_.getIndex());
+            final var name = xsymbols_.scanVariable(pattern_, nameEnd, pattern_.length());
+            if (name != null) {
+                return lookupVariable(name, start, start, nameEnd);
+            }
+        }
+        // First try to get the next character without parsing escapes.
+        final int first = chars_.next(charsOptions_ & ~RuleCharacterIterator.PARSE_ESCAPES);
+        if (first == '[' || first == '\\') {
+            final RuleCharacterIterator.Position afterFirst = getPos();
+            // This could be a property-query or named-element.
+            final int second =
+                    chars_.next(
+                            charsOptions_
+                                    & ~(RuleCharacterIterator.PARSE_ESCAPES
+                                            | RuleCharacterIterator.SKIP_WHITESPACE));
+            if ((first == '[' && second == ':')
+                    || (first == '\\' && (second == 'p' || second == 'P' || second == 'N'))) {
+                if (second == 'N') {
+                    final int queryResult = scanNamedElementBrackets();
+                    return new LexicalElement(
+                            LexicalElement.Category.NAMED_ELEMENT,
+                            Character.toString(queryResult),
+                            getPos(),
+                            /* set= */ null,
+                            pattern_.subSequence(start, parsePosition_.getIndex()));
+                } else {
+                    UnicodeSet queryResult = scanPropertyQueryAfterStart(first, second, start);
+                    return new LexicalElement(
+                            LexicalElement.Category.PROPERTY_QUERY,
+                            null,
+                            getPos(),
+                            /* set= */ queryResult,
+                            pattern_.subSequence(start, parsePosition_.getIndex()));
+                }
+            }
+            // Not a property-query.
+            chars_.setPos(afterFirst);
+        }
+        if (first == '$' && symbols_ != null && xsymbols_ == null) {
+            final var nameEnd = new ParsePosition(parsePosition_.getIndex());
+            // The SymbolTable defines the lexing of variable names past the $.
+            final String name = symbols_.parseReference(pattern_, nameEnd, pattern_.length());
+            if (name != null) {
+                return lookupVariable(name, start, start + 1, nameEnd);
+            }
+        }
+        switch (first) {
+            case '[':
+                return new LexicalElement(
+                        LexicalElement.Category.SET_OPERATOR,
+                        "[",
+                        getPos(),
+                        /* set= */ null,
+                        pattern_.subSequence(start, parsePosition_.getIndex()));
+            case '\\':
+                {
+                    // Now try to parse the escape.
+                    chars_.setPos(before);
+                    int codePoint = chars_.next(charsOptions_);
+                    return new LexicalElement(
+                            LexicalElement.Category.ESCAPED_ELEMENT,
+                            Character.toString(codePoint),
+                            getPos(),
+                            /* set= */ null,
+                            pattern_.subSequence(start, parsePosition_.getIndex()));
+                }
+            case '&':
+            case '-':
+            case ']':
+            case '^':
+            case '$':
+                // We make $ a set-operator to handle the ICU extensions involving $.
+                return new LexicalElement(
+                        LexicalElement.Category.SET_OPERATOR,
+                        Character.toString(first),
+                        getPos(),
+                        /* set= */ null,
+                        pattern_.subSequence(start, parsePosition_.getIndex()));
+            case '{':
+                {
+                    final var string = new StringBuilder();
+                    boolean escaped;
+                    int next;
+                    int codePointCount = 0;
+                    while (!chars_.atEnd()) {
+                        final RuleCharacterIterator.Position beforeNext = getPos();
+                        next =
+                                chars_.next(
+                                        charsOptions_
+                                                & ~(RuleCharacterIterator.PARSE_ESCAPES
+                                                        | RuleCharacterIterator.SKIP_WHITESPACE));
+                        if (next == '\\') {
+                            final int afterBackslash =
+                                    chars_.next(
+                                            charsOptions_
+                                                    & ~(RuleCharacterIterator.PARSE_ESCAPES
+                                                            | RuleCharacterIterator
+                                                                    .SKIP_WHITESPACE));
+                            if (afterBackslash == 'N') {
+                                next = scanNamedElementBrackets();
+                                escaped = true;
+                            } else if (afterBackslash == 'p' || afterBackslash == 'P') {
+                                throw lexicalError(
+                                        "Invalid escape sequence \\"
+                                                + Character.toString(afterBackslash)
+                                                + " in UnicodeSet string");
+                            } else {
+                                chars_.setPos(beforeNext);
+                                // Parse the escape.
+                                next = chars_.next(charsOptions_);
+                                escaped = chars_.isEscaped();
+                            }
+                        } else {
+                            if (VersionInfo.ICU_VERSION.getMajor() < 81) {
+                                if (PatternProps.isWhiteSpace(next)) {
+                                    // Transitional prohibition of unescaped spaces in string
+                                    // literals (in ICU 78 and earlier, these were ignored; in
+                                    // ICU 81 they will mean themselves).
+                                    throw lexicalError(
+                                            "Unescaped Pattern_White_Space in UnicodeSet string"
+                                                    + " literals is prohibited until ICU 81. "
+                                                    + " Escape U+"
+                                                    + Utility.hex(next)
+                                                    + ".");
+                                }
+                            } else {
+                                throw new IllegalArgumentException(
+                                        "Remove this transitional check, see ICU-23307"
+                                                + " and ICU-TC minutes of 2026-01-16.");
+                            }
+                            escaped = false;
+                        }
+                        if (!escaped && next == '}') {
+                            return new LexicalElement(
+                                    codePointCount == 1
+                                            ? LexicalElement.Category.BRACKETED_ELEMENT
+                                            : LexicalElement.Category.STRING_LITERAL,
+                                    string.toString(),
+                                    getPos(),
+                                    /* set= */ null,
+                                    pattern_.subSequence(start, parsePosition_.getIndex()));
+                        }
+                        string.append(Character.toString(next));
+                        codePointCount += 1;
+                    }
+                    throw lexicalError(
+                            "String literal was not terminated: "
+                                    + pattern_.subSequence(start, parsePosition_.getIndex()));
+                }
+            default:
+                return new LexicalElement(
+                        LexicalElement.Category.LITERAL_ELEMENT,
+                        Character.toString(first),
+                        getPos(),
+                        /* set= */ null,
+                        pattern_.subSequence(start, parsePosition_.getIndex()));
+        }
+    }
+
+    private LexicalElement lookupVariable(
+            String name, int lexicalElementStart, int nameStart, ParsePosition nameEnd) {
+        chars_.jumpahead(nameEnd.getIndex() - nameStart);
+        final var source = pattern_.subSequence(lexicalElementStart, parsePosition_.getIndex());
+        UnicodeSet precomputedSet = symbols_.lookupSet(name);
+        if (precomputedSet != null) {
+            return new LexicalElement(
+                    LexicalElement.Category.VARIABLE, null, getPos(), precomputedSet, source);
+        }
+        // The variable was not a precomputed set.  Use the old-fashioned `lookup`, which
+        // should give us its source text; if that parses as a single set or element, use
+        // it.  Note that variables are not allowed in that expansion.
+        // Implementers of higher-level syntaxes that pre-parse UnicodeSet-valued variables
+        // can use variables in their variable definitions, but those that simply use the
+        // source text substitution API cannot.
+        char[] expression = symbols_.lookup(name);
+        if (expression == null) {
+            throw lexicalError("Undefined variable " + name);
+        }
+        return evaluateVariable(new String(expression), source);
+    }
+
+    private int scanNamedElementBrackets() {
+        int open =
+                chars_.next(
+                        charsOptions_
+                                & ~(RuleCharacterIterator.PARSE_ESCAPES
+                                        | RuleCharacterIterator.SKIP_WHITESPACE));
+        if (open == '{') {
+            int start = parsePosition_.getIndex();
+            Integer hex = null;
+            Integer literal = null;
+            while (!chars_.atEnd()) {
+                int last =
+                        chars_.next(
+                                charsOptions_
+                                        & ~(RuleCharacterIterator.PARSE_ESCAPES
+                                                | RuleCharacterIterator.SKIP_WHITESPACE));
+                if (last == ':') {
+                    if (hex == null) {
+                        hex = 0;
+                        if (start == parsePosition_.getIndex() - 1) {
+                            throw lexicalError("Empty hexadecimal-digits in named-element");
+                        }
+                        for (int digit :
+                                (Iterable<Integer>)
+                                        pattern_.subSequence(start, parsePosition_.getIndex() - 1)
+                                                        .chars()
+                                                ::iterator) {
+                            int nibble;
+                            if (digit >= '0' && digit <= '9') {
+                                nibble = digit - '0';
+                            } else {
+                                digit = digit & ~0x20;
+                                if (digit >= 'A' && digit <= 'F') {
+                                    nibble = digit - 'A' + 0xA;
+                                } else {
+                                    throw lexicalError(
+                                            "Ill-formed hexadecimal-digits: "
+                                                    + pattern_.subSequence(
+                                                            start, parsePosition_.getIndex() - 1));
+                                }
+                            }
+                            hex = (hex << 4) + nibble;
+                            if (hex > 0x10FFFF) {
+                                throw lexicalError(
+                                        "hexadecimal-digits out of range: "
+                                                + pattern_.subSequence(
+                                                        start, parsePosition_.getIndex() - 1));
+                            }
+                        }
+                    } else if (literal == null) {
+                        final var literalCodePoints =
+                                pattern_.subSequence(start, parsePosition_.getIndex() - 1)
+                                        .codePoints()
+                                        .toArray();
+                        if (literalCodePoints.length != 1) {
+                            throw lexicalError(
+                                    "Ill-formed named-literal-element '"
+                                            + pattern_.subSequence(
+                                                    start, parsePosition_.getIndex() - 1)
+                                            + "' ("
+                                            + literalCodePoints.length
+                                            + " code points)");
+                        }
+                        literal = literalCodePoints[0];
+                    } else {
+                        throw lexicalError("Too many colons in named-element");
+                    }
+                    start = parsePosition_.getIndex();
+                } else if (last == '}') {
+                    final var name = pattern_.substring(start, parsePosition_.getIndex() - 1);
+                    // TODO(egg): Consider changing this to not construct a by default set when
+                    // fixing ICU-3736.  Note that we should still use the "Name" property of the
+                    // XSymbolTable if present, so we cannot directly call
+                    // UCharacter.getCharFromName vel sim., and in the presence of an XSymbolTable
+                    // we still need to construct a set.
+                    final var resultSet = new UnicodeSet();
+                    resultSet.applyPropertyAlias("Name", name, symbols_);
+                    int result = resultSet.charAt(0);
+                    if (result < 0
+                            || (hex != null && result != hex)
+                            || (literal != null && result != literal)) {
+                        throw lexicalError(
+                                "Ill-formed named-element: "
+                                        + (result < 0
+                                                ? name + " not found"
+                                                : "inconsistent with "
+                                                        + (hex != null
+                                                                ? Utility.hex(hex) + ":"
+                                                                : "")
+                                                        + (literal != null
+                                                                ? (Character.toString(literal)
+                                                                        + ":")
+                                                                : "")));
+                    }
+                    return result;
+                }
+            }
+        }
+        throw lexicalError("Ill-formed named-element");
+    }
+
+    private LexicalElement evaluateVariable(String expression, CharSequence source) {
+        ParsePosition expressionPosition = new ParsePosition(0);
+        final var expressionIterator =
+                new RuleCharacterIterator(expression, symbols_, expressionPosition);
+        // Do not pass the symbols: we do not support recursive expansion of variables.
+        final var expressionLexer =
+                new UnicodeSetLexer(
+                        expression,
+                        expressionPosition,
+                        expressionIterator,
+                        unicodeSetOptions_,
+                        /* symbols= */ null);
+        final var variableToken = expressionLexer.lookahead();
+        if (variableToken.isSetOperator('[')) {
+            final var rebuiltPattern = new StringBuilder();
+            final var expressionValue = new UnicodeSet();
+            try {
+                expressionValue.parseUnicodeSet(
+                        expressionLexer, rebuiltPattern, unicodeSetOptions_, /* depth= */ 0);
+            } catch (IllegalArgumentException e) {
+                throw lexicalError(
+                        "The value of variable "
+                                + source
+                                + " failed to parse as a UnicodeSet ("
+                                + e.getMessage()
+                                + "). See usage of "
+                                + source
+                                + ":" /*lexcalError will show the context here.*/);
+            }
+            expressionValue.setPattern(rebuiltPattern.toString());
+            if (!expressionLexer.atEnd()) {
+                throw lexicalError(
+                        "Variable "
+                                + source
+                                + " expands to '"
+                                + expression
+                                + "' which contains additional text beyond a UnicodeSet expression: "
+                                + expression);
+            }
+            return new LexicalElement(
+                    LexicalElement.Category.VARIABLE,
+                    null,
+                    getPos(),
+                    /* set= */ expressionValue,
+                    source);
+        } else {
+            expressionLexer.advance();
+            if (!expressionLexer.atEnd()) {
+                throw lexicalError(
+                        "Variable "
+                                + source
+                                + " expands to '"
+                                + expression
+                                + "' which consists of several lexical elements that do not form a UnicodeSet expression");
+            }
+            switch (variableToken.category_) {
+                case LITERAL_ELEMENT:
+                case ESCAPED_ELEMENT:
+                case NAMED_ELEMENT:
+                case BRACKETED_ELEMENT:
+                case STRING_LITERAL:
+                case PROPERTY_QUERY:
+                    // Return the same lexical element that we found while parsing the variable
+                    // contents, except the source position corresponds to the position of the
+                    // variable rather than 0 in its expansion, and the source is the name of the
+                    // variable rather than its expansion.
+                    return new LexicalElement(
+                            variableToken.category_,
+                            variableToken.string_,
+                            getPos(),
+                            variableToken.set_,
+                            source);
+                default:
+                    throw lexicalError(
+                            "Value of variable "
+                                    + source
+                                    + " expands to invalid lexical element of type "
+                                    + variableToken.category_
+                                    + " :"
+                                    + expression);
+            }
+        }
+    }
+
+    private UnicodeSet scanPropertyQueryAfterStart(int first, int second, int queryStart) {
+        Integer queryOperatorPosition = null;
+        int queryExpressionStart = parsePosition_.getIndex();
+        boolean exteriorlyNegated = false;
+        boolean interiorlyNegated = false;
+        // Do not skip whitespace so we can recognize unspaced :].  Lex escapes and
+        // named-element: while ICU does not support string-valued properties and thus has no
+        // use for escapes, we still want to lex through escapes to allow downstream
+        // implementations (mostly unicodetools) to implement string-valued properties.
+        int third =
+                chars_.next(
+                        charsOptions_
+                                & ~(RuleCharacterIterator.PARSE_ESCAPES
+                                        | RuleCharacterIterator.SKIP_WHITESPACE));
+        if (first == '\\') {
+            if (third != '{') {
+                throw lexicalError("Missing { in property-query");
+            }
+            exteriorlyNegated = second == 'P';
+            queryExpressionStart = parsePosition_.getIndex();
+        } else {
+            if (third == '^') {
+                exteriorlyNegated = true;
+                queryExpressionStart = parsePosition_.getIndex();
+            }
+        }
+        RuleCharacterIterator.Position beforePenultimate = getPos();
+        int penultimateUnescaped =
+                chars_.next(
+                        charsOptions_
+                                & ~(RuleCharacterIterator.PARSE_ESCAPES
+                                        | RuleCharacterIterator.SKIP_WHITESPACE));
+
+        while (!chars_.atEnd()) {
+            RuleCharacterIterator.Position beforeLast = getPos();
+            int lastUnescaped =
+                    chars_.next(
+                            charsOptions_
+                                    & ~(RuleCharacterIterator.PARSE_ESCAPES
+                                            | RuleCharacterIterator.SKIP_WHITESPACE));
+            if (penultimateUnescaped == '\\') {
+                if (lastUnescaped == 'N') {
+                    scanNamedElementBrackets();
+                } else {
+                    // There must be an escaped-element starting at beforePenultimate.  Go
+                    // back there and advance through it.
+                    chars_.setPos(beforePenultimate);
+                    chars_.next(charsOptions_ & ~RuleCharacterIterator.SKIP_WHITESPACE);
+                }
+                // Neither a named-element nor an escaped-element can be part of a closing :].
+                lastUnescaped = -1;
+            } else if (queryOperatorPosition == null && lastUnescaped == '=') {
+                queryOperatorPosition = parsePosition_.getIndex() - 1;
+            } else if (queryOperatorPosition == null && lastUnescaped == '≠') {
+                if (exteriorlyNegated) {
+                    // Reject doubly negated property queries.
+                    throw lexicalError("Found doubly negated property-query");
+                }
+                interiorlyNegated = true;
+                queryOperatorPosition = parsePosition_.getIndex() - 1;
+            } else if ((first == '[' && penultimateUnescaped == ':' && lastUnescaped == ']')
+                    || (first == '\\' && lastUnescaped == '}')) {
+                // Note that no unescaping is performed here, as ICU does not support string-valued
+                // or miscellaneous properties.
+                // The unicodetools use this implementation and support such properties; they should
+                // do their own unescaping.
+                int queryExpressionLimit =
+                        first == '['
+                                ? parsePosition_.getIndex() - 2
+                                : parsePosition_.getIndex() - 1;
+                // Note that in C++, we pass an empty, rather than null, propertyPredicate for
+                // \p{X}.  In Java we distinguish those since ICU4J underlies the unicodetools,
+                // which support properties for which \p{X=} is meaningful, e.g., \p{nfckcf=}:
+                // https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7BNFKC_Casefold%3D%7D
+                // See also https://github.com/unicode-org/icu/pull/3456.
+                String propertyPredicate = null;
+                if (queryOperatorPosition != null) {
+                    propertyPredicate =
+                            pattern_.substring(queryOperatorPosition + 1, queryExpressionLimit);
+                }
+                final var result = new UnicodeSet();
+                result.applyPropertyAlias(
+                        pattern_.substring(
+                                queryExpressionStart,
+                                queryOperatorPosition != null
+                                        ? queryOperatorPosition
+                                        : queryExpressionLimit),
+                        propertyPredicate,
+                        symbols_);
+                if (exteriorlyNegated != interiorlyNegated) {
+                    result.complement().removeAllStrings();
+                }
+                result.setPattern(pattern_.substring(queryStart, parsePosition_.getIndex()));
+                return result;
+            }
+            beforePenultimate = beforeLast;
+            penultimateUnescaped = lastUnescaped;
+        }
+        throw lexicalError("property-query was not terminated");
+    }
+
+    final String pattern_;
+    final ParsePosition parsePosition_;
+    RuleCharacterIterator chars_;
+    final int unicodeSetOptions_;
+    final int charsOptions_;
+    final SymbolTable symbols_;
+    final XSymbolTable xsymbols_;
+    LexicalElement ahead_;
+    LexicalElement ahead2_;
+}

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UnicodeSetTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UnicodeSetTest.java
@@ -8,8 +8,13 @@
  */
 package com.ibm.icu.dev.test.lang;
 
+import static com.ibm.icu.dev.test.lang.UnicodeSetTest.LookupSymbolTableTestCase.*;
+import static com.ibm.icu.dev.test.lang.UnicodeSetTest.SymbolTableTestCase.*;
+
 import com.ibm.icu.dev.test.CoreTestFmwk;
 import com.ibm.icu.dev.test.TestFmwk;
+import com.ibm.icu.dev.test.lang.UnicodeSetTest.LookupSymbolTableTestCase.SetValuedVariable;
+import com.ibm.icu.dev.test.lang.UnicodeSetTest.LookupSymbolTableTestCase.StringValuedVariable;
 import com.ibm.icu.impl.SortedSetRelation;
 import com.ibm.icu.impl.Utility;
 import com.ibm.icu.lang.CharacterProperties;
@@ -24,6 +29,7 @@ import com.ibm.icu.text.UnicodeSet;
 import com.ibm.icu.text.UnicodeSet.ComparisonStyle;
 import com.ibm.icu.text.UnicodeSet.EntryRange;
 import com.ibm.icu.text.UnicodeSet.SpanCondition;
+import com.ibm.icu.text.UnicodeSet.XSymbolTable;
 import com.ibm.icu.text.UnicodeSetIterator;
 import com.ibm.icu.text.UnicodeSetSpanner;
 import com.ibm.icu.text.UnicodeSetSpanner.CountMethod;
@@ -41,12 +47,16 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.StringJoiner;
+import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -1731,15 +1741,55 @@ public class UnicodeSetTest extends CoreTestFmwk {
         }
     }
 
+    static class SymbolTableTestCase {
+        static class Variable {
+            public Variable(String name, String value) {
+                this.name = name;
+                this.value = value;
+            }
+
+            public String name;
+            public String value;
+        }
+
+        public static Variable variable(String name, String value) {
+            return new Variable(name, value);
+        }
+
+        public static SymbolTableTestCase error(
+                List<Variable> variables, String expression, String expectedErrorMessage) {
+            final var result = new SymbolTableTestCase();
+            result.variables = variables;
+            result.expression = expression;
+            result.expectedErrorMessage = expectedErrorMessage;
+            return result;
+        }
+
+        public static SymbolTableTestCase success(
+                List<Variable> variables, String expression, String expectedPattern) {
+            final var result = new SymbolTableTestCase();
+            result.variables = variables;
+            result.expression = expression;
+            result.expectedPattern = expectedPattern;
+            return result;
+        }
+
+        public List<Variable> variables;
+        public String expression;
+        public String expectedErrorMessage;
+        public String expectedPattern;
+    }
+
     @Test
     public void TestSymbolTable() {
         // Multiple test cases can be set up here.  Each test case
         // is terminated by null:
         // var, value, var, value,..., input pat., exp. output pat., null
         String DATA[] = {
-            "us", "a-z", "[0-1$us]", "[0-1a-z]", null,
             "us", "[a-z]", "[0-1$us]", "[0-1[a-z]]", null,
-            "us", "\\[a\\-z\\]", "[0-1$us]", "[-01\\[\\]az]", null
+            // Variables do not expand inside string literals.
+            "us", "[a-z]", "[$us{$us}]", "[a-z{\\$us}]", null,
+            "privateUse", "[[:Co:]]", "$privateUse", "[[:Co:]]", null,
         };
 
         for (int i = 0; i < DATA.length; ++i) {
@@ -1784,6 +1834,168 @@ public class UnicodeSetTest extends CoreTestFmwk {
                 errln("FAIL: Failed, got " + inSet + ", expected " + expSet);
             } else {
                 logln("OK: got " + inSet);
+            }
+        }
+        final String open = "[a";
+        final String close = "]";
+        String deep = "[a]";
+        String deepReference = "$deep";
+        for (int i = 0; i < 100; ++i) {
+            deep = open + deep + close;
+            deepReference = open + deepReference + close;
+        }
+        final String deeper = open + deep + close;
+        final String deeperReference = open + deepReference + close;
+        final String unfathomableDepths =
+                deepReference.substring(0, 200) + deep + deepReference.substring(205);
+        for (final var testCase :
+                new SymbolTableTestCase[] {
+                    // a-z is neither a single element nor a set (that would be [a-z]).
+                    error(
+                            List.of(variable("us", "a-z")),
+                            "[0-1$us]",
+                            "Variable $us expands to 'a-z' which consists of several lexical"
+                                    + " elements that do not form a UnicodeSet expression"
+                                    + " [0-1$us☜]"),
+                    // Same with \[a\-z\].
+                    error(
+                            List.of(variable("us", "(\\[a\\-z\\])")),
+                            "[0-1$us]",
+                            "Variable $us expands to '(\\[a\\-z\\])' which consists of several"
+                                    + " lexical elements that do not form a UnicodeSet expression"
+                                    + " [0-1$us☜]"),
+                    // Same with :-D.
+                    error(
+                            List.of(variable("smiling", ":-]"), variable("laughing", ":-D")),
+                            "[ {$smiling} $laughing $smiling",
+                            "Variable $laughing expands to ':-D' which consists of several lexical"
+                                    + " elements that do not form a UnicodeSet expression"
+                                    + " [ {$smiling} $laughing☜ $smiling"),
+                    // Variables cannot be partial UnicodeSet expressions.
+                    error(
+                            List.of(
+                                    variable("privateUseOrUnassigned", "[[:Co:][:Cn:]"),
+                                    variable("close", "]")),
+                            "$privateUseOrUnassigned$close",
+                            "The value of variable $privateUseOrUnassigned failed to parse as a"
+                                    + " UnicodeSet (Expected ], got (end of text) ''"
+                                    + " [[:Co:][:Cn:]☞). See usage of $privateUseOrUnassigned:"
+                                    + " $privateUseOrUnassigned☜$close"),
+                    // Variables cannot be set-operators.
+                    error(
+                            List.of(variable("open", "[")),
+                            "$open a-z]",
+                            "The value of variable $open failed to parse as a UnicodeSet"
+                                    + " (Expected ], got (end of text) '' [☞). See usage of $open:"
+                                    + " $open☜ a-z]"),
+                    error(
+                            List.of(
+                                    variable("open", "["),
+                                    variable("close", "]"),
+                                    variable("hyphenMinus", "-")),
+                            "[ $open a $hyphenMinus z] $hyphenMinus [ c-z $close $hyphenMinus ]",
+                            "The value of variable $open failed to parse as a UnicodeSet"
+                                    + " (Expected ], got (end of text) '' [☞). See usage of $open:"
+                                    + " [ $open☜ a $hyphenMinus z] $hyphenMinus [ c-z $close $hyphenMinus ]"),
+                    // Variables cannot be unpaired string delimiters.
+                    error(
+                            List.of(variable("string", "{"), variable("end", "}")),
+                            "[$string Zeichenkette $end]",
+                            "String literal was not terminated: { {☜"),
+                    // This works and it is fine.
+                    success(List.of(variable("privateUse", "[[:Co:]]")), "$privateUse", "[[:Co:]]"),
+                    // This also works now.
+                    success(List.of(variable("privateUse", "[:Co:]")), "[$privateUse]", "[[:Co:]]"),
+                    // Variables cannot piece together a property-query.
+                    error(
+                            List.of(variable("sad", ":C"), variable("surprised", "o:")),
+                            "[$sad$surprised]",
+                            "Variable $sad expands to ':C' which consists of several lexical"
+                                    + " elements that do not form a UnicodeSet expression"
+                                    + " [$sad☜$surprised]"),
+                    // The empty string is neither a set nor an element.
+                    error(
+                            List.of(variable("leer", "")),
+                            "[$leer]",
+                            "Value of variable $leer expands to invalid lexical element of"
+                                    + " type (end of text) : [$leer☜]"),
+                    // The empty string literal is an element.
+                    success(List.of(variable("leer", "{}")), "[$leer]", "[{}]"),
+                    // Check that we don’t recursively expand variables.
+                    // In ICU 78 and earlier, this would have been U_ZERO_ERROR with [[\$y][\$x]];
+                    // but \$y
+                    // is a sequence of elements, so it is not a valid variable value.
+                    error(
+                            List.of(variable("x", "$y"), variable("y", "$x")),
+                            "[[$x][$y]]",
+                            "Variable $x expands to '$y' which consists of several lexical"
+                                    + " elements that do not form a UnicodeSet expression"
+                                    + " [[$x☜][$y]]"),
+                    // Since variable expansion spawns a new parser in the lexer, which is by design
+                    // unaware of the outer parser, a variable can be used to double the maximum
+                    // depth of a UnicodeSet.  Check that this doesn’t explode the stack, and check
+                    // that both the variable and the outer expression can produce an error if they
+                    // are too deep.
+                    success(List.of(variable("deep", deep)), deepReference, unfathomableDepths),
+                    error(
+                            List.of(variable("deep", deeper)),
+                            deepReference,
+                            "The value of variable $deep failed to parse as a UnicodeSet"
+                                    + " (Expected depth <= 100, got depth = 101 [a⋯[a☞[a]]⋯])."
+                                    + " See usage of $deep: [a⋯[a$deep☜]⋯]"),
+                    error(
+                            List.of(variable("deep", deep)),
+                            deeperReference,
+                            "Expected depth <= 100, got depth = 101 [a[a⋯[a☞$deep]⋯]]"),
+                    error(
+                            List.of(variable("deep", deeper)),
+                            deeperReference,
+                            "The value of variable $deep failed to parse as a UnicodeSet"
+                                    + " (Expected depth <= 100, got depth = 101 [a⋯[a☞[a]]⋯])."
+                                    + " See usage of $deep: [a⋯[a$deep☜]⋯]"),
+                }) {
+            final var symbols = new TokenSymbolTable();
+            for (var variable : testCase.variables) {
+                symbols.add(variable.name, variable.value);
+            }
+            try {
+                final var set = new UnicodeSet(testCase.expression, new ParsePosition(0), symbols);
+                final String actual = set.toPattern(true);
+                if (testCase.expectedErrorMessage != null) {
+                    errln(
+                            "Parsing "
+                                    + testCase.expression
+                                    + ": Expected IllegalArgumentException, got no exception,"
+                                    + " resulting UnicodeSet is "
+                                    + actual);
+                    continue;
+                }
+                if (!actual.equals(testCase.expectedPattern)) {
+                    errln(
+                            "UnicodeSet(R\"("
+                                    + testCase.expression
+                                    + ")\").toPattern() expected "
+                                    + testCase.expectedPattern
+                                    + ", got "
+                                    + actual);
+                }
+            } catch (IllegalArgumentException e) {
+                final var matcher =
+                        Pattern.compile(
+                                        Arrays.stream(testCase.expectedErrorMessage.split("⋯"))
+                                                .map(Pattern::quote)
+                                                .collect(Collectors.joining(".*")))
+                                .matcher(e.getMessage());
+                if (!matcher.matches()) {
+                    errln(
+                            "Error while parsing "
+                                    + testCase.expression
+                                    + ": expected \""
+                                    + testCase.expectedErrorMessage
+                                    + "\", got \""
+                                    + e.getMessage()
+                                    + "\"");
+                }
             }
         }
     }
@@ -2393,6 +2605,228 @@ public class UnicodeSetTest extends CoreTestFmwk {
                             + "\"");
             pos.setIndex(i);
             return text.substring(start, i);
+        }
+    }
+
+    static class LookupSymbolTableTestCase {
+        abstract static class Variable {
+            public String name;
+        }
+
+        static class SetValuedVariable extends Variable {
+            public UnicodeSet value;
+        }
+
+        static class StringValuedVariable extends Variable {
+            public String value;
+        }
+
+        public static SetValuedVariable newVariable(String name, UnicodeSet value) {
+            var result = new SetValuedVariable();
+            result.name = name;
+            result.value = value;
+            return result;
+        }
+
+        public static StringValuedVariable newVariable(String name, String value) {
+            var result = new StringValuedVariable();
+            result.name = name;
+            result.value = value;
+            return result;
+        }
+
+        public LookupSymbolTableTestCase(
+                String expression,
+                String expectedErrorMessage,
+                String expectedPattern,
+                String expectedRegeneratedPattern,
+                List<String> expectedLookups,
+                List<Variable> variables) {
+            this.expression = expression;
+            this.expectedErrorMessage = expectedErrorMessage;
+            this.expectedPattern = expectedPattern;
+            this.expectedRegeneratedPattern = expectedRegeneratedPattern;
+            this.expectedLookups = expectedLookups;
+            this.variables = variables;
+        }
+
+        String expression;
+        String expectedErrorMessage;
+        String expectedPattern;
+        String expectedRegeneratedPattern;
+        List<String> expectedLookups;
+        // Variables for `lookup` and `lookupSet`.
+        List<Variable> variables;
+    }
+
+    @Test
+    public void TestLookupSymbolTable() {
+        class TestSymbolTable implements SymbolTable {
+            @Override
+            public char[] lookup(String name) {
+                lookupTrace_.add("lookup(" + name + ")");
+                return variables_.stream()
+                        .filter(v -> v.name.equals(name) && v instanceof StringValuedVariable)
+                        .findFirst()
+                        .map(v -> ((StringValuedVariable) v).value.toCharArray())
+                        .orElse(null);
+            }
+
+            @Override
+            public UnicodeSet lookupSet(String name) {
+                lookupTrace_.add("lookupSet(" + name + ")");
+                return variables_.stream()
+                        .filter(v -> v.name.equals(name) && v instanceof SetValuedVariable)
+                        .findFirst()
+                        .map(v -> ((SetValuedVariable) v).value)
+                        .orElse(null);
+            }
+
+            @Override
+            public UnicodeMatcher lookupMatcher(int c) {
+                errln("Unexpected call to lookupMatcher() while parsing UnicodeSet");
+                return null;
+            }
+
+            @Override
+            public String parseReference(String text, ParsePosition pos, int limit) {
+                final CharSequence limitedText = text.subSequence(pos.getIndex(), limit);
+                int codePointPos = pos.getIndex();
+                for (int codePoint : (Iterable<Integer>) limitedText.codePoints()::iterator) {
+                    if (!Character.isUnicodeIdentifierPart(codePoint)) {
+                        final var result =
+                                (String) limitedText.subSequence(0, codePointPos - pos.getIndex());
+                        pos.setIndex(codePointPos);
+                        return result;
+                    }
+                    if (codePoint > 0xFFFF) {
+                        codePointPos += 2;
+                    } else {
+                        ++codePointPos;
+                    }
+                }
+                pos.setIndex(limit);
+                return (String) limitedText;
+            }
+
+            void setVariables(List<LookupSymbolTableTestCase.Variable> variables) {
+                variables_ = variables;
+            }
+
+            List<String> getLookupTrace() {
+                return lookupTrace_;
+            }
+
+            void clearLookupTrace() {
+                lookupTrace_.clear();
+            }
+
+            List<LookupSymbolTableTestCase.Variable> variables_;
+            List<String> lookupTrace_ = new ArrayList<>();
+        }
+        final var symbols = new TestSymbolTable();
+        for (final var testCase :
+                new LookupSymbolTableTestCase[] {
+                    // Variables that are found by lookupSet are not looked up with the old lookup.
+                    new LookupSymbolTableTestCase(
+                            "[0-$one]",
+                            "Expected RangeElement, got variable '$one' [0-☞$one]",
+                            "[]",
+                            "[]",
+                            List.of("lookupSet(one)"),
+                            List.of(newVariable("one", new UnicodeSet("[ b-c ]")))),
+                    new LookupSymbolTableTestCase(
+                            "[$zero-$one]",
+                            null,
+                            "[[a-z]-[bc]]",
+                            "[ad-z]",
+                            List.of("lookupSet(zero)", "lookupSet(one)"),
+                            List.of(
+                                    newVariable("zero", new UnicodeSet("[ a-z ]")),
+                                    newVariable("one", new UnicodeSet("[ b-c ]")))),
+                    new LookupSymbolTableTestCase(
+                            "[ $two & $one ]",
+                            null,
+                            "[[: Co :]&[bc]]",
+                            "[]",
+                            List.of("lookupSet(two)", "lookupSet(one)"),
+                            List.of(
+                                    newVariable("two", new UnicodeSet("[: Co :]")),
+                                    newVariable("one", new UnicodeSet("[ b-c ]")))),
+                    // A variable that is not found by lookupSet is then looked up with the old
+                    // lookup.
+                    new LookupSymbolTableTestCase(
+                            "[ $two$one ]",
+                            null,
+                            "[[: Co :][bc]]",
+                            "[bc\\uE000-\\uF8FF\\U000F0000-\\U000FFFFD\\U00100000-\\U0010FFFD]",
+                            List.of("lookupSet(two)", "lookup(two)", "lookupSet(one)"),
+                            List.of(
+                                    newVariable("two", "[: Co :]"),
+                                    newVariable("one", new UnicodeSet("[ b-c ]")))),
+                    // If neither lookupSet nor lookup return something, we get an error.
+                    new LookupSymbolTableTestCase(
+                            "[ $two$one ]",
+                            "Undefined variable two [ $two☜$one ]",
+                            "[]",
+                            "[]",
+                            List.of("lookupSet(two)", "lookup(two)"),
+                            List.of(newVariable("one", new UnicodeSet("[ b-c ]")))),
+                }) {
+            symbols.setVariables(testCase.variables);
+            symbols.clearLookupTrace();
+            try {
+                final var set = new UnicodeSet(testCase.expression, new ParsePosition(0), symbols);
+                final String actualToPattern = set.toPattern(true);
+                if (testCase.expectedErrorMessage != null) {
+                    errln(
+                            "Parsing "
+                                    + testCase.expression
+                                    + ": Expected IllegalArgumentException, got no exception, resulting UnicodeSet is "
+                                    + actualToPattern);
+                    continue;
+                }
+                if (!actualToPattern.equals(testCase.expectedPattern)) {
+                    errln(
+                            "UnicodeSet(R\"("
+                                    + testCase.expression
+                                    + ")\").toPattern() expected "
+                                    + testCase.expectedPattern
+                                    + ", got "
+                                    + actualToPattern);
+                }
+                final String regeneratedPattern =
+                        new UnicodeSet(set).complement().complement().toPattern(true);
+                if (!regeneratedPattern.equals(testCase.expectedRegeneratedPattern)) {
+                    errln(
+                            "UnicodeSet(R\"("
+                                    + testCase.expression
+                                    + ")\").complement().complement().toPattern() expected "
+                                    + testCase.expectedRegeneratedPattern
+                                    + ", got "
+                                    + regeneratedPattern);
+                }
+            } catch (IllegalArgumentException e) {
+                assertEquals(
+                        "Error while parsing " + testCase.expression,
+                        testCase.expectedErrorMessage,
+                        e.getMessage());
+            }
+            if (!symbols.getLookupTrace().equals(testCase.expectedLookups)) {
+                final var expected = new StringBuilder();
+                final var actual = new StringBuilder();
+                for (final var l : testCase.expectedLookups) {
+                    expected.append("u\"" + l + "\", ");
+                }
+                for (final var l : symbols.getLookupTrace()) {
+                    actual.append("u\"" + l + "\", ");
+                }
+                errln(
+                        "Unexpected sequence of lookups:\nExpected : "
+                                + expected
+                                + "\nActual   : "
+                                + actual);
+            }
         }
     }
 
@@ -3275,19 +3709,21 @@ public class UnicodeSetTest extends CoreTestFmwk {
     @Test
     public void TestAStringRange() {
         String[][] tests = {
-            {"[{ax}-{bz}]", "[{ax}{ay}{az}{bx}{by}{bz}]"},
+            // Support for this (meaning [{ax}{ay}{az}{bx}{by}{bz}] was added by ICU-11738 (ICU 56,
+            // but only ever implemented in Java), and removed by ICU-23312 (ICU 79).
+            {"[{ax}-{bz}]", "Expected ], got string-literal '{bz}' [{ax}-☞{bz}]"},
+            // Retained by ICU-23312.
             {"[{a}-{c}]", "[a-c]"},
-            // {"[a-{c}]", "[a-c]"}, // don't handle these yet: enable once we do
-            // {"[{a}-c]", "[a-c]"}, // don't handle these yet: enable once we do
-            {
-                "[{ax}-{by}-{cz}]",
-                "Error: '-' not after char, string, or set at \"[{ax}-{by}-{|cz}]\""
-            },
-            {"[{a}-{bz}]", "Error: Range must have equal-length strings at \"[{a}-{bz}|]\""},
-            {"[{ax}-{b}]", "Error: Range must have equal-length strings at \"[{ax}-{b}|]\""},
-            {"[{ax}-bz]", "Error: Invalid range at \"[{ax}-b|z]\""},
-            {"[ax-{bz}]", "Error: Range must have 2 valid strings at \"[ax-{bz}|]\""},
-            {"[{bx}-{az}]", "Error: Range must have xᵢ ≤ yᵢ for each index i at \"[{bx}-{az}|]\""},
+            // Support for these two was added by ICU-23312.
+            {"[a-{c}]", "[a-c]"},
+            {"[{a}-c]", "[a-c]"},
+            // These were never allowed.
+            {"[{ax}-{by}-{cz}]", "Expected ], got string-literal '{by}' [{ax}-☞{by}-{cz}]"},
+            {"[{a}-{bz}]", "Expected RangeElement, got string-literal '{bz}' [{a}-☞{bz}]"},
+            {"[{ax}-{b}]", "Expected ], got bracketed-element '{b}' [{ax}-☞{b}]"},
+            {"[{ax}-bz]", "Expected ], got literal-element 'b' [{ax}-☞bz]"},
+            {"[ax-{bz}]", "Expected RangeElement, got string-literal '{bz}' [ax-☞{bz}]"},
+            {"[{bx}-{az}]", "Expected ], got string-literal '{az}' [{bx}-☞{az}]"},
         };
         int i = 0;
         for (String[] test : tests) {
@@ -3752,5 +4188,600 @@ public class UnicodeSetTest extends CoreTestFmwk {
         System.out.println("Speed (normal/parallel)  : " + (double) timeNormal / timeParallel);
 
         assertEquals("normal and parallel give different sum", sumNormal, sumParallel);
+    }
+
+    @Test
+    public void testToPatternOutput() {
+        class TestCase {
+            public TestCase(String expression, String expected) {
+                this.expression = expression;
+                this.expected = expected;
+            }
+
+            public String expression;
+            public String expected;
+        }
+        for (final var testCase :
+                new TestCase[] {
+                    // For a UnicodeSet which is not a property-query nor a named-element and
+                    // without any
+                    // Restriction among its Terms (that is, whose Union consists solely a sequence
+                    // of Elements
+                    // UnescapedHyphenMinus), toPattern merges and sorts ranges, and introduces a
+                    // complement to
+                    // minimize the result.
+                    new TestCase("[c-za-b]", "[a-z]"),
+                    new TestCase("[  c - z  a - b  ]", "[a-z]"),
+                    new TestCase("[ ^ \\u0000-b d-\\U0010FFFF ]", "[c]"),
+                    new TestCase("[ \\u0000-b d-\\U0010FFFF ]", "[^c]"),
+                    new TestCase("[{Baden-Württemberg}]", "[{Baden\\-Württemberg}]"),
+                    new TestCase("[{\\Ba\\den\\-\\W\\ürtte\\mber\\g}]", "[{Baden\\-Württemberg}]"),
+                    new TestCase("[{N\\or\\man\\d\\ie}]", "[{Normandie}]"),
+                    new TestCase("[{P\\icar\\d\\ie}]", "[{Picardie}]"),
+                    new TestCase(
+                            "[{Pr\\ovence\\-\\A\\lpe\\s\\-\\C\\ôte\\ \\d\\'\\A\\zur}]",
+                            "[{Provence\\-Alpes\\-Côte\\ d'Azur}]"),
+                    new TestCase("[ - - ]", "[\\-]"),
+                    new TestCase("[ - _ - ]", "[\\-_]"),
+                    new TestCase("[ - + - ]", "[+\\-]"),
+                    new TestCase("[$d-za-c]", "[\\$a-z]"),
+                    new TestCase("[a-c$d-z]", "[\\$a-z]"),
+                    new TestCase("[\\uFFFFa-z]", "[a-z\\uFFFF]"),
+                    new TestCase("[!-$z]", "[!-\\$z]"),
+                    new TestCase("[-a-cd-z$-]", "[\\$\\-a-z]"),
+                    new TestCase("[-$-]", "[\\$\\-]"),
+                    // A property-query or named-element is kept as-is:
+                    new TestCase(
+                            "\\p{ General_Category = Punctuation }",
+                            "\\p{ General_Category = Punctuation }"),
+                    new TestCase("\\p{P}", "\\p{P}"),
+                    new TestCase("\\p{gc=P}", "\\p{gc=P}"),
+                    new TestCase(
+                            "[: general category = punctuation :]",
+                            "[: general category = punctuation :]"),
+                    new TestCase("\\P{ gc = punctuation }", "\\P{ gc = punctuation }"),
+                    new TestCase("[\\N{ latin small letter a }]", "[a]"),
+                    // If there is any Restriction among the terms, its syntax is mostly as-is
+                    // (spaces are
+                    // still eliminated), with the exception that an initial UnescapedHyphenMinus
+                    // gets escaped.
+                    // This is applied recursively, so innermost ranges-only UnicodeSets get
+                    // normalized.
+                    new TestCase("[ c-z a-b [c-f g-z] ]", "[c-za-b[c-z]]"),
+                    new TestCase("[- + c-z a-b [c-f g-z] -]", "[\\-+c-za-b[c-z]-]"),
+                    new TestCase(
+                            "[ c-z a-b \\p{ General_Category = Punctuation } ]",
+                            "[c-za-b\\p{ General_Category = Punctuation }]"),
+                    new TestCase("[^[c]]", "[^[c]]"),
+                    new TestCase("[ ^ [ \\u0000-b d-\\U0010FFFF ] ]", "[^[^c]]"),
+                    new TestCase("[$[]]", "[\\$[]]"),
+                    // In ICU 78 and earlier, a named-element was a nested set, so it was preserved
+                    // and
+                    // caused the syntax to be preserved.  Now it is treated like an escape.
+                    new TestCase("[ \\N{LATIN CAPITAL LETTER Z}eichenmenge ]", "[Zceg-imn]"),
+                    // This was ill-formed in ICU 78 and earlier (in a convoluted way:
+                    // {\\N{LATIN CAPITAL LETTER Z} was a well-formed string literal, but then the
+                    // second }
+                    // was unpaired).
+                    new TestCase(
+                            "[ {\\N{LATIN CAPITAL LETTER Z}eichenkette} ]", "[{Zeichenkette}]"),
+                    // This used to be equal to [A] in ICU 78 and earlier.
+                    new TestCase(
+                            "[ \\N{LATIN CAPITAL LETTER A} - \\N{LATIN CAPITAL LETTER Z} ]",
+                            "[A-Z]"),
+                    // Escapes added by ICU-23314.
+                    new TestCase(
+                            "[ \\N{41:A:LATIN CAPITAL LETTER A} - \\N{005A:LATIN CAPITAL LETTER Z} ]",
+                            "[A-Z]"),
+                    new TestCase("[ \\N{0001226D:𒉭:CUNEIFORM SIGN NUNUZ} ]", "[𒉭]"),
+                    new TestCase(
+                            "[ {\\N{1202D:CUNEIFORM SIGN AN}\\N{12240:𒉀:CUNEIFORM SIGN NAGA}} ]",
+                            "[{𒀭𒉀}]"),
+                    new TestCase("[ \\N{20: :SPACE} ]", "[\\ ]"),
+                    new TestCase("[ \\N{BED:TAMIL DIGIT SEVEN} ]", "[௭]"),
+                    // Some character names happen to be sequences of hexadecimal digits.
+                    new TestCase("[ \\N{BED} ]", "[🛏]"),
+                    // An anchor also causes the syntax to be preserved.
+                    new TestCase("[ d-z a-c $ ]", "[d-za-c$]"),
+                    new TestCase("[ - a-c d-z $ ]", "[\\-a-cd-z$]"),
+                    new TestCase("[$$$]", "[\\$\\$$]"),
+                    // Ill-formed in ICU4C 78 and earlier, made well-formed by ICU-23312.
+                    new TestCase("[a-{z}]", "[a-z]"),
+                    new TestCase("[{a}-z]", "[a-z]"),
+                    new TestCase(
+                            "[\\N{PRESENTATION FORM FOR VERTICAL RIGHT WHITE LENTICULAR BRAKCET}]",
+                            "[︘]"),
+                    new TestCase("[\\N{bell}]", "[🔔]"),
+                    // Ill-formed in ICU 78 and earlier, made well-formed by ICU-23350:
+                    new TestCase(
+                            "[\\N{PRESENTATION FORM FOR VERTICAL RIGHT WHITE LENTICULAR BRACKET}]",
+                            "[︘]"),
+                    /*
+                    // TODO(egg): ICU-3736 not yet done in Java.
+                    // Loose matching: These were ill-formed in ICU 78 and earlier, and were
+                    // made well-formed by ICU-3736.
+                    new TestCase("[\\N{Latin small ligature o-e}]", "[œ]"),
+                    new TestCase("[\\N{Hangul jungseong O-E}]", "[ᆀ]"),
+                    new TestCase("[\\N{Hangul jungseong O -E}]", "[ᆀ]"),
+                    new TestCase("[\\N{Hangul jungseong OE}]", "[ᅬ]"),
+                    new TestCase("[\\N{Tibetan letter -a}]", "[འ]"),
+                    new TestCase("[\\N{Tibetan letter - a}]", "[འ]"),
+                    new TestCase("[\\N{TIBETAN_LETTER_-A}]", "[འ]"),
+                    new TestCase("[\\N{TIBETAN LETTER-A}]", "[ཨ]"),
+                    new TestCase("[\\N{Tibetan mark BKA- SHOG YIG MGO}]", "[༊]"),
+                    new TestCase("[\\N{Tibetan mark BKA -SHOG-YIG-MGO}]", "[༊]"),
+                    new TestCase("[\\N{CJK UNIFIED IDEOGRAPH-55B5}]", "[喵]"),
+                    new TestCase("[\\N{CJK unified ideograph 5-5-b-5}]", "[喵]"),
+                    new TestCase("[{\\N{Hangul syllable YA}\\N{Hangul syllable ONG}}]", "[{야옹}]"),
+                    new TestCase("[{\\N{Hangul-syllable-y-a}\\N{Hangul-syllable-o-ng}}]", "[{야옹}]"),
+                    */
+                }) {
+            final var set = new UnicodeSet(testCase.expression);
+            final String actual = set.toPattern(false);
+            if (!actual.equals(testCase.expected)) {
+                errln(
+                        "UnicodeSet(R\"("
+                                + testCase.expression
+                                + ")\").toPattern() expected "
+                                + testCase.expected
+                                + ", got "
+                                + actual);
+            }
+        }
+    }
+
+    @Test
+    public void testParseErrors() {
+        for (final var expression : new String[] {"[\\u]", "[\\x{}]"}) {
+            try {
+                final var set = new UnicodeSet(expression);
+                errln(
+                        expression
+                                + ": Expected IllegalArgumentException, set is "
+                                + set.complement().complement().toPattern(true));
+            } catch (IllegalArgumentException e) {
+            }
+        }
+        for (final var testCase :
+                new String[][] {
+                    {"[a-[b]]", "Expected RangeElement, got set-operator '[' [a-☞[b]]"},
+                    {"a-z", "Expected property-query | [, got literal-element 'a' ☞a-z"},
+                    {"[[a]&]", "Expected property-query | [, got set-operator ']' [[a]&☞]"},
+                    {"[[a]&-[z]]", "Expected property-query | [, got set-operator '-' [[a]&☞-[z]]"},
+                    {"[[a]--[z]]", "Expected property-query | [, got set-operator '-' [[a]-☞-[z]]"},
+                    {"[{aa}-{zz}]", "Expected ], got string-literal '{zz}' [{aa}-☞{zz}]"},
+                    {
+                        "[a&z]",
+                        "Expected RangeElement | string-literal, got set-operator '&' [a☞&z]"
+                    },
+                    {
+                        "[{aa}&{zz}]",
+                        "Expected RangeElement | string-literal, got set-operator '&' [{aa}☞&{zz}]"
+                    },
+                    {
+                        "[a^z]",
+                        "Expected RangeElement | string-literal, got set-operator '^' [a☞^z]"
+                    },
+                    {"[a-{zz}]", "Expected RangeElement, got string-literal '{zz}' [a-☞{zz}]"},
+                    {
+                        "[[a]-{zz}]",
+                        "Expected property-query | [, got string-literal '{zz}' [[a]-☞{zz}]"
+                    },
+                    {
+                        "[[a]&{zz}]",
+                        "Expected property-query | [, got string-literal '{zz}' [[a]&☞{zz}]"
+                    },
+                    {"[{aa]", "String literal was not terminated: {aa] [{aa]☜"},
+                    {
+                        "[a-$]",
+                        "Expected Term after Range ending in unescaped $, got set-operator '$' followed by set-operator ']' [a-☞$]"
+                    },
+                    {
+                        "[!-$]",
+                        "Expected Term after Range ending in unescaped $, got set-operator '$' followed by set-operator ']' [!-☞$]"
+                    },
+                    {
+                        "[a-a]", "Expected first < last in Range, got a-a [a-☞a]"
+                    }, // TODO(egg): Exclude in PDUTS61.
+                    {"[z-a]", "Expected first < last in Range, got a-z [z-☞a]"},
+                    {"[[a]-z]", "Expected property-query | [, got literal-element 'z' [[a]-☞z]"},
+                    {"[[a]&z]", "Expected property-query | [, got literal-element 'z' [[a]&☞z]"},
+                    {"[a-z", "Expected ], got (end of text) '' [a-z☞"},
+                    // This was a well-formed string in ICU 78 and earlier, with the value
+                    // "N{LATINCAPITALLETTERZ".
+                    {
+                        "[{\\N{LATIN CAPITAL LETTER Z}]",
+                        "String literal was not terminated: {\\N{LATIN CAPITAL LETTER Z}] [{\\N{LATIN CAPITAL LETTER Z}]☜"
+                    },
+                    // These three were well-formed in ICU 78 and earlier.
+                    {"[{\\Normandie}]", "Ill-formed named-element [{\\No☜rmandie}]"},
+                    {
+                        "[{\\Picardie}]",
+                        "Invalid escape sequence \\P in UnicodeSet string [{\\P☜icardie}]"
+                    },
+                    {
+                        "[{Provence-Al\\pes-Côte d'Azur}]",
+                        "Invalid escape sequence \\p in UnicodeSet string [{Provence-Al\\p☜es-Côte d'Azur}]"
+                    },
+                    // This was a well-formed set in ICU 78 and earlier; now it must be enclosed in
+                    // square
+                    // brackets.
+                    {
+                        "\\N{ latin small letter a }",
+                        "Expected property-query | [, got named-element '\\N{ latin small letter a }' ☞\\N{ latin small letter a }"
+                    },
+                    // Well-formed in ICU 78 and earlier (spaces ignored).
+                    // In ICU 81 and later, the spaces will mean spaces.
+                    // Ill-formed in ICU 79 and 80.
+                    {
+                        "[ { Z e i c h e n k e t t e } Zeichenmenge ]",
+                        "Unescaped Pattern_White_Space in UnicodeSet string literals is prohibited until ICU 81.  Escape U+0020. [ { ☜Z e i c h e n k e t t e } Zeichenmenge ]"
+                    },
+                    {
+                        "[ { \\x5A e i c h e n k e t t e } \\x5Aeichenmenge ]",
+                        "Unescaped Pattern_White_Space in UnicodeSet string literals is prohibited until ICU 81.  Escape U+0020. [ { ☜\\x5A e i c h e n k e t t e } \\x5Aeichenmenge ]"
+                    },
+                    {
+                        "[ { Z e i c h e n k e t t e } [] Zeichenmenge ]",
+                        "Unescaped Pattern_White_Space in UnicodeSet string literals is prohibited until ICU 81.  Escape U+0020. [ { ☜Z e i c h e n k e t t e } [] Zeichenmenge ]"
+                    },
+                    {
+                        "[ { \\x5A e i c h e n k e t t e } [] \\x5Aeichenmenge ]",
+                        "Unescaped Pattern_White_Space in UnicodeSet string literals is prohibited until ICU 81.  Escape U+0020. [ { ☜\\x5A e i c h e n k e t t e } [] \\x5Aeichenmenge ]"
+                    },
+                }) {
+            final String expression = testCase[0];
+            final String errorMessage = testCase[1];
+            try {
+                final var set = new UnicodeSet(expression);
+                errln(
+                        expression
+                                + ": Expected IllegalArgumentException, set is "
+                                + set.complement().complement().toPattern(true));
+            } catch (IllegalArgumentException e) {
+                assertEquals("Error while parsing " + expression, errorMessage, e.getMessage());
+            }
+        }
+        for (final var testCase :
+                new String[][] {
+                    {"[:]", "property-query was not terminated [:]☜"},
+                    {"\\p", "Missing { in property-query \\p☜"},
+                    {"[:^]", "property-query was not terminated [:^]☜"},
+                    {"\\P", "Missing { in property-query \\P☜"},
+                    {"\\N", "Ill-formed named-element \\N☜"},
+                    {"[\\p{Some_Property=\\u}]", "Invalid escape"},
+                    {"[:Some_Property=\\u:]", "Invalid escape"},
+                    {"\\p{Some_Property=\\N{SOME CHARACTER}}", "Invalid character name"},
+                    {"[\\N{}]", "Invalid character name"},
+                    {
+                        "[ \\N{FFFFFFFF:NOT A CODE POINT} ]",
+                        "hexadecimal-digits out of range: FFFFFFFF [ \\N{FFFFFFFF:☜NOT A CODE POINT} ]"
+                    },
+                    {
+                        "[ \\N{0A:LATIN CAPITAL LETTER A} ]",
+                        "Ill-formed named-element: inconsistent with 000A: [ \\N{0A:LATIN CAPITAL LETTER A}☜ ]"
+                    },
+                    {
+                        "[ \\N{41:a:LATIN CAPITAL LETTER A} ]",
+                        "Ill-formed named-element: inconsistent with 0041:a: [ \\N{41:a:LATIN CAPITAL LETTER A}☜ ]"
+                    },
+                    {
+                        "[ \\N{12240:𒊺𒉀:CUNEIFORM SIGN NAGA} ]",
+                        "Ill-formed named-literal-element '𒊺𒉀' (2 code points) [ \\N{12240:𒊺𒉀:☜CUNEIFORM SIGN NAGA} ]"
+                    },
+                    {
+                        "[ \\N{12240::CUNEIFORM SIGN NAGA} ]",
+                        "Ill-formed named-literal-element '' (0 code points) [ \\N{12240::☜CUNEIFORM SIGN NAGA} ]"
+                    },
+                    {
+                        "[ \\N{:CUNEIFORM SIGN NAGA} ]",
+                        "Empty hexadecimal-digits in named-element [ \\N{:☜CUNEIFORM SIGN NAGA} ]"
+                    },
+                    {
+                        "[ \\N{::CUNEIFORM SIGN NAGA} ]",
+                        "Empty hexadecimal-digits in named-element [ \\N{:☜:CUNEIFORM SIGN NAGA} ]"
+                    },
+                    {
+                        "[ \\N{12240:𒉀::CUNEIFORM SIGN NAGA} ]",
+                        "Too many colons in named-element [ \\N{12240:𒉀::☜CUNEIFORM SIGN NAGA} ]"
+                    },
+                    {
+                        "[ \\N{12240:𒉀:CUNEIFORM SIGN NAGA:} ]",
+                        "Too many colons in named-element [ \\N{12240:𒉀:CUNEIFORM SIGN NAGA:☜} ]"
+                    },
+                    {
+                        "[ \\N{12240:CUNEIFORM SIGN NAGA:𒉀} ]",
+                        "Ill-formed named-literal-element 'CUNEIFORM SIGN NAGA' (19 code points) [ \\N{12240:CUNEIFORM SIGN NAGA:☜𒉀} ]"
+                    },
+                    {
+                        "[ \\N{𒉀:12240:CUNEIFORM SIGN NAGA} ]",
+                        "Ill-formed hexadecimal-digits: 𒉀 [ \\N{𒉀:☜12240:CUNEIFORM SIGN NAGA} ]"
+                    },
+                    {"[ \\N{12240} ]", "Invalid character name"},
+                    {"[ \\N{12240:𒉀} ]", "Invalid character name"},
+                    {
+                        "[ \\N{𒉀:CUNEIFORM SIGN NAGA} ]",
+                        "Ill-formed hexadecimal-digits: 𒉀 [ \\N{𒉀:☜CUNEIFORM SIGN NAGA} ]"
+                    },
+                    {
+                        "[ \\N{BED:BED} ]",
+                        "Ill-formed named-element: inconsistent with 0BED: [ \\N{BED:BED}☜ ]"
+                    },
+                    // Well-formed in ICU 78 and earlier, disallowed by ICU-23308.
+                    {"\\p{XID_Continue=}", "Invalid name: "},
+                    {"\\p{Uppercase_Letter=}", "Invalid name: Uppercase_Letter"},
+                    // Well-formed in ICU 78 and earlier, disallowed by ICU-23306.
+                    {"[: ^general category = punctuation :]", "Invalid name:  ^general category "},
+                    // Doubly negated property queries.
+                    {
+                        "\\P{Decomposition_Type≠compat}",
+                        "Found doubly negated property-query \\P{Decomposition_Type≠☜compat}"
+                    },
+                    {
+                        "[:^Noncharacter_Code_Point≠No:]",
+                        "Found doubly negated property-query [:^Noncharacter_Code_Point≠☜No:]"
+                    },
+                    // This should be [\a]; tracked by ICU-8963.
+                    {"[\\N{BEL}]", "Invalid character name"},
+                    // The leading hyphen does not match the medial hyphen in the real character
+                    // name.
+                    {"[\\N{CJK UNIFIED IDEOGRAPH -55B5}]", "Invalid character name"},
+                    // A medial hyphen does not match the trailing hyphen in BKA-.
+                    {"[\\N{Tibetan mark BKA-SHOG-YIG-MGO}]", "Invalid character name"},
+                    // With -- in the query, neither hyphen is medial, and two hyphens do not match
+                    // one.
+                    {"[\\N{Tibetan mark BKA--SHOG-YIG-MGO}]", "Invalid character name"},
+                }) {
+            final String expression = testCase[0];
+            final String errorMessage = testCase[1];
+            try {
+                final var set = new UnicodeSet(expression);
+                errln(
+                        expression
+                                + ": Expected IllegalArgumentException, set is "
+                                + set.complement().complement().toPattern(true));
+            } catch (IllegalArgumentException e) {
+                assertEquals("Error while parsing " + expression, errorMessage, e.getMessage());
+            }
+        }
+    }
+
+    // A whimsical symbol table that gives some code points the names of characters from
+    // Shakespeare’s plays.
+    // The symbol table requires exact matches for the property value (and thus checks that the
+    // UnicodeSet implementation does not apply loose matching too early).
+    // Variables are prefixed by a dollar, and consist of XID_Continue characters.
+    // The names of plays (case- and punctuation-insensitive) are recognized as variables for the
+    // sets of their characters.
+    static class ShakespeareanSymbolTable extends XSymbolTable {
+        static final Map<String, List<String>> DRAMATIS_PERSONAE;
+
+        static final List<String> ALL_CHARACTERS;
+
+        static {
+            DRAMATIS_PERSONAE = new TreeMap<>();
+            // Spellings from
+            // https://internetshakespeare.uvic.ca/Library/facsimile/book/BPL_Rowe1/462/index.html%3Fzoom=450.html.
+            DRAMATIS_PERSONAE.put(
+                    "Love’s Labour’s loſt",
+                    List.of(
+                            "Ferdinand",
+                            "Biron",
+                            "Longaville",
+                            "Dumain",
+                            "Boyet",
+                            "Macard",
+                            "Don Adriana de Armado",
+                            "Nathaniel",
+                            "Dull",
+                            "Holofernes",
+                            "Coſtard",
+                            "Moth",
+                            "Roſaline",
+                            "Maria",
+                            "Catherine",
+                            "Jaquenetta"));
+            DRAMATIS_PERSONAE.put(
+                    // Spellings from
+                    // https://internetshakespeare.uvic.ca/Library/facsimile/book/BPL_Rowe1/62/index.html%3Fzoom=450.html.
+                    "A Midſummer-Night’s Dream",
+                    List.of(
+                            "Theſeus",
+                            "Egeus",
+                            "Lyſander",
+                            "Demetrius",
+                            "Quince",
+                            "Snug",
+                            "Bottom",
+                            "Flute",
+                            "Snowt",
+                            "Starveling",
+                            "Hippolita",
+                            "Hermia",
+                            "Helena",
+                            "Oberon",
+                            "Titania",
+                            "Puck",
+                            "peaſebloſſom",
+                            "Cobweb",
+                            "Moth",
+                            "Muſtardſeed"));
+            ALL_CHARACTERS =
+                    DRAMATIS_PERSONAE.values().stream()
+                            .flatMap(characters -> characters.stream())
+                            .distinct()
+                            .collect(Collectors.toList());
+        }
+
+        @Override
+        public boolean applyPropertyAlias(
+                String propertyName, String propertyValue, UnicodeSet result) {
+            final String nameSkeleton =
+                    propertyName.replaceAll("[_ -]", "").toLowerCase(Locale.ROOT);
+            if (nameSkeleton.equals("name") || nameSkeleton.equals("na")) {
+                final int character = ALL_CHARACTERS.indexOf(propertyValue);
+                if (character < 0) {
+                    throw new IllegalArgumentException("Unknown character " + propertyValue);
+                }
+                result.add(character);
+                return true;
+            }
+            // We do not touch the other properties.
+            return false;
+        }
+
+        @Override
+        public UnicodeSet lookupSet(String name) {
+
+            final String foldedName =
+                    UCharacter.foldCase(name, /* defaultmapping= */ true)
+                            .codePoints()
+                            .filter(cp -> UCharacter.isLetter(cp))
+                            .mapToObj(Character::toString)
+                            .collect(Collectors.joining());
+            for (final var play : DRAMATIS_PERSONAE.entrySet()) {
+                final String foldedPlayName =
+                        UCharacter.foldCase(play.getKey(), /* defaultmapping= */ true)
+                                .codePoints()
+                                .filter(cp -> UCharacter.isLetter(cp))
+                                .mapToObj(Character::toString)
+                                .collect(Collectors.joining());
+                if (foldedPlayName.equals(foldedName)) {
+                    final var result = new UnicodeSet();
+                    for (final String character : play.getValue()) {
+                        applyPropertyAlias("Name", character, result);
+                    }
+                    return result;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public String parseReference(String text, ParsePosition pos, int limit) {
+            if (limit <= pos.getIndex()) {
+                // A $ at the end of text is not a variable.
+                return null;
+            }
+            for (int i = pos.getIndex(); i < limit; i = text.offsetByCodePoints(i, 1)) {
+                if (!UCharacter.hasBinaryProperty(text.codePointAt(i), UProperty.XID_CONTINUE)) {
+                    if (i == pos.getIndex()) {
+                        // A lone $ is not a variable.
+                        return null;
+                    }
+                    final String result = text.substring(pos.getIndex(), i);
+                    pos.setIndex(i);
+                    return result;
+                }
+            }
+            final String result = text.substring(pos.getIndex(), limit);
+            pos.setIndex(limit);
+            return result;
+        }
+    }
+
+    // Same as above, but the variables have no sigil, and allow for RIGHT SINGLE QUOTATION MARK,
+    // spaces, and medial hyphens, demonstrating that XSymbolTable allows for extensions that
+    // require complex lexing.
+    static class ShakespeareanSymbolTableWithCustomVariables extends ShakespeareanSymbolTable {
+        @Override
+        public String scanVariable(String text, ParsePosition pos, int limit) {
+            if (pos.getIndex() >= limit
+                    || !UCharacter.hasBinaryProperty(
+                            text.codePointAt(pos.getIndex()), UProperty.XID_START)) {
+                return null;
+            }
+            int previous = text.codePointAt(pos.getIndex());
+            for (int i = pos.getIndex() + 1; i < limit; i = text.offsetByCodePoints(i, 1)) {
+                int cp = text.codePointAt(i);
+                if ((cp == '-'
+                                && (!UCharacter.isLetter(previous)
+                                        || i + 1 == limit
+                                        || !UCharacter.isLetter(text.codePointAt(i + 1))))
+                        || (cp != '-'
+                                && cp != ' '
+                                && cp != '’'
+                                && !UCharacter.hasBinaryProperty(cp, UProperty.XID_CONTINUE))) {
+                    final String result = text.substring(pos.getIndex(), i);
+                    pos.setIndex(i);
+                    return result;
+                }
+                previous = cp;
+            }
+            final String result = text.substring(pos.getIndex(), limit);
+            pos.setIndex(limit);
+            return result;
+        }
+    }
+
+    @Test
+    public void TestXSymbolTable() {
+        ShakespeareanSymbolTable sstable = new ShakespeareanSymbolTable();
+        for (String[] test :
+                new String[][] {
+                    {"[\\p{Name=Biron}]", "[\\u0015]"},
+                    {"[\\N{Moth}]", "[\\u0012]"},
+                    {"[\\p{Name=LATIN SMALL LETTER A}]", "Unknown character LATIN SMALL LETTER A"},
+                    {"[\\N{LATIN SMALL LETTER A}]", "Unknown character LATIN SMALL LETTER A"},
+                    {"[\\p{Name=biron}]", "Unknown character biron"},
+                    {"[$AMidsummerNightsDream&$LovesLaboursLost]", "[\\N{Moth}]"},
+                    {
+                        "[$AMidsummerNightsDream-$LovesLaboursLost]",
+                        "[\\N{Theſeus}-\\N{Cobweb}\\N{Muſtardſeed}]"
+                    },
+                }) {
+            String expected = test[1];
+            if (test[1].startsWith("[")) {
+                expected = new UnicodeSet(expected, new ParsePosition(0), sstable).toPattern(false);
+            }
+            String actual;
+            try {
+                actual =
+                        new UnicodeSet(test[0], new ParsePosition(0), sstable)
+                                .complement()
+                                .complement()
+                                .toPattern(false);
+            } catch (Exception e) {
+                actual = e.getMessage();
+            }
+            assertEquals(test[0] + " with " + sstable.getClass(), expected, actual);
+        }
+        sstable = new ShakespeareanSymbolTableWithCustomVariables();
+        for (String[] test :
+                new String[][] {
+                    // With this lexing of variables, the dollar is not part of the variable.
+                    {"[$AMidsummerNightsDream]", "[\\N{Theſeus}-\\N{Muſtardſeed} \\$]"},
+                    {
+                        "[$AMidsummerNightsDream&$LovesLaboursLost]",
+                        "Expected property-query | [, got set-operator '$' [$AMidsummerNightsDream&☞$LovesLaboursLost]"
+                    },
+                    // Medial hyphens do not terminate variable names (and so do not act as
+                    // operators):
+                    {
+                        "[AMidsummerNightsDream-LovesLaboursLost]",
+                        "Undefined variable AMidsummerNightsDream-LovesLaboursLost [AMidsummerNightsDream-LovesLaboursLost☜]"
+                    },
+                    // Neither do spaces; but non-medial hyphens do terminate variable names.
+                    {
+                        "[A Midſummer-Night’s Dream - Love’s Labour’s loſt]",
+                        "[\\N{Theſeus}-\\N{Cobweb}\\N{Muſtardſeed}]"
+                    },
+                }) {
+            String expected = test[1];
+            if (test[1].startsWith("[")) {
+                expected = new UnicodeSet(expected, new ParsePosition(0), sstable).toPattern(false);
+            }
+            String actual;
+            try {
+                actual =
+                        new UnicodeSet(test[0], new ParsePosition(0), sstable)
+                                .complement()
+                                .complement()
+                                .toPattern(false);
+            } catch (Exception e) {
+                actual = e.getMessage();
+            }
+            assertEquals(test[0] + " with " + sstable.getClass(), expected, actual);
+        }
     }
 }

--- a/icu4j/main/translit/src/main/java/com/ibm/icu/text/TransliteratorParser.java
+++ b/icu4j/main/translit/src/main/java/com/ibm/icu/text/TransliteratorParser.java
@@ -190,6 +190,22 @@ class TransliteratorParser {
             return variableNames.get(name);
         }
 
+        @Override
+        public UnicodeSet lookupSet(String name) {
+            final char[] value = variableNames.get(name);
+            if (value == null || value.length != 1) {
+                return null;
+            }
+            final int i = value[0] - curData.variablesBase;
+            if (0 <= i && i < variablesVector.size()) {
+                final var result = variablesVector.get(i);
+                if (result instanceof UnicodeSet) {
+                    return (UnicodeSet) result;
+                }
+            }
+            return null;
+        }
+
         /** Implement SymbolTable API. */
         @Override
         public UnicodeMatcher lookupMatcher(int ch) {

--- a/icu4j/main/translit/src/test/java/com/ibm/icu/dev/test/translit/TransliteratorTest.java
+++ b/icu4j/main/translit/src/test/java/com/ibm/icu/dev/test/translit/TransliteratorTest.java
@@ -711,9 +711,9 @@ public class TransliteratorTest extends TestFmwk {
         String[] DATA = {
             "$abe = ab;"
                     + "$pat = x[yY]z;"
-                    + "$ll  = 'a-z';"
+                    + "$ll  = [a-z];"
                     + "$llZ = [$ll];"
-                    + "$llY = [$ll$pat];"
+                    + "$llY = [$ll Y];"
                     + "$emp = ;"
                     + "$abe > ABE;"
                     + "$pat > END;"


### PR DESCRIPTION
I ported the C++ as it currently is instead of reënacting its history, so this covers a number of JIRA tickets, see below.
I am not using ICU-23179 (the one that had the biggest change, the semantics-preserving C++ parser rewrite) because that went into 78, so I am arbitrarily picking the next ticket that got addressed in C++, ICU-23297, as the ticket for this PR.
1. ICU-23179 Test UnicodeSet behavior edge & error cases
   * C++: #3591, #3595, #3604, #3612
1. ICU-23297 Stop using lookupMatcher in UnicodeSet parsing
   * C++: #3806, #3827, #3832
1. ICU-23301 UnicodeSet: Force variables to be grammatical instead of arbitrary text replacement
   * C++: #3825
1. ICU-22851 UnicodeSet should treat \N like a character not like a set
   *  C++: #3828
1. ICU-23308 Disallow trailing = on UnicodeSet unary-query
   * C++: #3840
1. ICU-23306 [:^ should be atomic in UnicodeSet syntax
   * C++: #3838
1. ICU-23311 UnicodeSet: Regularize escapes in strings
   * C++: #3847
1. ICU-23307 UnicodeSet string literals should be space-sensitive
   * C++: #3839
1. ICU-23313 UnicodeSet: binary query negation with NOT EQUAL TO
   * C++: #3858
1. ICU-23314 UnicodeSet: extended name escapes
   * C++: #3860
1. ICU-23312 UnicodeSet: bracketed ranges but no string ranges
   * C++: #3857

This does _not_ cover ICU-3736 Unicode loose character name matching.

#### Checklist
- [x] Required: Issue filed: ICU-23297
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
