### PR TITLE
ICU-23371 Intern subdivision strings with a local pool instead of String.intern()

### DIFF
--- a/icu4j/main/core/src/main/java/com/ibm/icu/impl/ValidIdentifiers.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/impl/ValidIdentifiers.java
@@ -53,6 +53,7 @@ public class ValidIdentifiers {
 
         public ValiditySet(Set<String> plainData, boolean makeMap) {
             if (makeMap) {
+                Map<String, String> uniqueSubdivisions = new HashMap<String, String>();
                 HashMap<String, Set<String>> _subdivisionData = new HashMap<String, Set<String>>();
                 for (String s : plainData) {
                     int pos = s.indexOf('-'); // read v28 data also
@@ -61,7 +62,8 @@ public class ValidIdentifiers {
                         pos2 = pos = s.charAt(0) < 'A' ? 3 : 2;
                     }
                     final String key = s.substring(0, pos);
-                    final String subdivision = s.substring(pos2).intern();
+                    String subdivision =
+                            uniqueSubdivisions.computeIfAbsent(s.substring(pos2), k -> k);
 
                     Set<String> oldSet = _subdivisionData.get(key);
                     if (oldSet == null) {


### PR DESCRIPTION
A local temporary pool is faster than String.intern() and the memory used by the table could be released by the GC.

#### Checklist
- [x] Required: Issue filed: ICU-23371
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf
