### PR TITLE
ICU-23016 Bail out CollationFastLatin when it encounters a digit and …

### DIFF
--- a/icu4c/source/i18n/collationfastlatin.cpp
+++ b/icu4c/source/i18n/collationfastlatin.cpp
@@ -101,8 +101,13 @@ CollationFastLatin::getOptions(const CollationData *data, const CollationSetting
         for(UChar32 c = 0x30; c <= 0x39; ++c) { primaries[c] = 0; }
     }
 
+    // NUMERIC flag is also used for indicating digits are reordered
+    // in fast-Latin options.
+    int options = digitsAreReordered ?
+        settings.options | CollationSettings::NUMERIC : settings.options;
+
     // Shift the miniVarTop above other options.
-    return (static_cast<int32_t>(miniVarTop) << 16) | settings.options;
+    return (static_cast<int32_t>(miniVarTop) << 16) | options;
 }
 
 int32_t

--- a/icu4c/source/i18n/collationsettings.h
+++ b/icu4c/source/i18n/collationsettings.h
@@ -42,6 +42,10 @@ struct U_I18N_API CollationSettings : public SharedObject {
      *
      * Treat digit sequences as numbers with CE sequences in numeric order,
      * rather than returning a normal CE for each digit.
+     * 
+     * This bit is also used for indicating that digits are reordered in the fast-Latin code.
+     * When the fast-Latin code encounters a digit and this bit is set in the options, it bails out
+     * and fallback to the regular collation code.
      */
     static const int32_t NUMERIC = 2;
     /**

--- a/icu4c/source/test/cintltst/cmsccoll.c
+++ b/icu4c/source/test/cintltst/cmsccoll.c
@@ -5386,6 +5386,28 @@ static void TestReorderWithNumericCollation(void)
     ucol_close(myReorderCollation);
 }
 
+static void TestDigitReordering(void)
+{
+    const UChar *str1[] = {u"123", u"123", u"ABC"};
+    const UChar *str2[] = {u"ABC", u"124", u"ABD"};
+    const UCollationResult exp[] = {UCOL_GREATER, UCOL_LESS, UCOL_LESS};
+
+    UErrorCode status = U_ZERO_ERROR;
+    UCollator *coll;
+    int32_t i;
+
+    coll = ucol_open("en_US@colReorder=latn-digit", &status);
+    if (U_FAILURE(status)) {
+        log_err_status(status, "ERROR: in creation of collator: %s\n", myErrorName(status));
+        return;
+    }
+    for (i = 0; i < 3; i++) {
+        doTest(coll, str1[i], str2[i], exp[i]);
+    }
+    ucol_close(coll);
+}
+
+
 static int compare_uint8_t_arrays(const uint8_t* a, const uint8_t* b)
 {
   for (; *a == *b; ++a, ++b) {
@@ -5966,6 +5988,7 @@ void addMiscCollTest(TestNode** root)
     TEST(TestMultipleReorder);
     TEST(TestReorderingAcrossCloning);
     TEST(TestReorderWithNumericCollation);
+    TEST(TestDigitReordering);
     
     TEST(TestCaseLevelBufferOverflow);
     TEST(TestNextSortKeyPartJaIdentical);

--- a/icu4j/main/collate/src/main/java/com/ibm/icu/impl/coll/CollationFastLatin.java
+++ b/icu4j/main/collate/src/main/java/com/ibm/icu/impl/coll/CollationFastLatin.java
@@ -280,8 +280,15 @@ public final class CollationFastLatin /* all static */ {
             }
         }
 
+        // NUMERIC flag is also used for indicating digits are reordered
+        // in fast-Latin options.
+        int options =
+                digitsAreReordered
+                        ? CollationSettings.NUMERIC | settings.options
+                        : settings.options;
+
         // Shift the miniVarTop above other options.
-        return (miniVarTop << 16) | settings.options;
+        return (miniVarTop << 16) | options;
     }
 
     public static int compareUTF16(

--- a/icu4j/main/collate/src/main/java/com/ibm/icu/impl/coll/CollationSettings.java
+++ b/icu4j/main/collate/src/main/java/com/ibm/icu/impl/coll/CollationSettings.java
@@ -26,6 +26,10 @@ public final class CollationSettings extends SharedObject {
      *
      * <p>Treat digit sequences as numbers with CE sequences in numeric order, rather than returning
      * a normal CE for each digit.
+     *
+     * <p>This bit is also used for indicating that digits are reordered in the fast-Latin code.
+     * When the fast-Latin code encounters a digit and this bit is set in the options, it bails out
+     * and fallback to the regular collation code.
      */
     public static final int NUMERIC = 2;
 

--- a/icu4j/main/collate/src/test/java/com/ibm/icu/dev/test/collator/CollationMiscTest.java
+++ b/icu4j/main/collate/src/test/java/com/ibm/icu/dev/test/collator/CollationMiscTest.java
@@ -3617,6 +3617,18 @@ public class CollationMiscTest extends TestFmwk {
     }
 
     @Test
+    public void TestDigitReordering() {
+        String[] str1 = {"123", "123", "ABC"};
+        String[] str2 = {"ABC", "124", "ABD"};
+        int[] exp = {1, -1, -1};
+
+        Collator coll = Collator.getInstance(new ULocale("en_US@colReorder=latn-digit"));
+        for (int i = 0; i < str1.length; i++) {
+            CollationTest.doTest(this, (RuleBasedCollator) coll, str1[i], str2[i], exp[i]);
+        }
+    }
+
+    @Test
     public void TestFrozeness() {
         Collator myCollation = Collator.getInstance(ULocale.CANADA);
         boolean exceptionCaught = false;


### PR DESCRIPTION
…digits are reordered.

When order of Latin letters and digits are changed by colReorder (kr) option, the comparison code in CollationFastLatin cannot handle it. The implementation was designed to bail out whenever it encounters the situation. However, it failed to detect this condition and returned an incorrect result.

To fix the issue, when digits are reordered, then CollationFastLatin::getOptions() sets the CollationSettings::NUMERIC bit, which in the fast-Latin code is only used to bail out when digits are encountered.

#### Checklist
- [x] Required: Issue filed: ICU-23016
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
