### PR TITLE
ICU-23437 Test rules with lookaheads that must coëxist

### DIFF
--- a/icu4c/source/test/intltest/rbbitst.cpp
+++ b/icu4c/source/test/intltest/rbbitst.cpp
@@ -158,6 +158,7 @@ void RBBITest::runIndexedTest( int32_t index, UBool exec, const char* &name, cha
     TESTCASE_AUTO(TestBug22585);
     TESTCASE_AUTO(TestBug22602);
     TESTCASE_AUTO(TestBug22636);
+    TESTCASE_AUTO(TestLookaheadPolychromy);
 
 #if U_ENABLE_TRACING
     TESTCASE_AUTO(TestTraceCreateCharacter);
@@ -4931,4 +4932,93 @@ void RBBITest::TestBug22581() {
 
     RuleBasedBreakIterator bi(ruleStr, pe, ec);
 }
+
+/*
+ * Tests some rule sets that require the lookaheads to occupy different slots.
+ */
+void RBBITest::TestLookaheadPolychromy() {
+
+    UErrorCode status = U_ZERO_ERROR;
+    UParseError parseError;
+    // The first lookahead must occupy a different slot from the other two, because after
+    // encountering x y two different break positions can be returned depending on the third
+    // character: the graph of lookahead reachability is a cherry (🍒, the first one with an edge
+    // from the other two, the last two with no edge between each other).  Its chromatic number
+    // is 2.
+    RuleBasedBreakIterator lookaheadCherry(uR"(
+                                               [x] / [wy]   [z];
+                                               [x]   [y]  / [t];
+                                               [x]   [w]  / [u];
+                                               .*;
+                                           )",
+                                           parseError, status);
+    for (auto const &[text, firstSegment] :
+         std::vector<std::pair<UnicodeString, std::u16string_view>>{
+             // If lookaheads 1 and 2 use the same slot, 2 stomps over 1 and we get xy instead of x
+             // here.
+             {u"xyz", u"x"},
+             // If lookaheads 1 and 3 use the same slot, 3 stomps over 1 and we get xw instead of x
+             // here.
+             {u"xwz", u"x"},
+             {u"xyt", u"xy"},
+             {u"xwt", u"xwt"},
+             {u"xyu", u"xyu"},
+             {u"xwu", u"xw"},
+         }) {
+        lookaheadCherry.setText(text);
+        std::u16string_view actual = text.tempSubString(0, lookaheadCherry.next());
+        if (actual != firstSegment)
+            errln(UnicodeString(u"First segment of ") + text + " with lookaheadCherry: expected " +
+                  firstSegment + ", got " + actual);
+    }
+    // The state that accepts lookahead 1 is reachable from those that set lookaheads 2 and 3, and
+    // the set that accepts lookahead 2 is reachable from the one that sets lookahead 3: the graph
+    // of lookaheads is a triangle, its chromatic number is 3; the lookaheads all need different
+    // slots.
+    RuleBasedBreakIterator lookaheadTriangle(uR"(
+                                                 [x] / [y]   [z]    [1];
+                                                 [x]   [y] / [z]    [2];
+                                                 [x]   [y]   [z] /  [3];
+                                                 .*;
+                                             )",
+                                             parseError, status);
+    for (auto const &[text, firstSegment] :
+         std::vector<std::pair<UnicodeString, std::u16string_view>>{
+             {u"xyz1", u"x"},
+             {u"xyz2", u"xy"},
+             {u"xyz3", u"xyz"},
+             {u"xyzn", u"xyzn"},
+         }) {
+        lookaheadTriangle.setText(UnicodeString::readOnlyAlias(text));
+        std::u16string_view actual = text.tempSubString(0, lookaheadTriangle.next());
+        if (actual != firstSegment)
+            errln(UnicodeString(u"First segment of ") + text + " with lookaheadTriangle: expected " +
+                  firstSegment + ", got " + actual);
+    }
+    // Consecutive lookaheads must occupy different slots ; the graph of lookahead reachability is a
+    // path graph.  Its chromatic number is 2.
+    RuleBasedBreakIterator lookaheadPath(uR"(
+                                             [x]  / [y]   [z]   [1];
+                                             [x]?   [y] / [z]   [2];
+                                                     [y]   [z] / [t]   [1];
+                                                     [y]   [z]   [t] / [2];
+                                             .*;
+                                         )",
+                                         parseError, status);
+    for (auto const &[text, firstSegment] :
+         std::vector<std::pair<UnicodeString, std::u16string_view>>{
+             {u"xyz1", u"x"},
+             {u"xyz2", u"xy"},
+             {u"yz2", u"y"},
+             {u"yzt1", u"yz"},
+             {u"yzt2", u"yzt"},
+         }) {
+        lookaheadPath.setText(UnicodeString::readOnlyAlias(text));
+        std::u16string_view actual = text.tempSubString(0, lookaheadPath.next());
+        if (actual != firstSegment)
+            errln(UnicodeString(u"First segment of ") + text + " with lookaheadPath: expected " +
+                  firstSegment + ", got " + actual);
+    }
+}
+
 #endif // #if !UCONFIG_NO_BREAK_ITERATION

--- a/icu4c/source/test/intltest/rbbitst.h
+++ b/icu4c/source/test/intltest/rbbitst.h
@@ -107,6 +107,7 @@ public:
     void TestBug22585();
     void TestBug22602();
     void TestBug22636();
+    void TestLookaheadPolychromy();
 
 #if U_ENABLE_TRACING
     void TestTraceCreateCharacter();


### PR DESCRIPTION
This looks like a weirdly specific test, and it passes without problem, but it is relevant to the optimization that is coming in https://github.com/unicode-org/icu/pull/4028 as part of this ticket. We currently have no test cases that require remembering multiple lookahead positions at the same time, so the forthcoming lookahead colouring algorithm would not be tested without these.

Indeed commit 638fff9a2147f3fcea02034afa844b6b142223b3 in #4028 which just assumes 1-colourability currently passes CI with flying colours; it would fail these new tests, with
```
         First segment of xyz with lookaheadCherry: expected x, got xy
         First segment of xwz with lookaheadCherry: expected x, got xw
         First segment of xyz1 with lookaheadTriangle: expected x, got xyz
         First segment of xyz2 with lookaheadTriangle: expected xy, got xyz
         First segment of xyz1 with lookaheadPath: expected x, got xy
         First segment of yz2 with lookaheadPath: expected y, got yz
         First segment of yzt1 with lookaheadPath: expected yz, got yzt
```

I am not yet formally describing the lookahead reachability relation in the comments in this test, this will come in #4028 where we actually use it to merge lookaheads (or rather, to not merge them).

In case anyone is curious what the state machines for the cherry, triangle, and path segmenters look like, I pushed them to https://github.com/eggrobin/unicodetools/tree/chromatic-number-testcases, see (cherry|triangle|path)Break(Symbols|States|Transitions).txt.

running `lb_fragen.py` there prints the following, confirming the descriptions of the graphs of lookaheads in the comments here:
```
=== cherry ===
8 states
3 lookaheads
By x w z,
x / w z reachable from x w / u
By x y z,
x / w z reachable from x y / t
lookaheads are not 1-colourable
lookaheads are 2-colourable
[['x w / u', 'x y / t'], ['x / w z']]
refining group of size 2 into subgroups of sizes [1, 1]
refining group of size 2 into subgroups of sizes [1, 1]
7 parts after minimization
from 8
['x']
['x w u', 'x y t']
['x w z']
['whatever']
['START']
['x y']
['x w']
=== triangle ===
8 states
3 lookaheads
By x y z 1,
x / y z 1 reachable from x y / z 2
By x y z 1,
x / y z 1 reachable from x y z / 3
By x y z 2,
x y / z 2 reachable from x y z / 3
lookaheads are not 1-colourable
lookaheads are not 2-colourable
lookaheads are 3-colourable
[['x y z / 3'], ['x y / z 2'], ['x / y z 1']]
refining group of size 2 into subgroups of sizes [1, 1]
8 parts after minimization
from 8
['x']
['x y']
['x y z']
['x y z 1']
['x y z 2']
['x y z 3']
['whatever']
['START']
=== path ===
12 states
4 lookaheads
By x y z 1,
x / y z 1 reachable from y / z 2
By y z 2,
y / z 2 reachable from y z / t 1
By y z t 1,
y z / t 1 reachable from y z t / 2
lookaheads are not 1-colourable
lookaheads are 2-colourable
[['y / z 2', 'y z t / 2'], ['x / y z 1', 'y z / t 1']]
refining group of size 3 into subgroups of sizes [1, 1, 1]
refining group of size 2 into subgroups of sizes [1, 1]
refining group of size 3 into subgroups of sizes [1, 1, 1]
10 parts after minimization
from 12
['y z 2', 'y z t 2']
['x y z 1', 'y z t 1']
['whatever']
['x y z']
['START']
['x']
['y z']
['y z t']
['x y']
['y']
```

#### Checklist
- [x] Required: Issue filed: ICU-23437
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
