### PR TITLE
ICU-23425 Fix broken links in documentation site

### DIFF
--- a/docs/devsetup/cpp/vscode.md
+++ b/docs/devsetup/cpp/vscode.md
@@ -37,5 +37,5 @@ parent: C++ Setup
 
 NOTE:
 Run the
-[`./runConfigureICU` command](https://unicode-org.github.io/icu/userguide/icufaq)
+[`./runConfigureICU` command](../../userguide/icu4c/faq.md)
 before building `icu4c` from VSCode.

--- a/docs/devsetup/source/index.md
+++ b/docs/devsetup/source/index.md
@@ -102,7 +102,7 @@ There are many resources available to help you work with git, here are a few:
 *   <https://try.github.io/> - Resources to learn Git
 
 Want to contribute back to ICU? See
-[How to contribute](../../userguide/processes/contribute.md).
+[How to contribute](../../userguide/dev/index.md).
 
 ## Repository Layout
 
@@ -138,7 +138,7 @@ There are other tags and branches which may be cleaned up/deleted at any time.
 *   long running shared feature branches (In general, feature work is done on
     personal forks of the repository.)
 
-See also the [Tips (for developers)](repository/tips/index.md) subpage.
+See also the [git and Github for ICU Developers](../../userguide/dev/gitdev.md) subpage.
 
 ## A Bit of History
 

--- a/docs/download/76.md
+++ b/docs/download/76.md
@@ -255,7 +255,7 @@ We accept patches for other platforms.
 For ICU 76, we have received a contribution to make ICU4C work again on z/OS,
 using a newer (clang-based) compiler. ([ICU-22714](https://unicode-org.atlassian.net/browse/ICU-22714) [icu/pull/3008](https://github.com/unicode-org/icu/pull/3008) + [ICU-22916](https://unicode-org.atlassian.net/browse/ICU-22916) [icu/pull/3208](https://github.com/unicode-org/icu/pull/3208))
 
-Windows: The minimum supported version is Windows 7. (See [How To Build And Install On Windows](../userguide/icu4c/build.html#how-to-build-and-install-on-windows) for more details.)
+Windows: The minimum supported version is Windows 7. (See [How To Build And Install On Windows](../userguide/icu4c/build#how-to-build-and-install-on-windows) for more details.)
 
 ## ICU4J Platform Support
 

--- a/docs/download/77.md
+++ b/docs/download/77.md
@@ -129,7 +129,7 @@ We routinely test on recent versions of Linux, macOS, and Windows.
 
 We accept patches for other platforms.
 
-Windows: The minimum supported version is Windows 7. (See [How To Build And Install On Windows](../userguide/icu4c/build.html#how-to-build-and-install-on-windows) for more details.)
+Windows: The minimum supported version is Windows 7. (See [How To Build And Install On Windows](../userguide/icu4c/build#how-to-build-and-install-on-windows) for more details.)
 
 ## ICU4J Platform Support
 

--- a/docs/download/78.md
+++ b/docs/download/78.md
@@ -221,7 +221,7 @@ We routinely test on recent versions of Linux, macOS, and Windows.
 We accept patches for other platforms.
 
 Windows: The minimum supported version is Windows 7.
-(See [How To Build And Install On Windows](../userguide/icu4c/build.html#how-to-build-and-install-on-windows)
+(See [How To Build And Install On Windows](../userguide/icu4c/build#how-to-build-and-install-on-windows)
 for more details.)
 
 ## ICU4J Platform Support

--- a/docs/processes/cldr-icu.md
+++ b/docs/processes/cldr-icu.md
@@ -290,7 +290,7 @@ ant proddata 2>&1 | tee $NOTES/cldr-newData-proddataLog.txt
 
 > Note, for CLDR development, at this point tests are sometimes run on the
    production data, see
-   [BRS: Run tests on production data](https://cldr.unicode.org/development/cldr-big-red-switch/brs-run-tests-on-production-data)
+   [BRS: Run tests on production data](https://cldr.unicode.org/development/cldr-big-red-switch/)
 
 > Note, also for CLDR development, periodically at this point the CompareResolved
   tool should be run to compare the fully-resolved data generated from `$CLDR_DIR/common/main`

--- a/docs/processes/release/tasks/docs.md
+++ b/docs/processes/release/tasks/docs.md
@@ -70,7 +70,7 @@ See the [User Guide, ICU Architectural Design, ICU API
 compatibility](https://unicode-org.github.io/icu/userguide/icu/design#icu-api-compatibility).
 
 On ICU4J, run
-[com.ibm.icu.dev.tool.docs.CheckTags](https://github.com/unicode-org/icu/blob/main/icu4j/tools/build/src/com/ibm/icu/dev/tool/docs/CheckTags.java)
+[com.ibm.icu.dev.tool.docs.CheckTags](https://github.com/unicode-org/icu/blob/main/icu4j/tools/build/src/main/java/com/ibm/icu/dev/tool/docs/CheckTags.java)
 (see file for instructions). This requires a JDK with javadoc available, i.e, JDK11. The
 tool will need to change to reflect the release number to search for.
 
@@ -303,7 +303,7 @@ Instructions ***for ICU4C 4.8.x and earlier***:
 
 Run the ICU4J versus JDK API comparison tool against the target JDK (anything
 that will come out before our next release, basically) with the tool
-[com.ibm.icu.dev.tool.docs.ICUJDKCompare](https://github.com/unicode-org/icu/blob/main/icu4j/tools/build/src/com/ibm/icu/dev/tool/docs/ICUJDKCompare.java)
+[com.ibm.icu.dev.tool.docs.ICUJDKCompare](https://github.com/unicode-org/icu/blob/main/icu4j/tools/build/src/main/java/com/ibm/icu/dev/tool/docs/ICUJDKCompare.java)
 and make sure ICU4J adequately covers the JDK API for the classes we replicate.
 
 ---

--- a/docs/processes/release/tasks/integration.md
+++ b/docs/processes/release/tasks/integration.md
@@ -372,8 +372,7 @@ Instructions for verifying the XLIFF conversion tools.
 ## Test sample and demo programs
 
 Build and run all of the sample and demo apps that are included with ICU, on
-each of the reference platforms. A list of them is in the
-[readme](http://icu.sanjose.ibm.com/internal/checklist/icu-progs-list.html).
+each of the reference platforms. A list of them [here](../../../demos/index.md).
 Also see the build system.
 
 Another worthy test: Test suites and demos *from the previous release* should

--- a/docs/processes/release/tasks/legal/index.md
+++ b/docs/processes/release/tasks/legal/index.md
@@ -25,7 +25,7 @@ License & terms of use: http://www.unicode.org/copyright.html#License
 
 Scan the source code to make sure that every file that was touched recently has
 the current year in the copyright statement. See the [ICU Copyright
-Scanner](../../../copyright-scan.md) page and follow the link to the scripts and
+Scanner](https://icu.unicode.org/processes/copyright-scan) page and follow the link to the scripts and
 the readme.
 
 Scan the source code to include third-party company names in copyright notices

--- a/docs/processes/release/tasks/publish/index.md
+++ b/docs/processes/release/tasks/publish/index.md
@@ -339,7 +339,7 @@ That new flow overlaps with _"Using the output from the build bots"_ below.
 
 *   Manual process:
     *   Build with MSVC x64 Release. (See the ICU
-        [readme.html](https://github.com/unicode-org/icu/main/blob/icu4c/readme.html)
+        [readme.html](https://github.com/unicode-org/icu/blob/main/icu4c/readme.html)
         file for details).
     *   Open a command prompt.
         ```
@@ -522,8 +522,8 @@ Note that updating ICU4C demos online requires Gcloud access.
 
 ### Online information update
 
-Collation and [comparison](../../../../charts/comparison/index.md) charts need
-to be updated. See [charts/Performance & Size](../../../../charts/index.md).
+Collation and [comparison](https://icu.unicode.org/charts/comparison) charts need
+to be updated. See [charts/Performance & Size](https://icu.unicode.org/charts).
 
 ### Old sensitive tickets
 
@@ -581,9 +581,9 @@ Jira.
 ## Update readme
 
 Update [ICU4C
-readme.html](https://github.com/unicode-org/icu/main/icu4c/readme.html)
+readme.html](https://github.com/unicode-org/icu/blob/main/icu4c/readme.html)
 and [ICU4J
-readme.html](https://github.com/unicode-org/icu/main/icu4j/readme.html)
+readme.html](https://github.com/unicode-org/icu/blob/main/icu4j/readme.html)
 before every milestone (GA / RC / Milestone-N). Make sure the following items
 are up to date.
 

--- a/docs/processes/release/tasks/versions.md
+++ b/docs/processes/release/tasks/versions.md
@@ -64,8 +64,7 @@ If you need values different than that, you can specify them as the command line
 
 #### Since ICU 68
 
-In
-[tools/cldr/cldr-to-icu/build-icu-data.xml](https://github.com/unicode-org/icu/blob/main/tools/cldr/cldr-to-icu/build-icu-data.xml)
+In `tools/cldr/cldr-to-icu/build-icu-data.xml`
 edit `<property name="icuVersion" value="67.1.0.0"/>` and `<property
 name="icuDataVersion" value="67.1.0.0"/>`.
 
@@ -265,7 +264,7 @@ Time Zone Data Version: 2011g
 
 For updating ICU version numbers, follow the steps below.
 
-1. [icu4j/main/shared/build/common.properties](https://github.com/unicode-org/icu/blob/main/icu4j/main/shared/build/common.properties)
+1. `icu4j/main/shared/build/common.properties`
 
     *   icu4j.spec.version: This is API spec version, therefore, 2-digit major
         version only. The version number won't be changed for maintenance
@@ -282,7 +281,7 @@ For updating ICU version numbers, follow the steps below.
         is updated to the current year for a new release (also applicable to a
         maintenance release).
 
-2. icu4j/build.properties (For API change report and release target)
+2. `icu4j/build.properties` (For API change report and release target)
 
     *   api.report.version: 2 digit release number. Note: If necessary, we may
         include maintenance release number. (e.g "54", "481")
@@ -384,8 +383,7 @@ For updating ICU version numbers, follow the steps below.
     ***Note: We no longer use time bombs since ICU4J 52. In the trunk,
     logKnownIssue() is used for skipping known test failures. The new scheme no
     longer depends on the current ICU4J version, so there are no updates
-    necessary in test codes when version number is updated. See [Skipping Known
-    Test Failures](../../../setup/eclipse/time.md) for more details.***
+    necessary in test codes when version number is updated.***
 
     There might be some test cases intentionally skipped for the current ICU4J
     version. When ICU4J version is updated, these time bombed test cases may
@@ -423,12 +421,11 @@ For updating ICU version numbers, follow the steps below.
    ICU4J Eclipse plug-in use the standard Eclipse versioning scheme -
    X.Y.Z.v<build date>, for example, com.ibm.icu_4.2.1.v20100412.jar. By
    default, the build script compose the version string from
-   icu4j.plugin.impl.version.string property in
-   [eclipse-build/build.properties](https://github.com/unicode-org/icu/blob/main/icu4j/eclipse-build/build.properties)
+   icu4j.plugin.impl.version.string property in `eclipse-build/build.properties`
    with current date at the build time. However, when we tag a version, we want
    to freeze the build date part. To force a fixed version string, we add a
-   property - icu4j.eclipse.build.version.string in the build.properties. For
-   example, see
+   property - `icu4j.eclipse.build.version.string` in the `build.properties`.
+   For example, see
    [tags/release-4-4-2-eclipse37-20110208/eclipse-build/build.properties](http://source.icu-project.org/repos/icu/tags/icu4j/release-4-4-2-eclipse37-20110208/eclipse-build/build.properties).
 
 7. [DebugUtilitiesData.java](https://github.com/unicode-org/icu/blob/main/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/util/DebugUtilities.java)

--- a/docs/userguide/boundaryanalysis/break-rules.md
+++ b/docs/userguide/boundaryanalysis/break-rules.md
@@ -416,12 +416,6 @@ Here is the syntax for the boundary rules. (The EBNF Syntax is given below.)
    used by the standard rules for word, line and sentence breaking. An
    alternative is probably needed. The existing implementation is incomplete.
 
-## Additional Sample Code
-
-**C/C++**
-See [icu/source/samples/break/](https://github.com/unicode-org/icu/tree/main/icu4c/source/samples/break/)
-in the ICU source distribution for code samples showing the use of ICU boundary analysis.
-
 ## Details about Dictionary-Based Break Iteration
 
 > :point_right: **Note**: This section below is originally from August 2012.

--- a/docs/userguide/collation/architecture.md
+++ b/docs/userguide/collation/architecture.md
@@ -58,7 +58,7 @@ when opening collators:
 
 2.  The empty locale name ("") means the root locale.
     The Collation Service adheres to the ICU conventions described in the
-    "[ICU Architectural Design](../design.md) " section of the users guide.
+    "[ICU Architectural Design](../icu/design.md) " section of the users guide.
     In particular:
 
 3.  The standard error code convention is usually followed. (Functions that do

--- a/docs/userguide/conversion/converters.md
+++ b/docs/userguide/conversion/converters.md
@@ -264,7 +264,7 @@ There are four ways to create a converter:
 > define the default codepage to something that supports Hindi.
 > The default converter is used in expressions such as: `UnicodeString text("abc");`
 > to convert 'abc', and in the `u_uastrcpy()` C functions.
-> Code operating at the [OS level](../design.md) MAY choose to
+> Code operating at the [OS level](../icu/design.md) MAY choose to
 > change the default converter with `ucnv_setDefaultName()`.
 > However, be aware that this change has inconsistent results if it is done after
 > ICU components are initialized.
@@ -274,7 +274,7 @@ There are four ways to create a converter:
 Closing a converter frees memory occupied by that instance of the converter.
 However it does not release the larger shared data tables the converter might
 use. OS-level code may call `ucnv_flushCache()` to explicitly free memory occupied
-by [unused tables](../design.md).
+by [unused tables](../icu/design.md).
 
 ```c
 ucnv_close(conv)
@@ -283,7 +283,7 @@ ucnv_close(conv)
 ### Converter Life Cycle
 
 Note that a Converter is created with a certain type (for instance, ISO-8859-3)
-which does not change over the life of that [object](../design.md). Converters
+which does not change over the life of that [object](../icu/design.md). Converters
 should be allocated one per thread. They are cheap to create, as the shared data
 doesn't need to be reallocated.
 
@@ -829,7 +829,3 @@ UnicodeString str("ABCDEF", "iso-8859-1");
 int32_t targetsize = str.extract(0, str.length(), target, sizeof(target), "SJIS");
 target[targetsize] = 0; /* NULL termination */
 ```
-
-## Conversion Examples
-
-See the [ICU Conversion Examples](https://github.com/unicode-org/icu/blob/main/icu4c/source/samples/ucnv/convsamp.cpp) for more information.

--- a/docs/userguide/conversion/index.md
+++ b/docs/userguide/conversion/index.md
@@ -129,7 +129,7 @@ Unicode.
         date.
 
     5.  ICU's default build includes about 200 conversion tables. See the [ICU
-        Data](../icudata.md) chapter for how to add or remove conversion tables
+        Data](../icu_data/index.md) chapter for how to add or remove conversion tables
         and other data.
 
     6.  In ICU, you can (and should) also use APIs that map a charset name
@@ -146,9 +146,7 @@ Unicode.
     8.  For some text formats, especially XML and HTML, it is possible to set an
         "escape callback" function that turns unmappable Unicode code points
         into corresponding escape sequences, preventing data loss. See the API
-        references and the [ucnv sample
-        code](https://github.com/unicode-org/icu/tree/main/icu4c/source/samples/ucnv/)
-        .
+        references.
 
     9.  **Never modify a conversion table.** Instead, use existing ones that
         match precisely those in systems with which you communicate. "Modifying"

--- a/docs/userguide/datetime/index.md
+++ b/docs/userguide/datetime/index.md
@@ -81,7 +81,7 @@ details.*
 ### References
 
 The ICU system time zones are derived from the tz database (also known as the
-“Olson” database) at [ftp://elsie.nci.nih.gov/pub](ftp://elsie.nci.nih.gov/pub).
+“Olson” database) at <https://www.iana.org/time-zones>.
 This is the data used across much of the industry, including by UNIX systems,
 and is usually updated several times each year. ICU (since version 2.8) and base
 Java (since Java 1.4) contain code and tz data supporting both current and

--- a/docs/userguide/datetime/timezone/index.md
+++ b/docs/userguide/datetime/timezone/index.md
@@ -144,7 +144,7 @@ update strategies are possible, depending on the ICU version and configuration.
   * Data is loaded from individual files: drop in the updated binary .res
     files.
 
-The [ICU Data](../../icudata.md) section of this user guide gives more
+The [ICU Data](../../icu_data/index.md) section of this user guide gives more
 information on how ICU loads resources.
 
 The ICU resource files required for time zone data updates are posted at
@@ -220,7 +220,7 @@ file directory.
 If the ICU-using application sets an ICU data path (or can be changed to set
 one), then the time zone .res file can be placed there. Download the files as
 described above and copy them to the specified directory. See the
-[ICU Data](../../icudata.md) page of the user guide for more information about
+[ICU Data](../../icu_data/index.md) page of the user guide for more information about
 the ICU data path.
 
 ### ICU4C TZ update when ICU data is built into a shared library

--- a/docs/userguide/dev/codingguidelines.md
+++ b/docs/userguide/dev/codingguidelines.md
@@ -177,7 +177,7 @@ also mark every API with whether it is `@draft`, `@stable`, `@deprecated` or
 `@internal`. (Where `@internal` is used when something is not actually supported
 API but needs to be physically public anyway.) A new API is usually marked with
 "`@draft ICU 4.8`". For details of how we mark APIs see the "ICU API
-compatibility" section of the [ICU Architectural Design](../design.md) page. In
+compatibility" section of the [ICU Architectural Design](../icu/design.md) page. In
 Java, also see existing @draft APIs for complete examples.
 
 Functions that override a base class or interface definition take the API status

--- a/docs/userguide/dev/editing.md
+++ b/docs/userguide/dev/editing.md
@@ -31,7 +31,7 @@ for Jekyll sites.
 
 Because ICU User Guide source files are now contained within the main
 repository, changes can now be made through the same process for contributing 
-code patches. See [Contributions to the ICU Library](constributions.md) for the
+code patches. See [Contributions to the ICU Library](index.md) for the
 current process of filing an issue and submitting a pull request.
 
 In the case of a single file edit (ex: typo correction), a convenient way to
@@ -52,7 +52,7 @@ prevent the changes from being rendered.
 
 Jekyll site-wide configurations are stored
 in the `_config.yml` file. The current theme being used is
-[Just the Docs](https://pmarsceill.github.io/just-the-docs/).
+[Just the Docs](https://github.com/just-the-docs/just-the-docs/).
 
 Due to incompatibilities between this theme and GitHub’s built-in implementation of the
 CommonMark Markdown parser, the default Jekyll Markdown parser, Kramdown, is
@@ -63,7 +63,7 @@ used.
 Major chapters have Introduction pages, and further sections in a chapter are
 subpages of that main chapter page. The navigation bar is generated from the
 information provided in the header section of the Markdown file according to
-the theme's [navigation annotations](https://pmarsceill.github.io/just-the-docs/docs/navigation-structure/).
+the theme's [navigation annotations](https://just-the-docs.com/docs/navigation/).
 
 ## Syntax
 

--- a/docs/userguide/dev/index.md
+++ b/docs/userguide/dev/index.md
@@ -16,6 +16,6 @@ details:
 
 [Coding Guidelines](codingguidelines.md)
 
-[Contributions to the ICU library](contributions.md)
+[Contributions to the ICU library](https://github.com/unicode-org/icu/blob/main/CONTRIBUTING.md)
 
 [Synchronization Issues](sync/index.md)

--- a/docs/userguide/dev/sync/index.md
+++ b/docs/userguide/dev/sync/index.md
@@ -22,7 +22,7 @@ License & terms of use: http://www.unicode.org/copyright.html
 ## Overview
 
 ICU is designed for use in multi-threaded environments. Guidelines for
-developers using ICU are in the [ICU Design](../../design.md) section of the
+developers using ICU are in the [ICU Design](../../icu/design.md) section of the
 user guide.
 
 Within the ICU implementation, access to shared or global data sometimes must be

--- a/docs/userguide/format_parse/numbers/legacy-numberformat.md
+++ b/docs/userguide/format_parse/numbers/legacy-numberformat.md
@@ -131,10 +131,6 @@ and display name, but also the correct number of fraction digits and the correct
 [rounding mode](rounding-modes.md). This is not the case with the base JDK. See
 the API references for more details.
 
-There is ICU4C sample code at
-[icu4c/source/samples/numfmt/main.cpp](https://github.com/unicode-org/icu/blob/main/icu4c/source/samples/numfmt/main.cpp)
-which illustrates the use of `NumberFormat.setCurrency()`.
-
 #### Displaying Numbers
 
 You can also control the display of numbers with methods such as
@@ -206,10 +202,3 @@ locale data. The `DecimalFormatSymbols` can be adopted by a `DecimalFormat`
 instance, or it can be specified when a `DecimalFormat` is created. If you need to
 change any of these symbols, can get the `DecimalFormatSymbols` object from your
 `DecimalFormat` and then modify it.
-
-## Additional Sample Code
-
-C/C++: See
-[icu4c/source/samples/numfmt/](https://github.com/unicode-org/icu/blob/main/icu4c/source/samples/numfmt/)
-in the ICU source distribution for code samples showing the use of ICU number
-formatting.

--- a/docs/userguide/format_parse/numbers/rbnf-examples.md
+++ b/docs/userguide/format_parse/numbers/rbnf-examples.md
@@ -106,4 +106,4 @@ syntax can be found in the [API
 Documentation](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classRuleBasedNumberFormat.html).
 
 More rule examples can be found in the `RuleBasedNumberFormat` [demo
-source](https://github.com/unicode-org/icu/blob/main/icu4j/demos/src/com/ibm/icu/dev/demo/rbnf/RbnfSampleRuleSets.java).
+source](https://github.com/unicode-org/icu/blob/main/icu4j/demos/src/main/java/com/ibm/icu/dev/demo/rbnf/RbnfSampleRuleSets.java).

--- a/docs/userguide/icu/design.md
+++ b/docs/userguide/icu/design.md
@@ -46,9 +46,9 @@ to programming language restrictions. These features include the following:
 
 Locale IDs are composed of language, country, and variant information. The
 following links provide additional useful information regarding ISO standards:
-[ISO-639](http://lcweb.loc.gov/standards/iso639-2/englangn.html), and an ISO
+[ISO-639](https://www.iso.org/iso-639-language-code), and an ISO
 Country Code,
-[ISO-3166](http://www.iso.org/iso/en/prods-services/iso3166ma/02iso-3166-code-lists/list-en1.html).
+[ISO-3166](https://www.iso.org/iso-3166-country-codes.html).
 For example, Italian, Italy, and Euro are designated as: it_IT_EURO.
 
 ### Data-driven Services
@@ -211,7 +211,7 @@ the pool.
 ICU4C APIs are designed to allow separate heaps for its libraries vs. the
 application. This is achieved by providing functions to allocate and release
 objects owned by ICU4C using only ICU4C library functions. For more details see
-the Memory Usage section in the [Coding Guidelines](dev/codingguidelines.md#memory-usage).
+the Memory Usage section in the [Coding Guidelines](../dev/codingguidelines.md#memory-usage).
 
 ### ICU4C Initialization and Termination
 
@@ -229,7 +229,7 @@ any other use of ICU. This functionality is not commonly used.
 `u_setAppData()`. One or more of these functions will be required when ICU is
 configured to load its data directly from files rather than taking it from the
 default data DLL, and the files are not in the default location. Again, this is
-not common. See [ICU Data](icudata#icu-data-directory).
+not common. See [ICU Data](../icu_data/index#icu-data-directory).
 
 3. Sanity check that ICU is functioning and able to access data. This is
 important because configuration or installation problems that leave ICU unable

--- a/docs/userguide/icu/glossary.md
+++ b/docs/userguide/icu/glossary.md
@@ -28,7 +28,7 @@ For additional Unicode terms, please see the official
 **- B -** |  
 **base character** | A base character is a Unicode character that does not graphically combine with any preceding character. This does not include control or formatting characters. This is a characteristic of most Unicode characters.
 **baseline** | A conceptual line with respect to which successive characters are aligned.
-**Basic Multilingual Plane** | As defined by International Standard [ISO/IEC 10646](http://std.dkuug.dk/jtc1/sc2/wg2/), Unicode values `0000` through `FFFF`. This range covers all of the major living languages around the world.
+**Basic Multilingual Plane** | As defined by International Standard [ISO/IEC 10646](https://en.wikipedia.org/wiki/Universal_Coded_Character_Set), Unicode values `0000` through `FFFF`. This range covers all of the major living languages around the world.
 **bidi** | See bidirectional.
 **bidirectional** | Text which has a mixture of languages that read and write either left-to-right or right-to-left. Languages such as Arabic, Hebrew, and Yiddish have a general flow of text that proceeds horizontally from right to left, but numbers and Latin based languages like English are written from left to right.
 **big-endian** | A computer architecture that stores multiple-byte numerical values with the most significant byte (MSB or big end) values first in a computer's addressable memory. This is the opposite from little-endian.

--- a/docs/userguide/icu4c/faq.md
+++ b/docs/userguide/icu4c/faq.md
@@ -70,7 +70,7 @@ MSVC compiler. See the [Building ICU4C](./build) page.
 #### Can you help me build ICU4C for ...
 
 We can try ... make sure you read the [Building ICU4C](./build) section and also the [ICU
-Data](../icudata.md) section. You might also [searching the icu-support
+Data](../icu_data/index.md) section. You might also [searching the icu-support
 archives](https://icu.unicode.org/contacts), and then posting a question
 there. Additionally, sites such as
 [StackOverflow](http://stackoverflow.com/search?q=icu) may have helpful tips for
@@ -88,8 +88,8 @@ your topic.
 #### What is the ICU binary compatibility policy?
 
 Please see the section on
-[binary compatibility](../design#icu-binary-compatibility)
-in the [design chapter](../design.md).
+[binary compatibility](../icu/design#icu-binary-compatibility)
+in the [design chapter](../icu/design.md).
 
 #### How is ICU licensed?
 
@@ -120,8 +120,8 @@ upgrade-friendly.
 
 *   **API:** ensure that you are not using draft APIs which may have changed in
     a future release. See the section on
-    [API compatibility](../design#icu-api-compatibility) in the
-    [design chapter](../design.md).
+    [API compatibility](../icu/design#icu-api-compatibility) in the
+    [design chapter](../icu/design.md).
 *   **Unicode:** See the release notes for particular versions of Unicode to
     ensure that your code is not affected by property changes or other
     specification changes.
@@ -133,8 +133,8 @@ upgrade-friendly.
     currencies, types of calendars
 *   **Building/Deploying your Application (ICU4C):** ICU4C usually builds with
     symbol renaming (See:
-    [binary compatibility](../design#icu-binary-compatibility)
-    in the [design chapter](../design.md)). Be sure that you build your
+    [binary compatibility](../icu/design#icu-binary-compatibility)
+    in the [design chapter](../icu/design.md)). Be sure that you build your
     application with the updated ICU header files, so that it will link against
     the current ICU. Also, don't hard-code the names of ICU libraries in your
     build scripts and projects. Where possible, link against just the
@@ -185,8 +185,8 @@ Support List](https://icu.unicode.org/contacts) .
 
 Use the [Data Customizer](https://unicode-org.atlassian.net/browse/ICU-12835)
 or see
-[Customizing ICU's Data Library](../icudata#customizing-icus-data-library)
-in the [ICU Data Management](../icudata.md) chapter of this User's Guide.
+[Customizing ICU's Data Library](../icu_data/index.md#customizing-icus-data-library)
+in the [ICU Data Management](../icu_data/index.md) chapter of this User's Guide.
 
 #### Why am I seeing a small ( only a few K ) instead of a large ( several megabytes ) data shared library (icudt)?
 #### Opening ICU services fails with U_MISSING_RESOURCE_ERROR and u_init() returns failure.
@@ -203,8 +203,8 @@ Studio.
 
 #### Can I add or remove a converter from ICU?
 
-Yes. Please see [Customizing ICU's Data Library](../icudata#customizing-icus-data-library)
-in the [ICU Data Management](../icudata.md) of this User's Guide. You can also
+Yes. Please see [Customizing ICU's Data Library](../icu_data/index.md#customizing-icus-data-library)
+in the [ICU Data Management](../icu_data/index.md) of this User's Guide. You can also
 get extra converters from <https://icu.unicode.org/charts/charset> or use
 the [ICU Data Customizer](https://unicode-org.atlassian.net/browse/ICU-12835)
 tool.
@@ -268,8 +268,8 @@ ICU4C (ICU) is written in C and C++, and ICU4J is written in Java™.
 
 #### How are the APIs documented for deprecation?
 
-Please read the [ICU API compatibility](../design#icu-api-compatibility)
-section in the [ICU Design](../design.md) chapter.
+Please read the [ICU API compatibility](../icu/design#icu-api-compatibility)
+section in the [ICU Design](../icu/design.md) chapter.
 
 #### What version of Unicode standard does ICU support?
 
@@ -409,7 +409,7 @@ Chapter](../locale/index.md) of this User's Guide.
 
 #### How is ICU versioned?
 
-Please read the [ICU Design](../design.md) chapter of the User's Guide.
+Please read the [ICU Design](../icu/design.md) chapter of the User's Guide.
 
 #### What is the relationship between ICU locale data and system locale data?
 
@@ -445,7 +445,7 @@ puts("callMyFunction() Failed!");
 }
 ```
 
-Please see the [ICU Design](../design.md) chapter for details.
+Please see the [ICU Design](../icu/design.md) chapter for details.
 
 #### With calendar classes, why are months 0-based?
 

--- a/docs/userguide/icu4c/index.md
+++ b/docs/userguide/icu4c/index.md
@@ -346,7 +346,7 @@ ICU 2.4 and earlier versions were not prepared for multithreaded use on multi-CP
 
 #### Using ICU in a Multithreaded Environment on HP-UX
 
-When ICU is built with aCC on HP-UX, the [`-AA`](http://h21007.www2.hp.com/portal/site/dspp/menuitem.863c3e4cbcdc3f3515b49c108973a801?ciid=eb08b3f1eee02110b3f1eee02110275d6e10RCRD) compiler flag is used. It is required in order to use the latest `<iostream>` API in a thread safe manner. This compiler flag affects the version of the C++ library being used. Your applications will also need to be compiled with `-AA` in order to use ICU.
+When ICU is built with aCC on HP-UX, the `-AA` compiler flag is used. It is required in order to use the latest `<iostream>` API in a thread safe manner. This compiler flag affects the version of the C++ library being used. Your applications will also need to be compiled with `-AA` in order to use ICU.
 
 #### Using ICU in a Multithreaded Environment on Solaris
 

--- a/docs/userguide/icu4c/packaging.md
+++ b/docs/userguide/icu4c/packaging.md
@@ -40,7 +40,7 @@ distribution from conflicting with any libraries that you need. On operating sys
 that do not have a standard C++ ABI (name mangling) for compilers, it is recommended to
 do this special packaging anyway. More details on customizing ICU are available in the
 [User Guide](../).
-The [ICU Source Code Organization](./index/#icu-source-code-organization) section of
+The [ICU Source Code Organization](./index#icu-source-code-organization) section of
 the ICU4C gives a more complete description of the libraries.
 
 ICU has several libraries for you to use. Here is an example of libraries that are frequently packaged.
@@ -75,7 +75,7 @@ with -DU_STATIC_IMPLEMENTATION. Also see [How To Use ICU](../icu/howtouseicu.md)
 
 ### Reduce the number of libraries used
 
-ICU consists of a number of different libraries. The library dependency chart in the [Design](../design#library-dependencies-c)
+ICU consists of a number of different libraries. The library dependency chart in the [Design](../icu/design#library-dependencies-c)
 chapter can be used to understand and
 determine the exact set of libraries needed.
 
@@ -145,12 +145,12 @@ There are many ways in which ICU data may be reduced. If only certain locales or
 converters will be used, others may be removed. Additionally, data may be
 packaged as individual files or interchangeable archives (.dat files), allowing
 data to be installed and removed without rebuilding ICU. For details, see the
-[ICU Data](../icudata.md) chapter.
+[ICU Data](../icu_data/index.md) chapter.
 
 ## ICU Versions
 
-(This section assumes the reader is familiar with [ICU version numbers](../design#version-numbers-in-icu) as
-covered in the [Design](../design.md) chapter, and filename conventions for
+(This section assumes the reader is familiar with [ICU version numbers](../icu/design#version-numbers-in-icu) as
+covered in the [Design](../icu/design.md) chapter, and filename conventions for
 libraries as described above.)
 
 ### POSIX Library Names
@@ -237,5 +237,5 @@ DLLs will be copied with names such as 'icuuc55.dll'.
 The services which are now known as ICU were written to provide operating
 system-level and application environment-level services. Several operating
 systems include ICU as a standard or optional package.
-See [ICU Binary Compatibility](../design#icu-binary-compatibility) for
+See [ICU Binary Compatibility](../icu/design#icu-binary-compatibility) for
 more details.

--- a/docs/userguide/icu4j/faq.md
+++ b/docs/userguide/icu4j/faq.md
@@ -62,7 +62,7 @@ Time Zone Data Version: 2011g
 #### I'm using ICU4J X, but planning to upgrade ICU4J version to X+1 soon. What should I do for the migration?
 
 See the user guide section
-[Version Numbers in ICU](../design#version-numbers-in-icu)
+[Version Numbers in ICU](../icu/design#version-numbers-in-icu)
 for the details about the meaning of the version number parts and how the ICU
 version number changes.
 
@@ -70,7 +70,7 @@ In general, two different reference releases are not binary compatible (i.e.
 drop-in jar file replacement would not work). To use a new reference version of
 ICU4J, you should rebuild your application with the new ICU4J library. ICU
 project has the
-[API compatibility policy](../design#icu-api-compatibility)
+[API compatibility policy](../icu/design#icu-api-compatibility)
 long as you're using ICU APIs marked as @stable in the API reference
 documentation, your application should successfully compile with the new
 reference version of ICU4J library without any source code modifications. (Note:
@@ -86,22 +86,6 @@ with the pattern in a new version.
 For every ICU4J release, we publish
 [APIChangeReport.html](https://htmlpreview.github.io/?https://github.com/unicode-org/icu/blob/main/icu4j/APIChangeReport.html)
 which captures all API changes since previous reference release.
-However, someone may want to see the changes between the
-current release and much older ICU4J version. For example, you're currently
-using ICU4J 60 and considering to upgrade to ICU4J 64. In this case, you can
-generate a change report page by following steps.
-
-1.  Download [ICU4J 64 source package
-    archive](https://icu.unicode.org/download/64#TOC-ICU4J-Download)
-    from the ICU 64 download page and extract files to your local system.
-2.  Set up ICU4J build environment as explained in the
-    [ICU4C Readme](./index).
-3.  Edit
-    [build.properties](https://github.com/unicode-org/icu/blob/main/icu4j/build.properties)
-    in the root directory and change the property value api.report.prev.version
-    from 63 to 60.
-4.  Invoke ant target "apireport".
-5.  The output is generated at out/icu4j_compare_60_64.html.
 
 ### International Calendars
 

--- a/docs/userguide/icu_data/index.md
+++ b/docs/userguide/icu_data/index.md
@@ -55,7 +55,7 @@ manually editing them is not usually recommended.
 
 Data which is NOT sourced from CLDR includes:
 
-*   [Conversion Data](conversion/data.md)
+*   [Conversion Data](../conversion/data.md)
 *   Break Iterator Dictionary Data ( Thai, CJK, etc )
 *   Break Iterator Rule Data (as of this writing, it is manually kept in sync
     with the CLDR datasets)
@@ -737,7 +737,7 @@ A much less radical approach is to keep the collation data tables but remove the
 tailoring rule strings from which they were built. Those rule strings are
 rarely used at runtime. For documentation about their use and how to remove
 them see the section "Building on Existing Locales" in the
-[Collation Customization chapter](collation/customization/index.md).
+[Collation Customization chapter](../collation/customization/index.md).
 
 ### Adding Locale Data to ICU's Data
 You need to write a resource bundle file for it with a structure like the
@@ -896,7 +896,7 @@ Emoji properties of strings added.
     [genrb](https://github.com/unicode-org/icu/blob/main/icu4c/source/tools/genrb)
 
 #### Rule-based break iterator data
-*   Source format: .txt: [Boundary Analysis chapter](boundaryanalysis/index.md)
+*   Source format: .txt: [Boundary Analysis chapter](../boundaryanalysis/index.md)
 *   Binary format: .brk:
     [source/common/rbbidata.h](https://github.com/unicode-org/icu/blob/main/icu4c/source/common/rbbidata.h)
 *   Generator tool:
@@ -911,7 +911,7 @@ Emoji properties of strings added.
     [gendict](https://github.com/unicode-org/icu/blob/main/icu4c/source/tools/gendict)
 
 #### Rule-based transform (transliterator) data
-*   Source format: .txt (in resource bundles): [Transform Rule Tutorial chapter](transforms/general/rules.md)
+*   Source format: .txt (in resource bundles): [Transform Rule Tutorial chapter](../transforms/general/rules.md)
 *   Binary format: Uses genrb to make binary format
 *   Generator tool: Does not apply
 
@@ -943,7 +943,7 @@ Emoji properties of strings added.
 
 #### Unicode Character Data (Normalization before ICU 4.4; for Java only: was hardcoded in C common library)
 *   Source format:
-    [source/data/unidata/*.txt]((https://github.com/unicode-org/icu/blob/main/icu4c/source/data/unidata):
+    [source/data/unidata/*.txt](https://github.com/unicode-org/icu/blob/main/icu4c/source/data/unidata):
     [Unicode Character Database](http://www.unicode.org/onlinedat/online.html)
 *   Binary format: unorm.icu:
     [source/common/unormimp.h](https://github.com/unicode-org/icu/blob/main/icu4c/source/common/unormimp.h)

--- a/docs/userguide/locale/resources.md
+++ b/docs/userguide/locale/resources.md
@@ -145,7 +145,7 @@ section on APIs). A lot of ICU frameworks (collation, formatting etc.) relies on
 the data stored in resource bundles.
 
 Resource bundles rely on the ICU data framework. For more information on the
-functioning of ICU data, see the appropriate [section](../icudata.md).
+functioning of ICU data, see the appropriate [section](../icu_data/index.md).
 
 Users of the ICU library can also use the resource bundle framework to store and
 retrieve localizable data in their projects.
@@ -796,16 +796,13 @@ steps:
 6.  However, you might want to have only one file containing all the data. In
     that case you need to use the package data tool. It can produce either a
     memory mapped file or a dynamically linked library. For more information on
-    how to use package data tool, see the appropriate [section](../icudata.md).
+    how to use package data tool, see the appropriate [section](../icu_data/index.md).
 
 Rolling out your own data takes some practice, especially if you want to package
 it all together. You might want to take a look at how we package data. Good
 places to start (except of course ICU's own
 [data](https://github.com/unicode-org/icu/blob/main/icu4c/source/data/)) are
-[source/test/testdata/](https://github.com/unicode-org/icu/blob/main/icu4c/source/test/testdata/)
-and
-[source/samples/ufortune/resources/](https://github.com/unicode-org/icu/blob/main/icu4c/source/samples/ufortune/resources/)
-directories.
+[source/test/testdata/](https://github.com/unicode-org/icu/blob/main/icu4c/source/test/testdata/) directory.
 
 Also, here is a sample Windows batch file that does compiling and packing of
 several resources:

--- a/docs/userguide/strings/characteriterator.md
+++ b/docs/userguide/strings/characteriterator.md
@@ -178,9 +178,3 @@ text under iteration:
 This text (and the length) may include more than the actual iteration area
 because the start and end indexes may not be the start and end of the entire
 text. The text and the iteration range are set in the implementing subclasses.
-
-## Additional Sample Code
-
-C/C++: See
-[icu4c/source/samples/citer/](https://github.com/unicode-org/icu/blob/main/icu4c/source/samples/citer/)
-in the ICU source distribution for code samples.

--- a/docs/userguide/strings/index.md
+++ b/docs/userguide/strings/index.md
@@ -15,10 +15,6 @@ License & terms of use: http://www.unicode.org/copyright.html
 
 This section explains how to handle Unicode strings with ICU in C and C++.
 
-Sample code is available in the ICU source code library at
-[icu/source/samples/ustring/ustring.cpp](https://github.com/unicode-org/icu/blob/main/icu4c/source/samples/ustring/ustring.cpp)
-.
-
 ## Text Access Overview
 
 Strings are the most common and fundamental form of handling text in software.

--- a/docs/userguide/strings/properties.md
+++ b/docs/userguide/strings/properties.md
@@ -31,9 +31,7 @@ notes to all characters. It defines standard algorithms for critical text
 processing, and the data is publicly provided and kept up-to-date. See
 https://www.unicode.org/ and https://www.unicode.org/main.html for more information.
 
-Sample code is available in the ICU source code library at
-[icu4c/source/samples/props/props.cpp](https://github.com/unicode-org/icu/blob/main/icu4c/source/samples/props/props.cpp).
-See also the source code for the [Unicode
+For an example see the source code for the [Unicode
 browser](https://github.com/unicode-org/icu-demos/tree/main/ubrowse) demo
 application, which can be used
 [online](https://icu4c-demos.unicode.org/icu-bin/ubrowse) to browse Unicode

--- a/docs/userguide/transforms/casemappings.md
+++ b/docs/userguide/transforms/casemappings.md
@@ -45,10 +45,6 @@ Shrew".
 > :point_right: **Note**: *As of Unicode 11, Georgian now has Mkhedruli (lowercase) and Mtavruli
 (uppercase) which form case pairs, but are not used in title case.*
 
-Sample code is available in the ICU source code library at
-[icu/source/samples/ustring/ustring.cpp](https://github.com/unicode-org/icu/blob/main/icu4c/source/samples/ustring/ustring.cpp)
-.
-
 Please refer to the following sections in the [The Unicode Standard](http://www.unicode.org/versions/latest/)
 for more information about case mapping:
 

--- a/docs/userguide/transforms/general/index.md
+++ b/docs/userguide/transforms/general/index.md
@@ -83,8 +83,8 @@ underlying words. The following shows a sample of script transliteration:
 > :point_right: **Note**: *Some of the characters may not be
 visible on the screen unless you have a Unicode font with all the Greek letters.
 If you have a licensed copy of Microsoft® Office, you can use the "Arial Unicode
-MS" font, or you can download the [CODE2000](http://www.code2000.net/) font for
-free. For more information, see [Display
+MS" font, or you can download the [Noto fonts](https://fonts.google.com/noto)
+for free. For more information, see [Display
 Problems?](http://www.unicode.org/help/display_problems.html) on the Unicode web
 site.*
 
@@ -1415,4 +1415,4 @@ For more information, see:
 
 6.  [ISO-15915 (Kannada)](http://transliteration.eki.ee/pdf/Kannada.pdf)
 
-7.  [ISCII-91](http://www.cdacindia.com/html/gist/down/iscii_d.asp)
+7.  [ISCII-91](https://cdac.in/index.aspx?id=mlc_gist_iscii)

--- a/docs/userguide/transforms/general/rules.md
+++ b/docs/userguide/transforms/general/rules.md
@@ -60,7 +60,7 @@ transliterate the Greek accents that are no longer in use in modern Greek.
 > :point_right: **Note**: *Some of the characters may not be visible on the screen unless you have a
 Unicode font with all the Greek letters. If you have a licensed copy of
 Microsoft® Office, you can use the "Arial Unicode MS" font, or you can download
-the [CODE2000](http://www.code2000.net/) font for free. For more information,
+the [Noto fonts](https://fonts.google.com/noto) for free. For more information,
 see [Display Problems?](http://www.unicode.org/help/display_problems.html) on
 the Unicode web site.*
 


### PR DESCRIPTION
Most fixes only required a change in relative paths.

* A few web sites don't exist anymore. I replaced them with what I thought are good alternatives.
* In some cases I had to remove full paragraphs (for example mentions of samples in `icu4c\source\samples`).
* Some of the releasing steps depend on the ICU version.
And when the documentation was `"modify the [foo.bar](link) file"` mentioning a file that
was deleted in the meantime, I just removed the link, letting the file path be just text.
* There are still a few external links that are flaky (don't always answer), tbd what to do about them.

#### Checklist
- [x] Required: Issue filed: ICU-23425
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf
