### PR TITLE
:construction: ICU-23424 MF2: Allow registered functions to override standards

### DIFF
--- a/icu4c/source/i18n/messageformat2_formatter.cpp
+++ b/icu4c/source/i18n/messageformat2_formatter.cpp
@@ -281,15 +281,15 @@ namespace message2 {
                                      UErrorCode& status) const {
         NULL_ON_ERROR(status);
 
-        if (isBuiltInFunction(functionName)) {
-            return standardMFFunctionRegistry.getFunction(functionName);
-        }
         if (hasCustomMFFunctionRegistry()) {
             const MFFunctionRegistry& customMFFunctionRegistry = getCustomMFFunctionRegistry();
             Function* function = customMFFunctionRegistry.getFunction(functionName);
             if (function != nullptr) {
                 return function;
             }
+        }
+        if (isBuiltInFunction(functionName)) {
+            return standardMFFunctionRegistry.getFunction(functionName);
         }
         // Either there is no custom function registry and the function
         // isn't built-in, or the function doesn't exist in either the built-in

--- a/icu4c/source/i18n/messageformat2_function_registry_internal.h
+++ b/icu4c/source/i18n/messageformat2_function_registry_internal.h
@@ -84,7 +84,7 @@ static constexpr std::u16string_view YEAR = u"year";
       per https://github.com/unicode-org/message-format-wg/blob/main/spec/registry.md
       as of https://github.com/unicode-org/message-format-wg/releases/tag/LDML45-alpha
     */
-    class StandardFunctions {
+    class U_I18N_API_CLASS StandardFunctions { // TODO: had to export StandardFunctions
         friend class MessageFormatter;
 
         public:
@@ -98,6 +98,8 @@ static constexpr std::u16string_view YEAR = u"year";
                                              std::u16string_view optionName,
                                              UErrorCode& errorCode);
 
+// TODO: ICU-23424 had to make this public to be callable
+public:
         class DateTime;
         class DateTimeValue;
 

--- a/icu4c/source/i18n/unicode/messageformat2_function_registry.h
+++ b/icu4c/source/i18n/unicode/messageformat2_function_registry.h
@@ -272,7 +272,7 @@ namespace message2 {
             Locale locale;
             UMFBidiOption dir;
             UnicodeString id;
-
+public: // TODO ICU-23424 had to make this public so FunctionContext is constructable
             FunctionContext(const Locale& loc, UMFBidiOption d, UnicodeString i)
                 : locale(loc), dir(d), id(i) {}
     }; // class FunctionContext

--- a/icu4c/source/test/intltest/messageformat2test.cpp
+++ b/icu4c/source/test/intltest/messageformat2test.cpp
@@ -13,6 +13,8 @@
 #include "unicode/gregocal.h"
 #include "unicode/messageformat2.h"
 #include "messageformat2test.h"
+// TODO ICU-23424: had to include internal .h to be able to chain load internal functions
+#include "messageformat2_function_registry_internal.h"
 
 using namespace icu::message2;
 
@@ -31,6 +33,7 @@ TestMessageFormat2::runIndexedTest(int32_t index, UBool exec,
     TESTCASE_AUTO(testLowLoneSurrogate);
     TESTCASE_AUTO(testLoneSurrogateInQuotedLiteral);
     TESTCASE_AUTO(dataDrivenTests);
+    TESTCASE_AUTO(testSetFormatLocale);
     TESTCASE_AUTO_END;
 }
 
@@ -477,6 +480,234 @@ void TestMessageFormat2::dataDrivenTests() {
     IcuTestErrorCode errorCode(*this, "jsonTests");
 
     jsonTestsFromFiles(errorCode);
+}
+
+namespace EnFunctionTest {
+
+// //TODO: This function is duplicated from messageformat2test_custom.cpp
+// // but should it be a library function?
+// static UnicodeString getStringOption(const FunctionOptionsMap &opt, const UnicodeString &k) {
+//     if (opt.count(k) == 0) {
+//         return {};
+//     }
+//     UErrorCode localErrorCode = U_ZERO_ERROR;
+//     const message2::FunctionValue *optVal = opt.at(k);
+//     if (optVal == nullptr) {
+//         return {};
+//     }
+//     const UnicodeString &formatted = optVal->formatToString(localErrorCode);
+//     if (U_SUCCESS(localErrorCode)) {
+//         return formatted;
+//     }
+//     const UnicodeString &original = optVal->unwrap().getString(localErrorCode);
+//     if (U_SUCCESS(localErrorCode)) {
+//         return original;
+//     }
+//     return {};
+// }
+
+// //TODO: This function is duplicated from messageformat2test_custom.cpp
+// // but should it be a library function?
+// static bool hasStringOption(const FunctionOptionsMap &opt, const UnicodeString &k,
+//                             const UnicodeString &v) {
+//     return getStringOption(opt, k) == v;
+// }
+// class EnDateValue : public FunctionValue {
+//     public:
+//     UnicodeString formatToString(UErrorCode&) const override;
+//     EnDateValue();
+//     virtual ~EnDateValue();
+//     private:
+//     friend class EnDateFunction;
+
+//     UnicodeString formattedString;
+//     EnDateValue(const FunctionValue&, const FunctionOptions&, UErrorCode&);
+// }; // class EnDateValue
+
+
+// UnicodeString EnDateValue::formatToString(UErrorCode& status) const {
+//     (void) status;
+//     return formattedString;
+// }
+// EnDateValue::~EnDateValue() {}
+
+
+// EnDateValue::EnDateValue(const FunctionValue& arg,
+//                                  const FunctionOptions& options,
+//                                  UErrorCode& errorCode) {
+//     if (U_FAILURE(errorCode)) {
+//         return;
+//     }
+//     innerValue = arg.unwrap();
+//     opts = options;
+
+//     const icu::message2::Formattable* toFormat = &innerValue;
+//     if (U_FAILURE(errorCode)) {
+//         errorCode = U_MF_OPERAND_MISMATCH_ERROR;
+//         return;
+//     }
+
+//     // FunctionOptionsMap opt = opts.getOptions();
+
+//     // bool useFormal = hasStringOption(opt, "formality", "formal");
+//     // UnicodeString length = getStringOption(opt, "length");
+//     // if (length.length() == 0) {
+//     //     length = "short";
+//     // }
+
+//     const FormattableObject* fp = toFormat->getObject(errorCode);
+//     if (errorCode == U_ILLEGAL_ARGUMENT_ERROR) {
+//         errorCode = U_MF_FORMATTING_ERROR;
+//         return;
+//     }
+
+//     if (fp == nullptr || fp->tag() != u"person") {
+//         errorCode = U_MF_FORMATTING_ERROR;
+//         return;
+//     }
+//     const icu::message2::Formattable* p = static_cast<const icu::message2::Formattable*>(fp);
+
+//     p->
+
+//     if (length == "long") {
+//         formattedString += title;
+//         formattedString += " ";
+//         formattedString += firstName;
+//         formattedString += " ";
+//         formattedString += lastName;
+//     } else if (length == "medium") {
+//         if (useFormal) {
+//             formattedString += firstName;
+//             formattedString += " ";
+//             formattedString += lastName;
+//         } else {
+//             formattedString += title;
+//             formattedString += " ";
+//             formattedString += firstName;
+//         }
+//     } else if (useFormal) {
+//         // Default to "short" length
+//         formattedString += title;
+//         formattedString += " ";
+//         formattedString += lastName;
+//     } else {
+//         formattedString += firstName;
+//     }
+// }
+class EnDateFunction : public Function {
+  public:
+    EnDateFunction(UErrorCode& status);
+    LocalPointer<FunctionValue> call(const FunctionContext &, const FunctionValue &,
+                                     const FunctionOptions &, UErrorCode &) override;
+    virtual ~EnDateFunction();
+
+  private:
+    LocalPointer<Function> delegate;
+};
+
+EnDateFunction::EnDateFunction(UErrorCode& status)
+: delegate(icu::message2::StandardFunctions::DateTime::date(status)) {
+
+}
+
+LocalPointer<FunctionValue> EnDateFunction::call(const FunctionContext &context,
+                                                 const FunctionValue &arg,
+                                                 const FunctionOptions &opts,
+                                                 UErrorCode &errorCode) {
+    (void)context;
+
+    if (U_FAILURE(errorCode)) {
+        return LocalPointer<FunctionValue>();
+    }
+    FunctionContext enContext(Locale::getEnglish(), context.getDirection(), context.getID());
+
+    return delegate->call(enContext, arg, opts, errorCode);
+}
+
+EnDateFunction::~EnDateFunction() {}
+} // namespace EnFunctionTest
+
+
+void TestMessageFormat2::testSetFormatLocale() {
+    IcuTestErrorCode errorCode(*this, "testSetFormatLocale");
+    UParseError parseError;
+
+    std::map<UnicodeString, icu::message2::Formattable> argsBuilder;
+    argsBuilder["count"] = message2::Formattable((int64_t)13);
+    argsBuilder["name"] = message2::Formattable("US");
+    argsBuilder["birthday"] = message2::Formattable("1776-07-04");
+    icu::message2::MessageArguments args(argsBuilder, errorCode);
+        UnicodeString expectedResult(u"PASS 13 @ 7/4/76");
+
+    const UnicodeString orig_pattern(
+        u""
+        ".input {$count :number} .input {$name :string} .input {$birthday :date}\n"
+        ".match $count\n"
+        "many {{PASS {$count} @ {$birthday :date style=short}}}\n"
+        "* {{FAIL wrong bucket {$count} @ {$birthday :date style=short}}}\n");
+
+    {
+        // try with a modified pattern
+        // build the function registry
+        icu::message2::MFFunctionRegistry::Builder builder(errorCode);
+        MFFunctionRegistry functionRegistry =
+            builder
+                .adoptFunction(data_model::FunctionName("en_date"),
+                               new EnFunctionTest::EnDateFunction(errorCode), errorCode)
+                .build();
+
+        UnicodeString modified_pattern = orig_pattern;
+        modified_pattern.findAndReplace(u":date", u":en_date");
+        icu::message2::MessageFormatter mf =
+            MessageFormatter::Builder(errorCode)
+                .setErrorHandlingBehavior(MessageFormatter::U_MF_BEST_EFFORT)
+                .setPattern(modified_pattern, parseError, errorCode)
+                .setFunctionRegistry(functionRegistry)
+                .setLocale(Locale("pl"))
+                .build(errorCode);
+
+        if (errorCode.errIfFailureAndReset("build")) {
+            errln("UParseError = %d:%d", parseError.line, parseError.offset);
+            return;
+        }
+
+        UnicodeString result = mf.formatToString(args, errorCode);
+        if (errorCode.errIfFailureAndReset("formatToString")) {
+            return;
+        }
+        assertEquals("testSetFormatLocale", expectedResult, result);
+
+    }
+    {
+        // try with the original pattern
+        // build the function registry
+        icu::message2::MFFunctionRegistry::Builder builder(errorCode);
+        MFFunctionRegistry functionRegistry =
+            builder
+                .adoptFunction(data_model::FunctionName("date"), // override
+                               new EnFunctionTest::EnDateFunction(errorCode), errorCode)
+                .build();
+
+        icu::message2::MessageFormatter mf =
+            MessageFormatter::Builder(errorCode)
+                .setErrorHandlingBehavior(MessageFormatter::U_MF_BEST_EFFORT)
+                .setPattern(orig_pattern, parseError, errorCode)
+                .setFunctionRegistry(functionRegistry)
+                .setLocale(Locale("pl"))
+                .build(errorCode);
+
+        if (errorCode.errIfFailureAndReset("build")) {
+            errln("UParseError = %d:%d", parseError.line, parseError.offset);
+            return;
+        }
+
+        UnicodeString result = mf.formatToString(args, errorCode);
+        if (errorCode.errIfFailureAndReset("formatToString")) {
+            return;
+        }
+        assertEquals("testSetFormatLocale", expectedResult, result);
+
+    }
 }
 
 TestCase::~TestCase() {}

--- a/icu4c/source/test/intltest/messageformat2test.h
+++ b/icu4c/source/test/intltest/messageformat2test.h
@@ -53,6 +53,7 @@ public:
     void testBidiAPI(void);
     void testAPI(void);
     void testAPISimple(void);
+    void testSetFormatLocale(void);
 
 private:
     void jsonTestsFromFiles(IcuTestErrorCode&);


### PR DESCRIPTION
Alternate to PR #4021
For discussion.

- allows registered functions to override standard ones
- add a test for overriding standard functions

- A number of "TODO ICU-23424" mark places where the API was insufficient for overriding:

1. was not able to call the built-in functions. Rather than expose them directly, it would be sufficient to have some kind of `const MFFunctionRegistry& getDefaultFunctionRegistry()` where I could call `getFunction("date")`… etc
2. was not able to mutate or construct the `FunctionContext`. Add a builder for it.

Note: seems this fails on Windows due to linkage. 

#### Checklist
- [X] Required: Issue filed: ICU-23424
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [X] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
