### PR TITLE
Fix out-of-bounds reads in Arabic shaping space handling

### DIFF
--- a/icu4c/source/common/ushape.cpp
+++ b/icu4c/source/common/ushape.cpp
@@ -822,8 +822,8 @@ handleGeneratedSpaces(char16_t *dest, int32_t sourceLength,
     if(lamAlefOption || tashkeelOption){
         uprv_memset(tempbuffer, 0, (sourceLength+1)*U_SIZEOF_UCHAR);
         
-        i = j = sourceLength; count = 0;
-        
+        i = j = sourceLength-1; count = 0;
+
         while(i >= 0) {
             if ( (lamAlefOption && dest[i] == LAMALEF_SPACE_SUB) ||
                  (tashkeelOption && dest[i] == TASHKEEL_SPACE_SUB) ){
@@ -1055,7 +1055,7 @@ expandCompositCharAtNear(char16_t *dest, int32_t sourceLength, int32_t destSize,
 
                     *pErrorCode=U_NO_SPACE_AVAILABLE;
                 }
-            }else if(lamAlefOption && isLamAlefChar(dest[i+1])) {
+            }else if(lamAlefOption && (i < sourceLength-1) && isLamAlefChar(dest[i+1])) {
                 if(dest[i] == SPACE_CHAR){
                     lamalefChar = dest[i+1];
                     dest[i+1] = LAM_CHAR;

--- a/icu4c/source/test/cintltst/cbiditst.c
+++ b/icu4c/source/test/cintltst/cbiditst.c
@@ -76,6 +76,8 @@ static void _testPresentationForms(const UChar *in);
 
 static void doArabicShapingTestForNewCharacters(void);
 
+static void doArabicShapingTestForBufferOverflow(void);
+
 static void testReorder(void);
 
 static void testReorderArabicMathSymbols(void);
@@ -156,6 +158,7 @@ addComplexTest(TestNode** root) {
     addTest(root, testReorderArabicMathSymbols, "complex/bidi/bug-9024");
     addTest(root, doArabicShapingTestForBug9024, "complex/arabic-shaping/bug-9024");
     addTest(root, doArabicShapingTestForNewCharacters, "complex/arabic-shaping/shaping2");
+    addTest(root, doArabicShapingTestForBufferOverflow, "complex/arabic-shaping/overflow");
 }
 
 static void
@@ -3171,6 +3174,58 @@ doArabicShapingTestForBug8703(void) {
 
     if(U_FAILURE(errorCode) || length!=UPRV_LENGTHOF(letters_dest8) || memcmp(dest, letters_dest8, length*U_SIZEOF_UCHAR)!=0) {
         log_err("failure in u_shapeArabic(letters_source8)\n");
+    }
+}
+
+static void
+doArabicShapingTestForBufferOverflow(void) {
+    /*
+     * The internal shaping work buffer holds exactly sourceLength UChars when
+     * no resizing option is used, so a length above the 300-element stack
+     * buffer forces a heap allocation of that exact size. The lamalef/tashkeel
+     * "begin" space handling and the near lamalef expansion used to read one
+     * element past that buffer; exercise both paths with such a length.
+     */
+    enum { LEN = 400 };
+    UChar shapeSource[LEN];   /* LAM + ALEF + SPACE + presentation LAM-ALEF */
+    UChar unshapeSource[LEN]; /* SPACE + presentation LAM-ALEF, ready to expand */
+    UChar dest[2 * LEN];
+    UErrorCode errorCode;
+    int32_t length;
+    int32_t i;
+
+    for(i = 0; i < LEN; ++i) {
+        switch(i & 3) {
+        case 0:  shapeSource[i] = 0x0644; break; /* LAM  */
+        case 1:  shapeSource[i] = 0x0627; break; /* ALEF */
+        case 2:  shapeSource[i] = 0x0020; break; /* SPACE */
+        default: shapeSource[i] = 0xFEFB; break; /* LAM-ALEF */
+        }
+        unshapeSource[i] = (i & 1) ? 0xFEFB : 0x0020;
+    }
+
+    errorCode = U_ZERO_ERROR;
+    length = u_shapeArabic(shapeSource, LEN, dest, UPRV_LENGTHOF(dest),
+                           U_SHAPE_TEXT_DIRECTION_LOGICAL | U_SHAPE_LAMALEF_BEGIN | U_SHAPE_LETTERS_SHAPE,
+                           &errorCode);
+    if(U_FAILURE(errorCode) || length > UPRV_LENGTHOF(dest)) {
+        log_err("failure in u_shapeArabic(LAMALEF_BEGIN, length %d): %s\n", (int)LEN, u_errorName(errorCode));
+    }
+
+    errorCode = U_ZERO_ERROR;
+    length = u_shapeArabic(shapeSource, LEN, dest, UPRV_LENGTHOF(dest),
+                           U_SHAPE_TEXT_DIRECTION_LOGICAL | U_SHAPE_TASHKEEL_BEGIN | U_SHAPE_LETTERS_SHAPE,
+                           &errorCode);
+    if(U_FAILURE(errorCode) || length > UPRV_LENGTHOF(dest)) {
+        log_err("failure in u_shapeArabic(TASHKEEL_BEGIN, length %d): %s\n", (int)LEN, u_errorName(errorCode));
+    }
+
+    errorCode = U_ZERO_ERROR;
+    length = u_shapeArabic(unshapeSource, LEN, dest, UPRV_LENGTHOF(dest),
+                           U_SHAPE_LAMALEF_NEAR | U_SHAPE_LETTERS_UNSHAPE,
+                           &errorCode);
+    if(U_FAILURE(errorCode) || length > UPRV_LENGTHOF(dest)) {
+        log_err("failure in u_shapeArabic(UNSHAPE|LAMALEF_NEAR, length %d): %s\n", (int)LEN, u_errorName(errorCode));
     }
 }
 


### PR DESCRIPTION
`handleGeneratedSpaces` and `expandCompositCharAtNear` in `ushape.cpp` walk the shaping scratch buffer one element past its end: the begin-spacing loop starts its index at `sourceLength` so it reads `dest[sourceLength]`, and the near lamalef expansion reads `dest[i+1]` without checking `i+1` is still in range. `u_shapeArabic` hands these helpers a buffer of exactly `sourceLength` UChars, heap-allocated once the input passes the 300-element stack fallback, so `U_SHAPE_LAMALEF_BEGIN`, `U_SHAPE_TASHKEEL_BEGIN` and `U_SHAPE_LETTERS_UNSHAPE | U_SHAPE_LAMALEF_NEAR` read out of bounds on a ~400-char input, which AddressSanitizer reports at `ushape.cpp:828`. The begin loop now starts at `sourceLength-1` like its sibling at line 929, and the lamalef lookahead is guarded with `(i < sourceLength-1)` the way the nearby code at line 1396 already does. The new cintltst case fails under asan before the change and passes after, and the existing shaping output is unchanged.

#### Checklist
- [ ] Required: Issue filed: ICU-NNNNN
- [ ] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
