### PR TITLE
ICU-23443 Fix heap under-allocation and missing OOM check in VTimeZone/IZRule C wrappers

### DIFF
--- a/icu4c/source/i18n/vzone.cpp
+++ b/icu4c/source/i18n/vzone.cpp
@@ -83,30 +83,60 @@ U_CAPI void U_EXPORT2
 vzone_write(VZone* zone, char16_t* & result, int32_t & resultLength, UErrorCode& status) {
     UnicodeString s;
     ((VTimeZone*)zone)->VTimeZone::write(s, status);
+    if (U_FAILURE(status)) {
+        result = nullptr;
+        resultLength = 0;
+        return;
+    }
 
     resultLength = s.length();
-    result = (char16_t*)uprv_malloc(resultLength);
-    memcpy(result,s.getBuffer(),resultLength);
+    result = static_cast<char16_t*>(uprv_malloc(resultLength * sizeof(char16_t)));
+    if (result == nullptr) {
+        status = U_MEMORY_ALLOCATION_ERROR;
+        resultLength = 0;
+        return;
+    }
+    memcpy(result, s.getBuffer(), resultLength * sizeof(char16_t));
 }
 
 U_CAPI void U_EXPORT2
 vzone_writeFromStart(VZone* zone, UDate start, char16_t* & result, int32_t & resultLength, UErrorCode& status) {
     UnicodeString s;
     ((VTimeZone*)zone)->VTimeZone::write(start, s, status);
+    if (U_FAILURE(status)) {
+        result = nullptr;
+        resultLength = 0;
+        return;
+    }
 
     resultLength = s.length();
-    result = (char16_t*)uprv_malloc(resultLength);
-    memcpy(result,s.getBuffer(),resultLength);
+    result = static_cast<char16_t*>(uprv_malloc(resultLength * sizeof(char16_t)));
+    if (result == nullptr) {
+        status = U_MEMORY_ALLOCATION_ERROR;
+        resultLength = 0;
+        return;
+    }
+    memcpy(result, s.getBuffer(), resultLength * sizeof(char16_t));
 }
 
 U_CAPI void U_EXPORT2
 vzone_writeSimple(VZone* zone, UDate time, char16_t* & result, int32_t & resultLength, UErrorCode& status) {
     UnicodeString s;
     ((VTimeZone*)zone)->VTimeZone::writeSimple(time, s, status);
+    if (U_FAILURE(status)) {
+        result = nullptr;
+        resultLength = 0;
+        return;
+    }
 
     resultLength = s.length();
-    result = (char16_t*)uprv_malloc(resultLength);
-    memcpy(result,s.getBuffer(),resultLength);
+    result = static_cast<char16_t*>(uprv_malloc(resultLength * sizeof(char16_t)));
+    if (result == nullptr) {
+        status = U_MEMORY_ALLOCATION_ERROR;
+        resultLength = 0;
+        return;
+    }
+    memcpy(result, s.getBuffer(), resultLength * sizeof(char16_t));
 }
 
 U_CAPI int32_t U_EXPORT2

--- a/icu4c/source/i18n/zrule.cpp
+++ b/icu4c/source/i18n/zrule.cpp
@@ -93,8 +93,12 @@ izrule_getName(IZRule* rule, char16_t* & name, int32_t & nameLength) {
     UnicodeString s;
     ((InitialTimeZoneRule*)rule)->InitialTimeZoneRule::getName(s);
     nameLength = s.length();
-    name = (char16_t*)uprv_malloc(nameLength);
-    memcpy(name, s.getBuffer(), nameLength);
+    name = (char16_t*)uprv_malloc(nameLength * sizeof(char16_t));
+    if (name == nullptr) {
+        nameLength = 0;
+        return;
+    }
+    memcpy(name, s.getBuffer(), nameLength * sizeof(char16_t));
 }
 
 U_CAPI int32_t U_EXPORT2


### PR DESCRIPTION
### Linked Jira issue
ICU-23443

### Summary
Four C wrapper functions in `icu4c/source/i18n/vzone.cpp` and
`icu4c/source/i18n/zrule.cpp` allocated their output `char16_t*`
buffer with `uprv_malloc(length)` instead of
`uprv_malloc(length * sizeof(char16_t))`, and then copied
`length` bytes instead of `length * sizeof(char16_t)` bytes —
so the returned buffer was half the size implied by the
returned length. They also did not check the malloc result
for nullptr before `memcpy`.

Affected functions:
- `vzone_write`
- `vzone_writeFromStart`
- `vzone_writeSimple`
- `izrule_getName`

### Cause
`UnicodeString::length()` returns the number of UTF-16 code units;
each unit is `sizeof(char16_t) == 2` bytes. The malloc/memcpy used
that count as a byte count. On OOM `uprv_malloc` returns nullptr and
the subsequent `memcpy` is undefined behavior.

### Fix
- Allocate and copy `length * sizeof(char16_t)` bytes.
- Check the malloc result; on failure set
  `status = U_MEMORY_ALLOCATION_ERROR` (where a `UErrorCode&`
  parameter is available) and reset the out-parameters.
- For the `vzone_*` functions also bail out early when the inner
  `VTimeZone::write*` call already set a failure.
- `izrule_getName` has no `UErrorCode` parameter (changing the
  signature would break ABI), so on OOM it can only signal by
  setting `nameLength = 0` and leaving `name = nullptr`.

### Testing
Existing tests pass (no behavior change on the success path beyond
returning the full UTF-16 buffer that callers always assumed).
No new test added — the OOM path requires allocator injection that
is not part of the standard test harness.

### Notes
Found by static analysis (Svace, ISP RAS).

#### Checklist
- [x] Required: Issue filed: ICU-23443
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf