### PR TITLE
ICU-23444 Fix null pointer dereference and leak in SpoofData::reserveSpace on uprv_realloc failure

### DIFF
--- a/icu4c/source/i18n/uspoof_impl.cpp
+++ b/icu4c/source/i18n/uspoof_impl.cpp
@@ -735,7 +735,13 @@ void *SpoofData::reserveSpace(int32_t numBytes,  UErrorCode &status) {
     numBytes = (numBytes + 15) & ~15;   // Round up to a multiple of 16
     uint32_t returnOffset = fMemLimit;
     fMemLimit += numBytes;
-    fRawData = static_cast<SpoofDataHeader *>(uprv_realloc(fRawData, fMemLimit));
+    SpoofDataHeader *newRawData =
+        static_cast<SpoofDataHeader *>(uprv_realloc(fRawData, fMemLimit));
+    if (newRawData == nullptr) {
+        status = U_MEMORY_ALLOCATION_ERROR;
+        return nullptr;
+    }
+    fRawData = newRawData;
     fRawData->fLength = fMemLimit;
     uprv_memset((char *)fRawData + returnOffset, 0, numBytes);
     initPtrs(status);


### PR DESCRIPTION
### Linked Jira issue
ICU-23444

### Summary
In `SpoofData::reserveSpace` (`icu4c/source/i18n/uspoof_impl.cpp`),
the result of `uprv_realloc(fRawData, fMemLimit)` was assigned
directly back to `fRawData` and immediately dereferenced
(`fRawData->fLength = ...`).

### Cause
Two problems:
1. **Null pointer dereference on OOM.** `uprv_realloc` returns
   nullptr on allocation failure; the next write through that
   nullptr is undefined behavior.
2. **Memory leak via the standard `realloc` gotcha.** When
   `realloc(p, n)` fails it returns nullptr but does *not* free
   the original buffer. Assigning the result directly back to
   `fRawData` overwrites the live pointer with nullptr and loses
   the original allocation.

### Fix
Take the `uprv_realloc` result into a temporary, check for nullptr,
set `status = U_MEMORY_ALLOCATION_ERROR` via the existing
`UErrorCode&` parameter and return without touching `fRawData`. On
success, assign the new pointer back to `fRawData`.

### Testing
Existing tests pass (no behavior change on the success path). No new
test added — the OOM path requires allocator injection that is not
part of the standard test harness.

### Notes
Found by static analysis (Svace, ISP RAS).

#### Checklist
- [x] Required: Issue filed: ICU-23444
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf