### PR TITLE
ICU-23481 mf2: C API improvements for composed functions

### DIFF
--- a/icu4c/source/i18n/messageformat2.cpp
+++ b/icu4c/source/i18n/messageformat2.cpp
@@ -269,7 +269,7 @@ static UnicodeString reserialize(const UnicodeString& s) {
     U_ASSERT(U_SUCCESS(status));
     // Call the function
     LocalPointer<FunctionValue>
-        functionResult(function->call(makeFunctionContext(options),
+        functionResult(function->call(makeFunctionContext(options, functionName),
                                       *functionArg,
                                       std::move(options),
                                       status));
@@ -299,13 +299,13 @@ static UnicodeString reserialize(const UnicodeString& s) {
 // Function options and context
 // ----------------------------
 
-FunctionContext MessageFormatter::makeFunctionContext(const FunctionOptions& options) const {
+FunctionContext MessageFormatter::makeFunctionContext(const FunctionOptions& options, const FunctionName& calledFunction) const {
     // Look up "u:dir", and "u:id" in the options
 
     UMFBidiOption dir = ubidi_getMFOption(options.getStringFunctionOption(options::U_DIR));
     UnicodeString id = options.getStringFunctionOption(options::U_ID);
 
-    return FunctionContext(locale, dir, id);
+    return FunctionContext(locale, dir, id, calledFunction);
 }
 
 // Resolves a function's options

--- a/icu4c/source/i18n/messageformat2.cpp
+++ b/icu4c/source/i18n/messageformat2.cpp
@@ -269,7 +269,7 @@ static UnicodeString reserialize(const UnicodeString& s) {
     U_ASSERT(U_SUCCESS(status));
     // Call the function
     LocalPointer<FunctionValue>
-        functionResult(function->call(makeFunctionContext(options),
+        functionResult(function->call(makeFunctionContext(options, functionName),
                                       *functionArg,
                                       std::move(options),
                                       status));
@@ -299,13 +299,13 @@ static UnicodeString reserialize(const UnicodeString& s) {
 // Function options and context
 // ----------------------------
 
-FunctionContext MessageFormatter::makeFunctionContext(const FunctionOptions& options) const {
+FunctionContext MessageFormatter::makeFunctionContext(const FunctionOptions& options, const FunctionName& calledFunction) const {
     // Look up "u:dir", and "u:id" in the options
 
     UMFBidiOption dir = ubidi_getMFOption(options.getStringFunctionOption(options::U_DIR));
     UnicodeString id = options.getStringFunctionOption(options::U_ID);
 
-    return FunctionContext(locale, dir, id);
+    return FunctionContext(locale, dir, id, standardMFFunctionRegistry, calledFunction);
 }
 
 // Resolves a function's options

--- a/icu4c/source/i18n/messageformat2_formatter.cpp
+++ b/icu4c/source/i18n/messageformat2_formatter.cpp
@@ -19,11 +19,103 @@
 #include "messageformat2_parser.h"
 #include "messageformat2_serializer.h"
 #include "uvector.h" // U_ASSERT
+#include "mutex.h"
+#include "ucln_in.h"
 
 U_NAMESPACE_BEGIN
 
 namespace message2 {
 
+// Singleton for the standard function registry
+class MF2RegistrySingleton : public UObject {
+public:
+  MF2RegistrySingleton(UErrorCode &success);
+  ~MF2RegistrySingleton(){}
+  /** @return an alias to the standard registry */
+  const MFFunctionRegistry* getStandardFunctionsRegistry() const {
+    return &standardMFFunctionRegistry;
+  }
+private:
+  MFFunctionRegistry standardMFFunctionRegistry;
+};
+
+MF2RegistrySingleton::MF2RegistrySingleton(UErrorCode &success) {
+  // Set up the standard function registry
+  MFFunctionRegistry::Builder standardFunctionsBuilder(success);
+  
+  LocalPointer<Function> dateTime(StandardFunctions::DateTime::dateTime(success));
+  LocalPointer<Function> date(StandardFunctions::DateTime::date(success));
+  LocalPointer<Function> time(StandardFunctions::DateTime::time(success));
+  LocalPointer<Function> currency(StandardFunctions::Number::currency(success));
+  LocalPointer<Function> number(StandardFunctions::Number::number(success));
+  LocalPointer<Function> integer(StandardFunctions::Number::integer(success));
+  LocalPointer<Function> string(StandardFunctions::String::string(success));
+  LocalPointer<Function> testFunction(StandardFunctions::TestFunction::testFunction(success));
+  LocalPointer<Function> testFormat(StandardFunctions::TestFunction::testFormat(success));
+  LocalPointer<Function> testSelect(StandardFunctions::TestFunction::testSelect(success));
+  CHECK_ERROR(success);
+  standardFunctionsBuilder.adoptFunction(FunctionName(functions::DATETIME),
+					 dateTime.orphan(), success)
+    .adoptFunction(FunctionName(functions::DATE), date.orphan(), success)
+    .adoptFunction(FunctionName(functions::TIME), time.orphan(), success)
+    .adoptFunction(FunctionName(functions::CURRENCY), currency.orphan(), success)
+    .adoptFunction(FunctionName(functions::NUMBER),
+		   number.orphan(), success)
+    .adoptFunction(FunctionName(functions::INTEGER),
+		   integer.orphan(), success)
+    .adoptFunction(FunctionName(functions::STRING),
+		   string.orphan(), success)
+    .adoptFunction(FunctionName(functions::TEST_FUNCTION),
+		   testFunction.orphan(), success)
+    .adoptFunction(FunctionName(functions::TEST_FORMAT),
+		   testFormat.orphan(), success)
+    .adoptFunction(FunctionName(functions::TEST_SELECT),
+		   testSelect.orphan(), success);
+  CHECK_ERROR(success);
+  standardMFFunctionRegistry = standardFunctionsBuilder.build();
+  CHECK_ERROR(success);
+  standardMFFunctionRegistry.checkStandard();
+}
+
+static MF2RegistrySingleton* mf2RegistrySingleton = nullptr;
+static icu::UInitOnce gMF2RegistryInitOnce {};
+
+// Clean up shared Registry objects
+static UBool mf2_registry_cleanup() {
+    if (mf2RegistrySingleton != nullptr) {
+        delete mf2RegistrySingleton;
+        mf2RegistrySingleton = nullptr;
+    }
+    return true;
+}
+
+static void initRegistryOnce(UErrorCode& errorCode) {
+    U_ASSERT(mf2RegistrySingleton == nullptr);
+
+    mf2RegistrySingleton = new MF2RegistrySingleton( errorCode);
+
+    if (mf2RegistrySingleton == nullptr) {
+        errorCode = U_MEMORY_ALLOCATION_ERROR;
+        mf2_registry_cleanup();
+        return;
+    }
+    ucln_i18n_registerCleanup(UCLN_I18N_MF2_REGISTRY, mf2_registry_cleanup);
+}
+
+  static void initRegistry(UErrorCode& errorCode) {
+    CHECK_ERROR(errorCode);
+
+    umtx_initOnce(gMF2RegistryInitOnce, &initRegistryOnce, errorCode);
+  }
+
+  const MFFunctionRegistry *MFFunctionRegistry::getStandardFunctionsRegistry(UErrorCode& errorCode) {
+    initRegistry(errorCode);
+    if (U_FAILURE(errorCode) || mf2RegistrySingleton == nullptr) {
+      return nullptr;
+    }
+    return mf2RegistrySingleton->getStandardFunctionsRegistry();
+  }
+  
     // MessageFormatter::Builder
 
     // -------------------------------------
@@ -153,44 +245,9 @@ namespace message2 {
     // MessageFormatter
 
     MessageFormatter::MessageFormatter(const MessageFormatter::Builder& builder, UErrorCode &success) : locale(builder.locale), customMFFunctionRegistry(builder.customMFFunctionRegistry) {
+        standardMFFunctionRegistry = MFFunctionRegistry::getStandardFunctionsRegistry(success);
         CHECK_ERROR(success);
-
-        // Set up the standard function registry
-        MFFunctionRegistry::Builder standardFunctionsBuilder(success);
-
-        LocalPointer<Function> dateTime(StandardFunctions::DateTime::dateTime(success));
-        LocalPointer<Function> date(StandardFunctions::DateTime::date(success));
-        LocalPointer<Function> time(StandardFunctions::DateTime::time(success));
-        LocalPointer<Function> currency(StandardFunctions::Number::currency(success));
-        LocalPointer<Function> number(StandardFunctions::Number::number(success));
-        LocalPointer<Function> integer(StandardFunctions::Number::integer(success));
-        LocalPointer<Function> string(StandardFunctions::String::string(success));
-        LocalPointer<Function> testFunction(StandardFunctions::TestFunction::testFunction(success));
-        LocalPointer<Function> testFormat(StandardFunctions::TestFunction::testFormat(success));
-        LocalPointer<Function> testSelect(StandardFunctions::TestFunction::testSelect(success));
-        CHECK_ERROR(success);
-        standardFunctionsBuilder.adoptFunction(FunctionName(functions::DATETIME),
-                                                      dateTime.orphan(), success)
-            .adoptFunction(FunctionName(functions::DATE), date.orphan(), success)
-            .adoptFunction(FunctionName(functions::TIME), time.orphan(), success)
-            .adoptFunction(FunctionName(functions::CURRENCY), currency.orphan(), success)
-            .adoptFunction(FunctionName(functions::NUMBER),
-                                  number.orphan(), success)
-            .adoptFunction(FunctionName(functions::INTEGER),
-                                  integer.orphan(), success)
-            .adoptFunction(FunctionName(functions::STRING),
-                                  string.orphan(), success)
-            .adoptFunction(FunctionName(functions::TEST_FUNCTION),
-                                  testFunction.orphan(), success)
-            .adoptFunction(FunctionName(functions::TEST_FORMAT),
-                                  testFormat.orphan(), success)
-            .adoptFunction(FunctionName(functions::TEST_SELECT),
-                                  testSelect.orphan(), success);
-        CHECK_ERROR(success);
-        standardMFFunctionRegistry = standardFunctionsBuilder.build();
-        CHECK_ERROR(success);
-        standardMFFunctionRegistry.checkStandard();
-
+	
         normalizedInput = builder.normalizedInput;
         signalErrors = builder.signalErrors;
         bidiIsolationStrategy = builder.bidiIsolationStrategy;
@@ -275,7 +332,7 @@ namespace message2 {
     // Function registry
 
     bool MessageFormatter::isBuiltInFunction(const FunctionName& functionName) const {
-        return standardMFFunctionRegistry.hasFunction(functionName);
+        return standardMFFunctionRegistry->hasFunction(functionName);
     }
 
     const Function*
@@ -291,7 +348,7 @@ namespace message2 {
             }
         }
         if (isBuiltInFunction(functionName)) {
-            return standardMFFunctionRegistry.getFunction(functionName);
+            return standardMFFunctionRegistry->getFunction(functionName);
         }
         // Either there is no custom function registry and the function
         // isn't built-in, or the function doesn't exist in either the built-in

--- a/icu4c/source/i18n/messageformat2_function_registry_internal.h
+++ b/icu4c/source/i18n/messageformat2_function_registry_internal.h
@@ -106,7 +106,7 @@ static constexpr std::u16string_view YEAR = u"year";
     // Built-in functions
     // See https://github.com/unicode-org/message-format-wg/blob/main/spec/functions/README.md
     class StandardFunctions {
-        friend class MessageFormatter;
+      friend class MF2RegistrySingleton;
 
         public:
 

--- a/icu4c/source/i18n/ucln_in.h
+++ b/icu4c/source/i18n/ucln_in.h
@@ -65,6 +65,7 @@ typedef enum ECleanupI18NType {
     UCLN_I18N_NUMSYS,
     UCLN_I18N_MF2_UNISETS,
     UCLN_I18N_MF2_DATE_PARSERS,
+    UCLN_I18N_MF2_REGISTRY,
     UCLN_I18N_COUNT /* This must be last */
 } ECleanupI18NType;
 

--- a/icu4c/source/i18n/unicode/messageformat2.h
+++ b/icu4c/source/i18n/unicode/messageformat2.h
@@ -461,7 +461,7 @@ namespace message2 {
         [[nodiscard]] InternalValue evalLiteral(const UnicodeString&, const data_model::Literal&, UErrorCode&) const;
         [[nodiscard]] UnicodeString& bidiIsolate(UMFBidiOption, UMFDirectionality, UnicodeString&) const;
         void formatPattern(MessageContext&, Environment&, const data_model::Pattern&, UErrorCode&, UnicodeString&) const;
-        FunctionContext makeFunctionContext(const FunctionOptions&) const;
+        FunctionContext makeFunctionContext(const FunctionOptions&, const FunctionName&) const;
         [[nodiscard]] InternalValue& apply(Environment&, const FunctionName&, InternalValue&, FunctionOptions&&,
                                            MessageContext&, UErrorCode&) const;
         [[nodiscard]] InternalValue& evalExpression(const UnicodeString&, Environment&, const data_model::Expression&, MessageContext&, UErrorCode&) const;
@@ -504,7 +504,7 @@ namespace message2 {
         /* const */ Locale locale;
 
         // Registry for built-in functions
-        MFFunctionRegistry standardMFFunctionRegistry;
+        const MFFunctionRegistry *standardMFFunctionRegistry;
         // Registry for custom functions; may be null if no custom registry supplied
         // Note: this is *not* owned by the MessageFormatter object
         // The reason for this choice is to have a non-destructive MessageFormatter::Builder,

--- a/icu4c/source/i18n/unicode/messageformat2.h
+++ b/icu4c/source/i18n/unicode/messageformat2.h
@@ -461,7 +461,7 @@ namespace message2 {
         [[nodiscard]] InternalValue evalLiteral(const UnicodeString&, const data_model::Literal&, UErrorCode&) const;
         [[nodiscard]] UnicodeString& bidiIsolate(UMFBidiOption, UMFDirectionality, UnicodeString&) const;
         void formatPattern(MessageContext&, Environment&, const data_model::Pattern&, UErrorCode&, UnicodeString&) const;
-        FunctionContext makeFunctionContext(const FunctionOptions&) const;
+        FunctionContext makeFunctionContext(const FunctionOptions&, const FunctionName&) const;
         [[nodiscard]] InternalValue& apply(Environment&, const FunctionName&, InternalValue&, FunctionOptions&&,
                                            MessageContext&, UErrorCode&) const;
         [[nodiscard]] InternalValue& evalExpression(const UnicodeString&, Environment&, const data_model::Expression&, MessageContext&, UErrorCode&) const;

--- a/icu4c/source/i18n/unicode/messageformat2_function_registry.h
+++ b/icu4c/source/i18n/unicode/messageformat2_function_registry.h
@@ -204,9 +204,19 @@ namespace message2 {
          */
         virtual ~MFFunctionRegistry();
 
+	/**
+	 * Get the standard function registry.
+	 * @internal ICU 79 technology preview
+	 * @deprecated This API is for technology preview only.
+	 * @param status Input/output error code
+	 * @return A const alias to the registry, or nullptr on error
+	 */
+	static const MFFunctionRegistry* getStandardFunctionsRegistry(UErrorCode &status);
+	
     private:
         friend class MessageContext;
         friend class MessageFormatter;
+	friend class MF2RegistrySingleton;
 
         // Do not define copy constructor or copy assignment operator
         MFFunctionRegistry& operator=(const MFFunctionRegistry&) = delete;
@@ -267,15 +277,39 @@ namespace message2 {
              * @deprecated This API is for technology preview only.
              */
             U_I18N_API const UnicodeString& getID() const { return id; }
+
+            /**
+             * Returns the original called function name from this context.
+             *
+             * @return The function name, as registered, used for this function
+             *
+             * @internal ICU 79 technology preview
+             * @deprecated This API is for technology preview only.
+             */
+            U_I18N_API const FunctionName& getCalledFunctionName() const { return calledFunction; }
+
+            /**
+             * Returns a new context with the specified locale.
+             *
+             * @return a new locale
+             *
+             * @internal ICU 79 technology preview
+             * @deprecated This API is for technology preview only.
+             */
+            U_I18N_API FunctionContext withLocale(const Locale& loc) const {
+                return FunctionContext(loc, getDirection(), getID(), getCalledFunctionName());
+            }
+
         private:
             friend class MessageFormatter;
 
             Locale locale;
             UMFBidiOption dir;
             UnicodeString id;
+            const FunctionName& calledFunction;
 
-            FunctionContext(const Locale& loc, UMFBidiOption d, UnicodeString i)
-                : locale(loc), dir(d), id(i) {}
+            FunctionContext(const Locale& loc, UMFBidiOption d, UnicodeString i, const FunctionName& calledFn)
+                : locale(loc), dir(d), id(i), calledFunction(calledFn) {}
     }; // class FunctionContext
 
     class FunctionValue;
@@ -465,7 +499,7 @@ namespace message2 {
              * @internal ICU 79 technology preview
              * @deprecated This API is for technology preview only.
              */
-            U_I18N_API virtual const UnicodeString& getFunctionName() const { return functionName; }
+            U_I18N_API virtual const FunctionName& getFunctionName() const { return functionName; }
             /**
              * Returns a fallback string that can be used as output
              * if processing this function results in an error.
@@ -506,7 +540,7 @@ namespace message2 {
              * @internal ICU 79 technology preview
              * @deprecated This API is for technology preview only.
              */
-            UnicodeString functionName;
+            FunctionName functionName;
             /**
              * Fallback string that can be used if a later function encounters
              * an error when processing this FunctionValue.

--- a/icu4c/source/i18n/unicode/messageformat2_function_registry.h
+++ b/icu4c/source/i18n/unicode/messageformat2_function_registry.h
@@ -266,15 +266,63 @@ namespace message2 {
              * @deprecated This API is for technology preview only.
              */
             U_I18N_API const UnicodeString& getID() const { return id; }
+
+            /**
+             * Returns the original called function name from this context.
+             *
+             * @return The function name, as registered, used for this function
+             *
+             * @internal ICU 79 technology preview
+             * @deprecated This API is for technology preview only.
+             */
+            U_I18N_API const FunctionName& getCalledFunctionName() const { return calledFunction; }
+
+            /**
+             * Returns a new context with the specified locale.
+             *
+             * @return a new locale
+             *
+             * @internal ICU 79 technology preview
+             * @deprecated This API is for technology preview only.
+             */
+            U_I18N_API FunctionContext withLocale(const Locale& loc) const {
+                return FunctionContext(loc, getDirection(), getID(), standardFunctions, getCalledFunctionName());
+            }
+
+            /**
+             * Returns a pointer to a standard function.
+             * This function may only be used within the implementation of call()
+             * The returned pointer is invalid once this FunctionContext goes out of scope.
+             * A U_INVALID_PARAMETER is setif the requested function is not one of
+             * the standard functions.
+             *
+             * @param name the name of the standard function, such as "datetime" or "number"
+             * @return pointer to the standard function, or nullptr
+             *
+             * @internal ICU 79 technology preview
+             * @deprecated This API is for technology preview only.
+             */
+            U_I18N_API Function *getStandardFunction(const FunctionName &name,
+                                                     UErrorCode &errorCode) const {
+                if (U_FAILURE(errorCode)) return nullptr;
+                Function *p = standardFunctions.getFunction(name);
+                if (p == nullptr) {
+                    errorCode = U_ILLEGAL_ARGUMENT_ERROR;
+                }
+                return p;
+            }
+
         private:
             friend class MessageFormatter;
 
             Locale locale;
             UMFBidiOption dir;
             UnicodeString id;
+            const MFFunctionRegistry& standardFunctions;
+            const FunctionName& calledFunction;
 
-            FunctionContext(const Locale& loc, UMFBidiOption d, UnicodeString i)
-                : locale(loc), dir(d), id(i) {}
+            FunctionContext(const Locale& loc, UMFBidiOption d, UnicodeString i, const MFFunctionRegistry& fns, const FunctionName& calledFn)
+                : locale(loc), dir(d), id(i), standardFunctions(fns), calledFunction(calledFn) {}
     }; // class FunctionContext
 
     class FunctionValue;
@@ -464,7 +512,7 @@ namespace message2 {
              * @internal ICU 79 technology preview
              * @deprecated This API is for technology preview only.
              */
-            U_I18N_API virtual const UnicodeString& getFunctionName() const { return functionName; }
+            U_I18N_API virtual const FunctionName& getFunctionName() const { return functionName; }
             /**
              * Returns a fallback string that can be used as output
              * if processing this function results in an error.
@@ -505,7 +553,7 @@ namespace message2 {
              * @internal ICU 79 technology preview
              * @deprecated This API is for technology preview only.
              */
-            UnicodeString functionName;
+            FunctionName functionName;
             /**
              * Fallback string that can be used if a later function encounters
              * an error when processing this FunctionValue.

--- a/icu4c/source/test/intltest/messageformat2test.cpp
+++ b/icu4c/source/test/intltest/messageformat2test.cpp
@@ -32,6 +32,7 @@ TestMessageFormat2::runIndexedTest(int32_t index, UBool exec,
     TESTCASE_AUTO(testLoneSurrogateInQuotedLiteral);
     TESTCASE_AUTO(dataDrivenTests);
     TESTCASE_AUTO(testOverrideFunctions);
+    TESTCASE_AUTO(testComposeInternalFunctions);
     TESTCASE_AUTO_END;
 }
 
@@ -541,13 +542,12 @@ FixedDateFunction::~FixedDateFunction() {}
 void TestMessageFormat2::testOverrideFunctions() {
     IcuTestErrorCode errorCode(*this, "testOverrideFunctions");
     UParseError parseError;
-
     std::map<UnicodeString, icu::message2::Formattable> argsBuilder;
     argsBuilder["count"] = message2::Formattable((int64_t)13);
     argsBuilder["name"] = message2::Formattable("US");
     argsBuilder["birthday"] = message2::Formattable("1776-07-04");
     icu::message2::MessageArguments args(argsBuilder, errorCode);
-        UnicodeString expectedResult(u"PASS 13 @ \u2068A Day ending in Y\u2069");
+    UnicodeString expectedResult(u"PASS 13 @ \u2068A Day ending in Y\u2069");
 
     const UnicodeString orig_pattern(
         u""
@@ -584,6 +584,123 @@ void TestMessageFormat2::testOverrideFunctions() {
         }
         assertEquals("testSetFormatLocale", expectedResult, result);
     }
+}
+
+namespace ComposableFunctionTest {
+
+    class LocaleOverrideFunction : public Function {
+  public:
+    LocaleOverrideFunction(const Locale &loc, UErrorCode &status);
+    LocalPointer<FunctionValue> call(const FunctionContext &, const FunctionValue &,
+                                     const FunctionOptions &, UErrorCode &) const override;
+    virtual ~LocaleOverrideFunction();
+
+  private:
+    Locale overrideLocale;
+};
+
+LocaleOverrideFunction::LocaleOverrideFunction(const Locale &loc, UErrorCode &/*status*/)
+    : overrideLocale(loc) {}
+
+LocalPointer<FunctionValue> LocaleOverrideFunction::call(const FunctionContext &context,
+                                                 const FunctionValue &arg,
+                                                 const FunctionOptions &opts,
+                                                 UErrorCode &errorCode) const {
+    const FunctionName& myFunction = context.getCalledFunctionName();
+    const FunctionName& stdFunction = myFunction.tempSubString(1); // _date -> date
+
+    const MFFunctionRegistry* standardRegistry = MFFunctionRegistry::getStandardFunctionsRegistry(errorCode);
+ 
+    if (U_FAILURE(errorCode)) {
+        return LocalPointer<FunctionValue>();
+    }
+    
+    //    const Function *delegateFunction = context.getStandardFunction(stdFunction, errorCode);
+    const Function *delegateFunction = standardRegistry->getFunction(stdFunction);
+    
+    if (U_FAILURE(errorCode)) {
+        return LocalPointer<FunctionValue>();
+    }
+    // create a new context, with our updated locale
+    FunctionContext myContext = context.withLocale(overrideLocale);
+    // call the delegated function
+    return delegateFunction->call(myContext, arg, opts, errorCode);
+}
+
+LocaleOverrideFunction::~LocaleOverrideFunction() {}
+} // namespace ComposableFunctionTest
+
+void TestMessageFormat2::testComposeInternalFunctions() {
+    IcuTestErrorCode errorCode(*this, "testComposeInternalFunctions");
+    UParseError parseError;
+    std::map<UnicodeString, icu::message2::Formattable> argsBuilder;
+    argsBuilder["pop"] = message2::Formattable((int64_t)2148076);
+    argsBuilder["count"] = message2::Formattable((int64_t)13);
+    argsBuilder["name"] = message2::Formattable("US");
+    argsBuilder["birthday"] = message2::Formattable("1776-07-04");
+    icu::message2::MessageArguments args(argsBuilder, errorCode);
+    if (errorCode.errIfFailureAndReset("args")) {
+        errln("%s:%d: err %s", __FILE__, __LINE__, errorCode.errorName());
+        return;
+    }
+
+    // Note on what's happening here:
+    // - 'pl' plurals are used (thus PASS)
+    // - US date format 7/4/76
+    // - US number format 2,148,076
+    UnicodeString expectedResult(u"PASS 13 2,148,076 @ 7/4/76");
+
+    // Function _number and _date turn around and call number and date, but with the fixed Locale
+    // myLocale. Overriding standard functions is another concern, in a separate PR.
+    const UnicodeString orig_pattern(
+        u""
+        ".input {$count :number} .input {$name :string} .input {$birthday :date} .input {$pop "
+        ":number}\n"
+        ".match $count\n"
+        "many {{PASS {$count :_number} {$pop :_number} @ {$birthday :_date style=short}}}\n"
+        "* {{FAIL wrong bucket {$count :_number} {$pop :_number} @ {$birthday :_date "
+        "style=short}}}\n");
+
+    // try with a modified pattern
+    // build the function registry
+    const Locale myLocale(Locale::getUS());
+    icu::message2::MFFunctionRegistry::Builder builder(errorCode);
+    if (errorCode.errIfFailureAndReset("MFFunctionRegistry::Builder")) {
+        errln("%s:%d: err %s", __FILE__, __LINE__, errorCode.errorName());
+        return;
+    }
+    MFFunctionRegistry functionRegistry =
+        builder
+            .adoptFunction(data_model::FunctionName("_date"),
+                           new ComposableFunctionTest::LocaleOverrideFunction(myLocale, errorCode),
+                           errorCode)
+            .adoptFunction(data_model::FunctionName("_number"),
+                           new ComposableFunctionTest::LocaleOverrideFunction(myLocale, errorCode),
+                           errorCode)
+            .build();
+    if (errorCode.errIfFailureAndReset("something")) {
+        errln("%s:%d: err %s", __FILE__, __LINE__, errorCode.errorName());
+        return;
+    }
+
+    icu::message2::MessageFormatter mf =
+        MessageFormatter::Builder(errorCode)
+            .setErrorHandlingBehavior(MessageFormatter::U_MF_BEST_EFFORT)
+            .setPattern(orig_pattern, parseError, errorCode)
+            .setFunctionRegistry(functionRegistry)
+            .setLocale(Locale("pl"))
+            .build(errorCode);
+
+    if (errorCode.errIfFailureAndReset("build")) {
+        errln("UParseError = %d:%d", parseError.line, parseError.offset);
+        return;
+    }
+
+    UnicodeString result = mf.formatToString(args, errorCode);
+    if (errorCode.errIfFailureAndReset("formatToString")) {
+        return;
+    }
+    assertEquals("testComposeInternalFunctions", expectedResult, result);
 }
 
 TestCase::~TestCase() {}

--- a/icu4c/source/test/intltest/messageformat2test.cpp
+++ b/icu4c/source/test/intltest/messageformat2test.cpp
@@ -31,6 +31,7 @@ TestMessageFormat2::runIndexedTest(int32_t index, UBool exec,
     TESTCASE_AUTO(testLowLoneSurrogate);
     TESTCASE_AUTO(testLoneSurrogateInQuotedLiteral);
     TESTCASE_AUTO(dataDrivenTests);
+    TESTCASE_AUTO(testComposeInternalFunctions);
     TESTCASE_AUTO_END;
 }
 
@@ -477,6 +478,112 @@ void TestMessageFormat2::dataDrivenTests() {
     IcuTestErrorCode errorCode(*this, "jsonTests");
 
     jsonTestsFromFiles(errorCode);
+}
+
+namespace ComposableFunctionTest {
+
+    class LocaleOverrideFunction : public Function {
+  public:
+    LocaleOverrideFunction(const Locale &loc, UErrorCode &status);
+    LocalPointer<FunctionValue> call(const FunctionContext &, const FunctionValue &,
+                                     const FunctionOptions &, UErrorCode &) override;
+    virtual ~LocaleOverrideFunction();
+
+  private:
+    Locale overrideLocale;
+};
+
+LocaleOverrideFunction::LocaleOverrideFunction(const Locale &loc, UErrorCode &/*status*/)
+    : overrideLocale(loc) {}
+
+LocalPointer<FunctionValue> LocaleOverrideFunction::call(const FunctionContext &context,
+                                                 const FunctionValue &arg,
+                                                 const FunctionOptions &opts,
+                                                 UErrorCode &errorCode) {
+    const FunctionName& myFunction = context.getCalledFunctionName();
+    const FunctionName& stdFunction = myFunction.tempSubString(1); // _date -> date
+    Function *delegateFunction =
+        context.getStandardFunction(stdFunction, errorCode);
+    if (U_FAILURE(errorCode)) {
+        return LocalPointer<FunctionValue>();
+    }
+    // create a new context, with our updated locale
+    FunctionContext myContext = context.withLocale(overrideLocale);
+    // call the delegated function
+    return delegateFunction->call(myContext, arg, opts, errorCode);
+}
+
+LocaleOverrideFunction::~LocaleOverrideFunction() {}
+} // namespace ComposableFunctionTest
+
+void TestMessageFormat2::testComposeInternalFunctions() {
+    IcuTestErrorCode errorCode(*this, "testComposeInternalFunctions");
+    UParseError parseError;
+
+    std::map<UnicodeString, icu::message2::Formattable> argsBuilder;
+    argsBuilder["count"] = message2::Formattable((int64_t)13);
+    argsBuilder["pop"] = message2::Formattable((int64_t)2148076);
+    argsBuilder["name"] = message2::Formattable("US");
+    argsBuilder["birthday"] = message2::Formattable("1776-07-04");
+    icu::message2::MessageArguments args(argsBuilder, errorCode);
+
+    // Note on what's happening here:
+    // - 'pl' plurals are used (thus PASS)
+    // - US date format 7/4/76
+    // - US number format 2,148,076
+    UnicodeString expectedResult(u"PASS 13 2,148,076 @ 7/4/76");
+
+    if (errorCode.errIfFailureAndReset("setup")) {
+        errln("%s:%d: err %s", __FILE__, __LINE__, errorCode.errorName());
+        return;
+    }
+
+    // Function _number and _date turn around and call number and date, but with the fixed Locale myLocale.
+    // Overriding standard functions is another concern, in a separate PR.
+    const UnicodeString orig_pattern(
+        u""
+        ".input {$count :number} .input {$name :string} .input {$birthday :date} .input {$pop "
+        ":number}\n"
+        ".match $count\n"
+        "many {{PASS {$count :_number} {$pop :_number} @ {$birthday :_date style=short}}}\n"
+        "* {{FAIL wrong bucket {$count :_number} {$pop :_number} @ {$birthday :_date style=short}}}\n");
+
+    // try with a modified pattern
+    // build the function registry
+    const Locale myLocale(Locale::getUS());
+    icu::message2::MFFunctionRegistry::Builder builder(errorCode);
+    MFFunctionRegistry functionRegistry =
+        builder
+            .adoptFunction(data_model::FunctionName("_date"),
+                           new ComposableFunctionTest::LocaleOverrideFunction(myLocale, errorCode),
+                           errorCode)
+            .adoptFunction(data_model::FunctionName("_number"),
+                           new ComposableFunctionTest::LocaleOverrideFunction(myLocale, errorCode),
+                           errorCode)
+            .build();
+    if (errorCode.errIfFailureAndReset("something")) {
+        errln("%s:%d: err %s", __FILE__, __LINE__, errorCode.errorName());
+        return;
+    }
+
+    icu::message2::MessageFormatter mf =
+        MessageFormatter::Builder(errorCode)
+            .setErrorHandlingBehavior(MessageFormatter::U_MF_BEST_EFFORT)
+            .setPattern(orig_pattern, parseError, errorCode)
+            .setFunctionRegistry(functionRegistry)
+            .setLocale(Locale("pl"))
+            .build(errorCode);
+
+    if (errorCode.errIfFailureAndReset("build")) {
+        errln("UParseError = %d:%d", parseError.line, parseError.offset);
+        return;
+    }
+
+    UnicodeString result = mf.formatToString(args, errorCode);
+    if (errorCode.errIfFailureAndReset("formatToString")) {
+        return;
+    }
+    assertEquals("testComposeInternalFunctions", expectedResult, result);
 }
 
 TestCase::~TestCase() {}

--- a/icu4c/source/test/intltest/messageformat2test.h
+++ b/icu4c/source/test/intltest/messageformat2test.h
@@ -54,6 +54,7 @@ public:
     void testAPI(void);
     void testAPISimple(void);
     void testOverrideFunctions(void);
+    void testComposeInternalFunctions(void);
 
 private:
     void jsonTestsFromFiles(IcuTestErrorCode&);

--- a/icu4c/source/test/intltest/messageformat2test.h
+++ b/icu4c/source/test/intltest/messageformat2test.h
@@ -53,6 +53,7 @@ public:
     void testBidiAPI(void);
     void testAPI(void);
     void testAPISimple(void);
+    void testComposeInternalFunctions(void);
 
 private:
     void jsonTestsFromFiles(IcuTestErrorCode&);


### PR DESCRIPTION
OBimprovements for composable functions.

- FunctionContext.getCalledFunctionName()
- FunctionContext.withLocale()
- FunctionContext.getStandardFunction()

Also,
- internal improvements to support the above
- FunctionValue.getFunctionName() now returns a `FunctionName`

#### Checklist
- [X] Required: Issue filed: ICU-23481
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [X] API docs and/or User Guide docs changed or added, if applicable
- [X] Approver: Feel free to merge on my behalf


Note: this was formerly under ICU-23424
