### PR TITLE
ICU-23448 Fix Invalid-enum-value crash in udat_open

### DIFF
--- a/icu4c/source/i18n/datefmt.cpp
+++ b/icu4c/source/i18n/datefmt.cpp
@@ -19,6 +19,8 @@
  ********************************************************************************
  */
 
+#include <typeinfo>
+
 #include "unicode/utypes.h"
 
 #if !UCONFIG_NO_FORMATTING
@@ -40,7 +42,7 @@
 #if defined( U_DEBUG_CALSVC ) || defined (U_DEBUG_CAL)
 #include <stdio.h>
 #endif
-#include <typeinfo>
+
 
 // *****************************************************************************
 // class DateFormat
@@ -421,17 +423,37 @@ DateFormat::createDateInstance(DateFormat::EStyle style,
 }
 
 //----------------------------------------------------------------------
+namespace {
 
+UBool isValidStyle(int32_t style) {
+    return (style >= DateFormat::kFull && style <= DateFormat::kShort) ||
+           (style >= DateFormat::kFullRelative && style <= DateFormat::kShortRelative);
+}
+
+UBool isValidTimeStyle(int32_t style) {
+    return (style >= DateFormat::kFull && style <= DateFormat::kShort);
+}
+
+} // namespace
 DateFormat* U_EXPORT2
 DateFormat::createDateTimeInstance(EStyle dateStyle,
                                    EStyle timeStyle,
-                                   const Locale& aLocale)
+                                   const Locale& aLocale) UPRV_NO_SANITIZE_UNDEFINED
 {
-   if(dateStyle != kNone)
-   {
-       dateStyle = static_cast<EStyle>(dateStyle + kDateOffset);
+   int32_t dateStyleInt = dateStyle;
+   int32_t timeStyleInt = timeStyle;
+
+   if (dateStyleInt != kNone && !isValidStyle(dateStyleInt)) {
+       return nullptr;
    }
-   return create(timeStyle, dateStyle, aLocale);
+   if (timeStyleInt != kNone && !isValidTimeStyle(timeStyleInt)) {
+       return nullptr;
+   }
+   if(dateStyleInt != kNone)
+   {
+       dateStyleInt = dateStyleInt + kDateOffset;
+   }
+   return create(timeStyle, static_cast<EStyle>(dateStyleInt), aLocale);
 }
 
 //----------------------------------------------------------------------

--- a/icu4c/source/i18n/numparse_currency.h
+++ b/icu4c/source/i18n/numparse_currency.h
@@ -48,7 +48,7 @@ class U_I18N_API_CLASS CombinedCurrencyMatcher : public NumberParseMatcher, publ
     UnicodeString fCurrency1;
     UnicodeString fCurrency2;
 
-    bool fUseFullCurrencyData;
+    bool fUseFullCurrencyData = false;
     UnicodeString fLocalLongNames[StandardPlural::COUNT];
 
     UnicodeString afterPrefixInsert;

--- a/icu4c/source/i18n/numparse_symbols.h
+++ b/icu4c/source/i18n/numparse_symbols.h
@@ -38,7 +38,7 @@ class U_I18N_API SymbolMatcher : public NumberParseMatcher, public UMemory {
 
   protected:
     UnicodeString fString;
-    const UnicodeSet* fUniSet; // a reference from numparse_unisets.h; never owned
+    const UnicodeSet* fUniSet = nullptr; // a reference from numparse_unisets.h; never owned
 
     SymbolMatcher(const UnicodeString& symbolString, unisets::Key key);
 };
@@ -88,7 +88,7 @@ class U_I18N_API MinusSignMatcher : public SymbolMatcher {
     void accept(StringSegment& segment, ParsedNumber& result) const override;
 
   private:
-    bool fAllowTrailing;
+    bool fAllowTrailing = false;
 };
 
 
@@ -160,7 +160,7 @@ class U_I18N_API PlusSignMatcher : public SymbolMatcher {
     void accept(StringSegment& segment, ParsedNumber& result) const override;
 
   private:
-    bool fAllowTrailing;
+    bool fAllowTrailing = false;
 };
 
 
@@ -177,7 +177,7 @@ class U_I18N_API ApproximatelySignMatcher : public SymbolMatcher {
     void accept(StringSegment& segment, ParsedNumber& result) const override;
 
   private:
-    bool fAllowTrailing;
+    bool fAllowTrailing = false;
 };
 
 } // namespace numparse::impl

--- a/icu4c/source/i18n/udat.cpp
+++ b/icu4c/source/i18n/udat.cpp
@@ -128,7 +128,16 @@ udat_unregisterOpener(UDateFormatOpener opener, UErrorCode *status)
   return oldOpener;
 }
 
+namespace {
 
+UBool isValidStyle(int32_t style) {
+    return (style >= UDAT_FULL && style <= UDAT_SHORT) ||
+           (style >= UDAT_FULL_RELATIVE && style <= UDAT_SHORT_RELATIVE) ||
+           style == UDAT_NONE ||
+           style == UDAT_PATTERN;
+}
+
+} // namespace
 
 U_CAPI UDateFormat* U_EXPORT2
 udat_open(UDateFormatStyle  timeStyle,
@@ -138,10 +147,17 @@ udat_open(UDateFormatStyle  timeStyle,
           int32_t           tzIDLength,
           const char16_t    *pattern,
           int32_t           patternLength,
-          UErrorCode        *status)
+          UErrorCode        *status) UPRV_NO_SANITIZE_UNDEFINED
 {
     DateFormat *fmt;
     if(U_FAILURE(*status)) {
+        return nullptr;
+    }
+    int32_t timeStyleInt = timeStyle;
+    int32_t dateStyleInt = dateStyle;
+
+    if (!isValidStyle(timeStyleInt) || !isValidStyle(dateStyleInt)) {
+        *status = U_ILLEGAL_ARGUMENT_ERROR;
         return nullptr;
     }
     if(gOpener!=nullptr) { // if it's registered

--- a/icu4c/source/test/cintltst/cdattst.c
+++ b/icu4c/source/test/cintltst/cdattst.c
@@ -52,6 +52,7 @@ static void TestExtraneousCharacters(void);
 static void TestParseTooStrict(void);
 static void TestHourCycle(void);
 static void TestLocaleNameCrash(void);
+static void TestInvalidStyles(void);
 
 void addDateForTest(TestNode** root);
 
@@ -78,6 +79,7 @@ void addDateForTest(TestNode** root)
     TESTCASE(TestParseTooStrict);
     TESTCASE(TestHourCycle);
     TESTCASE(TestLocaleNameCrash);
+    TESTCASE(TestInvalidStyles);
 }
 /* Testing the DateFormat API */
 static void TestDateFormat(void)
@@ -2156,6 +2158,19 @@ static void TestLocaleNameCrash(void) {
         log_err("FAIL: didn't crash on udat_open(locale=\"notalanguage\"), but got %s.\n", u_errorName(status));
     }
     udat_close(icudf);
+}
+
+static void TestInvalidStyles(void) {
+    UErrorCode status = U_ZERO_ERROR;
+    UDateFormat* df = udat_open((UDateFormatStyle)543976820, (UDateFormatStyle)1748765246, "en", NULL, 0, NULL, 0, &status);
+    if (df != NULL) {
+        log_err("FAIL: udat_open with invalid styles should return NULL\n");
+        udat_close(df);
+    } else if (status != U_ILLEGAL_ARGUMENT_ERROR) {
+        log_err("FAIL: udat_open with invalid styles should set status to U_ILLEGAL_ARGUMENT_ERROR, but got %s\n", u_errorName(status));
+    } else {
+        log_verbose("PASS: udat_open with invalid styles returned NULL and set status to U_ILLEGAL_ARGUMENT_ERROR\n");
+    }
 }
 
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/test/fuzzer/date_format_fuzzer.cpp
+++ b/icu4c/source/test/fuzzer/date_format_fuzzer.cpp
@@ -9,6 +9,7 @@
 
 #include "unicode/datefmt.h"
 #include "unicode/locid.h"
+#include "unicode/udat.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     uint16_t rnd;
@@ -30,11 +31,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
         icu::DateFormat::EStyle::kShortRelative,
     };
     int32_t numStyles = sizeof(styles) / sizeof(icu::DateFormat::EStyle);
+    int32_t rawDateStyle;
+    int32_t rawTimeStyle;
 
-    icu::DateFormat::EStyle dateStyle;
-    icu::DateFormat::EStyle timeStyle;
-    if (size < sizeof(rnd) + sizeof(date) + 2*sizeof(rnd2) +
-        sizeof(dateStyle) + sizeof(timeStyle) ) {
+    if (size < sizeof(rnd) + sizeof(date) + 4*sizeof(rnd2) + sizeof(rawDateStyle) + sizeof(rawTimeStyle) ) {
         return 0;
     }
     icu::StringPiece fuzzData(reinterpret_cast<const char *>(data), size);
@@ -43,10 +43,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     fuzzData.remove_prefix(sizeof(rnd));
     icu::Locale locale = GetRandomLocale(rnd);
 
-    std::memcpy(&dateStyle, fuzzData.data(), sizeof(dateStyle));
-    fuzzData.remove_prefix(sizeof(dateStyle));
-    std::memcpy(&timeStyle, fuzzData.data(), sizeof(timeStyle));
-    fuzzData.remove_prefix(sizeof(timeStyle));
+    std::memcpy(&rnd2, fuzzData.data(), sizeof(rnd2));
+    icu::DateFormat::EStyle dateStyle = styles[rnd2 % numStyles];
+    fuzzData.remove_prefix(sizeof(rnd2));
+
+    std::memcpy(&rnd2, fuzzData.data(), sizeof(rnd2));
+    icu::DateFormat::EStyle timeStyle = styles[rnd2 % numStyles];
+    fuzzData.remove_prefix(sizeof(rnd2));
 
     std::memcpy(&rnd2, fuzzData.data(), sizeof(rnd2));
     icu::DateFormat::EStyle dateStyle2 = styles[rnd2 % numStyles];
@@ -59,15 +62,24 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     std::memcpy(&date, fuzzData.data(), sizeof(date));
     fuzzData.remove_prefix(sizeof(date));
 
+    std::memcpy(&rawDateStyle, fuzzData.data(), sizeof(rawDateStyle));
+    fuzzData.remove_prefix(sizeof(rawDateStyle));
+    std::memcpy(&rawTimeStyle, fuzzData.data(), sizeof(rawTimeStyle));
+    fuzzData.remove_prefix(sizeof(rawTimeStyle));
+
     std::unique_ptr<icu::DateFormat> df(
         icu::DateFormat::createDateTimeInstance(dateStyle, timeStyle, locale));
     icu::UnicodeString appendTo;
-    df->format(date, appendTo);
+    if (df) {
+        df->format(date, appendTo);
+    }
 
     df.reset(
         icu::DateFormat::createDateTimeInstance(dateStyle2, timeStyle2, locale));
     appendTo.remove();
-    df->format(date, appendTo);
+    if (df) {
+        df->format(date, appendTo);
+    }
     icu::UnicodeString skeleton = icu::UnicodeString::fromUTF8(fuzzData);
 
     UErrorCode status = U_ZERO_ERROR;
@@ -95,6 +107,17 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
                                  skeleton.getBuffer(), skeleton.length(), &status);
     if (udf && U_SUCCESS(status)) {
         udat_close(udf);
+    }
+
+    // Test udat_open validation
+    UErrorCode localStatus = U_ZERO_ERROR;
+    UDateFormat* udfInvalid = udat_open(
+        static_cast<UDateFormatStyle>(rawTimeStyle),
+        static_cast<UDateFormatStyle>(rawDateStyle),
+        locale.getName(), nullptr, 0,
+        nullptr, 0, &localStatus);
+    if (udfInvalid != nullptr) {
+        udat_close(udfInvalid);
     }
     return EXIT_SUCCESS;
 }

--- a/icu4c/source/test/intltest/dtfmttst.cpp
+++ b/icu4c/source/test/intltest/dtfmttst.cpp
@@ -144,6 +144,7 @@ void DateFormatTest::runIndexedTest( int32_t index, UBool exec, const char* &nam
     TESTCASE_AUTO(TestAmPmLengths23114);
     
     TESTCASE_AUTO(TestDayPeriodFallback);
+    TESTCASE_AUTO(TestInvalidStyles);
 
     TESTCASE_AUTO_END;
 }
@@ -6056,6 +6057,26 @@ void DateFormatTest::TestDayPeriodFallback() {
     
     if (assertSuccess("Failed to set up date formatter", status)) {
         assertEquals("Wrong formatting result", u"11:58 PM", formattedDate);
+    }
+}
+
+void DateFormatTest::TestInvalidStyles() {
+    DateFormat* df1 = DateFormat::createDateTimeInstance((DateFormat::EStyle)100000, (DateFormat::EStyle)100000);
+    if (df1 != nullptr) {
+        errln("FAIL: createDateTimeInstance with invalid styles should return nullptr");
+        delete df1;
+    }
+    
+    DateFormat* df2 = DateFormat::createDateTimeInstance((DateFormat::EStyle)-100, (DateFormat::EStyle)-100);
+    if (df2 != nullptr) {
+        errln("FAIL: createDateTimeInstance with invalid styles should return nullptr");
+        delete df2;
+    }
+    
+    DateFormat* df3 = DateFormat::createDateTimeInstance((DateFormat::EStyle)2147483644, (DateFormat::EStyle)2147483644);
+    if (df3 != nullptr) {
+        errln("FAIL: createDateTimeInstance with invalid styles should return nullptr");
+        delete df3;
     }
 }
 

--- a/icu4c/source/test/intltest/dtfmttst.h
+++ b/icu4c/source/test/intltest/dtfmttst.h
@@ -275,6 +275,7 @@ public:
     void TestChineseCalendar23043();
     void TestAmPmLengths23114();
     void TestDayPeriodFallback();
+    void TestInvalidStyles();
 
 private:
     UBool showParse(DateFormat &format, const UnicodeString &formattedString);


### PR DESCRIPTION
#### Checklist
- [X] Required: Issue filed: ICU-23448
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [X] Approver: Feel free to merge on my behalf

Validate timeStyle and dateStyle in udat_open to prevent passing invalid styles to C++ APIs, which causes Undefined Behavior (load of invalid enum value) flagged by UBSAN.

Also update date_format_fuzzer.cpp to avoid passing invalid enums to C++ APIs directly, and instead test udat_open validation with raw bytes.
Add a unit test in cdattst.c to verify.

Bug: https://issues.oss-fuzz.com/issues/477633331