### PR TITLE
ICU-23305 Fix signed integer overflow in NumeratorSubstitution::doParse

### DIFF
--- a/icu4c/source/i18n/nfsubs.cpp
+++ b/icu4c/source/i18n/nfsubs.cpp
@@ -1343,10 +1343,16 @@ NumeratorSubstitution::doParse(const UnicodeString& text,
         int64_t n = result.getLong(status); // force conversion!
         int64_t d = 1;
         while (d <= n) {
+            if (d > INT64_MAX / 10) {
+                return false;
+            }
             d *= 10;
         }
         // now add the zeros
         while (zeroCount > 0) {
+            if (d > INT64_MAX / 10) {
+                return false;
+            }
             d *= 10;
             --zeroCount;
         }

--- a/icu4c/source/test/intltest/itrbnf.cpp
+++ b/icu4c/source/test/intltest/itrbnf.cpp
@@ -88,6 +88,7 @@ void IntlTestRBNF::runIndexedTest(int32_t index, UBool exec, const char* &name, 
         TESTCASE(38, TestAmbiguousDelimiter);
         TESTCASE(39, TestDividedByZero);
         TESTCASE(40, TestTurkishSpellout);
+        TESTCASE(41, TestNumeratorSubstitutionOverflow);
 #else
         TESTCASE(0, TestRBNFDisabled);
 #endif
@@ -2862,6 +2863,27 @@ IntlTestRBNF::TestTurkishSpellout() {
         };
         doLenientParseTest(&formatter, lpTestData);
 	}
+}
+
+void
+IntlTestRBNF::TestNumeratorSubstitutionOverflow() {
+    // This test case comes from a fuzzer (Bug 471607891).
+    // The goal is to make sure that the code does not crash or trigger UBSan
+    // (Undefined Behavior Sanitizer) with invalid/extreme inputs,
+    // rather than looking for a particular result value.
+    UnicodeString rulesStr(
+        u"> \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+        u"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+        u"\u0001a;x0x:>%a>a;%a:a;>;\u00024<;<<<a\u0089;"
+        u"\u0010a\u0000\u0300<<<\u0003>;\u0000;\u001faz>;a;>;\u00024<;<<<Ya",
+        77);
+    UParseError perror;
+    UErrorCode status = U_ZERO_ERROR;
+    RuleBasedNumberFormat rbfmt(rulesStr, Locale::getUS(), perror, status);
+    if (U_SUCCESS(status)) {
+        Formattable result;
+        rbfmt.parse(rulesStr, result, status);
+    }
 }
 
 /* U_HAVE_RBNF */

--- a/icu4c/source/test/intltest/itrbnf.h
+++ b/icu4c/source/test/intltest/itrbnf.h
@@ -171,6 +171,7 @@ public:
     void TestAmbiguousDelimiter();
     void TestDividedByZero();
     void TestTurkishSpellout();
+    void TestNumeratorSubstitutionOverflow();
 
 protected:
     virtual void doTest(RuleBasedNumberFormat* formatter, const char* const testData[][2], UBool testParsing);

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/RbnfTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/RbnfTest.java
@@ -2358,4 +2358,23 @@ public class RbnfTest extends CoreTestFmwk {
             // Expected exception or parse failure is fine, but not others like NPE.
         }
     }
+
+    @Test
+    public void TestNumeratorSubstitutionOverflow() {
+        // This test case comes from a fuzzer (Bug 471607891).
+        // The goal is to make sure that the code does not loop infinitely or throw unexpected
+        // exceptions (like NullPointerException) with invalid/extreme inputs,
+        // rather than looking for a particular result value.
+        String rulesStr =
+                "> \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+                        + "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+                        + "\u0001a;x0x:>%a>a;%a:a;>;\u00024<;<<<a\u0089;"
+                        + "\u0010a\u0000\u0300<<<\u0003>;\u0000;\u001faz>;a;>;\u00024<;<<<Ya";
+        try {
+            RuleBasedNumberFormat rbfmt = new RuleBasedNumberFormat(rulesStr, Locale.US);
+            rbfmt.parse(rulesStr);
+        } catch (IllegalArgumentException | ParseException e) {
+            // Expected exception or parse failure is fine, but not others like NPE.
+        }
+    }
 }

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/NFSubstitution.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/NFSubstitution.java
@@ -1722,10 +1722,18 @@ class NumeratorSubstitution extends NFSubstitution {
             long n = result.longValue();
             long d = 1;
             while (d <= n) {
+                if (d > Long.MAX_VALUE / 10) {
+                    parsePosition.setIndex(0);
+                    return 0;
+                }
                 d *= 10;
             }
             // now add the zeros
             while (zeroCount > 0) {
+                if (d > Long.MAX_VALUE / 10) {
+                    parsePosition.setIndex(0);
+                    return 0;
+                }
                 d *= 10;
                 --zeroCount;
             }


### PR DESCRIPTION
#### Checklist
- [X] Required: Issue filed: ICU-23305
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [X] Approver: Feel free to merge on my behalf

Fixes signed integer overflow in NumeratorSubstitution::doParse and uninitialized members in SymbolMatcher and CombinedCurrencyMatcher.