### PR TITLE
ICU-23407 Fix null pointer dereference in NumeratorSubstitution::doParse

### DIFF
--- a/icu4c/source/i18n/nfsubs.cpp
+++ b/icu4c/source/i18n/nfsubs.cpp
@@ -1305,7 +1305,7 @@ NumeratorSubstitution::doParse(const UnicodeString& text,
     int32_t zeroCount = 0;
     UnicodeString workText(text);
 
-    if (withZeros) {
+    if (withZeros && getRuleSet() != nullptr) {
         ParsePosition workPos(1);
         Formattable temp;
 

--- a/icu4c/source/test/intltest/itrbnfp.cpp
+++ b/icu4c/source/test/intltest/itrbnfp.cpp
@@ -39,6 +39,7 @@ void IntlTestRBNFParse::runIndexedTest(int32_t index, UBool exec, const char* &n
 #if U_HAVE_RBNF
         TESTCASE(0, TestParse);
         TESTCASE(1, TestNullRuleSet);
+        TESTCASE(2, Test23407NullDereferenceREAD);
 #else
         TESTCASE(0, TestRBNFParseDisabled);
 #endif
@@ -152,6 +153,22 @@ IntlTestRBNFParse::TestNullRuleSet() {
    if (status != U_PARSE_ERROR) {
         logln("should get U_PARSE_ERROR");
    }
+}
+
+void
+IntlTestRBNFParse::Test23407NullDereferenceREAD() {
+    // This is "garbage" from a fuzzer run. We test that the code does not crash.
+    // Parse failure is expected.
+    logln("Test23407NullDereferenceREAD");
+    icu::UnicodeString fuzzstr(u"x0x:>%䀾>Ā;%䀾:>;>;;<0<<>");
+
+    UErrorCode status = U_ZERO_ERROR;
+    UParseError perror;
+    icu::RuleBasedNumberFormat rbfmt(fuzzstr, Locale::getUS(), perror, status);
+    icu::Formattable result;
+    if (U_SUCCESS(status)) {
+        rbfmt.parse(fuzzstr, result, status);
+    }
 }
 
 void

--- a/icu4c/source/test/intltest/itrbnfp.h
+++ b/icu4c/source/test/intltest/itrbnfp.h
@@ -30,6 +30,7 @@ class IntlTestRBNFParse : public IntlTest {
    */
   virtual void TestParse();
   virtual void TestNullRuleSet();
+  virtual void Test23407NullDereferenceREAD();
 
   void testfmt(RuleBasedNumberFormat* formatter, double val, UErrorCode& status);
   void testfmt(RuleBasedNumberFormat* formatter, int val, UErrorCode& status);

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/RbnfTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/format/RbnfTest.java
@@ -2346,4 +2346,16 @@ public class RbnfTest extends CoreTestFmwk {
 
         doParsingTest(formatter, lpTestData, true);
     }
+
+    @Test
+    public void Test23407NullDereferenceREAD() {
+        // This is "garbage" from a fuzzer run. We test that the code does not crash.
+        String fuzzstr = "x0x:>%䀾>Ā;%䀾:>;>;;<0<<>";
+        try {
+            RuleBasedNumberFormat rbfmt = new RuleBasedNumberFormat(fuzzstr, Locale.US);
+            rbfmt.parse(fuzzstr);
+        } catch (IllegalArgumentException | ParseException e) {
+            // Expected exception or parse failure is fine, but not others like NPE.
+        }
+    }
 }

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/NFSubstitution.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/NFSubstitution.java
@@ -1669,7 +1669,7 @@ class NumeratorSubstitution extends NFSubstitution {
         // if withZeros is true, we need to count the zeros
         // and use that to adjust the parse result
         int zeroCount = 0;
-        if (withZeros) {
+        if (withZeros && ruleSet != null) {
             String workText = text;
             ParsePosition workPos = new ParsePosition(1);
 
@@ -1714,7 +1714,7 @@ class NumeratorSubstitution extends NFSubstitution {
                         nonNumericalExecutedRuleMask,
                         recursionCount);
 
-        if (withZeros) {
+        if (withZeros && result != null) {
             // any base value will do in this case.  is there a way to
             // force this to not bother trying all the base values?
 


### PR DESCRIPTION
#### Checklist
- [X] Required: Issue filed: ICU-23407
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [X] Approver: Feel free to merge on my behalf

Fixes ICU-23407 (OSS-Fuzz 458867041).

When a NumeratorSubstitution is configured to parse leading zeros (withZeros is true) but it does not have an associated rule set (getRuleSet() returns nullptr), doParse would crash attempting to call parse on the null rule set.

This fix guards the rule set parse call with a null check, falling back to the default parse behavior if the rule set is null.