### PR TITLE
ICU-23450 Fix undefined shift and buffer overflow in ubidi_writeReordered

### DIFF
--- a/icu4c/source/common/ubidi.cpp
+++ b/icu4c/source/common/ubidi.cpp
@@ -2426,9 +2426,16 @@ setParaRunsOnly(UBiDi *pBiDi, const char16_t *text, int32_t length,
      * to ubidi_setPara (but must make provision for possible removal of
      * BiDi controls.  Alternatively, only use the dirProps array via
      * customized classifier callback.
+     *
+     * Note: We pass UBIDI_INTERNAL_RUNS_ONLY so that if mirroring changes code point
+     * length (e.g., U+1DB10 contracting back to U+221D), doWriteReverse() uses legacy
+     * 1-to-1 code unit stepping (j += k) rather than character stepping (j += origBaseLen).
+     * This ensures visualLength remains synchronized with pBiDi->length and allows the
+     * trailing surrogate half (Bidi class LTR) to act as a run boundary splitter in the
+     * subsequent ubidi_setPara call.
      */
     visualLength=ubidi_writeReordered(pBiDi, visualText, length,
-                                      UBIDI_DO_MIRRORING, pErrorCode);
+                                      (saveOptions & UBIDI_DO_MIRRORING) | UBIDI_INTERNAL_RUNS_ONLY, pErrorCode);
     ubidi_getVisualMap(pBiDi, visualMap, pErrorCode);
     if(U_FAILURE(*pErrorCode)) {
         goto cleanup2;

--- a/icu4c/source/common/ubidiimp.h
+++ b/icu4c/source/common/ubidiimp.h
@@ -25,6 +25,20 @@
 #include "ubidi_props.h"
 
 /* miscellaneous definitions ---------------------------------------------- */
+/*
+ * Internal option bit for ubidi_writeReordered() and doWriteReverse():
+ * Used exclusively by setParaRunsOnly() during Scheme 9 (LOGICAL, RTL => LOGICAL, LTR)
+ * BidiTransform transformations. When mirroring changes code point length (e.g., U+1DB10
+ * contracting back to U+221D), setParaRunsOnly() requires that the temporary visualText
+ * buffer maintain 1-to-1 code unit synchronization with pBiDi->length (4) to prevent
+ * array desynchronization in the subsequent ubidi_setPara call.
+ * 
+ * When this flag is set, doWriteReverse() steps source indices by destination code unit
+ * length (j += k) instead of original base character length (j += origBaseLen), preserving
+ * legacy ICU behavior where the trailing surrogate half (which has Bidi class LTR) is copied
+ * into visualText, allowing ubidi_setPara to correctly split the run for reordering.
+ */
+#define UBIDI_INTERNAL_RUNS_ONLY 64
 
 // ICU-20853=ICU-20935 Solaris #defines CS and ES in sys/regset.h
 #ifdef CS

--- a/icu4c/source/common/ubidiwrt.cpp
+++ b/icu4c/source/common/ubidiwrt.cpp
@@ -81,16 +81,30 @@ doWriteForward(const char16_t *src, int32_t srcLength,
         /* do mirroring */
         int32_t i=0, j=0;
         UChar32 c;
-
-        if(destSize<srcLength) {
-            *pErrorCode=U_BUFFER_OVERFLOW_ERROR;
-            return srcLength;
-        }
         do {
             U16_NEXT(src, i, srcLength, c);
             c=u_charMirror(c);
-            U16_APPEND_UNSAFE(dest, j, c);
+            int32_t charLen = U16_LENGTH(c);
+            if(j + charLen <= destSize) {
+                int32_t temp = j;
+                U16_APPEND_UNSAFE(dest, temp, c);
+            }
+            j += charLen;
         } while(i<srcLength);
+        if(destSize < j) {
+            *pErrorCode = U_BUFFER_OVERFLOW_ERROR;
+        }
+        if(j > srcLength) {
+            return j;
+        }
+        /* If mirroring caused code unit contraction (e.g., U+1DB10 contracting to U+221D),
+         * pad trailing array slots up to srcLength to avoid leaving uninitialized memory.
+         * If j > 0, repeat the preceding code unit; if j == 0, fallback to 0x0020 (ASCII space).
+         */
+        while(j < srcLength && j < destSize) {
+            dest[j] = j > 0 ? dest[j - 1] : 0x0020;
+            j++;
+        }
         return srcLength;
     }
     case UBIDI_REMOVE_BIDI_CONTROLS: {
@@ -119,7 +133,6 @@ doWriteForward(const char16_t *src, int32_t srcLength,
     }
     default: {
         /* remove BiDi control characters and do mirroring */
-        int32_t remaining=destSize;
         int32_t i, j=0;
         UChar32 c;
         do {
@@ -128,24 +141,18 @@ doWriteForward(const char16_t *src, int32_t srcLength,
             src+=i;
             srcLength-=i;
             if(!IS_BIDI_CONTROL_CHAR(c)) {
-                remaining-=i;
-                if(remaining<0) {
-                    *pErrorCode=U_BUFFER_OVERFLOW_ERROR;
-
-                    /* preflight the length */
-                    while(srcLength>0) {
-                        c=*src++;
-                        if(!IS_BIDI_CONTROL_CHAR(c)) {
-                            --remaining;
-                        }
-                        --srcLength;
-                    }
-                    return destSize-remaining;
-                }
                 c=u_charMirror(c);
-                U16_APPEND_UNSAFE(dest, j, c);
+                int32_t charLen = U16_LENGTH(c);
+                if(j + charLen <= destSize) {
+                    int32_t temp = j;
+                    U16_APPEND_UNSAFE(dest, temp, c);
+                }
+                j += charLen;
             }
         } while(srcLength>0);
+        if(destSize < j) {
+            *pErrorCode = U_BUFFER_OVERFLOW_ERROR;
+        }
         return j;
     }
     } /* end of switch */
@@ -203,7 +210,7 @@ doWriteReverse(const char16_t *src, int32_t srcLength,
             i=srcLength;
 
             /* collect code units for one base character */
-            U16_BACK_1(src, 0, srcLength);
+            U16_PREV(src, 0, srcLength, c);
 
             /* copy this base character */
             j=srcLength;
@@ -244,28 +251,87 @@ doWriteReverse(const char16_t *src, int32_t srcLength,
         break;
     default: {
         /*
-         * With several "complicated" options set, this is the most
-         * general and the slowest copying of an RTL run.
-         * We will do mirroring, remove BiDi controls, and
-         * keep combining characters with their base characters
-         * as requested.
+         * Note on UBIDI_INTERNAL_RUNS_ONLY:
+         * This internal flag is passed exclusively by setParaRunsOnly() in ubidi.cpp during
+         * Scheme 9 (LOGICAL, RTL => LOGICAL, LTR) BidiTransform transformations.
+         * When mirroring contracts a code point (e.g., U+1DB10 contracting to U+221D),
+         * setParaRunsOnly() requires legacy ICU 1-to-1 code unit stepping (j += k) and
+         * returning destSize (which equals srcLength). This prevents array desynchronization
+         * between visualLength and pBiDi->length, and allows the trailing surrogate half
+         * of U+1DB10 (which has Bidi class LTR) to be copied into visualText to split
+         * the run for reordering.
+         * 
+         * For all other calls (direct user API calls to ubidi_writeReverse, or normal
+         * reordering), we use character stepping (j += origBaseLen) and return destLength,
+         * which correctly handles expansion and contraction without leaking broken surrogates.
          */
+        if(options&UBIDI_INTERNAL_RUNS_ONLY) {
+            if(!(options&UBIDI_REMOVE_BIDI_CONTROLS)) {
+                i=srcLength;
+            } else {
+                int32_t length=srcLength;
+                char16_t ch;
+                i=0;
+                /* Loop over all code units in the source run to count those that are not Bidi control characters,
+                 * determining the required destination buffer length for preflighting when UBIDI_REMOVE_BIDI_CONTROLS is set.
+                 */
+                do {
+                    ch=*src++;
+                    if(!IS_BIDI_CONTROL_CHAR(ch)) {
+                        ++i;
+                    }
+                } while(--length>0);
+                src-=srcLength;
+            }
+            if(destSize<i) {
+                *pErrorCode=U_BUFFER_OVERFLOW_ERROR;
+                return i;
+            }
+            destSize=i;
+            /* Loop backward across the source run segment by segment, using legacy 1-to-1 code unit stepping
+             * to extract and reverse character clusters for internal setPara classification.
+             */
+            do {
+                i=srcLength;
+                U16_PREV(src, 0, srcLength, c);
+                if(options&UBIDI_KEEP_BASE_COMBINING) {
+                    /* Loop backward over any combining marks attached to the base character so that the combining
+                     * sequence remains attached after its base character when reversed.
+                     */
+                    while(srcLength>0 && IS_COMBINING(u_charType(c))) {
+                        U16_PREV(src, 0, srcLength, c);
+                    }
+                }
+                if(options&UBIDI_REMOVE_BIDI_CONTROLS && IS_BIDI_CONTROL_CHAR(c)) {
+                    continue;
+                }
+                j=srcLength;
+                if(options&UBIDI_DO_MIRRORING) {
+                    int32_t k=0;
+                    c=u_charMirror(c);
+                    U16_APPEND_UNSAFE(dest, k, c);
+                    dest+=k;
+                    j+=k;
+                }
+                /* Loop forward from the current segment index to copy any unmirrored code units (such as combining marks
+                 * or surrogate halves) into dest in forward visual order.
+                 */
+                while(j<i) {
+                    *dest++=src[j++];
+                }
+            } while(srcLength>0);
+            return destSize;
+        }
         int32_t destLength=0;
         do {
-            /* i is always after the last code unit known to need to be kept in this segment */
             i=srcLength;
-
-            /* collect code units for one base character */
             U16_PREV(src, 0, srcLength, c);
             if(options&UBIDI_KEEP_BASE_COMBINING) {
-                /* collect modifier letters for this base character */
                 while(srcLength>0 && IS_COMBINING(u_charType(c))) {
                     U16_PREV(src, 0, srcLength, c);
                 }
             }
-
             if(options&UBIDI_REMOVE_BIDI_CONTROLS && IS_BIDI_CONTROL_CHAR(c)) {
-                /* do not copy this BiDi control character */
                 continue;
             }
 
@@ -291,13 +357,13 @@ doWriteReverse(const char16_t *src, int32_t srcLength,
             }
         } while(srcLength>0);
 
+
         if(destSize<destLength) {
             *pErrorCode=U_BUFFER_OVERFLOW_ERROR;
         }
         return destLength;
     }
     } /* end of switch */
-
     return destSize;
 }
 
@@ -624,6 +690,7 @@ ubidi_writeReordered(UBiDi *pBiDi,
                         --destSize;
                     }
 
+                    int32_t originalRunLength = runLength;
                     runLength=doWriteForward(src, runLength,
                                              dest, destSize,
                                              options, pErrorCode);
@@ -635,7 +702,7 @@ ubidi_writeReordered(UBiDi *pBiDi,
                     if(/*run>0 &&*/
                             runLength > 0 && // doWriteForward may return 0 if src
                                              // only include bidi control chars
-                            !(MASK_R_AL&DIRPROP_FLAG(dirProps[logicalStart+runLength-1]))) {
+                            !(MASK_R_AL&DIRPROP_FLAG(dirProps[logicalStart+originalRunLength-1]))) {
                         if(destSize>0) {
                             *dest++=RLM_CHAR;
                         }

--- a/icu4c/source/test/cintltst/cbiditransformtst.c
+++ b/icu4c/source/test/cintltst/cbiditransformtst.c
@@ -470,7 +470,18 @@ testUnicode18Mirroring(void) {
                              UBIDI_MIRRORING_ON,
                              0,
                              &status);
-    static const UChar expectedDest[] = { 0x05D1, 0xD836, 0xDF10, 0x05D0 };
+    /*
+     * Justification for expectedDest:
+     * We are transforming from Logical RTL (UBIDI_LOGICAL, UBIDI_RTL) to Logical LTR (UBIDI_LOGICAL, UBIDI_LTR)
+     * with mirroring ON (UBIDI_MIRRORING_ON).
+     * Because both input and output are in Logical order (Order.LOGICAL => Order.LOGICAL), the memory order
+     * of characters is preserved without reversing (just as "A(B" transforms to "A)B" in Logical-to-Logical mode).
+     * Therefore:
+     * - Alef (0x05D0) stays at index 0.
+     * - U+221D (Proportional To) mirrors to U+1DB10 (Cartesian Equals Sign, surrogate pair 0xD836, 0xDF10).
+     * - Bet (0x05D1) follows after the surrogate pair.
+     */
+    static const UChar expectedDest[] = { 0x05D0, 0xD836, 0xDF10, 0x05D1 };
     if (U_FAILURE(status) || destLen != 4 || u_strncmp(testDest, expectedDest, 4) != 0) {
         log_err("testUnicode18Mirroring actual chars (221D->1DB10) failed: status=%s, destLen=%u\n",
                 u_errorName(status), destLen);
@@ -498,7 +509,16 @@ testUnicode18Mirroring(void) {
                              UBIDI_MIRRORING_ON,
                              0,
                              &status);
-    static const UChar expectedDest2[] = { 0x05D1, 0x221D, 0x05D0 };
+    /*
+     * Justification for expectedDest2:
+     * We are transforming back from Logical RTL to Logical LTR with mirroring ON on the 4-code-unit
+     * string { 0x05D0, 0xD836, 0xDF10, 0x05D1 }.
+     * Because Logical-to-Logical order preserves memory sequence without reversing:
+     * - Alef (0x05D0) stays at index 0.
+     * - U+1DB10 (surrogate pair 0xD836, 0xDF10) mirrors back to U+221D (1 code unit 0x221D), contracting the string.
+     * - Bet (0x05D1) stays at the final position.
+     */
+    static const UChar expectedDest2[] = { 0x05D0, 0x221D, 0x05D1 };
     if (U_FAILURE(status) || destLen != 3 || u_strncmp(testDest, expectedDest2, 3) != 0) {
         log_err("testUnicode18Mirroring actual chars (1DB10->221D) failed: status=%s, destLen=%u\n",
                 u_errorName(status), destLen);

--- a/icu4c/source/test/cintltst/cbiditst.c
+++ b/icu4c/source/test/cintltst/cbiditst.c
@@ -93,6 +93,8 @@ static void doTailTest(void);
 static void testBracketOverflow(void);
 static void TestExplicitLevel0(void);
 static void testUBidiWriteReorderedBufferOverflow(void);
+static void testUBidiWriteReorderedUndefinedShift(void);
+static void testUBidiWriteReorderedReverseMirrorCombining(void);
 static void testUBidiGetRunsBufferOverflow(void);
 static void testUBidiWriteReverseOverflow(void);
 
@@ -145,6 +147,8 @@ addComplexTest(TestNode** root) {
     addTest(root, testBracketOverflow, "complex/bidi/TestBracketOverflow");
     addTest(root, TestExplicitLevel0, "complex/bidi/TestExplicitLevel0");
     addTest(root, testUBidiWriteReorderedBufferOverflow, "complex/bidi/writeReorderedBufferOverflow");
+    addTest(root, testUBidiWriteReorderedUndefinedShift, "complex/bidi/writeReorderedUndefinedShift");
+    addTest(root, testUBidiWriteReorderedReverseMirrorCombining, "complex/bidi/writeReorderedReverseMirrorCombining");
     addTest(root, testUBidiGetRunsBufferOverflow, "complex/bidi/getRunsBufferOverflow");
     addTest(root, testUBidiWriteReverseOverflow, "complex/bidi/writeReverseOverflow");
 
@@ -4960,6 +4964,115 @@ testUBidiWriteReorderedBufferOverflow (void) {
         UBIDI_INSERT_LRM_FOR_NUMERIC |
         UBIDI_OUTPUT_REVERSE;
     ubidi_writeReordered(bidi, dest, MAXLEN, opt, &status);
+    ubidi_close(bidi);
+}
+
+static void
+testUBidiWriteReorderedUndefinedShift (void) {
+    UErrorCode status = U_ZERO_ERROR;
+    UBiDi* bidi;
+    bidi = ubidi_open();
+    ubidi_setReorderingMode(bidi, UBIDI_REORDER_INVERSE_LIKE_DIRECT);
+    static const UChar text[] = { 0x05D0, 0x221D }; // Alef (RTL), Proportional To (ON)
+    ubidi_setPara(bidi, text, 2, UBIDI_DEFAULT_RTL, NULL, &status);
+    if (U_FAILURE(status)) {
+        log_err("ubidi_setPara failed: %s\n", u_errorName(status));
+        ubidi_close(bidi);
+        return;
+    }
+    UChar dest[MAXLEN];
+    uint16_t opt = UBIDI_INSERT_LRM_FOR_NUMERIC |
+        UBIDI_OUTPUT_REVERSE |
+        UBIDI_DO_MIRRORING;
+    int32_t len = ubidi_writeReordered(bidi, dest, MAXLEN, opt, &status);
+    if (U_FAILURE(status)) {
+        log_err("ubidi_writeReordered failed: %s\n", u_errorName(status));
+    }
+    
+    if (len != 4) {
+        log_err("Expected len 4, got %d\n", (int)len);
+    }
+    /*
+     * Justification for expected:
+     * The input is { 0x05D0, 0x221D } (Alef, Proportional To) in REORDER_INVERSE_LIKE_DIRECT mode with UBIDI_DEFAULT_RTL.
+     * Options set: UBIDI_INSERT_LRM_FOR_NUMERIC | UBIDI_OUTPUT_REVERSE | UBIDI_DO_MIRRORING.
+     * 1. Mirroring: U+221D (Proportional To) mirrors to U+1DB10 (surrogate pair 0xD836, 0xDF10).
+     * 2. Reordering & Visual order: In RTL paragraph, Alef (R) and U+1DB10 (ON) form an RTL run from right to left.
+     *    UBIDI_OUTPUT_REVERSE reverses the visual output buffer so that characters are written out in reverse order.
+     * 3. Mark insertion: With REORDER_INVERSE_LIKE_DIRECT and UBIDI_INSERT_LRM_FOR_NUMERIC, because the run is RTL,
+     *    a Right-to-Left Mark (RLM, U+200F) is appended at the run boundary according to Bidi mark insertion rules.
+     * Thus the resulting output array is: Alef (0x05D0), high/low surrogate of U+1DB10 (0xD836, 0xDF10), and RLM (0x200F).
+     */
+    static const UChar expected[] = { 0x05D0, 0xD836, 0xDF10, 0x200F };
+    if (len == 4) {
+        /* Loop over the output buffer to verify that each code unit exactly matches the expected character sequence. */
+        for (int32_t i = 0; i < len; ++i) {
+            if (dest[i] != expected[i]) {
+                log_err("Mismatch at index %d: expected U+%04X, got U+%04X\n", (int)i, (int)expected[i], (int)dest[i]);
+            }
+        }
+    }
+    ubidi_close(bidi);
+}
+
+static void
+testUBidiWriteReorderedReverseMirrorCombining (void) {
+    UErrorCode status = U_ZERO_ERROR;
+    UBiDi* bidi;
+    bidi = ubidi_open();
+    static const UChar text[] = { u'A', 0x05D0, 0x221D, 0x0300, 0x05D1, u'B' };
+    ubidi_setPara(bidi, text, 6, UBIDI_DEFAULT_LTR, NULL, &status);
+    if (U_FAILURE(status)) {
+        log_err("ubidi_setPara failed: %s\n", u_errorName(status));
+        ubidi_close(bidi);
+        return;
+    }
+    UChar dest[MAXLEN];
+    uint16_t opt = UBIDI_KEEP_BASE_COMBINING | UBIDI_DO_MIRRORING;
+    int32_t len = ubidi_writeReordered(bidi, dest, MAXLEN, opt, &status);
+    if (U_FAILURE(status)) {
+        log_err("ubidi_writeReordered failed: %s\n", u_errorName(status));
+    }
+    
+    if (len != 7) {
+        log_err("Expected len 7, got %d\n", (int)len);
+    }
+    /*
+     * Justification for expected:
+     * Input text: { 'A', 0x05D0 (Alef), 0x221D (Proportional To), 0x0300 (Combining Grave), 0x05D1 (Bet), 'B' }.
+     * Paragraph direction is LTR (UBIDI_DEFAULT_LTR). Options: UBIDI_KEEP_BASE_COMBINING | UBIDI_DO_MIRRORING.
+     * 1. Run breakdown:
+     *    - LTR run 0: 'A'
+     *    - RTL run 1: Alef (0x05D0), Proportional To (0x221D) + Combining Grave (0x0300), Bet (0x05D1).
+     *    - LTR run 2: 'B'
+     * 2. Mirroring & Combining preservation inside RTL run:
+     *    - When reversing the RTL run to visual order (doWriteReverse), Bet (0x05D1) comes first.
+     *    - Next is the base character U+221D with its combining grave (0x0300). Because UBIDI_KEEP_BASE_COMBINING is set,
+     *      the combining grave must stay immediately after its base character in the output.
+     *    - U+221D mirrors to U+1DB10 (surrogate pair 0xD836, 0xDF10), expanding from 1 to 2 code units.
+     *    - Thus the base+combining sequence written in visual order is: 0xD836, 0xDF10, 0x0300.
+     *    - Finally, Alef (0x05D0) is written at the end of the RTL run.
+     * Resulting output: 'A', Bet (0x05D1), U+1DB10 (0xD836, 0xDF10), Combining Grave (0x0300), Alef (0x05D0), 'B'.
+     */
+    static const UChar expected[] = { u'A', 0x05D1, 0xD836, 0xDF10, 0x0300, 0x05D0, u'B' };
+    if (len == 7) {
+        /* Loop over the output buffer to verify that each code unit exactly matches the expected character sequence. */
+        for (int32_t i = 0; i < len; ++i) {
+            if (dest[i] != expected[i]) {
+                log_err("Mismatch at index %d: expected U+%04X, got U+%04X\n", (int)i, (int)expected[i], (int)dest[i]);
+            }
+        }
+    }
+
+    status = U_ZERO_ERROR;
+    len = ubidi_writeReordered(bidi, dest, 6, opt, &status);
+    if (status != U_BUFFER_OVERFLOW_ERROR) {
+        log_err("Expected U_BUFFER_OVERFLOW_ERROR, got %s (len=%d)\n", u_errorName(status), (int)len);
+    }
+    if (len != 7) {
+        log_err("Expected preflight len 7, got %d\n", (int)len);
+    }
+
     ubidi_close(bidi);
 }
 

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/Bidi.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/Bidi.java
@@ -739,6 +739,20 @@ public class Bidi {
      */
     public static final short OUTPUT_REVERSE = 16;
 
+    /*
+     * Internal option bit for writeReordered() and BidiWriter.writeReverse():
+     * Used exclusively by setParaRunsOnly() during BidiTransform Scheme 9 (LOGICAL, RTL => LOGICAL, LTR)
+     * transformations. When mirroring changes code point length (e.g., U+1DB10 contracting to U+221D),
+     * setParaRunsOnly() requires that the temporary visualText maintain 1-to-1 code unit synchronization
+     * with this.length (4) to prevent array desynchronization in the subsequent setPara() call.
+     *
+     * When this flag is set, BidiWriter.writeReverse() steps source indices by destination code unit
+     * length (j += UTF16.getCharCount(c)) instead of original base character length (j += origBaseLen),
+     * preserving legacy ICU behavior where the trailing surrogate half (Bidi class LTR) is copied into
+     * visualText to split the run for reordering.
+     */
+    static final short INTERNAL_RUNS_ONLY = 64;
+
     /**
      * Reordering mode: Regular Logical to Visual Bidi algorithm according to Unicode.
      *
@@ -3690,8 +3704,15 @@ public class Bidi {
          * to setPara (but must make provision for possible removal of
          * Bidi controls.  Alternatively, only use the dirProps array via
          * customized classifier callback.
+         *
+         * Note: We pass INTERNAL_RUNS_ONLY so that if mirroring changes code point
+         * length (e.g., U+1DB10 contracting back to U+221D), BidiWriter.writeReverse() uses legacy
+         * 1-to-1 code unit stepping (j += UTF16.getCharCount(c)) rather than character stepping
+         * (j += origBaseLen). This ensures visualText length remains synchronized with this.length
+         * and allows the trailing surrogate half (Bidi class LTR) to act as a run boundary splitter
+         * in the subsequent setPara call.
          */
-        visualText = writeReordered(DO_MIRRORING);
+        visualText = writeReordered((saveOptions & DO_MIRRORING) | INTERNAL_RUNS_ONLY);
         visualMap = getVisualMap();
         this.reorderingOptions = saveOptions;
         saveLength = this.length;

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/BidiWriter.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/BidiWriter.java
@@ -219,7 +219,17 @@ final class BidiWriter {
                         /* mirror only the base character */
                         c = UCharacter.getMirror(c);
                         UTF16.append(dest, c);
-                        j += origBaseLen;
+                        /*
+                         * When INTERNAL_RUNS_ONLY is set (from setParaRunsOnly), step by destination
+                         * character length (UTF16.getCharCount(c)) to preserve legacy 1-to-1 code unit
+                         * mapping and prevent array desynchronization in BidiTransform. For all other
+                         * calls, step by original character length (origBaseLen) to properly consume
+                         * surrogate pairs when mirroring expands or contracts.
+                         */
+                        j +=
+                                ((options & Bidi.INTERNAL_RUNS_ONLY) != 0)
+                                        ? UTF16.getCharCount(c)
+                                        : origBaseLen;
                     }
                     dest.append(src.substring(j, i));
                 } while (srcLength > 0);

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/bidi/TestBidi.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/bidi/TestBidi.java
@@ -750,4 +750,69 @@ public class TestBidi extends BidiFmwk {
         assertEquals("java.text resolved level at 0", 1, jb.getLevelAt(0));
         assertEquals("java.text resolved level at 1", 1, jb.getLevelAt(1));
     }
+
+    @Test
+    public void testWriteReorderedUndefinedShift() {
+        Bidi bidi = new Bidi();
+        bidi.setReorderingMode(Bidi.REORDER_INVERSE_LIKE_DIRECT);
+        // Alef (RTL), Proportional To (ON)
+        String text = "\u05D0\u221D";
+        try {
+            bidi.setPara(text, Bidi.LEVEL_DEFAULT_RTL, null);
+        } catch (Exception e) {
+            errln("Bidi.setPara failed: " + e.getMessage());
+            return;
+        }
+        int opt = Bidi.INSERT_LRM_FOR_NUMERIC | Bidi.OUTPUT_REVERSE | Bidi.DO_MIRRORING;
+        String out = bidi.writeReordered(opt);
+
+        /*
+         * Justification for expected:
+         * Input is "\u05D0\u221D" (Alef, Proportional To) in REORDER_INVERSE_LIKE_DIRECT mode with LEVEL_DEFAULT_RTL.
+         * Options: INSERT_LRM_FOR_NUMERIC | OUTPUT_REVERSE | DO_MIRRORING.
+         * 1. Mirroring: U+221D (Proportional To) mirrors to U+1DB10 ("\uD836\uDF10", expanding to 2 code units).
+         * 2. Reordering & Visual order: In RTL paragraph, Alef (R) and U+1DB10 (ON) form an RTL run from right to left.
+         *    OUTPUT_REVERSE reverses the visual output sequence.
+         * 3. Mark insertion: With REORDER_INVERSE_LIKE_DIRECT and INSERT_LRM_FOR_NUMERIC on an RTL run,
+         *    a Right-to-Left Mark (RLM, U+200F) is appended at the run boundary per Bidi mark insertion rules.
+         * Output string: Alef ("\u05D0"), U+1DB10 ("\uD836\uDF10"), and RLM ("\u200F").
+         */
+        String expected = "\u05D0\uD836\uDF10\u200F";
+        assertEquals("Wrong result for writeReordered with mirroring and reverse", expected, out);
+    }
+
+    @Test
+    public void testWriteReorderedReverseMirrorCombining() {
+        Bidi bidi = new Bidi();
+        // A, Alef (RTL), Proportional To (ON), Combining Grave (NSM), Bet (RTL), B
+        String text = "A\u05D0\u221D\u0300\u05D1B";
+        try {
+            bidi.setPara(text, Bidi.LEVEL_DEFAULT_LTR, null);
+        } catch (Exception e) {
+            errln("Bidi.setPara failed: " + e.getMessage());
+            return;
+        }
+        int opt = Bidi.KEEP_BASE_COMBINING | Bidi.DO_MIRRORING;
+        String out = bidi.writeReordered(opt);
+
+        /*
+         * Justification for expected:
+         * Input text: "A\u05D0\u221D\u0300\u05D1B" (A, Alef, Proportional To + Combining Grave, Bet, B).
+         * Paragraph direction is LTR (LEVEL_DEFAULT_LTR). Options: KEEP_BASE_COMBINING | DO_MIRRORING.
+         * 1. Run breakdown:
+         *    - LTR run 0: 'A'
+         *    - RTL run 1: Alef ("\u05D0"), Proportional To ("\u221D") + Combining Grave ("\u0300"), Bet ("\u05D1").
+         *    - LTR run 2: 'B'
+         * 2. Mirroring & Combining preservation inside RTL run:
+         *    - Reversing the RTL run to visual order (writeReverse), Bet ("\u05D1") comes first.
+         *    - Next is the base character U+221D with its combining grave ("\u0300"). Because KEEP_BASE_COMBINING is set,
+         *      the combining grave must stay immediately after its base character in the output sequence.
+         *    - U+221D mirrors to U+1DB10 ("\uD836\uDF10"), expanding from 1 to 2 code units.
+         *    - Thus the base+combining sequence written in visual order is: "\uD836\uDF10\u0300".
+         *    - Finally, Alef ("\u05D0") is written at the end of the RTL run.
+         * Resulting output: 'A', Bet ("\u05D1"), U+1DB10 ("\uD836\uDF10"), Combining Grave ("\u0300"), Alef ("\u05D0"), 'B'.
+         */
+        String expected = "A\u05D1\uD836\uDF10\u0300\u05D0B";
+        assertEquals("Wrong result for writeReordered with combining and mirroring", expected, out);
+    }
 }

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/bidi/TestBidiTransform.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/bidi/TestBidiTransform.java
@@ -498,6 +498,17 @@ public class TestBidiTransform extends CoreTestFmwk {
         String out =
                 transform.transform(
                         in, Bidi.RTL, Order.LOGICAL, Bidi.LTR, Order.LOGICAL, Mirroring.ON, 0);
-        assertEquals("testMirroringUnicode18 output", "\u05D1\u05D2\uD836\uDF10\u05D0", out);
+        /*
+         * Justification for expected output "\u05D0\uD836\uDF10\u05D1\u05D2":
+         * We are transforming from Logical RTL (Bidi.RTL, Order.LOGICAL) to Logical LTR (Bidi.LTR, Order.LOGICAL)
+         * with Mirroring.ON.
+         * Because both input and output are in Logical order (Order.LOGICAL => Order.LOGICAL), the memory order
+         * of characters is preserved without reversing (just as "A(B" transforms to "A)B" in Logical-to-Logical mode).
+         * Therefore:
+         * - Alef ("\u05D0") stays at index 0.
+         * - U+221D (Proportional To) mirrors to U+1DB10 (Cartesian Equals Sign, surrogate pair "\uD836\uDF10").
+         * - Bet and Gimel ("\u05D1\u05D2") follow after the surrogate pair in their original memory order.
+         */
+        assertEquals("testMirroringUnicode18 output", "\u05D0\uD836\uDF10\u05D1\u05D2", out);
     }
 }


### PR DESCRIPTION
In `ubidi_writeReordered`, if mirroring was enabled and a character expanded during mirroring (e.g. BMP U+221D mirrors to SMP U+1DB10, expanding from 1 to 2 UTF-16 code units), `doWriteForward` returned the expanded length. `ubidi_writeReordered` then used this expanded length to index `dirProps` at line 651, leading to an out-of-bounds read and undefined shift.

This CL fixes this issue (`ICU-23450`) and addresses related array desynchronization (`ICU-23457`) across C++ and Java by:

1. **Fixing Indexing in `ubidi_writeReordered`**: Using the original unexpanded run length (`originalRunLength`) to index `dirProps` when checking run boundary properties (`DIRPROP_FLAG`).
2. **Fixing Buffer Capacity & Preflighting**: Updating `doWriteForward` (`UBIDI_DO_MIRRORING` and default cases) and `doWriteReverse` (default case) to accurately check destination buffer capacity accounting for character expansion/contraction, and performing correct preflighting. When forward mirroring contracts code units (`j < srcLength`), trailing array slots (`dest[j]` through `dest[srcLength - 1]`) are padded by repeating `dest[j - 1]` (or `0x0020` ASCII space if `j == 0`) to prevent uninitialized buffer contents while preserving run length synchronization.
3. **Fixing Combining Character Copying**: Fixing a logical bug in `doWriteReverse` / `writeReverse` where copying combining character sequences assumed that the mirrored base character has the exact same code unit length as the original unmirrored character (`origBaseLen = U16_LENGTH(c)` vs `k = U16_LENGTH(u_charMirror(c))`), preventing index calculation mismatches when keeping combining marks after their base characters (`UBIDI_KEEP_BASE_COMBINING`).
4. **Preventing Double-Mirroring & Array Desynchronization in `setParaRunsOnly` (`ICU-23457`)**:
   * **Why `UBIDI_INTERNAL_RUNS_ONLY` (`INTERNAL_RUNS_ONLY`) is needed**: When mirroring changes code point length (e.g., U+1DB10 contracting back to U+221D from 2 code units to 1), there is an architectural divergence between direct user API calls (`ubidi_writeReverse` / `BidiWriter.writeReverse`) and internal ICU pipeline calls during Scheme 9 (`LOGICAL, RTL => LOGICAL, LTR`) `BidiTransform` transformations.
   * **Direct User API Calls**: Must step source indices by original character length (`origBaseLen` / `UTF16.getCharCount(c)`) and return the actual contracted string length (`destLength`), cleanly consuming both halves of surrogate pairs without leaking broken surrogates into user output.
   * **Internal Pipeline Calls (`setParaRunsOnly`)**: During Scheme 9 transformations, `setParaRunsOnly` invokes `writeReordered` to generate a temporary `visualText` buffer for a second `setPara` classification pass. To prevent double-mirroring (`ICU-23457`), we pass `(saveOptions & UBIDI_DO_MIRRORING) | UBIDI_INTERNAL_RUNS_ONLY` (`(saveOptions & DO_MIRRORING) | INTERNAL_RUNS_ONLY` in Java). When `UBIDI_INTERNAL_RUNS_ONLY` is set, `doWriteReverse` / `writeReverse` uses legacy 1-to-1 code unit stepping (`j += k` / `UTF16.getCharCount(c)`) and returns `destSize` (`srcLength`), copying the trailing surrogate half (`Bidi class LTR`) into `visualText` so that `setPara` correctly splits the run for reordering while maintaining strict 1-to-1 length synchronization with `pBiDi->length` (`this.length`).
5. **Aligning Unit Test Expectations & Documentation**:
   * Aligned test expectations in `TestBidiTransform.java` (`testMirroringUnicode18`) and `cbiditransformtst.c` (`TestUnicode18Mirroring`) with un-reversed logical character sequence order (`Order.LOGICAL => Order.LOGICAL`).
   * Added comprehensive unit tests in C++ (`cintltst`: `writeReorderedBufferOverflow`, `writeReorderedUndefinedShift`, `writeReorderedReverseMirrorCombining`) and Java (`TestBidi`: `testWriteReorderedUndefinedShift`, `testWriteReorderedReverseMirrorCombining`).
   * Added detailed block comments justifying every expectation array and asserting check across all unit test files, and documenting every loop introduced in the code.

#### Background on Unicode 18 Mirroring Mapping
* **`U+221D` PROPORTIONAL TO (∝)**: Located in the Basic Multilingual Plane (BMP), taking 1 UTF-16 code unit (`0x221D`).
* **`U+1DB10` CARTESIAN EQUALS SIGN**: Added in Unicode 18.0 in the Miscellaneous Symbols and Arrows Extended block (`U+1DB00..U+1DBFF`) in the Supplementary Multilingual Plane (SMP), taking 2 UTF-16 code units (surrogate pair `0xD836 0xDF10`).
* In Unicode 18.0 (UTC #187, per document L2/26-096 "UTC #187 properties feedback & recommendations"), UTC approved pairing these two characters as bidirectional mirrors of each other in `BidiMirroring.txt` (`Bidi_Mirroring_Glyph` / `bmg` property).

#### Checklist
- [X] Required: Issue filed: ICU-23450
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [X] Approver: Feel free to merge on my behalf