### PR TITLE
ICU-23428 Comments only: change attributes for an internal MessageFormat method

### DIFF
--- a/icu4c/source/i18n/messageformat2_serializer.h
+++ b/icu4c/source/i18n/messageformat2_serializer.h
@@ -26,8 +26,6 @@ namespace message2 {
 
     // Serializer class (private)
     // Converts a data model back to a string
-    // TODO(ICU-23428): Should be private; made public so tests
-    // can use it
     class U_I18N_API Serializer : public UMemory {
     public:
         Serializer(const MFDataModel& m, UnicodeString& s) : dataModel(m), result(s) {}

--- a/icu4c/source/i18n/unicode/messageformat2.h
+++ b/icu4c/source/i18n/unicode/messageformat2.h
@@ -417,14 +417,12 @@ namespace message2 {
             U_I18N_API virtual ~Builder();
         }; // class MessageFormatter::Builder
 
-        // TODO(ICU-23428): Shouldn't be public; only used for testing
         /**
          * Returns a string consisting of the input with optional spaces removed.
          *
          * @return        A normalized string representation of the input
          *
-         * @internal ICU 75 technology preview
-         * @deprecated This API is for technology preview only.
+         * @internal ICU 75: This API is ICU internal only.
          */
         U_I18N_API const UnicodeString& getNormalizedPattern() const { return normalizedInput; }
 


### PR DESCRIPTION
Change doc comment for MessageFormatter::getNormalizedPattern() to indicate that it is private to ICU, rather than being part of the tech preview.

In addition, remove the TODO comment from the Serializer class, as this class is already in an internal header file.

#### Checklist
- [x] Required: Issue filed: ICU-23428
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf
