### PR TITLE
ICU-13694 Support TZ set to a zoneinfo file path in timezone detection

### DIFF
--- a/icu4c/source/common/putil.cpp
+++ b/icu4c/source/common/putil.cpp
@@ -1085,6 +1085,32 @@ static void u_property_read(void* cookie, const char* name, const char* value,
 }
 #endif
 
+#if defined(CHECK_LOCALTIME_LINK) && !defined(DEBUG_SKIP_LOCALTIME_LINK)
+/* Attempt to extract a valid Olson ID from the path of a zoneinfo file, i.e.
+ * the part following TZZONEINFOTAIL ("/zoneinfo/"). The path is first copied
+ * into gTimeZoneBuffer so that the ID pointed to by gTimeZoneBufferPtr stays
+ * valid after the caller's string is gone. Caller must handle threading
+ * issues. */
+static bool extractOlsonIdFromPath(const char* path) {
+    U_ASSERT(gTimeZoneBufferPtr == nullptr);
+    if (uprv_strlen(path) >= sizeof(gTimeZoneBuffer)) {
+        return false;
+    }
+    uprv_strcpy(gTimeZoneBuffer, path);
+    const char* tzZoneInfoTailPtr = uprv_strstr(gTimeZoneBuffer, TZZONEINFOTAIL);
+    if (tzZoneInfoTailPtr == nullptr) {
+        return false;
+    }
+    tzZoneInfoTailPtr += uprv_strlen(TZZONEINFOTAIL);
+    skipZoneIDPrefix(&tzZoneInfoTailPtr);
+    if (!isValidOlsonID(tzZoneInfoTailPtr)) {
+        return false;
+    }
+    gTimeZoneBufferPtr = tzZoneInfoTailPtr;
+    return true;
+}
+#endif
+
 U_CAPI void U_EXPORT2
 uprv_tzname_clear_cache()
 {
@@ -1158,19 +1184,46 @@ uprv_tzname(int n)
 #else
     tzid = getenv("TZ");
 #endif
-    if (tzid != nullptr && isValidOlsonID(tzid)
+    if (tzid != nullptr && (isValidOlsonID(tzid)
+#if defined(CHECK_LOCALTIME_LINK) && !defined(DEBUG_SKIP_LOCALTIME_LINK)
+        /* TZ can also hold the full path of a zoneinfo file, with or without
+           a leading colon, in which case it need not look like an Olson ID
+           (e.g. the zoneinfo directory itself may contain digits). */
+        || tzid[0] == '/' || (tzid[0] == ':' && tzid[1] == '/')
+#endif
+        )
 #if U_PLATFORM == U_PF_SOLARIS
     /* Don't misinterpret TZ "localtime" on Solaris as a time zone name. */
         && uprv_strcmp(tzid, TZ_ENV_CHECK) != 0
 #endif
     ) {
-        /* The colon forces tzset() to treat the remainder as zoneinfo path */
+        /* The colon forces tzset() to treat the remainder as a zoneinfo path.
+           At least glibc also accepts an absolute path without the leading
+           colon. */
         if (tzid[0] == ':') {
             tzid++;
         }
         /* This might be a good Olson ID. */
         skipZoneIDPrefix(&tzid);
+#if defined(CHECK_LOCALTIME_LINK) && !defined(DEBUG_SKIP_LOCALTIME_LINK)
+        if (tzid[0] != '/') {
+            return tzid;
+        }
+        /* TZ can also hold the full path of a zoneinfo file, e.g.
+           TZ=:/usr/share/zoneinfo/America/New_York. Try to extract the Olson
+           ID following TZZONEINFOTAIL in the path. If the path does not
+           contain TZZONEINFOTAIL (e.g. TZ=:/etc/localtime, possibly a symlink
+           to a zoneinfo file), fall through to the TZDEFAULT handling below.
+           Caller must handle threading issues. */
+        if (gTimeZoneBufferPtr != nullptr) {
+            return gTimeZoneBufferPtr;
+        }
+        if (extractOlsonIdFromPath(tzid)) {
+            return gTimeZoneBufferPtr;
+        }
+#else
         return tzid;
+#endif
     }
     /* else U_TZNAME will give a better result. */
 #endif

--- a/icu4c/source/test/cintltst/putiltst.c
+++ b/icu4c/source/test/cintltst/putiltst.c
@@ -547,6 +547,69 @@ static void TestString(void)
   Test_aestrncpy(__LINE__, str_exp3, str_tst, 8);
 }
 
+/* Test uprv_tzname() handling of the TZ environment variable, including a
+   full zoneinfo file path (ICU-13694). Restrict to the platforms where
+   putil.cpp defines CHECK_LOCALTIME_LINK (except Android, which reads the
+   timezone from a system property instead of TZ, and iOS, where
+   CHECK_LOCALTIME_LINK may not be defined). uprv_tzname() extracts the Olson
+   ID from a path without checking that the file exists, so the fabricated
+   paths below keep this test hermetic. */
+#if !UCONFIG_NO_FILE_IO && U_PLATFORM != U_PF_ANDROID && U_PLATFORM != U_PF_IPHONE && \
+    (U_PLATFORM_IS_DARWIN_BASED || U_PLATFORM_IS_LINUX_BASED || U_PLATFORM == U_PF_BSD || U_PLATFORM == U_PF_SOLARIS)
+#define TEST_TZNAME_ENV 1
+#include <stdlib.h>
+#endif
+
+#ifdef TEST_TZNAME_ENV
+static void expectTZName(int32_t line, const char* tzval, const char* expected) {
+    if (setenv("TZ", tzval, 1) != 0) {
+        log_err("setenv(TZ=%s) failed (line %d)\n", tzval, (int)line);
+        return;
+    }
+    uprv_tzname_clear_cache();
+    const char* id = uprv_tzname(0);
+    if (id == NULL || uprv_strcmp(id, expected) != 0) {
+        log_err("uprv_tzname(0) for TZ=%s gave \"%s\", expected \"%s\" (line %d)\n",
+                tzval, id == NULL ? "(null)" : id, expected, (int)line);
+    }
+}
+
+static void TestTZNameEnv(void) {
+    char savedTZ[200];
+    UBool hadTZ = false;
+    const char* env = getenv("TZ");
+    if (env != NULL) {
+        if (uprv_strlen(env) >= sizeof(savedTZ)) {
+            log_verbose("TZ value too long, skipping TestTZNameEnv\n");
+            return;
+        }
+        uprv_strcpy(savedTZ, env);
+        hadTZ = true;
+    }
+
+    /* Plain Olson IDs, with and without the leading colon. */
+    expectTZName(__LINE__, "America/New_York", "America/New_York");
+    expectTZName(__LINE__, ":Asia/Seoul", "Asia/Seoul");
+    expectTZName(__LINE__, "posix/Asia/Seoul", "Asia/Seoul");
+    expectTZName(__LINE__, "PST8PDT", "PST8PDT");
+    /* Full zoneinfo file paths, with and without the leading colon
+       (ICU-13694). */
+    expectTZName(__LINE__, ":/icutest/zoneinfo/America/New_York", "America/New_York");
+    expectTZName(__LINE__, "/icutest/zoneinfo/Asia/Seoul", "Asia/Seoul");
+    expectTZName(__LINE__, ":/icutest/zoneinfo/posix/Asia/Tokyo", "Asia/Tokyo");
+    /* The directories above the Olson ID may contain digits, e.g. a tzdata
+       version, and need not look like an Olson ID themselves. */
+    expectTZName(__LINE__, ":/icutest-2026a/zoneinfo/Europe/Paris", "Europe/Paris");
+
+    if (hadTZ) {
+        setenv("TZ", savedTZ, 1);
+    } else {
+        unsetenv("TZ");
+    }
+    uprv_tzname_clear_cache();
+}
+#endif
+
 void addPUtilTest(TestNode** root);
 
 static void addToolUtilTests(TestNode** root);
@@ -560,6 +623,9 @@ addPUtilTest(TestNode** root)
     addTest(root, &TestErrorName, "putiltst/TestErrorName");
     addTest(root, &TestPUtilAPI,       "putiltst/TestPUtilAPI");
     addTest(root, &TestString,    "putiltst/TestString");
+#ifdef TEST_TZNAME_ENV
+    addTest(root, &TestTZNameEnv, "putiltst/TestTZNameEnv");
+#endif
     addToolUtilTests(root);
 }
 


### PR DESCRIPTION
Supersedes #2213 by @jungshik, rebased onto the current realpath-based TZDEFAULT logic in putil.cpp and restructured per the review feedback on that PR.

#### Problem

On Linux with glibc (and on other platforms with tzset()), the TZ environment variable may be set to the full path of a zoneinfo file, with or without a leading colon, e.g. `TZ=:/usr/share/zoneinfo/America/New_York`. Some Linux distributions configure TZ this way. In that case ICU's host timezone detection previously returned the whole path as the timezone ID, so detection failed: `TimeZone::detectHostTimeZone()` reported the raw path (e.g. `/usr/share/zoneinfo/Asia/Seoul`) as the zone ID.

#### Fix

In `uprv_tzname()`, when TZ holds an absolute path, extract the Olson ID from the portion of the path following `/zoneinfo/` (TZZONEINFOTAIL), mirroring the existing handling of the /etc/localtime symlink target. Notes:

- A path is recognized before the `isValidOlsonID()` check, because the directories above the Olson ID need not look like an Olson ID themselves: they may contain digits, e.g. a tzdata version such as `/nix/store/abc-tzdata-2024a/share/zoneinfo/America/New_York`.
- If the path does not contain `/zoneinfo/` (e.g. `TZ=:/etc/localtime`), the code falls through to the existing TZDEFAULT handling, which resolves the /etc/localtime symlink.
- `posix/` and `right/` prefixes after `/zoneinfo/` are skipped as elsewhere.
- The fix applies on all platforms where CHECK_LOCALTIME_LINK is defined (Linux, macOS, BSD, Solaris), since their tzset() implementations also accept zoneinfo paths and extracting the ID is strictly better than returning a path that can never resolve to a zone.
- Behaviour is unchanged for plain Olson IDs, `PST8PDT` style IDs, POSIX rule strings such as `CST6CDT5,J129,J131/19:30`, and unset TZ.

#### Tests

Added `putiltst/TestTZNameEnv` to cintltst. It is hermetic: `uprv_tzname()` extracts the ID from the path by string parsing without checking that the file exists, so the test uses fabricated paths and does not depend on the host's zoneinfo layout. Verified that the test fails with exactly the four path cases against unpatched putil.cpp and passes with the fix.

Also verified manually on Ubuntu 24.04 (glibc, arm64) and macOS with a matrix of 13 TZ values, cross-checked against glibc's own interpretation of each value, and ran `intltest format/TimeZoneTest format/TimeZoneRuleTest format/TimeZoneFormatTest`: all pass.

##### Checklist

- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-13694
- [x] Required: The PR title must be prefixed with a JIRA Issue number.
- [x] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [x] Required: Each commit message must be prefixed with a JIRA Issue number.
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
