### PR TITLE
ICU-23454 Fix buffer overflow in ubidi_writeReverse when mirroring changes code unit length

### DIFF
--- a/icu4c/source/common/ubidiwrt.cpp
+++ b/icu4c/source/common/ubidiwrt.cpp
@@ -37,8 +37,7 @@
  *   ("minimum-length-problem" of UTF-8)
  * - The BiDi control characters need only one code unit each
  *
- * Further assumptions for all UTFs:
- * - u_charMirror(c) needs the same number of code units as c
+ * Note: Since Unicode 18, u_charMirror(c) may change the number of code units.
  */
 #if defined(UTF_SIZE) && UTF_SIZE==8
 # error reimplement ubidi_writeReordered() for UTF-8, see comment above
@@ -243,7 +242,7 @@ doWriteReverse(const char16_t *src, int32_t srcLength,
             } while(j<i);
         } while(srcLength>0);
         break;
-    default:
+    default: {
         /*
          * With several "complicated" options set, this is the most
          * general and the slowest copying of an RTL run.
@@ -251,31 +250,7 @@ doWriteReverse(const char16_t *src, int32_t srcLength,
          * keep combining characters with their base characters
          * as requested.
          */
-        if(!(options&UBIDI_REMOVE_BIDI_CONTROLS)) {
-            i=srcLength;
-        } else {
-            /* we need to find out the destination length of the run,
-               which will not include the BiDi control characters */
-            int32_t length=srcLength;
-            char16_t ch;
-
-            i=0;
-            do {
-                ch=*src++;
-                if(!IS_BIDI_CONTROL_CHAR(ch)) {
-                    ++i;
-                }
-            } while(--length>0);
-            src-=srcLength;
-        }
-
-        if(destSize<i) {
-            *pErrorCode=U_BUFFER_OVERFLOW_ERROR;
-            return i;
-        }
-        destSize=i;
-
-        /* preserve character integrity */
+        int32_t destLength=0;
         do {
             /* i is always after the last code unit known to need to be kept in this segment */
             i=srcLength;
@@ -294,21 +269,33 @@ doWriteReverse(const char16_t *src, int32_t srcLength,
                 continue;
             }
 
-            /* copy this "user character" */
+            int32_t origBaseLen=U16_LENGTH(c);
             j=srcLength;
             if(options&UBIDI_DO_MIRRORING) {
                 /* mirror only the base character */
-                int32_t k=0;
                 c=u_charMirror(c);
-                U16_APPEND_UNSAFE(dest, k, c);
-                dest+=k;
-                j+=k;
+                int32_t k=U16_LENGTH(c);
+                if(destLength+k<=destSize) {
+                    int32_t temp=destLength;
+                    U16_APPEND_UNSAFE(dest, temp, c);
+                }
+                destLength+=k;
+                j+=origBaseLen;
             }
             while(j<i) {
-                *dest++=src[j++];
+                if(destLength<destSize) {
+                    dest[destLength]=src[j];
+                }
+                destLength++;
+                j++;
             }
         } while(srcLength>0);
-        break;
+
+        if(destSize<destLength) {
+            *pErrorCode=U_BUFFER_OVERFLOW_ERROR;
+        }
+        return destLength;
+    }
     } /* end of switch */
 
     return destSize;

--- a/icu4c/source/test/cintltst/cbiditst.c
+++ b/icu4c/source/test/cintltst/cbiditst.c
@@ -94,6 +94,7 @@ static void testBracketOverflow(void);
 static void TestExplicitLevel0(void);
 static void testUBidiWriteReorderedBufferOverflow(void);
 static void testUBidiGetRunsBufferOverflow(void);
+static void testUBidiWriteReverseOverflow(void);
 
 /* new BIDI API */
 static void testReorderingMode(void);
@@ -145,6 +146,7 @@ addComplexTest(TestNode** root) {
     addTest(root, TestExplicitLevel0, "complex/bidi/TestExplicitLevel0");
     addTest(root, testUBidiWriteReorderedBufferOverflow, "complex/bidi/writeReorderedBufferOverflow");
     addTest(root, testUBidiGetRunsBufferOverflow, "complex/bidi/getRunsBufferOverflow");
+    addTest(root, testUBidiWriteReverseOverflow, "complex/bidi/writeReverseOverflow");
 
     addTest(root, doArabicShapingTest, "complex/arabic-shaping/ArabicShapingTest");
     addTest(root, doLamAlefSpecialVLTRArabicShapingTest, "complex/arabic-shaping/lamalef");
@@ -5005,4 +5007,52 @@ static void TestExplicitLevel0(void) {
         }
     }
     ubidi_close(bidi);
+}
+
+static void
+testUBidiWriteReverseOverflow(void) {
+    UErrorCode status = U_ZERO_ERROR;
+    static const UChar src[] = { 0x05D0, 0x221D, 0x05D1 };
+    int32_t srcLen = 3;
+    UChar dest[10];
+    int32_t outLen = ubidi_writeReverse(src, srcLen, dest, 3, 
+                                        UBIDI_DO_MIRRORING | UBIDI_KEEP_BASE_COMBINING, 
+                                        &status);
+    if (status != U_BUFFER_OVERFLOW_ERROR || outLen != 4) {
+        log_err("testUBidiWriteReverseOverflow failed: expected U_BUFFER_OVERFLOW_ERROR and outLen=4, got %s and outLen=%d\n",
+                u_errorName(status), outLen);
+    }
+
+    status = U_ZERO_ERROR;
+    u_memset(dest, 0, 10);
+    outLen = ubidi_writeReverse(src, srcLen, dest, 10,
+                                UBIDI_DO_MIRRORING | UBIDI_KEEP_BASE_COMBINING,
+                                &status);
+    static const UChar expectedDest[] = { 0x05D1, 0xD836, 0xDF10, 0x05D0 };
+    if (U_FAILURE(status) || outLen != 4 || u_strncmp(dest, expectedDest, 4) != 0) {
+        log_err("testUBidiWriteReverseOverflow actual chars (221D->1DB10) failed: status=%s, outLen=%d\n",
+                u_errorName(status), outLen);
+    }
+
+    status = U_ZERO_ERROR;
+    static const UChar src2[] = { 0x05D0, 0xD836, 0xDF10, 0x05D1 };
+    int32_t src2Len = 4;
+    outLen = ubidi_writeReverse(src2, src2Len, dest, 2,
+                                UBIDI_DO_MIRRORING | UBIDI_KEEP_BASE_COMBINING,
+                                &status);
+    if (status != U_BUFFER_OVERFLOW_ERROR || outLen != 3) {
+        log_err("testUBidiWriteReverseOverflow (1DB10->221D overflow) failed: expected U_BUFFER_OVERFLOW_ERROR and outLen=3, got %s and outLen=%d\n",
+                u_errorName(status), outLen);
+    }
+
+    status = U_ZERO_ERROR;
+    u_memset(dest, 0, 10);
+    outLen = ubidi_writeReverse(src2, src2Len, dest, 10,
+                                UBIDI_DO_MIRRORING | UBIDI_KEEP_BASE_COMBINING,
+                                &status);
+    static const UChar expectedDest2[] = { 0x05D1, 0x221D, 0x05D0 };
+    if (U_FAILURE(status) || outLen != 3 || u_strncmp(dest, expectedDest2, 3) != 0) {
+        log_err("testUBidiWriteReverseOverflow actual chars (1DB10->221D) failed: status=%s, outLen=%d\n",
+                u_errorName(status), outLen);
+    }
 }


### PR DESCRIPTION
Jira Issue: https://unicode-org.atlassian.net/browse/ICU-23454
In `ubidi_writeReverse` (and `ubidi_writeReordered` with `UBIDI_OUTPUT_REVERSE`), when `UBIDI_DO_MIRRORING` is specified, `doWriteReverse` assumed `u_charMirror(c)` preserves UTF-16 code unit length.
In Unicode 18.0, BMP U+221D mirrors to SMP U+1DB10, causing heap buffer overflows and combining-mark index corruption.
This PR dynamically tracks required output capacity and advances the source index by the unmirrored base character length when copying combining marks.

#### Checklist
- [X] Required: Issue filed: ICU-23454
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [X] Approver: Feel free to merge on my behalf