### PR TITLE
ICU-23455 Fix buffer overflow in ubiditransform_transform with UBIDI_DO_MIRRORING

### DIFF
--- a/icu4c/source/common/ubiditransform.cpp
+++ b/icu4c/source/common/ubiditransform.cpp
@@ -308,17 +308,25 @@ action_mirror(UBiDiTransform *pTransform, UErrorCode *pErrorCode)
     if (0 == (pTransform->reorderingOptions & UBIDI_DO_MIRRORING)) {
         return false;
     }
-    if (pTransform->destSize < pTransform->srcLength) {
-        *pErrorCode = U_BUFFER_OVERFLOW_ERROR;
-        return false;
-    }
     do {
         UBool isOdd = ubidi_getLevelAt(pTransform->pBidi, i) & 1;
         U16_NEXT(pTransform->src, i, pTransform->srcLength, c); 
-        U16_APPEND_UNSAFE(pTransform->dest, j, isOdd ? u_charMirror(c) : c);
+        if (isOdd) {
+            c = u_charMirror(c);
+        }
+        uint32_t k = U16_LENGTH(c);
+        if (j + k <= pTransform->destSize) {
+            U16_APPEND_UNSAFE(pTransform->dest, j, c);
+        } else {
+            j += k;
+        }
     } while (i < pTransform->srcLength);
     
-    *pTransform->pDestLength = pTransform->srcLength;
+    *pTransform->pDestLength = j;
+    if (pTransform->destSize < j) {
+        *pErrorCode = U_BUFFER_OVERFLOW_ERROR;
+        return false;
+    }
     pTransform->reorderingOptions = UBIDI_REORDER_DEFAULT;
     return true;
 }
@@ -526,5 +534,5 @@ cleanup:
         pBiDiTransform->srcLength = 0;
         pBiDiTransform->destSize = 0;
     }
-    return U_FAILURE(*pErrorCode) ? 0 : destLength;
+    return (U_FAILURE(*pErrorCode) && *pErrorCode != U_BUFFER_OVERFLOW_ERROR) ? 0 : destLength;
 }

--- a/icu4c/source/test/cintltst/cbiditransformtst.c
+++ b/icu4c/source/test/cintltst/cbiditransformtst.c
@@ -56,6 +56,7 @@ void addBidiTransformTest(TestNode** root);
 static void testAutoDirection(void);
 
 static void testAllTransformOptions(void);
+static void testUnicode18Mirroring(void);
 
 static char* pseudoScript(const UChar *str);
 
@@ -431,8 +432,76 @@ addBidiTransformTest(TestNode** root)
 {
     addTest(root, testAutoDirection, "complex/bidi-transform/TestAutoDirection");
     addTest(root, testAllTransformOptions, "complex/bidi-transform/TestAllTransformOptions");
+    addTest(root, testUnicode18Mirroring, "complex/bidi-transform/TestUnicode18Mirroring");
 }
 
 #ifdef __cplusplus
 }
 #endif
+
+static void
+testUnicode18Mirroring(void) {
+    UErrorCode status = U_ZERO_ERROR;
+    UBiDiTransform* transform = ubiditransform_open(&status);
+    if (U_FAILURE(status)) {
+        log_err("ubiditransform_open failed: %s\n", u_errorName(status));
+        return;
+    }
+    static const UChar testSrc[] = { 0x05D0, 0x221D, 0x05D1 };
+    int32_t srcLen = 3;
+    UChar testDest[10];
+    
+    uint32_t destLen = ubiditransform_transform(transform, testSrc, srcLen, testDest, 3,
+                             UBIDI_RTL, UBIDI_LOGICAL,
+                             UBIDI_LTR, UBIDI_LOGICAL,
+                             UBIDI_MIRRORING_ON,
+                             0,
+                             &status);
+    if (status != U_BUFFER_OVERFLOW_ERROR || destLen != 4) {
+        log_err("testUnicode18Mirroring overflow check failed: expected U_BUFFER_OVERFLOW_ERROR and destLen=4, got %s and destLen=%u\n",
+                u_errorName(status), destLen);
+    }
+
+    status = U_ZERO_ERROR;
+    u_memset(testDest, 0, 10);
+    destLen = ubiditransform_transform(transform, testSrc, srcLen, testDest, 10,
+                             UBIDI_RTL, UBIDI_LOGICAL,
+                             UBIDI_LTR, UBIDI_LOGICAL,
+                             UBIDI_MIRRORING_ON,
+                             0,
+                             &status);
+    static const UChar expectedDest[] = { 0x05D1, 0xD836, 0xDF10, 0x05D0 };
+    if (U_FAILURE(status) || destLen != 4 || u_strncmp(testDest, expectedDest, 4) != 0) {
+        log_err("testUnicode18Mirroring actual chars (221D->1DB10) failed: status=%s, destLen=%u\n",
+                u_errorName(status), destLen);
+    }
+
+    status = U_ZERO_ERROR;
+    static const UChar testSrc2[] = { 0x05D0, 0xD836, 0xDF10, 0x05D1 };
+    int32_t src2Len = 4;
+    destLen = ubiditransform_transform(transform, testSrc2, src2Len, testDest, 2,
+                             UBIDI_RTL, UBIDI_LOGICAL,
+                             UBIDI_LTR, UBIDI_LOGICAL,
+                             UBIDI_MIRRORING_ON,
+                             0,
+                             &status);
+    if (status != U_BUFFER_OVERFLOW_ERROR || destLen != 3) {
+        log_err("testUnicode18Mirroring (1DB10->221D overflow) failed: expected U_BUFFER_OVERFLOW_ERROR and destLen=3, got %s and destLen=%u\n",
+                u_errorName(status), destLen);
+    }
+
+    status = U_ZERO_ERROR;
+    u_memset(testDest, 0, 10);
+    destLen = ubiditransform_transform(transform, testSrc2, src2Len, testDest, 10,
+                             UBIDI_RTL, UBIDI_LOGICAL,
+                             UBIDI_LTR, UBIDI_LOGICAL,
+                             UBIDI_MIRRORING_ON,
+                             0,
+                             &status);
+    static const UChar expectedDest2[] = { 0x05D1, 0x221D, 0x05D0 };
+    if (U_FAILURE(status) || destLen != 3 || u_strncmp(testDest, expectedDest2, 3) != 0) {
+        log_err("testUnicode18Mirroring actual chars (1DB10->221D) failed: status=%s, destLen=%u\n",
+                u_errorName(status), destLen);
+    }
+    ubiditransform_close(transform);
+}


### PR DESCRIPTION
Jira Issue: https://unicode-org.atlassian.net/browse/ICU-23455
When `ubiditransform_transform` is called with `UBIDI_MIRRORING_ON`, `action_mirror` assumed `u_charMirror(c)` preserves UTF-16 code unit length. When mirroring expands a character from 1 to 2 code units, `U16_APPEND_UNSAFE` overflows the destination buffer and returns an incorrect destination length.\n\nThis PR replaces static `destSize < srcLength` checks with dynamic code unit tracking and proper buffer overflow reporting.

#### Checklist
- [X] Required: Issue filed: ICU-23455
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [X] Approver: Feel free to merge on my behalf