### PR TITLE
ICU-23456 Fix IndexOutOfBoundsException in BidiWriter.writeReverse

### DIFF
--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/BidiWriter.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/BidiWriter.java
@@ -212,13 +212,14 @@ final class BidiWriter {
                         continue;
                     }
 
+                    int origBaseLen = UTF16.getCharCount(c);
                     /* copy this "user character" */
                     int j = srcLength;
                     if ((options & Bidi.DO_MIRRORING) != 0) {
                         /* mirror only the base character */
                         c = UCharacter.getMirror(c);
                         UTF16.append(dest, c);
-                        j += UTF16.getCharCount(c);
+                        j += origBaseLen;
                     }
                     dest.append(src.substring(j, i));
                 } while (srcLength > 0);

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/bidi/TestInverse.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/bidi/TestInverse.java
@@ -271,4 +271,21 @@ public class TestInverse extends BidiFmwk {
         String out = bidi.writeReordered(Bidi.OUTPUT_REVERSE | Bidi.INSERT_LRM_FOR_NUMERIC);
         assertEquals("\nInvalid output with RLM at both sides", "\u200f   \u200f", out);
     }
+
+    @Test
+    public void testWriteReverseMirroring() {
+        String src = "\u05D0\u221D\u0300\u05D1";
+        Bidi bidi = new Bidi(src, Bidi.DIRECTION_RIGHT_TO_LEFT);
+        String out =
+                bidi.writeReordered(
+                        Bidi.OUTPUT_REVERSE | Bidi.DO_MIRRORING | Bidi.KEEP_BASE_COMBINING);
+        assertEquals("testWriteReverseMirroring output", "\u05D0\uD836\uDF10\u0300\u05D1", out);
+
+        String src2 = "\u05D0\uD836\uDF10\u0300\u05D1";
+        Bidi bidi2 = new Bidi(src2, Bidi.DIRECTION_RIGHT_TO_LEFT);
+        String out2 =
+                bidi2.writeReordered(
+                        Bidi.OUTPUT_REVERSE | Bidi.DO_MIRRORING | Bidi.KEEP_BASE_COMBINING);
+        assertEquals("testWriteReverseMirroring reverse output", "\u05D0\u221D\u0300\u05D1", out2);
+    }
 }


### PR DESCRIPTION
Jira Issue: https://unicode-org.atlassian.net/browse/ICU-23456
In `BidiWriter.writeReverse`, when `DO_MIRRORING` and `KEEP_BASE_COMBINING` are set, the loop advanced the source index `j` by the UTF-16 length of the mirrored character. When a BMP character mirrors to a supplementary character (e.g. U+221D -> U+1DB10 in Unicode 18.0), `j` advances too far, causing `IndexOutOfBoundsException` when copying combining marks.
This PR records `origBaseLen` prior to mirroring and advances `j` by `origBaseLen`.

#### Checklist
- [X] Required: Issue filed: ICU-23456
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [X] Approver: Feel free to merge on my behalf