### PR TITLE
ICU-23457 Fix array desynchronization in BidiTransform.transform with Mirroring.ON

### DIFF
--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/BidiTransform.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/BidiTransform.java
@@ -307,16 +307,18 @@ public class BidiTransform {
         if ((reorderingOptions & Bidi.DO_MIRRORING) == 0) {
             return;
         }
-        StringBuffer sb = new StringBuffer(text);
+        StringBuffer dest = new StringBuffer(text.length() * 2);
         byte[] levels = bidi.getLevels();
         for (int i = 0, n = levels.length; i < n; ) {
-            int ch = UTF16.charAt(sb, i);
+            int ch = UTF16.charAt(text, i);
+            int origLen = UTF16.getCharCount(ch);
             if ((levels[i] & 1) != 0) {
-                UTF16.setCharAt(sb, i, UCharacter.getMirror(ch));
+                ch = UCharacter.getMirror(ch);
             }
-            i += UTF16.getCharCount(ch);
+            UTF16.append(dest, ch);
+            i += origLen;
         }
-        text = sb.toString();
+        text = dest.toString();
         reorderingOptions &= ~Bidi.DO_MIRRORING;
     }
 

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/bidi/TestBidiTransform.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/bidi/TestBidiTransform.java
@@ -490,4 +490,14 @@ public class TestBidiTransform extends CoreTestFmwk {
             }
         }
     }
+
+    @Test
+    public void testMirroringUnicode18() {
+        BidiTransform transform = new BidiTransform();
+        String in = "\u05D0\u221D\u05D1\u05D2";
+        String out =
+                transform.transform(
+                        in, Bidi.RTL, Order.LOGICAL, Bidi.LTR, Order.LOGICAL, Mirroring.ON, 0);
+        assertEquals("testMirroringUnicode18 output", "\u05D1\u05D2\uD836\uDF10\u05D0", out);
+    }
 }


### PR DESCRIPTION
Jira Issue: https://unicode-org.atlassian.net/browse/ICU-23457
In `BidiTransform.transform` with `Mirroring.ON`, `mirror()` modified a `StringBuffer` in-place using `UTF16.setCharAt` while iterating over embedding levels. When mirroring expands a character from 1 to 2 code units (e.g. U+221D -> U+1DB10 in Unicode 18.0), inserting a surrogate pair shifts subsequent characters in the buffer, desynchronizing the buffer from the levels array and corrupting text.
This PR replaces in-place modification with sequential appending to a new `StringBuffer`.

#### Checklist
- [X] Required: Issue filed: ICU-23457
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [X] Approver: Feel free to merge on my behalf