### PR TITLE
ICU-23007 Fix Hebrew calendar year <= 0 Kislev length and Dechiya boundary rules (ICU-23070, ICU-22441)

### DIFF
--- a/icu4c/source/i18n/hebrwcal.cpp
+++ b/icu4c/source/i18n/hebrwcal.cpp
@@ -437,22 +437,23 @@ int32_t startOfYear(int32_t year, UErrorCode &status)
             (235LL * static_cast<int64_t>(year) - 234LL), 19LL);
 
         int64_t frac = months * MONTH_FRACT + BAHARAD;  // Fractional part of day #
-        day  = months * 29LL + frac / DAY_PARTS;        // Whole # part of calculation
-        frac = frac % DAY_PARTS;                        // Time of day
+        int64_t fracDiv = ClockMath::floorDivideInt64(frac, DAY_PARTS);
+        day  = months * 29LL + fracDiv;                 // Whole # part of calculation
+        frac = frac - (fracDiv * DAY_PARTS);            // Time of day
 
-        int32_t wd = (day % 7);                        // Day of week (0 == Monday)
+        int32_t wd = static_cast<int32_t>((day % 7 + 7) % 7); // Day of week (0 == Monday)
 
         if (wd == 2 || wd == 4 || wd == 6) {
             // If the 1st is on Sun, Wed, or Fri, postpone to the next day
             day += 1;
-            wd = (day % 7);
-        } else if (wd == 1 && frac > 15*HOUR_PARTS+204 && !HebrewCalendar::isLeapYear(year) ) {
+            wd = static_cast<int32_t>((day % 7 + 7) % 7);
+        } else if (wd == 1 && frac >= 15*HOUR_PARTS+204 && !HebrewCalendar::isLeapYear(year) ) {
             // If the new moon falls after 3:11:20am (15h204p from the previous noon)
             // on a Tuesday and it is not a leap year, postpone by 2 days.
             // This prevents 356-day years.
             day += 2;
         }
-        else if (wd == 0 && frac > 21*HOUR_PARTS+589 && HebrewCalendar::isLeapYear(year-1) ) {
+        else if (wd == 0 && frac >= 21*HOUR_PARTS+589 && HebrewCalendar::isLeapYear(year-1) ) {
             // If the new moon falls after 9:32:43 1/3am (21h589p from yesterday noon)
             // on a Monday and *last* year was a leap year, postpone by 1 day.
             // Prevents 382-day years.
@@ -521,9 +522,8 @@ int32_t yearType(int32_t year, UErrorCode& status)
 * The formula below performs the same test, believe it or not.
 */
 UBool HebrewCalendar::isLeapYear(int32_t year) {
-    //return (year * 12 + 17) % 19 >= 12;
-    int64_t x = (year*12LL + 17) % YEARS_IN_CYCLE;
-    return x >= ((x < 0) ? -7 : 12);
+    int64_t x = ((year*12LL + 17) % YEARS_IN_CYCLE + YEARS_IN_CYCLE) % YEARS_IN_CYCLE;
+    return x >= 12;
 }
 
 namespace{

--- a/icu4c/source/test/intltest/caltest.cpp
+++ b/icu4c/source/test/intltest/caltest.cpp
@@ -209,6 +209,9 @@ void CalendarTest::runIndexedTest( int32_t index, UBool exec, const char* &name,
 
     TESTCASE_AUTO(Test22633HebrewLargeNegativeDay);
     TESTCASE_AUTO(Test23069HebrewHanukkah);
+    TESTCASE_AUTO(Test23007HebrewYearZero);
+    TESTCASE_AUTO(Test23070HebrewGaRadMaT);
+    TESTCASE_AUTO(Test22441Year88369);
     TESTCASE_AUTO(Test22730JapaneseOverflow);
     TESTCASE_AUTO(Test22730CopticOverflow);
     TESTCASE_AUTO(Test22962ComputeJulianDayOverflow);
@@ -6034,6 +6037,102 @@ void CalendarTest::Test23069HebrewHanukkah() {
                    cas.hebrewYear, 1+icu::HebrewCalendar::KISLEV);
         }
     }
+}
+
+void CalendarTest::Test23007HebrewYearZero() {
+    UErrorCode status = U_ZERO_ERROR;
+    LocalPointer<Calendar> gc(Calendar::createInstance(*TimeZone::getGMT(), Locale("en_US@calendar=gregorian"), status));
+    LocalPointer<Calendar> hc(Calendar::createInstance(*TimeZone::getGMT(), Locale("he_IL@calendar=hebrew"), status));
+    if (failure(status, "Create calendar instances", true)) return;
+
+    // Gregorian 16 Dec -3761 (year -3761 in astronomical/ICU = 3762 BCE)
+    gc->set(-3761, UCAL_DECEMBER, 16, 0, 0, 0);
+    UDate instant = gc->getTime(status);
+    hc->setTime(instant, status);
+    if (failure(status, "Set time", true)) return;
+
+    int32_t year = hc->get(UCAL_YEAR, status);
+    int32_t month = hc->get(UCAL_MONTH, status);
+    int32_t day = hc->get(UCAL_DATE, status);
+    assertEquals("Hebrew year for -3761-12-16", 0, year);
+    assertEquals("Hebrew month for -3761-12-16", HebrewCalendar::KISLEV, month);
+    assertEquals("Hebrew day for -3761-12-16", 30, day);
+
+    gc->set(-3761, UCAL_DECEMBER, 17, 0, 0, 0);
+    instant = gc->getTime(status);
+    hc->setTime(instant, status);
+    if (failure(status, "Set time 2", true)) return;
+
+    year = hc->get(UCAL_YEAR, status);
+    month = hc->get(UCAL_MONTH, status);
+    day = hc->get(UCAL_DATE, status);
+    assertEquals("Hebrew year for -3761-12-17", 0, year);
+    assertEquals("Hebrew month for -3761-12-17", HebrewCalendar::TEVET, month);
+    assertEquals("Hebrew day for -3761-12-17", 1, day);
+}
+
+void CalendarTest::Test23070HebrewGaRadMaT() {
+    UErrorCode status = U_ZERO_ERROR;
+    LocalPointer<Calendar> hc(Calendar::createInstance(*TimeZone::getGMT(), Locale("he_IL@calendar=hebrew"), status));
+    LocalPointer<Calendar> gc(Calendar::createInstance(*TimeZone::getGMT(), Locale("en_US@calendar=gregorian"), status));
+    if (failure(status, "Create calendar instances", true)) return;
+
+    // Test Hebrew year 193151, which triggers Dechiya GaRadMaT (Tuesday 15h204p).
+    // Before our fix (using > instead of >=), year 193151 was not postponed by 2 days,
+    // causing an illegal 356-day year and empty strings on 189393-11-23 and 189393-11-24.
+    // With >=, year 193151 is postponed by 2 days (length 354 days, Normal year, Elul 29 days).
+    gc->set(189393, UCAL_NOVEMBER, 22, 0, 0, 0);
+    hc->setTime(gc->getTime(status), status);
+    if (failure(status, "Set time 1", true)) return;
+
+    assertEquals("Hebrew year for 189393-11-22", 193151, hc->get(UCAL_YEAR, status));
+    assertEquals("Hebrew month for 189393-11-22", HebrewCalendar::ELUL, hc->get(UCAL_MONTH, status));
+    assertEquals("Hebrew day for 189393-11-22", 27, hc->get(UCAL_DATE, status));
+
+    gc->set(189393, UCAL_NOVEMBER, 23, 0, 0, 0);
+    hc->setTime(gc->getTime(status), status);
+    if (failure(status, "Set time 2", true)) return;
+
+    assertEquals("Hebrew year for 189393-11-23", 193151, hc->get(UCAL_YEAR, status));
+    assertEquals("Hebrew month for 189393-11-23", HebrewCalendar::ELUL, hc->get(UCAL_MONTH, status));
+    assertEquals("Hebrew day for 189393-11-23", 28, hc->get(UCAL_DATE, status));
+
+    gc->set(189393, UCAL_NOVEMBER, 24, 0, 0, 0);
+    hc->setTime(gc->getTime(status), status);
+    if (failure(status, "Set time 3", true)) return;
+
+    assertEquals("Hebrew year for 189393-11-24", 193151, hc->get(UCAL_YEAR, status));
+    assertEquals("Hebrew month for 189393-11-24", HebrewCalendar::ELUL, hc->get(UCAL_MONTH, status));
+    assertEquals("Hebrew day for 189393-11-24", 29, hc->get(UCAL_DATE, status));
+
+    gc->set(189393, UCAL_NOVEMBER, 25, 0, 0, 0);
+    hc->setTime(gc->getTime(status), status);
+    if (failure(status, "Set time 4", true)) return;
+
+    assertEquals("Hebrew year for 189393-11-25", 193152, hc->get(UCAL_YEAR, status));
+    assertEquals("Hebrew month for 189393-11-25", HebrewCalendar::TISHRI, hc->get(UCAL_MONTH, status));
+    assertEquals("Hebrew day for 189393-11-25", 1, hc->get(UCAL_DATE, status));
+}
+
+void CalendarTest::Test22441Year88369() {
+    UErrorCode status = U_ZERO_ERROR;
+    LocalPointer<Calendar> hc(Calendar::createInstance(*TimeZone::getGMT(), Locale("he_IL@calendar=hebrew"), status));
+    if (failure(status, "Create calendar instance", true)) return;
+
+    // Test Hebrew year 88369, which triggers Dechiya BaTuTaKPaT (Monday 21h589p) at the start of 88370.
+    // Before our fix (using > instead of >=), Dechiya 3 did not trigger for year 88370,
+    // causing year 88369 to have an illegal length of 382 days (which evaluated to 352 after subtracting 30).
+    // With >=, year 88370 is postponed by 1 day, giving year 88369 a valid Deficient leap year length of 383 days.
+    hc->set(88369, HebrewCalendar::TISHRI, 1, 0, 0, 0);
+    UDate start88369 = hc->getTime(status);
+    if (failure(status, "Get time for 88369-01-01", true)) return;
+
+    hc->set(88370, HebrewCalendar::TISHRI, 1, 0, 0, 0);
+    UDate start88370 = hc->getTime(status);
+    if (failure(status, "Get time for 88370-01-01", true)) return;
+
+    int32_t yearLengthDays = static_cast<int32_t>((start88370 - start88369) / 86400000.0 + 0.5);
+    assertEquals("Hebrew year 88369 length in days", 383, yearLengthDays);
 }
 
 void CalendarTest::Test22730JapaneseOverflow() {

--- a/icu4c/source/test/intltest/caltest.h
+++ b/icu4c/source/test/intltest/caltest.h
@@ -364,6 +364,9 @@ public: // package
     void TestChineseCalendarComputeMonthStart();
     void Test22633HebrewLargeNegativeDay();
     void Test23069HebrewHanukkah();
+    void Test23007HebrewYearZero();
+    void Test23070HebrewGaRadMaT();
+    void Test22441Year88369();
 
     void RunChineseCalendarInTemporalLeapYearTest(Calendar* cal);
     void RunIslamicCalendarInTemporalLeapYearTest(Calendar* cal);

--- a/icu4j/main/core/src/main/java/com/ibm/icu/util/HebrewCalendar.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/util/HebrewCalendar.java
@@ -626,21 +626,22 @@ public class HebrewCalendar extends Calendar {
                                     YEARS_IN_CYCLE);
 
             long frac = months * MONTH_FRACT + BAHARAD; // Fractional part of day #
-            day = months * 29 + (frac / DAY_PARTS); // Whole # part of calculation
-            frac = frac % DAY_PARTS; // Time of day
+            long fracDiv = floorDivide(frac, DAY_PARTS);
+            day = months * 29 + fracDiv; // Whole # part of calculation
+            frac = frac - (fracDiv * DAY_PARTS); // Time of day
 
-            int wd = (int) (day % 7); // Day of week (0 == Monday)
+            int wd = (int) ((day % 7 + 7) % 7); // Day of week (0 == Monday)
 
             if (wd == 2 || wd == 4 || wd == 6) {
                 // If the 1st is on Sun, Wed, or Fri, postpone to the next day
                 day += 1;
-                wd = (int) (day % 7);
-            } else if (wd == 1 && frac > 15 * HOUR_PARTS + 204 && !isLeapYear(year)) {
+                wd = (int) ((day % 7 + 7) % 7);
+            } else if (wd == 1 && frac >= 15 * HOUR_PARTS + 204 && !isLeapYear(year)) {
                 // If the new moon falls after 3:11:20am (15h204p from the previous noon)
                 // on a Tuesday and it is not a leap year, postpone by 2 days.
                 // This prevents 356-day years.
                 day += 2;
-            } else if (wd == 0 && frac > 21 * HOUR_PARTS + 589 && isLeapYear(year - 1)) {
+            } else if (wd == 0 && frac >= 21 * HOUR_PARTS + 589 && isLeapYear(year - 1)) {
                 // If the new moon falls after 9:32:43 1/3am (21h589p from yesterday noon)
                 // on a Monday and *last* year was a leap year, postpone by 1 day.
                 // Prevents 382-day years.
@@ -704,9 +705,8 @@ public class HebrewCalendar extends Calendar {
      */
     @Deprecated
     public static boolean isLeapYear(int year) {
-        // return (year * 12 + 17) % 19 >= 12;
-        int x = (year * 12 + 17) % YEARS_IN_CYCLE;
-        return x >= ((x < 0) ? -7 : 12);
+        int x = ((year * 12 + 17) % YEARS_IN_CYCLE + YEARS_IN_CYCLE) % YEARS_IN_CYCLE;
+        return x >= 12;
     }
 
     private static int monthsInYear(int year) {

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/CalendarTestFmwk.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/CalendarTestFmwk.java
@@ -299,11 +299,6 @@ public class CalendarTestFmwk extends CoreTestFmwk {
             cal.setTimeInMillis(greg.getTimeInMillis());
             for (int j = 0; j < fieldsToTest.length; ++j) {
                 int f = fieldsToTest[j];
-                if (cal.getType().equals("hebrew")
-                        && greg.get(Calendar.YEAR) > 2500
-                        && logKnownIssue("ICU-22441", "Hebrew calendar illegal year length")) {
-                    break;
-                }
                 int v = cal.get(f);
                 int minActual = cal.getActualMinimum(f);
                 int maxActual = cal.getActualMaximum(f);

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/HebrewTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/calendar/HebrewTest.java
@@ -671,4 +671,78 @@ public class HebrewTest extends CalendarTestFmwk {
             }
         }
     }
+
+    @Test
+    public void Test23007HebrewYearZero() {
+        GregorianCalendar gc = new GregorianCalendar(UTC, Locale.US);
+        gc.clear();
+        gc.set(Calendar.ERA, GregorianCalendar.BC);
+        gc.set(Calendar.YEAR, 3762); // 3762 BC = astronomical -3761
+        gc.set(Calendar.MONTH, Calendar.DECEMBER);
+        gc.set(Calendar.DATE, 16);
+        long instant = gc.getTimeInMillis();
+
+        HebrewCalendar hc = new HebrewCalendar(UTC, Locale.US);
+        hc.setTimeInMillis(instant);
+        assertEquals("Hebrew year for -3761-12-16", 0, hc.get(Calendar.YEAR));
+        assertEquals("Hebrew month for -3761-12-16", KISLEV, hc.get(Calendar.MONTH));
+        assertEquals("Hebrew day for -3761-12-16", 30, hc.get(Calendar.DATE));
+
+        gc.set(Calendar.DATE, 17);
+        instant = gc.getTimeInMillis();
+        hc.setTimeInMillis(instant);
+        assertEquals("Hebrew year for -3761-12-17", 0, hc.get(Calendar.YEAR));
+        assertEquals("Hebrew month for -3761-12-17", TEVET, hc.get(Calendar.MONTH));
+        assertEquals("Hebrew day for -3761-12-17", 1, hc.get(Calendar.DATE));
+    }
+
+    @Test
+    public void Test23070HebrewGaRadMaT() {
+        GregorianCalendar gc = new GregorianCalendar(UTC, Locale.US);
+        gc.clear();
+        gc.set(189393, Calendar.NOVEMBER, 22);
+        long instant = gc.getTimeInMillis();
+
+        HebrewCalendar hc = new HebrewCalendar(UTC, Locale.US);
+        hc.setTimeInMillis(instant);
+        assertEquals("Hebrew year for 189393-11-22", 193151, hc.get(Calendar.YEAR));
+        assertEquals("Hebrew month for 189393-11-22", ELUL, hc.get(Calendar.MONTH));
+        assertEquals("Hebrew day for 189393-11-22", 27, hc.get(Calendar.DATE));
+
+        gc.set(189393, Calendar.NOVEMBER, 23);
+        instant = gc.getTimeInMillis();
+        hc.setTimeInMillis(instant);
+        assertEquals("Hebrew year for 189393-11-23", 193151, hc.get(Calendar.YEAR));
+        assertEquals("Hebrew month for 189393-11-23", ELUL, hc.get(Calendar.MONTH));
+        assertEquals("Hebrew day for 189393-11-23", 28, hc.get(Calendar.DATE));
+
+        gc.set(189393, Calendar.NOVEMBER, 24);
+        instant = gc.getTimeInMillis();
+        hc.setTimeInMillis(instant);
+        assertEquals("Hebrew year for 189393-11-24", 193151, hc.get(Calendar.YEAR));
+        assertEquals("Hebrew month for 189393-11-24", ELUL, hc.get(Calendar.MONTH));
+        assertEquals("Hebrew day for 189393-11-24", 29, hc.get(Calendar.DATE));
+
+        gc.set(189393, Calendar.NOVEMBER, 25);
+        instant = gc.getTimeInMillis();
+        hc.setTimeInMillis(instant);
+        assertEquals("Hebrew year for 189393-11-25", 193152, hc.get(Calendar.YEAR));
+        assertEquals("Hebrew month for 189393-11-25", TISHRI, hc.get(Calendar.MONTH));
+        assertEquals("Hebrew day for 189393-11-25", 1, hc.get(Calendar.DATE));
+    }
+
+    @Test
+    public void Test22441Year88369() {
+        HebrewCalendar hc = new HebrewCalendar(UTC, Locale.US);
+        hc.clear();
+        hc.set(88369, TISHRI, 1);
+        long start88369 = hc.getTimeInMillis();
+
+        hc.clear();
+        hc.set(88370, TISHRI, 1);
+        long start88370 = hc.getTimeInMillis();
+
+        long yearLengthDays = (start88370 - start88369) / (24 * 60 * 60 * 1000L);
+        assertEquals("Hebrew year 88369 length in days", 383, yearLengthDays);
+    }
 }


### PR DESCRIPTION
Fixes three long-standing Hebrew calendar bugs:

1. **ICU-23007 (Year <= 0 Kislev length):** Replaced truncating integer division `/` and signed remainder `%` in `startOfYear` and `isLeapYear` with Euclidean floor division (`ClockMath::floorDivideInt64` / `floorDivide`) and positive Euclidean modulo `(day % 7 + 7) % 7` in both C++ and Java. Ensures year 0 evaluates as a 384-day Normal year where Kislev has 30 days.
2. **ICU-23070 (Error formatting +189393-11-23) & ICU-22441 (Illegal year length 352 in year 88369):** In traditional Hebrew calendar rules, Dechiya GaRadMaT (Dechiya 2) and Dechiya BeTuTaKPaT (Dechiya 3) trigger when the Molad falls **at or after** the critical halakim boundary (`15h 204p` on Tuesday non-leap, `21h 589p` on Monday after-leap). Changed strict inequality `>` to `>=` in both C++ and Java so that when the Molad lands precisely on the boundary (as in year 193151 and year 88370), the postponement triggers correctly. This prevents illegal 356-day non-leap years (fixing `189393-11-23` and `-24` formatting) and illegal 382-day leap years (which caused `Illegal year length 352 in year 88369`).
3. Removed explicit test suppression for ICU-22441 in `CalendarTestFmwk.java` so that limit testing runs freely past year 88,369 without exceptions.

#### Checklist
- [X] Required: Issue filed: ICU-23007
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [X] Approver: Feel free to merge on my behalf
