### PR TITLE
ICU-23144 Prevent NumberFormatter timeout when formatting hugely out-of-bounds magnitude

### DIFF
--- a/icu4c/source/i18n/number_formatimpl.cpp
+++ b/icu4c/source/i18n/number_formatimpl.cpp
@@ -24,6 +24,17 @@ using namespace icu;
 using namespace icu::number;
 using namespace icu::number::impl;
 
+namespace {
+
+// Maximum number of integer or fraction digits we will output during formatting.
+// Set to 999,999 to allow valid large-range performance tests (e.g., test21684_Performance
+// formatting -1e99999) while preventing runaway loops, allocation spikes, and timeouts
+// when formatting numbers with hugely out-of-bounds magnitudes (like scale/1e200000000).
+// This value may be tuned to a smaller value later if necessary.
+constexpr int32_t kMaxFormattedDigits = 999999;
+
+}  // namespace
+
 
 NumberFormatterImpl::NumberFormatterImpl(const MacroProps& macros, UErrorCode& status)
     : NumberFormatterImpl(macros, true, status) {
@@ -537,6 +548,11 @@ int32_t NumberFormatterImpl::writeNumber(
                 status);
 
     } else {
+        if (quantity.getUpperDisplayMagnitude() + 1 > kMaxFormattedDigits ||
+            -quantity.getLowerDisplayMagnitude() > kMaxFormattedDigits) {
+            status = U_ILLEGAL_ARGUMENT_ERROR;
+            return 0;
+        }
         // Add the integer digits
         length += writeIntegerDigits(
             micros,
@@ -594,8 +610,13 @@ int32_t NumberFormatterImpl::writeIntegerDigits(
         FormattedStringBuilder& string,
         int32_t index,
         UErrorCode& status) {
+    if (U_FAILURE(status)) { return 0; }
     int length = 0;
     int integerCount = quantity.getUpperDisplayMagnitude() + 1;
+    if (integerCount > kMaxFormattedDigits) {
+        status = U_ILLEGAL_ARGUMENT_ERROR;
+        return 0;
+    }
     for (int i = 0; i < integerCount; i++) {
         // Add grouping separator
         if (micros.grouping.groupAtPosition(i, quantity)) {
@@ -629,8 +650,13 @@ int32_t NumberFormatterImpl::writeFractionDigits(
         FormattedStringBuilder& string,
         int32_t index,
         UErrorCode& status) {
+    if (U_FAILURE(status)) { return 0; }
     int length = 0;
     int fractionCount = -quantity.getLowerDisplayMagnitude();
+    if (fractionCount > kMaxFormattedDigits) {
+        status = U_ILLEGAL_ARGUMENT_ERROR;
+        return 0;
+    }
     for (int i = 0; i < fractionCount; i++) {
         // Get and append the next digit value
         int8_t nextDigit = quantity.getDigit(-i - 1);

--- a/icu4c/source/test/intltest/numbertest.h
+++ b/icu4c/source/test/intltest/numbertest.h
@@ -307,6 +307,7 @@ class NumberSkeletonTest : public IntlTest {
     void measurementSystemOverride();
     void longSkeletonCrash();
     void unitAliases();
+    void testIssue23144();
 
     void runIndexedTest(int32_t index, UBool exec, const char*& name, char* par = nullptr) override;
 

--- a/icu4c/source/test/intltest/numbertest_skeletons.cpp
+++ b/icu4c/source/test/intltest/numbertest_skeletons.cpp
@@ -37,6 +37,7 @@ void NumberSkeletonTest::runIndexedTest(int32_t index, UBool exec, const char*& 
         TESTCASE_AUTO(measurementSystemOverride);
         TESTCASE_AUTO(longSkeletonCrash);
         TESTCASE_AUTO(unitAliases);
+        TESTCASE_AUTO(testIssue23144);
     TESTCASE_AUTO_END;
 }
 
@@ -607,6 +608,18 @@ void NumberSkeletonTest::unitAliases() {
             assertEquals(testCase.skeleton, testCase.expectedResult, actualResult);
         }
     }
+}
+
+void NumberSkeletonTest::testIssue23144() {
+    IcuTestErrorCode status(*this, "testIssue23144");
+    UErrorCode err = U_ZERO_ERROR;
+    UnlocalizedNumberFormatter nf = NumberFormatter::forSkeleton(u"scale/1e200000000", err);
+    if (!assertSuccess("forSkeleton", err)) {
+        return;
+    }
+    FormattedNumber fn = nf.locale("en").formatDouble(1.0, err);
+    assertEquals("Expected U_ILLEGAL_ARGUMENT_ERROR when formatting hugely out-of-bounds magnitude",
+                 U_ILLEGAL_ARGUMENT_ERROR, err);
 }
 
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4j/main/core/src/main/java/com/ibm/icu/number/NumberFormatterImpl.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/number/NumberFormatterImpl.java
@@ -46,6 +46,15 @@ import com.ibm.icu.util.MeasureUnit;
  */
 class NumberFormatterImpl {
 
+    /**
+     * Maximum number of integer or fraction digits we will output during formatting. Set to 999,999
+     * to allow valid large-range performance tests (e.g., test21684_Performance formatting
+     * -1e99999) while preventing runaway loops, allocation spikes, and timeouts when formatting
+     * numbers with hugely out-of-bounds magnitudes (like scale/1e200000000). This value may be
+     * tuned to a smaller value later if necessary.
+     */
+    private static final int MAX_FORMATTED_DIGITS = 999999;
+
     /** Builds a "safe" MicroPropsGenerator, which is thread-safe and can be used repeatedly. */
     public NumberFormatterImpl(MacroProps macros) {
         micros = new MicroProps(true);
@@ -521,6 +530,11 @@ class NumberFormatterImpl {
                             length + index, micros.symbols.getNaN(), NumberFormat.Field.INTEGER);
 
         } else {
+            if (quantity.getUpperDisplayMagnitude() + 1 > MAX_FORMATTED_DIGITS
+                    || -quantity.getLowerDisplayMagnitude() > MAX_FORMATTED_DIGITS) {
+                throw new IllegalArgumentException(
+                        "Magnitude exceeds maximum required integer or fraction digits.");
+            }
             // Add the integer digits
             length += writeIntegerDigits(micros, quantity, string, length + index);
 
@@ -578,6 +592,10 @@ class NumberFormatterImpl {
             MicroProps micros, DecimalQuantity quantity, FormattedStringBuilder string, int index) {
         int length = 0;
         int integerCount = quantity.getUpperDisplayMagnitude() + 1;
+        if (integerCount > MAX_FORMATTED_DIGITS) {
+            throw new IllegalArgumentException(
+                    "Magnitude exceeds maximum required integer digits.");
+        }
         for (int i = 0; i < integerCount; i++) {
             // Add grouping separator
             if (micros.grouping.groupAtPosition(i, quantity)) {
@@ -613,6 +631,10 @@ class NumberFormatterImpl {
             MicroProps micros, DecimalQuantity quantity, FormattedStringBuilder string, int index) {
         int length = 0;
         int fractionCount = -quantity.getLowerDisplayMagnitude();
+        if (fractionCount > MAX_FORMATTED_DIGITS) {
+            throw new IllegalArgumentException(
+                    "Magnitude exceeds maximum required fraction digits.");
+        }
         for (int i = 0; i < fractionCount; i++) {
             // Get and append the next digit value
             byte nextDigit = quantity.getDigit(-i - 1);

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/number/NumberSkeletonTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/number/NumberSkeletonTest.java
@@ -6,6 +6,7 @@ import com.ibm.icu.dev.test.CoreTestFmwk;
 import com.ibm.icu.number.LocalizedNumberFormatter;
 import com.ibm.icu.number.NumberFormatter;
 import com.ibm.icu.number.SkeletonSyntaxException;
+import com.ibm.icu.number.UnlocalizedNumberFormatter;
 import com.ibm.icu.util.MeasureUnit;
 import com.ibm.icu.util.ULocale;
 import java.math.RoundingMode;
@@ -588,6 +589,18 @@ public class NumberSkeletonTest extends CoreTestFmwk {
             } catch (SkeletonSyntaxException e) {
                 fail(testCase.skeleton);
             }
+        }
+    }
+
+    @Test
+    public void testIssue23144() {
+        UnlocalizedNumberFormatter nf = NumberFormatter.forSkeleton("scale/1e200000000");
+        try {
+            nf.locale(Locale.US).format(1.0);
+            fail(
+                    "Expected IllegalArgumentException when formatting hugely out-of-bounds magnitude");
+        } catch (IllegalArgumentException e) {
+            // expected
         }
     }
 }


### PR DESCRIPTION

#### Checklist
- [x] Required: Issue filed: ICU-23144
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf



## Description

Fixes OSS-Fuzz issue [42538226](https://g-issues.oss-fuzz.com/issues/42538226) / [ICU-23144](https://unicode-org.atlassian.net/browse/ICU-23144) (libFuzzer timeout inside `NumberFormatterImpl::writeIntegerDigits`).

When a number skeleton or input (such as `scale/1e200000000`) sets `getUpperDisplayMagnitude()` or `-getLowerDisplayMagnitude()` to an extremely large value (> 999,999), `writeIntegerDigits` and `writeFractionDigits` would iterate millions or billions of times appending zeros during formatting. This caused severe memory allocation spikes and libFuzzer timeouts (>60 seconds).

By defining internal named constants `constexpr int32_t kMaxFormattedDigits = 999999` in C++ (`number_formatimpl.cpp`) inside an anonymous namespace and `private static final int MAX_FORMATTED_DIGITS = 999999` in Java (`NumberFormatterImpl.java`) with thorough documentation comments, and checking against them at the entry point of formatting (`writeNumber`, `writeIntegerDigits`, and `writeFractionDigits`), the formatter immediately returns `U_ILLEGAL_ARGUMENT_ERROR` (in C++) or throws `IllegalArgumentException` (in Java) in `O(1)` time without entering a runaway loop. The constant is structured specifically so it can be easily tuned to a smaller value in the future if necessary.

[ICU-23144]: https://unicode-org.atlassian.net/browse/ICU-23144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ICU-23144]: https://unicode-org.atlassian.net/browse/ICU-23144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ