### PR TITLE
ICU-23468 Limit test data in rule_based_break_iterator_fuzzer to avoid meaningless timeout

### DIFF
--- a/icu4c/source/test/fuzzer/rule_based_break_iterator_fuzzer.cpp
+++ b/icu4c/source/test/fuzzer/rule_based_break_iterator_fuzzer.cpp
@@ -10,6 +10,11 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   UErrorCode status = U_ZERO_ERROR;
+  if (size > 2000) {
+      // Limit the effective test data to only 2000 bytes to avoid meaningless
+      // timeout.
+      size = 2000;
+  }
 
   size_t unistr_size = size/2;
   std::unique_ptr<char16_t[]> fuzzbuff(new char16_t[unistr_size]);


### PR DESCRIPTION
OSS-Fuzz issue 385221814 (Buganizer b/385221814) reports an Out-of-Memory (OOM) and timeout condition in `rule_based_break_iterator_fuzzer`.

During table compilation mode (`RBBIRuleBuilder::buildData`), when `RuleBasedBreakIterator` is provided with a large, complex fuzzer-generated rule string (`fuzzstr`), compiling the state tables consumes excessive time and memory. Unlike other rule-based fuzzers (such as `collator_rulebased_fuzzer.cpp` and `timezone_create_fuzzer.cpp` which limit input size with `if (size > 2000) { size = 2000; }`), `rule_based_break_iterator_fuzzer.cpp` currently has no input size check.

This CL fixes this by limiting the input test data size in `LLVMFuzzerTestOneInput` of `icu4c/source/test/fuzzer/rule_based_break_iterator_fuzzer.cpp` to 2000 bytes.

#### Checklist
- [X] Required: Issue filed: ICU-23468
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [X] Approver: Feel free to merge on my behalf