### PR TITLE
ICU-22486 Add test cases for Locale::forLanguageTag with POSIX variants

### DIFF
--- a/icu4c/source/test/intltest/loctest.cpp
+++ b/icu4c/source/test/intltest/loctest.cpp
@@ -6182,6 +6182,11 @@ void LocaleTest::TestForLanguageTag() {
       {"und-x-private", "@x=private"},
       {"de-1994-biske-rozaj-x-private", "de__1994_BISKE_ROZAJ@x=private"},
       {"und-1994-biske-rozaj-x-private", "__1994_BISKE_ROZAJ@x=private"},
+      // ICU-22486
+      {"en-US-POSIX", "en_US_POSIX"},
+      {"de-DE-POSIX", "de_DE_POSIX"},
+      {"en-GB-POSIX", "en_GB_POSIX"},
+      {"en-US-u-va-posix", "en_US_POSIX"},
     };
     int32_t i;
     for (i=0; i < UPRV_LENGTHOF(testCases); i++) {

--- a/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/util/ULocaleTest.java
+++ b/icu4j/main/common_tests/src/test/java/com/ibm/icu/dev/test/util/ULocaleTest.java
@@ -3409,6 +3409,10 @@ public class ULocaleTest extends CoreTestFmwk {
             {"und-us", "_US", NOERROR},
             {"und-latn", "_Latn", NOERROR},
             {"en-us-posix", "en_US_POSIX", NOERROR},
+            /* ICU-22486 */
+            {"en-US-POSIX", "en_US_POSIX", NOERROR},
+            {"de-DE-POSIX", "de_DE_POSIX", NOERROR},
+            {"en-GB-POSIX", "en_GB_POSIX", NOERROR},
             {"de-de_euro", "de", 3},
             {"kok-in", "kok_IN", NOERROR},
             {"123", "", 0},


### PR DESCRIPTION
Jira ticket: https://unicode-org.atlassian.net/browse/ICU-22486

The underlying issue reported in ICU-22486 (`Locale::forLanguageTag` failing to parse `en-US-POSIX` or `POSIX` variant tags) was addressed when `ulocimp_getSubtags` handling for `-u-va-posix` / `POSIX` was fixed in ICU-23031. However, comprehensive unit tests verifying `forLanguageTag` with `POSIX` variant tags across C++ (`loctest.cpp`) and Java (`ULocaleTest.java`) were not added at that time.

This CL adds comprehensive test coverage in C++ and Java verifying that `Locale::forLanguageTag` (`ULocale.forLanguageTag`) properly parses `en-US-POSIX`, `de-DE-POSIX`, `en-GB-POSIX`, and `en-US-u-va-posix`, ensuring this behavior remains covered and regression-tested going forward.

#### Checklist
- [X] Required: Issue filed: ICU-22486
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [X] Approver: Feel free to merge on my behalf