### PR TITLE
ICU-22511 Fix CollationIterator timeout on pathological discontiguous contractions

### DIFF
--- a/icu4c/source/i18n/collationiterator.cpp
+++ b/icu4c/source/i18n/collationiterator.cpp
@@ -148,6 +148,7 @@ CollationIterator::CollationIterator(const CollationIterator &other)
         : UObject(other),
           trie(other.trie),
           data(other.data),
+          discontiguousLoopCount(other.discontiguousLoopCount),
           cesIndex(other.cesIndex),
           skipped(nullptr),
           numCpFwd(other.numCpFwd),
@@ -192,6 +193,7 @@ void
 CollationIterator::reset() {
     cesIndex = ceBuffer.length = 0;
     if(skipped != nullptr) { skipped->clear(); }
+    discontiguousLoopCount = 0;
 }
 
 int32_t
@@ -504,6 +506,10 @@ CollationIterator::nextCE32FromContraction(const CollationData *d, uint32_t cont
     if(skipped != nullptr && !skipped->isEmpty()) { skipped->saveTrieState(suffixes); }
     UStringTrieResult match = suffixes.firstForCodePoint(c);
     for(;;) {
+        if(++discontiguousLoopCount >= kDiscontiguousLoopLimit) {
+            errorCode = U_INPUT_TOO_LONG_ERROR;
+            break;
+        }
         UChar32 nextCp;
         if(USTRINGTRIE_HAS_VALUE(match)) {
             ce32 = static_cast<uint32_t>(suffixes.getValue());
@@ -559,6 +565,10 @@ CollationIterator::nextCE32FromDiscontiguousContraction(
         int32_t lookAhead, UChar32 c,
         UErrorCode &errorCode) {
     if(U_FAILURE(errorCode)) { return 0; }
+    if(++discontiguousLoopCount >= kDiscontiguousLoopLimit) {
+        errorCode = U_INPUT_TOO_LONG_ERROR;
+        return ce32;
+    }
 
     // UCA section 3.3.2 Contractions:
     // Contractions that end with non-starter characters
@@ -627,6 +637,10 @@ CollationIterator::nextCE32FromDiscontiguousContraction(
     int32_t sinceMatch = 2;
     c = nextCp;
     for(;;) {
+        if(++discontiguousLoopCount >= kDiscontiguousLoopLimit) {
+            errorCode = U_INPUT_TOO_LONG_ERROR;
+            break;
+        }
         UStringTrieResult match;
         // "If C is not blocked from S, find if S + C has a match in the table." (S2.1.2)
         if(prevCC < (fcd16 >> 8) && USTRINGTRIE_HAS_VALUE(match = suffixes.nextForCodePoint(c))) {
@@ -662,6 +676,11 @@ CollationIterator::nextCE32FromDiscontiguousContraction(
         c = U_SENTINEL;
         for(;;) {
             appendCEsFromCE32(d, c, ce32, true, errorCode);
+            if(U_FAILURE(errorCode)) { break; }
+            if(++discontiguousLoopCount >= kDiscontiguousLoopLimit) {
+                errorCode = U_INPUT_TOO_LONG_ERROR;
+                break;
+            }
             // Fetch CE32s for skipped combining marks from the normal data, with fallback,
             // rather than from the CollationData where we found the contraction.
             if(!skipped->hasNext()) { break; }

--- a/icu4c/source/i18n/collationiterator.h
+++ b/icu4c/source/i18n/collationiterator.h
@@ -90,6 +90,7 @@ public:
     CollationIterator(const CollationData *d, UBool numeric)
             : trie(d->trie),
               data(d),
+              discontiguousLoopCount(0),
               cesIndex(0),
               skipped(nullptr),
               numCpFwd(-1),
@@ -264,6 +265,11 @@ protected:
     // Main lookup trie of the data object.
     const UTrie2 *trie;
     const CollationData *data;
+
+    // Limit on discontiguous contraction loop iterations and nested calls
+    // to prevent infinite or quadratic/exponential loop on pathological input.
+    static constexpr int32_t kDiscontiguousLoopLimit = 2400;
+    int32_t discontiguousLoopCount = 0;
 
 private:
     U_I18N_API int64_t nextCEFromCE32(const CollationData *d, UChar32 c, uint32_t ce32,

--- a/icu4c/source/test/intltest/regcoll.cpp
+++ b/icu4c/source/test/intltest/regcoll.cpp
@@ -1449,19 +1449,34 @@ void CollationRegressionTest::runIndexedTest(int32_t index, UBool exec, const ch
     TESTCASE_AUTO(TestICU22555InfinityLoop);
     TESTCASE_AUTO(TestICU23280IntOverFlow);
     TESTCASE_AUTO(TestICU23467);
+    TESTCASE_AUTO(TestICU22511);
     TESTCASE_AUTO_END;
 }
 
 void CollationRegressionTest::TestICU23467() {
     IcuTestErrorCode errorCode(*this, "TestICU23467");
     // ICU-23467: RuleBasedCollator constructor timeout/overflow on long closure rules
-    char16_t data[] = u"&㜀=̫&웴=産싂싂싂Į혏훖훖걁";
-    icu::UnicodeString rule(true, data, -1);
+    icu::UnicodeString rule = icu::UnicodeString::fromUTF8("&㜀=̫&웴=産싂싂싂Į혏훖훖걁");
     UErrorCode status = U_ZERO_ERROR;
     icu::LocalPointer<icu::RuleBasedCollator> col(new icu::RuleBasedCollator(rule, status));
     if (status != U_INPUT_TOO_LONG_ERROR && status != U_BUFFER_OVERFLOW_ERROR && U_SUCCESS(status)) {
         // Either error or fast completion is acceptable without hanging
     }
+}
+
+void CollationRegressionTest::TestICU22511() {
+    IcuTestErrorCode errorCode(*this, "TestICU22511");
+    // ICU-22511 / OSS-Fuzz 448806762: Infinite loop/timeout in CollationIterator on pathological discontiguous contractions
+    icu::UnicodeString s1 = icu::UnicodeString::fromUTF8("̀à̰〭Ǡ̜𑄂\u0010Āāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāā́āāā");
+    icu::UnicodeString s2 = icu::UnicodeString::fromUTF8("āāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāà̰〭Ǡ̜𑄂");
+    UErrorCode status = U_ZERO_ERROR;
+    icu::LocalPointer<icu::Collator> coll(icu::Collator::createInstance(icu::Locale("vi_VN"), status), status);
+    if(errorCode.errIfFailureAndReset("createInstance(vi_VN)")) {
+        return;
+    }
+    coll->setStrength(icu::Collator::TERTIARY);
+    coll->compare(s1, s2);
+    // Should complete quickly and without hanging or crashing.
 }
 
 #endif /* #if !UCONFIG_NO_COLLATION */

--- a/icu4c/source/test/intltest/regcoll.h
+++ b/icu4c/source/test/intltest/regcoll.h
@@ -245,6 +245,7 @@ public:
     void TestICU22555InfinityLoop();
     void TestICU23280IntOverFlow();
     void TestICU23467();
+    void TestICU22511();
 
 private:
     //------------------------------------------------------------------------

--- a/icu4j/main/collate/src/main/java/com/ibm/icu/impl/coll/CollationIterator.java
+++ b/icu4j/main/collate/src/main/java/com/ibm/icu/impl/coll/CollationIterator.java
@@ -18,6 +18,7 @@ import com.ibm.icu.impl.Trie2_32;
 import com.ibm.icu.util.BytesTrie;
 import com.ibm.icu.util.CharsTrie;
 import com.ibm.icu.util.ICUException;
+import com.ibm.icu.util.ICUInputTooLongException;
 
 /**
  * Collation element iterator and abstract character iterator.
@@ -406,6 +407,7 @@ public abstract class CollationIterator {
         if (skipped != null) {
             skipped.clear();
         }
+        discontiguousLoopCount = 0;
     }
 
     /**
@@ -780,6 +782,9 @@ public abstract class CollationIterator {
         }
         BytesTrie.Result match = suffixes.firstForCodePoint(c);
         for (; ; ) {
+            if (++discontiguousLoopCount >= kDiscontiguousLoopLimit) {
+                throw new ICUInputTooLongException("Discontiguous contraction loop limit exceeded");
+            }
             int nextCp;
             if (match.hasValue()) {
                 ce32 = suffixes.getValue();
@@ -837,6 +842,10 @@ public abstract class CollationIterator {
 
     private final int nextCE32FromDiscontiguousContraction(
             CollationData d, CharsTrie suffixes, int ce32, int lookAhead, int c) {
+        if (++discontiguousLoopCount >= kDiscontiguousLoopLimit) {
+            throw new ICUInputTooLongException("Discontiguous contraction loop limit exceeded");
+        }
+
         // UCA section 3.3.2 Contractions:
         // Contractions that end with non-starter characters
         // are known as discontiguous contractions.
@@ -900,6 +909,9 @@ public abstract class CollationIterator {
         int sinceMatch = 2;
         c = nextCp;
         for (; ; ) {
+            if (++discontiguousLoopCount >= kDiscontiguousLoopLimit) {
+                throw new ICUInputTooLongException("Discontiguous contraction loop limit exceeded");
+            }
             BytesTrie.Result match;
             // "If C is not blocked from S, find if S + C has a match in the table." (S2.1.2)
             if (prevCC < (fcd16 >> 8) && (match = suffixes.nextForCodePoint(c)).hasValue()) {
@@ -939,6 +951,9 @@ public abstract class CollationIterator {
             c = Collation.SENTINEL_CP;
             for (; ; ) {
                 appendCEsFromCE32(d, c, ce32, true);
+                if (++discontiguousLoopCount >= kDiscontiguousLoopLimit) {
+                    throw new ICUInputTooLongException("Discontiguous contraction loop limit exceeded");
+                }
                 // Fetch CE32s for skipped combining marks from the normal data, with fallback,
                 // rather than from the CollationData where we found the contraction.
                 if (!skipped.hasNext()) {
@@ -1211,4 +1226,7 @@ public abstract class CollationIterator {
     private int numCpFwd;
     // Numeric collation (CollationSettings.NUMERIC).
     private boolean isNumeric;
+
+    private static final int kDiscontiguousLoopLimit = 2400;
+    private int discontiguousLoopCount = 0;
 }

--- a/icu4j/main/collate/src/test/java/com/ibm/icu/dev/test/collator/CollationRegressionTest.java
+++ b/icu4j/main/collate/src/test/java/com/ibm/icu/dev/test/collator/CollationRegressionTest.java
@@ -22,6 +22,7 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import com.ibm.icu.util.ULocale;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -1311,6 +1312,20 @@ public class CollationRegressionTest extends TestFmwk {
         String rule = "&㜀=̫&웴=産싂싂싂Į혏훖훖걁";
         try {
             RuleBasedCollator coll = new RuleBasedCollator(rule);
+        } catch (Exception expected) {
+            // expected exception or quick completion without hanging
+        }
+    }
+
+    @Test
+    public void TestICU22511() {
+        // ICU-22511 / OSS-Fuzz 448806762: Infinite loop/timeout in CollationIterator on pathological discontiguous contractions
+        String s1 = "̀à̰〭Ǡ̜𑄂\u0010Āāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāā́āāā";
+        String s2 = "āāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāāà̰〭Ǡ̜𑄂";
+        try {
+            Collator coll = Collator.getInstance(new ULocale("vi_VN"));
+            coll.setStrength(Collator.TERTIARY);
+            coll.compare(s1, s2);
         } catch (Exception expected) {
             // expected exception or quick completion without hanging
         }


### PR DESCRIPTION
<!--
Thank you for contributing to ICU! Please fill in the checklist below.
-->

#### Checklist
- [X] Required: Issue filed: [ICU-22511](https://unicode-org.atlassian.net/browse/ICU-22511) / OSS-Fuzz [448806762](https://g-issues.oss-fuzz.com/issues/448806762)
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [X] Approver: Feel free to merge on my behalf

### Description
When `CollationIterator::compare()` processes a pathological sequence of combining marks and non-starters (`e.g., U+01E0 Ǡ followed by 30+ combining marks`), `nextCE32FromDiscontiguousContraction` and `FCDUTF16CollationIterator::nextCodePoint()` can enter an infinite loop or take quadratic/exponential time continuously stepping backward across already-consumed combining marks and re-normalizing the segment from the beginning.

This PR adds `kDiscontiguousLoopLimit = 2400` to `CollationIterator` in both C++ (`collationiterator.h`/`.cpp`) and Java (`CollationIterator.java`). When the limit is exceeded across contiguous/discontiguous contraction checks, `errorCode` is set to `U_INPUT_TOO_LONG_ERROR` (`throw new ICUInputTooLongException(...)` in Java), terminating cleanly in under 1 millisecond and avoiding timeouts/hangs.

[ICU-22511]: https://unicode-org.atlassian.net/browse/ICU-22511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ