### PR TITLE
ICU-23454 Fix buffer overflow in ubidi_fuzzer and doWriteReverse with UBIDI_INTERNAL_RUNS_ONLY

### DIFF
--- a/icu4c/source/common/ubidiwrt.cpp
+++ b/icu4c/source/common/ubidiwrt.cpp
@@ -287,7 +287,8 @@ doWriteReverse(const char16_t *src, int32_t srcLength,
                 *pErrorCode=U_BUFFER_OVERFLOW_ERROR;
                 return i;
             }
-            destSize=i;
+            char16_t *saveDest=dest;
+            int32_t destLength=0;
             /* Loop backward across the source run segment by segment, using legacy 1-to-1 code unit stepping
              * to extract and reverse character clusters for internal setPara classification.
              */
@@ -305,22 +306,33 @@ doWriteReverse(const char16_t *src, int32_t srcLength,
                 if(options&UBIDI_REMOVE_BIDI_CONTROLS && IS_BIDI_CONTROL_CHAR(c)) {
                     continue;
                 }
+                int32_t origBaseLen=U16_LENGTH(c);
                 j=srcLength;
                 if(options&UBIDI_DO_MIRRORING) {
-                    int32_t k=0;
                     c=u_charMirror(c);
-                    U16_APPEND_UNSAFE(dest, k, c);
-                    dest+=k;
-                    j+=k;
+                    int32_t k=U16_LENGTH(c);
+                    if(destLength+k<=destSize) {
+                        int32_t temp=destLength;
+                        U16_APPEND_UNSAFE(saveDest, temp, c);
+                    }
+                    destLength+=k;
+                    j+=origBaseLen;
                 }
                 /* Loop forward from the current segment index to copy any unmirrored code units (such as combining marks
                  * or surrogate halves) into dest in forward visual order.
                  */
                 while(j<i) {
-                    *dest++=src[j++];
+                    if(destLength<destSize) {
+                        saveDest[destLength]=src[j];
+                    }
+                    destLength++;
+                    j++;
                 }
             } while(srcLength>0);
-            return destSize;
+            if(destSize<destLength) {
+                *pErrorCode=U_BUFFER_OVERFLOW_ERROR;
+            }
+            return destLength;
         }
         int32_t destLength=0;
         do {

--- a/icu4c/source/test/cintltst/cbiditst.c
+++ b/icu4c/source/test/cintltst/cbiditst.c
@@ -97,6 +97,7 @@ static void testUBidiWriteReorderedUndefinedShift(void);
 static void testUBidiWriteReorderedReverseMirrorCombining(void);
 static void testUBidiGetRunsBufferOverflow(void);
 static void testUBidiWriteReverseOverflow(void);
+static void testUBidiWriteReverseInternalRunsOnlyOverflow(void);
 
 /* new BIDI API */
 static void testReorderingMode(void);
@@ -151,6 +152,7 @@ addComplexTest(TestNode** root) {
     addTest(root, testUBidiWriteReorderedReverseMirrorCombining, "complex/bidi/writeReorderedReverseMirrorCombining");
     addTest(root, testUBidiGetRunsBufferOverflow, "complex/bidi/getRunsBufferOverflow");
     addTest(root, testUBidiWriteReverseOverflow, "complex/bidi/writeReverseOverflow");
+    addTest(root, testUBidiWriteReverseInternalRunsOnlyOverflow, "complex/bidi/writeReverseInternalRunsOnlyOverflow");
 
     addTest(root, doArabicShapingTest, "complex/arabic-shaping/ArabicShapingTest");
     addTest(root, doLamAlefSpecialVLTRArabicShapingTest, "complex/arabic-shaping/lamalef");
@@ -5169,3 +5171,34 @@ testUBidiWriteReverseOverflow(void) {
                 u_errorName(status), outLen);
     }
 }
+
+static void
+testUBidiWriteReverseInternalRunsOnlyOverflow(void) {
+    UErrorCode status = U_ZERO_ERROR;
+    static const UChar src[] = { 0x05D0, 0x221D, 0x05D1 };
+    int32_t srcLen = 3;
+    UChar dest[10];
+    /* 64 is UBIDI_INTERNAL_RUNS_ONLY from ubidiimp.h. When UBIDI_DO_MIRRORING causes expansion
+     * (U+221D expanding to U+1DB10, 2 code units), case UBIDI_INTERNAL_RUNS_ONLY must check destination
+     * capacity to avoid out-of-bounds writes into dest when destSize <= srcLen.
+     */
+    int32_t outLen = ubidi_writeReverse(src, srcLen, dest, 3,
+                                        UBIDI_DO_MIRRORING | 64 /* UBIDI_INTERNAL_RUNS_ONLY */,
+                                        &status);
+    if (status != U_BUFFER_OVERFLOW_ERROR || outLen != 4) {
+        log_err("testUBidiWriteReverseInternalRunsOnlyOverflow failed: expected U_BUFFER_OVERFLOW_ERROR and outLen=4, got %s and outLen=%d\n",
+                u_errorName(status), outLen);
+    }
+
+    status = U_ZERO_ERROR;
+    u_memset(dest, 0, 10);
+    outLen = ubidi_writeReverse(src, srcLen, dest, 10,
+                                UBIDI_DO_MIRRORING | 64 /* UBIDI_INTERNAL_RUNS_ONLY */,
+                                &status);
+    static const UChar expectedDest[] = { 0x05D1, 0xD836, 0xDF10, 0x05D0 };
+    if (U_FAILURE(status) || outLen != 4 || u_strncmp(dest, expectedDest, 4) != 0) {
+        log_err("testUBidiWriteReverseInternalRunsOnlyOverflow actual chars failed: status=%s, outLen=%d\n",
+                u_errorName(status), outLen);
+    }
+}
+

--- a/icu4c/source/test/fuzzer/ubidi_fuzzer.cpp
+++ b/icu4c/source/test/fuzzer/ubidi_fuzzer.cpp
@@ -149,7 +149,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
       if (checkVisual) {
         testVisual(bidi);
       } else {
-        ubidi_writeReordered(bidi, reorderedText, reorderedTextLength+1, options2, &status);
+        int32_t secondSize = reorderedTextLength + 1;
+        if (secondSize > MAXLEN) {
+          secondSize = MAXLEN;
+        }
+        ubidi_writeReordered(bidi, reorderedText, secondSize, options2, &status);
       }
     }
   }


### PR DESCRIPTION
<!--
Thank you for contributing to ICU! Please fill in the checklist below.
-->

#### Checklist
- [X] Required: Issue filed: [ICU-23454](https://unicode-org.atlassian.net/browse/ICU-23454) / OSS-Fuzz [534996860](https://g-issues.oss-fuzz.com/issues/534996860)
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [X] Approver: Feel free to merge on my behalf

### Description
This PR completes our fixes for OSS-Fuzz issue `#534996860` (`Invalid-enum-value in ubidi_fuzzer` / `Stack-buffer-overflow WRITE 2 doWriteReverse ubidi_writeReordered_79 ubidi_fuzzer.cpp`):

1. **In `ubidi_fuzzer.cpp`**: When `ubidi_writeReordered` is called for the second time (`checkVisual == false`), `reorderedTextLength + 1` was previously passed as the destination capacity without bounding it. If `reorderedTextLength >= MAXLEN` (`200`), passing `reorderedTextLength + 1` (`201` or more) told `ubidi_writeReordered` that the stack array `reorderedText[MAXLEN]` had 201+ capacity, overflowing 2 bytes (`WRITE 2`) right into adjacent stack memory (overwriting the `status` `UErrorCode` value right next to `reorderedText`, triggering UBSan load of invalid enum `538976288` / `0x20202020` in `u_terminateUChars`). We now cap `secondSize` to `MAXLEN` (`if (secondSize > MAXLEN) secondSize = MAXLEN;`).
2. **In `ubidiwrt.cpp` (`doWriteReverse`)**: Inside `case UBIDI_INTERNAL_RUNS_ONLY`, when `options & UBIDI_DO_MIRRORING` is set (or when mirroring changes code unit length), `U16_APPEND_UNSAFE` and `*dest++ = src[j++]` lacked destination capacity checks. We now check buffer capacity (`destLength + k <= destSize` and `destLength < destSize`) and track `destLength` accurately across all segments.

[ICU-23454]: https://unicode-org.atlassian.net/browse/ICU-23454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ