### PR TITLE
ICU-23471 Fix sanitizer check for state minimization in rbbitblb.cpp

### DIFF
--- a/icu4c/source/common/rbbitblb.cpp
+++ b/icu4c/source/common/rbbitblb.cpp
@@ -985,7 +985,7 @@ void RBBITableBuilder::minimizeStates() {
         return;
     }
 
-#if UPRV_HAS_FEATURE(address_sanitizer) || UPRV_HAS_FEATURE(undefined_behavior_sanitizer)
+#if UPRV_HAS_SANITIZER
     if (fDStates->size() > 512) {
         // This algorithm is sluggish on large state machines, and even more sluggish with
         // sanitizers, which leads the fuzzer into the weeds, see

--- a/icu4c/source/common/unicode/platform.h
+++ b/icu4c/source/common/unicode/platform.h
@@ -408,6 +408,17 @@
 #else
 #   define UPRV_HAS_FEATURE(x) 0
 #endif
+#if UPRV_HAS_FEATURE(address_sanitizer) || \
+    UPRV_HAS_FEATURE(memory_sanitizer) || \
+    UPRV_HAS_FEATURE(thread_sanitizer) || \
+    UPRV_HAS_FEATURE(undefined_sanitizer) || \
+    defined(__SANITIZE_ADDRESS__) || \
+    defined(__SANITIZE_THREAD__) || \
+    defined(__SANITIZE_UNDEFINED__)
+#   define UPRV_HAS_SANITIZER 1
+#else
+#   define UPRV_HAS_SANITIZER 0
+#endif
 #ifdef __has_extension
 #   define UPRV_HAS_EXTENSION(x) __has_extension(x)
 #else

--- a/icu4c/source/test/fuzzer/fuzzer_driver.cpp
+++ b/icu4c/source/test/fuzzer/fuzzer_driver.cpp
@@ -16,10 +16,7 @@ int main(int argc, char* argv[])
 {
     bool show_warning = true;
     bool show_error = true;
-#if UPRV_HAS_FEATURE(address_sanitizer)
-    show_warning = false;
-#endif
-#if UPRV_HAS_FEATURE(memory_sanitizer)
+#if UPRV_HAS_SANITIZER
     show_warning = false;
 #endif
     if (argc > 2 && strcmp(argv[2], "-q") == 0) {


### PR DESCRIPTION
Jira ticket: https://unicode-org.atlassian.net/browse/ICU-23471
OSS-Fuzz issue: 535572196 (https://g-issues.oss-fuzz.com/issues/535572196 / https://oss-fuzz.com/testcase?key=5980909850132480)

In `rbbitblb.cpp`, the state size check in `RBBITableBuilder::minimizeStates()` was guarded by `#if UPRV_HAS_FEATURE(address_sanitizer) || UPRV_HAS_FEATURE(undefined_behavior_sanitizer)`.
In Clang, `__has_feature` for UndefinedBehaviorSanitizer is named `undefined_sanitizer` (not `undefined_behavior_sanitizer`). Furthermore, MSan, TSan, and GCC/Clang sanitizer macros (`__SANITIZE_ADDRESS__`, `__SANITIZE_UNDEFINED__`, etc.) were not checked. As a result, UBSan fuzzer builds (`libfuzzer_ubsan_icu`) did not enable the state size threshold and timed out (> 60s) during DFA state minimization on inputs generating large state machines.

This PR:
1. Adds `UPRV_HAS_SANITIZER` in `unicode/platform.h` covering ASan, MSan, TSan, and UBSan across Clang, GCC, and MSVC.
2. Updates `rbbitblb.cpp` and `fuzzer_driver.cpp` to use `#if UPRV_HAS_SANITIZER`.

---

#### Checklist
- [X] Required: Issue filed: ICU-23471
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [X] Approver: Feel free to merge on my behalf