### PR TITLE
ICU-20570 Fix data race in initializeFCD via UInitOnce

### DIFF
--- a/icu4c/source/i18n/usearch.cpp
+++ b/icu4c/source/i18n/usearch.cpp
@@ -22,6 +22,7 @@
 #include "cmemory.h"
 #include "ucln_in.h"
 #include "uassert.h"
+#include "umutex.h"
 #include "ustr_imp.h"
 
 U_NAMESPACE_USE
@@ -33,6 +34,7 @@ U_NAMESPACE_USE
 #define SUPPLEMENTARY_MIN_VALUE_ 0x10000
 
 static const Normalizer2Impl *g_nfcImpl = nullptr;
+static UInitOnce gSearchNFCInitOnce {};
 
 // internal methods -------------------------------------------------
 
@@ -76,9 +78,15 @@ U_CDECL_BEGIN
 static UBool U_CALLCONV
 usearch_cleanup() {
     g_nfcImpl = nullptr;
+    gSearchNFCInitOnce.reset();
     return true;
 }
 U_CDECL_END
+
+static void U_CALLCONV initNFCImpl(UErrorCode *status) {
+    g_nfcImpl = Normalizer2Factory::getNFCImpl(*status);
+    ucln_i18n_registerCleanup(UCLN_I18N_USEARCH, usearch_cleanup);
+}
 
 /**
 * Initializing the fcd tables.
@@ -89,10 +97,7 @@ U_CDECL_END
 static
 inline void initializeFCD(UErrorCode *status)
 {
-    if (g_nfcImpl == nullptr) {
-        g_nfcImpl = Normalizer2Factory::getNFCImpl(*status);
-        ucln_i18n_registerCleanup(UCLN_I18N_USEARCH, usearch_cleanup);
-    }
+    umtx_initOnce(gSearchNFCInitOnce, &initNFCImpl, status);
 }
 
 /**

--- a/icu4c/source/test/intltest/tsmthred.cpp
+++ b/icu4c/source/test/intltest/tsmthred.cpp
@@ -28,6 +28,10 @@
 #include "sharedobject.h"
 #include "unifiedcache.h"
 #include "uassert.h"
+#if !UCONFIG_NO_COLLATION && !UCONFIG_NO_BREAK_ITERATION
+#include "unicode/stsearch.h"
+#include "unicode/uclean.h"
+#endif
 
 
 MultithreadTest::MultithreadTest()
@@ -79,6 +83,9 @@ void MultithreadTest::runIndexedTest( int32_t index, UBool exec,
     TESTCASE_AUTO(Test20104);
 #endif /* #if !UCONFIG_NO_FORMATTING */
 #endif /* #if !UCONFIG_NO_TRANSLITERATION */
+#if !UCONFIG_NO_COLLATION && !UCONFIG_NO_BREAK_ITERATION
+    TESTCASE_AUTO(TestInitializeFCD);
+#endif /* #if !UCONFIG_NO_COLLATION && !UCONFIG_NO_BREAK_ITERATION */
     TESTCASE_AUTO_END;
 }
 
@@ -1368,3 +1375,41 @@ void MultithreadTest::Test20104() {
 #endif /* !UCONFIG_NO_FORMATTING */
 
 #endif /* !UCONFIG_NO_TRANSLITERATION */
+
+#if !UCONFIG_NO_COLLATION && !UCONFIG_NO_BREAK_ITERATION
+// Verify that initializeFCD is thread safe by constructing the first StringSearch object
+// from multiple threads simultaneously.
+class TestInitializeFCDThread : public SimpleThread {
+public:
+    u_atomic_int32_t *fGate;
+    int32_t fNumThreads;
+
+    TestInitializeFCDThread() : fGate(nullptr), fNumThreads(0) {}
+    virtual void run() override {
+        // Wait until all threads are ready to call initializeFCD together.
+        umtx_atomic_inc(fGate);
+        while (umtx_loadAcquire(*fGate) < fNumThreads) {}
+        UErrorCode status = U_ZERO_ERROR;
+        UnicodeString pattern("a");
+        UnicodeString target("banana");
+        StringSearch search(pattern, target, Locale::getEnglish(), nullptr, status);
+    }
+};
+
+void MultithreadTest::TestInitializeFCD() {
+    // Force g_nfcImpl back to null so every thread must call initializeFCD.
+    u_cleanup();
+    static constexpr int32_t NUM_THREADS = 16;
+    u_atomic_int32_t gate{0};
+    TestInitializeFCDThread threads[NUM_THREADS];
+    for (auto &thread : threads) {
+        thread.fGate = &gate;
+        thread.fNumThreads = NUM_THREADS;
+        thread.start();
+    }
+    for (auto &thread : threads) {
+        thread.join();
+    }
+    // Note: failure is reported by ThreadSanitizer. Test body itself succeeds.
+}
+#endif /* !UCONFIG_NO_COLLATION && !UCONFIG_NO_BREAK_ITERATION */

--- a/icu4c/source/test/intltest/tsmthred.h
+++ b/icu4c/source/test/intltest/tsmthred.h
@@ -49,6 +49,9 @@ public:
     void TestBreakTranslit();
     void TestIncDec();
     void Test20104();
+#if !UCONFIG_NO_COLLATION && !UCONFIG_NO_BREAK_ITERATION
+    void TestInitializeFCD();
+#endif
 };
 
 #endif


### PR DESCRIPTION
If multiple threads try to use ICU for the first time in the process concurrently, ICU initialization will have a data race inside of `initializeFCD`. `UInitOnce` seems to be the [standard pattern used widely in ICU](https://github.com/unicode-org/icu/pull/631), so I am applying it here as well. Here is a standalone repro of the issue: https://godbolt.org/z/9PPK84KT7

<details><summary>Reproduction and Testing</summary>
I added a new unit test which reproduces the issue under TSAN:

```
Before fix:

mkdir -p ~/icu/build-tsan && cd ~/icu/build-tsan
../icu4c/source/configure \
  CC="$CLANG" CXX="$CLANGXX" \
  CPPFLAGS="-fsanitize=thread -g" CXXFLAGS="-std=c++17" LDFLAGS="-fsanitize=thread" \
  --enable-debug --disable-release
gmake -j$(nproc)
TSAN_OPTIONS="halt_on_error=0" LD_LIBRARY_PATH=lib:tools/ctestfw test/intltest/intltest utility/MultithreadTest/TestInitializeFCD
...
=== Handling test: utility/MultithreadTest/TestInitializeFCD: ===
   utility {
      MultithreadTest {
         TestInitializeFCD {
         } OK:   TestInitializeFCD  (257ms) 
      } OK:   MultithreadTest  (258ms) 
   } OK:   utility  (258ms)

After fix:

mkdir -p ~/icu/build-tsan && cd ~/icu/build-tsan
../icu4c/source/configure \
  CC="$CLANG" CXX="$CLANGXX" \
  CPPFLAGS="-fsanitize=thread -g" CXXFLAGS="-std=c++17" LDFLAGS="-fsanitize=thread" \
  --enable-debug --disable-release
gmake -j$(nproc)
TSAN_OPTIONS="halt_on_error=0" LD_LIBRARY_PATH=lib:tools/ctestfw test/intltest/intltest utility/MultithreadTest/TestInitializeFCD
...
=== Handling test: utility/MultithreadTest/TestInitializeFCD: ===
   utility {
      MultithreadTest {
         TestInitializeFCD {
==================
WARNING: ThreadSanitizer: data race (pid=2548260)
  Read of size 8 at 0xffffab2d2e78 by thread T16:
    #0 initializeFCD(UErrorCode*) /home/bhannel/icu/build-tsan/i18n/../../icu4c/source/i18n/usearch.cpp:92:9 (libicui18n.so.79+0x571608)
    #1 usearch_openFromCollator_79 /home/bhannel/icu/build-tsan/i18n/../../icu4c/source/i18n/usearch.cpp:593:9 (libicui18n.so.79+0x570f08)
    #2 usearch_open_79 /home/bhannel/icu/build-tsan/i18n/../../icu4c/source/i18n/usearch.cpp:544:35 (libicui18n.so.79+0x570cbc)
    #3 icu_79::StringSearch::StringSearch(icu_79::UnicodeString const&, icu_79::UnicodeString const&, icu_79::Locale const&, icu_79::BreakIterator*, UErrorCode&) /home/bhannel/icu/build-tsan/i18n/../../icu4c/source/i18n/stsearch.cpp:39:18 (libicui18n.so.79+0x4e1510)
    #4 TestInitializeFCDThread::run() /home/bhannel/icu/build-tsan/test/intltest/../../../icu4c/source/test/intltest/tsmthred.cpp:1398:22 (intltest+0x92ff28)
    #5 void std::__invoke_impl<void, void (SimpleThread::*)(), SimpleThread*>(std::__invoke_memfun_deref, void (SimpleThread::*&&)(), SimpleThread*&&) /opt/rh/devtoolset-10/root/usr/lib/gcc/aarch64-redhat-linux/10/../../../../include/c++/10/bits/invoke.h:73:14 (intltest+0xc1fdd4)
    #6 std::__invoke_result<void (SimpleThread::*)(), SimpleThread*>::type std::__invoke<void (SimpleThread::*)(), SimpleThread*>(void (SimpleThread::*&&)(), SimpleThread*&&) /opt/rh/devtoolset-10/root/usr/lib/gcc/aarch64-redhat-linux/10/../../../../include/c++/10/bits/invoke.h:95:14 (intltest+0xc1fc58)
    #7 void std::thread::_Invoker<std::tuple<void (SimpleThread::*)(), SimpleThread*>>::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) /opt/rh/devtoolset-10/root/usr/lib/gcc/aarch64-redhat-linux/10/../../../../include/c++/10/thread:264:13 (intltest+0xc1fbf0)
    #8 std::thread::_Invoker<std::tuple<void (SimpleThread::*)(), SimpleThread*>>::operator()() /opt/rh/devtoolset-10/root/usr/lib/gcc/aarch64-redhat-linux/10/../../../../include/c++/10/thread:271:11 (intltest+0xc1fb70)
    #9 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (SimpleThread::*)(), SimpleThread*>>>::_M_run() /opt/rh/devtoolset-10/root/usr/lib/gcc/aarch64-redhat-linux/10/../../../../include/c++/10/thread:215:13 (intltest+0xc1f954)
    #10 <null> <null> (libstdc++.so.6+0xd28f8) (BuildId: ce3c93e2f96852be40b95ff93f79d247e5e0b1b0)

  Previous write of size 8 at 0xffffab2d2e78 by thread T14:
    #0 initializeFCD(UErrorCode*) /home/bhannel/icu/build-tsan/i18n/../../icu4c/source/i18n/usearch.cpp:93:19 (libicui18n.so.79+0x57163c)
    #1 usearch_openFromCollator_79 /home/bhannel/icu/build-tsan/i18n/../../icu4c/source/i18n/usearch.cpp:593:9 (libicui18n.so.79+0x570f08)
    #2 usearch_open_79 /home/bhannel/icu/build-tsan/i18n/../../icu4c/source/i18n/usearch.cpp:544:35 (libicui18n.so.79+0x570cbc)
    #3 icu_79::StringSearch::StringSearch(icu_79::UnicodeString const&, icu_79::UnicodeString const&, icu_79::Locale const&, icu_79::BreakIterator*, UErrorCode&) /home/bhannel/icu/build-tsan/i18n/../../icu4c/source/i18n/stsearch.cpp:39:18 (libicui18n.so.79+0x4e1510)
    #4 TestInitializeFCDThread::run() /home/bhannel/icu/build-tsan/test/intltest/../../../icu4c/source/test/intltest/tsmthred.cpp:1398:22 (intltest+0x92ff28)
    #5 void std::__invoke_impl<void, void (SimpleThread::*)(), SimpleThread*>(std::__invoke_memfun_deref, void (SimpleThread::*&&)(), SimpleThread*&&) /opt/rh/devtoolset-10/root/usr/lib/gcc/aarch64-redhat-linux/10/../../../../include/c++/10/bits/invoke.h:73:14 (intltest+0xc1fdd4)
    #6 std::__invoke_result<void (SimpleThread::*)(), SimpleThread*>::type std::__invoke<void (SimpleThread::*)(), SimpleThread*>(void (SimpleThread::*&&)(), SimpleThread*&&) /opt/rh/devtoolset-10/root/usr/lib/gcc/aarch64-redhat-linux/10/../../../../include/c++/10/bits/invoke.h:95:14 (intltest+0xc1fc58)
    #7 void std::thread::_Invoker<std::tuple<void (SimpleThread::*)(), SimpleThread*>>::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) /opt/rh/devtoolset-10/root/usr/lib/gcc/aarch64-redhat-linux/10/../../../../include/c++/10/thread:264:13 (intltest+0xc1fbf0)
    #8 std::thread::_Invoker<std::tuple<void (SimpleThread::*)(), SimpleThread*>>::operator()() /opt/rh/devtoolset-10/root/usr/lib/gcc/aarch64-redhat-linux/10/../../../../include/c++/10/thread:271:11 (intltest+0xc1fb70)
    #9 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (SimpleThread::*)(), SimpleThread*>>>::_M_run() /opt/rh/devtoolset-10/root/usr/lib/gcc/aarch64-redhat-linux/10/../../../../include/c++/10/thread:215:13 (intltest+0xc1f954)
    #10 <null> <null> (libstdc++.so.6+0xd28f8) (BuildId: ce3c93e2f96852be40b95ff93f79d247e5e0b1b0)
```
</details>

#### Checklist
- [x] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-20570
  - This is a closely related, but not identical issue. I was unable to create a new issue in the ICU Jira workspace. Clicking the "Create" button does nothing - there is not even an error popup or console log.
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
