### PR TITLE
ICU-23378 A version of make_unique with a UErrorCode

### DIFF
--- a/icu4c/source/common/cmemory.h
+++ b/icu4c/source/common/cmemory.h
@@ -28,6 +28,7 @@
 
 #include "unicode/utypes.h"
 
+#include <limits.h>
 #include <stddef.h>
 #include <string.h>
 #include "unicode/localpointer.h"
@@ -171,7 +172,9 @@ uprv_deleteUObject(void *obj);
 
 #ifdef __cplusplus
 
+#include <memory>
 #include <utility>
+#include <type_traits>
 #include "unicode/uobject.h"
 
 U_NAMESPACE_BEGIN
@@ -889,6 +892,244 @@ public:
     }
 };
 
+namespace prv {
+
+#if U_OVERRIDE_CXX_ALLOCATION
+
+/**
+ * A deleter (as used by std::unique_ptr) that deallocates using `deallocate`.
+ * @internal
+ */
+template <typename T, void deallocate(void *), typename = void> class Deleter {
+  public:
+    Deleter() = default;
+    void operator()(T *const ptr) const {
+        if constexpr (!std::is_trivially_destructible_v<T>) {
+            ptr->~T();
+        }
+        deallocate(ptr);
+    }
+};
+
+/**
+ * A deleter (as used by std::unique_ptr) that deallocates using `deallocate`: specialization for
+ * arrays of trivially destructible objects, e.g., int32_t[].
+ * @internal
+ */
+template <typename T, void deallocate(void *)>
+class Deleter<T[], deallocate, std::enable_if_t<std::is_trivially_destructible_v<T>>> {
+  public:
+    Deleter() = default;
+    void operator()(T *const ptr) const { deallocate(ptr); }
+};
+
+/**
+ * A deleter (as used by std::unique_ptr) that deallocates using `deallocate`: specialization for
+ * arrays of nontrivially destructible objects, e.g., UnicodeString[].
+ * @internal
+ */
+template <typename T, void deallocate(void *)>
+class Deleter<T[], deallocate, std::enable_if_t<!std::is_trivially_destructible_v<T>>> {
+  public:
+    Deleter(const std::size_t size) : size_(size) {}
+    void operator()(T *const ptr) const {
+        for (std::ptrdiff_t i = static_cast<std::ptrdiff_t>(size_) - 1; i >= 0; --i) {
+            ptr[i]->~T();
+        }
+        deallocate(ptr);
+    }
+  private:
+    const std::size_t size_;
+};
+
+/**
+ * An std::unique_ptr that deallocates using uprv_free.
+ * @internal
+ */
+template <typename T> using unique_ptr = std::unique_ptr<T, Deleter<T, uprv_free>>;
+
+#else
+
+using std::unique_ptr;
+
+#endif
+
+/**
+ * Helper for make_unique<T, Args...>; forwards all but the last of args to the constructor of
+ * T, uses the last of args as the error code for allocation errors.
+ * @internal
+ */
+template <typename T, typename... Args, std::size_t... i>
+unique_ptr<T> make_unique_impl(std::tuple<Args...> args,
+                               std::index_sequence<i...> constructor_arg_indices) {
+    static_assert(std::is_same_v<decltype(constructor_arg_indices),
+                                 std::make_index_sequence<sizeof...(Args) - 1>>);
+#if U_OVERRIDE_CXX_ALLOCATION
+    auto &&error = std::get<sizeof...(Args) - 1>(args);
+    static_assert(std::is_same_v<decltype(error), UErrorCode &>);
+    void *const buffer = uprv_malloc(sizeof(T));
+    if (buffer == nullptr) {
+        error = U_MEMORY_ALLOCATION_ERROR;
+        return nullptr;
+    }
+    return unique_ptr<T>(new (buffer) T(std::get<i>(args)...));
+#else
+    return std::make_unique<T>(std::get<i>(args)...);
+#endif
+}
+
+/**
+ * A version of std::make_unique<T> that is compatible with ICU allocation error handling.
+ * If U_OVERRIDE_CXX_ALLOCATION, allocates using uprv_malloc, and sets a UErrorCode on failure.
+ * Otherwise, equivalent to std::make_unique<T>; the trailing UErrorCode& parameter is not used.
+ *   prv::make_unique<T>(Args... args, UErrorCode& status)
+ * corresponds to
+ *   std::make_unique<T>(Args... args)
+ * and
+ *   new T(Args... args).
+ *
+ * With empty args, this corresponds to new T(), and the allocated object is value-initialized; in
+ * particular, scalar types are zero-initialized; cf. make_unique_for_overwrite which
+ * corresponds to new T.
+ *
+ * @internal
+ */
+template <typename T, typename... Args, typename = std::enable_if_t<!std::is_array_v<T>>>
+unique_ptr<T> make_unique(Args &&...args) {
+    return make_unique_impl<T>(std::forward_as_tuple(args...),
+                               std::make_index_sequence<sizeof...(Args) - 1>());
+}
+
+/**
+ * A version of std::make_unique<T[]> that is compatible with ICU allocation error handling.
+ * If U_OVERRIDE_CXX_ALLOCATION, allocates using uprv_malloc, and sets a UErrorCode on failure.
+ * Otherwise, equivalent to std::make_unique<T[]>; the trailing UErrorCode& parameter is not used.
+ *   prv::make_unique<T[]>(std::size_t n, UErrorCode& status)
+ * corresponds to
+ *   std::make_unique<T[]>(std::size_t n)
+ * and
+ *   new T[std::size_t n]().
+ *
+ * The allocated objects are value-initialized; in particular, scalar types are zero-initialized;
+ * cf. make_unique_for_overwrite which corresponds to new T[n].
+ *
+ * @internal
+ */
+template <typename T,
+          // In C++20, this could require is_unbounded_array_v<T>.
+          typename = std::enable_if_t<std::is_same_v<std::remove_extent_t<T>[], T>>>
+unique_ptr<T> make_unique(const std::size_t n, [[maybe_unused]] UErrorCode &error) {
+#if U_OVERRIDE_CXX_ALLOCATION
+    // In C23/C++26, we could use ckd_mul.
+    constexpr std::size_t maxSize = SIZE_MAX / sizeof(std::remove_extent_t<T>);
+    if (n > maxSize) {
+        error = U_ILLEGAL_ARGUMENT_ERROR;
+        return nullptr;
+    }
+    void *const buffer = uprv_malloc(sizeof(std::remove_extent_t<T>) * n);
+    if (buffer == nullptr) {
+        error = U_MEMORY_ALLOCATION_ERROR;
+        if constexpr (std::is_trivially_destructible_v<std::remove_extent_t<T>>) {
+            return nullptr;
+        } else {
+            return unique_ptr<T>(nullptr, Deleter<T, uprv_free>(0));
+        }
+    }
+    if constexpr (std::is_trivially_destructible_v<std::remove_extent_t<T>>) {
+        return unique_ptr<T>(new (buffer) std::remove_extent_t<T>[n]());
+    } else {
+        return unique_ptr<T>(new (buffer) std::remove_extent_t<T>[n](), Deleter<T, uprv_free>(n));
+    }
+#else
+    return std::make_unique<T>(n);
+#endif
+}
+
+/**
+ * A version of std::make_unique_for_overwrite<T> that is compatible with ICU allocation error
+ * handling.
+ * If U_OVERRIDE_CXX_ALLOCATION, allocates using uprv_malloc, and sets a UErrorCode on failure.
+ * Otherwise, equivalent to std::make_unique_for_overwrite<T>; the trailing UErrorCode& parameter is
+ * not used.
+ *   prv::make_unique_for_overwrite<T>(UErrorCode& status)
+ * corresponds to
+ *   std::make_unique_for_overwrite<T>()
+ * and
+ *   new T.
+ *
+ * The allocated object is default-initialized.  For some types, e.g., scalar types, this means it
+ * has an indeterminate value, or an erroneous value since C++26 (in plain English, the memory is
+ * uninitialized).
+ *
+ * @internal
+ */
+template <typename T, typename = std::enable_if_t<!std::is_array_v<T>>>
+unique_ptr<T> make_unique_for_overwrite([[maybe_unused]] UErrorCode &error) {
+#if U_OVERRIDE_CXX_ALLOCATION
+    void *const buffer = uprv_malloc(sizeof(T));
+    if (buffer == nullptr) {
+        error = U_MEMORY_ALLOCATION_ERROR;
+        return nullptr;
+    }
+    return unique_ptr<T>(new (buffer) T);
+#elif U_CPLUSPLUS_VERSION >= 20
+    return std::make_unique_for_overwrite<T>();
+#else
+    return unique_ptr<T>(new T);
+#endif
+}
+
+/**
+ * A version of std::make_unique_for_overwrite<T[]> that is compatible with ICU allocation error
+ * handling.
+ * If U_OVERRIDE_CXX_ALLOCATION, allocates using uprv_malloc, and sets a UErrorCode on failure.
+ * Otherwise, equivalent to std::make_unique_for_overwrite<T[]>; the trailing UErrorCode& parameter
+ * is not used.
+ *   prv::make_unique_for_overwrite<T[]>(std::size_t n, UErrorCode& status)
+ * corresponds to
+ *   std::make_unique_for_overwrite<T[]>(std::size_t n)
+ * and
+ *   new T[std::size_t n].
+ *
+ * The allocated objects are default-initialized.  For some types, e.g., scalar types, this means
+ * they have indeterminate values, or erroneous values since C++26 (in plain English, the memory is
+ * uninitialized).
+ *
+ * @internal
+ */
+template <typename T,
+          // In C++20, this could require is_unbounded_array_v<T>.
+          typename = std::enable_if_t<std::is_same_v<std::remove_extent_t<T>[], T>>>
+unique_ptr<T> make_unique_for_overwrite(const std::size_t n, [[maybe_unused]] UErrorCode &error) {
+#if U_OVERRIDE_CXX_ALLOCATION
+    // In C23/C++26, we could use ckd_mul.
+    constexpr std::size_t maxSize = SIZE_MAX / sizeof(std::remove_extent_t<T>);
+    if (n > maxSize) {
+        error = U_ILLEGAL_ARGUMENT_ERROR;
+        return nullptr;
+    }
+    void *const buffer = uprv_malloc(sizeof(std::remove_extent_t<T>) * n);
+    if (buffer == nullptr) {
+        error = U_MEMORY_ALLOCATION_ERROR;
+        if constexpr (std::is_trivially_destructible_v<std::remove_extent_t<T>>) {
+            return nullptr;
+        } else {
+            return unique_ptr<T>(nullptr, Deleter<T, uprv_free>(0));
+        }
+    }
+    if constexpr (std::is_trivially_destructible_v<std::remove_extent_t<T>>) {
+        return unique_ptr<T>(new (buffer) std::remove_extent_t<T>[n]);
+    } else {
+        return unique_ptr<T>(new (buffer) std::remove_extent_t<T>[n], Deleter<T, uprv_free>(n));
+    }
+#elif U_CPLUSPLUS_VERSION >= 20
+    return std::make_unique_for_overwrite<T>(n);
+#else
+    return unique_ptr<T>(new std::remove_extent_t<T>[n]);
+#endif
+}
+
+}  // namespace prv
 
 U_NAMESPACE_END
 

--- a/icu4c/source/common/rbbitblb.cpp
+++ b/icu4c/source/common/rbbitblb.cpp
@@ -51,14 +51,7 @@ bool reachableByTransitions(const UVector &states, const int32_t source,
             }
         }
     }
-    // We cannot use LocalArray nor new[] because, on uint16_t, they would call the global new[] and
-    // delete[].
-    LocalMemory<bool> visited(static_cast<bool *>(uprv_malloc(sizeof(bool) * states.size())));
-    if (visited == nullptr) {
-      status = U_MEMORY_ALLOCATION_ERROR;
-      return false;
-    }
-    memset(visited.getAlias(), 0, sizeof(bool) * states.size());
+    const auto visited = prv::make_unique<bool[]>(states.size(), status);
     while (U_SUCCESS(status) && !boundary.empty()) {
         const int32_t s = boundary.popi();
         if (isSink(s)) {
@@ -1057,8 +1050,8 @@ void RBBITableBuilder::minimizeStates() {
                    fTagsIdx == other.fTagsIdx;
         }
     };
-    // We wrap `UVector`s in `LocalPointer`s throughout so we can move them,
-    // including into `UVector`s (by orphaning them from the `LocalPointer`
+    // We wrap `UVector`s in `unique_ptr``s throughout so we can move them,
+    // including into `UVector`s (by releasing them from the `unique_ptr`
     // and having the enclosing `UVector` adopt them). 
     // Group the states by types (but we have no maps so this is verbose).
     // If there are no lookaheads and no tags, there are only two types
@@ -1066,9 +1059,9 @@ void RBBITableBuilder::minimizeStates() {
     // of Algorithm 3.6.
     struct TypeToStates : UMemory {
         TypeToStates(const StateType &type, UErrorCode &status)
-            : type(type), states(new UVector(status), status) {}
+            : type(type), states(prv::make_unique<UVector>(status, status)) {}
         StateType type;
-        LocalPointer<UVector> states;
+        prv::unique_ptr<UVector> states;
     };
     UVector initialPartition(*fStatus);
     initialPartition.setDeleter(
@@ -1089,18 +1082,18 @@ void RBBITableBuilder::minimizeStates() {
             }
         }
         if (j == initialPartition.size()) {
-            auto newEntry = LocalPointer<TypeToStates>(new TypeToStates(type, *fStatus), *fStatus);
+            auto newEntry = prv::make_unique<TypeToStates>(type, *fStatus, *fStatus);
             if (U_FAILURE(*fStatus)) {
                 return;
             }
             newEntry->states->addElement(i, *fStatus);
-            initialPartition.adoptElement(newEntry.orphan(), *fStatus);
+            initialPartition.adoptElement(newEntry.release(), *fStatus);
         }
     }
     // The partition Π from Algorithm 3.6.
     // (We could call it Π, but some member companies that integrate the ICU
     // code base prohibit non-ASCII identifiers…).
-    LocalPointer<UVector> partition(new UVector(*fStatus), *fStatus);
+    auto partition = prv::make_unique<UVector>(*fStatus, *fStatus);
     if (U_FAILURE(*fStatus)) {
         return;
     }
@@ -1109,7 +1102,7 @@ void RBBITableBuilder::minimizeStates() {
     
     for (int32_t i = 0; i < initialPartition.size(); ++i) {
         partition->adoptElement(
-            static_cast<TypeToStates*>(initialPartition.elementAt(i))->states.orphan(),
+            static_cast<TypeToStates*>(initialPartition.elementAt(i))->states.release(),
             *fStatus);
     }
     // Given the index of a state 𝑠 in `fDStates`, returns a UVector of integers
@@ -1118,38 +1111,32 @@ void RBBITableBuilder::minimizeStates() {
     // We then have σ(𝑠) == σ(𝑡) if and only if “for all input symbols 𝑎, states
     // 𝑠 and 𝑡 have transitions on 𝑎 to states in the same group of Π” (which is
     // what defines the refinement of 𝐺 in Fig. 3.45).
-    auto partition_signature =
-        [&partition, this](int32_t stateIndex) -> LocalPointer<UVector> {
-            const RBBIStateDescriptor &state =
-                *static_cast<RBBIStateDescriptor*>(
-                    fDStates->elementAt(stateIndex));
-            LocalPointer<UVector> result(
-                new UVector(state.fDtran->size(), *fStatus), *fStatus);
-            if (U_FAILURE(*fStatus)) {
-                return LocalPointer<UVector>(nullptr);
-            }
-            for (int32_t i = 0; i < state.fDtran->size(); ++i) {
-                int32_t toState = state.fDtran->elementAti(i);
-                for (int32_t partIndex = 0;
-                     partIndex < partition->size();
-                     ++partIndex) {
-                    const UVector &part =
-                        *static_cast<UVector*>(partition->elementAt(partIndex));
-                    if (part.contains(toState)) {
-                        result->addElement(partIndex, *fStatus);
-                        break;
-                    }
+    auto partition_signature = [&partition, this](int32_t stateIndex) -> prv::unique_ptr<UVector> {
+        const RBBIStateDescriptor &state =
+            *static_cast<RBBIStateDescriptor *>(fDStates->elementAt(stateIndex));
+        auto result = prv::make_unique<UVector>(state.fDtran->size(), *fStatus, *fStatus);
+        if (U_FAILURE(*fStatus)) {
+            return nullptr;
+        }
+        for (int32_t i = 0; i < state.fDtran->size(); ++i) {
+            int32_t toState = state.fDtran->elementAti(i);
+            for (int32_t partIndex = 0; partIndex < partition->size(); ++partIndex) {
+                const UVector &part = *static_cast<UVector *>(partition->elementAt(partIndex));
+                if (part.contains(toState)) {
+                    result->addElement(partIndex, *fStatus);
+                    break;
                 }
             }
-            result->setComparer([](const UElement left, const UElement right) -> UBool {
-                return left.integer == right.integer;
-            });
-            return result;
-        };
+        }
+        result->setComparer([](const UElement left, const UElement right) -> UBool {
+            return left.integer == right.integer;
+        });
+        return result;
+    };
     // The loop between steps 2. and 3. of Algorithm 3.6.
     for (;;) {
         // Π_new.
-        LocalPointer<UVector> partitionNew(new UVector(*fStatus), *fStatus);
+        auto partitionNew = prv::make_unique<UVector>(*fStatus, *fStatus);
         if (U_FAILURE(*fStatus)) {
             return;
         }
@@ -1162,11 +1149,11 @@ void RBBITableBuilder::minimizeStates() {
             const UVector &group = *static_cast<UVector*>(partition->elementAt(i));
             // Partition 𝐺 based on the signature, see above.
             struct SignatureToStates : UMemory {
-                SignatureToStates(LocalPointer<UVector> signature, UErrorCode &status)
-                    : signature(std::move(signature)), states(new UVector(status), status) {
+                SignatureToStates(prv::unique_ptr<UVector> signature, UErrorCode &status)
+                    : signature(std::move(signature)), states(prv::make_unique<UVector>(status, status)) {
                 }
-                LocalPointer<UVector> signature;
-                LocalPointer<UVector> states;
+                prv::unique_ptr<UVector> signature;
+                prv::unique_ptr<UVector> states;
             };
             UVector groupRefinement(*fStatus);
             groupRefinement.setDeleter([](void *p) { delete static_cast<SignatureToStates*>(p); });
@@ -1201,7 +1188,7 @@ void RBBITableBuilder::minimizeStates() {
             for (int32_t j = 0; j < groupRefinement.size(); ++j) {
                 auto &[_, subgroup] = *static_cast<SignatureToStates*>(
                     groupRefinement.elementAt(j));
-                partitionNew->adoptElement(subgroup.orphan(), *fStatus);
+                partitionNew->adoptElement(subgroup.release(), *fStatus);
             }
         }
         if (refined) {
@@ -1233,12 +1220,8 @@ void RBBITableBuilder::minimizeStates() {
     if (U_FAILURE(*fStatus)) {
         return;
     }
-    // We cannot use LocalArray nor new[] because, on uint16_t, they would call
-    // the global new[] and delete[].
-    LocalMemory<uint16_t> oldStateToPart(static_cast<uint16_t*>(
-        uprv_malloc(sizeof(uint16_t) * fDStates->size())));
-    if (oldStateToPart == nullptr) {
-        *fStatus = U_MEMORY_ALLOCATION_ERROR;
+    auto oldStateToPart = prv::make_unique_for_overwrite<uint16_t[]>(fDStates->size(), *fStatus);
+    if (U_FAILURE(*fStatus)) {
         return;
     }
     for (int i = 0; i < partition->size(); ++i) {
@@ -1247,8 +1230,8 @@ void RBBITableBuilder::minimizeStates() {
             oldStateToPart[part.elementAti(j)] = i;
         }
     }
-    LocalPointer<UVector> oldStates(fDStates);
-    fDStates = LocalPointer<UVector>(new UVector(*fStatus), *fStatus).orphan();
+    auto const oldStates = prv::unique_ptr<UVector>(fDStates);
+    fDStates = prv::make_unique<UVector>(*fStatus, *fStatus).release();
     if (U_FAILURE(*fStatus)) {
         return;
     }
@@ -1589,15 +1572,11 @@ void RBBITableBuilder::minimizeLookaheads() {
         return *static_cast<RBBIStateDescriptor *>(fDStates->elementAt(state));
     };
 
-    // We cannot use LocalArray nor new[] because, on bool, they would call
-    // the global new[] and delete[].
-    const std::size_t lookaheadReachabilityBytes = sizeof(bool) * lookaheadCount * lookaheadCount;
-    LocalMemory<bool> lookaheadReachability(static_cast<bool *>(uprv_malloc(lookaheadReachabilityBytes)));
-    if (lookaheadReachability.isNull()) {
-        *fStatus = U_MEMORY_ALLOCATION_ERROR;
+    const auto lookaheadReachability =
+        prv::make_unique<bool[]>(lookaheadCount * lookaheadCount, *fStatus);
+    if (U_FAILURE(*fStatus)) {
         return;
     }
-    uprv_memset(lookaheadReachability.getAlias(), 0, lookaheadReachabilityBytes);
     for (int32_t l = firstLookahead; l <= fLASlotsInUse; ++l) {
         for (int32_t k = firstLookahead; k <= fLASlotsInUse; ++k) {
             if (k != l) {
@@ -1623,12 +1602,8 @@ void RBBITableBuilder::minimizeLookaheads() {
         }
     }
 
-    // We cannot use LocalArray nor new[] because, on int32_t, they would call
-    // the global new[] and delete[].
-    const std::size_t coloursBytes = sizeof(int32_t) * lookaheadCount;
-    LocalMemory<int32_t> colours(static_cast<int32_t *>(uprv_malloc(coloursBytes)));
-    if (colours.isNull()) {
-        *fStatus = U_MEMORY_ALLOCATION_ERROR;
+    const auto colours = prv::make_unique_for_overwrite<int32_t[]>(lookaheadCount, *fStatus);
+    if (U_FAILURE(*fStatus)) {
         return;
     }
     // Brute-force colouring: the number of lookaheads is in practice small, and the chromatic
@@ -1638,7 +1613,7 @@ void RBBITableBuilder::minimizeLookaheads() {
     // The outer loop terminates after at most `lookaheadCount` iterations
     // (when the chromatic number equals the number of lookaheads being coloured).
     for (int32_t chromaticNumber = 1;; ++chromaticNumber) {
-        uprv_memset(colours.getAlias(), 0, coloursBytes);
+        uprv_memset(colours.get(), 0, sizeof(int32_t) * lookaheadCount);
         // This loop terminates after at most chromaticNumber ** lookaheadCount iterations.
         for (;;) {
             // Here `source` and `sink` correspond to lookaheads, not states.


### PR DESCRIPTION
With this, we should be able to replace any non-API usages of `LocalPointer<T>` (constructed wrapping `new`), `LocalArray<T>` (constructed wrapping `new`), and `LocalMemory<T>` (constructed wrapping uprv_malloc followed by a null check) with `prv::unique_ptr<T>` and `prv::unique_ptr<T[]>`, created with `prv::make_unique<T>` and `prv::make_unique<T[]>`, or, in the `LocalMemory` case when no `memset` to 0 follows, with `prv::make_unique_for_overwrite<T[]>`.

#### Checklist
- [x] Required: Issue filed: ICU-23378 
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
