### PR TITLE
ICU-23247 Fewer warnings when generating icu4j

### DIFF
--- a/icu4j/main/icu4j/pom.xml
+++ b/icu4j/main/icu4j/pom.xml
@@ -73,20 +73,12 @@
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
-            <id>source-jar</id>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <createSourcesJar>true</createSourcesJar>
-            </configuration>
-          </execution>
-          <execution>
             <goals>
               <goal>shade</goal>
             </goals>
             <phase>package</phase>
             <configuration>
+              <createSourcesJar>true</createSourcesJar>
               <createDependencyReducedPom>true</createDependencyReducedPom>
               <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
               <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
@@ -97,6 +89,8 @@
                   <excludes>
                     <!-- Exclude taglets code -->
                     <exclude>com/ibm/icu/dev/tool/docs/**</exclude>
+                    <!-- We exclude the manifests in dependencies -->
+                    <exclude>META-INF/MANIFEST.MF</exclude>
                     <!-- Exclude maven info for unpublished artifacts -->
                     <exclude>META-INF/maven/com.ibm.icu/core/**</exclude>
                     <exclude>META-INF/maven/com.ibm.icu/tools_taglets/**</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
     <mf.Specification-Version>${icu.major.version}</mf.Specification-Version>
     <mf.Implementation-Version>${project.version}</mf.Implementation-Version>
     <mf.Bundle-Version>${project.version}</mf.Bundle-Version>
-    <mf.Bundle-RequiredExecutionEnvironment>JavaSE-1.8</mf.Bundle-RequiredExecutionEnvironment>
+    <mf.Bundle-RequiredExecutionEnvironment>JavaSE-${maven.compiler.release}</mf.Bundle-RequiredExecutionEnvironment>
 
     <!-- For most modules artifactId does not have an "icu4j" prefix, so this is a good default -->
     <module-name>${project.artifactId}</module-name>


### PR DESCRIPTION
I've built (`mvn clean package`) before and after this change with the following profiles activated:

* none
* `-P with_sources`
* `-P with_javadoc`
* `-P with_sources,with_javadoc`
* `-P with_full_javadoc`

Then I extracted the content of the generated jars and compared the results before / after.

They results are (almost) identical.

There are some differences in the `sources.jar`, but they are good differences.
This can be seen in the released `icu4j-78.3-sources.jar`

1. The "before" source jar contains `pom.xml` and `pom.properties` for all the artifacts:
(for example META-INF/maven/com.ibm.icu/translit/)
This was actually a bug fixed in the "executable" jar, but not in sources (see ICU-23258)

2. The "before" source jar contains the sources of the javadoc taglet. Which is not "icu proper" (in com/ibm/icu/dev/tool/docs/)

3. The "before" source jar `META-INF/MANIFEST.MF` is "bare-bone". No bundle name, copyright, version, vendor, etc.

4. Fix for all jars: `Bundle-RequiredExecutionEnvironment: JavaSE-1.8`, changed to use 11 same as the compiler, using a property (so we don't forget it next time)

#### Checklist
- [x] Required: Issue filed: ICU-23247
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf
