### PR TITLE
Use uprv_calloc for array allocations to prevent integer overflow

### DIFF
--- a/icu4c/source/common/localematcher.cpp
+++ b/icu4c/source/common/localematcher.cpp
@@ -372,7 +372,7 @@ LocaleMatcher::LocaleMatcher(const Builder &builder, UErrorCode &errorCode) :
         // so that when different types are used (e.g., language tag strings)
         // we can return those by parallel index.
         supportedLocales = static_cast<const Locale **>(
-            uprv_malloc(supportedLocalesLength * sizeof(const Locale *)));
+            uprv_calloc(supportedLocalesLength, sizeof(const Locale *)));
         // Supported LRSs in input order.
         // In C++, we store these permanently to simplify ownership management
         // in the hash tables. Duplicate LSRs (if any) are unused overhead.
@@ -406,9 +406,9 @@ LocaleMatcher::LocaleMatcher(const Builder &builder, UErrorCode &errorCode) :
                                              supportedLocalesLength, &errorCode);
         if (U_FAILURE(errorCode)) { return; }
         supportedLSRs = static_cast<const LSR **>(
-            uprv_malloc(supportedLocalesLength * sizeof(const LSR *)));
+            uprv_calloc(supportedLocalesLength, sizeof(const LSR *)));
         supportedIndexes = static_cast<int32_t *>(
-            uprv_malloc(supportedLocalesLength * sizeof(int32_t)));
+            uprv_calloc(supportedLocalesLength, sizeof(int32_t)));
         if (supportedLSRs == nullptr || supportedIndexes == nullptr) {
             errorCode = U_MEMORY_ALLOCATION_ERROR;
             return;

--- a/icu4c/source/common/loclikelysubtags.cpp
+++ b/icu4c/source/common/loclikelysubtags.cpp
@@ -201,7 +201,7 @@ struct LikelySubtagsData {
 
         if (partitionsLength > 0) {
             distanceData.partitions = static_cast<const char **>(
-                uprv_malloc(partitionsLength * sizeof(const char *)));
+                uprv_calloc(partitionsLength, sizeof(const char *)));
             if (distanceData.partitions == nullptr) {
                 errorCode = U_MEMORY_ALLOCATION_ERROR;
                 return;

--- a/icu4c/source/common/rbbi.cpp
+++ b/icu4c/source/common/rbbi.cpp
@@ -73,7 +73,7 @@ RuleBasedBreakIterator::RuleBasedBreakIterator(RBBIDataHeader* data, UErrorCode 
     }
     if (fData->fForwardTable->fLookAheadResultsSize > 0) {
         fLookAheadMatches = static_cast<int32_t *>(
-            uprv_malloc(fData->fForwardTable->fLookAheadResultsSize * sizeof(int32_t)));
+            uprv_calloc(fData->fForwardTable->fLookAheadResultsSize, sizeof(int32_t)));
         if (fLookAheadMatches == nullptr) {
             status = U_MEMORY_ALLOCATION_ERROR;
             return;
@@ -123,7 +123,7 @@ RuleBasedBreakIterator::RuleBasedBreakIterator(const uint8_t *compiledRules,
     }
     if (fData->fForwardTable->fLookAheadResultsSize > 0) {
         fLookAheadMatches = static_cast<int32_t *>(
-            uprv_malloc(fData->fForwardTable->fLookAheadResultsSize * sizeof(int32_t)));
+            uprv_calloc(fData->fForwardTable->fLookAheadResultsSize, sizeof(int32_t)));
         if (fLookAheadMatches == nullptr) {
             status = U_MEMORY_ALLOCATION_ERROR;
             return;
@@ -149,7 +149,7 @@ RuleBasedBreakIterator::RuleBasedBreakIterator(UDataMemory* udm, UErrorCode &sta
     }
     if (fData->fForwardTable->fLookAheadResultsSize > 0) {
         fLookAheadMatches = static_cast<int32_t *>(
-            uprv_malloc(fData->fForwardTable->fLookAheadResultsSize * sizeof(int32_t)));
+            uprv_calloc(fData->fForwardTable->fLookAheadResultsSize, sizeof(int32_t)));
         if (fLookAheadMatches == nullptr) {
             status = U_MEMORY_ALLOCATION_ERROR;
             return;
@@ -319,7 +319,7 @@ RuleBasedBreakIterator::operator=(const RuleBasedBreakIterator& that) {
     fLookAheadMatches = nullptr;
     if (fData && fData->fForwardTable->fLookAheadResultsSize > 0) {
         fLookAheadMatches = static_cast<int32_t *>(
-            uprv_malloc(fData->fForwardTable->fLookAheadResultsSize * sizeof(int32_t)));
+            uprv_calloc(fData->fForwardTable->fLookAheadResultsSize, sizeof(int32_t)));
     }
 
 

--- a/icu4c/source/common/ucnvsel.cpp
+++ b/icu4c/source/common/ucnvsel.cpp
@@ -175,7 +175,7 @@ ucnvsel_open(const char* const*  converterList, int32_t converterListSize,
     converterListSize = ucnv_countAvailable();
   }
   newSelector->encodings =
-    (char**)uprv_malloc(converterListSize * sizeof(char*));
+    (char**)uprv_calloc(converterListSize, sizeof(char*));
   if (!newSelector->encodings) {
     *status = U_MEMORY_ALLOCATION_ERROR;
     return nullptr;
@@ -716,7 +716,7 @@ static UEnumeration *selectForMask(const UConverterSelector* sel,
   int16_t numOnes = countOnes(mask.getAlias(), columns);
   // now, we know the exact space we need for index
   if (numOnes > 0) {
-    result->index = static_cast<int16_t*>(uprv_malloc(numOnes * sizeof(int16_t)));
+    result->index = static_cast<int16_t*>(uprv_calloc(numOnes, sizeof(int16_t)));
     if (result->index == nullptr) {
       *status = U_MEMORY_ALLOCATION_ERROR;
       return nullptr;

--- a/icu4c/source/common/uidna.cpp
+++ b/icu4c/source/common/uidna.cpp
@@ -228,7 +228,7 @@ _internal_toASCII(const char16_t* src, int32_t srcLength,
     }
     
     if(srcLength > b1Capacity){
-        b1 = static_cast<char16_t*>(uprv_malloc(srcLength * U_SIZEOF_UCHAR));
+        b1 = static_cast<char16_t*>(uprv_calloc(srcLength, U_SIZEOF_UCHAR));
         if(b1==nullptr){
             *status = U_MEMORY_ALLOCATION_ERROR;
             goto CLEANUP;
@@ -257,7 +257,7 @@ _internal_toASCII(const char16_t* src, int32_t srcLength,
             if(b1 != b1Stack){
                 uprv_free(b1);
             }
-            b1 = static_cast<char16_t*>(uprv_malloc(b1Len * U_SIZEOF_UCHAR));
+            b1 = static_cast<char16_t*>(uprv_calloc(b1Len, U_SIZEOF_UCHAR));
             if(b1==nullptr){
                 *status = U_MEMORY_ALLOCATION_ERROR;
                 goto CLEANUP;
@@ -343,7 +343,7 @@ _internal_toASCII(const char16_t* src, int32_t srcLength,
             if(bufferStatus == U_BUFFER_OVERFLOW_ERROR){
                 // redo processing of string
                 /* we do not have enough room so grow the buffer*/
-                b2 = static_cast<char16_t*>(uprv_malloc(b2Len * U_SIZEOF_UCHAR));
+                b2 = static_cast<char16_t*>(uprv_calloc(b2Len, U_SIZEOF_UCHAR));
                 if(b2 == nullptr){
                     *status = U_MEMORY_ALLOCATION_ERROR;
                     goto CLEANUP;
@@ -465,7 +465,7 @@ _internal_toUnicode(const char16_t* src, int32_t srcLength,
         if(bufferStatus == U_BUFFER_OVERFLOW_ERROR){
             // redo processing of string
             /* we do not have enough room so grow the buffer*/
-            b1 = static_cast<char16_t*>(uprv_malloc(b1Len * U_SIZEOF_UCHAR));
+            b1 = static_cast<char16_t*>(uprv_calloc(b1Len, U_SIZEOF_UCHAR));
             if(b1==nullptr){
                 *status = U_MEMORY_ALLOCATION_ERROR;
                 goto CLEANUP;
@@ -507,7 +507,7 @@ _internal_toUnicode(const char16_t* src, int32_t srcLength,
         if(bufferStatus == U_BUFFER_OVERFLOW_ERROR){
             // redo processing of string
             /* we do not have enough room so grow the buffer*/
-            b2 = static_cast<char16_t*>(uprv_malloc(b2Len * U_SIZEOF_UCHAR));
+            b2 = static_cast<char16_t*>(uprv_calloc(b2Len, U_SIZEOF_UCHAR));
             if(b2==nullptr){
                 *status = U_MEMORY_ALLOCATION_ERROR;
                 goto CLEANUP;
@@ -525,7 +525,7 @@ _internal_toUnicode(const char16_t* src, int32_t srcLength,
         if(bufferStatus == U_BUFFER_OVERFLOW_ERROR){
             // redo processing of string
             /* we do not have enough room so grow the buffer*/
-            b3 = static_cast<char16_t*>(uprv_malloc(b3Len * U_SIZEOF_UCHAR));
+            b3 = static_cast<char16_t*>(uprv_calloc(b3Len, U_SIZEOF_UCHAR));
             if(b3==nullptr){
                 *status = U_MEMORY_ALLOCATION_ERROR;
                 goto CLEANUP;
@@ -888,7 +888,7 @@ uidna_compare(  const char16_t *s1, int32_t length1,
     b1Len = uidna_IDNToASCII(s1, length1, b1, b1Capacity, options, &parseError, &bufferStatus);
     if(bufferStatus == U_BUFFER_OVERFLOW_ERROR){
         // redo processing of string
-        b1 = (char16_t*) uprv_malloc(b1Len * U_SIZEOF_UCHAR);
+        b1 = (char16_t*) uprv_calloc(b1Len, U_SIZEOF_UCHAR);
         if(b1==nullptr){
             *status = U_MEMORY_ALLOCATION_ERROR;
             goto CLEANUP;
@@ -902,7 +902,7 @@ uidna_compare(  const char16_t *s1, int32_t length1,
     b2Len = uidna_IDNToASCII(s2,length2, b2,b2Capacity, options, &parseError, &bufferStatus);
     if(bufferStatus == U_BUFFER_OVERFLOW_ERROR){
         // redo processing of string
-        b2 = (char16_t*) uprv_malloc(b2Len * U_SIZEOF_UCHAR);
+        b2 = (char16_t*) uprv_calloc(b2Len, U_SIZEOF_UCHAR);
         if(b2==nullptr){
             *status = U_MEMORY_ALLOCATION_ERROR;
             goto CLEANUP;

--- a/icu4c/source/common/uniset.cpp
+++ b/icu4c/source/common/uniset.cpp
@@ -1644,7 +1644,7 @@ bool UnicodeSet::ensureCapacity(int32_t newLen) {
         return true;
     }
     int32_t newCapacity = nextCapacity(newLen);
-    UChar32* temp = static_cast<UChar32*>(uprv_malloc(newCapacity * sizeof(UChar32)));
+    UChar32* temp = static_cast<UChar32*>(uprv_calloc(newCapacity, sizeof(UChar32)));
     if (temp == nullptr) {
         setToBogus(); // set the object to bogus state if an OOM failure occurred.
         return false;
@@ -1667,7 +1667,7 @@ bool UnicodeSet::ensureBufferCapacity(int32_t newLen) {
         return true;
     }
     int32_t newCapacity = nextCapacity(newLen);
-    UChar32* temp = static_cast<UChar32*>(uprv_malloc(newCapacity * sizeof(UChar32)));
+    UChar32* temp = static_cast<UChar32*>(uprv_calloc(newCapacity, sizeof(UChar32)));
     if (temp == nullptr) {
         setToBogus();
         return false;

--- a/icu4c/source/common/ustr_wcs.cpp
+++ b/icu4c/source/common/ustr_wcs.cpp
@@ -41,7 +41,7 @@ u_growAnyBufferFromStatic(void *context,
                        int32_t length, int32_t size) {
     // Use char* not void* to avoid the compiler's strict-aliasing assumptions
     // and related warnings.
-    char *newBuffer=(char *)uprv_malloc(reqCapacity*size);
+    char *newBuffer=(char *)uprv_calloc(reqCapacity, size);
     if(newBuffer!=nullptr) {
         if(length>0) {
             uprv_memcpy(newBuffer, *pBuffer, (size_t)length*size);
@@ -146,7 +146,7 @@ _strToWCS(wchar_t *dest,
      * no more than 2 wchar_ts
      */
     intTargetCapacity =  (count * _BUFFER_CAPACITY_MULTIPLIER + 1) /*for null termination */;
-    intTarget = (wchar_t*)uprv_malloc( intTargetCapacity * sizeof(wchar_t) );
+    intTarget = (wchar_t*)uprv_calloc( intTargetCapacity, sizeof(wchar_t) );
 
     if(intTarget){
 

--- a/icu4c/source/i18n/timezone.cpp
+++ b/icu4c/source/i18n/timezone.cpp
@@ -630,7 +630,7 @@ static void U_CALLCONV initMap(USystemTimeZoneType type, UErrorCode& ec) {
     res = ures_getByKey(res, kNAMES, res, &ec); // dereference Zones section
     if (U_SUCCESS(ec)) {
         int32_t size = ures_getSize(res);
-        int32_t* m = static_cast<int32_t*>(uprv_malloc(size * sizeof(int32_t)));
+        int32_t* m = static_cast<int32_t*>(uprv_calloc(size, sizeof(int32_t)));
         if (m == nullptr) {
             ec = U_MEMORY_ALLOCATION_ERROR;
         } else {
@@ -845,7 +845,7 @@ public:
 
         if (region != nullptr || rawOffset != nullptr) {
             int32_t filteredMapSize = DEFAULT_FILTERED_MAP_SIZE;
-            filteredMap = static_cast<int32_t*>(uprv_malloc(filteredMapSize * sizeof(int32_t)));
+            filteredMap = static_cast<int32_t*>(uprv_calloc(filteredMapSize, sizeof(int32_t)));
             if (filteredMap == nullptr) {
                 ec = U_MEMORY_ALLOCATION_ERROR;
                 return nullptr;
@@ -932,7 +932,7 @@ public:
 
     TZEnumeration(const TZEnumeration &other) : StringEnumeration(), map(nullptr), localMap(nullptr), len(0), pos(0) {
         if (other.localMap != nullptr) {
-            localMap = static_cast<int32_t*>(uprv_malloc(other.len * sizeof(int32_t)));
+            localMap = static_cast<int32_t*>(uprv_calloc(other.len, sizeof(int32_t)));
             if (localMap != nullptr) {
                 len = other.len;
                 uprv_memcpy(localMap, other.localMap, len * sizeof(int32_t));


### PR DESCRIPTION
Replace `uprv_malloc(count * sizeof(T))` with `uprv_calloc(count, sizeof(T))` in array allocation sites across ICU4C common and i18n libraries.

Unlike `uprv_malloc`, `uprv_calloc` checks for integer overflow in the `count * size` computation and returns `NULL` instead of allocating an undersized buffer when the product would wrap around (CWE-190 → CWE-122).

### Changed files

| File | Sites | Description |
|------|-------|-------------|
| `uidna.cpp` | 8 | IDNA domain name processing buffers |
| `rbbi.cpp` | 4 | Rule-based break iterator lookahead tables |
| `localematcher.cpp` | 3 | Locale matching arrays |
| `timezone.cpp` | 3 | Timezone enumeration maps |
| `uniset.cpp` | 2 | Unicode set capacity growth |
| `ucnvsel.cpp` | 2 | Converter selector arrays |
| `ustr_wcs.cpp` | 2 | Wide character string buffer growth |
| `loclikelysubtags.cpp` | 1 | Locale subtag partition data |

All 25 sites are mechanical conversions with identical error handling. The zero-initialization from `uprv_calloc` is harmless since all buffers are immediately filled after allocation.