### PR TITLE
ICU-21870 Replace Java finalizer with Cleaner in collation shared object

### DIFF
--- a/icu4j/main/collate/src/main/java/com/ibm/icu/impl/coll/CollationTailoring.java
+++ b/icu4j/main/collate/src/main/java/com/ibm/icu/impl/coll/CollationTailoring.java
@@ -34,9 +34,9 @@ public final class CollationTailoring {
             assert (baseSettings.readOnly().reorderCodes.length == 0);
             assert (baseSettings.readOnly().reorderTable == null);
             assert (baseSettings.readOnly().minHighNoReorder == 0);
-            settings = baseSettings.clone();
+            settings = new SharedObject.Reference<>(baseSettings);
         } else {
-            settings = new SharedObject.Reference<CollationSettings>(new CollationSettings());
+            settings = new SharedObject.Reference<>(new CollationSettings());
         }
     }
 

--- a/icu4j/main/collate/src/main/java/com/ibm/icu/impl/coll/SharedObject.java
+++ b/icu4j/main/collate/src/main/java/com/ibm/icu/impl/coll/SharedObject.java
@@ -14,6 +14,7 @@
 package com.ibm.icu.impl.coll;
 
 import com.ibm.icu.util.ICUCloneNotSupportedException;
+import java.lang.ref.Cleaner;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -31,56 +32,20 @@ import java.util.concurrent.atomic.AtomicInteger;
  *     public clone() { ... }
  * }
  *
- * // Either use the nest class Reference (which costs an extra allocation),
- * // or duplicate its code in the class that uses S
- * // (which duplicates code and is more error-prone).
+ * // Use the nest class Reference (which costs an extra allocation),
  * class U {
  *     // For read-only access, use s.readOnly().
  *     // For writable access, use S ownedS = s.copyOnWrite();
  *     private SharedObject.Reference&lt;S&gt; s;
+ *     public U(Reference&lt;U&gt; ref) {
+ *         ...
+ *     }
  *     // Returns a writable version of s.
  *     // If there is exactly one owner, then s itself is returned.
  *     // If there are multiple owners, then s is replaced with a clone,
  *     // and that is returned.
  *     private S getOwnedS() {
  *         return s.copyOnWrite();
- *     }
- *     public U clone() {
- *         ...
- *         c.s = s.clone();
- *         ...
- *     }
- * }
- *
- * class V {
- *     // For read-only access, use s directly.
- *     // For writable access, use S ownedS = getOwnedS();
- *     private S s;
- *     // Returns a writable version of s.
- *     // If there is exactly one owner, then s itself is returned.
- *     // If there are multiple owners, then s is replaced with a clone,
- *     // and that is returned.
- *     private S getOwnedS() {
- *         if(s.getRefCount() > 1) {
- *             S ownedS = s.clone();
- *             s.removeRef();
- *             s = ownedS;
- *             ownedS.addRef();
- *         }
- *         return s;
- *     }
- *     public U clone() {
- *         ...
- *         s.addRef();
- *         ...
- *     }
- *     protected void finalize() {
- *         ...
- *         if(s != null) {
- *             s.removeRef();
- *             s = null;
- *         }
- *         ...
  *     }
  * }
  * </pre>
@@ -92,66 +57,94 @@ import java.util.concurrent.atomic.AtomicInteger;
  * model.
  */
 public class SharedObject implements Cloneable {
-    /** Similar to a smart pointer, basically a port of the static methods of C++ SharedObject. */
-    public static final class Reference<T extends SharedObject> implements Cloneable {
-        private T ref;
+    /**
+     * A class wrapping SharedObject. We need a final field in Reference class to access a
+     * SharedObject. This class implements Runnable interface which will be used for clean up a
+     * SharedObject with no references.
+     */
+    private static final class SharedObjectHolder<T extends SharedObject> implements Runnable {
+        private T sharedObj;
 
-        public Reference(T r) {
-            ref = r;
-            if (r != null) {
-                r.addRef();
-            }
+        SharedObjectHolder(T so) {
+            this.sharedObj = so;
         }
 
-        @SuppressWarnings("unchecked")
+        void set(T otherSo) {
+            this.sharedObj = otherSo;
+        }
+
+        T get() {
+            return sharedObj;
+        }
+
+        /*
+         * This method is triggered by the Cleaner in Reference class below.
+         */
         @Override
-        public Reference<T> clone() {
-            Reference<T> c;
-            try {
-                c = (Reference<T>) super.clone();
-            } catch (CloneNotSupportedException e) {
-                // Should never happen.
-                throw new ICUCloneNotSupportedException(e);
+        public void run() {
+            if (sharedObj != null) {
+                sharedObj.removeRef();
+                sharedObj = null;
             }
-            if (ref != null) {
-                ref.addRef();
-            }
-            return c;
         }
+    }
 
-        public T readOnly() {
-            return ref;
+    public static final class Reference<T extends SharedObject> implements AutoCloseable {
+        private static final Cleaner CLEANER = Cleaner.create();
+
+        // We need a final field to reach the SharedObject to be cleaned when
+        // it is no longer used.
+        private final SharedObjectHolder<T> sharedObjectHolder;
+        private final Cleaner.Cleanable cleanable;
+
+        public Reference(T so) {
+            this.sharedObjectHolder = new SharedObjectHolder<T>(so);
+            if (so != null) {
+                so.addRef();
+            }
+            // Registers this object to the CLEANER with a sharedObjectHolder implementing
+            // Runnable used for clean up action.
+            this.cleanable = CLEANER.register(this, sharedObjectHolder);
         }
 
         /**
-         * Returns a writable version of the reference. If there is exactly one owner, then the
-         * reference itself is returned. If there are multiple owners, then the reference is
-         * replaced with a clone, and that is returned.
+         * Copy constructor. Previously this class implemented Cloneable and had clone() method.
+         * Cloning an object with a final field which require modification is tricky (need to use
+         * reflection to force updating the field) and discouraged. The new implementation uses this
+         * copy constructor instead of clone().
+         *
+         * @param ref A Reference object pointing a SharedObject. This constructor automatically
+         *     increment reference count of the SharedObject.
          */
+        public Reference(Reference<T> ref) {
+            this(ref.readOnly());
+        }
+
+        public T readOnly() {
+            return sharedObjectHolder.get();
+        }
+
         public T copyOnWrite() {
-            T r = ref;
-            if (r.getRefCount() <= 1) {
-                return r;
+            T so = sharedObjectHolder.get();
+            if (so.getRefCount() <= 1) {
+                return so;
             }
             @SuppressWarnings("unchecked")
-            T r2 = (T) r.clone();
-            r.removeRef();
-            ref = r2;
-            r2.addRef();
-            return r2;
+            T cso = (T) so.clone();
+            so.removeRef();
+            cso.addRef();
+            sharedObjectHolder.set(cso);
+            return cso;
         }
 
-        public void clear() {
-            if (ref != null) {
-                ref.removeRef();
-                ref = null;
-            }
-        }
-
+        /**
+         * It's recommended to implement AutoCloseable in a class utilizing Java Cleaner. Although
+         * it's currently not used by ICU4J implementation, this design allow ICU4J developer to use
+         * try-with-resource statement to close the resource automatically.
+         */
         @Override
-        protected void finalize() throws Throwable {
-            super.finalize();
-            clear();
+        public void close() throws Exception {
+            cleanable.clean();
         }
     }
 

--- a/icu4j/main/collate/src/main/java/com/ibm/icu/text/RuleBasedCollator.java
+++ b/icu4j/main/collate/src/main/java/com/ibm/icu/text/RuleBasedCollator.java
@@ -355,7 +355,7 @@ public final class RuleBasedCollator extends Collator implements Cloneable {
             // since all collation data in the RuleBasedCollator do not change
             // we can safely assign the result.fields to this collator
             // except in cases where we can't
-            result.settings = settings.clone();
+            result.settings = new SharedObject.Reference<>(settings);
             result.collationBuffer = null;
             result.frozenLock = null;
             return result;
@@ -1824,7 +1824,7 @@ public final class RuleBasedCollator extends Collator implements Cloneable {
 
     RuleBasedCollator(CollationTailoring t, ULocale vl) {
         data = t.data;
-        settings = t.settings.clone();
+        settings = new SharedObject.Reference<>(t.settings);
         tailoring = t;
         validLocale = vl;
         actualLocaleIsSameAsValid = false;
@@ -1833,7 +1833,7 @@ public final class RuleBasedCollator extends Collator implements Cloneable {
     private void adoptTailoring(CollationTailoring t) {
         assert (settings == null && data == null && tailoring == null);
         data = t.data;
-        settings = t.settings.clone();
+        settings = new SharedObject.Reference<>(t.settings);
         tailoring = t;
         validLocale = t.actualLocale;
         actualLocaleIsSameAsValid = false;


### PR DESCRIPTION
Java finalizer was deprecated in Java 9, permanently markd for removal in Java 18. SharedObject.Reference class relied on Java finalizer to manage reference count of SharedObject. We have no guarantee that Java finalizer continue to work as we want in future. Java offers Cleaner / AutoCloseable for replacing the finalizer. The migration required a minor refactoring for SharedObject.Reference class and need to add a class wrapping SharedObject.


#### Checklist
- [x] Required: Issue filed: ICU-21870
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
