### PR TITLE
ICU-23066 int64/long cast in nodeFromNextIndex

### DIFF
--- a/icu4c/source/i18n/collationbuilder.h
+++ b/icu4c/source/i18n/collationbuilder.h
@@ -252,7 +252,7 @@ private:
         return static_cast<int64_t>(previous) << 28;
     }
     static inline int64_t nodeFromNextIndex(int32_t next) {
-        return next << 8;
+        return static_cast<int64_t>(next) << 8;
     }
     static inline int64_t nodeFromStrength(int32_t strength) {
         return strength;

--- a/icu4j/main/collate/src/main/java/com/ibm/icu/impl/coll/CollationBuilder.java
+++ b/icu4j/main/collate/src/main/java/com/ibm/icu/impl/coll/CollationBuilder.java
@@ -1588,7 +1588,7 @@ public final class CollationBuilder extends CollationRuleParser.Sink {
     }
 
     private static long nodeFromNextIndex(int next) {
-        return next << 8;
+        return (long) next << 8;
     }
 
     private static long nodeFromStrength(int strength) {


### PR DESCRIPTION
CollationBuilder::nodeFromNextIndex(int32_t next) could cause integer overflow if it takes any arbitrary input value. Although the range of the input is limited to 0xFFFFF and should never cause the overflow issue, casting int32_t/int value to int64_t/long should be safer, and probably preventing static code analyzer to produce warnings.

#### Checklist
- [x] Required: Issue filed: ICU-23066
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
