### PR TITLE
ICU-23479 Skip TZ file search without a default file

### DIFF
--- a/icu4c/source/common/putil.cpp
+++ b/icu4c/source/common/putil.cpp
@@ -885,7 +885,6 @@ typedef struct DefaultTZInfo {
     char* defaultTZBuffer;
     int64_t defaultTZFileSize;
     FILE* defaultTZFilePtr;
-    UBool defaultTZstatus;
     int32_t defaultTZPosition;
 } DefaultTZInfo;
 
@@ -893,7 +892,7 @@ typedef struct DefaultTZInfo {
  * This method compares the two files given to see if they are a match.
  * It is currently use to compare two TZ files.
  */
-static UBool compareBinaryFiles(const char* defaultTZFileName, const char* TZFileName, DefaultTZInfo* tzInfo) {
+static UBool compareBinaryFiles(const char* TZFileName, DefaultTZInfo* tzInfo) {
     FILE* file;
     int64_t sizeFile;
     int64_t sizeFileLeft;
@@ -902,14 +901,12 @@ static UBool compareBinaryFiles(const char* defaultTZFileName, const char* TZFil
     char bufferFile[MAX_READ_SIZE];
     UBool result = true;
 
-    if (tzInfo->defaultTZFilePtr == nullptr) {
-        tzInfo->defaultTZFilePtr = fopen(defaultTZFileName, "r");
-    }
+    U_ASSERT(tzInfo->defaultTZFilePtr != nullptr);
     file = fopen(TZFileName, "r");
 
     tzInfo->defaultTZPosition = 0; /* reset position to begin search */
 
-    if (file != nullptr && tzInfo->defaultTZFilePtr != nullptr) {
+    if (file != nullptr) {
         /* First check that the file size are equal. */
         if (tzInfo->defaultTZFileSize == 0) {
             fseek(tzInfo->defaultTZFilePtr, 0, SEEK_END);
@@ -989,6 +986,11 @@ static char* searchForTZFile(const char* path, DefaultTZInfo* tzInfo) {
     char* result = nullptr;
     UErrorCode status = U_ZERO_ERROR;
 
+    /* There is no reference file to compare against, so do not traverse the zoneinfo tree. */
+    if (tzInfo->defaultTZFilePtr == nullptr) {
+        return nullptr;
+    }
+
     /* Save the current path */
     CharString curpath(path, -1, status);
     if (U_FAILURE(status)) {
@@ -1040,7 +1042,7 @@ static char* searchForTZFile(const char* path, DefaultTZInfo* tzInfo) {
                 if (result != nullptr)
                     break;
             } else {
-                if(compareBinaryFiles(TZDEFAULT, newpath.data(), tzInfo)) {
+                if(compareBinaryFiles(newpath.data(), tzInfo)) {
                     int32_t amountToSkip = sizeof(TZZONEINFO) - 1;
                     if (amountToSkip > newpath.length()) {
                         amountToSkip = newpath.length();
@@ -1215,8 +1217,7 @@ uprv_tzname(int n)
             if (tzInfo != nullptr) {
                 tzInfo->defaultTZBuffer = nullptr;
                 tzInfo->defaultTZFileSize = 0;
-                tzInfo->defaultTZFilePtr = nullptr;
-                tzInfo->defaultTZstatus = false;
+                tzInfo->defaultTZFilePtr = fopen(TZDEFAULT, "r");
                 tzInfo->defaultTZPosition = 0;
 
                 gTimeZoneBufferPtr = searchForTZFile(TZZONEINFO, tzInfo);


### PR DESCRIPTION
### Problem

When `TZ` is unset and `realpath(TZDEFAULT)` fails, ICU falls back to recursively searching the zoneinfo tree for a file matching `/etc/localtime`.

If `/etc/localtime` is absent or unreadable, `compareBinaryFiles()` retries opening it for every candidate. The search cannot succeed without a readable reference file, but it still traverses the full tree and opens candidates. This is especially expensive in distroless containers with a populated zoneinfo database.

See [ICU-23479](https://unicode-org.atlassian.net/browse/ICU-23479) for source analysis and a controlled container A/B where setting only `TZ=Etc/UTC` reduced first-evaluation p50 from 5,662 ms to 193 ms.

### Fix

- Open `TZDEFAULT` once before starting the recursive search.
- Return immediately from `searchForTZFile()` when the default file could not be opened, because no binary match is possible.
- Remove the unused `defaultTZstatus` field and the repeated lazy-open path from `compareBinaryFiles()`.

The existing libc-derived fallback remains unchanged.

### Verification

- Configured and built ICU4C on macOS with `runConfigureICU MacOSX --enable-strict`.
- Ran `cintltst /putiltst`; all focused tests passed.
- Simulated a missing `/etc/localtime` without changing the host by forcing its `realpath()` lookup to fail and sandbox-denying reads while leaving the system zoneinfo tree readable:

| Revision | Zoneinfo directory opens | Default-zone lookup samples | p50 |
|---|---:|---:|---:|
| `main` | 644 | 22.386 / 18.471 / 18.517 ms | 18.517 ms |
| This PR | 0 | 1.537 / 0.465 / 0.443 ms | 0.465 ms |

Both variants reached the same UTC fallback. No source test was added because ICU currently has no hermetic override for the absolute `TZDEFAULT` and `TZZONEINFO` host paths; the filesystem probe exercises the exact missing-file branch without mutating those host files.

#### Checklist

- [x] Required: Issue filed: [ICU-23479](https://unicode-org.atlassian.net/browse/ICU-23479)
- [x] Required: The PR title is prefixed with the Jira issue number.
- [x] Required: Each commit message is prefixed with the Jira issue number.
- [ ] Issue accepted (pending ICU Technical Committee triage)
- [ ] Tests included, if applicable (focused existing tests and a manual missing-file regression probe are documented above)
- [x] API docs and/or User Guide docs changed or added, if applicable (not applicable)
- [ ] Approver: Feel free to merge on my behalf

[ICU-23479]: https://unicode-org.atlassian.net/browse/ICU-23479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ICU-23479]: https://unicode-org.atlassian.net/browse/ICU-23479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ