### PR TITLE
ICU-5628 Fix using install-sh in out-of-source builds

### DIFF
--- a/icu4c/source/configure
+++ b/icu4c/source/configure
@@ -4563,6 +4563,9 @@ printf "%s\n" "no" >&6; }
 		PKG_CONFIG=""
 	fi
 fi
+if test -z "$PKG_CONFIG"; then
+	as_fn_error $? "pkg-config not found" "$LINENO" 5
+fi
 
 pkg_failed=no
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for icu-le-hb" >&5
@@ -4935,12 +4938,12 @@ test -z "$INSTALL_DATA" && INSTALL_DATA='${INSTALL} -m 644'
 
 
 
-# make sure install is relative to srcdir - if a script
-if test "$srcdir" = "."; then
-  # If srcdir isn't just ., then (srcdir) is already prepended.
-  if test "${ac_install_sh}" = "${INSTALL}"; then
-   INSTALL="\\\$(top_srcdir)/${ac_install_sh}"
-  fi
+# If using the included install-sh, make INSTALL work from any build dir.
+if test "${ac_install_sh}" = "${INSTALL}"; then
+    case "$srcdir" in
+        .|./*|../*)  INSTALL="\\\$(top_builddir)/${ac_install_sh}" ;;
+        *) ;;
+    esac
 fi
 
 # TODO(ICU-20301): Remove fallback to Python 2.

--- a/icu4c/source/configure.ac
+++ b/icu4c/source/configure.ac
@@ -186,12 +186,12 @@ AC_PROG_INSTALL
 
 AC_SUBST(cross_compiling)
 
-# make sure install is relative to srcdir - if a script
-if test "$srcdir" = "."; then
-  # If srcdir isn't just ., then (srcdir) is already prepended.
-  if test "${ac_install_sh}" = "${INSTALL}"; then
-   INSTALL="\\\$(top_srcdir)/${ac_install_sh}"
-  fi
+# If using the included install-sh, make INSTALL work from any build dir.
+if test "${ac_install_sh}" = "${INSTALL}"; then
+    case "$srcdir" in
+        .|./*|../*)  INSTALL="\\\$(top_builddir)/${ac_install_sh}" ;;
+        *) ;;
+    esac
 fi
 
 # TODO(ICU-20301): Remove fallback to Python 2.


### PR DESCRIPTION
Cf. https://github.com/microsoft/vcpkg/pull/53279:  
icu's `configure.ac` uses `AC_PROG_INSTALL` which tries to find a fast binary `install` and uses a slow `install-sh` script as fallback. Via `@INSTALL@`, the result is baked into `icudefs.mk` in the toplevel build directory.
When the fallback is used, icu prepends `$(top_srcdir)` for in-source builds (i.e. `${srcdir} = ".")`. (I assume this was meant as a fix for ICU-525 which is the same error for in-source builds.)   
For out-of-source builds, nothing is prepended, and so the value of `INSTALL` is valid only for the toplevel build dir. This leads to errors when it is actually used in subdirs.  
This change prepends `$(top_builddir)` instead, so that a valid path is construct for every possible case. Prepending is scoped to situations where `srcpath` is relative.

To reproduce the original issue, rename /usr/bin/install and similar candidates before running `../path/to/icu/source/configure`. 

The change from this PR is in `configure.ac`. `configure` is generated from that file.

#### Checklist
- [x] Required: Issue filed: ICU-5628
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf
