### PR TITLE
ICU-23247 Delete trailing space in DEFAULT_ICU_PLUGINS flag

### DIFF
--- a/icu4c/source/common/Makefile.in
+++ b/icu4c/source/common/Makefile.in
@@ -65,7 +65,7 @@ DEFS += -DU_COMMON_IMPLEMENTATION
 LDFLAGS += $(LDFLAGSICUUC)
 
 # for plugin configuration
-CPPFLAGS += "-DDEFAULT_ICU_PLUGINS=\"$(libdir)/icu\" "
+CPPFLAGS += "-DDEFAULT_ICU_PLUGINS=\"$(libdir)/icu\""
 
 # for icu data location
 ifeq ($(PKGDATA_MODE),common)


### PR DESCRIPTION
Trailing space in flag breaks Cosmopolitan libc compilation. Discovered by @dfyz while compiling TexLive for [cosmocc](https://github.com/jart/cosmopolitan): https://github.com/busytex/busytex/blob/fb945f69c2e203edea1690187a890c07a9bc1754/Makefile#L221

#### Checklist
- [x] Required: Issue filed: ICU-23247
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
