### PR TITLE
ICU-23489 WEEK_OF_MONTH in the Gregorian cutover year

### DIFF
--- a/icu4c/source/i18n/gregocal.cpp
+++ b/icu4c/source/i18n/gregocal.cpp
@@ -334,7 +334,20 @@ GregorianCalendar::setGregorianChange(UDate date, UErrorCode& status)
     if (cal->get(UCAL_ERA, status) == BC) {
         fGregorianCutoverYear = 1 - fGregorianCutoverYear;
     }
-    fCutoverJulianDay = static_cast<int32_t>(cutoverDay);
+    // fCutoverJulianDay holds an actual Julian Day count, consistent with
+    // the kCutoverJulianDay constant used by the constructors above and with
+    // the jd values it is compared against in handleComputeJulianDay() and
+    // handleComputeFields(). cutoverDay, in contrast, is a day count relative
+    // to the 1970 epoch, so convert it to a Julian Day in 64 bits first and
+    // then clamp to the int32_t range, the same way as above.
+    int64_t cutoverJulianDay64 = static_cast<int64_t>(cutoverDay) + kEpochStartAsJulianDay;
+    if (cutoverJulianDay64 <= INT32_MIN) {
+        fCutoverJulianDay = INT32_MIN;
+    } else if (cutoverJulianDay64 >= INT32_MAX) {
+        fCutoverJulianDay = INT32_MAX;
+    } else {
+        fCutoverJulianDay = static_cast<int32_t>(cutoverJulianDay64);
+    }
     delete cal;
 }
 
@@ -494,12 +507,31 @@ int32_t GregorianCalendar::handleComputeJulianDay(UCalendarDateFields bestField,
 #endif
                 jd -= gregShift;
             } else if ( bestField == UCAL_WEEK_OF_MONTH ) {
-                int32_t weekShift = 14;
+                // Only the month that actually contains the cutover point loses
+                // days (10 days vanish from the transition month), so only that
+                // month's weeks need to be pushed forward to avoid colliding
+                // with the weeks before the gap. The requested month is compared
+                // against the month the cutover falls in, derived from
+                // fGregorianCutover (whose units, milliseconds, are unambiguous;
+                // fCutoverJulianDay is not usable here since its units depend on
+                // how the cutover was set). No range normalization is applied to
+                // the requested month, so an out-of-range month is by definition
+                // not the cutover month and gets no shift.
+                int32_t requestedMonth = internalGetMonth(status);
+                if (U_SUCCESS(status)) {
+                    int32_t cutoverYear, cutoverMillisInDay;
+                    int8_t cutoverMonth, cutoverDom;
+                    Grego::timeToFields(fGregorianCutover, cutoverYear, cutoverMonth,
+                                        cutoverDom, cutoverMillisInDay, status);
+                    if (U_SUCCESS(status) && requestedMonth == cutoverMonth) {
+                        int32_t weekShift = 14;
 #if defined (U_DEBUG_CAL)
-                fprintf(stderr, "%s:%d: [WOY/WOM] gregorian week shift of %d += %d\n", 
-                    __FILE__, __LINE__, jd, weekShift);
+                        fprintf(stderr, "%s:%d: [WOY/WOM] gregorian week shift of %d += %d\n",
+                            __FILE__, __LINE__, jd, weekShift);
 #endif
-                jd += weekShift; // shift by weeks for week based fields.
+                        jd += weekShift; // shift by weeks for week based fields.
+                    }
+                }
             }
         }
 

--- a/icu4c/source/test/intltest/calregts.cpp
+++ b/icu4c/source/test/intltest/calregts.cpp
@@ -100,6 +100,8 @@ CalendarRegressionTest::runIndexedTest( int32_t index, UBool exec, const char* &
         CASE(56,TestUTCWrongAMPM22023);
         CASE(57,TestAsiaManilaAfterSetGregorianChange22043);
         CASE(58,TestRespectUExtensionFw);
+        CASE(59,TestExplicitCutoverMatchesDefault23489);
+        CASE(60,TestWeekOfMonthInCutoverYear23489);
     default: name = ""; break;
     }
 }
@@ -3277,4 +3279,285 @@ void CalendarRegressionTest::TestRespectUExtensionFw() { // ICU-22226
             + localeId + "' locale", expected, actual);
     }
 }
+void CalendarRegressionTest::TestExplicitCutoverMatchesDefault23489() {
+    // A calendar explicitly given the standard papal cutover date must
+    // compute the same instants as the default calendar, which uses that
+    // same date implicitly. This is not automatic: fCutoverJulianDay holds a
+    // true Julian Day by default, so setGregorianChange() must convert to
+    // that same unit for the two calendars to agree.
+    UErrorCode status = U_ZERO_ERROR;
+    SimpleDateFormat sdf(UnicodeString("yyyy-MM-dd"), Locale::getUS(), status);
+    sdf.setTimeZone(*TimeZone::getGMT());
+    if (failure(status, "initializing SimpleDateFormat")) {
+        return;
+    }
+
+    for (int32_t month = UCAL_JANUARY; month <= UCAL_DECEMBER; ++month) {
+        for (int32_t wom = 1; wom <= 5; ++wom) {
+            status = U_ZERO_ERROR;
+            GregorianCalendar defaultCal(*TimeZone::getGMT(), status);
+            GregorianCalendar explicitCal(*TimeZone::getGMT(), status);
+            if (U_FAILURE(status)) {
+                dataerrln("Error creating Calendar: %s", u_errorName(status));
+                return;
+            }
+            explicitCal.setGregorianChange(-12219292800000.0, status);
+            if (failure(status, "setGregorianChange")) {
+                return;
+            }
+
+            defaultCal.setFirstDayOfWeek(UCAL_SUNDAY);
+            defaultCal.setMinimalDaysInFirstWeek(1);
+            defaultCal.clear();
+            defaultCal.set(UCAL_YEAR, 1582);
+            defaultCal.set(UCAL_MONTH, month);
+            defaultCal.set(UCAL_WEEK_OF_MONTH, wom);
+            UDate expected = defaultCal.getTime(status);
+            if (failure(status, "computing the default calendar date")) {
+                continue;
+            }
+
+            explicitCal.setFirstDayOfWeek(UCAL_SUNDAY);
+            explicitCal.setMinimalDaysInFirstWeek(1);
+            explicitCal.clear();
+            explicitCal.set(UCAL_YEAR, 1582);
+            explicitCal.set(UCAL_MONTH, month);
+            explicitCal.set(UCAL_WEEK_OF_MONTH, wom);
+            UDate actual = explicitCal.getTime(status);
+            if (failure(status, "computing the setGregorianChange date")) {
+                continue;
+            }
+
+            if (actual != expected) {
+                UnicodeString actualStr, expectedStr;
+                sdf.format(actual, actualStr);
+                sdf.format(expected, expectedStr);
+                errln(UnicodeString("FAIL: explicit setGregorianChange, MONTH=") + (month + 1) +
+                      ", WEEK_OF_MONTH=" + wom + ": got " + actualStr + ", expected " + expectedStr);
+            }
+        }
+    }
+}
+// Test case for ticket 23489.
+// In the year of the Gregorian cutover, only the month that contains the
+// cutover point loses days, so only that month's weeks are shifted. Every
+// other month of that year must resolve WEEK_OF_MONTH like an ordinary
+// month, as ICU4J does.
+void CalendarRegressionTest::TestWeekOfMonthInCutoverYear23489() {
+    struct {
+        int32_t year;
+        int32_t month;
+        int32_t wom;
+        int32_t expYear;
+        int32_t expMonth;
+        int32_t expDay;
+    } const kData[] = {
+        // October 1582: the only month that actually loses days to the
+        // cutover (October 5-14, 1582 do not exist), so it needs the
+        // compensating shift that other months of the same year do not.
+        // Week 1 falls entirely before the cutover point (October 15,
+        // 1582), so it is expressed as a Julian calendar date; that same
+        // moment in time is printed here as September 30, 1582.
+        { 1582, UCAL_OCTOBER, 1, 1582, UCAL_SEPTEMBER, 30 },
+        { 1582, UCAL_OCTOBER, 2, 1582, UCAL_OCTOBER,   17 },
+        { 1582, UCAL_OCTOBER, 3, 1582, UCAL_OCTOBER,   24 },
+        { 1582, UCAL_OCTOBER, 4, 1582, UCAL_OCTOBER,   31 },
+        { 1582, UCAL_OCTOBER, 5, 1582, UCAL_NOVEMBER,   7 },
+        // November 1582
+        { 1582, UCAL_NOVEMBER, 1, 1582, UCAL_OCTOBER,  31 },
+        { 1582, UCAL_NOVEMBER, 2, 1582, UCAL_NOVEMBER,  7 },
+        { 1582, UCAL_NOVEMBER, 3, 1582, UCAL_NOVEMBER, 14 },
+        { 1582, UCAL_NOVEMBER, 4, 1582, UCAL_NOVEMBER, 21 },
+        { 1582, UCAL_NOVEMBER, 5, 1582, UCAL_NOVEMBER, 28 },
+        // December 1582
+        { 1582, UCAL_DECEMBER, 1, 1582, UCAL_NOVEMBER, 28 },
+        { 1582, UCAL_DECEMBER, 2, 1582, UCAL_DECEMBER,  5 },
+        { 1582, UCAL_DECEMBER, 3, 1582, UCAL_DECEMBER, 12 },
+        { 1582, UCAL_DECEMBER, 4, 1582, UCAL_DECEMBER, 19 },
+        { 1582, UCAL_DECEMBER, 5, 1582, UCAL_DECEMBER, 26 },
+        // January 1583
+        { 1583, UCAL_JANUARY, 1, 1582, UCAL_DECEMBER, 26 },
+        { 1583, UCAL_JANUARY, 2, 1583, UCAL_JANUARY,   2 },
+        { 1583, UCAL_JANUARY, 3, 1583, UCAL_JANUARY,   9 },
+        { 1583, UCAL_JANUARY, 4, 1583, UCAL_JANUARY,  16 },
+        { 1583, UCAL_JANUARY, 5, 1583, UCAL_JANUARY,  23 },
+        // January 2024 (sanity check well outside the cutover year)
+        { 2024, UCAL_JANUARY, 1, 2023, UCAL_DECEMBER, 31 },
+        { 2024, UCAL_JANUARY, 2, 2024, UCAL_JANUARY,   7 },
+        { 2024, UCAL_JANUARY, 3, 2024, UCAL_JANUARY,  14 },
+        { 2024, UCAL_JANUARY, 4, 2024, UCAL_JANUARY,  21 },
+        { 2024, UCAL_JANUARY, 5, 2024, UCAL_JANUARY,  28 },
+    };
+
+    UErrorCode status = U_ZERO_ERROR;
+    SimpleDateFormat sdf(UnicodeString("yyyy-MM-dd"), Locale::getUS(), status);
+    sdf.setTimeZone(*TimeZone::getGMT());
+    if (failure(status, "initializing SimpleDateFormat")) {
+        return;
+    }
+
+    for (int32_t i = 0; i < UPRV_LENGTHOF(kData); ++i) {
+        status = U_ZERO_ERROR;
+        GregorianCalendar cal(*TimeZone::getGMT(), status);
+        if (U_FAILURE(status)) {
+            dataerrln("Error creating Calendar: %s", u_errorName(status));
+            return;
+        }
+        cal.setFirstDayOfWeek(UCAL_SUNDAY);
+        cal.setMinimalDaysInFirstWeek(1);
+        cal.clear();
+        cal.set(UCAL_YEAR, kData[i].year);
+        cal.set(UCAL_MONTH, kData[i].month);
+        cal.set(UCAL_WEEK_OF_MONTH, kData[i].wom);
+        UDate actual = cal.getTime(status);
+        if (failure(status, "computing the date")) {
+            continue;
+        }
+
+        GregorianCalendar expCal(*TimeZone::getGMT(), status);
+        if (U_FAILURE(status)) {
+            dataerrln("Error creating Calendar: %s", u_errorName(status));
+            return;
+        }
+        expCal.clear();
+        expCal.set(kData[i].expYear, kData[i].expMonth, kData[i].expDay);
+        UDate expected = expCal.getTime(status);
+        if (failure(status, "computing the expected date")) {
+            continue;
+        }
+
+        if (actual != expected) {
+            UnicodeString actualStr, expectedStr;
+            sdf.format(actual, actualStr);
+            sdf.format(expected, expectedStr);
+            errln(UnicodeString("FAIL: year=") + kData[i].year +
+                  ", month=" + (kData[i].month + 1) +
+                  ", WEEK_OF_MONTH=" + kData[i].wom +
+                  ": got " + actualStr + ", expected " + expectedStr);
+        }
+    }
+
+    // The five weeks of October 1582 must be five distinct moments in time,
+    // each exactly 7 days after the previous one. This specifically catches
+    // a regression where weeks 4 and 5 collapse onto the same instants as
+    // weeks 2 and 3 (i.e. WEEK_OF_MONTH=4 and 2 -- and 5 and 3 -- resolving
+    // to the same date).
+    UDate previous = 0;
+    UBool havePrevious = false;
+    for (int32_t wom = 1; wom <= 5; ++wom) {
+        status = U_ZERO_ERROR;
+        GregorianCalendar cal(*TimeZone::getGMT(), status);
+        if (U_FAILURE(status)) {
+            dataerrln("Error creating Calendar: %s", u_errorName(status));
+            return;
+        }
+        cal.setFirstDayOfWeek(UCAL_SUNDAY);
+        cal.setMinimalDaysInFirstWeek(1);
+        cal.clear();
+        cal.set(UCAL_YEAR, 1582);
+        cal.set(UCAL_MONTH, UCAL_OCTOBER);
+        cal.set(UCAL_WEEK_OF_MONTH, wom);
+        UDate current = cal.getTime(status);
+        if (failure(status, "computing October 1582 week boundaries")) {
+            havePrevious = false;
+            continue;
+        }
+
+        if (havePrevious) {
+            UDate diff = current - previous;
+            if (diff != 7.0 * U_MILLIS_PER_DAY) {
+                errln(UnicodeString("FAIL: October 1582 WEEK_OF_MONTH=") + (wom - 1) +
+                      " to WEEK_OF_MONTH=" + wom + " should be exactly 7 days apart, got " +
+                      (diff / U_MILLIS_PER_DAY) + " days");
+            }
+        }
+        previous = current;
+        havePrevious = true;
+    }
+
+    // The month can be resolved from UCAL_ORDINAL_MONTH rather than
+    // UCAL_MONTH. Both paths must name the same month to the cutover check,
+    // and so must produce the same instant.
+    {
+        status = U_ZERO_ERROR;
+        GregorianCalendar monthCal(*TimeZone::getGMT(), status);
+        GregorianCalendar ordinalCal(*TimeZone::getGMT(), status);
+        if (U_FAILURE(status)) {
+            dataerrln("Error creating Calendar: %s", u_errorName(status));
+            return;
+        }
+        monthCal.setFirstDayOfWeek(UCAL_SUNDAY);
+        monthCal.setMinimalDaysInFirstWeek(1);
+        monthCal.clear();
+        monthCal.set(UCAL_YEAR, 1582);
+        monthCal.set(UCAL_MONTH, UCAL_NOVEMBER);
+        monthCal.set(UCAL_WEEK_OF_MONTH, 3);
+        UDate expected = monthCal.getTime(status);
+        if (failure(status, "computing the MONTH date")) {
+            return;
+        }
+
+        ordinalCal.setFirstDayOfWeek(UCAL_SUNDAY);
+        ordinalCal.setMinimalDaysInFirstWeek(1);
+        ordinalCal.clear();
+        ordinalCal.set(UCAL_YEAR, 1582);
+        ordinalCal.set(UCAL_ORDINAL_MONTH, 10);
+        ordinalCal.set(UCAL_WEEK_OF_MONTH, 3);
+        UDate actual = ordinalCal.getTime(status);
+        if (failure(status, "computing the ORDINAL_MONTH date")) {
+            return;
+        }
+
+        if (actual != expected) {
+            UnicodeString actualStr, expectedStr;
+            sdf.format(actual, actualStr);
+            sdf.format(expected, expectedStr);
+            errln(UnicodeString("FAIL: YEAR=1582, ORDINAL_MONTH=10, WEEK_OF_MONTH=3: got ") +
+                  actualStr + ", expected " + expectedStr);
+        }
+    }
+
+    // Regression test: a month value outside 0..11 must not be treated as
+    // the cutover month even if it would normalize into it -- the guard
+    // compares the raw requested month with no range normalization.
+    {
+        status = U_ZERO_ERROR;
+        GregorianCalendar overflowCal(*TimeZone::getGMT(), status);
+        GregorianCalendar normalizedCal(*TimeZone::getGMT(), status);
+        if (U_FAILURE(status)) {
+            dataerrln("Error creating Calendar: %s", u_errorName(status));
+            return;
+        }
+        overflowCal.setFirstDayOfWeek(UCAL_SUNDAY);
+        overflowCal.setMinimalDaysInFirstWeek(1);
+        overflowCal.clear();
+        overflowCal.set(UCAL_YEAR, 1582);
+        overflowCal.set(UCAL_MONTH, 14);
+        overflowCal.set(UCAL_WEEK_OF_MONTH, 1);
+        UDate actual = overflowCal.getTime(status);
+        if (failure(status, "computing the out-of-range month date")) {
+            return;
+        }
+
+        normalizedCal.setFirstDayOfWeek(UCAL_SUNDAY);
+        normalizedCal.setMinimalDaysInFirstWeek(1);
+        normalizedCal.clear();
+        normalizedCal.set(UCAL_YEAR, 1583);
+        normalizedCal.set(UCAL_MONTH, UCAL_MARCH);
+        normalizedCal.set(UCAL_WEEK_OF_MONTH, 1);
+        UDate expected = normalizedCal.getTime(status);
+        if (failure(status, "computing the out-of-range month date")) {
+            return;
+        }
+
+        if (actual != expected) {
+            UnicodeString actualStr, expectedStr;
+            sdf.format(actual, actualStr);
+            sdf.format(expected, expectedStr);
+            errln(UnicodeString("FAIL: YEAR=1582, MONTH=14, WEEK_OF_MONTH=1: got ") +
+                  actualStr + ", expected " + expectedStr);
+        }
+    }
+}
+
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/test/intltest/calregts.h
+++ b/icu4c/source/test/intltest/calregts.h
@@ -86,6 +86,8 @@ public:
 
     void Test13745();
     void TestRespectUExtensionFw();
+    void TestExplicitCutoverMatchesDefault23489();
+    void TestWeekOfMonthInCutoverYear23489();
 
     void printdate(GregorianCalendar *cal, const char *string);
     void dowTest(UBool lenient) ;


### PR DESCRIPTION
Two related fixes, squashed into one commit as the single-commit check asks.
The first is a prerequisite: without it the second one changes behaviour for
calendars whose cutover was set explicitly.

## 1. Store a Julian Day in `fCutoverJulianDay` when the cutover is set explicitly

The constructors store `kCutoverJulianDay`, 2299161, an actual Julian Day, and
that is what `handleComputeJulianDay()` and `handleComputeFields()` compare the
field against. `setGregorianChange()` stored `floorDivide(date, kOneDay)`
instead, a day count relative to the 1970 epoch, 2440588 days off.

The visible effect: a calendar given the standard papal cutover date explicitly
resolves dates of the cutover year differently from the default calendar, which
uses that very same date implicitly. With `WEEK_OF_MONTH` in 1582, GMT, first
day of week Sunday, minimal days in first week 1, the two disagree in 25 of the
60 month and week combinations, February, March, June, August and September
each by seven days.

`TestExplicitCutoverMatchesDefault23489` pins the two against each other across
the whole cutover year.

ICU4J has the same defect at `GregorianCalendar.java:514`, with the same
2299161 default at line 323. I have not touched it here, since I have no way to
build and run ICU4J; happy to file it separately.

## 2. Apply the cutover-year WEEK_OF_MONTH shift only to the cutover month

`handleComputeJulianDay` adds 14 days when the calendar is Gregorian, the
extended year equals the cutover year, and the best field is `WEEK_OF_MONTH`.
The condition tests the year, so it fired for every month of that year rather
than for the month that loses days.

With the default cutover only October 1582 is short: 1582-10-01 to 1582-10-04,
then 1582-10-15 to 1582-10-31. November and December 1582 are ordinary months.
1582-11-01 is a Monday and 1582-12-01 is a Wednesday, so with weeks starting on
Sunday the first week of November begins on 1582-10-31 and the first week of
December begins on 1582-11-28. ICU4C resolved those to 1582-11-14 and
1582-12-12, two weeks late. ICU4J, which has no such shift, returns the earlier
dates. An out of range month was shifted too: YEAR 1582 with MONTH 14 landed two
weeks after YEAR 1583 with MONTH 2.

The shift is now applied only when the requested month is the month the cutover
falls in. The month comes from `internalGetMonth()`, the same accessor
`Calendar::handleComputeJulianDay` uses to compute the day, so a month resolved
from `ORDINAL_MONTH` is treated identically to one set through `MONTH`. The
cutover month is derived from `fGregorianCutover`.

| input | before | after |
| --- | --- | --- |
| October 1582, weeks 1-5 | five consecutive Sundays | unchanged |
| November 1582, week 1 | 1582-11-14 | 1582-10-31 |
| December 1582, week 1 | 1582-12-12 | 1582-11-28 |
| YEAR 1582, MONTH 14, week 1 | 1583-03-13 | 1583-02-27 |
| January 1583, January 2024 | unchanged | unchanged |

Deleting the branch outright is not correct, in case that looks tempting:
without the shift, weeks 4 and 5 of October 1582 collapse onto the same instants
as weeks 2 and 3, verified to the millisecond.

The 14 day constant is left as is. It is tied to the ten day gap of the 1582
cutover, and a cutover set through `setGregorianChange` needs a different value.
That case is ICU-3350, which is open for exactly this.

`TestWeekOfMonthInCutoverYear23489` covers October, November and December 1582,
two control months outside the cutover year, the `ORDINAL_MONTH` path, an out of
range month, and pins the five weeks of October 1582 as five distinct instants
exactly seven days apart.

## Verification

`intltest` and `cintltst` both pass in full, from a clean build.

Reverting the whole change: `TestExplicitCutoverMatchesDefault23489` fails on 25
of its 60 rows, and `TestWeekOfMonthInCutoverYear23489` on 11, November,
December and the out of range month.

The two parts have to travel together. Reverting only the `setGregorianChange`
part while keeping the narrowed condition makes
`TestExplicitCutoverMatchesDefault23489` fail on 45 rows rather than 25: the
narrowed condition removes a shift that used to mask the unit mismatch for
explicitly set cutovers. Reverting only the narrowed condition while keeping the
unit fix leaves `TestWeekOfMonthInCutoverYear23489` failing on its 11 rows.

## ICU4J parity

For the ordinary months of the cutover year ICU4C now agrees with ICU4J, which
is what this ticket is about.

For October 1582 the two still differ, and this does not paper over it: ICU4J
resolves weeks 4 and 5 to the same instants as weeks 2 and 3, while ICU4C keeps
five distinct weeks. ICU4C looks right here, so a mirrored ICU4J test would fail
today rather than pass. Worth a separate ticket if you agree.


#### Checklist
- [x] Required: Issue filed: ICU-23489
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [ ] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
