### PR TITLE
ICU-23248 Generate more modern javadoc for site

### DIFF
--- a/.github/workflows/release-icu4j-maven.yml
+++ b/.github/workflows/release-icu4j-maven.yml
@@ -34,13 +34,18 @@ on:
         type: string
 
 env:
-  SHARED_MVN_ARGS: '--no-transfer-progress --show-version --batch-mode'
+  SHARED_MVN_ARGS: '--show-version --batch-mode'
   RELEASE_FOLDER: '${{ github.workspace }}/releaseDist'
 
 permissions:
   contents: read
 
 jobs:
+  # This job builds and tests Maven Central artifacts (compiled, source, javadoc, signatures, checksums)
+  # Then the artifacts are:
+  #   - Published to Maven Cental (if `deployToMaven` set)
+  #   - Attached as Github Action artifacts
+  #   - Uploaded to the GitHub release (at `gitReleaseTag`)
   publish:
     runs-on: ubuntu-24.04  # Updated in BRS
     environment: release-env
@@ -121,20 +126,75 @@ jobs:
         mv ${RELEASE_FOLDER}/icu4j-charset-javadoc.jar ${RELEASE_FOLDER}/icu4j-charset-${github_rel_version}-javadoc.jar
         mv ${RELEASE_FOLDER}/icu4j-charset-sources.jar ${RELEASE_FOLDER}/icu4j-charset-${github_rel_version}-sources.jar
 
-        # Build the full javadoc to be posted on the public site
-        mvn site \
-          ${SHARED_MVN_ARGS} \
-          -DskipITs -DskipTests \
-          -P with_full_javadoc
-        # Archive the full doc in a jar. Should also be posted to the web as official doc.
-        jar -Mcf ${RELEASE_FOLDER}/icu4j-${github_rel_version}-fulljavadoc.jar \
-          -C target/site/apidocs/ .
         popd # out of icu4j
 
     - name: Upload build results
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: icu4j-binaries
+        path: ${{ env.RELEASE_FOLDER }}
+        retention-days: 3 # TBD if we want to keep them longer
+        overwrite: true
+
+    - name: Upload to release
+      if: ${{ inputs.gitReleaseTag && startsWith(inputs.gitReleaseTag, 'release-') }}
+      run: |
+        gh release upload ${INPUTS_GITRELEASETAG} ${RELEASE_FOLDER}/* --clobber --repo=${{ github.repository }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+        INPUTS_GITRELEASETAG: ${{ inputs.gitReleaseTag }}
+
+  # Builds everything we need to for the unified javadoc (icu4j + icu4j-charset) for web publishing.
+  # No testing, the only thing we use from this is the javadoc for the site.
+  # The results are:
+  #   - Attached as Github Action artifacts
+  #   - Uploaded to the GitHub release
+  # This job was split from `publish` so that we can use the jdk 26 version of javadoc,
+  # which has some really nice improvements.
+  javadoc_for_website_publishing:
+    runs-on: ubuntu-24.04  # Updated in BRS
+    environment: release-env
+
+    permissions:
+      contents: write # So that we can upload to release
+
+    steps:
+
+    - name: Checkout repo files
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Set up JDK
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+      with:
+        java-version: '26'
+        distribution: 'temurin'
+
+    - name: Build and install everything so that `site` can find the artifacts for reporting
+      run: |
+        mvn install --file icu4j \
+          ${SHARED_MVN_ARGS} \
+          -DskipTests -DskipITs
+
+    # These files will end in the "Release" section of the GitHub repo and on apidoc site
+    - name: Prepare site with full javadoc
+      run: |
+        # Get the ICU release version in github_rel_version
+        source icu4j/releases_tools/shared.sh
+        # Build the full javadoc to be posted on the public site
+        mvn site --file icu4j \
+          ${SHARED_MVN_ARGS} \
+          -DskipITs -DskipTests \
+          -P with_full_javadoc
+        # Archive the full doc in a jar. Should also be posted to the web as official doc.
+        jar -Mcf ${RELEASE_FOLDER}/icu4j-${github_rel_version}-fulljavadoc.jar \
+          -C icu4j/target/site/apidocs/ .
+
+    - name: Upload build results
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: icu4j-fulljavadoc
         path: ${{ env.RELEASE_FOLDER }}
         retention-days: 3 # TBD if we want to keep them longer
         overwrite: true

--- a/icu4j/pom.xml
+++ b/icu4j/pom.xml
@@ -276,7 +276,6 @@
   <reporting>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <reportSets>
           <reportSet>
@@ -291,6 +290,24 @@
             <reports>
               <report>javadoc</report>
             </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+      <plugin>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <reportSets>
+          <reportSet>
+            <!-- No reports, except the javadoc above.
+              Without this the `mvn site` tries to create many reports:
+              Dependencies, Plugin Management, SCM, Mailing Lists, etc.
+              See https://maven.apache.org/plugins/maven-project-info-reports-plugin/plugin-info.html
+              Some (for example, the "Dependencies" report) throw a
+              `java.nio.file.NoSuchFileException` because something
+              that was needed for the report was not build / installed.
+              We can build everything before `site`, but we don't need any
+              of these reports, so we just disable them instead.
+            -->
+            <reports />
           </reportSet>
         </reportSets>
       </plugin>


### PR DESCRIPTION
This was discussed by email in the ICU team ("Updating javadoc look and feel?", May 15).

It generates a more modern javadoc:
* left panel (navigation bar?) with sections, TOC, and filtering
  Compare [MessageFormat current](https://unicode-org.github.io/icu-docs/apidoc/dev/icu4j/com/ibm/icu/text/MessageFormat.html) vs [MessageFormat new](https://mihai-nita.net/tmp/javadoc26/com/ibm/icu/text/MessageFormat.html)
* more mobile friendly (try making the window narrower in namespace view / class view)
* theme support (at the top, after OVERVIEW, TREE, INDEX ... HELP there is a sun / moon icon)

---

I tested the changes by running the action in my repo.

See the result of the run here: https://github.com/mihnita/icu/actions/runs/32469385369
The artifacts (`icu4j-binaries` and `icu4j-fulljavadoc`) are at the bottom of the action.
They are also uploaded in the (fake) release in my repo: https://github.com/mihnita/icu/releases/tag/release-79.1

Then I downloaded the artifacts attached to the action and diff-ed them against the ones in the release (identical).

Finally, I extracted the `icu4j-79.0.1-fulljavadoc.jar` and posted it to my web site: https://mihai-nita.net/tmp/javadoc26/
Then I navigated it randomly, did some searches, etc. All good, from all I can see.

#### Checklist
- [x] Required: Issue filed: ICU-23248
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf
