### PR TITLE
ICU-22104 Add more comprehensive tests for set/getMaxLabelCount in Al…

### DIFF
--- a/icu4c/source/test/intltest/alphaindextst.cpp
+++ b/icu4c/source/test/intltest/alphaindextst.cpp
@@ -68,6 +68,8 @@ void AlphabeticIndexTest::runIndexedTest( int32_t index, UBool exec, const char*
     TESTCASE_AUTO(TestJapaneseKanji);
     TESTCASE_AUTO(TestChineseUnihan);
     TESTCASE_AUTO(testHasBuckets);
+    TESTCASE_AUTO(TestMaxLabelCountRange);
+    TESTCASE_AUTO(TestBucketCountAfterSetMaxLabelCount);
     TESTCASE_AUTO_END;
 }
 
@@ -757,4 +759,79 @@ void AlphabeticIndexTest::checkHasBuckets(const Locale &locale, UScriptCode scri
             uscript_getScript(bucket->getLabel().char32At(0), errorCode));
 }
 
+void AlphabeticIndexTest::TestMaxLabelCountRange() {
+    UErrorCode status = U_ZERO_ERROR;
+    AlphabeticIndex index(Locale("en"), status);
+    TEST_CHECK_STATUS;
+    int32_t maxLabelCount = index.getMaxLabelCount();
+
+    // 0 is not a valid value for maxLabelCount
+    index.setMaxLabelCount(0, status);
+    assertEquals("Status returned for maxLabelCount=0", U_ILLEGAL_ARGUMENT_ERROR, status);
+    assertEquals("Max label count should remain unchanged (0)", maxLabelCount, index.getMaxLabelCount());
+
+    // Negative values are not valid for maxLabelCount
+    status = U_ZERO_ERROR;
+    index.setMaxLabelCount(-100, status);
+    assertEquals("Status returned for maxLabelCount=-100", U_ILLEGAL_ARGUMENT_ERROR, status);
+    assertEquals("Max label count should remain unchanged (-100)", maxLabelCount, index.getMaxLabelCount());
+
+    // MAX_INT32 should be accepted
+    status = U_ZERO_ERROR;
+    index.setMaxLabelCount(INT32_MAX, status);
+    TEST_CHECK_STATUS;
+    assertEquals("Max label count should be set to INT32_MAX", INT32_MAX, index.getMaxLabelCount());
+}
+
+void AlphabeticIndexTest::TestBucketCountAfterSetMaxLabelCount() {
+    checkBucketCountAfterSetMaxLabelCount(Locale("en_US"));
+    checkBucketCountAfterSetMaxLabelCount(Locale("de_DE"));
+    checkBucketCountAfterSetMaxLabelCount(Locale("ja_JP"));
+    checkBucketCountAfterSetMaxLabelCount(Locale("ko_KR"));
+    checkBucketCountAfterSetMaxLabelCount(Locale("zh_CN"));
+    checkBucketCountAfterSetMaxLabelCount(Locale("ru_RU"));
+}
+
+void AlphabeticIndexTest::checkBucketCountAfterSetMaxLabelCount(const Locale &loc) {
+    const char16_t* records[] = {
+        u"Hello", u"Bye",
+        u"Hallo", u"Tschüss",
+        u"こんにちは", u"さよなら",
+        u"안녕하세요", u"안녕",
+        u"你好", u"안녕",
+        u"Привет", u"Пока"
+    };
+    int32_t numRecords = std::size(records);
+
+    UErrorCode status = U_ZERO_ERROR;
+    AlphabeticIndex index(loc, status);
+    int32_t prevBucketCount = index.getBucketCount(status);
+    TEST_CHECK_STATUS;
+
+    for (int32_t i = 0; i < numRecords; ++i) {
+        index.addRecord(records[i], records[i], status);
+        TEST_CHECK_STATUS;
+    }
+
+    for (int32_t maxLabelCount = index.getMaxLabelCount() - 1; maxLabelCount > 0; maxLabelCount--) {
+        index.setMaxLabelCount(maxLabelCount, status);
+        int32_t bucketCount = index.getBucketCount(status);
+        TEST_CHECK_STATUS;
+        assertEquals(UnicodeString("New max label count - ") + loc.getName(), index.getMaxLabelCount(), maxLabelCount);
+        assertTrue(UnicodeString("New bucket count is less than or equal to the previous count - ") + loc.getName(),
+            bucketCount <= prevBucketCount);
+
+        // Total number of records collected from all buckets should be unchanged.
+        int32_t count = 0;
+        index.resetBucketIterator(status);
+        TEST_CHECK_STATUS;
+        while(index.nextBucket(status)) {
+            TEST_CHECK_STATUS;
+            count += index.getBucketRecordCount();
+        }
+        assertEquals(UnicodeString("Total number of records from all buckets - ") + loc.getName(), numRecords, count);
+
+        prevBucketCount = bucketCount;
+    }
+}
 #endif

--- a/icu4c/source/test/intltest/alphaindextst.h
+++ b/icu4c/source/test/intltest/alphaindextst.h
@@ -53,6 +53,10 @@ public:
 
     void testHasBuckets();
     void checkHasBuckets(const Locale &locale, UScriptCode script);
+
+    void TestMaxLabelCountRange();
+    void TestBucketCountAfterSetMaxLabelCount();
+    void checkBucketCountAfterSetMaxLabelCount(const Locale &locale);
 };
 
 #endif

--- a/icu4j/main/collate/src/main/java/com/ibm/icu/text/AlphabeticIndex.java
+++ b/icu4j/main/collate/src/main/java/com/ibm/icu/text/AlphabeticIndex.java
@@ -432,6 +432,9 @@ public final class AlphabeticIndex<V> implements Iterable<Bucket<V>> {
      * @stable ICU 4.8
      */
     public AlphabeticIndex<V> setMaxLabelCount(int maxLabelCount) {
+        if (maxLabelCount <= 0) {
+            throw new IllegalArgumentException("Maximum number of labels must be greater than 0");
+        }
         this.maxLabelCount = maxLabelCount;
         buckets = null;
         return this;

--- a/icu4j/main/collate/src/test/java/com/ibm/icu/dev/test/collator/AlphabeticIndexTest.java
+++ b/icu4j/main/collate/src/test/java/com/ibm/icu/dev/test/collator/AlphabeticIndexTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -2465,5 +2466,90 @@ public class AlphabeticIndexTest extends TestFmwk {
                 loc + " expected script",
                 script,
                 UScript.getScript(bucket.getLabel().codePointAt(0)));
+    }
+
+    @Test
+    public void testMaxLabelCountRange() {
+        AlphabeticIndex<String> index = new AlphabeticIndex<>(Locale.ENGLISH);
+        int maxLabelCount = index.getMaxLabelCount();
+
+        // 0 is not a valid value for maxLabelCount
+        try {
+            index.setMaxLabelCount(0);
+            fail("IllegalArgumentException should be thrown when maxLabelCount=0");
+        } catch (IllegalArgumentException e) {
+            // Expected. maxLabelCount should remain unchanged
+            assertEquals(
+                    "Max label count should remain unchanged (0)",
+                    maxLabelCount,
+                    index.getMaxLabelCount());
+        }
+
+        // Negative values are not valid for maxLabelCount
+        try {
+            index.setMaxLabelCount(-100);
+            fail("IllegalArgumentException should be thrown when maxLabelCount=-100");
+        } catch (IllegalArgumentException e) {
+            // Expected. maxLabelCount should remain unchanged
+            assertEquals(
+                    "Max label count should remain unchanged (-100)",
+                    maxLabelCount,
+                    index.getMaxLabelCount());
+        }
+
+        index.setMaxLabelCount(Integer.MAX_VALUE);
+        assertEquals(
+                "Max label count should be set to Integer.MAX_VALUE",
+                Integer.MAX_VALUE,
+                index.getMaxLabelCount());
+    }
+
+    @Test
+    public void testBucketCountAfterSetMaxLabelCount() {
+        checkBucketCountAfterSetMaxLabelCount(Locale.US);
+        checkBucketCountAfterSetMaxLabelCount(Locale.GERMAN);
+        checkBucketCountAfterSetMaxLabelCount(Locale.JAPAN);
+        checkBucketCountAfterSetMaxLabelCount(Locale.KOREA);
+        checkBucketCountAfterSetMaxLabelCount(Locale.PRC);
+        checkBucketCountAfterSetMaxLabelCount(Locale.forLanguageTag("ru-RU"));
+    }
+
+    private void checkBucketCountAfterSetMaxLabelCount(Locale loc) {
+        final String[] records = {
+            "Hello", "Bye", "Hallo", "Tschüss", "こんにちは", "さよなら", "안녕하세요", "안녕", "你好", "再见",
+            "Привет", "Пока"
+        };
+        int numRecords = records.length;
+
+        AlphabeticIndex<String> index = new AlphabeticIndex<>(loc);
+        int prevBucketCount = index.getBucketCount();
+
+        for (String record : records) {
+            index.addRecord(record, record);
+        }
+
+        // Decrement the max label count and check if bucket count is less than or equal to
+        // the previous bucket count. Also check if the total number of records collected from
+        // all buckets is unchanged.
+        for (int maxLabelCount = index.getMaxLabelCount() - 1; maxLabelCount > 0; maxLabelCount--) {
+            index.setMaxLabelCount(maxLabelCount);
+            assertEquals("New max label count - " + loc, maxLabelCount, index.getMaxLabelCount());
+            int bucketCount = index.getBucketCount();
+            assertTrue(
+                    "New bucket count is less than or equal to the previous count - " + loc,
+                    bucketCount <= prevBucketCount);
+            // Total number of records collected from all buckets should be unchanged.
+            final AtomicInteger count = new AtomicInteger(0);
+            index.forEach(
+                    b -> {
+                        count.addAndGet(b.size());
+                    });
+            assertEquals(
+                    "Total number of records from all buckets - " + loc,
+                    numRecords,
+                    count.intValue());
+
+            prevBucketCount = bucketCount;
+        }
     }
 }


### PR DESCRIPTION
…phabeticIndex

ICU4J setMaxLabelCount(int) did not have input validation. When the input value is 0 or negative, ICU4C set ILLEGAL_ARGUMENT_ERROR. To be consistent, ICU4J implementation is updated to throw IllegalArgumentException for 0 or negative input.

#### Checklist
- [x] Required: Issue filed: ICU-22104
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf
