### PR TITLE
ICU-23247 Update docker image and published Fedora 44

### DIFF
--- a/.github/Dockerfile_fedora
+++ b/.github/Dockerfile_fedora
@@ -1,8 +1,7 @@
 FROM fedora:latest
 
 RUN dnf install -y gcc-c++ zip unzip git-core git-lfs doxygen
-RUN git lfs install --skip-repo \
-    && ln -s /usr/bin/python3 /usr/bin/python
+RUN git lfs install --skip-repo
 
 WORKDIR /root
 

--- a/.github/HOWTO.md
+++ b/.github/HOWTO.md
@@ -15,10 +15,10 @@ When prompted use these:
 * **User:** the github user
 * **Password:** the github token
 
-Update the timestamp (`20240929`) with the current date, ISO style:
+Update the timestamp (`20260828`) with the current date, ISO style:
 ```
-docker build --tag ghcr.io/unicode-org/fedora-docker-gcr:20240929 -f Dockerfile_fedora .
-docker push ghcr.io/unicode-org/fedora-docker-gcr:20240929
+docker build --tag ghcr.io/unicode-org/fedora-docker-gcr:20260828 -f Dockerfile_fedora .
+docker push ghcr.io/unicode-org/fedora-docker-gcr:20260828
 ```
 
 For more info see:


### PR DESCRIPTION
Fedora 40 (currently used for the ICU Fedora artifacts) was officially released on April 23, 2024, end of life May 13, 2025.

#### Checklist
- [x] Required: Issue filed: ICU-23247
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf
