### PR TITLE
ICU-23247 Only run attestation on manual triggers

### DIFF
--- a/.github/workflows/icu4c_msvcdistrelease.yml
+++ b/.github/workflows/icu4c_msvcdistrelease.yml
@@ -120,6 +120,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           INPUTS_GITRELEASETAG: ${{ inputs.gitReleaseTag }}
       - name: Generate artifact attestation
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: icu4c/source/dist/${{ env.newZipName }}.zip

--- a/.github/workflows/icu4x_icuexportdata.yml
+++ b/.github/workflows/icu4x_icuexportdata.yml
@@ -143,6 +143,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           INPUTS_GITRELEASETAG: ${{ inputs.gitReleaseTag }}
       - name: Generate artifact attestation
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: ${{ env.newZipName }}

--- a/.github/workflows/release-icu4c-fedora.yml
+++ b/.github/workflows/release-icu4c-fedora.yml
@@ -93,6 +93,7 @@ jobs:
         INPUTS_GITRELEASETAG: ${{ inputs.gitReleaseTag }}
 
     - name: Generate artifact attestation
+      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
       uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
       with:
         subject-path: ${{ env.RELEASE_FOLDER }}

--- a/.github/workflows/release-icu4c-ubuntu.yml
+++ b/.github/workflows/release-icu4c-ubuntu.yml
@@ -90,6 +90,7 @@ jobs:
         INPUTS_GITRELEASETAG: ${{ inputs.gitReleaseTag }}
 
     - name: Generate artifact attestation
+      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
       uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
       with:
         subject-path: ${{ env.RELEASE_FOLDER }}

--- a/.github/workflows/release-icu4j-maven.yml
+++ b/.github/workflows/release-icu4j-maven.yml
@@ -217,6 +217,7 @@ jobs:
         INPUTS_GITRELEASETAG: ${{ inputs.gitReleaseTag }}
 
     - name: Generate artifact attestation
+      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
       uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
       with:
         subject-path: ${{ env.RELEASE_FOLDER }}


### PR DESCRIPTION
Some of the workflows doing attestation (`actions/attest`) are triggered on `push`, `pull_request`, `workflow_dispatch`.

But `pull_request` automatically resets the permissions to `read` when the pull is from a fork.

This makes the workflow fail, and people can't submit PRs that change workflow files.
(unless they create a branch under `unicode-org/icu`, and we try to avoid that)

This PR limits the `actions/attest` steps only to `push`, `workflow_dispatch`.

`workflow_dispatch` means the workflow was triggered manually.
But happens only rarely, on release.
So we also attest on `push`, to make sure the `actions/attest` step works. It might break from actions updates, all kind of other reasons, and we don't want to only find out this is broken at release time.

#### Checklist
- [x] Required: Issue filed: ICU-23247
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf
