### PR TITLE
ICU-23343 add UCharacter.UnicodeBlock.NO_BLOCK_ID

### DIFF
--- a/icu4j/main/core/src/main/java/com/ibm/icu/lang/UCharacter.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/lang/UCharacter.java
@@ -183,6 +183,11 @@ public final class UCharacter implements ECharacterCategory, ECharacterDirection
         // block id corresponding to icu4c -----------------------------------
 
         /**
+         * @stable ICU 79
+         */
+        public static final int NO_BLOCK_ID = 0;
+
+        /**
          * @stable ICU 2.4
          */
         public static final int INVALID_CODE_ID = -1;
@@ -2035,7 +2040,7 @@ public final class UCharacter implements ECharacterCategory, ECharacterDirection
         /**
          * @stable ICU 2.6
          */
-        public static final UnicodeBlock NO_BLOCK = new UnicodeBlock("NO_BLOCK", 0);
+        public static final UnicodeBlock NO_BLOCK = new UnicodeBlock("NO_BLOCK", NO_BLOCK_ID);
 
         /**
          * @stable ICU 2.4

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/PropNumbersTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/PropNumbersTest.java
@@ -253,6 +253,7 @@ public class PropNumbersTest extends CoreTestFmwk {
         assertEquals("blk", UProperty.BLOCK, 4097);
         // ICU4C UBLOCK_NO_BLOCK:
         assertEquals("blk=NB", intValue(UnicodeBlock.NO_BLOCK), 0);
+        assertEquals("blk=NB", UnicodeBlock.NO_BLOCK_ID, 0);
         // ICU4C UBLOCK_BASIC_LATIN:
         assertEquals("blk=ASCII", intValue(UnicodeBlock.BASIC_LATIN), 1);
         assertEquals("blk=ASCII", UnicodeBlock.BASIC_LATIN_ID, 1);

--- a/tools/unicode/py/generate_prop_numbers_test_java.py
+++ b/tools/unicode/py/generate_prop_numbers_test_java.py
@@ -95,7 +95,7 @@ public class PropNumbersTest extends CoreTestFmwk {
           print(f'assertNotNull("{property}={value}", {icu4j_qualified_name});', file=out)
         else:
           print(f'assertEquals("{property}={value}", intValue({icu4j_qualified_name}), {number});', file=out)
-          if property == "blk" and value != "NB":
+          if property == "blk":
             print(f'assertEquals("{property}={value}", {icu4j_qualified_name}_ID, {number});', file=out)
   print("""
     }


### PR DESCRIPTION
This _ID value was missed when we added NO_BLOCK corresponding to Unicode Block=No_Block.

Discovered in
- https://github.com/unicode-org/icu/pull/4131#discussion_r3833207052

#### Checklist
- [x] Required: Issue filed: ICU-23343
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf
