### PR TITLE
ICU-23481 mf2 C++: fixes for standard functions

### DIFF
--- a/icu4c/source/i18n/messageformat2_formatter.cpp
+++ b/icu4c/source/i18n/messageformat2_formatter.cpp
@@ -42,7 +42,7 @@ private:
 MF2RegistrySingleton::MF2RegistrySingleton(UErrorCode &success) {
   // Set up the standard function registry
   MFFunctionRegistry::Builder standardFunctionsBuilder(success);
-  
+
   LocalPointer<Function> dateTime(StandardFunctions::DateTime::dateTime(success));
   LocalPointer<Function> date(StandardFunctions::DateTime::date(success));
   LocalPointer<Function> time(StandardFunctions::DateTime::time(success));
@@ -80,16 +80,17 @@ MF2RegistrySingleton::MF2RegistrySingleton(UErrorCode &success) {
 static MF2RegistrySingleton* mf2RegistrySingleton = nullptr;
 static icu::UInitOnce gMF2RegistryInitOnce {};
 
-// Clean up shared Registry objects
-static UBool mf2_registry_cleanup() {
+  // Clean up shared Registry objects
+  static UBool mf2_registry_cleanup() {
     if (mf2RegistrySingleton != nullptr) {
         delete mf2RegistrySingleton;
         mf2RegistrySingleton = nullptr;
     }
+    gMF2RegistryInitOnce.reset();
     return true;
-}
+  }
 
-static void initRegistryOnce(UErrorCode& errorCode) {
+  static void initRegistryOnce(UErrorCode& errorCode) {
     U_ASSERT(mf2RegistrySingleton == nullptr);
 
     mf2RegistrySingleton = new MF2RegistrySingleton( errorCode);
@@ -100,22 +101,27 @@ static void initRegistryOnce(UErrorCode& errorCode) {
         return;
     }
     ucln_i18n_registerCleanup(UCLN_I18N_MF2_REGISTRY, mf2_registry_cleanup);
-}
+  }
 
+  // ensure the registry is available
   static void initRegistry(UErrorCode& errorCode) {
     CHECK_ERROR(errorCode);
-
     umtx_initOnce(gMF2RegistryInitOnce, &initRegistryOnce, errorCode);
   }
 
+  // API:
   const MFFunctionRegistry *MFFunctionRegistry::getStandardFunctionsRegistry(UErrorCode& errorCode) {
     initRegistry(errorCode);
-    if (U_FAILURE(errorCode) || mf2RegistrySingleton == nullptr) {
+    if (U_FAILURE(errorCode)) {
+      return nullptr;
+    } else if(mf2RegistrySingleton == nullptr) {
+      // return error if we are about to return nullptr
+      errorCode = U_MEMORY_ALLOCATION_ERROR;
       return nullptr;
     }
     return mf2RegistrySingleton->getStandardFunctionsRegistry();
   }
-  
+
     // MessageFormatter::Builder
 
     // -------------------------------------
@@ -247,7 +253,7 @@ static void initRegistryOnce(UErrorCode& errorCode) {
     MessageFormatter::MessageFormatter(const MessageFormatter::Builder& builder, UErrorCode &success) : locale(builder.locale), customMFFunctionRegistry(builder.customMFFunctionRegistry) {
         standardMFFunctionRegistry = MFFunctionRegistry::getStandardFunctionsRegistry(success);
         CHECK_ERROR(success);
-	
+
         normalizedInput = builder.normalizedInput;
         signalErrors = builder.signalErrors;
         bidiIsolationStrategy = builder.bidiIsolationStrategy;

--- a/icu4c/source/i18n/messageformat2_function_registry.cpp
+++ b/icu4c/source/i18n/messageformat2_function_registry.cpp
@@ -1367,6 +1367,7 @@ static UBool mf2_date_parsers_cleanup() {
         delete dateTimeZoneParser;
         dateTimeZoneParser = nullptr;
     }
+    gMF2DateParsersInitOnce.reset();
     return true;
 }
 

--- a/icu4c/source/test/intltest/messageformat2test.cpp
+++ b/icu4c/source/test/intltest/messageformat2test.cpp
@@ -588,7 +588,8 @@ void TestMessageFormat2::testOverrideFunctions() {
 
 namespace ComposableFunctionTest {
 
-    class LocaleOverrideFunction : public Function {
+  class LocaleOverrideFunction : public Function {
+
   public:
     LocaleOverrideFunction(const Locale &loc, UErrorCode &status);
     LocalPointer<FunctionValue> call(const FunctionContext &, const FunctionValue &,
@@ -597,12 +598,12 @@ namespace ComposableFunctionTest {
 
   private:
     Locale overrideLocale;
-};
+  };
 
-LocaleOverrideFunction::LocaleOverrideFunction(const Locale &loc, UErrorCode &/*status*/)
+  LocaleOverrideFunction::LocaleOverrideFunction(const Locale &loc, UErrorCode &/*status*/)
     : overrideLocale(loc) {}
 
-LocalPointer<FunctionValue> LocaleOverrideFunction::call(const FunctionContext &context,
+  LocalPointer<FunctionValue> LocaleOverrideFunction::call(const FunctionContext &context,
                                                  const FunctionValue &arg,
                                                  const FunctionOptions &opts,
                                                  UErrorCode &errorCode) const {
@@ -610,24 +611,25 @@ LocalPointer<FunctionValue> LocaleOverrideFunction::call(const FunctionContext &
     const FunctionName& stdFunction = myFunction.tempSubString(1); // _date -> date
 
     const MFFunctionRegistry* standardRegistry = MFFunctionRegistry::getStandardFunctionsRegistry(errorCode);
- 
-    if (U_FAILURE(errorCode)) {
-        return LocalPointer<FunctionValue>();
-    }
-    
-    //    const Function *delegateFunction = context.getStandardFunction(stdFunction, errorCode);
-    const Function *delegateFunction = standardRegistry->getFunction(stdFunction);
-    
-    if (U_FAILURE(errorCode)) {
-        return LocalPointer<FunctionValue>();
-    }
-    // create a new context, with our updated locale
-    FunctionContext myContext = context.withLocale(overrideLocale);
-    // call the delegated function
-    return delegateFunction->call(myContext, arg, opts, errorCode);
-}
 
-LocaleOverrideFunction::~LocaleOverrideFunction() {}
+    if (U_FAILURE(errorCode)) {
+      return LocalPointer<FunctionValue>();
+    }
+    const Function *delegateFunction = standardRegistry->getFunction(stdFunction);
+
+    if (delegateFunction == nullptr && U_SUCCESS(errorCode)) {
+      errorCode = U_MF_UNKNOWN_FUNCTION_ERROR;  // function not found
+    }
+    if (U_FAILURE(errorCode)) {
+      return LocalPointer<FunctionValue>();
+    }
+    // create a new context, with our overridden locale
+    FunctionContext myContext = context.withLocale(overrideLocale);
+    // call the delegated function with the fixed-locale context
+    return delegateFunction->call(myContext, arg, opts, errorCode);
+  }
+
+  LocaleOverrideFunction::~LocaleOverrideFunction() {}
 } // namespace ComposableFunctionTest
 
 void TestMessageFormat2::testComposeInternalFunctions() {


### PR DESCRIPTION
- reset the UInitOnce for the registry on cleanup
- also fix the UInitOnce for the dateformatters, I had missed this.
- fix in getStandardFunctions() where error is always set if nullptr would be returned.
- also fix some indentation that wasn’t right

Update to #4054 

#### Checklist
- [X] Required: Issue filed: ICU-23481
- [X] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [X] Issue accepted (done by Technical Committee after discussion)
- [X] Tests included, if applicable
- [X] Approver: Feel free to merge on my behalf
