### PR TITLE
ICU-23155 Fix buffer overflow in SSearchTest diagnostics

### DIFF
--- a/icu4c/source/test/intltest/ssearch.cpp
+++ b/icu4c/source/test/intltest/ssearch.cpp
@@ -28,7 +28,9 @@
 #include "ssearch.h"
 #include "xmlparser.h"
 
-#include <stdio.h>  // for snprintf
+#include <iomanip>
+#include <sstream>
+#include <string>
 
 char testId[100];
 
@@ -524,40 +526,36 @@ UBool OrderList::matchesAt(int32_t offset, const OrderList &other) const
     return true;
 }
 
-static char *printOffsets(char *buffer, size_t n, OrderList &list)
-{
-    int32_t size = list.size();
-    char *s = buffer;
+static std::string printOffsets(const OrderList &list) {
+    std::ostringstream out;
 
-    for(int32_t i = 0; i < size; i += 1) {
+    for (int32_t i = 0; i < list.size(); i += 1) {
         const Order *order = list.get(i);
 
         if (i != 0) {
-            s += snprintf(s, n, ", ");
+            out << ", ";
         }
 
-        s += snprintf(s, n, "(%d, %d)", order->lowOffset, order->highOffset);
+        out << '(' << order->lowOffset << ", " << order->highOffset << ')';
     }
 
-    return buffer;
+    return out.str();
 }
 
-static char *printOrders(char *buffer, size_t n, OrderList &list)
-{
-    int32_t size = list.size();
-    char *s = buffer;
+static std::string printOrders(const OrderList &list) {
+    std::ostringstream out;
+    out << std::uppercase << std::hex << std::setfill('0');
 
-    for(int32_t i = 0; i < size; i += 1) {
+    for (int32_t i = 0; i < list.size(); i += 1) {
         const Order *order = list.get(i);
 
         if (i != 0) {
-            s += snprintf(s, n, ", ");
+            out << ", ";
         }
-
-        s += snprintf(s, n, "%8.8X", order->order);
+        out << std::setw(8) << order->order;
     }
 
-    return buffer;
+    return out.str();
 }
 
 void SSearchTest::offsetTest()
@@ -631,10 +629,6 @@ void SSearchTest::offsetTest()
         errcheckln(status, "Failed to create collator in offsetTest! - %s", u_errorName(status));
         return;
     }
-    char buffer[4096];  // A bit of a hack... just happens to be long enough for all the test cases...
-                        // We could allocate one that's the right size by (CE_count * 10) + 2
-                        // 10 chars is enough room for 8 hex digits plus ", ". 2 extra chars for "[" and "]"
-
     col->setAttribute(UCOL_NORMALIZATION_MODE, UCOL_ON, status);
 
     for(int32_t i = 0; i < testCount; i += 1) {
@@ -673,20 +667,18 @@ void SSearchTest::offsetTest()
 
         if (forwardList.compare(backwardList)) {
             logln("Works with \"%s\"", test[i]);
-            logln("Forward offsets:  [%s]", printOffsets(buffer, sizeof(buffer), forwardList));
-//          logln("Backward offsets: [%s]", printOffsets(buffer, sizeof(buffer), backwardList));
+            logln("Forward offsets:  [%s]", printOffsets(forwardList).c_str());
 
-            logln("Forward CEs:  [%s]", printOrders(buffer, sizeof(buffer), forwardList));
-//          logln("Backward CEs: [%s]", printOrders(buffer, sizeof(buffer), backwardList));
+            logln("Forward CEs:  [%s]", printOrders(forwardList).c_str());
 
             logln();
         } else {
             errln("Fails with \"%s\"", test[i]);
-            infoln("Forward offsets:  [%s]", printOffsets(buffer, sizeof(buffer), forwardList));
-            infoln("Backward offsets: [%s]", printOffsets(buffer, sizeof(buffer), backwardList));
+            infoln("Forward offsets:  [%s]", printOffsets(forwardList).c_str());
+            infoln("Backward offsets: [%s]", printOffsets(backwardList).c_str());
 
-            infoln("Forward CEs:  [%s]", printOrders(buffer, sizeof(buffer), forwardList));
-            infoln("Backward CEs: [%s]", printOrders(buffer, sizeof(buffer), backwardList));
+            infoln("Forward CEs:  [%s]", printOrders(forwardList).c_str());
+            infoln("Backward CEs: [%s]", printOrders(backwardList).c_str());
 
             infoln();
         }


### PR DESCRIPTION
This PR supersedes #3546 and incorporates the review feedback there.

The root cause was identified in #3546.
`printOffsets()` and `printOrders()` advanced their output pointer after each `snprintf()` call, but continued passing the original buffer size. This allowed writes beyond the end of the fixed-size buffer and caused `offsetTest()` to terminate with `buffer overflow detected` when `_FORTIFY_SOURCE=3` was enabled.

This PR change:
- returns dynamically sized diagnostic strings by value
- removes the fixed-size output buffer
- preserves the existing offset and collation-element output formats
- removes two redundant, commented-out diagnostic calls

The implementation follows the review feedback on #3546 by returning `std::string` directly instead of passing a caller-owned string buffer.

#### Testing

Configured an out-of-tree Linux/Clang build with strict compiler warnings and `_FORTIFY_SOURCE=3`:

```sh
CFLAGS='-O2 -Wp,-D_FORTIFY_SOURCE=3' \
CXXFLAGS='-O2 -Wp,-D_FORTIFY_SOURCE=3' \
../icu/icu4c/source/runConfigureICU Linux/clang --enable-strict

make -j$(nproc)
make -C test/intltest check
```

Before this change, make -C test/intltest check terminated with:

*** buffer overflow detected ***

After this change:

OK: All tests passed without error.

#### Checklist

- [x] Required: Issue filed: ICU-23155
- [x] Required: The PR title must be prefixed with a JIRA Issue number.
- [x] Required: Each commit message must be prefixed with a JIRA Issue number.
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable — not applicable; test-only change
- [x] Approver: Feel free to merge on my behalf