### PR TITLE
ICU-23502 Fix time of check to time of use bug in umapfile.cpp

### DIFF
--- a/icu4c/source/common/umapfile.cpp
+++ b/icu4c/source/common/umapfile.cpp
@@ -215,17 +215,18 @@ typedef HANDLE MemoryMap;
 
         UDataMemory_init(pData); /* Clear the output struct.        */
 
-        /* determine the length of the file */
-        if(stat(path, &mystat)!=0 || mystat.st_size<=0) {
-            return false;
-        }
-        length=mystat.st_size;
-
         /* open the file */
         fd=open(path, O_RDONLY);
         if(fd==-1) {
             return false;
         }
+
+        /* determine the length of the file */
+        if(stat(path, &mystat)!=0 || mystat.st_size<=0) {
+            close(fd);
+            return false;
+        }
+        length=mystat.st_size;
 
         /* get a view of the mapping */
 #if U_PLATFORM != U_PF_HPUX


### PR DESCRIPTION
 Fix time of check to time of use bug in umapfile.cpp

The file can be modified between the stat on the path and the call to open. Fix this by replacing the stat call with a call to fstat that works on the file descriptor we got back from open.

#### Checklist
- [x] Required: Issue filed: [ICU-23502](https://unicode-org.atlassian.net/browse/ICU-23502)
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf


[ICU-23502]: https://unicode-org.atlassian.net/browse/ICU-23502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ