### PR TITLE
ICU-22939 Declare ubidi_isolate() with U_CAPI linkage

### DIFF
--- a/icu4c/source/common/ubidi.cpp
+++ b/icu4c/source/common/ubidi.cpp
@@ -3079,7 +3079,7 @@ ubidi_getMFOption(const UnicodeString& s) {
 // `dir` is the directionality of `fmt`. This is determined from the resolved
 // value that `fmt` is part of; that is, each function can set the directionality
 // of the resolved value of its result.
-U_COMMON_API UnicodeString U_EXPORT2
+U_CAPI UnicodeString* U_EXPORT2
 ubidi_isolate(UMFBidiIsolationStrategy bidiIsolationStrategy,
                             UMFDirectionality msgdir,
                             UMFBidiIsolationStyle bidiIsolationStyle,
@@ -3091,7 +3091,7 @@ ubidi_isolate(UMFBidiIsolationStrategy bidiIsolationStrategy,
 
     // If strategy is 'none', just return the string
     if (bidiIsolationStrategy == U_MF_BIDI_OFF)
-        return fmt;
+        return &fmt;
 
     /* 1. Let msgdir be the directionality of the whole message, one of « 'LTR', 'RTL', 'unknown' ». These correspond to the message having left-to-right directionality, right-to-left directionality, and to the message's directionality not being known. */
 
@@ -3112,7 +3112,7 @@ ubidi_isolate(UMFBidiIsolationStrategy bidiIsolationStrategy,
         case U_MF_DIRECTIONALITY_LTR:
             if (msgdir == U_MF_DIRECTIONALITY_LTR && !isolate) {
                 // 2iv(a). If msgdir is 'LTR' in the formatted output, let fmt be itself
-                return fmt;
+                return &fmt;
             }
             // 2iii(b) Else, in the formatted output, prefix fmt with U+2066 LEFT-TO-RIGHT ISOLATE and postfix it with U+2069 POP DIRECTIONAL ISOLATE.
             if (bidiIsolationStyle == U_MF_BIDI_STYLE_CONTROL) {
@@ -3146,7 +3146,7 @@ ubidi_isolate(UMFBidiIsolationStrategy bidiIsolationStrategy,
             }
             break; // End of 2v
     } // `fmt` now contains the isolated string
-    return fmt;
+    return &fmt;
 }
 
 U_NAMESPACE_END

--- a/icu4c/source/common/unicode/ubidi.h
+++ b/icu4c/source/common/unicode/ubidi.h
@@ -2367,12 +2367,12 @@ ubidi_getMFOption(const UnicodeString& s);
  *        directionality of the resolved value of its result.
  * @param fmt String to isolate.
  *
- * @return A string bidi-isolated according to bidiIsolationStrategy.
+ * @return A pointer to a string bidi-isolated according to bidiIsolationStrategy.
  *
  * @internal ICU 79 technology preview
  * @deprecated This API is for technology preview only.
  */
-U_COMMON_API UnicodeString U_EXPORT2
+U_CAPI UnicodeString* U_EXPORT2
 ubidi_isolate(UMFBidiIsolationStrategy bidiIsolationStrategy,
               UMFDirectionality msgdir,
               UMFBidiIsolationStyle bidiIsolationStyle,

--- a/icu4c/source/common/unicode/urename.h
+++ b/icu4c/source/common/unicode/urename.h
@@ -475,6 +475,7 @@
 #define ubidi_isJoinControl U_ICU_ENTRY_POINT_RENAME(ubidi_isJoinControl)
 #define ubidi_isMirrored U_ICU_ENTRY_POINT_RENAME(ubidi_isMirrored)
 #define ubidi_isOrderParagraphsLTR U_ICU_ENTRY_POINT_RENAME(ubidi_isOrderParagraphsLTR)
+#define ubidi_isolate U_ICU_ENTRY_POINT_RENAME(ubidi_isolate)
 #define ubidi_open U_ICU_ENTRY_POINT_RENAME(ubidi_open)
 #define ubidi_openSized U_ICU_ENTRY_POINT_RENAME(ubidi_openSized)
 #define ubidi_orderParagraphsLTR U_ICU_ENTRY_POINT_RENAME(ubidi_orderParagraphsLTR)

--- a/icu4c/source/i18n/messageformat2.cpp
+++ b/icu4c/source/i18n/messageformat2.cpp
@@ -445,12 +445,12 @@ void MessageFormatter::formatPattern(MessageContext& context,
 
                   // Apply bidi isolation to the formatted result
                   UMFDirectionality dir = val->getDirection();
-                  result += ubidi_isolate(bidiIsolationStrategy,
-                                          msgdir,
-                                          bidiIsolationStyle,
-                                          val->getDirectionAnnotation(),
-                                          dir,
-                                          fmt);
+                  result += *(ubidi_isolate(bidiIsolationStrategy,
+                                            msgdir,
+                                            bidiIsolationStyle,
+                                            val->getDirectionAnnotation(),
+                                            dir,
+                                            fmt));
 
                   if (badSelectOption) {
                       context.getErrors().setBadOption(val->getFunctionName(), status);


### PR DESCRIPTION
Declare ubidi_isolate() with U_CAPI linkage for consistency with other functions. This entails changing its return type from UnicodeString to UnicodeString* so that it can have C linkage.

#### Checklist
- [x] Required: Issue filed: ICU-22939
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [x] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf
