### PR TITLE
ICU-23310 Hide U_LIFETIME_BOUND annotations from Doxygen

### DIFF
--- a/icu4c/source/Doxyfile.in
+++ b/icu4c/source/Doxyfile.in
@@ -2163,6 +2163,7 @@ PREDEFINED             = U_EXPORT2= \
                          U_SYSTEM= \
                          U_DEPRECATED= \
                          U_OBSOLETE= \
+                         U_LIFETIME_BOUND= \
                          U_CALLCONV_FPTR= \
                          U_CALLCONV= \
                          U_CDECL_BEGIN= \

--- a/icu4c/source/common/unicode/platform.h
+++ b/icu4c/source/common/unicode/platform.h
@@ -520,6 +520,7 @@
 #   define U_FALLTHROUGH
 #endif
 
+#ifndef U_IN_DOXYGEN
 /**
  * \def U_LIFETIME_BOUND
  *
@@ -547,6 +548,7 @@
 
 #ifndef U_LIFETIME_BOUND
 #   define U_LIFETIME_BOUND
+#endif
 #endif
 
 /** @} */


### PR DESCRIPTION
It seems that Doxygen doesn't handle such annotations on function parameters well.

#### Checklist
- [x] Required: Issue filed: ICU-23310
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [x] Approver: Feel free to merge on my behalf
