### PR TITLE
ICU-23509 Update the UnicodeSet parser to match the grammar that has the right precedence (no functional change)

### DIFF
--- a/icu4c/source/common/unicode/uniset.h
+++ b/icu4c/source/common/unicode/uniset.h
@@ -1717,28 +1717,28 @@ private:
                          int32_t depth,
                          UErrorCode &ec);
 
-    void parseUnion(Lexer &lexer,
-                    UnicodeString &rebuiltPat,
-                    uint32_t options,
-                    UnicodeSet &(UnicodeSet::*caseClosure)(int32_t attribute),
-                    int32_t depth,
-                    bool &containsRestrictions,
-                    UErrorCode &ec);
+    void parseContent(Lexer &lexer,
+                      UnicodeString &rebuiltPat,
+                      uint32_t options,
+                      UnicodeSet &(UnicodeSet::*caseClosure)(int32_t attribute),
+                      int32_t depth,
+                      bool &containsSetOperation,
+                      UErrorCode &ec);
 
-    void parseTerm(Lexer &lexer,
-                   UnicodeString &rebuiltPat,
-                   uint32_t options,
-                   UnicodeSet &(UnicodeSet::*caseClosure)(int32_t attribute),
-                   int32_t depth,
-                   bool &containsRestrictions,
-                   UErrorCode &ec);
+    void parseMutation(Lexer &lexer,
+                       UnicodeString &rebuiltPat,
+                       uint32_t options,
+                       UnicodeSet &(UnicodeSet::*caseClosure)(int32_t attribute),
+                       int32_t depth,
+                       bool &containsSetOperation,
+                       UErrorCode &ec);
 
-    void parseRestriction(Lexer &lexer,
-                          UnicodeString &rebuiltPat,
-                          uint32_t options,
-                          UnicodeSet &(UnicodeSet::*caseClosure)(int32_t attribute),
-                          int32_t depth,
-                          UErrorCode &ec);
+    void parseSetOperations(Lexer &lexer,
+                            UnicodeString &rebuiltPat,
+                            uint32_t options,
+                            UnicodeSet &(UnicodeSet::*caseClosure)(int32_t attribute),
+                            int32_t depth,
+                            UErrorCode &ec);
 
     void parseElements(Lexer &lexer,
                        UnicodeString &rebuiltPat,

--- a/icu4c/source/common/uniset_props.cpp
+++ b/icu4c/source/common/uniset_props.cpp
@@ -1070,16 +1070,16 @@ void UnicodeSet::parseUnicodeSet(Lexer &lexer,
         lexer.advance();
         preserveSyntaxInPattern = true;
     } else {
-        // UnicodeSet ::=                [   Union ]
-        //              | Complement ::= [ ^ Union ]
+        // UnicodeSet ::=                [   Content ]
+        //              | Complement ::= [ ^ Content ]
         if (lexer.acceptSetOperator(u'[')) {
             prettyPrintedPattern.append(u'[');
             if (lexer.acceptSetOperator(u'^')) {
                 prettyPrintedPattern.append(u'^');
                 isComplement = true;
             }
-            parseUnion(lexer, prettyPrintedPattern, options, caseClosure, depth,
-                       /*containsRestrictions=*/preserveSyntaxInPattern, ec);
+            parseContent(lexer, prettyPrintedPattern, options, caseClosure, depth,
+                         /*containsSetOperation=*/preserveSyntaxInPattern, ec);
             U_UNICODESET_RETURN_IF_ERROR(ec);
             if (!lexer.acceptSetOperator(u']')) {
                 U_UNICODESET_RETURN_WITH_PARSE_ERROR("]", lexer.lookahead().debugString(), lexer, ec);
@@ -1111,19 +1111,58 @@ void UnicodeSet::parseUnicodeSet(Lexer &lexer,
     }
 }
 
-void UnicodeSet::parseUnion(Lexer &lexer,
-                            UnicodeString &rebuiltPat,
-                            uint32_t options,
-                            UnicodeSet &(UnicodeSet::*caseClosure)(int32_t attribute),
-                            int32_t depth,
-                            bool &containsRestrictions,
-                            UErrorCode &ec) {
-    // Union ::= Terms
-    //         | UnescapedHyphenMinus Terms
-    //         | Terms UnescapedHyphenMinus
-    //         | UnescapedHyphenMinus Terms UnescapedHyphenMinus
-    // Terms ::= ""
-    //         | Terms Term
+void UnicodeSet::parseContent(Lexer &lexer,
+                              UnicodeString &rebuiltPat,
+                              uint32_t options,
+                              UnicodeSet &(UnicodeSet::*caseClosure)(int32_t attribute),
+                              int32_t depth,
+                              bool &containsSetOperation,
+                              UErrorCode &ec) {
+    //   Content ::= ""
+    //             | ElementList
+    //             | ElementList UnescapedHyphenMinus
+    //             -- ICU extensions:
+    //             | Æther
+    //             | ElementList Æther
+    //             | DollarElements UnescapedHyphenMinus
+    //             | DollarElements Æther
+    //             | ElementList DollarElements UnescapedHyphenMinus
+    //             | ElementList DollarElements Æther
+    //   Æther ::= $                                          -- ICU extension
+    //   ElementList ::= UnescapedHyphenMinus
+    //                 | Elements
+    //                 | ElementList Elements
+    //                 | SetOperation
+    //                 | ElementList DollarElements Elements  -- ICU extension
+    //   SetOperation ::= Union
+    //                  | Intersection
+    //                  | Difference
+    //   Union ::= UnicodeSet
+    //           | ElementList UnicodeSet
+    //           | ElementList DollarElements UnicodeSet      -- ICU extension
+    //   -- ICU extension:
+    //   DollarElements ::= $
+    //                    | RangeElement-$
+    // But that is not LL (we cannot tell if we have a SetOperation or not by looking at the
+    // first Elements), so we parse it as described in the note,
+    //   ElementList ::= Mutation Mutations | UnescapedHyphenMinus Mutations
+    //   Mutations   ::= "" | Mutation Mutations
+    //   Mutation    ::= Elements  | SetOperations
+    // Where a Mutation is not a subexpression, but a modification of the enclosing ElementList,
+    // either adding or removing characters; this means that parseMutation adds to or removes
+    // from this object, instead of returning a set.
+    // In parseSetOperations below, we will describe the logic both in terms of the LR
+    // expression grammar, and in terms of the LL grammar.
+    // With the DollarElements ICU extension, a non-final Mutation can be DollarElements, so this
+    // becomes
+    //   ElementList ::= Mutations FinalMutation
+    //                 | UnescapedHyphenMinus Mutations FinalMutation
+    //                 | UnescapedHyphenMinus
+    //   Mutation ::= Elements
+    //              | SetOperations
+    //              | DollarElements  -- ICU extension
+    //   FinalMutation ::= Elements
+    //                   | SetOperations
     if (lexer.acceptSetOperator(u'-')) {
         add(u'-');
         // When we otherwise preserve the syntax, we escape an initial UnescapedHyphenMinus, but not a
@@ -1141,57 +1180,71 @@ void UnicodeSet::parseUnion(Lexer &lexer,
             return;
         } else if (lexer.lookahead().isSetOperator(u'$')) {
             if (lexer.lookahead2().isSetOperator(u']')) {
-                // ICU extensions: A $ is allowed as a literal-element.
-                // A Term at the end of a Union consisting of a single $ is an anchor.
+                // ICU extensions: A $ is allowed in an ElementList if followed by Elements, or
+                // if followed by UnicodeSet (in a Union).
+                // A $ at the end of a Content is an Æther.
                 rebuiltPat.append(u'$');
                 // Consume the dollar.
                 lexer.advance();
                 add(U_ETHER);
-                containsRestrictions = true;
+                containsSetOperation = true;
                 return;
             }
         }
         if (lexer.lookahead().isSetOperator(u']')) {
             return;
         }
-        parseTerm(lexer, rebuiltPat, options, caseClosure, depth, containsRestrictions, ec);
+        // Also handles FinalMutation.
+        parseMutation(lexer, rebuiltPat, options, caseClosure, depth, containsSetOperation, ec);
         U_UNICODESET_RETURN_IF_ERROR(ec);
     }
 }
 
-void UnicodeSet::parseTerm(Lexer &lexer,
-                           UnicodeString &rebuiltPat,
-                           uint32_t options,
-                           UnicodeSet &(UnicodeSet::*caseClosure)(int32_t attribute),
-                           int32_t depth,
-                           bool &containsRestriction,
-                           UErrorCode &ec) {
-    // Term ::= Elements
-    //        | Restriction
+void UnicodeSet::parseMutation(Lexer &lexer,
+                               UnicodeString &rebuiltPat,
+                               uint32_t options,
+                               UnicodeSet &(UnicodeSet::*caseClosure)(int32_t attribute),
+                               int32_t depth,
+                               bool &containsSetOperation,
+                               UErrorCode &ec) {
+    //   Mutation ::= Elements
+    //              | SetOperations
+    //              | DollarElements  -- ICU extension
+    //   FinalMutation ::= Elements
+    //                   | SetOperations
+    //   SetOperations ::= UnicodeSet RightHandSides
+    // So if we see the beginning of a UnicodeSet, we have SetOperations.
     if (lexer.lookahead().isSetOperator('[') || lexer.lookahead().set() != nullptr) {
-        containsRestriction = true;
-        parseRestriction(lexer, rebuiltPat, options, caseClosure, depth, ec);
+        containsSetOperation = true;
+        parseSetOperations(lexer, rebuiltPat, options, caseClosure, depth, ec);
         U_UNICODESET_RETURN_IF_ERROR(ec);
     } else {
+        // Also handles DollarElements.
         parseElements(lexer, rebuiltPat, ec);
         U_UNICODESET_RETURN_IF_ERROR(ec);
     }
 }
 
-void UnicodeSet::parseRestriction(Lexer &lexer,
-                                  UnicodeString &rebuiltPat,
-                                  uint32_t options,
-                                  UnicodeSet &(UnicodeSet::*caseClosure)(int32_t attribute),
-                                  int32_t depth,
-                                  UErrorCode &ec) {
-    // Parse a https://www.unicode.org/reports/tr61/#Restriction:
-    //   Restriction  ::= UnicodeSet
+void UnicodeSet::parseSetOperations(Lexer &lexer,
+                                    UnicodeString &rebuiltPat,
+                                    uint32_t options,
+                                    UnicodeSet &(UnicodeSet::*caseClosure)(int32_t attribute),
+                                    int32_t depth,
+                                    UErrorCode &ec) {
+    // When we return from this function, this object represents a
+    // https://www.unicode.org/reports/tr61/#SetOperation:
+    //   SetOperation ::= Union
     //                  | Intersection
     //                  | Difference
-    //   Intersection ::= Restriction & UnicodeSet
-    //   Difference   ::= Restriction - UnicodeSet
-    // or, rewritten to be LL,
-    //   Restriction    ::= UnicodeSet RightHandSides
+    //   Union ::= UnicodeSet
+    //           | ElementList UnicodeSet
+    //           | ElementList DollarElements UnicodeSet  -- ICU extension
+    //   Intersection ::= SetOperation & UnicodeSet
+    //   Difference   ::= SetOperation - UnicodeSet
+    // since we parse top-down, we have already gone past any ElementList in the Union and added
+    // those to this object, and we end up with the UnicodeSet of the Union following by any
+    // right hand sides.  In the LL grammar from the note, this is:
+    //   SetOperations  ::= UnicodeSet RightHandSides
     //   RightHandSides ::= ""
     //                    | & UnicodeSet RightHandSides
     //                    | - UnicodeSet RightHandSides
@@ -1202,36 +1255,42 @@ void UnicodeSet::parseRestriction(Lexer &lexer,
     leftHandSide.parseUnicodeSet(lexer, rebuiltPat, options, caseClosure, depth + 1, ec);
     addAll(leftHandSide);
     U_UNICODESET_RETURN_IF_ERROR(ec);
-    // Now keep looking for an operator that would continue the RightHandSide.
-    // The loop terminates because when we run out of source text, the lookahead token will not be a set
-    // operator, so that we hit the else branch and return.
+    // In terms of the LR expression grammar, at this point this object is the Union, which is a
+    // SetOperation.
+
+    // Keep looking for an operator that would continue the RightHandSides in the LL grammar.
+    // The loop terminates because when we run out of source text, the lookahead token will not be a
+    // set operator, so that we hit the else branch and return.
     for (;;) {
+        // In terms of the LR expression grammar, at this point this object is a SetOperation; if &
+        // follows, we have an Intersection; if - follows, we have a Difference.
         if (lexer.acceptSetOperator(u'&')) {
-            // Intersection ::= Restriction & UnicodeSet
+            // Intersection ::= SetOperation & UnicodeSet
             rebuiltPat.append(u'&');
             UnicodeSet rightHandSide;
             rightHandSide.parseUnicodeSet(lexer, rebuiltPat, options, caseClosure, depth + 1, ec);
             U_UNICODESET_RETURN_IF_ERROR(ec);
             retainAll(rightHandSide);
         } else if (lexer.lookahead().isSetOperator(u'-')) {
-            // Here the grammar requires two tokens of lookahead to figure out whether the - is the operator
-            // of a Difference or an UnescapedHyphenMinus in the enclosing Union.
+            // Here the grammar requires two tokens of lookahead to figure out whether the - is
+            // the operator of a Difference or an UnescapedHyphenMinus in the enclosing Union.
             if (lexer.lookahead2().isSetOperator(u']')) {
-                // The operator is actually an UnescapedHyphenMinus; terminate the Restriction
-                // before it.  We return to parseTerm, which immediately returns to parseUnion,
-                // which will accept the - and add it to *this.
+                // The operator is actually an UnescapedHyphenMinus; terminate the SetOperation
+                // before it.  We return to parseMutation, which immediately returns to
+                // parseContent, which will accept the - and add it to *this.
                 return;
             }
             // Consume the hyphen-minus.
             lexer.advance();
-            // Difference ::= Restriction - UnicodeSet
+            // Difference ::= SetOperation - UnicodeSet
             rebuiltPat.append(u'-');
             UnicodeSet rightHandSide;
             rightHandSide.parseUnicodeSet(lexer, rebuiltPat, options, caseClosure, depth + 1, ec);
             U_UNICODESET_RETURN_IF_ERROR(ec);
             removeAll(rightHandSide);
         } else {
-            // Not an operator, end of the Restriction.
+            // Not an operator, end of the SetOperation (and of the SetOperations in the LL
+            // grammar).
             return;
         }
     }
@@ -1243,13 +1302,19 @@ void UnicodeSet::parseElements(Lexer &lexer,
     // Elements     ::= Element
     //                | Range
     // Range        ::= RangeElement - RangeElement
+    //                | $ - RangeElement             -- ICU extension
     // RangeElement ::= literal-element
     //                | escaped-element
     //                | named-element
     //                | bracketed-element
     // Element      ::= RangeElement
     //                | string-literal
-    // codePoint().has_value() on a lexical element if it is a RangeElement.
+    // In addition, this function handles the following ICU extension:
+    // DollarElements ::= $
+    //                  | RangeElement - $
+    // which cannot appear at the end of Content.
+    // A Content-final $ would already have been interpreted as an Æther by parseContent, so we
+    // only need to check that RangeElement - $ is not Content-final.
     if (lexer.lookahead().isStringLiteral()) {
         add(*lexer.lookahead().element());
         rebuiltPat.append(u'{');
@@ -1290,11 +1355,11 @@ void UnicodeSet::parseElements(Lexer &lexer,
     rebuiltPat.append(u'-');
     UChar32 last;
     if (lexer.lookahead().isSetOperator(u'$')) {
-        // Disallowed by UTS #61, but historically accepted by ICU except at the end of a Union.
+        // Disallowed by UTS #61, but historically accepted by ICU except at the end of a Content.
         // This is an extension.
         last = u'$';
         if (lexer.lookahead2().isSetOperator(u']')) {
-            U_UNICODESET_RETURN_WITH_PARSE_ERROR("Term after Range ending in unescaped $",
+            U_UNICODESET_RETURN_WITH_PARSE_ERROR("Elements or UnicodeSet after Range ending in unescaped $",
                                                  lexer.lookahead().debugString() + u" followed by " +
                                                      lexer.lookahead2().debugString(),
                                                  lexer, ec);

--- a/icu4j/main/core/src/main/java/com/ibm/icu/text/UnicodeSet.java
+++ b/icu4j/main/core/src/main/java/com/ibm/icu/text/UnicodeSet.java
@@ -4884,7 +4884,7 @@ public class UnicodeSet extends UnicodeFilter
     }
 
     private static class GrammaticalConstructProperties {
-        boolean containsRestriction = false;
+        boolean containsSetOperation = false;
     }
 
     void parseUnicodeSet(UnicodeSetLexer lexer, StringBuilder rebuiltPat, int options, int depth) {
@@ -4913,17 +4913,17 @@ public class UnicodeSet extends UnicodeFilter
             lexer.advance();
             preserveSyntaxInPattern = true;
         } else {
-            // UnicodeSet ::=                [   Union ]
-            //              | Complement ::= [ ^ Union ]
+            // UnicodeSet ::=                [   Content ]
+            //              | Complement ::= [ ^ Content ]
             if (lexer.acceptSetOperator('[')) {
                 prettyPrintedPattern.append('[');
                 if (lexer.acceptSetOperator('^')) {
                     prettyPrintedPattern.append('^');
                     isComplement = true;
                 }
-                final var unionProperties = new GrammaticalConstructProperties();
-                parseUnion(lexer, prettyPrintedPattern, options, depth, unionProperties);
-                preserveSyntaxInPattern |= unionProperties.containsRestriction;
+                final var contentProperties = new GrammaticalConstructProperties();
+                parseContent(lexer, prettyPrintedPattern, options, depth, contentProperties);
+                preserveSyntaxInPattern |= contentProperties.containsSetOperation;
                 if (!lexer.acceptSetOperator(']')) {
                     throw lexer.syntaxError("]", lexer.lookahead().debugString());
                 }
@@ -4953,29 +4953,66 @@ public class UnicodeSet extends UnicodeFilter
         }
     }
 
-    void parseUnion(
+    void parseContent(
             UnicodeSetLexer lexer,
             StringBuilder rebuiltPat,
             int options,
             int depth,
             GrammaticalConstructProperties properties) {
-        // Union ::= Terms
-        //         | UnescapedHyphenMinus Terms
-        //         | Terms UnescapedHyphenMinus
-        //         | UnescapedHyphenMinus Terms UnescapedHyphenMinus
-        // Terms ::= ""
-        //         | Terms Term
+        //   Content ::= ""
+        //             | ElementList
+        //             | ElementList UnescapedHyphenMinus
+        //             -- ICU extensions:
+        //             | Æther
+        //             | ElementList Æther
+        //             | DollarElements UnescapedHyphenMinus
+        //             | DollarElements Æther
+        //             | ElementList DollarElements UnescapedHyphenMinus
+        //             | ElementList DollarElements Æther
+        //   Æther ::= $                                          -- ICU extension
+        //   ElementList ::= UnescapedHyphenMinus
+        //                 | Elements
+        //                 | ElementList Elements
+        //                 | SetOperation
+        //                 | ElementList DollarElements Elements  -- ICU extension
+        //   SetOperation ::= Union
+        //                  | Intersection
+        //                  | Difference
+        //   Union ::= UnicodeSet
+        //           | ElementList UnicodeSet
+        //           | ElementList DollarElements UnicodeSet      -- ICU extension
+        //   -- ICU extension:
+        //   DollarElements ::= $
+        //                    | RangeElement-$
+        // But that is not LL (we cannot tell if we have a SetOperation or not by looking at the
+        // first Elements), so we parse it as described in the note,
+        //   ElementList ::= Mutation Mutations | UnescapedHyphenMinus Mutations
+        //   Mutations   ::= "" | Mutation Mutations
+        //   Mutation    ::= Elements  | SetOperations
+        // Where a Mutation is not a subexpression, but a modification of the enclosing ElementList,
+        // either adding or removing characters; this means that parseMutation adds to or removes
+        // from this object, instead of returning a set.
+        // In parseSetOperations below, we will describe the logic both in terms of the LR
+        // expression grammar, and in terms of the LL grammar.
+        // With the DollarElements ICU extension, a non-final Mutation can be DollarElements, so
+        // this becomes
+        //   ElementList ::= Mutations FinalMutation
+        //                 | UnescapedHyphenMinus Mutations FinalMutation
+        //                 | UnescapedHyphenMinus
+        //   Mutation ::= Elements
+        //              | SetOperations
+        //              | DollarElements  -- ICU extension
+        //   FinalMutation ::= Elements
+        //                   | SetOperations
         if (lexer.acceptSetOperator('-')) {
             add('-');
             // When we otherwise preserve the syntax, we escape an initial UnescapedHyphenMinus, but
-            // not a
-            // final one, for consistency with older ICU behaviour.
+            // not a final one, for consistency with older ICU behaviour.
             rebuiltPat.append("\\-");
         }
         while (!lexer.atEnd()) {
             // Note that while a HYPHEN-MINUS mapped by the symbol table is treated as a literal at
-            // the
-            // beginning of the Union, it is treated as a set elsewhere, including at the end.
+            // the beginning of the Content, it is treated as a set elsewhere, including at the end.
             if (lexer.acceptSetOperator('-')) {
                 // We can be here on the first iteration: [--] is allowed by the
                 // grammar and by the old parser.
@@ -4984,48 +5021,63 @@ public class UnicodeSet extends UnicodeFilter
                 return;
             } else if (lexer.lookahead().isSetOperator('$')) {
                 if (lexer.lookahead2().isSetOperator(']')) {
-                    // ICU extensions: A $ is allowed as a literal-element.
-                    // A Term at the end of a Union consisting of a single $ is an anchor.
+                    // ICU extensions: A $ is allowed in an ElementList if followed by Elements, or
+                    // if followed by UnicodeSet (in a Union).
+                    // A $ at the end of a Content is an Æther.
                     rebuiltPat.append('$');
                     // Consume the dollar.
                     lexer.advance();
                     add(ETHER);
-                    properties.containsRestriction = true;
+                    properties.containsSetOperation = true;
                     return;
                 }
             }
             if (lexer.lookahead().isSetOperator(']')) {
                 return;
             }
-            parseTerm(lexer, rebuiltPat, options, depth, properties);
+            // Also handles FinalMutation.
+            parseMutation(lexer, rebuiltPat, options, depth, properties);
         }
     }
 
-    void parseTerm(
+    void parseMutation(
             UnicodeSetLexer lexer,
             StringBuilder rebuiltPat,
             int options,
             int depth,
             GrammaticalConstructProperties properties) {
-        // Term ::= Elements
-        //        | Restriction
+        //   Mutation ::= Elements
+        //              | SetOperations
+        //              | DollarElements  -- ICU extension
+        //   FinalMutation ::= Elements
+        //                   | SetOperations
+        //   SetOperations ::= UnicodeSet RightHandSides
+        // So if we see the beginning of a UnicodeSet, we have SetOperations.
         if (lexer.lookahead().isSetOperator('[') || lexer.lookahead().set() != null) {
-            properties.containsRestriction = true;
-            parseRestriction(lexer, rebuiltPat, options, depth);
+            properties.containsSetOperation = true;
+            parseSetOperations(lexer, rebuiltPat, options, depth);
         } else {
+            // Also handles DollarElements.
             parseElements(lexer, rebuiltPat);
         }
     }
 
-    void parseRestriction(UnicodeSetLexer lexer, StringBuilder rebuiltPat, int options, int depth) {
-        // Parse a https://www.unicode.org/reports/tr61/#Restriction:
-        //   Restriction  ::= UnicodeSet
+    void parseSetOperations(
+            UnicodeSetLexer lexer, StringBuilder rebuiltPat, int options, int depth) {
+        // When we return from this function, this object represents a
+        // https://www.unicode.org/reports/tr61/#SetOperation:
+        //   SetOperation ::= Union
         //                  | Intersection
         //                  | Difference
-        //   Intersection ::= Restriction & UnicodeSet
-        //   Difference   ::= Restriction - UnicodeSet
-        // or, rewritten to be LL,
-        //   Restriction    ::= UnicodeSet RightHandSides
+        //   Union ::= UnicodeSet
+        //           | ElementList UnicodeSet
+        //           | ElementList DollarElements UnicodeSet  -- ICU extension
+        //   Intersection ::= SetOperation & UnicodeSet
+        //   Difference   ::= SetOperation - UnicodeSet
+        // since we parse top-down, we have already gone past any ElementList in the Union and added
+        // those to this object, and we end up with the UnicodeSet of the Union following by any
+        // right hand sides.  In the LL grammar from the note, this is:
+        //   SetOperations  ::= UnicodeSet RightHandSides
         //   RightHandSides ::= ""
         //                    | & UnicodeSet RightHandSides
         //                    | - UnicodeSet RightHandSides
@@ -5035,36 +5087,40 @@ public class UnicodeSet extends UnicodeFilter
         final var leftHandSide = new UnicodeSet();
         leftHandSide.parseUnicodeSet(lexer, rebuiltPat, options, depth + 1);
         addAll(leftHandSide);
-        // Now keep looking for an operator that would continue the RightHandSide.
+        // In terms of the LR expression grammar, at this point this object is the
+        // Union, which is a SetOperation.
+
+        // Keep looking for an operator that would continue the RightHandSides in the LL grammar.
         // The loop terminates because when we run out of source text, the lookahead token will not
-        // be a set
-        // operator, so that we hit the else branch and return.
+        // be a set operator, so that we hit the else branch and return.
         for (; ; ) {
+            // In terms of the LR expression grammar at this point this object is a SetOperation; if
+            // & follows, we have an Intersection; if - follows, we have a Difference.
             if (lexer.acceptSetOperator('&')) {
-                // Intersection ::= Restriction & UnicodeSet
+                // Intersection ::= SetOperation & UnicodeSet
                 rebuiltPat.append('&');
                 final var rightHandSide = new UnicodeSet();
                 rightHandSide.parseUnicodeSet(lexer, rebuiltPat, options, depth + 1);
                 retainAll(rightHandSide);
             } else if (lexer.lookahead().isSetOperator('-')) {
                 // Here the grammar requires two tokens of lookahead to figure out whether the - is
-                // the operator
-                // of a Difference or an UnescapedHyphenMinus in the enclosing Union.
+                // the operator of a Difference or an UnescapedHyphenMinus in the enclosing Union.
                 if (lexer.lookahead2().isSetOperator(']')) {
-                    // The operator is actually an UnescapedHyphenMinus; terminate the Restriction
-                    // before it.  We return to parseTerm, which immediately returns to parseUnion,
-                    // which will accept the - and add it to *this.
+                    // The operator is actually an UnescapedHyphenMinus; terminate the SetOperation
+                    // before it.  We return to parseMutation, which immediately returns to
+                    // parseContent, which will accept the - and add it to this.
                     return;
                 }
                 // Consume the hyphen-minus.
                 lexer.advance();
-                // Difference ::= Restriction - UnicodeSet
+                // Difference ::= SetOperation - UnicodeSet
                 rebuiltPat.append('-');
                 final var rightHandSide = new UnicodeSet();
                 rightHandSide.parseUnicodeSet(lexer, rebuiltPat, options, depth + 1);
                 removeAll(rightHandSide);
             } else {
-                // Not an operator, end of the Restriction.
+                // Not an operator, end of the SetOperation (and of the SetOperations in the LL
+                // grammar).
                 return;
             }
         }
@@ -5074,13 +5130,19 @@ public class UnicodeSet extends UnicodeFilter
         // Elements     ::= Element
         //                | Range
         // Range        ::= RangeElement - RangeElement
+        //                | $ - RangeElement             -- ICU extension
         // RangeElement ::= literal-element
         //                | escaped-element
         //                | named-element
         //                | bracketed-element
         // Element      ::= RangeElement
         //                | string-literal
-        // codePoint().has_value() on a lexical element if it is a RangeElement.
+        // In addition, this function handles the following ICU extension:
+        // DollarElements ::= $
+        //                  | RangeElement - $
+        // which cannot appear at the end of Content.
+        // A Content-final $ would already have been interpreted as an Æther by parseContent, so we
+        // only need to check that RangeElement - $ is not Content-final.
         if (lexer.lookahead().isStringLiteral()) {
             add(lexer.lookahead().element());
             rebuiltPat.append('{');
@@ -5108,8 +5170,7 @@ public class UnicodeSet extends UnicodeFilter
             return;
         }
         // Here the grammar requires two tokens of lookahead to figure out whether the - is the
-        // operator
-        // of a Range or an UnescapedHyphenMinus in the enclosing Union.
+        // operator of a Range or an UnescapedHyphenMinus in the enclosing Content.
         if (lexer.lookahead2().isSetOperator(']')) {
             // The operator is actually an UnescapedHyphenMinus; terminate the Elements before it.
             add(first);
@@ -5121,12 +5182,12 @@ public class UnicodeSet extends UnicodeFilter
         rebuiltPat.append('-');
         int last;
         if (lexer.lookahead().isSetOperator('$')) {
-            // Disallowed by UTS #61, but historically accepted by ICU except at the end of a Union.
-            // This is an extension.
+            // Disallowed by UTS #61, but historically accepted by ICU except at the end of a
+            // Content.  This is an extension.
             last = '$';
             if (lexer.lookahead2().isSetOperator(']')) {
                 throw lexer.syntaxError(
-                        "Term after Range ending in unescaped $",
+                        "Elements or UnicodeSet after Range ending in unescaped $",
                         lexer.lookahead().debugString()
                                 + " followed by "
                                 + lexer.lookahead2().debugString());

--- a/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UnicodeSetTest.java
+++ b/icu4j/main/core/src/test/java/com/ibm/icu/dev/test/lang/UnicodeSetTest.java
@@ -4414,11 +4414,11 @@ public class UnicodeSetTest extends CoreTestFmwk {
                     {"[{aa]", "String literal was not terminated: {aa] [{aa]☜"},
                     {
                         "[a-$]",
-                        "Expected Term after Range ending in unescaped $, got set-operator '$' followed by set-operator ']' [a-☞$]"
+                        "Expected Elements or UnicodeSet after Range ending in unescaped $, got set-operator '$' followed by set-operator ']' [a-☞$]"
                     },
                     {
                         "[!-$]",
-                        "Expected Term after Range ending in unescaped $, got set-operator '$' followed by set-operator ']' [!-☞$]"
+                        "Expected Elements or UnicodeSet after Range ending in unescaped $, got set-operator '$' followed by set-operator ']' [!-☞$]"
                     },
                     {
                         "[a-a]", "Expected first < last in Range, got a-a [a-☞a]"


### PR DESCRIPTION
The existing parser did not actually do what UTS61 said, so going back to a grammar that has the desired precedence (equal between union, intersection, and difference, instead of difference and intersection having higher precedence) has no effect.

##### How did the parser fail to implement the bad grammar?

See https://github.com/unicode-org/icu/blob/2ebc7054cdfd593baf846c8e604bca5d1dd91bb6/icu4c/source/common/uniset_props.cpp#L1181-L1192 Instead of https://github.com/unicode-org/icu/blob/2ebc7054cdfd593baf846c8e604bca5d1dd91bb6/icu4c/source/common/uniset_props.cpp#L1201-L1203 and then, in a loop, https://github.com/unicode-org/icu/blob/2ebc7054cdfd593baf846c8e604bca5d1dd91bb6/icu4c/source/common/uniset_props.cpp#L1212-L1215 or https://github.com/unicode-org/icu/blob/2ebc7054cdfd593baf846c8e604bca5d1dd91bb6/icu4c/source/common/uniset_props.cpp#L1229-L1232 a parser actually implementing what the grammar said would done leftHandSide.retainAll/removeAll, and leftHandSide.addAll only at the end of the Restriction.

#### Checklist
- [x] Required: Issue filed: ICU-23509
- [x] Required: The PR title must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Required: Each commit message must be prefixed with a JIRA Issue number. Example: "ICU-NNNNN Fix xyz"
- [x] Issue accepted (done by Technical Committee after discussion)
- [x] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
- [ ] Approver: Feel free to merge on my behalf

