### PR TITLE
ICU-23508 Rebind UText chunk contents after deep clone

### DIFF
--- a/icu4c/source/common/utext.cpp
+++ b/icu4c/source/common/utext.cpp
@@ -2101,6 +2101,7 @@ unistrTextClone(UText *dest, const UText *src, UBool deep, UErrorCode *status) {
     if (deep && U_SUCCESS(*status)) {
         const UnicodeString *srcString = (const UnicodeString *)src->context;
         dest->context = new UnicodeString(*srcString);
+        dest->chunkContents = ((const UnicodeString *)dest->context)->getBuffer();
         dest->providerProperties |= I32_FLAG(UTEXT_PROVIDER_OWNS_TEXT);
 
         // with deep clone, the copy is writable, even when the source is not.
@@ -2376,6 +2377,7 @@ ucstrTextClone(UText *dest, const UText * src, UBool deep, UErrorCode * status) 
             }
             copyStr[len] = 0;
             dest->context = copyStr;
+            dest->chunkContents = copyStr;
             dest->providerProperties |= I32_FLAG(UTEXT_PROVIDER_OWNS_TEXT);
         }
     }

--- a/icu4c/source/test/intltest/utxttest.cpp
+++ b/icu4c/source/test/intltest/utxttest.cpp
@@ -65,6 +65,7 @@ UTextTest::runIndexedTest(int32_t index, UBool exec,
     TESTCASE_AUTO(Ticket10983);
     TESTCASE_AUTO(Ticket12130);
     TESTCASE_AUTO(Ticket13344);
+    TESTCASE_AUTO(Ticket23508);
     TESTCASE_AUTO(AccessChangesChunkSize);
     TESTCASE_AUTO_END;
 }
@@ -1606,6 +1607,45 @@ void UTextTest::Ticket13344() {
     assertEquals("UTextTest::Ticket13344-trail-2", 3, utext_getNativeIndex(ut.getAlias()));
     utext_setNativeIndex(ut.getAlias(), 5);
     assertEquals("UTextTest::Ticket13344-bmp-2", 5, utext_getNativeIndex(ut.getAlias()));
+}
+
+// ICU-23508 Deep UText clones must not retain chunk contents from source storage.
+void UTextTest::Ticket23508() {
+    UErrorCode status = U_ZERO_ERROR;
+
+    // UChar* provider.
+    char16_t chars[] = u"ABC";
+    LocalUTextPointer charsText(
+            utext_openUChars(nullptr, chars, -1, &status));
+    assertSuccess("UTextTest::Ticket23508-UChars-open", status);
+
+    LocalUTextPointer charsClone(
+            utext_clone(nullptr, charsText.getAlias(), true, false, &status));
+    assertSuccess("UTextTest::Ticket23508-UChars-clone", status);
+
+    chars[0] = u'Z';
+    assertEquals(
+            "UTextTest::Ticket23508-UChars-independent",
+            0x41,
+            utext_char32At(charsClone.getAlias(), 0));
+
+    // UnicodeString provider.
+    status = U_ZERO_ERROR;
+    UnicodeString str(u"ABC");
+
+    LocalUTextPointer stringText(
+            utext_openUnicodeString(nullptr, &str, &status));
+    assertSuccess("UTextTest::Ticket23508-UnicodeString-open", status);
+
+    LocalUTextPointer stringClone(
+            utext_clone(nullptr, stringText.getAlias(), true, false, &status));
+    assertSuccess("UTextTest::Ticket23508-UnicodeString-clone", status);
+
+    str.setCharAt(0, u'Z');
+    assertEquals(
+            "UTextTest::Ticket23508-UnicodeString-independent",
+            0x41,
+            utext_char32At(stringClone.getAlias(), 0));
 }
 
 // ICU-21653 UText does not handle access callback that changes chunk size

--- a/icu4c/source/test/intltest/utxttest.h
+++ b/icu4c/source/test/intltest/utxttest.h
@@ -39,6 +39,7 @@ public:
     void Ticket10983();
     void Ticket12130();
     void Ticket13344();
+    void Ticket23508();
     void AccessChangesChunkSize();
 
 private:


### PR DESCRIPTION
## Summary

Fixes ICU-23508.

Deep cloning a `UText` backed by `UnicodeString` or `UChar*` replaced
`dest->context` with newly owned storage but left `dest->chunkContents`
pointing to the source storage.

This could cause a deep clone to continue reading from the original buffer
instead of its independent copy.

## Fix

Rebind `dest->chunkContents` to the newly allocated backing storage in:

- `unistrTextClone()`
- `ucstrTextClone()`

## Tests

Added `UTextTest::Ticket23508()` covering both affected providers.

The regression test:

- fails for both `UChar*` and `UnicodeString` without the fix;
- passes for both with the fix;
- and the full `utility/UTextTest` suite passes.

Tested with ICU 79.0.1.
